### PR TITLE
Refactor contract typing to be more concise and more correct

### DIFF
--- a/common/add-liquidity.ts
+++ b/common/add-liquidity.ts
@@ -1,12 +1,12 @@
 import { addCpmmLiquidity, getCpmmLiquidity } from './calculate-cpmm'
-import { Binary, Contract, CPMM } from './contract'
+import { CPMMContract } from './contract'
 import { LiquidityProvision } from './liquidity-provision'
 import { User } from './user'
 
 export const getNewLiquidityProvision = (
   user: User,
   amount: number,
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   newLiquidityProvisionId: string
 ) => {
   const { pool, p, totalLiquidity } = contract

--- a/common/add-liquidity.ts
+++ b/common/add-liquidity.ts
@@ -1,12 +1,12 @@
 import { addCpmmLiquidity, getCpmmLiquidity } from './calculate-cpmm'
-import { Binary, CPMM, FullContract } from './contract'
+import { Binary, Contract, CPMM } from './contract'
 import { LiquidityProvision } from './liquidity-provision'
 import { User } from './user'
 
 export const getNewLiquidityProvision = (
   user: User,
   amount: number,
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   newLiquidityProvisionId: string
 ) => {
   const { pool, p, totalLiquidity } = contract

--- a/common/antes.ts
+++ b/common/antes.ts
@@ -1,7 +1,12 @@
 import { range } from 'lodash'
 import { Bet, NumericBet } from './bet'
 import { getDpmProbability, getValueFromBucket } from './calculate-dpm'
-import { Binary, Contract, CPMM, DPM, FreeResponse, Numeric } from './contract'
+import {
+  CPMMBinaryContract,
+  DPMBinaryContract,
+  FreeResponseContract,
+  NumericContract,
+} from './contract'
 import { User } from './user'
 import { LiquidityProvision } from './liquidity-provision'
 import { noFees } from './fees'
@@ -16,7 +21,7 @@ export const HOUSE_LIQUIDITY_PROVIDER_ID = 'IPTOzEqrpkWmEzh6hwvAyY9PqFb2' // @Ma
 
 export function getCpmmInitialLiquidity(
   providerId: string,
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMBinaryContract,
   anteId: string,
   amount: number
 ) {
@@ -40,7 +45,7 @@ export function getCpmmInitialLiquidity(
 
 export function getAnteBets(
   creator: User,
-  contract: Contract<DPM & Binary>,
+  contract: DPMBinaryContract,
   yesAnteId: string,
   noAnteId: string
 ) {
@@ -82,7 +87,7 @@ export function getAnteBets(
 
 export function getFreeAnswerAnte(
   anteBettorId: string,
-  contract: Contract & FreeResponse,
+  contract: FreeResponseContract,
   anteBetId: string
 ) {
   const { totalBets, totalShares } = contract
@@ -110,7 +115,7 @@ export function getFreeAnswerAnte(
 
 export function getNumericAnte(
   anteBettorId: string,
-  contract: Contract & Numeric,
+  contract: NumericContract,
   ante: number,
   newBetId: string
 ) {

--- a/common/antes.ts
+++ b/common/antes.ts
@@ -1,14 +1,7 @@
 import { range } from 'lodash'
 import { Bet, NumericBet } from './bet'
 import { getDpmProbability, getValueFromBucket } from './calculate-dpm'
-import {
-  Binary,
-  CPMM,
-  DPM,
-  FreeResponse,
-  FullContract,
-  Numeric,
-} from './contract'
+import { Binary, Contract, CPMM, DPM, FreeResponse, Numeric } from './contract'
 import { User } from './user'
 import { LiquidityProvision } from './liquidity-provision'
 import { noFees } from './fees'
@@ -23,7 +16,7 @@ export const HOUSE_LIQUIDITY_PROVIDER_ID = 'IPTOzEqrpkWmEzh6hwvAyY9PqFb2' // @Ma
 
 export function getCpmmInitialLiquidity(
   providerId: string,
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   anteId: string,
   amount: number
 ) {
@@ -47,7 +40,7 @@ export function getCpmmInitialLiquidity(
 
 export function getAnteBets(
   creator: User,
-  contract: FullContract<DPM, Binary>,
+  contract: Contract<DPM & Binary>,
   yesAnteId: string,
   noAnteId: string
 ) {
@@ -89,7 +82,7 @@ export function getAnteBets(
 
 export function getFreeAnswerAnte(
   anteBettorId: string,
-  contract: FullContract<DPM, FreeResponse>,
+  contract: Contract & FreeResponse,
   anteBetId: string
 ) {
   const { totalBets, totalShares } = contract
@@ -117,7 +110,7 @@ export function getFreeAnswerAnte(
 
 export function getNumericAnte(
   anteBettorId: string,
-  contract: FullContract<DPM, Numeric>,
+  contract: Contract & Numeric,
   ante: number,
   newBetId: string
 ) {

--- a/common/calculate-cpmm.ts
+++ b/common/calculate-cpmm.ts
@@ -1,6 +1,6 @@
 import { sum, groupBy, mapValues, sumBy } from 'lodash'
 
-import { Binary, Contract, CPMM } from './contract'
+import { CPMMContract } from './contract'
 import { CREATOR_FEE, Fees, LIQUIDITY_FEE, noFees, PLATFORM_FEE } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
 import { addObjects } from './util/object'
@@ -14,7 +14,7 @@ export function getCpmmProbability(
 }
 
 export function getCpmmProbabilityAfterBetBeforeFees(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   outcome: string,
   bet: number
 ) {
@@ -31,7 +31,7 @@ export function getCpmmProbabilityAfterBetBeforeFees(
 }
 
 export function getCpmmOutcomeProbabilityAfterBet(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   outcome: string,
   bet: number
 ) {
@@ -59,7 +59,7 @@ function calculateCpmmShares(
 }
 
 export function getCpmmLiquidityFee(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   bet: number,
   outcome: string
 ) {
@@ -78,7 +78,7 @@ export function getCpmmLiquidityFee(
 }
 
 export function calculateCpmmSharesAfterFee(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   bet: number,
   outcome: string
 ) {
@@ -89,7 +89,7 @@ export function calculateCpmmSharesAfterFee(
 }
 
 export function calculateCpmmPurchase(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   bet: number,
   outcome: string
 ) {
@@ -133,7 +133,7 @@ function sellSharesK(
 }
 
 function calculateCpmmShareValue(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   shares: number,
   outcome: 'YES' | 'NO'
 ) {
@@ -168,7 +168,7 @@ function calculateCpmmShareValue(
 }
 
 export function calculateCpmmSale(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   shares: number,
   outcome: string
 ) {
@@ -222,7 +222,7 @@ export function calculateCpmmSale(
 }
 
 export function getCpmmProbabilityAfterSale(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   shares: number,
   outcome: 'YES' | 'NO'
 ) {
@@ -261,7 +261,7 @@ export function addCpmmLiquidity(
 }
 
 export function getCpmmLiquidityPoolWeights(
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   liquidities: LiquidityProvision[]
 ) {
   const { p } = contract
@@ -291,7 +291,7 @@ export function getCpmmLiquidityPoolWeights(
 }
 
 // export function removeCpmmLiquidity(
-//   contract: Contract<CPMM & Binary>,
+//   contract: CPMMContract,
 //   liquidity: number
 // ) {
 //   const { YES, NO } = contract.pool

--- a/common/calculate-cpmm.ts
+++ b/common/calculate-cpmm.ts
@@ -1,6 +1,6 @@
 import { sum, groupBy, mapValues, sumBy } from 'lodash'
 
-import { Binary, CPMM, FullContract } from './contract'
+import { Binary, Contract, CPMM } from './contract'
 import { CREATOR_FEE, Fees, LIQUIDITY_FEE, noFees, PLATFORM_FEE } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
 import { addObjects } from './util/object'
@@ -14,7 +14,7 @@ export function getCpmmProbability(
 }
 
 export function getCpmmProbabilityAfterBetBeforeFees(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   outcome: string,
   bet: number
 ) {
@@ -31,7 +31,7 @@ export function getCpmmProbabilityAfterBetBeforeFees(
 }
 
 export function getCpmmOutcomeProbabilityAfterBet(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   outcome: string,
   bet: number
 ) {
@@ -59,7 +59,7 @@ function calculateCpmmShares(
 }
 
 export function getCpmmLiquidityFee(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   bet: number,
   outcome: string
 ) {
@@ -78,7 +78,7 @@ export function getCpmmLiquidityFee(
 }
 
 export function calculateCpmmSharesAfterFee(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   bet: number,
   outcome: string
 ) {
@@ -89,7 +89,7 @@ export function calculateCpmmSharesAfterFee(
 }
 
 export function calculateCpmmPurchase(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   bet: number,
   outcome: string
 ) {
@@ -133,7 +133,7 @@ function sellSharesK(
 }
 
 function calculateCpmmShareValue(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   shares: number,
   outcome: 'YES' | 'NO'
 ) {
@@ -168,7 +168,7 @@ function calculateCpmmShareValue(
 }
 
 export function calculateCpmmSale(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   shares: number,
   outcome: string
 ) {
@@ -222,7 +222,7 @@ export function calculateCpmmSale(
 }
 
 export function getCpmmProbabilityAfterSale(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   shares: number,
   outcome: 'YES' | 'NO'
 ) {
@@ -261,7 +261,7 @@ export function addCpmmLiquidity(
 }
 
 export function getCpmmLiquidityPoolWeights(
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   liquidities: LiquidityProvision[]
 ) {
   const { p } = contract
@@ -291,7 +291,7 @@ export function getCpmmLiquidityPoolWeights(
 }
 
 // export function removeCpmmLiquidity(
-//   contract: FullContract<CPMM, Binary>,
+//   contract: Contract<CPMM & Binary>,
 //   liquidity: number
 // ) {
 //   const { YES, NO } = contract.pool

--- a/common/calculate-dpm.ts
+++ b/common/calculate-dpm.ts
@@ -1,13 +1,6 @@
 import { cloneDeep, range, sum, sumBy, sortBy, mapValues } from 'lodash'
 import { Bet, NumericBet } from './bet'
-import {
-  Binary,
-  DPM,
-  FreeResponse,
-  FullContract,
-  Numeric,
-  NumericContract,
-} from './contract'
+import { Binary, Contract, DPM, NumericContract } from './contract'
 import { DPM_FEES } from './fees'
 import { normpdf } from '../common/util/math'
 import { addObjects } from './util/object'
@@ -202,7 +195,7 @@ export function calculateDpmRawShareValue(
 }
 
 export function calculateDpmMoneyRatio(
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   bet: Bet,
   shareValue: number
 ) {
@@ -228,10 +221,7 @@ export function calculateDpmMoneyRatio(
   return actual / expected
 }
 
-export function calculateDpmShareValue(
-  contract: FullContract<DPM, any>,
-  bet: Bet
-) {
+export function calculateDpmShareValue(contract: Contract & DPM, bet: Bet) {
   const { pool, totalShares } = contract
   const { shares, outcome } = bet
 
@@ -243,17 +233,14 @@ export function calculateDpmShareValue(
   return adjShareValue
 }
 
-export function calculateDpmSaleAmount(
-  contract: FullContract<DPM, any>,
-  bet: Bet
-) {
+export function calculateDpmSaleAmount(contract: Contract & DPM, bet: Bet) {
   const { amount } = bet
   const winnings = calculateDpmShareValue(contract, bet)
   return deductDpmFees(amount, winnings)
 }
 
 export function calculateDpmPayout(
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   bet: Bet,
   outcome: string
 ) {
@@ -263,10 +250,7 @@ export function calculateDpmPayout(
   return calculateStandardDpmPayout(contract, bet, outcome)
 }
 
-export function calculateDpmCancelPayout(
-  contract: FullContract<DPM, any>,
-  bet: Bet
-) {
+export function calculateDpmCancelPayout(contract: Contract & DPM, bet: Bet) {
   const { totalBets, pool } = contract
   const betTotal = sum(Object.values(totalBets))
   const poolTotal = sum(Object.values(pool))
@@ -275,7 +259,7 @@ export function calculateDpmCancelPayout(
 }
 
 export function calculateStandardDpmPayout(
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   bet: Bet,
   outcome: string
 ) {
@@ -308,7 +292,7 @@ export function calculateStandardDpmPayout(
 }
 
 export function calculateDpmPayoutAfterCorrectBet(
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   bet: Bet
 ) {
   const { totalShares, pool, totalBets, outcomeType } = contract
@@ -338,13 +322,10 @@ export function calculateDpmPayoutAfterCorrectBet(
         : outcomeType,
   }
 
-  return calculateStandardDpmPayout(newContract, bet, outcome)
+  return calculateStandardDpmPayout(newContract as any, bet, outcome)
 }
 
-function calculateMktDpmPayout(
-  contract: FullContract<DPM, Binary | FreeResponse | Numeric>,
-  bet: Bet
-) {
+function calculateMktDpmPayout(contract: Contract & DPM, bet: Bet) {
   if (contract.outcomeType === 'BINARY')
     return calculateBinaryMktDpmPayout(contract, bet)
 
@@ -390,7 +371,7 @@ function calculateMktDpmPayout(
 }
 
 function calculateBinaryMktDpmPayout(
-  contract: FullContract<DPM, Binary>,
+  contract: Contract<DPM & Binary>,
   bet: Bet
 ) {
   const { resolutionProbability, totalShares, phantomShares } = contract
@@ -413,7 +394,7 @@ function calculateBinaryMktDpmPayout(
   return deductDpmFees(amount, winnings)
 }
 
-export function resolvedDpmPayout(contract: FullContract<DPM, any>, bet: Bet) {
+export function resolvedDpmPayout(contract: Contract & DPM, bet: Bet) {
   if (contract.resolution)
     return calculateDpmPayout(contract, bet, contract.resolution)
   throw new Error('Contract was not resolved')

--- a/common/calculate-dpm.ts
+++ b/common/calculate-dpm.ts
@@ -1,6 +1,6 @@
 import { cloneDeep, range, sum, sumBy, sortBy, mapValues } from 'lodash'
 import { Bet, NumericBet } from './bet'
-import { Binary, Contract, DPM, NumericContract } from './contract'
+import { DPMContract, DPMBinaryContract, NumericContract } from './contract'
 import { DPM_FEES } from './fees'
 import { normpdf } from '../common/util/math'
 import { addObjects } from './util/object'
@@ -195,7 +195,7 @@ export function calculateDpmRawShareValue(
 }
 
 export function calculateDpmMoneyRatio(
-  contract: Contract & DPM,
+  contract: DPMContract,
   bet: Bet,
   shareValue: number
 ) {
@@ -221,7 +221,7 @@ export function calculateDpmMoneyRatio(
   return actual / expected
 }
 
-export function calculateDpmShareValue(contract: Contract & DPM, bet: Bet) {
+export function calculateDpmShareValue(contract: DPMContract, bet: Bet) {
   const { pool, totalShares } = contract
   const { shares, outcome } = bet
 
@@ -233,14 +233,14 @@ export function calculateDpmShareValue(contract: Contract & DPM, bet: Bet) {
   return adjShareValue
 }
 
-export function calculateDpmSaleAmount(contract: Contract & DPM, bet: Bet) {
+export function calculateDpmSaleAmount(contract: DPMContract, bet: Bet) {
   const { amount } = bet
   const winnings = calculateDpmShareValue(contract, bet)
   return deductDpmFees(amount, winnings)
 }
 
 export function calculateDpmPayout(
-  contract: Contract & DPM,
+  contract: DPMContract,
   bet: Bet,
   outcome: string
 ) {
@@ -250,7 +250,7 @@ export function calculateDpmPayout(
   return calculateStandardDpmPayout(contract, bet, outcome)
 }
 
-export function calculateDpmCancelPayout(contract: Contract & DPM, bet: Bet) {
+export function calculateDpmCancelPayout(contract: DPMContract, bet: Bet) {
   const { totalBets, pool } = contract
   const betTotal = sum(Object.values(totalBets))
   const poolTotal = sum(Object.values(pool))
@@ -259,7 +259,7 @@ export function calculateDpmCancelPayout(contract: Contract & DPM, bet: Bet) {
 }
 
 export function calculateStandardDpmPayout(
-  contract: Contract & DPM,
+  contract: DPMContract,
   bet: Bet,
   outcome: string
 ) {
@@ -292,7 +292,7 @@ export function calculateStandardDpmPayout(
 }
 
 export function calculateDpmPayoutAfterCorrectBet(
-  contract: Contract & DPM,
+  contract: DPMContract,
   bet: Bet
 ) {
   const { totalShares, pool, totalBets, outcomeType } = contract
@@ -325,7 +325,7 @@ export function calculateDpmPayoutAfterCorrectBet(
   return calculateStandardDpmPayout(newContract as any, bet, outcome)
 }
 
-function calculateMktDpmPayout(contract: Contract & DPM, bet: Bet) {
+function calculateMktDpmPayout(contract: DPMContract, bet: Bet) {
   if (contract.outcomeType === 'BINARY')
     return calculateBinaryMktDpmPayout(contract, bet)
 
@@ -370,10 +370,7 @@ function calculateMktDpmPayout(contract: Contract & DPM, bet: Bet) {
   return deductDpmFees(amount, winnings)
 }
 
-function calculateBinaryMktDpmPayout(
-  contract: Contract<DPM & Binary>,
-  bet: Bet
-) {
+function calculateBinaryMktDpmPayout(contract: DPMBinaryContract, bet: Bet) {
   const { resolutionProbability, totalShares, phantomShares } = contract
   const p =
     resolutionProbability !== undefined
@@ -394,7 +391,7 @@ function calculateBinaryMktDpmPayout(
   return deductDpmFees(amount, winnings)
 }
 
-export function resolvedDpmPayout(contract: Contract & DPM, bet: Bet) {
+export function resolvedDpmPayout(contract: DPMContract, bet: Bet) {
   if (contract.resolution)
     return calculateDpmPayout(contract, bet, contract.resolution)
   throw new Error('Contract was not resolved')

--- a/common/calculate-fixed-payouts.ts
+++ b/common/calculate-fixed-payouts.ts
@@ -1,9 +1,9 @@
 import { Bet } from './bet'
 import { getProbability } from './calculate'
-import { Binary, FixedPayouts, FullContract } from './contract'
+import { Binary, Contract, FixedPayouts } from './contract'
 
 export function calculateFixedPayout(
-  contract: FullContract<FixedPayouts, Binary>,
+  contract: Contract<FixedPayouts & Binary>,
   bet: Bet,
   outcome: string
 ) {
@@ -24,7 +24,7 @@ export function calculateStandardFixedPayout(bet: Bet, outcome: string) {
 }
 
 function calculateFixedMktPayout(
-  contract: FullContract<FixedPayouts, Binary>,
+  contract: Contract<FixedPayouts & Binary>,
   bet: Bet
 ) {
   const { resolutionProbability } = contract

--- a/common/calculate-fixed-payouts.ts
+++ b/common/calculate-fixed-payouts.ts
@@ -1,9 +1,9 @@
 import { Bet } from './bet'
 import { getProbability } from './calculate'
-import { Binary, Contract, FixedPayouts } from './contract'
+import { CPMMContract } from './contract'
 
 export function calculateFixedPayout(
-  contract: Contract<FixedPayouts & Binary>,
+  contract: CPMMContract,
   bet: Bet,
   outcome: string
 ) {
@@ -23,10 +23,7 @@ export function calculateStandardFixedPayout(bet: Bet, outcome: string) {
   return shares
 }
 
-function calculateFixedMktPayout(
-  contract: Contract<FixedPayouts & Binary>,
-  bet: Bet
-) {
+function calculateFixedMktPayout(contract: CPMMContract, bet: Bet) {
   const { resolutionProbability } = contract
   const p =
     resolutionProbability !== undefined

--- a/common/calculate.ts
+++ b/common/calculate.ts
@@ -18,24 +18,15 @@ import {
   getDpmProbabilityAfterSale,
 } from './calculate-dpm'
 import { calculateFixedPayout } from './calculate-fixed-payouts'
-import {
-  Binary,
-  Contract,
-  CPMM,
-  DPM,
-  FreeResponseContract,
-  FullContract,
-} from './contract'
+import { Binary, Contract, FreeResponseContract } from './contract'
 
-export function getProbability(contract: FullContract<DPM | CPMM, Binary>) {
+export function getProbability(contract: Contract & Binary) {
   return contract.mechanism === 'cpmm-1'
     ? getCpmmProbability(contract.pool, contract.p)
     : getDpmProbability(contract.totalShares)
 }
 
-export function getInitialProbability(
-  contract: FullContract<DPM | CPMM, Binary>
-) {
+export function getInitialProbability(contract: Contract & Binary) {
   if (contract.initialProbability) return contract.initialProbability
 
   if (contract.mechanism === 'dpm-2' || (contract as any).totalShares)
@@ -59,11 +50,7 @@ export function getOutcomeProbabilityAfterBet(
   bet: number
 ) {
   return contract.mechanism === 'cpmm-1'
-    ? getCpmmOutcomeProbabilityAfterBet(
-        contract as FullContract<CPMM, Binary>,
-        outcome,
-        bet
-      )
+    ? getCpmmOutcomeProbabilityAfterBet(contract, outcome, bet)
     : getDpmOutcomeProbabilityAfterBet(contract.totalShares, outcome, bet)
 }
 
@@ -73,11 +60,7 @@ export function calculateShares(
   betChoice: string
 ) {
   return contract.mechanism === 'cpmm-1'
-    ? calculateCpmmSharesAfterFee(
-        contract as FullContract<CPMM, Binary>,
-        bet,
-        betChoice
-      )
+    ? calculateCpmmSharesAfterFee(contract, bet, betChoice)
     : calculateDpmShares(contract.totalShares, bet, betChoice)
 }
 
@@ -99,11 +82,7 @@ export function getProbabilityAfterSale(
   shares: number
 ) {
   return contract.mechanism === 'cpmm-1'
-    ? getCpmmProbabilityAfterSale(
-        contract as FullContract<CPMM, Binary>,
-        shares,
-        outcome as 'YES' | 'NO'
-      )
+    ? getCpmmProbabilityAfterSale(contract, shares, outcome as 'YES' | 'NO')
     : getDpmProbabilityAfterSale(contract.totalShares, outcome, shares)
 }
 

--- a/common/calculate.ts
+++ b/common/calculate.ts
@@ -18,15 +18,15 @@ import {
   getDpmProbabilityAfterSale,
 } from './calculate-dpm'
 import { calculateFixedPayout } from './calculate-fixed-payouts'
-import { Binary, Contract, FreeResponseContract } from './contract'
+import { Contract, BinaryContract, FreeResponseContract } from './contract'
 
-export function getProbability(contract: Contract & Binary) {
+export function getProbability(contract: BinaryContract) {
   return contract.mechanism === 'cpmm-1'
     ? getCpmmProbability(contract.pool, contract.p)
     : getDpmProbability(contract.totalShares)
 }
 
-export function getInitialProbability(contract: Contract & Binary) {
+export function getInitialProbability(contract: BinaryContract) {
   if (contract.initialProbability) return contract.initialProbability
 
   if (contract.mechanism === 'dpm-2' || (contract as any).totalShares)

--- a/common/contract.ts
+++ b/common/contract.ts
@@ -3,8 +3,13 @@ import { Fees } from './fees'
 
 export type AnyMechanism = DPM | CPMM
 export type AnyOutcomeType = Binary | Multi | FreeResponse | Numeric
+export type AnyContractType =
+  | (CPMM & Binary)
+  | (DPM & Binary)
+  | (DPM & (Multi | FreeResponse))
+  | (DPM & Numeric)
 
-export type FullContract<M extends AnyMechanism, T extends AnyOutcomeType> = {
+export type Contract<T extends AnyContractType = AnyContractType> = {
   id: string
   slug: string // auto-generated; must be unique
 
@@ -36,13 +41,10 @@ export type FullContract<M extends AnyMechanism, T extends AnyOutcomeType> = {
   volume7Days: number
 
   collectedFees: Fees
-} & M &
-  T
+} & T
 
-export type Contract = FullContract<AnyMechanism, AnyOutcomeType>
-export type BinaryContract = FullContract<AnyMechanism, Binary>
-export type FreeResponseContract = FullContract<AnyMechanism, FreeResponse>
-export type NumericContract = FullContract<DPM, Numeric>
+export type NumericContract = Contract & Numeric
+export type FreeResponseContract = Contract & FreeResponse
 
 export type DPM = {
   mechanism: 'dpm-2'

--- a/common/contract.ts
+++ b/common/contract.ts
@@ -1,10 +1,10 @@
 import { Answer } from './answer'
 import { Fees } from './fees'
 
-export type FullContract<
-  M extends DPM | CPMM,
-  T extends Binary | Multi | FreeResponse | Numeric
-> = {
+export type AnyMechanism = DPM | CPMM
+export type AnyOutcomeType = Binary | Multi | FreeResponse | Numeric
+
+export type FullContract<M extends AnyMechanism, T extends AnyOutcomeType> = {
   id: string
   slug: string // auto-generated; must be unique
 
@@ -39,12 +39,9 @@ export type FullContract<
 } & M &
   T
 
-export type Contract = FullContract<
-  DPM | CPMM,
-  Binary | Multi | FreeResponse | Numeric
->
-export type BinaryContract = FullContract<DPM | CPMM, Binary>
-export type FreeResponseContract = FullContract<DPM | CPMM, FreeResponse>
+export type Contract = FullContract<AnyMechanism, AnyOutcomeType>
+export type BinaryContract = FullContract<AnyMechanism, Binary>
+export type FreeResponseContract = FullContract<AnyMechanism, FreeResponse>
 export type NumericContract = FullContract<DPM, Numeric>
 
 export type DPM = {
@@ -94,7 +91,7 @@ export type Numeric = {
   resolutionValue?: number
 }
 
-export type outcomeType = 'BINARY' | 'MULTI' | 'FREE_RESPONSE' | 'NUMERIC'
+export type outcomeType = AnyOutcomeType['outcomeType']
 export const OUTCOME_TYPES = [
   'BINARY',
   'MULTI',

--- a/common/contract.ts
+++ b/common/contract.ts
@@ -43,8 +43,13 @@ export type Contract<T extends AnyContractType = AnyContractType> = {
   collectedFees: Fees
 } & T
 
+export type BinaryContract = Contract & Binary
 export type NumericContract = Contract & Numeric
 export type FreeResponseContract = Contract & FreeResponse
+export type DPMContract = Contract & DPM
+export type CPMMContract = Contract & CPMM
+export type DPMBinaryContract = BinaryContract & DPM
+export type CPMMBinaryContract = BinaryContract & CPMM
 
 export type DPM = {
   mechanism: 'dpm-2'
@@ -61,8 +66,6 @@ export type CPMM = {
   p: number // probability constant in y^p * n^(1-p) = k
   totalLiquidity: number // in M$
 }
-
-export type FixedPayouts = CPMM
 
 export type Binary = {
   outcomeType: 'BINARY'

--- a/common/new-bet.ts
+++ b/common/new-bet.ts
@@ -10,12 +10,9 @@ import {
 } from './calculate-dpm'
 import { calculateCpmmPurchase, getCpmmProbability } from './calculate-cpmm'
 import {
-  Binary,
-  Contract,
-  CPMM,
-  DPM,
-  FreeResponse,
-  Multi,
+  CPMMBinaryContract,
+  DPMBinaryContract,
+  FreeResponseContract,
   NumericContract,
 } from './contract'
 import { noFees } from './fees'
@@ -35,7 +32,7 @@ export type BetInfo = {
 export const getNewBinaryCpmmBetInfo = (
   outcome: 'YES' | 'NO',
   amount: number,
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMBinaryContract,
   loanAmount: number
 ) => {
   const { shares, newPool, newP, fees } = calculateCpmmPurchase(
@@ -69,7 +66,7 @@ export const getNewBinaryCpmmBetInfo = (
 export const getNewBinaryDpmBetInfo = (
   outcome: 'YES' | 'NO',
   amount: number,
-  contract: Contract<DPM & Binary>,
+  contract: DPMBinaryContract,
   loanAmount: number
 ) => {
   const { YES: yesPool, NO: noPool } = contract.pool
@@ -116,7 +113,7 @@ export const getNewBinaryDpmBetInfo = (
 export const getNewMultiBetInfo = (
   outcome: string,
   amount: number,
-  contract: Contract & (Multi | FreeResponse),
+  contract: FreeResponseContract,
   loanAmount: number
 ) => {
   const { pool, totalShares, totalBets } = contract

--- a/common/new-bet.ts
+++ b/common/new-bet.ts
@@ -11,10 +11,10 @@ import {
 import { calculateCpmmPurchase, getCpmmProbability } from './calculate-cpmm'
 import {
   Binary,
+  Contract,
   CPMM,
   DPM,
   FreeResponse,
-  FullContract,
   Multi,
   NumericContract,
 } from './contract'
@@ -35,7 +35,7 @@ export type BetInfo = {
 export const getNewBinaryCpmmBetInfo = (
   outcome: 'YES' | 'NO',
   amount: number,
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   loanAmount: number
 ) => {
   const { shares, newPool, newP, fees } = calculateCpmmPurchase(
@@ -69,7 +69,7 @@ export const getNewBinaryCpmmBetInfo = (
 export const getNewBinaryDpmBetInfo = (
   outcome: 'YES' | 'NO',
   amount: number,
-  contract: FullContract<DPM, Binary>,
+  contract: Contract<DPM & Binary>,
   loanAmount: number
 ) => {
   const { YES: yesPool, NO: noPool } = contract.pool
@@ -116,7 +116,7 @@ export const getNewBinaryDpmBetInfo = (
 export const getNewMultiBetInfo = (
   outcome: string,
   amount: number,
-  contract: FullContract<DPM, Multi | FreeResponse>,
+  contract: Contract & (Multi | FreeResponse),
   loanAmount: number
 ) => {
   const { pool, totalShares, totalBets } = contract

--- a/common/payouts-dpm.ts
+++ b/common/payouts-dpm.ts
@@ -2,11 +2,11 @@ import { sum, groupBy, sumBy, mapValues } from 'lodash'
 
 import { Bet, NumericBet } from './bet'
 import { deductDpmFees, getDpmProbability } from './calculate-dpm'
-import { Contract, DPM, FreeResponse, Multi } from './contract'
+import { DPMContract, FreeResponseContract } from './contract'
 import { DPM_CREATOR_FEE, DPM_FEES, DPM_PLATFORM_FEE } from './fees'
 import { addObjects } from './util/object'
 
-export const getDpmCancelPayouts = (contract: Contract & DPM, bets: Bet[]) => {
+export const getDpmCancelPayouts = (contract: DPMContract, bets: Bet[]) => {
   const { pool } = contract
   const poolTotal = sum(Object.values(pool))
   console.log('resolved N/A, pool M$', poolTotal)
@@ -28,7 +28,7 @@ export const getDpmCancelPayouts = (contract: Contract & DPM, bets: Bet[]) => {
 
 export const getDpmStandardPayouts = (
   outcome: string,
-  contract: Contract & DPM,
+  contract: DPMContract,
   bets: Bet[]
 ) => {
   const winningBets = bets.filter((bet) => bet.outcome === outcome)
@@ -75,7 +75,7 @@ export const getDpmStandardPayouts = (
 
 export const getNumericDpmPayouts = (
   outcome: string,
-  contract: Contract & DPM,
+  contract: DPMContract,
   bets: NumericBet[]
 ) => {
   const totalShares = sumBy(bets, (bet) => bet.allOutcomeShares[outcome] ?? 0)
@@ -126,7 +126,7 @@ export const getNumericDpmPayouts = (
 }
 
 export const getDpmMktPayouts = (
-  contract: Contract & DPM,
+  contract: DPMContract,
   bets: Bet[],
   resolutionProbability?: number
 ) => {
@@ -180,7 +180,7 @@ export const getDpmMktPayouts = (
 
 export const getPayoutsMultiOutcome = (
   resolutions: { [outcome: string]: number },
-  contract: Contract & (Multi | FreeResponse),
+  contract: FreeResponseContract,
   bets: Bet[]
 ) => {
   const poolTotal = sum(Object.values(contract.pool))

--- a/common/payouts-dpm.ts
+++ b/common/payouts-dpm.ts
@@ -2,14 +2,11 @@ import { sum, groupBy, sumBy, mapValues } from 'lodash'
 
 import { Bet, NumericBet } from './bet'
 import { deductDpmFees, getDpmProbability } from './calculate-dpm'
-import { DPM, FreeResponse, FullContract, Multi } from './contract'
+import { Contract, DPM, FreeResponse, Multi } from './contract'
 import { DPM_CREATOR_FEE, DPM_FEES, DPM_PLATFORM_FEE } from './fees'
 import { addObjects } from './util/object'
 
-export const getDpmCancelPayouts = (
-  contract: FullContract<DPM, any>,
-  bets: Bet[]
-) => {
+export const getDpmCancelPayouts = (contract: Contract & DPM, bets: Bet[]) => {
   const { pool } = contract
   const poolTotal = sum(Object.values(pool))
   console.log('resolved N/A, pool M$', poolTotal)
@@ -31,7 +28,7 @@ export const getDpmCancelPayouts = (
 
 export const getDpmStandardPayouts = (
   outcome: string,
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   bets: Bet[]
 ) => {
   const winningBets = bets.filter((bet) => bet.outcome === outcome)
@@ -78,7 +75,7 @@ export const getDpmStandardPayouts = (
 
 export const getNumericDpmPayouts = (
   outcome: string,
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   bets: NumericBet[]
 ) => {
   const totalShares = sumBy(bets, (bet) => bet.allOutcomeShares[outcome] ?? 0)
@@ -129,7 +126,7 @@ export const getNumericDpmPayouts = (
 }
 
 export const getDpmMktPayouts = (
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   bets: Bet[],
   resolutionProbability?: number
 ) => {
@@ -183,7 +180,7 @@ export const getDpmMktPayouts = (
 
 export const getPayoutsMultiOutcome = (
   resolutions: { [outcome: string]: number },
-  contract: FullContract<DPM, Multi | FreeResponse>,
+  contract: Contract & (Multi | FreeResponse),
   bets: Bet[]
 ) => {
   const poolTotal = sum(Object.values(contract.pool))

--- a/common/payouts-fixed.ts
+++ b/common/payouts-fixed.ts
@@ -3,7 +3,7 @@ import { sum } from 'lodash'
 import { Bet } from './bet'
 import { getProbability } from './calculate'
 import { getCpmmLiquidityPoolWeights } from './calculate-cpmm'
-import { Binary, Contract, CPMM, FixedPayouts } from './contract'
+import { CPMMContract } from './contract'
 import { noFees } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
 
@@ -30,7 +30,7 @@ export const getFixedCancelPayouts = (
 
 export const getStandardFixedPayouts = (
   outcome: string,
-  contract: Contract<FixedPayouts & Binary>,
+  contract: CPMMContract,
   bets: Bet[],
   liquidities: LiquidityProvision[]
 ) => {
@@ -65,7 +65,7 @@ export const getStandardFixedPayouts = (
 }
 
 export const getLiquidityPoolPayouts = (
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   outcome: string,
   liquidities: LiquidityProvision[]
 ) => {
@@ -81,7 +81,7 @@ export const getLiquidityPoolPayouts = (
 }
 
 export const getMktFixedPayouts = (
-  contract: Contract<FixedPayouts & Binary>,
+  contract: CPMMContract,
   bets: Bet[],
   liquidities: LiquidityProvision[],
   resolutionProbability?: number
@@ -116,7 +116,7 @@ export const getMktFixedPayouts = (
 }
 
 export const getLiquidityPoolProbPayouts = (
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   p: number,
   liquidities: LiquidityProvision[]
 ) => {

--- a/common/payouts-fixed.ts
+++ b/common/payouts-fixed.ts
@@ -3,7 +3,7 @@ import { sum } from 'lodash'
 import { Bet } from './bet'
 import { getProbability } from './calculate'
 import { getCpmmLiquidityPoolWeights } from './calculate-cpmm'
-import { Binary, CPMM, FixedPayouts, FullContract } from './contract'
+import { Binary, Contract, CPMM, FixedPayouts } from './contract'
 import { noFees } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
 
@@ -30,7 +30,7 @@ export const getFixedCancelPayouts = (
 
 export const getStandardFixedPayouts = (
   outcome: string,
-  contract: FullContract<FixedPayouts, Binary>,
+  contract: Contract<FixedPayouts & Binary>,
   bets: Bet[],
   liquidities: LiquidityProvision[]
 ) => {
@@ -65,7 +65,7 @@ export const getStandardFixedPayouts = (
 }
 
 export const getLiquidityPoolPayouts = (
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   outcome: string,
   liquidities: LiquidityProvision[]
 ) => {
@@ -81,7 +81,7 @@ export const getLiquidityPoolPayouts = (
 }
 
 export const getMktFixedPayouts = (
-  contract: FullContract<FixedPayouts, Binary>,
+  contract: Contract<FixedPayouts & Binary>,
   bets: Bet[],
   liquidities: LiquidityProvision[],
   resolutionProbability?: number
@@ -116,7 +116,7 @@ export const getMktFixedPayouts = (
 }
 
 export const getLiquidityPoolProbPayouts = (
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   p: number,
   liquidities: LiquidityProvision[]
 ) => {

--- a/common/payouts.ts
+++ b/common/payouts.ts
@@ -1,15 +1,7 @@
 import { sumBy, groupBy, mapValues } from 'lodash'
 
 import { Bet, NumericBet } from './bet'
-import {
-  Binary,
-  Contract,
-  DPM,
-  FixedPayouts,
-  FreeResponse,
-  FullContract,
-  Multi,
-} from './contract'
+import { Binary, Contract, DPM, FixedPayouts } from './contract'
 import { Fees } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
 import {
@@ -55,7 +47,7 @@ export type PayoutInfo = {
 }
 
 export const getPayouts = (
-  outcome: string,
+  outcome: string | undefined,
   resolutions: {
     [outcome: string]: number
   },
@@ -73,7 +65,6 @@ export const getPayouts = (
       resolutionProbability
     )
   }
-
   return getDpmPayouts(
     outcome,
     resolutions,
@@ -84,8 +75,8 @@ export const getPayouts = (
 }
 
 export const getFixedPayouts = (
-  outcome: string,
-  contract: FullContract<FixedPayouts, Binary>,
+  outcome: string | undefined,
+  contract: Contract<FixedPayouts & Binary>,
   bets: Bet[],
   liquidities: LiquidityProvision[],
   resolutionProbability?: number
@@ -108,11 +99,11 @@ export const getFixedPayouts = (
 }
 
 export const getDpmPayouts = (
-  outcome: string,
+  outcome: string | undefined,
   resolutions: {
     [outcome: string]: number
   },
-  contract: Contract,
+  contract: Contract & DPM,
   bets: Bet[],
   resolutionProbability?: number
 ): PayoutInfo => {
@@ -125,13 +116,10 @@ export const getDpmPayouts = (
 
     case 'MKT':
       return contract.outcomeType === 'FREE_RESPONSE'
-        ? getPayoutsMultiOutcome(
-            resolutions,
-            contract as FullContract<DPM, Multi | FreeResponse>,
-            openBets
-          )
+        ? getPayoutsMultiOutcome(resolutions, contract, openBets)
         : getDpmMktPayouts(contract, openBets, resolutionProbability)
     case 'CANCEL':
+    case undefined:
       return getDpmCancelPayouts(contract, openBets)
 
     default:

--- a/common/payouts.ts
+++ b/common/payouts.ts
@@ -1,7 +1,7 @@
 import { sumBy, groupBy, mapValues } from 'lodash'
 
 import { Bet, NumericBet } from './bet'
-import { Binary, Contract, DPM, FixedPayouts } from './contract'
+import { Contract, CPMMBinaryContract, DPMContract } from './contract'
 import { Fees } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
 import {
@@ -76,7 +76,7 @@ export const getPayouts = (
 
 export const getFixedPayouts = (
   outcome: string | undefined,
-  contract: Contract<FixedPayouts & Binary>,
+  contract: CPMMBinaryContract,
   bets: Bet[],
   liquidities: LiquidityProvision[],
   resolutionProbability?: number
@@ -103,7 +103,7 @@ export const getDpmPayouts = (
   resolutions: {
     [outcome: string]: number
   },
-  contract: Contract & DPM,
+  contract: DPMContract,
   bets: Bet[],
   resolutionProbability?: number
 ): PayoutInfo => {

--- a/common/scoring.ts
+++ b/common/scoring.ts
@@ -1,7 +1,7 @@
 import { groupBy, sumBy, mapValues, partition } from 'lodash'
 
 import { Bet } from './bet'
-import { Binary, Contract, FullContract } from './contract'
+import { Contract } from './contract'
 import { getPayouts } from './payouts'
 
 export function scoreCreators(contracts: Contract[]) {
@@ -24,23 +24,24 @@ export function scoreTraders(contracts: Contract[], bets: Bet[][]) {
   return userScores
 }
 
-export function scoreUsersByContract(
-  contract: FullContract<any, Binary>,
-  bets: Bet[]
-) {
-  const { resolution, resolutionProbability } = contract
+export function scoreUsersByContract(contract: Contract, bets: Bet[]) {
+  const { resolution } = contract
+  const resolutionProb =
+    contract.outcomeType == 'BINARY'
+      ? contract.resolutionProbability
+      : undefined
 
   const [closedBets, openBets] = partition(
     bets,
     (bet) => bet.isSold || bet.sale
   )
   const { payouts: resolvePayouts } = getPayouts(
-    resolution,
+    resolution as string,
     {},
     contract,
     openBets,
     [],
-    resolutionProbability
+    resolutionProb
   )
 
   const salePayouts = closedBets.map((bet) => {

--- a/common/sell-bet.ts
+++ b/common/sell-bet.ts
@@ -5,14 +5,14 @@ import {
   deductDpmFees,
 } from './calculate-dpm'
 import { calculateCpmmSale, getCpmmProbability } from './calculate-cpmm'
-import { Binary, Contract, DPM, CPMM } from './contract'
+import { CPMMContract, DPMContract } from './contract'
 import { DPM_CREATOR_FEE, DPM_PLATFORM_FEE, Fees } from './fees'
 import { User } from './user'
 
 export const getSellBetInfo = (
   user: User,
   bet: Bet,
-  contract: Contract & DPM,
+  contract: DPMContract,
   newBetId: string
 ) => {
   const { pool, totalShares, totalBets } = contract
@@ -87,7 +87,7 @@ export const getCpmmSellBetInfo = (
   user: User,
   shares: number,
   outcome: 'YES' | 'NO',
-  contract: Contract<CPMM & Binary>,
+  contract: CPMMContract,
   prevLoanAmount: number,
   newBetId: string
 ) => {

--- a/common/sell-bet.ts
+++ b/common/sell-bet.ts
@@ -5,14 +5,14 @@ import {
   deductDpmFees,
 } from './calculate-dpm'
 import { calculateCpmmSale, getCpmmProbability } from './calculate-cpmm'
-import { Binary, DPM, CPMM, FullContract } from './contract'
+import { Binary, Contract, DPM, CPMM } from './contract'
 import { DPM_CREATOR_FEE, DPM_PLATFORM_FEE, Fees } from './fees'
 import { User } from './user'
 
 export const getSellBetInfo = (
   user: User,
   bet: Bet,
-  contract: FullContract<DPM, any>,
+  contract: Contract & DPM,
   newBetId: string
 ) => {
   const { pool, totalShares, totalBets } = contract
@@ -87,7 +87,7 @@ export const getCpmmSellBetInfo = (
   user: User,
   shares: number,
   outcome: 'YES' | 'NO',
-  contract: FullContract<CPMM, Binary>,
+  contract: Contract<CPMM & Binary>,
   prevLoanAmount: number,
   newBetId: string
 ) => {

--- a/functions/src/create-answer.ts
+++ b/functions/src/create-answer.ts
@@ -1,12 +1,7 @@
 import * as functions from 'firebase-functions'
 import * as admin from 'firebase-admin'
 
-import {
-  Contract,
-  DPM,
-  FreeResponse,
-  FullContract,
-} from '../../common/contract'
+import { Contract } from '../../common/contract'
 import { User } from '../../common/user'
 import { getNewMultiBetInfo } from '../../common/new-bet'
 import { Answer, MAX_ANSWER_LENGTH } from '../../common/answer'
@@ -96,12 +91,7 @@ export const createAnswer = functions.runWith({ minInstances: 1 }).https.onCall(
       const loanAmount = 0
 
       const { newBet, newPool, newTotalShares, newTotalBets } =
-        getNewMultiBetInfo(
-          answerId,
-          amount,
-          contract as FullContract<DPM, FreeResponse>,
-          loanAmount
-        )
+        getNewMultiBetInfo(answerId, amount, contract, loanAmount)
 
       const newBalance = user.balance - amount
       const betDoc = firestore.collection(`contracts/${contractId}/bets`).doc()

--- a/functions/src/create-contract.ts
+++ b/functions/src/create-contract.ts
@@ -20,7 +20,6 @@ import { APIError, newEndpoint, validate, zTimestamp } from './api'
 
 import {
   FIXED_ANTE,
-  getAnteBets,
   getCpmmInitialLiquidity,
   getFreeAnswerAnte,
   getNumericAnte,
@@ -115,23 +114,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
   const providerId = isFree ? HOUSE_LIQUIDITY_PROVIDER_ID : user.id
 
-  if (outcomeType === 'BINARY' && contract.mechanism === 'dpm-2') {
-    const yesBetDoc = firestore
-      .collection(`contracts/${contract.id}/bets`)
-      .doc()
-
-    const noBetDoc = firestore.collection(`contracts/${contract.id}/bets`).doc()
-
-    const { yesBet, noBet } = getAnteBets(
-      user,
-      contract as any,
-      yesBetDoc.id,
-      noBetDoc.id
-    )
-
-    await yesBetDoc.set(yesBet)
-    await noBetDoc.set(noBet)
-  } else if (outcomeType === 'BINARY') {
+  if (outcomeType === 'BINARY') {
     const liquidityDoc = firestore
       .collection(`contracts/${contract.id}/liquidity`)
       .doc()

--- a/functions/src/create-contract.ts
+++ b/functions/src/create-contract.ts
@@ -2,14 +2,13 @@ import * as admin from 'firebase-admin'
 import { z } from 'zod'
 
 import {
-  Binary,
+  CPMMBinaryContract,
   Contract,
-  CPMM,
-  FreeResponse,
+  FreeResponseContract,
   MAX_DESCRIPTION_LENGTH,
   MAX_QUESTION_LENGTH,
   MAX_TAG_LENGTH,
-  Numeric,
+  NumericContract,
   OUTCOME_TYPES,
 } from '../../common/contract'
 import { slugify } from '../../common/util/slugify'
@@ -121,7 +120,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
     const lp = getCpmmInitialLiquidity(
       providerId,
-      contract as Contract<CPMM & Binary>,
+      contract as CPMMBinaryContract,
       liquidityDoc.id,
       ante
     )
@@ -141,7 +140,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
     const anteBet = getFreeAnswerAnte(
       providerId,
-      contract as Contract & FreeResponse,
+      contract as FreeResponseContract,
       anteBetDoc.id
     )
     await anteBetDoc.set(anteBet)
@@ -152,7 +151,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
     const anteBet = getNumericAnte(
       providerId,
-      contract as Contract & Numeric,
+      contract as NumericContract,
       ante,
       anteBetDoc.id
     )

--- a/functions/src/create-contract.ts
+++ b/functions/src/create-contract.ts
@@ -5,9 +5,7 @@ import {
   Binary,
   Contract,
   CPMM,
-  DPM,
   FreeResponse,
-  FullContract,
   MAX_DESCRIPTION_LENGTH,
   MAX_QUESTION_LENGTH,
   MAX_TAG_LENGTH,
@@ -126,7 +124,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
     const { yesBet, noBet } = getAnteBets(
       user,
-      contract as FullContract<DPM, Binary>,
+      contract as any,
       yesBetDoc.id,
       noBetDoc.id
     )
@@ -140,7 +138,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
     const lp = getCpmmInitialLiquidity(
       providerId,
-      contract as FullContract<CPMM, Binary>,
+      contract as Contract<CPMM & Binary>,
       liquidityDoc.id,
       ante
     )
@@ -160,7 +158,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
     const anteBet = getFreeAnswerAnte(
       providerId,
-      contract as FullContract<DPM, FreeResponse>,
+      contract as Contract & FreeResponse,
       anteBetDoc.id
     )
     await anteBetDoc.set(anteBet)
@@ -171,7 +169,7 @@ export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
 
     const anteBet = getNumericAnte(
       providerId,
-      contract as FullContract<DPM, Numeric>,
+      contract as Contract & Numeric,
       ante,
       anteBetDoc.id
     )

--- a/functions/src/redeem-shares.ts
+++ b/functions/src/redeem-shares.ts
@@ -4,7 +4,7 @@ import { partition, sumBy } from 'lodash'
 import { Bet } from '../../common/bet'
 import { getProbability } from '../../common/calculate'
 
-import { Binary, CPMM, FullContract } from '../../common/contract'
+import { Contract } from '../../common/contract'
 import { noFees } from '../../common/fees'
 import { User } from '../../common/user'
 
@@ -15,7 +15,7 @@ export const redeemShares = async (userId: string, contractId: string) => {
     if (!contractSnap.exists)
       return { status: 'error', message: 'Invalid contract' }
 
-    const contract = contractSnap.data() as FullContract<CPMM, Binary>
+    const contract = contractSnap.data() as Contract
     if (contract.outcomeType !== 'BINARY' || contract.mechanism !== 'cpmm-1')
       return { status: 'success' }
 

--- a/functions/src/scripts/correct-bet-probability.ts
+++ b/functions/src/scripts/correct-bet-probability.ts
@@ -6,14 +6,14 @@ initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { getDpmProbability } from '../../../common/calculate-dpm'
-import { Binary, Contract, DPM, FullContract } from '../../../common/contract'
+import { Binary, Contract, DPM } from '../../../common/contract'
 
 type DocRef = admin.firestore.DocumentReference
 const firestore = admin.firestore()
 
 async function migrateContract(
   contractRef: DocRef,
-  contract: FullContract<DPM, Binary>
+  contract: Contract<DPM & Binary>
 ) {
   const bets = await contractRef
     .collection('bets')
@@ -35,7 +35,7 @@ async function migrateContract(
 async function migrateContracts() {
   const snapshot = await firestore.collection('contracts').get()
   const contracts = snapshot.docs.map(
-    (doc) => doc.data() as FullContract<DPM, Binary>
+    (doc) => doc.data() as Contract<DPM & Binary>
   )
 
   console.log('Loaded contracts', contracts.length)

--- a/functions/src/scripts/correct-bet-probability.ts
+++ b/functions/src/scripts/correct-bet-probability.ts
@@ -6,14 +6,14 @@ initAdmin()
 
 import { Bet } from '../../../common/bet'
 import { getDpmProbability } from '../../../common/calculate-dpm'
-import { Binary, Contract, DPM } from '../../../common/contract'
+import { DPMBinaryContract } from '../../../common/contract'
 
 type DocRef = admin.firestore.DocumentReference
 const firestore = admin.firestore()
 
 async function migrateContract(
   contractRef: DocRef,
-  contract: Contract<DPM & Binary>
+  contract: DPMBinaryContract
 ) {
   const bets = await contractRef
     .collection('bets')
@@ -34,9 +34,7 @@ async function migrateContract(
 
 async function migrateContracts() {
   const snapshot = await firestore.collection('contracts').get()
-  const contracts = snapshot.docs.map(
-    (doc) => doc.data() as Contract<DPM & Binary>
-  )
+  const contracts = snapshot.docs.map((doc) => doc.data() as DPMBinaryContract)
 
   console.log('Loaded contracts', contracts.length)
 

--- a/functions/src/scripts/migrate-to-cfmm.ts
+++ b/functions/src/scripts/migrate-to-cfmm.ts
@@ -4,13 +4,7 @@ import { sortBy } from 'lodash'
 import { initAdmin } from './script-init'
 initAdmin()
 
-import {
-  Binary,
-  Contract,
-  CPMM,
-  DPM,
-  FullContract,
-} from '../../../common/contract'
+import { Binary, Contract, CPMM, DPM } from '../../../common/contract'
 import { Bet } from '../../../common/bet'
 import {
   calculateDpmPayout,
@@ -28,7 +22,7 @@ const firestore = admin.firestore()
 async function recalculateContract(contractRef: DocRef, isCommit = false) {
   await firestore.runTransaction(async (transaction) => {
     const contractDoc = await transaction.get(contractRef)
-    const contract = contractDoc.data() as FullContract<DPM, Binary>
+    const contract = contractDoc.data() as Contract<DPM & Binary>
 
     if (!contract?.slug) {
       console.log('missing slug; id=', contractRef.id)
@@ -110,7 +104,7 @@ async function recalculateContract(contractRef: DocRef, isCommit = false) {
       {
         ...contract,
         ...contractUpdate,
-      } as FullContract<CPMM, Binary>,
+      } as Contract<CPMM & Binary>,
       liquidityDocRef.id,
       ante
     )

--- a/functions/src/scripts/migrate-to-cfmm.ts
+++ b/functions/src/scripts/migrate-to-cfmm.ts
@@ -4,13 +4,16 @@ import { sortBy } from 'lodash'
 import { initAdmin } from './script-init'
 initAdmin()
 
-import { Binary, Contract, CPMM, DPM } from '../../../common/contract'
+import {
+  Contract,
+  DPMBinaryContract,
+  CPMMBinaryContract,
+} from '../../../common/contract'
 import { Bet } from '../../../common/bet'
 import {
   calculateDpmPayout,
   getDpmProbability,
 } from '../../../common/calculate-dpm'
-import { User } from '../../../common/user'
 import { getCpmmInitialLiquidity } from '../../../common/antes'
 import { noFees } from '../../../common/fees'
 import { addObjects } from '../../../common/util/object'
@@ -22,7 +25,7 @@ const firestore = admin.firestore()
 async function recalculateContract(contractRef: DocRef, isCommit = false) {
   await firestore.runTransaction(async (transaction) => {
     const contractDoc = await transaction.get(contractRef)
-    const contract = contractDoc.data() as Contract<DPM & Binary>
+    const contract = contractDoc.data() as DPMBinaryContract
 
     if (!contract?.slug) {
       console.log('missing slug; id=', contractRef.id)
@@ -104,7 +107,7 @@ async function recalculateContract(contractRef: DocRef, isCommit = false) {
       {
         ...contract,
         ...contractUpdate,
-      } as Contract<CPMM & Binary>,
+      } as CPMMBinaryContract,
       liquidityDocRef.id,
       ante
     )

--- a/functions/src/scripts/migrate-to-dpm-2.ts
+++ b/functions/src/scripts/migrate-to-dpm-2.ts
@@ -4,7 +4,7 @@ import { sortBy, sumBy } from 'lodash'
 import { initAdmin } from './script-init'
 initAdmin()
 
-import { Binary, Contract, DPM } from '../../../common/contract'
+import { Contract, DPMBinaryContract } from '../../../common/contract'
 import { Bet } from '../../../common/bet'
 import {
   calculateDpmShares,
@@ -32,7 +32,7 @@ async function recalculateContract(
 
   await firestore.runTransaction(async (transaction) => {
     const contractDoc = await transaction.get(contractRef)
-    const contract = contractDoc.data() as Contract<DPM & Binary>
+    const contract = contractDoc.data() as DPMBinaryContract
 
     const betDocs = await transaction.get(contractRef.collection('bets'))
     const bets = sortBy(

--- a/functions/src/scripts/migrate-to-dpm-2.ts
+++ b/functions/src/scripts/migrate-to-dpm-2.ts
@@ -4,7 +4,7 @@ import { sortBy, sumBy } from 'lodash'
 import { initAdmin } from './script-init'
 initAdmin()
 
-import { Binary, Contract, DPM, FullContract } from '../../../common/contract'
+import { Binary, Contract, DPM } from '../../../common/contract'
 import { Bet } from '../../../common/bet'
 import {
   calculateDpmShares,
@@ -32,7 +32,7 @@ async function recalculateContract(
 
   await firestore.runTransaction(async (transaction) => {
     const contractDoc = await transaction.get(contractRef)
-    const contract = contractDoc.data() as FullContract<DPM, Binary>
+    const contract = contractDoc.data() as Contract<DPM & Binary>
 
     const betDocs = await transaction.get(contractRef.collection('bets'))
     const bets = sortBy(

--- a/functions/src/sell-shares.ts
+++ b/functions/src/sell-shares.ts
@@ -2,7 +2,7 @@ import { partition, sumBy } from 'lodash'
 import * as admin from 'firebase-admin'
 import * as functions from 'firebase-functions'
 
-import { Binary, Contract } from '../../common/contract'
+import { BinaryContract } from '../../common/contract'
 import { User } from '../../common/user'
 import { getCpmmSellBetInfo } from '../../common/sell-bet'
 import { addObjects, removeUndefinedProps } from '../../common/util/object'
@@ -35,7 +35,7 @@ export const sellShares = functions.runWith({ minInstances: 1 }).https.onCall(
       const contractSnap = await transaction.get(contractDoc)
       if (!contractSnap.exists)
         return { status: 'error', message: 'Invalid contract' }
-      const contract = contractSnap.data() as Contract & Binary
+      const contract = contractSnap.data() as BinaryContract
       const { closeTime, mechanism, collectedFees, volume } = contract
 
       if (mechanism !== 'cpmm-1')

--- a/functions/src/sell-shares.ts
+++ b/functions/src/sell-shares.ts
@@ -2,7 +2,7 @@ import { partition, sumBy } from 'lodash'
 import * as admin from 'firebase-admin'
 import * as functions from 'firebase-functions'
 
-import { Binary, CPMM, FullContract } from '../../common/contract'
+import { Binary, Contract } from '../../common/contract'
 import { User } from '../../common/user'
 import { getCpmmSellBetInfo } from '../../common/sell-bet'
 import { addObjects, removeUndefinedProps } from '../../common/util/object'
@@ -35,7 +35,7 @@ export const sellShares = functions.runWith({ minInstances: 1 }).https.onCall(
       const contractSnap = await transaction.get(contractDoc)
       if (!contractSnap.exists)
         return { status: 'error', message: 'Invalid contract' }
-      const contract = contractSnap.data() as FullContract<CPMM, Binary>
+      const contract = contractSnap.data() as Contract & Binary
       const { closeTime, mechanism, collectedFees, volume } = contract
 
       if (mechanism !== 'cpmm-1')

--- a/web/components/answers/answer-bet-panel.tsx
+++ b/web/components/answers/answer-bet-panel.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { XIcon } from '@heroicons/react/solid'
 
 import { Answer } from 'common/answer'
-import { Contract, FreeResponse } from 'common/contract'
+import { FreeResponseContract } from 'common/contract'
 import { BuyAmountInput } from '../amount-input'
 import { Col } from '../layout/col'
 import { APIError, placeBet } from 'web/lib/firebase/api-call'
@@ -27,7 +27,7 @@ import { Bet } from 'common/bet'
 
 export function AnswerBetPanel(props: {
   answer: Answer
-  contract: Contract & FreeResponse
+  contract: FreeResponseContract
   closePanel: () => void
   className?: string
   isModal?: boolean

--- a/web/components/answers/answer-bet-panel.tsx
+++ b/web/components/answers/answer-bet-panel.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { XIcon } from '@heroicons/react/solid'
 
 import { Answer } from 'common/answer'
-import { DPM, FreeResponse, FullContract } from 'common/contract'
+import { Contract, FreeResponse } from 'common/contract'
 import { BuyAmountInput } from '../amount-input'
 import { Col } from '../layout/col'
 import { APIError, placeBet } from 'web/lib/firebase/api-call'
@@ -27,7 +27,7 @@ import { Bet } from 'common/bet'
 
 export function AnswerBetPanel(props: {
   answer: Answer
-  contract: FullContract<DPM, FreeResponse>
+  contract: Contract & FreeResponse
   closePanel: () => void
   className?: string
   isModal?: boolean

--- a/web/components/answers/answer-item.tsx
+++ b/web/components/answers/answer-item.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 
 import { Answer } from 'common/answer'
-import { DPM, FreeResponse, FullContract } from 'common/contract'
+import { Contract, FreeResponse } from 'common/contract'
 import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 import { Avatar } from '../avatar'
@@ -13,7 +13,7 @@ import { Linkify } from '../linkify'
 
 export function AnswerItem(props: {
   answer: Answer
-  contract: FullContract<DPM, FreeResponse>
+  contract: Contract & FreeResponse
   showChoice: 'radio' | 'checkbox' | undefined
   chosenProb: number | undefined
   totalChosenProb?: number

--- a/web/components/answers/answer-item.tsx
+++ b/web/components/answers/answer-item.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 
 import { Answer } from 'common/answer'
-import { Contract, FreeResponse } from 'common/contract'
+import { FreeResponseContract } from 'common/contract'
 import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 import { Avatar } from '../avatar'
@@ -13,7 +13,7 @@ import { Linkify } from '../linkify'
 
 export function AnswerItem(props: {
   answer: Answer
-  contract: Contract & FreeResponse
+  contract: FreeResponseContract
   showChoice: 'radio' | 'checkbox' | undefined
   chosenProb: number | undefined
   totalChosenProb?: number

--- a/web/components/answers/answer-resolve-panel.tsx
+++ b/web/components/answers/answer-resolve-panel.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { sum, mapValues } from 'lodash'
 import { useState } from 'react'
 
-import { DPM, FreeResponse, FullContract } from 'common/contract'
+import { Contract, FreeResponse } from 'common/contract'
 import { Col } from '../layout/col'
 import { resolveMarket } from 'web/lib/firebase/fn-call'
 import { Row } from '../layout/row'
@@ -11,7 +11,7 @@ import { ResolveConfirmationButton } from '../confirmation-button'
 import { removeUndefinedProps } from 'common/util/object'
 
 export function AnswerResolvePanel(props: {
-  contract: FullContract<DPM, FreeResponse>
+  contract: Contract & FreeResponse
   resolveOption: 'CHOOSE' | 'CHOOSE_MULTIPLE' | 'CANCEL' | undefined
   setResolveOption: (
     option: 'CHOOSE' | 'CHOOSE_MULTIPLE' | 'CANCEL' | undefined

--- a/web/components/answers/answers-graph.tsx
+++ b/web/components/answers/answers-graph.tsx
@@ -5,7 +5,7 @@ import { groupBy, sortBy, sumBy } from 'lodash'
 import { memo } from 'react'
 
 import { Bet } from 'common/bet'
-import { Contract, FreeResponse } from 'common/contract'
+import { FreeResponseContract } from 'common/contract'
 import { getOutcomeProbability } from 'common/calculate'
 import { useBets } from 'web/hooks/use-bets'
 import { useWindowSize } from 'web/hooks/use-window-size'
@@ -13,7 +13,7 @@ import { useWindowSize } from 'web/hooks/use-window-size'
 const NUM_LINES = 6
 
 export const AnswersGraph = memo(function AnswersGraph(props: {
-  contract: Contract & FreeResponse
+  contract: FreeResponseContract
   bets: Bet[]
   height?: number
 }) {
@@ -161,10 +161,7 @@ function formatTime(time: number, includeTime: boolean) {
   return dayjs(time).format('MMM D')
 }
 
-const computeProbsByOutcome = (
-  bets: Bet[],
-  contract: Contract & FreeResponse
-) => {
+const computeProbsByOutcome = (bets: Bet[], contract: FreeResponseContract) => {
   const { totalBets } = contract
 
   const betsByOutcome = groupBy(bets, (bet) => bet.outcome)

--- a/web/components/answers/answers-graph.tsx
+++ b/web/components/answers/answers-graph.tsx
@@ -5,7 +5,7 @@ import { groupBy, sortBy, sumBy } from 'lodash'
 import { memo } from 'react'
 
 import { Bet } from 'common/bet'
-import { DPM, FreeResponse, FullContract } from 'common/contract'
+import { Contract, FreeResponse } from 'common/contract'
 import { getOutcomeProbability } from 'common/calculate'
 import { useBets } from 'web/hooks/use-bets'
 import { useWindowSize } from 'web/hooks/use-window-size'
@@ -13,7 +13,7 @@ import { useWindowSize } from 'web/hooks/use-window-size'
 const NUM_LINES = 6
 
 export const AnswersGraph = memo(function AnswersGraph(props: {
-  contract: FullContract<DPM, FreeResponse>
+  contract: Contract & FreeResponse
   bets: Bet[]
   height?: number
 }) {
@@ -163,7 +163,7 @@ function formatTime(time: number, includeTime: boolean) {
 
 const computeProbsByOutcome = (
   bets: Bet[],
-  contract: FullContract<DPM, FreeResponse>
+  contract: Contract & FreeResponse
 ) => {
   const { totalBets } = contract
 

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -1,7 +1,7 @@
 import { sortBy, partition, sum, uniq } from 'lodash'
 import { useLayoutEffect, useState } from 'react'
 
-import { Contract, FreeResponse } from 'common/contract'
+import { FreeResponseContract } from 'common/contract'
 import { Col } from '../layout/col'
 import { useUser } from 'web/hooks/use-user'
 import { getDpmOutcomeProbability } from 'common/calculate-dpm'
@@ -25,7 +25,7 @@ import { UserLink } from 'web/components/user-page'
 import { Linkify } from 'web/components/linkify'
 import { BuyButton } from 'web/components/yes-no-selector'
 
-export function AnswersPanel(props: { contract: Contract & FreeResponse }) {
+export function AnswersPanel(props: { contract: FreeResponseContract }) {
   const { contract } = props
   const { creatorId, resolution, resolutions, totalBets } = contract
 
@@ -152,7 +152,7 @@ export function AnswersPanel(props: { contract: Contract & FreeResponse }) {
 }
 
 function getAnswerItems(
-  contract: Contract & FreeResponse,
+  contract: FreeResponseContract,
   answers: Answer[],
   user: User | undefined | null
 ) {
@@ -180,7 +180,7 @@ function getAnswerItems(
 }
 
 function OpenAnswer(props: {
-  contract: Contract & FreeResponse
+  contract: FreeResponseContract
   answer: Answer
   items: ActivityItem[]
   type: string

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -1,7 +1,7 @@
 import { sortBy, partition, sum, uniq } from 'lodash'
 import { useLayoutEffect, useState } from 'react'
 
-import { DPM, FreeResponse, FullContract } from 'common/contract'
+import { Contract, FreeResponse } from 'common/contract'
 import { Col } from '../layout/col'
 import { useUser } from 'web/hooks/use-user'
 import { getDpmOutcomeProbability } from 'common/calculate-dpm'
@@ -25,9 +25,7 @@ import { UserLink } from 'web/components/user-page'
 import { Linkify } from 'web/components/linkify'
 import { BuyButton } from 'web/components/yes-no-selector'
 
-export function AnswersPanel(props: {
-  contract: FullContract<DPM, FreeResponse>
-}) {
+export function AnswersPanel(props: { contract: Contract & FreeResponse }) {
   const { contract } = props
   const { creatorId, resolution, resolutions, totalBets } = contract
 
@@ -154,7 +152,7 @@ export function AnswersPanel(props: {
 }
 
 function getAnswerItems(
-  contract: FullContract<DPM, FreeResponse>,
+  contract: Contract & FreeResponse,
   answers: Answer[],
   user: User | undefined | null
 ) {
@@ -182,7 +180,7 @@ function getAnswerItems(
 }
 
 function OpenAnswer(props: {
-  contract: FullContract<any, FreeResponse>
+  contract: Contract & FreeResponse
   answer: Answer
   items: ActivityItem[]
   type: string

--- a/web/components/answers/create-answer-panel.tsx
+++ b/web/components/answers/create-answer-panel.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { useState } from 'react'
 import Textarea from 'react-expanding-textarea'
 
-import { DPM, FreeResponse, FullContract } from 'common/contract'
+import { Contract, FreeResponse } from 'common/contract'
 import { BuyAmountInput } from '../amount-input'
 import { Col } from '../layout/col'
 import { createAnswer } from 'web/lib/firebase/fn-call'
@@ -24,7 +24,7 @@ import { Bet } from 'common/bet'
 import { MAX_ANSWER_LENGTH } from 'common/answer'
 
 export function CreateAnswerPanel(props: {
-  contract: FullContract<DPM, FreeResponse>
+  contract: Contract & FreeResponse
 }) {
   const { contract } = props
   const user = useUser()

--- a/web/components/answers/create-answer-panel.tsx
+++ b/web/components/answers/create-answer-panel.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { useState } from 'react'
 import Textarea from 'react-expanding-textarea'
 
-import { Contract, FreeResponse } from 'common/contract'
+import { FreeResponseContract } from 'common/contract'
 import { BuyAmountInput } from '../amount-input'
 import { Col } from '../layout/col'
 import { createAnswer } from 'web/lib/firebase/fn-call'
@@ -23,9 +23,7 @@ import { firebaseLogin } from 'web/lib/firebase/users'
 import { Bet } from 'common/bet'
 import { MAX_ANSWER_LENGTH } from 'common/answer'
 
-export function CreateAnswerPanel(props: {
-  contract: Contract & FreeResponse
-}) {
+export function CreateAnswerPanel(props: { contract: FreeResponseContract }) {
   const { contract } = props
   const user = useUser()
   const [text, setText] = useState('')

--- a/web/components/bet-panel.tsx
+++ b/web/components/bet-panel.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { partition, sumBy } from 'lodash'
 
 import { useUser } from 'web/hooks/use-user'
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import { Binary, CPMM, Contract } from 'common/contract'
 import { Col } from './layout/col'
 import { Row } from './layout/row'
 import { Spacer } from './layout/spacer'
@@ -39,7 +39,7 @@ import { useSaveShares } from './use-save-shares'
 import { SignUpPrompt } from './sign-up-prompt'
 
 export function BetPanel(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   className?: string
 }) {
   const { contract, className } = props
@@ -78,7 +78,7 @@ export function BetPanel(props: {
 }
 
 export function BetPanelSwitcher(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   className?: string
   title?: string // Set if BetPanel is on a feed modal
   selected?: 'YES' | 'NO'
@@ -157,16 +157,19 @@ export function BetPanelSwitcher(props: {
           text={tradeType === 'BUY' ? title ?? 'Place a trade' : 'Sell shares'}
         />
 
-        {tradeType === 'SELL' && user && sharesOutcome && (
-          <SellPanel
-            contract={contract as FullContract<CPMM, Binary>}
-            shares={yesShares || noShares}
-            sharesOutcome={sharesOutcome}
-            user={user}
-            userBets={userBets ?? []}
-            onSellSuccess={onBetSuccess}
-          />
-        )}
+        {tradeType === 'SELL' &&
+          mechanism == 'cpmm-1' &&
+          user &&
+          sharesOutcome && (
+            <SellPanel
+              contract={contract}
+              shares={yesShares || noShares}
+              sharesOutcome={sharesOutcome}
+              user={user}
+              userBets={userBets ?? []}
+              onSellSuccess={onBetSuccess}
+            />
+          )}
 
         {tradeType === 'BUY' && (
           <BuyPanel
@@ -184,7 +187,7 @@ export function BetPanelSwitcher(props: {
 }
 
 function BuyPanel(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   user: User | null | undefined
   selected?: 'YES' | 'NO'
   onBuySuccess?: () => void
@@ -374,7 +377,7 @@ function BuyPanel(props: {
 }
 
 export function SellPanel(props: {
-  contract: FullContract<CPMM, Binary>
+  contract: Contract & CPMM & Binary
   userBets: Bet[]
   shares: number
   sharesOutcome: 'YES' | 'NO'

--- a/web/components/bet-panel.tsx
+++ b/web/components/bet-panel.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { partition, sumBy } from 'lodash'
 
 import { useUser } from 'web/hooks/use-user'
-import { Binary, CPMM, Contract } from 'common/contract'
+import { BinaryContract, CPMMBinaryContract } from 'common/contract'
 import { Col } from './layout/col'
 import { Row } from './layout/row'
 import { Spacer } from './layout/spacer'
@@ -39,7 +39,7 @@ import { useSaveShares } from './use-save-shares'
 import { SignUpPrompt } from './sign-up-prompt'
 
 export function BetPanel(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   className?: string
 }) {
   const { contract, className } = props
@@ -78,7 +78,7 @@ export function BetPanel(props: {
 }
 
 export function BetPanelSwitcher(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   className?: string
   title?: string // Set if BetPanel is on a feed modal
   selected?: 'YES' | 'NO'
@@ -187,7 +187,7 @@ export function BetPanelSwitcher(props: {
 }
 
 function BuyPanel(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   user: User | null | undefined
   selected?: 'YES' | 'NO'
   onBuySuccess?: () => void
@@ -377,7 +377,7 @@ function BuyPanel(props: {
 }
 
 export function SellPanel(props: {
-  contract: Contract & CPMM & Binary
+  contract: CPMMBinaryContract
   userBets: Bet[]
   shares: number
   sharesOutcome: 'YES' | 'NO'

--- a/web/components/bet-row.tsx
+++ b/web/components/bet-row.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 
 import { BetPanelSwitcher } from './bet-panel'
 import { YesNoSelector } from './yes-no-selector'
-import { Binary, Contract } from 'common/contract'
+import { BinaryContract } from 'common/contract'
 import { Modal } from './layout/modal'
 import { SellButton } from './sell-button'
 import { useUser } from 'web/hooks/use-user'
@@ -12,7 +12,7 @@ import { useSaveShares } from './use-save-shares'
 
 // Inline version of a bet panel. Opens BetPanel in a new modal.
 export default function BetRow(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   className?: string
   btnClassName?: string
   betPanelClassName?: string

--- a/web/components/bet-row.tsx
+++ b/web/components/bet-row.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 
 import { BetPanelSwitcher } from './bet-panel'
 import { YesNoSelector } from './yes-no-selector'
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import { Binary, Contract } from 'common/contract'
 import { Modal } from './layout/modal'
 import { SellButton } from './sell-button'
 import { useUser } from 'web/hooks/use-user'
@@ -12,7 +12,7 @@ import { useSaveShares } from './use-save-shares'
 
 // Inline version of a bet panel. Opens BetPanel in a new modal.
 export default function BetRow(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   className?: string
   btnClassName?: string
   betPanelClassName?: string

--- a/web/components/bets-list.tsx
+++ b/web/components/bets-list.tsx
@@ -255,7 +255,6 @@ function MyContractBets(props: {
   const [collapsed, setCollapsed] = useState(true)
 
   const isBinary = outcomeType === 'BINARY'
-  const probPercent = getBinaryProbPercent(contract)
 
   const { payout, profit, profitPercent, invested } = getContractBetMetrics(
     contract,
@@ -292,24 +291,27 @@ function MyContractBets(props: {
           </Row>
 
           <Row className="flex-1 items-center gap-2 text-sm text-gray-500">
-            {(isBinary || resolution) && (
+            {resolution ? (
               <>
-                {resolution ? (
-                  <div>
-                    Resolved{' '}
-                    <OutcomeLabel
-                      outcome={resolution}
-                      value={resolutionValue}
-                      contract={contract}
-                      truncate="short"
-                    />
-                  </div>
-                ) : (
-                  <div className="text-primary text-lg">{probPercent}</div>
-                )}
+                <div>
+                  Resolved{' '}
+                  <OutcomeLabel
+                    outcome={resolution}
+                    value={resolutionValue}
+                    contract={contract}
+                    truncate="short"
+                  />
+                </div>
                 <div>•</div>
               </>
-            )}
+            ) : isBinary ? (
+              <>
+                <div className="text-primary text-lg">
+                  {getBinaryProbPercent(contract)}
+                </div>
+                <div>•</div>
+              </>
+            ) : null}
             <UserLink
               name={contract.creatorName}
               username={contract.creatorUsername}

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -5,8 +5,8 @@ import { formatLargeNumber, formatPercent } from 'common/util/format'
 import { contractPath, getBinaryProbPercent } from 'web/lib/firebase/contracts'
 import { Col } from '../layout/col'
 import {
-  Binary,
   Contract,
+  BinaryContract,
   FreeResponseContract,
   NumericContract,
 } from 'common/contract'
@@ -125,7 +125,7 @@ export function ContractCard(props: {
 }
 
 export function BinaryResolutionOrChance(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   large?: boolean
   className?: string
 }) {

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -2,19 +2,12 @@ import clsx from 'clsx'
 import Link from 'next/link'
 import { Row } from '../layout/row'
 import { formatLargeNumber, formatPercent } from 'common/util/format'
-import {
-  Contract,
-  contractPath,
-  getBinaryProbPercent,
-} from 'web/lib/firebase/contracts'
+import { contractPath, getBinaryProbPercent } from 'web/lib/firebase/contracts'
 import { Col } from '../layout/col'
 import {
   Binary,
-  CPMM,
-  DPM,
-  FreeResponse,
+  Contract,
   FreeResponseContract,
-  FullContract,
   NumericContract,
 } from 'common/contract'
 import {
@@ -83,15 +76,12 @@ export function ContractCard(props: {
             {outcomeType === 'FREE_RESPONSE' &&
               (resolution ? (
                 <FreeResponseOutcomeLabel
-                  contract={contract as FreeResponseContract}
+                  contract={contract}
                   resolution={resolution}
                   truncate={'long'}
                 />
               ) : (
-                <FreeResponseTopAnswer
-                  contract={contract as FullContract<DPM, FreeResponse>}
-                  truncate="long"
-                />
+                <FreeResponseTopAnswer contract={contract} truncate="long" />
               ))}
 
             <MiscDetails
@@ -114,14 +104,14 @@ export function ContractCard(props: {
               {outcomeType === 'NUMERIC' && (
                 <NumericResolutionOrExpectation
                   className="items-center"
-                  contract={contract as NumericContract}
+                  contract={contract}
                 />
               )}
 
               {outcomeType === 'FREE_RESPONSE' && (
                 <FreeResponseResolutionOrChance
                   className="self-end text-gray-600"
-                  contract={contract as FullContract<DPM, FreeResponse>}
+                  contract={contract}
                   truncate="long"
                 />
               )}
@@ -135,7 +125,7 @@ export function ContractCard(props: {
 }
 
 export function BinaryResolutionOrChance(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   large?: boolean
   className?: string
 }) {

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -1,4 +1,4 @@
-import { Contract, tradingAllowed } from 'web/lib/firebase/contracts'
+import { tradingAllowed } from 'web/lib/firebase/contracts'
 import { Col } from '../layout/col'
 import { Spacer } from '../layout/spacer'
 import { ContractProbGraph } from './contract-prob-graph'
@@ -16,12 +16,7 @@ import { Bet } from 'common/bet'
 import { Comment } from 'common/comment'
 import BetRow from '../bet-row'
 import { AnswersGraph } from '../answers/answers-graph'
-import {
-  DPM,
-  FreeResponse,
-  FullContract,
-  NumericContract,
-} from 'common/contract'
+import { Contract } from 'common/contract'
 import { ContractDescription } from './contract-description'
 import { ContractDetails } from './contract-details'
 import { ShareMarket } from '../share-market'
@@ -58,7 +53,7 @@ export const ContractOverview = (props: {
 
           {outcomeType === 'NUMERIC' && (
             <NumericResolutionOrExpectation
-              contract={contract as NumericContract}
+              contract={contract}
               className="hidden items-end xl:flex"
             />
           )}
@@ -82,9 +77,7 @@ export const ContractOverview = (props: {
 
         {outcomeType === 'NUMERIC' && (
           <Row className="items-center justify-between gap-4 xl:hidden">
-            <NumericResolutionOrExpectation
-              contract={contract as NumericContract}
-            />
+            <NumericResolutionOrExpectation contract={contract} />
           </Row>
         )}
 
@@ -97,14 +90,9 @@ export const ContractOverview = (props: {
       <Spacer h={4} />
       {isBinary && <ContractProbGraph contract={contract} bets={bets} />}{' '}
       {outcomeType === 'FREE_RESPONSE' && (
-        <AnswersGraph
-          contract={contract as FullContract<DPM, FreeResponse>}
-          bets={bets}
-        />
+        <AnswersGraph contract={contract} bets={bets} />
       )}
-      {outcomeType === 'NUMERIC' && (
-        <NumericGraph contract={contract as NumericContract} />
-      )}
+      {outcomeType === 'NUMERIC' && <NumericGraph contract={contract} />}
       {(contract.description || isCreator) && <Spacer h={6} />}
       {isCreator && <ShareMarket className="px-2" contract={contract} />}
       <ContractDescription

--- a/web/components/contract/contract-prob-graph.tsx
+++ b/web/components/contract/contract-prob-graph.tsx
@@ -4,12 +4,12 @@ import dayjs from 'dayjs'
 import { memo } from 'react'
 import { Bet } from 'common/bet'
 import { getInitialProbability } from 'common/calculate'
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import { Binary, Contract } from 'common/contract'
 import { useBetsWithoutAntes } from 'web/hooks/use-bets'
 import { useWindowSize } from 'web/hooks/use-window-size'
 
 export const ContractProbGraph = memo(function ContractProbGraph(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   bets: Bet[]
   height?: number
 }) {

--- a/web/components/contract/contract-prob-graph.tsx
+++ b/web/components/contract/contract-prob-graph.tsx
@@ -4,12 +4,12 @@ import dayjs from 'dayjs'
 import { memo } from 'react'
 import { Bet } from 'common/bet'
 import { getInitialProbability } from 'common/calculate'
-import { Binary, Contract } from 'common/contract'
+import { BinaryContract } from 'common/contract'
 import { useBetsWithoutAntes } from 'web/hooks/use-bets'
 import { useWindowSize } from 'web/hooks/use-window-size'
 
 export const ContractProbGraph = memo(function ContractProbGraph(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   bets: Bet[]
   height?: number
 }) {

--- a/web/components/contract/quick-bet.tsx
+++ b/web/components/contract/quick-bet.tsx
@@ -5,16 +5,8 @@ import {
   getTopAnswer,
 } from 'common/calculate'
 import { getExpectedValue } from 'common/calculate-dpm'
-import {
-  Contract,
-  FullContract,
-  CPMM,
-  DPM,
-  Binary,
-  NumericContract,
-  FreeResponseContract,
-} from 'common/contract'
 import { User } from 'common/user'
+import { Contract, NumericContract } from 'common/contract'
 import {
   formatLargeNumber,
   formatMoney,
@@ -39,12 +31,12 @@ export function QuickBet(props: { contract: Contract; user: User }) {
   const userBets = useUserContractBets(user.id, contract.id)
   const topAnswer =
     contract.outcomeType === 'FREE_RESPONSE'
-      ? getTopAnswer(contract as FreeResponseContract)
+      ? getTopAnswer(contract)
       : undefined
 
   // TODO: yes/no from useSaveShares doesn't work on numeric contracts
   const { yesFloorShares, noFloorShares } = useSaveShares(
-    contract as FullContract<DPM | CPMM, Binary | FreeResponseContract>,
+    contract,
     userBets,
     topAnswer?.number.toString() || undefined
   )
@@ -226,10 +218,10 @@ function QuickOutcomeView(props: {
       display = getBinaryProbPercent(contract)
       break
     case 'NUMERIC':
-      display = formatLargeNumber(getExpectedValue(contract as NumericContract))
+      display = formatLargeNumber(getExpectedValue(contract))
       break
     case 'FREE_RESPONSE': {
-      const topAnswer = getTopAnswer(contract as FreeResponseContract)
+      const topAnswer = getTopAnswer(contract)
       display =
         topAnswer &&
         formatPercent(getOutcomeProbability(contract, topAnswer.id))
@@ -257,7 +249,7 @@ function getProb(contract: Contract) {
     : outcomeType === 'FREE_RESPONSE'
     ? getOutcomeProbability(contract, getTopAnswer(contract)?.id || '')
     : outcomeType === 'NUMERIC'
-    ? getNumericScale(contract as NumericContract)
+    ? getNumericScale(contract)
     : 1 // Should not happen
 }
 

--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -4,7 +4,7 @@ import { Answer } from 'common/answer'
 import { Bet } from 'common/bet'
 import { getOutcomeProbability } from 'common/calculate'
 import { Comment } from 'common/comment'
-import { Contract, DPM, FreeResponse, FullContract } from 'common/contract'
+import { Contract, FreeResponse } from 'common/contract'
 import { User } from 'common/user'
 import { mapCommentsByBetId } from 'web/lib/firebase/comments'
 
@@ -188,7 +188,7 @@ function groupBets(
 }
 
 function getAnswerGroups(
-  contract: FullContract<DPM, FreeResponse>,
+  contract: Contract & FreeResponse,
   bets: Bet[],
   comments: Comment[],
   user: User | undefined | null,
@@ -269,7 +269,7 @@ function getAnswerGroups(
 }
 
 function getAnswerAndCommentInputGroups(
-  contract: FullContract<DPM, FreeResponse>,
+  contract: Contract & FreeResponse,
   bets: Bet[],
   comments: Comment[],
   user: User | undefined | null
@@ -493,17 +493,11 @@ export function getRecentContractActivityItems(
   const items = []
   if (contract.outcomeType === 'FREE_RESPONSE') {
     items.push(
-      ...getAnswerGroups(
-        contract as FullContract<DPM, FreeResponse>,
-        bets,
-        comments,
-        user,
-        {
-          sortByProb: false,
-          abbreviated: true,
-          reversed: true,
-        }
-      )
+      ...getAnswerGroups(contract, bets, comments, user, {
+        sortByProb: false,
+        abbreviated: true,
+        reversed: true,
+      })
     )
   } else {
     items.push(
@@ -587,7 +581,7 @@ export function getSpecificContractActivityItems(
     case 'free-response-comment-answer-groups':
       items.push(
         ...getAnswerAndCommentInputGroups(
-          contract as FullContract<DPM, FreeResponse>,
+          contract as Contract & FreeResponse,
           bets,
           comments,
           user

--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -4,7 +4,7 @@ import { Answer } from 'common/answer'
 import { Bet } from 'common/bet'
 import { getOutcomeProbability } from 'common/calculate'
 import { Comment } from 'common/comment'
-import { Contract, FreeResponse } from 'common/contract'
+import { Contract, FreeResponseContract } from 'common/contract'
 import { User } from 'common/user'
 import { mapCommentsByBetId } from 'web/lib/firebase/comments'
 
@@ -188,7 +188,7 @@ function groupBets(
 }
 
 function getAnswerGroups(
-  contract: Contract & FreeResponse,
+  contract: FreeResponseContract,
   bets: Bet[],
   comments: Comment[],
   user: User | undefined | null,
@@ -269,7 +269,7 @@ function getAnswerGroups(
 }
 
 function getAnswerAndCommentInputGroups(
-  contract: Contract & FreeResponse,
+  contract: FreeResponseContract,
   bets: Bet[],
   comments: Comment[],
   user: User | undefined | null
@@ -581,7 +581,7 @@ export function getSpecificContractActivityItems(
     case 'free-response-comment-answer-groups':
       items.push(
         ...getAnswerAndCommentInputGroups(
-          contract as Contract & FreeResponse,
+          contract as FreeResponseContract,
           bets,
           comments,
           user

--- a/web/components/feed/feed-answer-comment-group.tsx
+++ b/web/components/feed/feed-answer-comment-group.tsx
@@ -1,4 +1,3 @@
-import { FreeResponse, FullContract } from 'common/contract'
 import { Answer } from 'common/answer'
 import { ActivityItem } from 'web/components/feed/activity-items'
 import { Bet } from 'common/bet'
@@ -26,7 +25,7 @@ import { CopyLinkDateTimeComponent } from 'web/components/feed/copy-link-date-ti
 import { useRouter } from 'next/router'
 
 export function FeedAnswerCommentGroup(props: {
-  contract: FullContract<any, FreeResponse>
+  contract: any
   answer: Answer
   items: ActivityItem[]
   type: string

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -3,13 +3,7 @@ import { ReactNode } from 'react'
 import { Answer } from 'common/answer'
 import { getProbability } from 'common/calculate'
 import { getValueFromBucket } from 'common/calculate-dpm'
-import {
-  Binary,
-  Contract,
-  FreeResponse,
-  Multi,
-  NumericContract,
-} from 'common/contract'
+import { BinaryContract, Contract, NumericContract } from 'common/contract'
 import { formatPercent } from 'common/util/format'
 import { ClientRender } from './client-render'
 
@@ -53,7 +47,7 @@ export function BinaryOutcomeLabel(props: {
 }
 
 export function BinaryContractOutcomeLabel(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   resolution: 'YES' | 'NO' | 'CANCEL' | 'MKT'
 }) {
   const { contract, resolution } = props
@@ -67,7 +61,7 @@ export function BinaryContractOutcomeLabel(props: {
 }
 
 export function FreeResponseOutcomeLabel(props: {
-  contract: Contract & (FreeResponse | Multi)
+  contract: Contract
   resolution: string | 'CANCEL' | 'MKT'
   truncate: 'short' | 'long' | 'none'
   answerClassName?: string

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -6,11 +6,8 @@ import { getValueFromBucket } from 'common/calculate-dpm'
 import {
   Binary,
   Contract,
-  CPMM,
-  DPM,
   FreeResponse,
-  FreeResponseContract,
-  FullContract,
+  Multi,
   NumericContract,
 } from 'common/contract'
 import { formatPercent } from 'common/util/format'
@@ -36,7 +33,7 @@ export function OutcomeLabel(props: {
 
   return (
     <FreeResponseOutcomeLabel
-      contract={contract as FullContract<DPM, FreeResponse>}
+      contract={contract}
       resolution={outcome}
       truncate={truncate}
       answerClassName={'font-bold text-base-400'}
@@ -56,7 +53,7 @@ export function BinaryOutcomeLabel(props: {
 }
 
 export function BinaryContractOutcomeLabel(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   resolution: 'YES' | 'NO' | 'CANCEL' | 'MKT'
 }) {
   const { contract, resolution } = props
@@ -70,7 +67,7 @@ export function BinaryContractOutcomeLabel(props: {
 }
 
 export function FreeResponseOutcomeLabel(props: {
-  contract: FreeResponseContract
+  contract: Contract & (FreeResponse | Multi)
   resolution: string | 'CANCEL' | 'MKT'
   truncate: 'short' | 'long' | 'none'
   answerClassName?: string
@@ -80,8 +77,9 @@ export function FreeResponseOutcomeLabel(props: {
   if (resolution === 'CANCEL') return <CancelLabel />
   if (resolution === 'MKT') return <MultiLabel />
 
-  const { answers } = contract
-  const chosen = answers?.find((answer) => answer.id === resolution)
+  const answers =
+    contract.outcomeType === 'FREE_RESPONSE' ? contract.answers : []
+  const chosen = answers.find((answer) => answer.id === resolution)
   if (!chosen) return <AnswerNumberLabel number={resolution} />
   return (
     <FreeResponseAnswerToolTip text={chosen.text}>

--- a/web/components/resolution-panel.tsx
+++ b/web/components/resolution-panel.tsx
@@ -10,12 +10,12 @@ import { resolveMarket } from 'web/lib/firebase/fn-call'
 import { ProbabilitySelector } from './probability-selector'
 import { DPM_CREATOR_FEE } from 'common/fees'
 import { getProbability } from 'common/calculate'
-import { Binary, Contract } from 'common/contract'
+import { BinaryContract } from 'common/contract'
 import { formatMoney } from 'common/util/format'
 
 export function ResolutionPanel(props: {
   creator: User
-  contract: Contract & Binary
+  contract: BinaryContract
   className?: string
 }) {
   useEffect(() => {

--- a/web/components/resolution-panel.tsx
+++ b/web/components/resolution-panel.tsx
@@ -10,12 +10,12 @@ import { resolveMarket } from 'web/lib/firebase/fn-call'
 import { ProbabilitySelector } from './probability-selector'
 import { DPM_CREATOR_FEE } from 'common/fees'
 import { getProbability } from 'common/calculate'
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import { Binary, Contract } from 'common/contract'
 import { formatMoney } from 'common/util/format'
 
 export function ResolutionPanel(props: {
   creator: User
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   className?: string
 }) {
   useEffect(() => {

--- a/web/components/sell-button.tsx
+++ b/web/components/sell-button.tsx
@@ -1,4 +1,4 @@
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import { Binary, Contract } from 'common/contract'
 import { User } from 'common/user'
 import { useUserContractBets } from 'web/hooks/use-user-bets'
 import { useState } from 'react'
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { SellSharesModal } from './sell-modal'
 
 export function SellButton(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   user: User | null | undefined
   sharesOutcome: 'YES' | 'NO' | undefined
   shares: number
@@ -40,7 +40,7 @@ export function SellButton(props: {
         {showSellModal && (
           <SellSharesModal
             className={panelClassName}
-            contract={contract as FullContract<CPMM, Binary>}
+            contract={contract}
             user={user}
             userBets={userBets ?? []}
             shares={shares}

--- a/web/components/sell-button.tsx
+++ b/web/components/sell-button.tsx
@@ -1,4 +1,4 @@
-import { Binary, Contract } from 'common/contract'
+import { BinaryContract } from 'common/contract'
 import { User } from 'common/user'
 import { useUserContractBets } from 'web/hooks/use-user-bets'
 import { useState } from 'react'
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { SellSharesModal } from './sell-modal'
 
 export function SellButton(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   user: User | null | undefined
   sharesOutcome: 'YES' | 'NO' | undefined
   shares: number

--- a/web/components/sell-modal.tsx
+++ b/web/components/sell-modal.tsx
@@ -1,4 +1,4 @@
-import { Binary, CPMM, FullContract } from 'common/contract'
+import { Binary, CPMM, Contract } from 'common/contract'
 import { Bet } from 'common/bet'
 import { User } from 'common/user'
 import { Modal } from './layout/modal'
@@ -11,7 +11,7 @@ import clsx from 'clsx'
 
 export function SellSharesModal(props: {
   className?: string
-  contract: FullContract<CPMM, Binary>
+  contract: Contract & CPMM & Binary
   userBets: Bet[]
   shares: number
   sharesOutcome: 'YES' | 'NO'

--- a/web/components/sell-modal.tsx
+++ b/web/components/sell-modal.tsx
@@ -1,4 +1,4 @@
-import { Binary, CPMM, Contract } from 'common/contract'
+import { CPMMBinaryContract } from 'common/contract'
 import { Bet } from 'common/bet'
 import { User } from 'common/user'
 import { Modal } from './layout/modal'
@@ -11,7 +11,7 @@ import clsx from 'clsx'
 
 export function SellSharesModal(props: {
   className?: string
-  contract: Contract & CPMM & Binary
+  contract: CPMMBinaryContract
   userBets: Bet[]
   shares: number
   sharesOutcome: 'YES' | 'NO'

--- a/web/components/sell-row.tsx
+++ b/web/components/sell-row.tsx
@@ -1,4 +1,4 @@
-import { Binary, Contract } from 'common/contract'
+import { BinaryContract } from 'common/contract'
 import { User } from 'common/user'
 import { useState } from 'react'
 import { Col } from './layout/col'
@@ -10,7 +10,7 @@ import { useSaveShares } from './use-save-shares'
 import { SellSharesModal } from './sell-modal'
 
 export function SellRow(props: {
-  contract: Contract & Binary
+  contract: BinaryContract
   user: User | null | undefined
   className?: string
 }) {

--- a/web/components/sell-row.tsx
+++ b/web/components/sell-row.tsx
@@ -1,4 +1,4 @@
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import { Binary, Contract } from 'common/contract'
 import { User } from 'common/user'
 import { useState } from 'react'
 import { Col } from './layout/col'
@@ -10,7 +10,7 @@ import { useSaveShares } from './use-save-shares'
 import { SellSharesModal } from './sell-modal'
 
 export function SellRow(props: {
-  contract: FullContract<DPM | CPMM, Binary>
+  contract: Contract & Binary
   user: User | null | undefined
   className?: string
 }) {
@@ -61,7 +61,7 @@ export function SellRow(props: {
         </Col>
         {showSellModal && (
           <SellSharesModal
-            contract={contract as FullContract<CPMM, Binary>}
+            contract={contract}
             user={user}
             userBets={userBets ?? []}
             shares={yesShares || noShares}

--- a/web/components/use-save-shares.ts
+++ b/web/components/use-save-shares.ts
@@ -1,17 +1,11 @@
-import {
-  Binary,
-  CPMM,
-  DPM,
-  FreeResponseContract,
-  FullContract,
-} from 'common/contract'
+import { Contract } from 'common/contract'
 import { Bet } from 'common/bet'
 import { useEffect, useState } from 'react'
 import { partition, sumBy } from 'lodash'
 import { safeLocalStorage } from 'web/lib/util/local'
 
 export const useSaveShares = (
-  contract: FullContract<CPMM | DPM, Binary | FreeResponseContract>,
+  contract: Contract,
   userBets: Bet[] | undefined,
   freeResponseAnswerOutcome?: string
 ) => {

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -17,7 +17,7 @@ import { range, sortBy, sum } from 'lodash'
 
 import { app } from './init'
 import { getValues, listenForValue, listenForValues } from './utils'
-import { Binary, Contract } from 'common/contract'
+import { BinaryContract, Contract } from 'common/contract'
 import { getDpmProbability } from 'common/calculate-dpm'
 import { createRNG, shuffle } from 'common/util/random'
 import { getCpmmProbability } from 'common/calculate-cpmm'
@@ -63,7 +63,7 @@ export function contractPool(contract: Contract) {
     : 'Empty pool'
 }
 
-export function getBinaryProb(contract: Contract & Binary) {
+export function getBinaryProb(contract: BinaryContract) {
   const { pool, resolutionProbability, mechanism } = contract
 
   return (
@@ -74,7 +74,7 @@ export function getBinaryProb(contract: Contract & Binary) {
   )
 }
 
-export function getBinaryProbPercent(contract: Contract & Binary) {
+export function getBinaryProbPercent(contract: BinaryContract) {
   return formatPercent(getBinaryProb(contract))
 }
 

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -17,7 +17,7 @@ import { range, sortBy, sum } from 'lodash'
 
 import { app } from './init'
 import { getValues, listenForValue, listenForValues } from './utils'
-import { Binary, Contract, FullContract } from 'common/contract'
+import { Binary, Contract } from 'common/contract'
 import { getDpmProbability } from 'common/calculate-dpm'
 import { createRNG, shuffle } from 'common/util/random'
 import { getCpmmProbability } from 'common/calculate-cpmm'
@@ -63,18 +63,18 @@ export function contractPool(contract: Contract) {
     : 'Empty pool'
 }
 
-export function getBinaryProb(contract: FullContract<any, Binary>) {
-  const { totalShares, pool, p, resolutionProbability, mechanism } = contract
+export function getBinaryProb(contract: Contract & Binary) {
+  const { pool, resolutionProbability, mechanism } = contract
 
   return (
     resolutionProbability ??
     (mechanism === 'cpmm-1'
-      ? getCpmmProbability(pool, p)
-      : getDpmProbability(totalShares))
+      ? getCpmmProbability(pool, contract.p)
+      : getDpmProbability(contract.totalShares))
   )
 }
 
-export function getBinaryProbPercent(contract: FullContract<any, Binary>) {
+export function getBinaryProbPercent(contract: Contract & Binary) {
   return formatPercent(getBinaryProb(contract))
 }
 

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -30,13 +30,6 @@ import { formatMoney } from 'common/util/format'
 import { useUserById } from 'web/hooks/use-users'
 import { ContractTabs } from 'web/components/contract/contract-tabs'
 import { FirstArgument } from 'common/util/types'
-import {
-  BinaryContract,
-  DPM,
-  FreeResponse,
-  FullContract,
-  NumericContract,
-} from 'common/contract'
 import { contractTextDetails } from 'web/components/contract/contract-details'
 import { useWindowSize } from 'web/hooks/use-window-size'
 import Confetti from 'react-confetti'
@@ -143,24 +136,15 @@ export function ContractPageContent(props: FirstArgument<typeof ContractPage>) {
     <Col className="gap-4">
       {allowTrade &&
         (isNumeric ? (
-          <NumericBetPanel
-            className="hidden xl:flex"
-            contract={contract as NumericContract}
-          />
+          <NumericBetPanel className="hidden xl:flex" contract={contract} />
         ) : (
           <BetPanel className="hidden xl:flex" contract={contract} />
         ))}
       {allowResolve &&
         (isNumeric ? (
-          <NumericResolutionPanel
-            creator={user}
-            contract={contract as NumericContract}
-          />
+          <NumericResolutionPanel creator={user} contract={contract} />
         ) : (
-          <ResolutionPanel
-            creator={user}
-            contract={contract as BinaryContract}
-          />
+          <ResolutionPanel creator={user} contract={contract} />
         ))}
     </Col>
   ) : null
@@ -205,18 +189,13 @@ export function ContractPageContent(props: FirstArgument<typeof ContractPage>) {
         {outcomeType === 'FREE_RESPONSE' && (
           <>
             <Spacer h={4} />
-            <AnswersPanel
-              contract={contract as FullContract<DPM, FreeResponse>}
-            />
+            <AnswersPanel contract={contract} />
             <Spacer h={4} />
           </>
         )}
 
         {isNumeric && (
-          <NumericBetPanel
-            className="xl:hidden"
-            contract={contract as NumericContract}
-          />
+          <NumericBetPanel className="xl:hidden" contract={contract} />
         )}
 
         {isResolved && (

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -1,12 +1,5 @@
 import { Bet } from 'common/bet'
-import {
-  BinaryContract,
-  Contract,
-  DPM,
-  FreeResponse,
-  FullContract,
-  NumericContract,
-} from 'common/contract'
+import { Contract } from 'common/contract'
 import { DOMAIN } from 'common/envs/constants'
 import { AnswersGraph } from 'web/components/answers/answers-graph'
 import BetRow from 'web/components/bet-row'
@@ -117,10 +110,9 @@ function ContractEmbed(props: { contract: Contract; bets: Bet[] }) {
 
           {isBinary && (
             <Row className="items-center gap-4">
-              <BetRow
-                contract={contract as BinaryContract}
-                betPanelClassName="scale-75"
-              />
+              // this fails typechecking, but it doesn't explode because we will
+              never
+              <BetRow contract={contract as any} betPanelClassName="scale-75" />
               <BinaryResolutionOrChance contract={contract} />
             </Row>
           )}
@@ -133,9 +125,7 @@ function ContractEmbed(props: { contract: Contract; bets: Bet[] }) {
           )}
 
           {outcomeType === 'NUMERIC' && (
-            <NumericResolutionOrExpectation
-              contract={contract as NumericContract}
-            />
+            <NumericResolutionOrExpectation contract={contract} />
           )}
         </Row>
 
@@ -152,18 +142,11 @@ function ContractEmbed(props: { contract: Contract; bets: Bet[] }) {
         )}
 
         {outcomeType === 'FREE_RESPONSE' && (
-          <AnswersGraph
-            contract={contract as FullContract<DPM, FreeResponse>}
-            bets={bets}
-            height={graphHeight}
-          />
+          <AnswersGraph contract={contract} bets={bets} height={graphHeight} />
         )}
 
         {outcomeType === 'NUMERIC' && (
-          <NumericGraph
-            contract={contract as NumericContract}
-            height={graphHeight}
-          />
+          <NumericGraph contract={contract} height={graphHeight} />
         )}
       </div>
     </Col>

--- a/web/pages/make-predictions.tsx
+++ b/web/pages/make-predictions.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import Textarea from 'react-expanding-textarea'
 
 import { getProbability } from 'common/calculate'
-import { Binary, CPMM, DPM, FullContract } from 'common/contract'
+import { Binary, Contract } from 'common/contract'
 import { parseWordsAsTags } from 'common/util/parse'
 import { BuyAmountInput } from 'web/components/amount-input'
 import { InfoTooltip } from 'web/components/info-tooltip'
@@ -26,7 +26,7 @@ type Prediction = {
   createdUrl?: string
 }
 
-function toPrediction(contract: FullContract<DPM | CPMM, Binary>): Prediction {
+function toPrediction(contract: Contract & Binary): Prediction {
   const startProb = getProbability(contract)
   return {
     question: contract.question,
@@ -103,7 +103,7 @@ export default function MakePredictions() {
   const [tags, setTags] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [createdContracts, setCreatedContracts] = useState<
-    FullContract<DPM | CPMM, Binary>[]
+    (Contract & Binary)[]
   >([])
 
   const [ante, setAnte] = useState<number | undefined>(100)
@@ -155,7 +155,7 @@ ${TEST_VALUE}
         ante,
         closeTime,
         tags: parseWordsAsTags(tags),
-      })) as FullContract<DPM | CPMM, Binary>
+      })) as Contract & Binary
 
       setCreatedContracts((prev) => [...prev, contract])
     }

--- a/web/pages/make-predictions.tsx
+++ b/web/pages/make-predictions.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import Textarea from 'react-expanding-textarea'
 
 import { getProbability } from 'common/calculate'
-import { Binary, Contract } from 'common/contract'
+import { BinaryContract } from 'common/contract'
 import { parseWordsAsTags } from 'common/util/parse'
 import { BuyAmountInput } from 'web/components/amount-input'
 import { InfoTooltip } from 'web/components/info-tooltip'
@@ -26,7 +26,7 @@ type Prediction = {
   createdUrl?: string
 }
 
-function toPrediction(contract: Contract & Binary): Prediction {
+function toPrediction(contract: BinaryContract): Prediction {
   const startProb = getProbability(contract)
   return {
     question: contract.question,
@@ -102,9 +102,7 @@ export default function MakePredictions() {
   const [description, setDescription] = useState('')
   const [tags, setTags] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [createdContracts, setCreatedContracts] = useState<
-    (Contract & Binary)[]
-  >([])
+  const [createdContracts, setCreatedContracts] = useState<BinaryContract[]>([])
 
   const [ante, setAnte] = useState<number | undefined>(100)
   const [anteError, setAnteError] = useState<string | undefined>()
@@ -155,7 +153,7 @@ ${TEST_VALUE}
         ante,
         closeTime,
         tags: parseWordsAsTags(tags),
-      })) as Contract & Binary
+      })) as BinaryContract
 
       setCreatedContracts((prev) => [...prev, contract])
     }


### PR DESCRIPTION
Prior to this change we had a problem. Right now there are 5 actual kinds of contracts in existence:

```typescript
FullContract<CPMM, Binary>
FullContract<DPM, Binary>
FullContract<DPM, FreeResponse>
FullContract<DPM, Multi>
FullContract<DPM, Numeric>
```
(I guess `Multi` doesn't actually exist anymore, but we can deal with that later -- it's not relevant to the logic of this PR.)

However, Typescript doesn't know that. It thinks there are 8 -- the combination of each outcome type and each mechanism. in my opinion, this causes two problems:

1. If you check to see if something is DPM, you logically know whether it's numeric, and vice versa, but Typescript doesn't know that, so you have to start doing `any` and casts and stuff to get Typescript on the same page.
2. If you do that, and then someone e.g. makes CPMM numeric markets, your code will not produce a type error, but it will explode at runtime. If we typed everything correctly, then making CPMM numeric markets would produce a type error for anyone relying on the fact that numeric === DPM.

```typescript
if (ct.outcomeType === 'NUMERIC') {
  // Current version: Type error. Tempts you to use `any`.
  // Current version if we use `any` and add new numeric mechanism: Looks great then kaboom at runtime!
  // New version: Works great.
  // New version if we add new numeric mechanism: Type error. This code needs to be fixed.
  console.log(ct.totalShares)
}
```

We can fix this problem if we define
```typescript
export type AnyContractType = (CPMM & Binary) | (DPM & AnyOutcomeType)
export type Contract<T extends AnyContractType = AnyContractType> = { ...common fields } & T
```

Now you will do `Contract<CPMM & Binary>` instead of `FullContract<CPMM, Binary>`. You can also do `Contract` to get the 'any possible contract' type, or e.g. `Contract & Binary` to get the 'any possible binary contract' type, or `Contract & CPMM` to get the 'any possible CPMM contract' type (which currently implies binary.) If you do `Contract<CPMM & Multi>` the compiler will yell.

As you can see, this fixes a ton of places in the codebase where we were making unnecessary casts, typing things as `any`, etc.

(P.S. Sometimes people would do `FullContract<any, Binary>` when they meant "binary CPMM or DPMM contracts." This was wrong -- `FullContract<any, Binary>` is defined as `{ FullContract stuff } & any & Binary` which is identical to `any`. They should have been doing `FullContract<CPMM | DPMM, Binary>`.)