### PR TITLE
Configure compiler to allow absolute imports from root

### DIFF
--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -1,8 +1,8 @@
-import { Bet } from '../../../../common/bet'
-import { getProbability } from '../../../../common/calculate'
-import { Comment } from '../../../../common/comment'
-import { Contract } from '../../../../common/contract'
-import { removeUndefinedProps } from '../../../../common/util/object'
+import { Bet } from 'common/bet'
+import { getProbability } from 'common/calculate'
+import { Comment } from 'common/comment'
+import { Contract } from 'common/contract'
+import { removeUndefinedProps } from 'common/util/object'
 
 export type LiteMarket = {
   // Unique identifer for this market

--- a/web/pages/api/v0/market/[id].ts
+++ b/web/pages/api/v0/market/[id].ts
@@ -1,9 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { Bet, listAllBets } from '../../../../lib/firebase/bets'
-import { listAllComments } from '../../../../lib/firebase/comments'
-import { getContractFromId } from '../../../../lib/firebase/contracts'
+import { Bet, listAllBets } from 'web/lib/firebase/bets'
+import { listAllComments } from 'web/lib/firebase/comments'
+import { getContractFromId } from 'web/lib/firebase/contracts'
+import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
 import { FullMarket, ApiError, toLiteMarket } from '../_types'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from '../../../../lib/api/cors'
 
 export default async function handler(
   req: NextApiRequest,

--- a/web/pages/api/v0/markets.ts
+++ b/web/pages/api/v0/markets.ts
@@ -1,8 +1,8 @@
 // Next.js API route support: https://vercel.com/docs/concepts/functions/serverless-functions
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { listAllContracts } from '../../../lib/firebase/contracts'
+import { listAllContracts } from 'web/lib/firebase/contracts'
+import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
 import { toLiteMarket } from './_types'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from '../../../lib/api/cors'
 
 type Data = any[]
 

--- a/web/pages/api/v0/slug/[slug].ts
+++ b/web/pages/api/v0/slug/[slug].ts
@@ -1,9 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { Bet, listAllBets } from '../../../../lib/firebase/bets'
-import { listAllComments } from '../../../../lib/firebase/comments'
-import { getContractFromSlug } from '../../../../lib/firebase/contracts'
+import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { Bet, listAllBets } from 'web/lib/firebase/bets'
+import { listAllComments } from 'web/lib/firebase/comments'
+import { getContractFromSlug } from 'web/lib/firebase/contracts'
 import { FullMarket, ApiError, toLiteMarket } from '../_types'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from '../../../../lib/api/cors'
 
 export default async function handler(
   req: NextApiRequest,

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "baseUrl": "../",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
I got really fed up with the `../../../../../common/foo` business so I fixed it. Now you can import stuff from the root of the repository, e.g. `common/foo` or `web/lib/firebase/bar`.

Fixed up the API endpoint imports as a proof of concept. If you guys like this style maybe we should find/replace it in the rest of the codebase later.