### PR TITLE
`MULTI` contracts are not a thing

### DIFF
--- a/common/contract.ts
+++ b/common/contract.ts
@@ -2,11 +2,11 @@ import { Answer } from './answer'
 import { Fees } from './fees'
 
 export type AnyMechanism = DPM | CPMM
-export type AnyOutcomeType = Binary | Multi | FreeResponse | Numeric
+export type AnyOutcomeType = Binary | FreeResponse | Numeric
 export type AnyContractType =
   | (CPMM & Binary)
   | (DPM & Binary)
-  | (DPM & (Multi | FreeResponse))
+  | (DPM & FreeResponse)
   | (DPM & Numeric)
 
 export type Contract<T extends AnyContractType = AnyContractType> = {
@@ -74,12 +74,6 @@ export type Binary = {
   resolution?: 'YES' | 'NO' | 'MKT' | 'CANCEL'
 }
 
-export type Multi = {
-  outcomeType: 'MULTI'
-  multiOutcomes: string[] // Used for outcomeType 'MULTI'.
-  resolutions?: { [outcome: string]: number } // Used for MKT resolution.
-}
-
 export type FreeResponse = {
   outcomeType: 'FREE_RESPONSE'
   answers: Answer[] // Used for outcomeType 'FREE_RESPONSE'.
@@ -97,12 +91,7 @@ export type Numeric = {
 }
 
 export type outcomeType = AnyOutcomeType['outcomeType']
-export const OUTCOME_TYPES = [
-  'BINARY',
-  'MULTI',
-  'FREE_RESPONSE',
-  'NUMERIC',
-] as const
+export const OUTCOME_TYPES = ['BINARY', 'FREE_RESPONSE', 'NUMERIC'] as const
 export const MAX_QUESTION_LENGTH = 480
 export const MAX_DESCRIPTION_LENGTH = 10000
 export const MAX_TAG_LENGTH = 60

--- a/functions/src/emails.ts
+++ b/functions/src/emails.ts
@@ -110,9 +110,7 @@ const toDisplayResolution = (
       getValueFromBucket(resolution, contract).toString()
     )
 
-  const answer = (contract as FreeResponseContract).answers?.find(
-    (a) => a.id === resolution
-  )
+  const answer = contract.answers.find((a) => a.id === resolution)
   if (answer) return answer.text
   return `#${resolution}`
 }

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 import { Answer } from 'common/answer'
 import { getProbability } from 'common/calculate'
 import { getValueFromBucket } from 'common/calculate-dpm'
-import { BinaryContract, Contract, NumericContract } from 'common/contract'
+import { BinaryContract, Contract, FreeResponseContract } from 'common/contract'
 import { formatPercent } from 'common/util/format'
 import { ClientRender } from './client-render'
 
@@ -21,7 +21,7 @@ export function OutcomeLabel(props: {
   if (contract.outcomeType === 'NUMERIC')
     return (
       <span className="text-blue-500">
-        {value ?? getValueFromBucket(outcome, contract as NumericContract)}
+        {value ?? getValueFromBucket(outcome, contract)}
       </span>
     )
 
@@ -61,7 +61,7 @@ export function BinaryContractOutcomeLabel(props: {
 }
 
 export function FreeResponseOutcomeLabel(props: {
-  contract: Contract
+  contract: FreeResponseContract
   resolution: string | 'CANCEL' | 'MKT'
   truncate: 'short' | 'long' | 'none'
   answerClassName?: string
@@ -71,9 +71,7 @@ export function FreeResponseOutcomeLabel(props: {
   if (resolution === 'CANCEL') return <CancelLabel />
   if (resolution === 'MKT') return <MultiLabel />
 
-  const answers =
-    contract.outcomeType === 'FREE_RESPONSE' ? contract.answers : []
-  const chosen = answers.find((answer) => answer.id === resolution)
+  const chosen = contract.answers.find((answer) => answer.id === resolution)
   if (!chosen) return <AnswerNumberLabel number={resolution} />
   return (
     <FreeResponseAnswerToolTip text={chosen.text}>


### PR DESCRIPTION
So, I don't actually understand the history here. All I see is that in #47, we added some code suggesting that there could be contracts with the `MULTI` outcome type, distinct from the `FREE_RESPONSE` outcome type, which would have an array of strings that were like outcomes, but weren't free response answers. Maybe they were gonna be like free response markets with a fixed list of answers set by the creator? However, we never implemented any actual code for creating these or using them, and they never came to exist. So in that case let's clean up the last tiny bit of stuff that thinks they exist.