### PR TITLE
Fix secret access for some email sending functions

### DIFF
--- a/functions/src/market-close-emails.ts
+++ b/functions/src/market-close-emails.ts
@@ -5,8 +5,9 @@ import { Contract } from '../../common/contract'
 import { getPrivateUser, getUserByUsername } from './utils'
 import { sendMarketCloseEmail } from './emails'
 
-export const marketCloseEmails = functions.pubsub
-  .schedule('every 1 hours')
+export const marketCloseEmails = functions
+  .runWith({ secrets: ['MAILGUN_KEY'] })
+  .pubsub.schedule('every 1 hours')
   .onRun(async () => {
     await sendMarketCloseEmails()
   })

--- a/functions/src/stripe.ts
+++ b/functions/src/stripe.ts
@@ -90,7 +90,7 @@ export const createCheckoutSession = functions
 export const stripeWebhook = functions
   .runWith({
     minInstances: 1,
-    secrets: ['STRIPE_APIKEY', 'STRIPE_WEBHOOKSECRET'],
+    secrets: ['MAILGUN_KEY', 'STRIPE_APIKEY', 'STRIPE_WEBHOOKSECRET'],
   })
   .https.onRequest(async (req, res) => {
     const stripe = initStripe()


### PR DESCRIPTION
Broken via #418. Omitting these meant that our "market closed" emails and our "thanks for paying us money" emails were not operational.