### PR TITLE
Add a /health function for ease of benchmarking

### DIFF
--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -137,11 +137,11 @@ export const validate = <T extends z.ZodTypeAny>(schema: T, val: unknown) => {
 
 export const newEndpoint = (methods: [string], fn: Handler) =>
   functions.runWith({ minInstances: 1 }).https.onRequest(async (req, res) => {
-    await applyCors(req, res, {
-      origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-      methods: methods,
-    })
     try {
+      await applyCors(req, res, {
+        origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
+        methods: methods,
+      })
       if (!methods.includes(req.method)) {
         const allowed = methods.join(', ')
         throw new APIError(405, `This endpoint supports only ${allowed}.`)

--- a/functions/src/health.ts
+++ b/functions/src/health.ts
@@ -1,0 +1,11 @@
+import { newEndpoint } from './api'
+
+export const health = newEndpoint(['GET'], async (_req, [user, _]) => {
+  return {
+    message: 'Server is working.',
+    user: {
+      id: user.id,
+      username: user.username,
+    },
+  }
+})

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,6 +3,7 @@ import * as admin from 'firebase-admin'
 admin.initializeApp()
 
 // export * from './keep-awake'
+export * from './health'
 export * from './transact'
 export * from './place-bet'
 export * from './resolve-market'


### PR DESCRIPTION
Usefully for our current purposes, it can be used to either hit the database (if you are authenticated it looks up your user) or not hit the database (if you have no `Authorization` header it will reject you outright.)