### PR TITLE
Bump web typescript to 4.5.3

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -52,7 +52,7 @@
     "pretty-quick": "3.1.2",
     "tailwindcss": "3.0.1",
     "tsc-files": "1.1.3",
-    "typescript": "4.5.2"
+    "typescript": "4.5.3"
   },
   "lint-staged": {
     "*.{ts,tsx}": "tsc-files --noEmit --incremental false"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,11 +5193,6 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
-
 typescript@4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"


### PR DESCRIPTION
This looks like a [small point release](https://github.com/microsoft/TypeScript/issues?q=milestone%3A%22TypeScript+4.5.3%22+) so I don't think it matters much. (Incidentally, someone might want to check whether 4.6 has any changes we want.)

But, why I did it, is that if `web` and `functions` (already using 4.5.3) aren't using a different version of Typescript for no particular reason, then that's dozens of megabytes of dependency you don't have to download during your `yarn install`. So they should be the same, not one point release off.