### PR TITLE
Fix free response answers with 0 bets disappearing

### DIFF
--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -200,9 +200,7 @@ function getAnswerGroups(
 ) {
   const { sortByProb, abbreviated, reversed } = options
 
-  let outcomes = uniq(bets.map((bet) => bet.outcome)).filter(
-    (outcome) => getOutcomeProbability(contract, outcome) > 0.0001
-  )
+  let outcomes = uniq(bets.map((bet) => bet.outcome))
   if (abbreviated) {
     const lastComment = last(comments)
     const lastCommentOutcome = bets.find(
@@ -274,9 +272,7 @@ function getAnswerAndCommentInputGroups(
   comments: Comment[],
   user: User | undefined | null
 ) {
-  let outcomes = uniq(bets.map((bet) => bet.outcome)).filter(
-    (outcome) => getOutcomeProbability(contract, outcome) > 0.0001
-  )
+  let outcomes = uniq(bets.map((bet) => bet.outcome))
   outcomes = sortBy(outcomes, (outcome) =>
     getOutcomeProbability(contract, outcome)
   )


### PR DESCRIPTION
Before this PR, free response answers and their associated comments disappeared when all shares in the answer were sold. If it's just an answer, this is a surprising UX but not that bad. But this can also disappear an entire comment thread with great discussion, as I noticed on one of my markets recently.

I suppose the downside is that these answers take up space and are more likely to be undesired - but I think answers with M$1 of bets are much more common anyway.