### PR TITLE
Fix tiny Tailwind config details

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,7 +1,6 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  mode: 'jit',
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
@@ -19,9 +18,6 @@ module.exports = {
         'world-trading': "url('/world-trading-background.webp')",
       },
     },
-  },
-  variants: {
-    extend: {},
   },
   plugins: [
     require('@tailwindcss/forms'),


### PR DESCRIPTION
No functionality change, but having the old Tailwind 2 version of these configs caused ugly warnings to fly out of the dev server every time you started it. These are all cleanups recommended by the [Tailwind 2->3 upgrade guide](https://tailwindcss.com/docs/upgrade-guide).
