### PR TITLE
Fix API calls to hit emulated Firebase

### DIFF
--- a/web/lib/api/proxy.ts
+++ b/web/lib/api/proxy.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { FIREBASE_CONFIG } from 'common/envs/constants'
 import { promisify } from 'util'
 import { pipeline } from 'stream'
+import { getFunctionUrl } from 'web/lib/firebase/api-call'
 import fetch, { Headers, Response } from 'node-fetch'
 
 function getProxiedRequestHeaders(req: NextApiRequest, whitelist: string[]) {
@@ -33,8 +33,7 @@ function getProxiedResponseHeaders(res: Response, whitelist: string[]) {
 }
 
 export const fetchBackend = (req: NextApiRequest, endpoint: string) => {
-  const { projectId, region } = FIREBASE_CONFIG
-  const url = `https://${region}-${projectId}.cloudfunctions.net/${endpoint}`
+  const url = getFunctionUrl(endpoint)
   const headers = getProxiedRequestHeaders(req, [
     'Authorization',
     'Content-Length',

--- a/web/lib/firebase/api-call.ts
+++ b/web/lib/firebase/api-call.ts
@@ -38,9 +38,11 @@ export async function call(url: string, method: string, params: any) {
 // app just hit the cloud functions directly -- there's no difference and it's
 // one less hop
 
-function getFunctionUrl(name: string) {
+export function getFunctionUrl(name: string) {
   const { projectId, region } = FIREBASE_CONFIG
-  return `https://${region}-${projectId}.cloudfunctions.net/${name}`
+  return process.env.NEXT_PUBLIC_FIREBASE_EMULATE
+    ? `http://localhost:5001/${projectId}/${region}/${name}`
+    : `https://${region}-${projectId}.cloudfunctions.net/${name}`
 }
 
 export function createContract(params: any) {


### PR DESCRIPTION
Oops, I just didn't realize this was broken recently by my API work where I changed these to be `onRequest` instead of `onCall` functions. Now it's fixed up.