### PR TITLE
Modularize imports of hero icons in compiler

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,6 +7,13 @@ module.exports = {
     externalDir: true,
     optimizeCss: true,
     modularizeImports: {
+      '@heroicons/react/solid/?(((\\w*)?/?)*)': {
+        transform: '@heroicons/react/solid/{{ matches.[1] }}/{{member}}',
+      },
+      '@heroicons/react/outline/?(((\\w*)?/?)*)': {
+        transform: '@heroicons/react/outline/{{ matches.[1] }}/{{member}}',
+      },
+
       lodash: {
         transform: 'lodash/{{member}}',
       },


### PR DESCRIPTION
This doesn't save that much total bundle size (by excluding unused icons), but it also lets all the icons we do use go into their individual page chunks instead of a big cross-page chunk that everything depends upon, so it's worth writing a couple lines of configuration for.