### PR TITLE
Make single sidebar slide in and out instead of dialog hack

### DIFF
--- a/web/components/nav/nav-bar.tsx
+++ b/web/components/nav/nav-bar.tsx
@@ -5,18 +5,14 @@ import {
   MenuAlt3Icon,
   PresentationChartLineIcon,
   SearchIcon,
-  XIcon,
 } from '@heroicons/react/outline'
-import { Transition, Dialog } from '@headlessui/react'
-import { useState, Fragment } from 'react'
-import Sidebar from './sidebar'
 import { useUser } from 'web/hooks/use-user'
 import { formatMoney } from 'common/util/format'
 import { Avatar } from '../avatar'
 
 // From https://codepen.io/chris__sev/pen/QWGvYbL
-export function BottomNavBar() {
-  const [sidebarOpen, setSidebarOpen] = useState(false)
+export function BottomNavBar(props: { toggleSidebar: () => void }) {
+  const { toggleSidebar } = props
 
   const user = useUser()
 
@@ -50,7 +46,7 @@ export function BottomNavBar() {
 
       <div
         className="w-full select-none py-1 px-3 text-center hover:cursor-pointer hover:bg-indigo-200 hover:text-indigo-700"
-        onClick={() => setSidebarOpen(true)}
+        onClick={() => toggleSidebar()}
       >
         {user === null ? (
           <>
@@ -72,80 +68,6 @@ export function BottomNavBar() {
           <></>
         )}
       </div>
-
-      <MobileSidebar
-        sidebarOpen={sidebarOpen}
-        setSidebarOpen={setSidebarOpen}
-      />
     </nav>
-  )
-}
-
-// Sidebar that slides out on mobile
-export function MobileSidebar(props: {
-  sidebarOpen: boolean
-  setSidebarOpen: (open: boolean) => void
-}) {
-  const { sidebarOpen, setSidebarOpen } = props
-  return (
-    <div>
-      <Transition.Root show={sidebarOpen} as={Fragment}>
-        <Dialog
-          as="div"
-          className="fixed inset-0 z-40 flex"
-          onClose={setSidebarOpen}
-        >
-          <Transition.Child
-            as={Fragment}
-            enter="transition-opacity ease-linear duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="transition-opacity ease-linear duration-300"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <Dialog.Overlay className="fixed inset-0 bg-gray-600 bg-opacity-75" />
-          </Transition.Child>
-          <Transition.Child
-            as={Fragment}
-            enter="transition ease-in-out duration-300 transform"
-            enterFrom="-translate-x-full"
-            enterTo="translate-x-0"
-            leave="transition ease-in-out duration-300 transform"
-            leaveFrom="translate-x-0"
-            leaveTo="-translate-x-full"
-          >
-            <div className="relative flex w-full max-w-xs flex-1 flex-col bg-white pt-5 pb-4">
-              <Transition.Child
-                as={Fragment}
-                enter="ease-in-out duration-300"
-                enterFrom="opacity-0"
-                enterTo="opacity-100"
-                leave="ease-in-out duration-300"
-                leaveFrom="opacity-100"
-                leaveTo="opacity-0"
-              >
-                <div className="absolute top-0 right-0 -mr-12 pt-2">
-                  <button
-                    type="button"
-                    className="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
-                    onClick={() => setSidebarOpen(false)}
-                  >
-                    <span className="sr-only">Close sidebar</span>
-                    <XIcon className="h-6 w-6 text-white" aria-hidden="true" />
-                  </button>
-                </div>
-              </Transition.Child>
-              <div className="mx-2 mt-5 h-0 flex-1 overflow-y-auto">
-                <Sidebar className="pl-2" />
-              </div>
-            </div>
-          </Transition.Child>
-          <div className="w-14 flex-shrink-0" aria-hidden="true">
-            {/* Dummy element to force sidebar to shrink to fit close icon */}
-          </div>
-        </Dialog>
-      </Transition.Root>
-    </div>
   )
 }

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -111,15 +111,13 @@ function MoreButton() {
 
 function CloseButton(props: { onClick: React.MouseEventHandler }) {
   return (
-    <div className="absolute top-0 right-0 -mr-12 pt-2 lg:hidden">
-      <button
-        className="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
-        onClick={props.onClick}
-      >
-        <span className="sr-only">Close sidebar</span>
-        <XIcon className="h-6 w-6 text-white" aria-hidden="true" />
-      </button>
-    </div>
+    <button
+      className="absolute top-2 -right-12 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white lg:hidden"
+      onClick={props.onClick}
+    >
+      <span className="sr-only">Close sidebar</span>
+      <XIcon className="h-6 w-6 text-white" aria-hidden="true" />
+    </button>
   )
 }
 

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -146,7 +146,7 @@ export default function Sidebar(props: { open: boolean; onClose: () => void }) {
 
   // TODO: I think this whole business would be simpler if the outer layout was flexbox...
   const sidebarClass = clsx(
-    'lg:p-0 lg:pt-0 lg:bg-inherit lg:top-4 lg:sticky lg:col-span-2 lg:self-start lg:w-auto',
+    'lg:p-0 lg:pt-0 lg:bg-inherit lg:top-6 lg:sticky lg:col-span-2 lg:self-start lg:w-auto',
     'p-4 pt-5 fixed bg-white w-80 transition-[left] duration-300 h-screen z-50 divide-gray-300',
     open ? 'left-0' : '-left-80'
   )

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -12,6 +12,7 @@ import {
 import clsx from 'clsx'
 import _ from 'lodash'
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { useFollowedFolds } from 'web/hooks/use-fold'
 import { useUser } from 'web/hooks/use-user'
@@ -121,11 +122,34 @@ function CloseButton(props: { onClick: React.MouseEventHandler }) {
   )
 }
 
-function ModalOverlay(props: { onClick: React.MouseEventHandler }) {
+function ModalOverlay(props: {
+  open: boolean
+  onClick: React.MouseEventHandler
+}) {
+  const { open, onClick } = props
+  const [visible, setVisible] = useState(open)
+
+  useEffect(() => {
+    // Disable scrolling page when sidebar is open
+    document.body.style.overflow = open ? 'hidden' : 'auto'
+    // If it's opened, make sure it's visible immediately so the fade-in will be apparent,
+    // but if it's closed, we wait and set it invisible only after the fade-out is done,
+    // via the onTransitionEnd handler.
+    if (open) {
+      setVisible(true)
+    }
+  }, [open])
+
+  const overlayClass = clsx(
+    'inset-0 z-40 flex fixed overflow-auto bg-gray-600 transition-opacity duration-300 lg:hidden',
+    visible ? 'visible' : 'invisible',
+    open ? 'opacity-75' : 'opacity-0'
+  )
   return (
     <div
-      className="fixed inset-0 z-40 flex overflow-auto bg-gray-600 bg-opacity-75 lg:hidden"
-      onClick={props.onClick}
+      className={overlayClass}
+      onClick={onClick}
+      onTransitionEnd={() => setVisible(open)}
     ></div>
   )
 }
@@ -153,7 +177,7 @@ export default function Sidebar(props: { open: boolean; onClose: () => void }) {
 
   return (
     <>
-      {open && <ModalOverlay onClick={onClose} />}
+      <ModalOverlay open={open} onClick={onClose} />
       <nav aria-label="Sidebar" className={sidebarClass}>
         {open && <CloseButton onClick={onClose} />}
         <ManifoldLogo className="pb-6" twoLine />

--- a/web/components/page.tsx
+++ b/web/components/page.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { useState } from 'react'
 import { BottomNavBar } from './nav/nav-bar'
 import Sidebar from './nav/sidebar'
 
@@ -10,6 +11,7 @@ export function Page(props: {
   children?: any
 }) {
   const { margin, assertUser, children, rightSidebar, suspend } = props
+  const [sidebarOpen, setSidebarOpen] = useState(false)
 
   return (
     <>
@@ -20,7 +22,7 @@ export function Page(props: {
         )}
         style={suspend ? visuallyHiddenStyle : undefined}
       >
-        <Sidebar className="sticky top-4 hidden divide-gray-300 self-start pl-2 lg:col-span-2 lg:block" />
+        <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <main
           className={clsx(
             'lg:col-span-8',
@@ -36,8 +38,7 @@ export function Page(props: {
           <div className="sticky top-4 space-y-4">{rightSidebar}</div>
         </aside>
       </div>
-
-      <BottomNavBar />
+      <BottomNavBar toggleSidebar={() => setSidebarOpen(!sidebarOpen)} />
     </>
   )
 }


### PR DESCRIPTION
Fixes the main-sidebar part of #191. Previously, the main sidebar was stuck in the flow to the left of the content, and when you were in mobile mode, it would be hidden with a media query, and then when you clicked the profile button, a whole new sidebar would be generated as a headlessui `Dialog` and dropped into place.

Now the sidebar basically is made the way you might expect; it uses media queries to decide whether to be a fixed-thing-on-the-left or a sticky-thing-not-as-far-on-the-left, and no `Dialog` is involved, although I had to reinvent an overlay component to replace it.

There are only small user-visible changes:

- Fixes the weird bugs where if you open the sidebar and then grow the browser window you will be in some kind of big-layout-but-with-open-mobile-sidebar mode.
- When you close the mobile sidebar, the background no longer does an animated fade-in; it just goes away. This is simpler but also intentional. During the fade-in you still couldn't use any of the UI on the page, and I really dislike implementing animations that block the user from doing anything while they are going on. Feel free to fight with me about this if you really want to.
- When the mobile sidebar is open, you can still scroll the page with e.g. scroll wheel. This seems fine.
- When the mobile sidebar is open, hitting a key doesn't close it. This seems fine.
- Very small fixes to some spacing to look slightly better to me.
- Fixes the issue where the sidebar moves slightly when you start scrolling down and it "sticks".