### PR TITLE
Show comments position

### DIFF
--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -316,17 +316,7 @@ function getCommentsWithPositions(
   comments: Comment[],
   contract: Contract
 ) {
-  function mapBetsByUserId(bets: Bet[]) {
-    return bets.reduce((acc, bet) => {
-      const userId = bet.userId
-      if (!acc[userId]) {
-        acc[userId] = []
-      }
-      acc[userId].push(bet)
-      return acc
-    }, {} as { [userId: string]: Bet[] })
-  }
-  const betsByUserId = mapBetsByUserId(bets)
+  const betsByUserId = _.groupBy(bets, (bet) => bet.userId)
 
   const items = comments.map((comment) => ({
     type: 'comment' as const,

--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -460,12 +460,14 @@ export function getSpecificContractActivityItems(
   switch (mode) {
     case 'bets':
       items.push(
-        ...groupBets(bets, comments, contract, user?.id, {
+        ...bets.map((bet) => ({
+          type: 'bet' as const,
+          id: bet.id,
+          bet,
+          contract,
           hideOutcome: false,
-          abbreviated: false,
           smallAvatar: false,
-          reversed: false,
-        })
+        }))
       )
       break
 

--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -31,7 +31,7 @@ type BaseActivityItem = {
 
 export type CommentInputItem = BaseActivityItem & {
   type: 'commentInput'
-  bets: Bet[]
+  betsByCurrentUser: Bet[]
   comments: Comment[]
 }
 
@@ -323,7 +323,7 @@ function getCommentsWithPositions(
     id: comment.id,
     contract: contract,
     comment,
-    betsBySameUser: bets.length === 0 ? [] : betsByUserId[comment.userId],
+    betsBySameUser: bets.length === 0 ? [] : betsByUserId[comment.userId] ?? [],
     truncate: true,
     hideOutcome: false,
     smallAvatar: false,
@@ -385,7 +385,7 @@ export function getAllContractActivityItems(
       type: 'commentInput',
       id: 'commentInput',
       contract,
-      bets: [],
+      betsByCurrentUser: [],
       comments: [],
     })
   } else {
@@ -411,7 +411,7 @@ export function getAllContractActivityItems(
       type: 'commentInput',
       id: 'commentInput',
       contract,
-      bets: [],
+      betsByCurrentUser: [],
       comments: [],
     })
   }
@@ -507,7 +507,9 @@ export function getSpecificContractActivityItems(
         type: 'commentInput',
         id: 'commentInput',
         contract,
-        bets: bets,
+        betsByCurrentUser: user
+          ? bets.filter((bet) => bet.userId === user.id)
+          : [],
         comments: comments,
       })
       break

--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -432,24 +432,13 @@ export function getRecentContractActivityItems(
       )
     )
   } else {
-    const onlyUsersBetsOrBetsWithComments = bets.filter((bet) =>
-      comments.some(
-        (comment) => comment.betId === bet.id || bet.userId === user?.id
-      )
-    )
     items.push(
-      ...groupBetsAndComments(
-        onlyUsersBetsOrBetsWithComments,
-        comments,
-        contract,
-        user?.id,
-        {
-          hideOutcome: false,
-          abbreviated: true,
-          smallAvatar: false,
-          reversed: true,
-        }
-      )
+      ...groupBetsAndComments(bets, comments, contract, user?.id, {
+        hideOutcome: false,
+        abbreviated: true,
+        smallAvatar: false,
+        reversed: true,
+      })
     )
   }
 

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -221,10 +221,10 @@ export function FeedComment(props: {
 
 export function CommentInput(props: {
   contract: Contract
-  bets: Bet[]
+  betsByCurrentUser: Bet[]
   comments: Comment[]
 }) {
-  const { contract, bets, comments } = props
+  const { contract, betsByCurrentUser, comments } = props
   const user = useUser()
   const [comment, setComment] = useState('')
 
@@ -238,7 +238,7 @@ export function CommentInput(props: {
   }
 
   // Should this be oldest bet or most recent bet?
-  const mostRecentCommentableBet = bets
+  const mostRecentCommentableBet = betsByCurrentUser
     .filter(
       (bet) =>
         canCommentOnBet(bet.userId, bet.createdTime, user) &&
@@ -258,7 +258,7 @@ export function CommentInput(props: {
     )
   }
   const { userPosition, userPositionMoney, yesFloorShares, noFloorShares } =
-    getBettorsPosition(contract, Date.now(), bets)
+    getBettorsPosition(contract, Date.now(), betsByCurrentUser)
 
   return (
     <>

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -56,8 +56,7 @@ import { trackClick } from '../../lib/firebase/tracking'
 import { firebaseLogin } from '../../lib/firebase/users'
 import { DAY_MS } from '../../../common/util/time'
 import NewContractBadge from '../new-contract-badge'
-import { useUserContractBets } from '../../hooks/use-user-bets'
-import { useSaveShares } from '../use-save-shares'
+import { calculateCpmmSale } from '../../../common/calculate-cpmm'
 
 export function FeedItems(props: {
   contract: Contract
@@ -131,29 +130,38 @@ function FeedItem(props: { item: ActivityItem }) {
 export function FeedComment(props: {
   contract: Contract
   comment: Comment
-  bet: Bet | undefined
+  betsBySameUser: Bet[]
   hideOutcome: boolean
   truncate: boolean
   smallAvatar: boolean
 }) {
-  const { contract, comment, bet, hideOutcome, truncate, smallAvatar } = props
-  let money: string | undefined
-  let outcome: string | undefined
-  let bought: string | undefined
-  if (bet) {
-    outcome = bet.outcome
-    bought = bet.amount >= 0 ? 'bought' : 'sold'
-    money = formatMoney(Math.abs(bet.amount))
-  }
-  const { text, userUsername, userName, userAvatarUrl, createdTime, userId } =
-    comment
+  const {
+    contract,
+    comment,
+    betsBySameUser,
+    hideOutcome,
+    truncate,
+    smallAvatar,
+  } = props
+  const { text, userUsername, userName, userAvatarUrl, createdTime } = comment
+  let outcome: string | undefined,
+    bought: string | undefined,
+    money: string | undefined
 
-  const userBets = useUserContractBets(userId, contract.id)
-  const { yesFloorShares, noFloorShares } = useSaveShares(
-    contract as FullContract<CPMM | DPM, Binary>,
-    userBets
-  )
-  const userPosition = yesFloorShares || noFloorShares
+  const matchedBet = betsBySameUser.find((bet) => bet.id === comment.betId)
+  if (matchedBet) {
+    outcome = matchedBet.outcome
+    bought = matchedBet.amount >= 0 ? 'bought' : 'sold'
+    money = formatMoney(Math.abs(matchedBet.amount))
+  }
+
+  // Only calculated if they don't have a matching bet
+  const [userPosition, userPositionMoney, yesFloorShares, noFloorShares] =
+    getBettorsPosition(
+      contract,
+      comment.createdTime,
+      matchedBet ? [] : betsBySameUser
+    )
 
   return (
     <>
@@ -171,36 +179,33 @@ export function FeedComment(props: {
               username={userUsername}
               name={userName}
             />{' '}
-            {contract.outcomeType === 'BINARY' ? (
-              userPosition > 0 && (
-                <>
-                  {'owns ' + userPosition + ' shares '}
-                  <>
-                    {' of '}
-                    <OutcomeLabel
-                      outcome={yesFloorShares > noFloorShares ? 'YES' : 'NO'}
-                      contract={contract}
-                      truncate="short"
-                    />
-                  </>
-                </>
-              )
-            ) : (
+            {!matchedBet && userPosition > 0 && (
               <>
-                {bought} {money}
-                {!hideOutcome && (
-                  <>
-                    {' '}
-                    of{' '}
-                    <OutcomeLabel
-                      outcome={outcome ? outcome : ''}
-                      contract={contract}
-                      truncate="short"
-                    />
-                  </>
-                )}
+                {'with ' + userPositionMoney + ' '}
+                <>
+                  {' of '}
+                  <OutcomeLabel
+                    outcome={yesFloorShares > noFloorShares ? 'YES' : 'NO'}
+                    contract={contract}
+                    truncate="short"
+                  />
+                </>
               </>
             )}
+            <>
+              {bought} {money}
+              {outcome && !hideOutcome && (
+                <>
+                  {' '}
+                  of{' '}
+                  <OutcomeLabel
+                    outcome={outcome ? outcome : ''}
+                    contract={contract}
+                    truncate="short"
+                  />
+                </>
+              )}
+            </>
             <RelativeTimestamp time={createdTime} />
           </p>
         </div>
@@ -214,20 +219,12 @@ export function FeedComment(props: {
   )
 }
 
-function RelativeTimestamp(props: { time: number }) {
-  const { time } = props
-  return (
-    <DateTimeTooltip time={time}>
-      <span className="ml-1 whitespace-nowrap text-gray-400">
-        {fromNow(time)}
-      </span>
-    </DateTimeTooltip>
-  )
-}
-
-export function CommentInput(props: { contract: Contract }) {
-  // see if we can comment input on any bet:
-  const { contract } = props
+export function CommentInput(props: {
+  contract: Contract
+  bets: Bet[]
+  comments: Comment[]
+}) {
+  const { contract, bets, comments } = props
   const user = useUser()
   const [comment, setComment] = useState('')
 
@@ -240,14 +237,50 @@ export function CommentInput(props: { contract: Contract }) {
     setComment('')
   }
 
+  // Should this be oldest bet or most recent bet?
+  const mostRecentCommentableBet = bets
+    .filter(
+      (bet) =>
+        canCommentOnBet(bet.userId, bet.createdTime, user) &&
+        !comments.some((comment) => comment.betId == bet.id)
+    )
+    .sort((b1, b2) => b1.createdTime - b2.createdTime)
+    .pop()
+
+  if (mostRecentCommentableBet) {
+    return (
+      <FeedBet
+        contract={contract}
+        bet={mostRecentCommentableBet}
+        hideOutcome={false}
+        smallAvatar={false}
+      />
+    )
+  }
+  const [userPosition, userPositionMoney, yesFloorShares, noFloorShares] =
+    getBettorsPosition(contract, Date.now(), bets)
+
   return (
     <>
-      <Row className={'flex w-full gap-2 pt-5'}>
+      <Row className={'flex w-full gap-2 pt-3'}>
         <div>
           <Avatar avatarUrl={user?.avatarUrl} username={user?.username} />
         </div>
         <div className={'min-w-0 flex-1 py-1.5'}>
           <div className="text-sm text-gray-500">
+            {user && userPosition > 0 && (
+              <>
+                {'You with ' + userPositionMoney + ' '}
+                <>
+                  {' of '}
+                  <OutcomeLabel
+                    outcome={yesFloorShares > noFloorShares ? 'YES' : 'NO'}
+                    contract={contract}
+                    truncate="short"
+                  />
+                </>
+              </>
+            )}
             <div className="mt-2">
               <Textarea
                 value={comment}
@@ -278,20 +311,68 @@ export function CommentInput(props: { contract: Contract }) {
   )
 }
 
+function RelativeTimestamp(props: { time: number }) {
+  const { time } = props
+  return (
+    <DateTimeTooltip time={time}>
+      <span className="ml-1 whitespace-nowrap text-gray-400">
+        {fromNow(time)}
+      </span>
+    </DateTimeTooltip>
+  )
+}
+
+function getBettorsPosition(
+  contract: Contract,
+  createdTime: number,
+  bets: Bet[]
+) {
+  let yesFloorShares = 0,
+    yesShares = 0,
+    noShares = 0,
+    noFloorShares = 0
+  // TODO: show which of the answers was their majority stake at time of comment for FR?
+  if (contract.outcomeType != 'BINARY') {
+    return [0, 0, 0, 0]
+  }
+  if (bets.length === 0) {
+    return [0, 0, 0, 0]
+  }
+
+  // Calculate the majority shares they had when they made the comment
+  const betsBefore = bets.filter((prevBet) => prevBet.createdTime < createdTime)
+  const [yesBets, noBets] = _.partition(
+    betsBefore ?? [],
+    (bet) => bet.outcome === 'YES'
+  )
+  yesShares = _.sumBy(yesBets, (bet) => bet.shares)
+  noShares = _.sumBy(noBets, (bet) => bet.shares)
+  yesFloorShares = Math.floor(yesShares)
+  noFloorShares = Math.floor(noShares)
+
+  const userPosition = yesFloorShares || noFloorShares
+  const { saleValue } = calculateCpmmSale(
+    contract as FullContract<CPMM, Binary>,
+    yesShares || noShares,
+    yesFloorShares > noFloorShares ? 'YES' : 'NO'
+  )
+  const userPositionMoney = formatMoney(Math.abs(saleValue))
+  return [userPosition, userPositionMoney, yesFloorShares, noFloorShares]
+}
+
 export function FeedBet(props: {
   contract: Contract
   bet: Bet
   hideOutcome: boolean
   smallAvatar: boolean
+  hideComment?: boolean
   bettor?: User // If set: reveal bettor identity
 }) {
-  const { contract, bet, hideOutcome, smallAvatar, bettor } = props
+  const { contract, bet, hideOutcome, smallAvatar, bettor, hideComment } = props
   const { id, amount, outcome, createdTime, userId } = bet
   const user = useUser()
   const isSelf = user?.id === userId
-  const canComment =
-    canCommentOnBet(userId, createdTime, user) &&
-    contract.outcomeType !== 'BINARY'
+  const canComment = canCommentOnBet(userId, createdTime, user) && !hideComment
 
   const [comment, setComment] = useState('')
   async function submitComment() {
@@ -304,71 +385,76 @@ export function FeedBet(props: {
 
   return (
     <>
-      <div>
-        {isSelf ? (
-          <Avatar
-            className={clsx(smallAvatar && 'ml-1')}
-            size={smallAvatar ? 'sm' : undefined}
-            avatarUrl={user.avatarUrl}
-            username={user.username}
-          />
-        ) : bettor ? (
-          <Avatar
-            className={clsx(smallAvatar && 'ml-1')}
-            size={smallAvatar ? 'sm' : undefined}
-            avatarUrl={bettor.avatarUrl}
-            username={bettor.username}
-          />
-        ) : (
-          <div className="relative px-1">
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200">
-              <UserIcon className="h-5 w-5 text-gray-500" aria-hidden="true" />
-            </div>
-          </div>
-        )}
-      </div>
-      <div className={'min-w-0 flex-1 py-1.5'}>
-        <div className="text-sm text-gray-500">
-          <span>{isSelf ? 'You' : bettor ? bettor.name : 'A trader'}</span>{' '}
-          {bought} {money}
-          {!hideOutcome && (
-            <>
-              {' '}
-              of{' '}
-              <OutcomeLabel
-                outcome={outcome}
-                contract={contract}
-                truncate="short"
-              />
-            </>
-          )}
-          <RelativeTimestamp time={createdTime} />
-          {(canComment || comment) && (
-            <div className="mt-2">
-              <Textarea
-                value={comment}
-                onChange={(e) => setComment(e.target.value)}
-                className="textarea textarea-bordered w-full resize-none"
-                placeholder="Add a comment..."
-                rows={3}
-                maxLength={MAX_COMMENT_LENGTH}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
-                    submitComment()
-                  }
-                }}
-              />
-              <button
-                className="btn btn-outline btn-sm text-transform: mt-1 capitalize"
-                onClick={submitComment}
-                disabled={!canComment}
-              >
-                Comment
-              </button>
+      <Row className={'flex w-full gap-2 pt-3'}>
+        <div>
+          {isSelf ? (
+            <Avatar
+              className={clsx(smallAvatar && 'ml-1')}
+              size={smallAvatar ? 'sm' : undefined}
+              avatarUrl={user.avatarUrl}
+              username={user.username}
+            />
+          ) : bettor ? (
+            <Avatar
+              className={clsx(smallAvatar && 'ml-1')}
+              size={smallAvatar ? 'sm' : undefined}
+              avatarUrl={bettor.avatarUrl}
+              username={bettor.username}
+            />
+          ) : (
+            <div className="relative px-1">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200">
+                <UserIcon
+                  className="h-5 w-5 text-gray-500"
+                  aria-hidden="true"
+                />
+              </div>
             </div>
           )}
         </div>
-      </div>
+        <div className={'min-w-0 flex-1 py-1.5'}>
+          <div className="text-sm text-gray-500">
+            <span>{isSelf ? 'You' : bettor ? bettor.name : 'A trader'}</span>{' '}
+            {bought} {money}
+            {!hideOutcome && (
+              <>
+                {' '}
+                of{' '}
+                <OutcomeLabel
+                  outcome={outcome}
+                  contract={contract}
+                  truncate="short"
+                />
+              </>
+            )}
+            <RelativeTimestamp time={createdTime} />
+            {(canComment || comment) && (
+              <div className="mt-2">
+                <Textarea
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  className="textarea textarea-bordered w-full resize-none"
+                  placeholder="Add a comment..."
+                  rows={3}
+                  maxLength={MAX_COMMENT_LENGTH}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                      submitComment()
+                    }
+                  }}
+                />
+                <button
+                  className="btn btn-outline btn-sm text-transform: mt-1 capitalize"
+                  onClick={submitComment}
+                  disabled={!canComment}
+                >
+                  Comment
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </Row>
     </>
   )
 }

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -156,7 +156,7 @@ export function FeedComment(props: {
   }
 
   // Only calculated if they don't have a matching bet
-  const [userPosition, userPositionMoney, yesFloorShares, noFloorShares] =
+  const { userPosition, userPositionMoney, yesFloorShares, noFloorShares } =
     getBettorsPosition(
       contract,
       comment.createdTime,
@@ -257,7 +257,7 @@ export function CommentInput(props: {
       />
     )
   }
-  const [userPosition, userPositionMoney, yesFloorShares, noFloorShares] =
+  const { userPosition, userPositionMoney, yesFloorShares, noFloorShares } =
     getBettorsPosition(contract, Date.now(), bets)
 
   return (
@@ -331,12 +331,20 @@ function getBettorsPosition(
     yesShares = 0,
     noShares = 0,
     noFloorShares = 0
+
+  const emptyReturn = {
+    userPosition: 0,
+    userPositionMoney: 0,
+    yesFloorShares,
+    noFloorShares,
+  }
+
   // TODO: show which of the answers was their majority stake at time of comment for FR?
   if (contract.outcomeType != 'BINARY') {
-    return [0, 0, 0, 0]
+    return emptyReturn
   }
   if (bets.length === 0) {
-    return [0, 0, 0, 0]
+    return emptyReturn
   }
 
   // Calculate the majority shares they had when they made the comment
@@ -357,7 +365,7 @@ function getBettorsPosition(
     yesFloorShares > noFloorShares ? 'YES' : 'NO'
   )
   const userPositionMoney = formatMoney(Math.abs(saleValue))
-  return [userPosition, userPositionMoney, yesFloorShares, noFloorShares]
+  return { userPosition, userPositionMoney, yesFloorShares, noFloorShares }
 }
 
 export function FeedBet(props: {

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx'
 import { Answer } from '../../common/answer'
 import { getProbability } from '../../common/calculate'
 import {
@@ -11,6 +10,7 @@ import {
   FullContract,
 } from '../../common/contract'
 import { formatPercent } from '../../common/util/format'
+import { ClientRender } from './client-render'
 
 export function OutcomeLabel(props: {
   contract: Contract
@@ -72,11 +72,13 @@ export function FreeResponseOutcomeLabel(props: {
   const chosen = answers?.find((answer) => answer.id === resolution)
   if (!chosen) return <AnswerNumberLabel number={resolution} />
   return (
-    <AnswerLabel
-      answer={chosen}
-      truncate={truncate}
-      className={answerClassName}
-    />
+    <FreeResponseAnswerToolTip text={chosen.text}>
+      <AnswerLabel
+        answer={chosen}
+        truncate={truncate}
+        className={answerClassName}
+      />
+    </FreeResponseAnswerToolTip>
   )
 }
 
@@ -125,4 +127,24 @@ export function AnswerLabel(props: {
   }
 
   return <span className={className}>{truncated}</span>
+}
+
+function FreeResponseAnswerToolTip(props: {
+  text: string
+  children?: React.ReactNode
+}) {
+  const { text } = props
+  return (
+    <>
+      <ClientRender>
+        <span
+          className="tooltip hidden cursor-default sm:inline-block"
+          data-tip={text}
+        >
+          {props.children}
+        </span>
+      </ClientRender>
+      <span className="whitespace-nowrap sm:hidden">{props.children}</span>
+    </>
+  )
 }

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -287,7 +287,7 @@ function ContractTopTrades(props: {
             <FeedComment
               contract={contract}
               comment={commentsById[topCommentId]}
-              bet={betsById[topCommentId]}
+              betsBySameUser={[betsById[topCommentId]]}
               hideOutcome={false}
               truncate={false}
               smallAvatar={false}


### PR DESCRIPTION
If a user has made a recent bet, they'll be prompted to comment on it. Otherwise, they'll be commenting with their position.

Ungrouped bets per user request in discord in the bets tab.

Added a tooltip for free response answer labels when a user comments as they can be unreadable when long.