### PR TITLE
Set up `eslint` for `common`, `functions` packages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,10 +33,18 @@ jobs:
       - name: Run Prettier on web client
         working-directory: web
         run: npx prettier --check .
+      - name: Run ESLint on common
+        if: ${{ success() || failure() }}
+        working-directory: common
+        run: npx eslint . --max-warnings 0
       - name: Run ESLint on web client
         if: ${{ success() || failure() }}
         working-directory: web
         run: yarn lint --max-warnings 0
+      - name: Run ESLint on cloud functions
+        if: ${{ success() || failure() }}
+        working-directory: functions
+        run: npx eslint . --max-warnings 0
       - name: Run Typescript checker on web client
         if: ${{ success() || failure() }}
         working-directory: web

--- a/common/.eslintrc.js
+++ b/common/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  extends: ['eslint:recommended'],
+  env: {
+    browser: true,
+    node: true,
+  },
+  overrides: [
+    {
+      files: ['**/*.ts'],
+      plugins: ['@typescript-eslint'],
+      parser: '@typescript-eslint/parser',
+    },
+  ],
+  rules: {
+    'no-unused-vars': 'off',
+    'no-constant-condition': ['error', { checkLoops: false }],
+  },
+}

--- a/functions/.eslintrc.js
+++ b/functions/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: ['eslint:recommended'],
+  ignorePatterns: ['lib'],
+  env: {
+    node: true,
+  },
+  overrides: [
+    {
+      files: ['**/*.ts'],
+      plugins: ['@typescript-eslint'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
+    },
+  ],
+  rules: {
+    'no-unused-vars': 'off',
+    'no-constant-condition': ['error', { checkLoops: false }],
+  },
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -26,15 +26,14 @@
     "firebase-functions": "3.16.0",
     "lodash": "4.17.21",
     "mailgun-js": "0.22.0",
-    "react-query": "3.39.0",
     "module-alias": "2.2.2",
+    "react-query": "3.39.0",
     "stripe": "8.194.0"
   },
   "devDependencies": {
-    "@types/module-alias": "2.0.1",
     "@types/mailgun-js": "0.22.12",
-    "firebase-functions-test": "0.3.3",
-    "typescript": "4.5.3"
+    "@types/module-alias": "2.0.1",
+    "firebase-functions-test": "0.3.3"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -8,5 +8,11 @@
   ],
   "scripts": {},
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "typescript": "4.6.4",
+    "@typescript-eslint/eslint-plugin": "5.25.0",
+    "@typescript-eslint/parser": "5.25.0",
+    "eslint": "8.15.0",
+    "prettier": "2.5.0"
+  }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -46,15 +46,12 @@
     "autoprefixer": "10.2.6",
     "concurrently": "6.5.1",
     "critters": "0.0.16",
-    "eslint": "8.15.0",
     "eslint-config-next": "12.1.6",
     "next-sitemap": "^2.5.14",
     "postcss": "8.3.5",
-    "prettier": "2.5.0",
     "prettier-plugin-tailwindcss": "^0.1.5",
     "tailwindcss": "3.0.1",
-    "tsc-files": "1.1.3",
-    "typescript": "4.5.3"
+    "tsc-files": "1.1.3"
   },
   "lint-staged": {
     "*.{ts,tsx}": "tsc-files --noEmit --incremental false"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,11 @@
   resolved "https://registry.yarnpkg.com/@types/hogan.js/-/hogan.js-3.0.1.tgz#64c54407b30da359763e14877f5702b8ae85d61c"
   integrity sha512-D03i/2OY7kGyMq9wdQ7oD8roE49z/ZCZThe/nbahtvuqCNZY9T2MfedOWyeBdbEpY2W8Gnh/dyJLdFtUCOkYbg==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1166,7 +1171,22 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@typescript-eslint/parser@^5.21.0":
+"@typescript-eslint/eslint-plugin@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz#e8ce050990e4d36cc200f2de71ca0d3eb5e77a31"
+  integrity sha512-icYrFnUzvm+LhW0QeJNKkezBu6tJs9p/53dpPLFH8zoM9w1tfaKzVurkPotEpAqQ8Vf8uaFyL5jHd0Vs6Z0ZQg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.25.0"
+    "@typescript-eslint/type-utils" "5.25.0"
+    "@typescript-eslint/utils" "5.25.0"
+    debug "^4.3.4"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.2.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@5.25.0", "@typescript-eslint/parser@^5.21.0":
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.25.0.tgz#fb533487147b4b9efd999a4d2da0b6c263b64f7f"
   integrity sha512-r3hwrOWYbNKP1nTcIw/aZoH+8bBnh/Lh1iDHoFpyG4DnCpvEdctrSl6LOo19fZbzypjQMHdajolxs6VpYoChgA==
@@ -1183,6 +1203,15 @@
   dependencies:
     "@typescript-eslint/types" "5.25.0"
     "@typescript-eslint/visitor-keys" "5.25.0"
+
+"@typescript-eslint/type-utils@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.25.0.tgz#5750d26a5db4c4d68d511611e0ada04e56f613bc"
+  integrity sha512-B6nb3GK3Gv1Rsb2pqalebe/RyQoyG/WDy9yhj8EE0Ikds4Xa8RR28nHz+wlt4tMZk5bnAr0f3oC8TuDAd5CPrw==
+  dependencies:
+    "@typescript-eslint/utils" "5.25.0"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/types@5.25.0":
   version "5.25.0"
@@ -1201,6 +1230,18 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.25.0.tgz#272751fd737733294b4ab95e16c7f2d4a75c2049"
+  integrity sha512-qNC9bhnz/n9Kba3yI6HQgQdBLuxDoMgdjzdhSInZh6NaDnFpTUlwNGxplUFWfY260Ya0TRPvkg9dd57qxrJI9g==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.25.0"
+    "@typescript-eslint/types" "5.25.0"
+    "@typescript-eslint/typescript-estree" "5.25.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/visitor-keys@5.25.0":
   version "5.25.0"
@@ -2378,6 +2419,14 @@ eslint-plugin-react@^7.29.4:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
@@ -2477,7 +2526,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -5078,10 +5127,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
-  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
+typescript@4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Now that we have this, we can do the business we discussed in #233 and enforce the import style across our code with eslint.

Note that there are a ton of recommended Typescript linting rules I haven't turned on because our codebase completely fails them all and it would be overwhelming. I will probably address them slowly over time and start turning them on at my discretion if they seem useful.