### PR TITLE
Keep FR answer panel open after betting

### DIFF
--- a/web/components/answers/answer-bet-panel.tsx
+++ b/web/components/answers/answer-bet-panel.tsx
@@ -63,7 +63,7 @@ export function AnswerBetPanel(props: {
 
     if (result?.status === 'success') {
       setIsSubmitting(false)
-      closePanel()
+      setBetAmount(undefined)
     } else {
       setError(result?.error || 'Error placing bet')
       setIsSubmitting(false)


### PR DESCRIPTION
[Ticket](https://www.notion.so/manifoldmarkets/After-submitting-a-FR-bet-the-popup-closes-so-you-can-t-answer-a-question-0c745cc29f774ca1a77cdc7652d7770c)