### PR TITLE
Clean the user's display name on update.

### DIFF
--- a/functions/src/change-user-info.ts
+++ b/functions/src/change-user-info.ts
@@ -5,7 +5,7 @@ import { getUser } from './utils'
 import { Contract } from 'common/contract'
 import { Comment } from 'common/comment'
 import { User } from 'common/user'
-import { cleanUsername } from 'common/util/clean-username'
+import { cleanUsername, cleanDisplayName } from 'common/util/clean-username'
 import { removeUndefinedProps } from 'common/util/object'
 import { Answer } from 'common/answer'
 
@@ -61,6 +61,10 @@ export const changeUser = async (
       if (!sameNameUser.empty) {
         throw new Error('Username already exists')
       }
+    }
+
+    if (update.name) {
+      update.name = cleanDisplayName(update.name);
     }
 
     const userRef = firestore.collection('users').doc(user.id)


### PR DESCRIPTION
The user's display name should always be clean (see for example
functions/src/create-user.ts). However, change-user-info.ts does not
enforce this, thus potentially allowing a malicious user to change their
name to something that doesn't satisfy the rules for clean display
names.

Note: this cannot happen currently because all callers (in profile.tsx)
clean the name. However, doing it here is good defense in depth
(similar to how the userName is cleaned).