### PR TITLE
Clean up some mess related to nullable `collectedFees`

### DIFF
--- a/common/contract.ts
+++ b/common/contract.ts
@@ -46,6 +46,7 @@ export type Contract = FullContract<
 export type BinaryContract = FullContract<DPM | CPMM, Binary>
 export type FreeResponseContract = FullContract<DPM | CPMM, FreeResponse>
 export type NumericContract = FullContract<DPM, Numeric>
+export type AnyOutcome = Binary | Multi | FreeResponse | Numeric
 
 export type DPM = {
   mechanism: 'dpm-2'

--- a/common/payouts-dpm.ts
+++ b/common/payouts-dpm.ts
@@ -3,13 +3,7 @@ import { sum, groupBy, sumBy, mapValues } from 'lodash'
 import { Bet, NumericBet } from './bet'
 import { deductDpmFees, getDpmProbability } from './calculate-dpm'
 import { DPM, FreeResponse, FullContract, Multi } from './contract'
-import {
-  DPM_CREATOR_FEE,
-  DPM_FEES,
-  DPM_PLATFORM_FEE,
-  Fees,
-  noFees,
-} from './fees'
+import { DPM_CREATOR_FEE, DPM_FEES, DPM_PLATFORM_FEE } from './fees'
 import { addObjects } from './util/object'
 
 export const getDpmCancelPayouts = (
@@ -31,7 +25,7 @@ export const getDpmCancelPayouts = (
     payouts,
     creatorPayout: 0,
     liquidityPayouts: [],
-    collectedFees: contract.collectedFees ?? noFees,
+    collectedFees: contract.collectedFees,
   }
 }
 
@@ -57,17 +51,11 @@ export const getDpmStandardPayouts = (
   const profits = sumBy(payouts, (po) => Math.max(0, po.profit))
   const creatorFee = DPM_CREATOR_FEE * profits
   const platformFee = DPM_PLATFORM_FEE * profits
-
-  const finalFees: Fees = {
+  const collectedFees = addObjects(contract.collectedFees, {
     creatorFee,
     platformFee,
     liquidityFee: 0,
-  }
-
-  const collectedFees = addObjects<Fees>(
-    finalFees,
-    contract.collectedFees ?? {}
-  )
+  })
 
   console.log(
     'resolved',
@@ -115,17 +103,11 @@ export const getNumericDpmPayouts = (
   const profits = sumBy(payouts, (po) => Math.max(0, po.profit))
   const creatorFee = DPM_CREATOR_FEE * profits
   const platformFee = DPM_PLATFORM_FEE * profits
-
-  const finalFees: Fees = {
+  const collectedFees = addObjects(contract.collectedFees, {
     creatorFee,
     platformFee,
     liquidityFee: 0,
-  }
-
-  const collectedFees = addObjects<Fees>(
-    finalFees,
-    contract.collectedFees ?? {}
-  )
+  })
 
   console.log(
     'resolved numeric bucket: ',
@@ -174,17 +156,11 @@ export const getDpmMktPayouts = (
 
   const creatorFee = DPM_CREATOR_FEE * profits
   const platformFee = DPM_PLATFORM_FEE * profits
-
-  const finalFees: Fees = {
+  const collectedFees = addObjects(contract.collectedFees, {
     creatorFee,
     platformFee,
     liquidityFee: 0,
-  }
-
-  const collectedFees = addObjects<Fees>(
-    finalFees,
-    contract.collectedFees ?? {}
-  )
+  })
 
   console.log(
     'resolved MKT',
@@ -233,17 +209,11 @@ export const getPayoutsMultiOutcome = (
 
   const creatorFee = DPM_CREATOR_FEE * profits
   const platformFee = DPM_PLATFORM_FEE * profits
-
-  const finalFees: Fees = {
+  const collectedFees = addObjects(contract.collectedFees, {
     creatorFee,
     platformFee,
     liquidityFee: 0,
-  }
-
-  const collectedFees = addObjects<Fees>(
-    finalFees,
-    contract.collectedFees ?? noFees
-  )
+  })
 
   console.log(
     'resolved',

--- a/common/payouts-dpm.ts
+++ b/common/payouts-dpm.ts
@@ -2,12 +2,12 @@ import { sum, groupBy, sumBy, mapValues } from 'lodash'
 
 import { Bet, NumericBet } from './bet'
 import { deductDpmFees, getDpmProbability } from './calculate-dpm'
-import { DPM, FreeResponse, FullContract, Multi } from './contract'
+import { DPM, FreeResponse, FullContract, Multi, AnyOutcome } from './contract'
 import { DPM_CREATOR_FEE, DPM_FEES, DPM_PLATFORM_FEE } from './fees'
 import { addObjects } from './util/object'
 
 export const getDpmCancelPayouts = (
-  contract: FullContract<DPM, any>,
+  contract: FullContract<DPM, AnyOutcome>,
   bets: Bet[]
 ) => {
   const { pool } = contract
@@ -31,7 +31,7 @@ export const getDpmCancelPayouts = (
 
 export const getDpmStandardPayouts = (
   outcome: string,
-  contract: FullContract<DPM, any>,
+  contract: FullContract<DPM, AnyOutcome>,
   bets: Bet[]
 ) => {
   const winningBets = bets.filter((bet) => bet.outcome === outcome)
@@ -78,7 +78,7 @@ export const getDpmStandardPayouts = (
 
 export const getNumericDpmPayouts = (
   outcome: string,
-  contract: FullContract<DPM, any>,
+  contract: FullContract<DPM, AnyOutcome>,
   bets: NumericBet[]
 ) => {
   const totalShares = sumBy(bets, (bet) => bet.allOutcomeShares[outcome] ?? 0)
@@ -129,7 +129,7 @@ export const getNumericDpmPayouts = (
 }
 
 export const getDpmMktPayouts = (
-  contract: FullContract<DPM, any>,
+  contract: FullContract<DPM, AnyOutcome>,
   bets: Bet[],
   resolutionProbability?: number
 ) => {

--- a/common/payouts.ts
+++ b/common/payouts.ts
@@ -9,6 +9,7 @@ import {
   FreeResponse,
   FullContract,
   Multi,
+  AnyOutcome,
 } from './contract'
 import { Fees } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
@@ -72,15 +73,17 @@ export const getPayouts = (
       liquidities,
       resolutionProbability
     )
+  } else if (contract.mechanism === 'dpm-2') {
+    return getDpmPayouts(
+      outcome,
+      resolutions,
+      contract,
+      bets,
+      resolutionProbability
+    )
+  } else {
+    throw new Error('Unknown contract mechanism.')
   }
-
-  return getDpmPayouts(
-    outcome,
-    resolutions,
-    contract,
-    bets,
-    resolutionProbability
-  )
 }
 
 export const getFixedPayouts = (
@@ -112,7 +115,7 @@ export const getDpmPayouts = (
   resolutions: {
     [outcome: string]: number
   },
-  contract: Contract,
+  contract: FullContract<DPM, AnyOutcome>,
   bets: Bet[],
   resolutionProbability?: number
 ): PayoutInfo => {

--- a/functions/src/sell-bet.ts
+++ b/functions/src/sell-bet.ts
@@ -78,7 +78,7 @@ export const sellBet = functions.runWith({ minInstances: 1 }).https.onCall(
           pool: newPool,
           totalShares: newTotalShares,
           totalBets: newTotalBets,
-          collectedFees: addObjects<Fees>(fees ?? {}, collectedFees ?? {}),
+          collectedFees: addObjects(fees, collectedFees),
           volume: volume + Math.abs(newBet.amount),
         })
       )

--- a/functions/src/sell-shares.ts
+++ b/functions/src/sell-shares.ts
@@ -101,7 +101,7 @@ export const sellShares = functions.runWith({ minInstances: 1 }).https.onCall(
         removeUndefinedProps({
           pool: newPool,
           p: newP,
-          collectedFees: addObjects(fees ?? {}, collectedFees ?? {}),
+          collectedFees: addObjects(fees, collectedFees),
           volume: volume + Math.abs(newBet.amount),
         })
       )

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -95,7 +95,7 @@ export function ContractInfoDialog(props: { contract: Contract; bets: Bet[] }) {
 
               <tr>
                 <td>Creator earnings</td>
-                <td>{formatMoney(contract.collectedFees?.creatorFee ?? 0)}</td>
+                <td>{formatMoney(contract.collectedFees.creatorFee)}</td>
               </tr>
 
               <tr>


### PR DESCRIPTION
Now that `contract.collectedFees` is [no longer secretly nullable](https://github.com/manifoldmarkets/manifold/commit/e5ce17c2ade2a1b36d69a7b049a8a249b5b09c81), we don't have to worry about it.