### PR TITLE
Destroy the blue notification bubble

### DIFF
--- a/web/components/notifications-icon.tsx
+++ b/web/components/notifications-icon.tsx
@@ -21,14 +21,19 @@ export default function NotificationsIcon(props: { className?: string }) {
     if (user) return listenForNotifications(user.id, setNotifications, true)
   }, [user])
 
+  // mqp - kill this until you can control what notifications you get, or
+  // until the defaults aren't so spammy
+  const notificationCountBubble = null
+  // const notificationCountBubble = (
+  //   <div className="-mt-0.75 absolute ml-3.5 min-w-[15px] rounded-full bg-indigo-500 p-[2px] text-center text-[10px] leading-3 text-white lg:-mt-1 lg:ml-2">
+  //     {notifications && notifications.length}
+  //   </div>
+  // )
+
   return (
     <Row className={clsx('justify-center')}>
       <div className={'relative'}>
-        {notifications && notifications.length > 0 && (
-          <div className="-mt-0.75 absolute ml-3.5 min-w-[15px] rounded-full bg-indigo-500 p-[2px] text-center text-[10px] leading-3 text-white lg:-mt-1 lg:ml-2">
-            {notifications.length}
-          </div>
-        )}
+        {notifications && notifications.length && notificationCountBubble}
         <BellIcon className={clsx(props.className)} />
       </div>
     </Row>


### PR DESCRIPTION
The point of notifications is to get ones you want to see and not get ones you don't want to see. Drawing people's attention to notifications they don't want to see is a way to actively piss off users. If this were on a different website that I am not working on I would have instantly made a uBlock rule hiding the "notifications" link in the nav forever.

This feature will be fine once there is a way to cause the notification bubble to only appear for things you want to see.