### PR TITLE
Show every user's bets on their profile

### DIFF
--- a/web/components/contract/contracts-list.tsx
+++ b/web/components/contract/contracts-list.tsx
@@ -19,7 +19,6 @@ export function ContractsGrid(props: {
   const isBottomVisible = useIsVisible(elem)
 
   useEffect(() => {
-    console.log({ isBottomVisible, hasMore })
     if (isBottomVisible) {
       loadMore()
     }

--- a/web/components/nav/nav-bar.tsx
+++ b/web/components/nav/nav-bar.tsx
@@ -47,7 +47,7 @@ export function BottomNavBar() {
       )}
 
       {user !== null && (
-        <Link href={`${user}?tab=Bets`}>
+        <Link href={`${user}/bets`}>
           <a className="block w-full py-1 px-3 text-center hover:bg-indigo-200 hover:text-indigo-700">
             <PresentationChartLineIcon
               className="my-1 mx-auto h-6 w-6"

--- a/web/components/nav/nav-bar.tsx
+++ b/web/components/nav/nav-bar.tsx
@@ -47,7 +47,7 @@ export function BottomNavBar() {
       )}
 
       {user !== null && (
-        <Link href="/portfolio">
+        <Link href={`${user}?tab=Bets`}>
           <a className="block w-full py-1 px-3 text-center hover:bg-indigo-200 hover:text-indigo-700">
             <PresentationChartLineIcon
               className="my-1 mx-auto h-6 w-6"

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -28,12 +28,18 @@ function IconFromUrl(url: string): React.ComponentType<{ className?: string }> {
   }
 }
 
-const navigation = [
-  { name: 'Home', href: '/home', icon: HomeIcon },
-  { name: 'Activity', href: '/activity', icon: ChatAltIcon },
-  { name: 'Portfolio', href: '/portfolio', icon: PresentationChartLineIcon },
-  { name: 'Charity', href: '/charity', icon: HeartIcon },
-]
+function getNavigation(userName: string) {
+  return [
+    { name: 'Home', href: '/home', icon: HomeIcon },
+    { name: 'Activity', href: '/activity', icon: ChatAltIcon },
+    {
+      name: 'Portfolio',
+      href: `${userName}?tab=Bets`,
+      icon: PresentationChartLineIcon,
+    },
+    { name: 'Charity', href: '/charity', icon: HeartIcon },
+  ]
+}
 
 const signedOutNavigation = [
   { name: 'Home', href: '/home', icon: HomeIcon },
@@ -119,7 +125,8 @@ export default function Sidebar(props: { className?: string }) {
   folds = _.sortBy(folds, 'followCount').reverse()
   const deservesDailyFreeMarket = !useHasCreatedContractToday(user)
 
-  const navigationOptions = user === null ? signedOutNavigation : navigation
+  const navigationOptions =
+    user === null ? signedOutNavigation : getNavigation(user?.name || 'error')
   const mobileNavigationOptions =
     user === null ? signedOutMobileNavigation : mobileNavigation
 

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -34,7 +34,7 @@ function getNavigation(userName: string) {
     { name: 'Activity', href: '/activity', icon: ChatAltIcon },
     {
       name: 'Portfolio',
-      href: `${userName}/bets`,
+      href: `/${userName}/bets`,
       icon: PresentationChartLineIcon,
     },
     { name: 'Charity', href: '/charity', icon: HeartIcon },

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -34,7 +34,7 @@ function getNavigation(userName: string) {
     { name: 'Activity', href: '/activity', icon: ChatAltIcon },
     {
       name: 'Portfolio',
-      href: `${userName}?tab=Bets`,
+      href: `${userName}/bets`,
       icon: PresentationChartLineIcon,
     },
     { name: 'Charity', href: '/charity', icon: HeartIcon },

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -21,6 +21,9 @@ import { getContractFromId, listContracts } from 'web/lib/firebase/contracts'
 import { LoadingIndicator } from './loading-indicator'
 import { useRouter } from 'next/router'
 import _ from 'lodash'
+import { BetsList } from './bets-list'
+import { Bet } from 'common/bet'
+import { getUserBets } from 'web/lib/firebase/bets'
 
 export function UserLink(props: {
   name: string
@@ -51,6 +54,7 @@ export function UserPage(props: {
   const [usersContracts, setUsersContracts] = useState<Contract[] | 'loading'>(
     'loading'
   )
+  const [usersBets, setUsersBets] = useState<Bet[] | 'loading'>('loading')
   const [commentsByContract, setCommentsByContract] = useState<
     Map<Contract, Comment[]> | 'loading'
   >('loading')
@@ -59,6 +63,7 @@ export function UserPage(props: {
     if (!user) return
     getUsersComments(user.id).then(setUsersComments)
     listContracts(user.id).then(setUsersContracts)
+    getUserBets(user.id).then(setUsersBets)
   }, [user])
 
   useEffect(() => {
@@ -218,6 +223,13 @@ export function UserPage(props: {
                 ),
                 tabIcon: (
                   <div className="px-0.5 font-bold">{usersComments.length}</div>
+                ),
+              },
+              {
+                title: 'Bets',
+                content: <BetsList user={user} />,
+                tabIcon: (
+                  <div className="px-0.5 font-bold">{usersBets.length}</div>
                 ),
               },
             ]}

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -192,7 +192,9 @@ export function UserPage(props: {
         {usersContracts !== 'loading' && commentsByContract != 'loading' ? (
           <Tabs
             className={'pb-2 pt-1 '}
-            defaultIndex={defaultTabTitle === 'Comments' ? 1 : 0}
+            defaultIndex={['Markets', 'Comments', 'Bets'].indexOf(
+              defaultTabTitle
+            )}
             onClick={(tabName) =>
               router.push(
                 {

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -227,7 +227,15 @@ export function UserPage(props: {
               },
               {
                 title: 'Bets',
-                content: <BetsList user={user} />,
+                content: (
+                  <div>
+                    <AlertBox
+                      title="Bets are becoming public on June 1st"
+                      text="hi"
+                    />
+                    {isCurrentUser && <BetsList user={user} />}
+                  </div>
+                ),
                 tabIcon: (
                   <div className="px-0.5 font-bold">{usersBets.length}</div>
                 ),
@@ -253,4 +261,28 @@ export function defaultBannerUrl(userId: string) {
     'https://images.unsplash.com/photo-1603399587513-136aa9398f2d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1467&q=80',
   ]
   return defaultBanner[genHash(userId)() % defaultBanner.length]
+}
+
+import { ExclamationIcon } from '@heroicons/react/solid'
+
+function AlertBox(props: { title: string; text: string }) {
+  const { title, text } = props
+  return (
+    <div className="rounded-md bg-yellow-50 p-4">
+      <div className="flex">
+        <div className="flex-shrink-0">
+          <ExclamationIcon
+            className="h-5 w-5 text-yellow-400"
+            aria-hidden="true"
+          />
+        </div>
+        <div className="ml-3">
+          <h3 className="text-sm font-medium text-yellow-800">{title}</h3>
+          <div className="mt-2 text-sm text-yellow-700">
+            <Linkify text={text} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -41,12 +41,13 @@ export function UserLink(props: {
   )
 }
 
+export const TAB_IDS = ['markets', 'comments', 'bets']
+
 export function UserPage(props: {
   user: User
   currentUser?: User
-  defaultTabTitle?: string
+  defaultTabTitle?: 'markets' | 'comments' | 'bets'
 }) {
-  const router = useRouter()
   const { user, currentUser, defaultTabTitle } = props
   const isCurrentUser = user.id === currentUser?.id
   const bannerUrl = user.bannerUrl ?? defaultBannerUrl(user.id)
@@ -192,19 +193,12 @@ export function UserPage(props: {
         {usersContracts !== 'loading' && commentsByContract != 'loading' ? (
           <Tabs
             className={'pb-2 pt-1 '}
-            defaultIndex={['Markets', 'Comments', 'Bets'].indexOf(
-              defaultTabTitle
-            )}
-            onClick={(tabName) =>
-              router.push(
-                {
-                  pathname: `/${user.username}`,
-                  query: { tab: tabName },
-                },
-                undefined,
-                { shallow: true }
-              )
-            }
+            defaultIndex={TAB_IDS.indexOf(defaultTabTitle || 'markets')}
+            onClick={(tabName) => {
+              const tabId = tabName.toLowerCase()
+              const subpath = tabId === 'markets' ? '' : '/' + tabId
+              window.history.pushState('', '', `/${user.username}${subpath}`)
+            }}
             tabs={[
               {
                 title: 'Markets',

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -228,8 +228,11 @@ export function UserPage(props: {
                 content: (
                   <div>
                     <AlertBox
-                      title="Bets are becoming public on June 1st"
-                      text="hi"
+                      title="Bets are becoming publicly visible on 2022-06-01"
+                      text="Bettor identities have always been traceable through the Manifold API.
+                      However, our interface implied that they were private.
+                      As we develop new features such as leaderboards and bet history, it won't be technically feasible to keep this info private.
+                      For more context, or if you'd like to wipe your bet history, see: https://manifold.markets/Austin/will-all-bets-on-manifold-be-public"
                     />
                     {isCurrentUser && <BetsList user={user} />}
                   </div>

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -197,7 +197,7 @@ export function UserPage(props: {
             onClick={(tabName) => {
               const tabId = tabName.toLowerCase()
               const subpath = tabId === 'markets' ? '' : '/' + tabId
-              window.history.pushState('', '', `/${user.username}${subpath}`)
+              window.history.replaceState('', '', `/${user.username}${subpath}`)
             }}
             tabs={[
               {

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -197,6 +197,8 @@ export function UserPage(props: {
             onClick={(tabName) => {
               const tabId = tabName.toLowerCase()
               const subpath = tabId === 'markets' ? '' : '/' + tabId
+              // BUG: if you start on `/Bob/bets`, then click on Markets, use-query-and-sort-params
+              // rewrites the url incorrectly to `/Bob/bets` instead of `/Bob`
               window.history.replaceState('', '', `/${user.username}${subpath}`)
             }}
             tabs={[

--- a/web/hooks/use-sort-and-query-params.tsx
+++ b/web/hooks/use-sort-and-query-params.tsx
@@ -47,7 +47,6 @@ export function useInitialQueryAndSort(options?: {
         }
         setInitialSort(localSort ?? defaultSort)
       } else {
-        console.log('ready setting to ', sort ?? defaultSort)
         setInitialSort(sort ?? defaultSort)
       }
     }

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -60,6 +60,12 @@ export function listenForBets(
   })
 }
 
+export async function getUserBets(userId: string) {
+  return getValues<Bet>(
+    query(collectionGroup(db, 'bets'), where('userId', '==', userId))
+  )
+}
+
 export function listenForUserBets(
   userId: string,
   setBets: (bets: Bet[]) => void

--- a/web/pages/[username]/bets.tsx
+++ b/web/pages/[username]/bets.tsx
@@ -1,0 +1,5 @@
+import UserProfile from '.'
+
+export default function UserBets() {
+  return <UserProfile tab="bets" />
+}

--- a/web/pages/[username]/comments.tsx
+++ b/web/pages/[username]/comments.tsx
@@ -1,0 +1,5 @@
+import UserProfile from '.'
+
+export default function UserBets() {
+  return <UserProfile tab="comments" />
+}

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -6,10 +6,12 @@ import { UserPage } from 'web/components/user-page'
 import { useUser } from 'web/hooks/use-user'
 import Custom404 from '../404'
 
-export default function UserProfile() {
+export default function UserProfile(props: {
+  tab?: 'markets' | 'comments' | 'bets'
+}) {
   const router = useRouter()
   const [user, setUser] = useState<User | null | 'loading'>('loading')
-  const { username, tab } = router.query as { username: string; tab: string }
+  const { username } = router.query as { username: string }
   useEffect(() => {
     if (username) {
       getUserByUsername(username).then(setUser)
@@ -24,7 +26,7 @@ export default function UserProfile() {
     <UserPage
       user={user}
       currentUser={currentUser || undefined}
-      defaultTabTitle={tab}
+      defaultTabTitle={props.tab}
     />
   ) : (
     <Custom404 />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/856034/167660099-cfbd741f-323b-44d4-983f-feb2f173f386.png)

Somewhat controversial to make all these bets public, but I think this is actually correct, in the context of radical transparency, and pragmatically all this data was available anyways. Hopefully encourages people to bet more, too -- more betting is one thing we're kind of constrained on atm.

Some proposals/ways to move forward:

P1: Ship this as-is -- it's not revealing anything that wasn't already query-able via Firebase command before
P1.5: Because this is making public things that weren't previously public, give everyone a chance to delete their account or any specific bets they didn't want to expose to the world

P2: Only you get to see this on your portfolio
P2.1: You can opt in to showing this to the world
P2.5: Show total bet count and total profit/loss for everybody else

P3: Get rid of the Portfolio page in the sidebar, since it's duplicated here

P4: Make bettor identities in the "bets" tab on each market public

P5: Make bettor identities public in the API

P6: Make all txn/transaction history public, everywhere all the time