### PR TITLE
Print out build info in console

### DIFF
--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,22 +1,27 @@
 import 'tailwindcss/tailwind.css'
 import type { AppProps } from 'next/app'
+import { useEffect } from 'react'
 import Head from 'next/head'
 import Script from 'next/script'
 import { usePreserveScroll } from 'web/hooks/use-preserve-scroll'
 
 function printBuildInfo() {
-  // undefined if e.g. dev server
+  // These are undefined if e.g. dev server
   if (process.env.NEXT_PUBLIC_VERCEL_ENV) {
     let env = process.env.NEXT_PUBLIC_VERCEL_ENV
-    let sha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
     let msg = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_MESSAGE
-    console.info(`Build: ${env} / ${sha || '???'} / ${msg || '???'}`)
+    let owner = process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER
+    let repo = process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG
+    let sha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
+    let url = `https://github.com/${owner}/${repo}/commit/${sha}`
+    console.info(`Build: ${env} / ${msg || '???'} / ${url}`)
   }
 }
 
 function MyApp({ Component, pageProps }: AppProps) {
-  printBuildInfo()
   usePreserveScroll()
+
+  useEffect(printBuildInfo)
 
   return (
     <>

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -4,7 +4,18 @@ import Head from 'next/head'
 import Script from 'next/script'
 import { usePreserveScroll } from 'web/hooks/use-preserve-scroll'
 
+function printBuildInfo() {
+  // undefined if e.g. dev server
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV) {
+    let env = process.env.NEXT_PUBLIC_VERCEL_ENV
+    let sha = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
+    let msg = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_MESSAGE
+    console.info(`Build: ${env} / ${sha || '???'} / ${msg || '???'}`)
+  }
+}
+
 function MyApp({ Component, pageProps }: AppProps) {
+  printBuildInfo()
   usePreserveScroll()
 
   return (


### PR DESCRIPTION
I noticed that when I do a deploy and I want to test to make sure everything is OK, I sit around looking at the site thinking, are my changes live yet? Now on page load it will print a helpful message in the console making it super clear what is the live code, so I don't have to wonder whether or not I got the new one.

![image](https://user-images.githubusercontent.com/428637/167763125-117f0adb-1d4e-408f-918e-b6778edca2d5.png)
