### PR TITLE
Tell eslint to run on the hooks directory

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,6 +7,10 @@ module.exports = {
     externalDir: true,
     optimizeCss: true,
   },
+
+  eslint: {
+    dirs: ['components', 'hooks', 'lib', 'pages'],
+  },
   images: {
     domains: ['lh3.googleusercontent.com', 'i.imgur.com'],
   },


### PR DESCRIPTION
Before, it was just not running on any of the stuff in `hooks`, because the default Next config is to only run on `lib`, `components`, and `pages`.

Of course there are a bunch of warnings that fly out, which I guess we can deal with at our leisure.