### PR TITLE
Represent DB avatar URLs as non-null

### DIFF
--- a/common/answer.ts
+++ b/common/answer.ts
@@ -9,7 +9,7 @@ export type Answer = {
   userId: string
   username: string
   name: string
-  avatarUrl?: string
+  avatarUrl: string
 
   text: string
 }

--- a/common/comment.ts
+++ b/common/comment.ts
@@ -13,5 +13,5 @@ export type Comment = {
   // Denormalized, for rendering comments
   userName: string
   userUsername: string
-  userAvatarUrl?: string
+  userAvatarUrl: string
 }

--- a/common/contract.ts
+++ b/common/contract.ts
@@ -11,7 +11,7 @@ export type FullContract<
   creatorId: string
   creatorName: string
   creatorUsername: string
-  creatorAvatarUrl?: string // Start requiring after 2022-03-01
+  creatorAvatarUrl: string
 
   question: string
   description: string // More info about what the contract is about

--- a/common/user.ts
+++ b/common/user.ts
@@ -4,7 +4,7 @@ export type User = {
 
   name: string
   username: string
-  avatarUrl?: string
+  avatarUrl: string
 
   // For their user page
   bio?: string

--- a/web/components/SEO.tsx
+++ b/web/components/SEO.tsx
@@ -6,7 +6,7 @@ export type OgCardProps = {
   metadata: string
   creatorName: string
   creatorUsername: string
-  creatorAvatarUrl?: string
+  creatorAvatarUrl: string
 }
 
 function buildCardUrl(props: OgCardProps) {
@@ -14,11 +14,6 @@ function buildCardUrl(props: OgCardProps) {
     props.probability === undefined
       ? ''
       : `&probability=${encodeURIComponent(props.probability ?? '')}`
-  const creatorAvatarUrlParam =
-    props.creatorAvatarUrl === undefined
-      ? ''
-      : `&creatorAvatarUrl=${encodeURIComponent(props.creatorAvatarUrl ?? '')}`
-
   // URL encode each of the props, then add them as query params
   return (
     `https://manifold-og-image.vercel.app/m.png` +
@@ -26,7 +21,7 @@ function buildCardUrl(props: OgCardProps) {
     probabilityParam +
     `&metadata=${encodeURIComponent(props.metadata)}` +
     `&creatorName=${encodeURIComponent(props.creatorName)}` +
-    creatorAvatarUrlParam +
+    `&creatorAvatarUrl=${encodeURIComponent(props.creatorAvatarUrl)}` +
     `&creatorUsername=${encodeURIComponent(props.creatorUsername)}`
   )
 }

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -12,7 +12,7 @@ export type LiteMarket = {
   creatorUsername: string
   creatorName: string
   createdTime: number
-  creatorAvatarUrl?: string
+  creatorAvatarUrl: string
 
   // Market attributes. All times are in milliseconds since epoch
   closeTime?: number


### PR DESCRIPTION
Since #127 null avatar URLs are no longer a thing in production. They are a thing in some super broken contracts on dev that are literally associated with deleted users, but those contracts deserve to be broken anyway, and if you are mad then you should delete them (or poke the database to associate them with real users).