### PR TITLE
Migrate placeBet and createContract to v2 functions

### DIFF
--- a/functions/src/create-contract.ts
+++ b/functions/src/create-contract.ts
@@ -48,7 +48,7 @@ const numericSchema = z.object({
   max: z.number(),
 })
 
-export const createContract = newEndpoint(['POST'], async (req, [user, _]) => {
+export const createmarket = newEndpoint(['POST'], async (req, [user, _]) => {
   const { question, description, tags, closeTime, outcomeType } = validate(
     bodySchema,
     req.body

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,15 +2,13 @@ import * as admin from 'firebase-admin'
 
 admin.initializeApp()
 
+// v1
 // export * from './keep-awake'
-export * from './health'
 export * from './transact'
-export * from './place-bet'
 export * from './resolve-market'
 export * from './stripe'
 export * from './sell-bet'
 export * from './sell-shares'
-export * from './create-contract'
 export * from './create-user'
 export * from './create-fold'
 export * from './create-answer'
@@ -31,3 +29,8 @@ export * from './add-liquidity'
 export * from './on-create-answer'
 export * from './on-update-contract'
 export * from './on-follow-user'
+
+// v2
+export * from './health'
+export * from './place-bet'
+export * from './create-contract'

--- a/functions/src/place-bet.ts
+++ b/functions/src/place-bet.ts
@@ -32,7 +32,7 @@ const numericSchema = z.object({
   value: z.number(),
 })
 
-export const placeBet = newEndpoint(['POST'], async (req, [bettor, _]) => {
+export const placebet = newEndpoint(['POST'], async (req, [bettor, _]) => {
   const { amount, contractId } = validate(bodySchema, req.body)
 
   const result = await firestore.runTransaction(async (trans) => {


### PR DESCRIPTION
***Deploy status: See below.***

This should dramatically improve our cold start -- and warm -- performance issues with these two functions, and if everything is working good, we can migrate other functions to work this way.

Some differences between the old and new:

- Annoyingly, v2 Cloud Functions don't allow capital letters in names. They allow hyphens, but the Javascript + Firebase CLI toolchain makes it impossible to get hyphens in there. Whatever.
- The v2 Cloud Functions have beefier CPUs, so the idle 1 minimum instance costs more money, but we don't care.
- I'm renaming `createContract` to `createmarket` while I'm at it.

Here's how this is gonna go down:

1. I merge this.
2. I `firebase deploy --only functions` on prod, without deleting old functions, creating new `placebet` and `createmarket` v2 endpoints with new URLs. (Cloud Functions v2 URLs aren't predictable until you deploy them. They include some nonce.)
3. I change the client code to point at the new functions and test it. Nobody deletes the old functions in between step 2 and 3.
4. I deploy again and delete the old functions.

See #433 for client changes.