### PR TITLE
Update leaderboards.tsx

### DIFF
--- a/web/pages/leaderboards.tsx
+++ b/web/pages/leaderboards.tsx
@@ -50,7 +50,7 @@ export default function Leaderboards(props: {
           users={topCreators}
           columns={[
             {
-              header: 'Market volume',
+              header: 'Market liquidity',
               renderCell: (user) => formatMoney(user.creatorVolumeCached),
             },
           ]}


### PR DESCRIPTION
Renamed top creators header from "market volume" to "market liquidity".