### PR TITLE
Feed container markup cleanup

### DIFF
--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -111,7 +111,7 @@ export function AnswersPanel(props: {
         <FeedItems
           contract={contract}
           items={answerItems}
-          className={''}
+          className={'pr-2 md:pr-0'}
           betRowClassName={''}
         />
       )}

--- a/web/components/feed/activity-feed.tsx
+++ b/web/components/feed/activity-feed.tsx
@@ -17,39 +17,7 @@ export function ActivityFeed(props: {
   getContractPath?: (contract: Contract) => string
 }) {
   const { feed, mode, getContractPath } = props
-
   const user = useUser()
-
-  return (
-    <FeedContainer
-      feed={feed}
-      renderItem={({ contract, recentBets, recentComments }) => (
-        <ContractActivity
-          user={user}
-          contract={contract}
-          bets={recentBets}
-          comments={recentComments}
-          mode={mode}
-          contractPath={getContractPath ? getContractPath(contract) : undefined}
-        />
-      )}
-    />
-  )
-}
-
-function FeedContainer(props: {
-  feed: {
-    contract: Contract
-    recentBets: Bet[]
-    recentComments: Comment[]
-  }[]
-  renderItem: (item: {
-    contract: Contract
-    recentBets: Bet[]
-    recentComments: Comment[]
-  }) => any
-}) {
-  const { feed, renderItem } = props
 
   return (
     <Col className="items-center">
@@ -57,7 +25,16 @@ function FeedContainer(props: {
         <Col className="w-full divide-y divide-gray-300 self-center bg-white">
           {feed.map((item) => (
             <div key={item.contract.id} className="py-6 px-2 sm:px-4">
-              {renderItem(item)}
+              <ContractActivity
+                user={user}
+                contract={item.contract}
+                bets={item.recentBets}
+                comments={item.recentComments}
+                mode={mode}
+                contractPath={
+                  getContractPath ? getContractPath(item.contract) : undefined
+                }
+              />
             </div>
           ))}
         </Col>

--- a/web/components/feed/activity-feed.tsx
+++ b/web/components/feed/activity-feed.tsx
@@ -20,25 +20,21 @@ export function ActivityFeed(props: {
   const user = useUser()
 
   return (
-    <Col className="items-center">
-      <Col className="w-full max-w-3xl">
-        <Col className="w-full divide-y divide-gray-300 self-center bg-white">
-          {feed.map((item) => (
-            <div key={item.contract.id} className="py-6 px-2 sm:px-4">
-              <ContractActivity
-                user={user}
-                contract={item.contract}
-                bets={item.recentBets}
-                comments={item.recentComments}
-                mode={mode}
-                contractPath={
-                  getContractPath ? getContractPath(item.contract) : undefined
-                }
-              />
-            </div>
-          ))}
-        </Col>
-      </Col>
+    <Col className="divide-y divide-gray-300 bg-white">
+      {feed.map((item) => (
+        <ContractActivity
+          key={item.contract.id}
+          className="py-6 px-2 sm:px-4"
+          user={user}
+          contract={item.contract}
+          bets={item.recentBets}
+          comments={item.recentComments}
+          mode={mode}
+          contractPath={
+            getContractPath ? getContractPath(item.contract) : undefined
+          }
+        />
+      ))}
     </Col>
   )
 }

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -65,7 +65,7 @@ export function FeedItems(props: {
   useSaveSeenContract(ref, contract)
 
   return (
-    <div className={clsx('flow-root pr-2 md:pr-0', className)} ref={ref}>
+    <div className={clsx('flow-root', className)} ref={ref}>
       <div className={clsx(tradingAllowed(contract) ? '' : '-mb-6')}>
         {items.map((item, activityItemIdx) => (
           <div


### PR DESCRIPTION
It seemed like all these wrappers and classes served no purpose.

There is one tiny user-visible change, which is that on the home page activity feed, on small screens, there is a little less right-padding on each feed item. I actually think this change is a bug fix; it means that the right and left margins are the same size, and it means that the right UI elements are right-aligned with e.g. the "create market" button at the top. So I am keeping this change.

I tested on all my browsers. I don't have an iPhone to test with. But the existence of the wrappers made no sense to me, so I don't feel it is likely to break anything.