### PR TITLE
Kill warmup spam

### DIFF
--- a/web/components/bets-list.tsx
+++ b/web/components/bets-list.tsx
@@ -553,10 +553,11 @@ function BetRow(props: { bet: Bet; contract: Contract; saleBet?: Bet }) {
   )
 }
 
+const warmUpSellBet = _.throttle(() => sellBet({}).catch(), 5000 /* ms */)
+
 function SellButton(props: { contract: Contract; bet: Bet }) {
   useEffect(() => {
-    // warm up cloud function
-    sellBet({}).catch()
+    warmUpSellBet()
   }, [])
 
   const { contract, bet } = props

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -77,11 +77,13 @@ const CACHED_USER_KEY = 'CACHED_USER_KEY'
 // used to avoid weird race condition
 let createUserPromise: Promise<User | null> | undefined = undefined
 
+const warmUpCreateUser = _.throttle(createUser, 5000 /* ms */)
+
 export function listenForLogin(onUser: (user: User | null) => void) {
   const cachedUser = localStorage.getItem(CACHED_USER_KEY)
   onUser(cachedUser ? JSON.parse(cachedUser) : null)
 
-  if (!cachedUser) createUser() // warm up cloud function
+  if (!cachedUser) warmUpCreateUser()
 
   return onAuthStateChanged(auth, async (fbUser) => {
     if (fbUser) {


### PR DESCRIPTION
I am skeptical whether it is good to make these warmup requests once. Perhaps it is. But it definitely isn't good to make them dozens of times on page load (e.g. on the portfolio page in the `sellBet` case, or all over the place in the `createUser` case.)