### PR TITLE
Update mantic.markets -> manifold.markets

### DIFF
--- a/functions/src/stripe.ts
+++ b/functions/src/stripe.ts
@@ -54,7 +54,7 @@ export const createCheckoutSession = functions
     }
 
     const referrer =
-      req.query.referer || req.headers.referer || 'https://mantic.markets'
+      req.query.referer || req.headers.referer || 'https://manifold.markets'
 
     const session = await stripe.checkout.sessions.create({
       metadata: {


### PR DESCRIPTION
The other references to "mantic" that I could find look legit, but the
referrer in stripe.ts should probably be updated.