### PR TITLE
Kill allowTransparency on 404 Discord widget

### DIFF
--- a/web/pages/404.tsx
+++ b/web/pages/404.tsx
@@ -19,7 +19,6 @@ export default function Custom404() {
           src="https://discord.com/widget?id=915138780216823849&theme=dark"
           width="350"
           height="500"
-          allowTransparency={true}
           frameBorder="0"
           sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
         ></iframe>


### PR DESCRIPTION
This isn't in the HTML spec (and is irrelevant to the Discord widget functionality) so React spews a big validation error in the console and doesn't pass it through to the DOM anyway. Let's not spew a big validation error in the console.