### PR TITLE
Fix comment links from /activity & add to emails

### DIFF
--- a/functions/src/emails.ts
+++ b/functions/src/emails.ts
@@ -262,7 +262,7 @@ export const sendNewCommentEmail = async (
     return
 
   const { question, creatorUsername, slug } = contract
-  const marketUrl = `https://${DOMAIN}/${creatorUsername}/${slug}`
+  const marketUrl = `https://${DOMAIN}/${creatorUsername}/${slug}#${comment.id}`
 
   const unsubscribeUrl = `https://us-central1-${PROJECT_ID}.cloudfunctions.net/unsubscribe?id=${userId}&type=market-comment`
 

--- a/web/components/feed/copy-link-date-time.tsx
+++ b/web/components/feed/copy-link-date-time.tsx
@@ -21,14 +21,11 @@ export function CopyLinkDateTimeComponent(props: {
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) {
     event.preventDefault()
+    let elementLocation = `https://${ENV_CONFIG.domain}${contractPath(
+      contract
+    )}#${elementId}`
 
-    let currentLocation = window.location.href.includes('/home')
-      ? `https://${ENV_CONFIG.domain}${contractPath(contract)}#${elementId}`
-      : window.location.href
-    if (currentLocation.includes('#')) {
-      currentLocation = currentLocation.split('#')[0]
-    }
-    copyToClipboard(`${currentLocation}#${elementId}`)
+    copyToClipboard(elementLocation)
     setShowToast(true)
     setTimeout(() => setShowToast(false), 2000)
   }

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -156,7 +156,7 @@ export function FeedComment(props: {
     <Row
       className={clsx(
         'flex space-x-1.5 transition-all duration-1000 sm:space-x-3',
-        highlighted ? `-m-2 rounded bg-indigo-500/[0.2] p-2` : ''
+        highlighted ? `-m-1 rounded bg-indigo-500/[0.2] p-2` : ''
       )}
     >
       <Avatar


### PR DESCRIPTION
I added the comment id to the market url in the comment email. The variable isn't appropriately named now though, but I'm not sure how to mess with the email template and I'm assuming it's looking for the key: 'marketurl'.

I also just defaulted to always adding the manifold.markets url to the comment link as who knows what page people will be linking from: /home, /activity, etc. On local dev you'll have to replace https://manifold.markets with localhost:3000.