### PR TITLE
Fix up API CORS header processing

### DIFF
--- a/common/envs/constants.ts
+++ b/common/envs/constants.ts
@@ -32,7 +32,7 @@ export const IS_PRIVATE_MANIFOLD = ENV_CONFIG.visibility === 'PRIVATE'
 
 // Manifold's domain or any subdomains thereof
 export const CORS_ORIGIN_MANIFOLD = new RegExp(
-  '^https?://(?:.+.)' + escapeRegExp(ENV_CONFIG.domain) + '$/'
+  '^https?://(?:[a-zA-Z0-9\\-]+\\.)*' + escapeRegExp(ENV_CONFIG.domain) + '$'
 )
 // Any localhost server on any port
 export const CORS_ORIGIN_LOCALHOST = /^http:\/\/localhost:\d+$/

--- a/common/envs/constants.ts
+++ b/common/envs/constants.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from 'lodash'
 import { DEV_CONFIG } from './dev'
 import { EnvConfig, PROD_CONFIG } from './prod'
 import { THEOREMONE_CONFIG } from './theoremone'
@@ -28,3 +29,10 @@ export const DOMAIN = ENV_CONFIG.domain
 export const FIREBASE_CONFIG = ENV_CONFIG.firebaseConfig
 export const PROJECT_ID = ENV_CONFIG.firebaseConfig.projectId
 export const IS_PRIVATE_MANIFOLD = ENV_CONFIG.visibility === 'PRIVATE'
+
+// Manifold's domain or any subdomains thereof
+export const CORS_ORIGIN_MANIFOLD = new RegExp(
+  '^https?://(?:.+.)' + escapeRegExp(ENV_CONFIG.domain) + '$/'
+)
+// Any localhost server on any port
+export const CORS_ORIGIN_LOCALHOST = /^http:\/\/localhost:\d+$/

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -3,6 +3,10 @@ import * as functions from 'firebase-functions'
 import * as Cors from 'cors'
 
 import { User, PrivateUser } from 'common/user'
+import {
+  CORS_ORIGIN_MANIFOLD,
+  CORS_ORIGIN_LOCALHOST,
+} from 'common/envs/constants'
 
 type Request = functions.https.Request
 type Response = functions.Response
@@ -89,9 +93,6 @@ export const lookupUser = async (creds: Credentials): Promise<AuthedUser> => {
       throw new APIError(500, 'Invalid credential type.')
   }
 }
-
-export const CORS_ORIGIN_MANIFOLD = /^https?:\/\/(?:.+\.)manifold\.markets$/
-export const CORS_ORIGIN_LOCALHOST = /^http:\/\/localhost:\d+$/
 
 export const applyCors = (req: any, res: any, params: object) => {
   return new Promise((resolve, reject) => {

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -90,7 +90,7 @@ export const lookupUser = async (creds: Credentials): Promise<AuthedUser> => {
   }
 }
 
-export const CORS_ORIGIN_MANIFOLD = /^https?:\/\/.+\.manifold\.markets$/
+export const CORS_ORIGIN_MANIFOLD = /^https?:\/\/(?:.+\.)manifold\.markets$/
 export const CORS_ORIGIN_LOCALHOST = /^http:\/\/localhost:\d+$/
 
 export const applyCors = (req: any, res: any, params: object) => {
@@ -107,7 +107,7 @@ export const applyCors = (req: any, res: any, params: object) => {
 export const newEndpoint = (methods: [string], fn: Handler) =>
   functions.runWith({ minInstances: 1 }).https.onRequest(async (req, res) => {
     await applyCors(req, res, {
-      origins: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
+      origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
       methods: methods,
     })
     try {

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -94,7 +94,11 @@ export const lookupUser = async (creds: Credentials): Promise<AuthedUser> => {
   }
 }
 
-export const applyCors = (req: any, res: any, params: object) => {
+export const applyCors = (
+  req: Request,
+  res: Response,
+  params: Cors.CorsOptions
+) => {
   return new Promise((resolve, reject) => {
     Cors(params)(req, res, (result) => {
       if (result instanceof Error) {

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -2,11 +2,11 @@ import * as admin from 'firebase-admin'
 import * as functions from 'firebase-functions'
 import * as Cors from 'cors'
 
-import { User, PrivateUser } from 'common/user'
+import { User, PrivateUser } from '../../common/user'
 import {
   CORS_ORIGIN_MANIFOLD,
   CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+} from '../../common/envs/constants'
 
 type Request = functions.https.Request
 type Response = functions.Response


### PR DESCRIPTION
This needs to be working and also the client API is about to have to generate real CORS headers for `placeBet` and `createContract` APIs, so get it into `common` instead of the `functions` package.