### PR TITLE
Disallow users deleting contracts

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,7 +13,7 @@ service cloud.firestore {
 
     match /users/{userId} {
       allow read;
-      allow update: if resource.data.id == request.auth.uid 
+      allow update: if resource.data.id == request.auth.uid
         && request.resource.data.diff(resource.data).affectedKeys()
             .hasOnly(['bio', 'bannerUrl', 'website', 'twitterHandle', 'discordHandle']);
     }
@@ -39,7 +39,6 @@ service cloud.firestore {
       allow update: if request.resource.data.diff(resource.data).affectedKeys()
         .hasOnly(['description', 'closeTime', 'tags', 'lowercaseTags']);
       allow update: if isAdmin();
-      allow delete: if resource.data.creatorId == request.auth.uid;
     }
 
     match /{somePath=**}/bets/{betId} {


### PR DESCRIPTION
According to Austin this used to serve some admin UI that was killed at some point.

If there's no UI for it, there's probably no use in allowing it, and there could be a lot of harm if other code is not expecting to see deleted contract IDs. If we wanted to allow contract deletion it would probably make more sense in 99% of cases to put a "deleted" bit on the document instead of blowing it away, anyway. So let's make it not a thing.