### PR TITLE
Fix generation of create market placeholder text

### DIFF
--- a/web/components/feed-create.tsx
+++ b/web/components/feed-create.tsx
@@ -76,7 +76,7 @@ export default function FeedCreate(props: {
   // Easter egg idea: click your own name to shuffle the placeholder
   // const daysSinceEpoch = Math.floor(Date.now() / 1000 / 60 / 60 / 24)
 
-  // take care not to produce a different placeholder on the server and client
+  // Take care not to produce a different placeholder on the server and client
   const [defaultPlaceholder, setDefaultPlaceholder] = useState('')
   useEffect(() => {
     setDefaultPlaceholder(


### PR DESCRIPTION
This was incorrect because of the problem described here: https://nextjs.org/docs/messages/react-hydration-error

I'm not sure if it caused any observable problem (it seems like the real problems are caused if the DOM structure is different between SSR and client, not just if some random HTML property is different) but it made React spit out a big red error message in development mode, so we might as well just fix it.