### PR TITLE
Handle free response outcomes for yes/no shares

### DIFF
--- a/web/components/contract/quick-bet.tsx
+++ b/web/components/contract/quick-bet.tsx
@@ -38,16 +38,20 @@ export function QuickBet(props: { contract: Contract }) {
 
   const user = useUser()
   const userBets = useUserContractBets(user?.id, contract.id)
+  const topAnswer =
+    contract.outcomeType === 'FREE_RESPONSE'
+      ? getTopAnswer(contract as FreeResponseContract)
+      : undefined
+
+  // TODO: yes/no from useSaveShares doesn't work on numeric contracts
   const { yesFloorShares, noFloorShares } = useSaveShares(
-    contract as FullContract<CPMM | DPM, Binary>,
-    userBets
+    contract as FullContract<DPM | CPMM, Binary | FreeResponseContract>,
+    userBets,
+    topAnswer?.number.toString() || undefined
   )
-  // TODO: This relies on a hack in useSaveShares, where noFloorShares includes
-  // all non-YES shares. Ideally, useSaveShares should group by all outcomes
-  const hasUpShares =
-    contract.outcomeType === 'BINARY' ? yesFloorShares : noFloorShares
+  const hasUpShares = yesFloorShares || contract.outcomeType === 'NUMERIC'
   const hasDownShares =
-    contract.outcomeType === 'BINARY' ? noFloorShares : yesFloorShares
+    noFloorShares && yesFloorShares <= 0 && contract.outcomeType !== 'NUMERIC'
 
   const [upHover, setUpHover] = useState(false)
   const [downHover, setDownHover] = useState(false)

--- a/web/components/use-save-shares.ts
+++ b/web/components/use-save-shares.ts
@@ -1,11 +1,18 @@
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import {
+  Binary,
+  CPMM,
+  DPM,
+  FreeResponseContract,
+  FullContract,
+} from 'common/contract'
 import { Bet } from 'common/bet'
 import { useEffect, useState } from 'react'
 import { partition, sumBy } from 'lodash'
 
 export const useSaveShares = (
-  contract: FullContract<CPMM | DPM, Binary>,
-  userBets: Bet[] | undefined
+  contract: FullContract<CPMM | DPM, Binary | FreeResponseContract>,
+  userBets: Bet[] | undefined,
+  freeResponseAnswerOutcome?: string
 ) => {
   const [savedShares, setSavedShares] = useState<
     | {
@@ -17,9 +24,11 @@ export const useSaveShares = (
     | undefined
   >()
 
-  const [yesBets, noBets] = partition(
-    userBets ?? [],
-    (bet) => bet.outcome === 'YES'
+  // TODO: How do we handle numeric yes / no bets? - maybe bet amounts above vs below the highest peak
+  const [yesBets, noBets] = partition(userBets ?? [], (bet) =>
+    freeResponseAnswerOutcome
+      ? bet.outcome === freeResponseAnswerOutcome
+      : bet.outcome === 'YES'
   )
   const [yesShares, noShares] = [
     sumBy(yesBets, (bet) => bet.shares),


### PR DESCRIPTION
Now with free response contracts the quick bet view will show a highlighted up arrow if the user has shares in the top answer. If they don't own shares in the top answer but do in other answers, it'll show the down arrow. For numeric markets it will just show the up arrow if they've bet on the market anywhere. This should probably be whether their bets are majority above or below the displayed value? 