### PR TITLE
Link to /home from portfolio page, not /

### DIFF
--- a/web/components/bets-list.tsx
+++ b/web/components/bets-list.tsx
@@ -213,7 +213,7 @@ const NoBets = () => {
   return (
     <div className="mx-4 text-gray-500">
       You have not made any bets yet.{' '}
-      <SiteLink href="/" className="underline">
+      <SiteLink href="/home" className="underline">
         Find a prediction market!
       </SiteLink>
     </div>


### PR DESCRIPTION
These two are different; the root page redirects you to `/home` if you are logged in. If you're on the portfolio page, you are logged in, so there's no reason not to send you straight to `/home`.

You might think this doesn't matter at all, but on my dev server (it's annoying to test on production because I would need an account with no bets) it's both 1. way faster and 2. doesn't produce a bunch of disturbing React errors about component memory leaks...

It would probably be smart to look into why linking to `/` seems to surprisingly suck so much, because there is probably some other bug to find, but it seems better to just link to `/home` anyway, so let's just fix the easy thing first.