### PR TITLE
Improve donate box UI in mid-size window

### DIFF
--- a/web/components/page.tsx
+++ b/web/components/page.tsx
@@ -32,7 +32,7 @@ export function Page(props: {
           {children}
 
           {/* If right sidebar is hidden, place its content at the bottom of the page. */}
-          <div className="block xl:hidden">{rightSidebar}</div>
+          <div className="mt-4 block xl:hidden">{rightSidebar}</div>
         </main>
         <aside className="hidden xl:col-span-3 xl:block">
           <div className="sticky top-4 space-y-4">{rightSidebar}</div>

--- a/web/pages/charity/[charitySlug].tsx
+++ b/web/pages/charity/[charitySlug].tsx
@@ -215,8 +215,8 @@ function DonationBox(props: {
         />
 
         <Col className="mt-3 w-full gap-3">
-          <Row className="items-center justify-between text-sm">
-            <span className="text-gray-500">{charity.name} receives</span>
+          <Row className="items-center text-sm xl:justify-between">
+            <span className="mr-1 text-gray-500">{charity.name} receives</span>
             <span>{manaToUSD(amount || 0)}</span>
           </Row>
           {/* TODO: matching pool */}


### PR DESCRIPTION
Make conversion to $ more clear even when donate box is super wide.
Long term, this should probably be more like the buy market UI instead.