### PR TITLE
Commented out code which was meant to be a comment

### DIFF
--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -110,8 +110,8 @@ function ContractEmbed(props: { contract: Contract; bets: Bet[] }) {
 
           {isBinary && (
             <Row className="items-center gap-4">
-              // this fails typechecking, but it doesn't explode because we will
-              never
+              {/* this fails typechecking, but it doesn't explode because we will
+              never */}
               <BetRow contract={contract as any} betPanelClassName="scale-75" />
               <BinaryResolutionOrChance contract={contract} />
             </Row>


### PR DESCRIPTION
This was not a comment, it shows up on embedded markets.
Screenshots:
![LessWrong](https://user-images.githubusercontent.com/61841994/171462664-dce6637f-b8dd-47d1-a03c-e2240588d262.png)
![research.bet](https://user-images.githubusercontent.com/61841994/171462818-a01aa6ca-e8ec-4d98-8902-4a9b97a7448e.png)