### PR TITLE
Clean up some stuff with SellPanel and AmountInput

### DIFF
--- a/web/components/amount-input.tsx
+++ b/web/components/amount-input.tsx
@@ -1,10 +1,8 @@
 import clsx from 'clsx'
-import _ from 'lodash'
 import { useUser } from 'web/hooks/use-user'
 import { formatMoney } from 'common/util/format'
 import { Col } from './layout/col'
 import { Spacer } from './layout/spacer'
-import { Binary, CPMM, FullContract } from 'common/contract'
 import { SiteLink } from './site-link'
 
 export function AmountInput(props: {

--- a/web/components/amount-input.tsx
+++ b/web/components/amount-input.tsx
@@ -1,12 +1,9 @@
 import clsx from 'clsx'
 import _ from 'lodash'
 import { useUser } from 'web/hooks/use-user'
-import { formatMoney, formatWithCommas } from 'common/util/format'
+import { formatMoney } from 'common/util/format'
 import { Col } from './layout/col'
-import { Row } from './layout/row'
-import { Bet } from 'common/bet'
 import { Spacer } from './layout/spacer'
-import { calculateCpmmSale } from 'common/calculate-cpmm'
 import { Binary, CPMM, FullContract } from 'common/contract'
 import { SiteLink } from './site-link'
 
@@ -143,9 +140,7 @@ export function SellAmountInput(props: {
   contract: FullContract<CPMM, Binary>
   amount: number | undefined
   onChange: (newAmount: number | undefined) => void
-  userBets: Bet[]
   error: string | undefined
-  setError: (error: string | undefined) => void
   disabled?: boolean
   className?: string
   inputClassName?: string
@@ -153,73 +148,25 @@ export function SellAmountInput(props: {
   inputRef?: React.MutableRefObject<any>
 }) {
   const {
-    contract,
     amount,
     onChange,
-    userBets,
     error,
-    setError,
     disabled,
     className,
     inputClassName,
     inputRef,
   } = props
 
-  const user = useUser()
-
-  const openUserBets = userBets.filter((bet) => !bet.isSold && !bet.sale)
-  const [yesBets, noBets] = _.partition(
-    openUserBets,
-    (bet) => bet.outcome === 'YES'
-  )
-  const [yesShares, noShares] = [
-    _.sumBy(yesBets, (bet) => bet.shares),
-    _.sumBy(noBets, (bet) => bet.shares),
-  ]
-
-  const sellOutcome = yesShares ? 'YES' : noShares ? 'NO' : undefined
-  const shares = Math.round(yesShares) || Math.round(noShares)
-
-  const sharesSold = Math.min(amount ?? 0, shares)
-
-  const { saleValue } = calculateCpmmSale(
-    contract,
-    sharesSold,
-    sellOutcome as 'YES' | 'NO'
-  )
-
-  const onAmountChange = (amount: number | undefined) => {
-    onChange(amount)
-
-    // Check for errors.
-    if (amount !== undefined) {
-      if (amount > shares) {
-        setError(`Maximum ${formatWithCommas(Math.floor(shares))} shares`)
-      } else {
-        setError(undefined)
-      }
-    }
-  }
-
   return (
     <AmountInput
       amount={amount}
-      onChange={onAmountChange}
+      onChange={onChange}
       label="Qty"
       error={error}
       disabled={disabled}
       className={className}
       inputClassName={inputClassName}
       inputRef={inputRef}
-    >
-      {user && (
-        <Col className="gap-3 text-sm">
-          <Row className="items-center justify-between gap-2 text-gray-500">
-            Sale proceeds{' '}
-            <span className="text-neutral">{formatMoney(saleValue)}</span>
-          </Row>
-        </Col>
-      )}
-    </AmountInput>
+    ></AmountInput>
   )
 }

--- a/web/components/amount-input.tsx
+++ b/web/components/amount-input.tsx
@@ -17,7 +17,6 @@ export function AmountInput(props: {
   inputClassName?: string
   // Needed to focus the amount input
   inputRef?: React.MutableRefObject<any>
-  children?: any
 }) {
   const {
     amount,
@@ -28,7 +27,6 @@ export function AmountInput(props: {
     className,
     inputClassName,
     inputRef,
-    children,
   } = props
 
   const onAmountChange = (str: string) => {
@@ -75,8 +73,6 @@ export function AmountInput(props: {
           )}
         </div>
       )}
-
-      {children}
     </Col>
   )
 }
@@ -133,40 +129,5 @@ export function BuyAmountInput(props: {
       inputClassName={inputClassName}
       inputRef={inputRef}
     />
-  )
-}
-
-export function SellAmountInput(props: {
-  contract: FullContract<CPMM, Binary>
-  amount: number | undefined
-  onChange: (newAmount: number | undefined) => void
-  error: string | undefined
-  disabled?: boolean
-  className?: string
-  inputClassName?: string
-  // Needed to focus the amount input
-  inputRef?: React.MutableRefObject<any>
-}) {
-  const {
-    amount,
-    onChange,
-    error,
-    disabled,
-    className,
-    inputClassName,
-    inputRef,
-  } = props
-
-  return (
-    <AmountInput
-      amount={amount}
-      onChange={onChange}
-      label="Qty"
-      error={error}
-      disabled={disabled}
-      className={className}
-      inputClassName={inputClassName}
-      inputRef={inputRef}
-    ></AmountInput>
   )
 }

--- a/web/components/bet-panel.tsx
+++ b/web/components/bet-panel.tsx
@@ -489,15 +489,12 @@ export function SellPanel(props: {
         inputClassName="w-full"
       />
 
-      <Col className="gap-3 text-sm">
+      <Col className="mt-3 w-full gap-3 text-sm">
         <Row className="items-center justify-between gap-2 text-gray-500">
-          Sale proceeds{' '}
+          Sale proceeds
           <span className="text-neutral">{formatMoney(saleValue)}</span>
         </Row>
-      </Col>
-
-      <Col className="mt-3 w-full gap-3">
-        <Row className="items-center justify-between text-sm">
+        <Row className="items-center justify-between">
           <div className="text-gray-500">Probability</div>
           <div>
             {formatPercent(initialProb)}

--- a/web/components/bet-panel.tsx
+++ b/web/components/bet-panel.tsx
@@ -67,7 +67,7 @@ export function BetPanel(props: {
         <div className="mb-6 text-2xl">Place your bet</div>
         {/* <Title className={clsx('!mt-0 text-neutral')} text="Place a trade" /> */}
 
-        <BuyPanel contract={contract} user={user} userBets={userBets ?? []} />
+        <BuyPanel contract={contract} user={user} />
 
         {user === null && (
           <button
@@ -178,7 +178,6 @@ export function BetPanelSwitcher(props: {
           <BuyPanel
             contract={contract}
             user={user}
-            userBets={userBets ?? []}
             selected={selected}
             onBuySuccess={onBetSuccess}
           />
@@ -200,11 +199,10 @@ export function BetPanelSwitcher(props: {
 function BuyPanel(props: {
   contract: FullContract<DPM | CPMM, Binary>
   user: User | null | undefined
-  userBets: Bet[]
   selected?: 'YES' | 'NO'
   onBuySuccess?: () => void
 }) {
-  const { contract, user, userBets, selected, onBuySuccess } = props
+  const { contract, user, selected, onBuySuccess } = props
 
   const [betChoice, setBetChoice] = useState<'YES' | 'NO' | undefined>(selected)
   const [betAmount, setBetAmount] = useState<number | undefined>(undefined)

--- a/web/components/bet-panel.tsx
+++ b/web/components/bet-panel.tsx
@@ -17,7 +17,7 @@ import { Title } from './title'
 import { firebaseLogin, User } from 'web/lib/firebase/users'
 import { Bet } from 'common/bet'
 import { placeBet, sellShares } from 'web/lib/firebase/api-call'
-import { BuyAmountInput, SellAmountInput } from './amount-input'
+import { AmountInput, BuyAmountInput } from './amount-input'
 import { InfoTooltip } from './info-tooltip'
 import { BinaryOutcomeLabel } from './outcome-label'
 import {
@@ -474,9 +474,7 @@ export function SellPanel(props: {
 
   return (
     <>
-      <SellAmountInput
-        inputClassName="w-full"
-        contract={contract}
+      <AmountInput
         amount={
           amount
             ? Math.round(amount) === 0
@@ -485,8 +483,10 @@ export function SellPanel(props: {
             : undefined
         }
         onChange={onAmountChange}
+        label="Qty"
         error={error}
         disabled={isSubmitting}
+        inputClassName="w-full"
       />
 
       <Col className="gap-3 text-sm">


### PR DESCRIPTION
Previously, I felt this code was fishy because all the logic in `SellAmountInput` was responsible for producing the first row of "sale proceeds" UI, which was clearly not conceptually tied to the input component -- it was supposed to be part of the `SellPanel` above it. By moving this logic up, that markup got simpler, and `SellAmountInput` basically turned into nothing.

What do you think?

In the future, I think this could be further improved to throw out more code and unify some of the validation and error-handling logic between buy and sell components (which is subtly different in ways that I think are as likely accidental as intentional.)

There should be no user-visible changes.