### PR TITLE
Add script to denormalize avatars into other docs

### DIFF
--- a/functions/src/scripts/denormalize-avatar-urls.ts
+++ b/functions/src/scripts/denormalize-avatar-urls.ts
@@ -1,0 +1,101 @@
+// Script for lining up users and contracts/comments to make sure the denormalized avatar URLs in the contracts and
+// comments match the user avatar URLs.
+
+import * as admin from 'firebase-admin'
+import { initAdmin } from './script-init'
+import {
+  DocumentCorrespondence,
+  findDiffs,
+  describeDiff,
+  applyDiff,
+} from './denormalize'
+import { DocumentSnapshot, Transaction } from 'firebase-admin/firestore'
+
+initAdmin()
+const firestore = admin.firestore()
+
+async function getUsersById(
+  transaction: Transaction
+): Promise<Map<string, DocumentSnapshot>> {
+  const results = new Map()
+  const users = await transaction.get(firestore.collection('users'))
+  users.forEach((doc) => {
+    results.set(doc.get('id'), doc)
+  })
+  console.log(`Found ${results.size} unique users.`)
+  return results
+}
+
+async function getContractsByUserId(
+  transaction: Transaction
+): Promise<Map<string, DocumentSnapshot[]>> {
+  let n = 0
+  const results = new Map()
+  const contracts = await transaction.get(firestore.collection('contracts'))
+  contracts.forEach((doc) => {
+    let creatorId = doc.get('creatorId')
+    let creatorContracts = results.get(creatorId) || []
+    creatorContracts.push(doc)
+    results.set(creatorId, creatorContracts)
+    n++
+  })
+  console.log(`Found ${n} contracts from ${results.size} unique users.`)
+  return results
+}
+
+async function getCommentsByUserId(
+  transaction: Transaction
+): Promise<Map<string, DocumentSnapshot[]>> {
+  let n = 0
+  let results = new Map()
+  let comments = await transaction.get(firestore.collectionGroup('comments'))
+  comments.forEach((doc) => {
+    let userId = doc.get('userId')
+    let userComments = results.get(userId) || []
+    userComments.push(doc)
+    results.set(userId, userComments)
+    n++
+  })
+  console.log(`Found ${n} comments from ${results.size} unique users.`)
+  return results
+}
+
+if (require.main === module) {
+  admin.firestore().runTransaction(async (transaction) => {
+    let [usersById, contractsByUserId, commentsByUserId] = await Promise.all([
+      getUsersById(transaction),
+      getContractsByUserId(transaction),
+      getCommentsByUserId(transaction),
+    ])
+
+    let usersContracts = Array.from(
+      usersById.entries(),
+      ([id, doc]): DocumentCorrespondence => {
+        return [doc, contractsByUserId.get(id) || []]
+      }
+    )
+    let contractDiffs = findDiffs(
+      usersContracts,
+      'avatarUrl',
+      'creatorAvatarUrl'
+    )
+    console.log(`Found ${contractDiffs.length} contracts with mismatches.`)
+    contractDiffs.forEach((d) => {
+      console.log(describeDiff(d))
+      applyDiff(transaction, d)
+    })
+
+    let usersComments = Array.from(
+      usersById.entries(),
+      ([id, doc]): DocumentCorrespondence => {
+        return [doc, commentsByUserId.get(id) || []]
+      }
+    )
+    let commentDiffs = findDiffs(usersComments, 'avatarUrl', 'userAvatarUrl')
+    console.log(`Found ${commentDiffs.length} comments with mismatches.`)
+    commentDiffs.forEach((d) => {
+      console.log(describeDiff(d))
+      applyDiff(transaction, d)
+    })
+  })
+}

--- a/functions/src/scripts/denormalize-avatar-urls.ts
+++ b/functions/src/scripts/denormalize-avatar-urls.ts
@@ -14,10 +14,8 @@ import { DocumentSnapshot, Transaction } from 'firebase-admin/firestore'
 initAdmin()
 const firestore = admin.firestore()
 
-async function getUsersById(
-  transaction: Transaction
-): Promise<Map<string, DocumentSnapshot>> {
-  const results = new Map()
+async function getUsersById(transaction: Transaction) {
+  const results = new Map<string, DocumentSnapshot>()
   const users = await transaction.get(firestore.collection('users'))
   users.forEach((doc) => {
     results.set(doc.get('id'), doc)
@@ -26,15 +24,13 @@ async function getUsersById(
   return results
 }
 
-async function getContractsByUserId(
-  transaction: Transaction
-): Promise<Map<string, DocumentSnapshot[]>> {
+async function getContractsByUserId(transaction: Transaction) {
   let n = 0
-  const results = new Map()
+  const results = new Map<string, DocumentSnapshot[]>()
   const contracts = await transaction.get(firestore.collection('contracts'))
   contracts.forEach((doc) => {
-    let creatorId = doc.get('creatorId')
-    let creatorContracts = results.get(creatorId) || []
+    const creatorId = doc.get('creatorId')
+    const creatorContracts = results.get(creatorId) || []
     creatorContracts.push(doc)
     results.set(creatorId, creatorContracts)
     n++
@@ -43,15 +39,13 @@ async function getContractsByUserId(
   return results
 }
 
-async function getCommentsByUserId(
-  transaction: Transaction
-): Promise<Map<string, DocumentSnapshot[]>> {
+async function getCommentsByUserId(transaction: Transaction) {
   let n = 0
-  let results = new Map()
-  let comments = await transaction.get(firestore.collectionGroup('comments'))
+  const results = new Map<string, DocumentSnapshot[]>()
+  const comments = await transaction.get(firestore.collectionGroup('comments'))
   comments.forEach((doc) => {
-    let userId = doc.get('userId')
-    let userComments = results.get(userId) || []
+    const userId = doc.get('userId')
+    const userComments = results.get(userId) || []
     userComments.push(doc)
     results.set(userId, userComments)
     n++
@@ -60,15 +54,13 @@ async function getCommentsByUserId(
   return results
 }
 
-async function getAnswersByUserId(
-  transaction: Transaction
-): Promise<Map<string, DocumentSnapshot[]>> {
+async function getAnswersByUserId(transaction: Transaction) {
   let n = 0
-  let results = new Map()
-  let answers = await transaction.get(firestore.collectionGroup('answers'))
+  const results = new Map<string, DocumentSnapshot[]>()
+  const answers = await transaction.get(firestore.collectionGroup('answers'))
   answers.forEach((doc) => {
-    let userId = doc.get('userId')
-    let userAnswers = results.get(userId) || []
+    const userId = doc.get('userId')
+    const userAnswers = results.get(userId) || []
     userAnswers.push(doc)
     results.set(userId, userAnswers)
     n++
@@ -79,7 +71,7 @@ async function getAnswersByUserId(
 
 if (require.main === module) {
   admin.firestore().runTransaction(async (transaction) => {
-    let [usersById, contractsByUserId, commentsByUserId, answersByUserId] =
+    const [usersById, contractsByUserId, commentsByUserId, answersByUserId] =
       await Promise.all([
         getUsersById(transaction),
         getContractsByUserId(transaction),
@@ -87,13 +79,13 @@ if (require.main === module) {
         getAnswersByUserId(transaction),
       ])
 
-    let usersContracts = Array.from(
+    const usersContracts = Array.from(
       usersById.entries(),
       ([id, doc]): DocumentCorrespondence => {
         return [doc, contractsByUserId.get(id) || []]
       }
     )
-    let contractDiffs = findDiffs(
+    const contractDiffs = findDiffs(
       usersContracts,
       'avatarUrl',
       'creatorAvatarUrl'
@@ -104,26 +96,26 @@ if (require.main === module) {
       applyDiff(transaction, d)
     })
 
-    let usersComments = Array.from(
+    const usersComments = Array.from(
       usersById.entries(),
       ([id, doc]): DocumentCorrespondence => {
         return [doc, commentsByUserId.get(id) || []]
       }
     )
-    let commentDiffs = findDiffs(usersComments, 'avatarUrl', 'userAvatarUrl')
+    const commentDiffs = findDiffs(usersComments, 'avatarUrl', 'userAvatarUrl')
     console.log(`Found ${commentDiffs.length} comments with mismatches.`)
     commentDiffs.forEach((d) => {
       console.log(describeDiff(d))
       applyDiff(transaction, d)
     })
 
-    let usersAnswers = Array.from(
+    const usersAnswers = Array.from(
       usersById.entries(),
       ([id, doc]): DocumentCorrespondence => {
         return [doc, answersByUserId.get(id) || []]
       }
     )
-    let answerDiffs = findDiffs(usersAnswers, 'avatarUrl', 'avatarUrl')
+    const answerDiffs = findDiffs(usersAnswers, 'avatarUrl', 'avatarUrl')
     console.log(`Found ${answerDiffs.length} answers with mismatches.`)
     answerDiffs.forEach((d) => {
       console.log(describeDiff(d))

--- a/functions/src/scripts/denormalize.ts
+++ b/functions/src/scripts/denormalize.ts
@@ -1,0 +1,48 @@
+// Helper functions for maintaining the relationship between fields in one set of documents and denormalized copies in
+// another set of documents.
+
+import { DocumentSnapshot, Transaction } from 'firebase-admin/firestore'
+
+export type DocumentValue = {
+  doc: DocumentSnapshot
+  field: string
+  val: any
+}
+export type DocumentCorrespondence = [DocumentSnapshot, DocumentSnapshot[]]
+export type DocumentDiff = {
+  src: DocumentValue
+  dest: DocumentValue
+}
+
+export function findDiffs(
+  docs: DocumentCorrespondence[],
+  srcPath: string,
+  destPath: string
+): DocumentDiff[] {
+  let diffs = []
+  for (let [srcDoc, destDocs] of docs) {
+    const srcVal = srcDoc.get(srcPath)
+    for (let destDoc of destDocs) {
+      const destVal = destDoc.get(destPath)
+      if (destVal !== srcVal) {
+        diffs.push({
+          src: { doc: srcDoc, field: srcPath, val: srcVal },
+          dest: { doc: destDoc, field: destPath, val: destVal },
+        })
+      }
+    }
+  }
+  return diffs
+}
+
+export function describeDiff(diff: DocumentDiff): string {
+  function describeDocVal(x: DocumentValue): string {
+    return `${x.doc.ref.path}.${x.field}: ${x.val}`
+  }
+  return `${describeDocVal(diff.src)} -> ${describeDocVal(diff.dest)}`
+}
+
+export function applyDiff(transaction: Transaction, diff: DocumentDiff) {
+  let { src, dest } = diff
+  transaction.update(dest.doc.ref, dest.field, src.val)
+}

--- a/functions/src/scripts/denormalize.ts
+++ b/functions/src/scripts/denormalize.ts
@@ -18,8 +18,8 @@ export function findDiffs(
   docs: DocumentCorrespondence[],
   srcPath: string,
   destPath: string
-): DocumentDiff[] {
-  let diffs = []
+) {
+  const diffs: DocumentDiff[] = []
   for (let [srcDoc, destDocs] of docs) {
     const srcVal = srcDoc.get(srcPath)
     for (let destDoc of destDocs) {
@@ -35,7 +35,7 @@ export function findDiffs(
   return diffs
 }
 
-export function describeDiff(diff: DocumentDiff): string {
+export function describeDiff(diff: DocumentDiff) {
   function describeDocVal(x: DocumentValue): string {
     return `${x.doc.ref.path}.${x.field}: ${x.val}`
   }
@@ -43,6 +43,6 @@ export function describeDiff(diff: DocumentDiff): string {
 }
 
 export function applyDiff(transaction: Transaction, diff: DocumentDiff) {
-  let { src, dest } = diff
+  const { src, dest } = diff
   transaction.update(dest.doc.ref, dest.field, src.val)
 }


### PR DESCRIPTION
It seems that this was never actually fixed up for old contracts. Now all contracts have a correct `creatorAvatarUrl`. (It turns out that all comments already did have one -- I was just suspicious.)

I already ran this on dev/prod but I would be interested in anyone taking a glance at it since I have zero experience writing either Typescript or writing code against Firestore.

EDIT: Also answers already had correct avatar URLs.