### PR TITLE
Make tags page filter contracts in Firebase

### DIFF
--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -115,6 +115,18 @@ export async function listContracts(creatorId: string): Promise<Contract[]> {
   return snapshot.docs.map((doc) => doc.data() as Contract)
 }
 
+export async function listTaggedContractsCaseInsensitive(
+  tag: string
+): Promise<Contract[]> {
+  const q = query(
+    contractCollection,
+    where('lowercaseTags', 'array-contains', tag.toLowerCase()),
+    orderBy('createdTime', 'desc')
+  )
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map((doc) => doc.data() as Contract)
+}
+
 export async function listAllContracts(): Promise<Contract[]> {
   const q = query(contractCollection, orderBy('createdTime', 'desc'))
   const snapshot = await getDocs(q)


### PR DESCRIPTION
The tags page totally broke and was returning 500s. Evidence suggests this is because the `getStaticProps` payload exceeded 5 MB, which is a [server limit imposed by Vercel](https://vercel.com/docs/concepts/limits/overview#serverless-function-payload-size-limit).

I didn't see any reason to try to somehow weasel around the limit when I could just rewrite the tags page to make a normal Firebase query that only gets the tag we're interested in, so that's what I did.

This commit requires an index on `lowercaseTags` and `createdTime`, which I made. The `firestore.indexes` file checked into the repo seems to be in some state disconnected from the actual state of Firestore, so I am ignoring it for now while I fix the problem.