### PR TITLE
Change how Firebase scripts auth

### DIFF
--- a/functions/src/scripts/change-user-info.ts
+++ b/functions/src/scripts/change-user-info.ts
@@ -1,15 +1,8 @@
 import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
-// Generate your own private key, and set the path below:
-// https://console.firebase.google.com/u/0/project/mantic-markets/settings/serviceaccounts/adminsdk
-
-// const serviceAccount = require('../../../../../../Downloads/dev-mantic-markets-firebase-adminsdk-sir5m-b2d27f8970.json')
-const serviceAccount = require('../../../../../../Downloads/mantic-markets-firebase-adminsdk-1ep46-351a65eca3.json')
-
-admin.initializeApp({
-  credential: admin.credential.cert(serviceAccount),
-})
+import { initAdmin } from './script-init'
+initAdmin()
 
 import { getUserByUsername } from '../utils'
 import { changeUser } from '../change-user-info'

--- a/functions/src/scripts/correct-bet-probability.ts
+++ b/functions/src/scripts/correct-bet-probability.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('stephen')
+initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { getDpmProbability } from '../../../common/calculate-dpm'

--- a/functions/src/scripts/create-private-users.ts
+++ b/functions/src/scripts/create-private-users.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('stephen')
+initAdmin()
 
 import { PrivateUser, STARTING_BALANCE, User } from '../../../common/user'
 

--- a/functions/src/scripts/get-json-dump.ts
+++ b/functions/src/scripts/get-json-dump.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash'
 import * as fs from 'fs'
 
 import { initAdmin } from './script-init'
-initAdmin('james')
+initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { Contract } from '../../../common/contract'

--- a/functions/src/scripts/lowercase-fold-tags.ts
+++ b/functions/src/scripts/lowercase-fold-tags.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('james')
+initAdmin()
 
 import { getValues } from '../utils'
 import { Fold } from '../../../common/fold'

--- a/functions/src/scripts/make-contracts-public.ts
+++ b/functions/src/scripts/make-contracts-public.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('james')
+initAdmin()
 
 import { Contract } from '../../../common/contract'
 

--- a/functions/src/scripts/migrate-contract.ts
+++ b/functions/src/scripts/migrate-contract.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('james')
+initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { Contract } from '../../../common/contract'

--- a/functions/src/scripts/migrate-to-cfmm.ts
+++ b/functions/src/scripts/migrate-to-cfmm.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('stephenDev')
+initAdmin()
 
 import {
   Binary,

--- a/functions/src/scripts/migrate-to-dpm-2.ts
+++ b/functions/src/scripts/migrate-to-dpm-2.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('stephenDev')
+initAdmin()
 
 import { Binary, Contract, DPM, FullContract } from '../../../common/contract'
 import { Bet } from '../../../common/bet'

--- a/functions/src/scripts/pay-out-contract-again.ts
+++ b/functions/src/scripts/pay-out-contract-again.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('james')
+initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { Contract } from '../../../common/contract'

--- a/functions/src/scripts/recalculate-contract-totals.ts
+++ b/functions/src/scripts/recalculate-contract-totals.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('james')
+initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { Contract } from '../../../common/contract'

--- a/functions/src/scripts/remove-answer-ante.ts
+++ b/functions/src/scripts/remove-answer-ante.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('james')
+initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { Contract } from '../../../common/contract'

--- a/functions/src/scripts/rename-user-contracts.ts
+++ b/functions/src/scripts/rename-user-contracts.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('stephenDev')
+initAdmin()
 
 import { Contract } from '../../../common/contract'
 import { getValues } from '../utils'

--- a/functions/src/scripts/script-init.ts
+++ b/functions/src/scripts/script-init.ts
@@ -1,32 +1,71 @@
+import * as path from 'path'
+import * as fs from 'fs'
+import * as os from 'os'
 import * as admin from 'firebase-admin'
 
-// Generate your own private key, and set the path below:
-// Prod:
-// https://console.firebase.google.com/u/0/project/mantic-markets/settings/serviceaccounts/adminsdk
-// Dev:
-// https://console.firebase.google.com/u/0/project/dev-mantic-markets/settings/serviceaccounts/adminsdk
+// First, generate a private key from the Google service account management page:
+// Prod: https://console.firebase.google.com/u/0/project/mantic-markets/settings/serviceaccounts/adminsdk
+// Dev: https://console.firebase.google.com/u/0/project/dev-mantic-markets/settings/serviceaccounts/adminsdk
+// Then set GOOGLE_ACCOUNT_CREDENTIALS_PROD or GOOGLE_ACCOUNT_CREDENTIALS_DEV to the path of the key.
 
-const pathsToPrivateKey = {
-  james:
-    '/Users/jahooma/mantic-markets-firebase-adminsdk-1ep46-820891bb87.json',
-  jamesDev:
-    '/Users/jahooma/dev-mantic-markets-firebase-adminsdk-sir5m-f38cdbee37.json',
-  stephen:
-    '../../../../../../Downloads/mantic-markets-firebase-adminsdk-1ep46-351a65eca3.json',
-  stephenDev:
-    '../../../../../../Downloads/dev-mantic-markets-firebase-adminsdk-sir5m-b2d27f8970.json',
+// Then, to run a script, make sure you are pointing at the Firebase you intend to:
+// $ firebase use dev (or prod)
+//
+// Followed by, if you have https://github.com/TypeStrong/ts-node installed (recommended):
+// $ ts-node my-script.ts
+//
+// Or compile it and run the compiled version:
+// $ yarn build && ../../lib/functions/scripts/src/my-script.js
+
+const getFirebaseProjectRoot = (cwd: string) => {
+  // see https://github.com/firebase/firebase-tools/blob/master/src/detectProjectRoot.ts
+  let dir = cwd
+  while (!fs.existsSync(path.resolve(dir, './firebase.json'))) {
+    const parentDir = path.dirname(dir)
+    if (parentDir === dir) {
+      return null
+    }
+    dir = parentDir
+  }
+  return dir
 }
 
-export const initAdmin = (who: keyof typeof pathsToPrivateKey) => {
-  const serviceAccount = require(pathsToPrivateKey[who])
+const getFirebaseActiveProject = (cwd: string) => {
+  // firebase uses this configstore package https://github.com/yeoman/configstore/blob/main/index.js#L9
+  const projectRoot = getFirebaseProjectRoot(cwd)
+  if (projectRoot == null) {
+    return null
+  }
+  const xdgConfig =
+    process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
+  const configPath = path.join(xdgConfig, 'configstore', 'firebase-tools.json')
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'))
+    return config['activeProjects'][projectRoot]
+  } catch (e) {
+    return null
+  }
+}
 
+export const initAdmin = (env?: string) => {
+  env = env || getFirebaseActiveProject(process.cwd())
+  if (env == null) {
+    console.error(
+      "Couldn't find active Firebase project; did you do `firebase use <alias>?`"
+    )
+    return
+  }
+  const envVar = `GOOGLE_AUTHENTICATION_CREDENTIALS_${env.toUpperCase()}`
+  const keyPath = process.env[envVar]
+  if (keyPath == null) {
+    console.error(
+      `Please set the ${envVar} environment variable to contain the path to your ${env} environment key file.`
+    )
+    return
+  }
+  console.log(`Initializing connection to ${env} Firebase...`)
+  const serviceAccount = require(keyPath)
   admin.initializeApp({
     credential: admin.credential.cert(serviceAccount),
   })
 }
-
-// Then:
-// yarn watch (or yarn build)
-// firebase use dev (or firebase use prod)
-// Run script:
-// node lib/functions/src/scripts/update-contract-tags.js

--- a/functions/src/scripts/update-contract-tags.ts
+++ b/functions/src/scripts/update-contract-tags.ts
@@ -2,7 +2,7 @@ import * as admin from 'firebase-admin'
 import * as _ from 'lodash'
 
 import { initAdmin } from './script-init'
-initAdmin('jamesDev')
+initAdmin()
 
 import { Contract } from '../../../common/contract'
 import { parseTags } from '../../../common/util/parse'


### PR DESCRIPTION
Now, to run a script requiring admin authentication:

1. Download your admin SDK private key from the site as before.
2. Set the `GOOGLE_ACCOUNT_CREDENTIALS_[DEV|PROD]` environment variable to contain the path to your key. (This is named to be similar to the `GOOGLE_ACCOUNT_CREDENTIALS` environment variable, which is what Firebase looks at to find a default key if you don't specify any credentials in `initializeApp`.)
3. Activate your intended Firebase CLI database via `firebase use [dev|prod]`.
4. Run the script. It will respect your currently active database and consult your environment for the associated key.

Compared to the old version:

1. You don't have to embed the path to the key a script uses inside the script, so it's much more convenient for anyone but James and Stephen.
2. It seems much less likely that someone is going to do an oops-thought-this-script-was-on-dev-but-accidentally-ran-it-on-prod.