### PR TITLE
Fr comment ux improvements

### DIFF
--- a/web/components/feed/activity-items.ts
+++ b/web/components/feed/activity-items.ts
@@ -362,7 +362,9 @@ function getCommentThreads(
   comments: Comment[],
   contract: Contract
 ) {
-  const parentComments = comments.filter((comment) => !comment.replyToCommentId)
+  let parentComments = comments.filter((comment) => !comment.replyToCommentId)
+  if (contract.outcomeType === 'FREE_RESPONSE')
+    parentComments = comments.filter((comment) => !comment.replyToCommentId)
 
   const items = parentComments.map((comment) => ({
     type: 'commentThread' as const,

--- a/web/components/feed/feed-answer-comment-group.tsx
+++ b/web/components/feed/feed-answer-comment-group.tsx
@@ -1,8 +1,6 @@
 import { Answer } from 'common/answer'
-import { ActivityItem } from 'web/components/feed/activity-items'
 import { Bet } from 'common/bet'
 import { Comment } from 'common/comment'
-import { useUser } from 'web/hooks/use-user'
 import { getDpmOutcomeProbability } from 'common/calculate-dpm'
 import { formatPercent } from 'common/util/format'
 import React, { useEffect, useState } from 'react'
@@ -16,44 +14,74 @@ import { Linkify } from 'web/components/linkify'
 import clsx from 'clsx'
 import { tradingAllowed } from 'web/lib/firebase/contracts'
 import { BuyButton } from 'web/components/yes-no-selector'
-import { FeedItem } from 'web/components/feed/feed-items'
 import {
   CommentInput,
+  CommentRepliesList,
   getMostRecentCommentableBet,
 } from 'web/components/feed/feed-comments'
 import { CopyLinkDateTimeComponent } from 'web/components/feed/copy-link-date-time'
 import { useRouter } from 'next/router'
+import { groupBy } from 'lodash'
+import { User } from 'common/user'
 
 export function FeedAnswerCommentGroup(props: {
   contract: any
+  user: User | undefined | null
   answer: Answer
-  items: ActivityItem[]
-  type: string
-  betsByCurrentUser?: Bet[]
-  commentsByCurrentUser?: Comment[]
+  comments: Comment[]
+  bets: Bet[]
 }) {
-  const { answer, items, contract, betsByCurrentUser, commentsByCurrentUser } =
-    props
+  const { answer, contract, comments, bets, user } = props
   const { username, avatarUrl, name, text } = answer
   const answerElementId = `answer-${answer.id}`
-  const user = useUser()
-  const mostRecentCommentableBet = getMostRecentCommentableBet(
-    betsByCurrentUser ?? [],
-    commentsByCurrentUser ?? [],
-    user,
-    answer.number + ''
+  const betsByUserId = groupBy(bets, (bet) => bet.userId)
+  const commentsByUserId = groupBy(comments, (comment) => comment.userId)
+  const [replyToUsername, setReplyToUsername] = useState('')
+  const answerComments = comments.filter(
+    (comment) => comment.answerOutcome === answer.number.toString()
   )
+  const commentReplies = comments.filter(
+    (comment) =>
+      comment.replyToCommentId &&
+      !comment.answerOutcome &&
+      answerComments.map((c) => c.id).includes(comment.replyToCommentId)
+  )
+  const commentsList = answerComments.concat(commentReplies)
+
   const prob = getDpmOutcomeProbability(contract.totalShares, answer.id)
   const probPercent = formatPercent(prob)
   const [open, setOpen] = useState(false)
   const [showReply, setShowReply] = useState(false)
+  const betsByCurrentUser = (user && betsByUserId[user.id]) || []
+  const commentsByCurrentUser = (user && commentsByUserId[user.id]) || []
   const isFreeResponseContractPage = !!commentsByCurrentUser
-  if (mostRecentCommentableBet && !showReply) setShowReplyAndFocus(true)
+  const mostRecentCommentableBet = getMostRecentCommentableBet(
+    betsByCurrentUser,
+    commentsByCurrentUser,
+    user,
+    answer.number.toString()
+  )
+  if (mostRecentCommentableBet && !showReply)
+    scrollAndOpenReplyInput(undefined, answer)
+
+  useEffect(() => {
+    // Only show one comment input for a bet at a time
+    const usersMostRecentBet = bets
+      .filter((b) => b.userId === user?.id)
+      .sort((a, b) => b.createdTime - a.createdTime)[0]
+    if (
+      usersMostRecentBet &&
+      usersMostRecentBet.outcome !== answer.number.toString()
+    ) {
+      setShowReply(false)
+    }
+  }, [answer.number, bets, user])
+
   const [inputRef, setInputRef] = useState<HTMLTextAreaElement | null>(null)
 
-  // If they've already opened the input box, focus it once again
-  function setShowReplyAndFocus(show: boolean) {
-    setShowReply(show)
+  function scrollAndOpenReplyInput(comment?: Comment, answer?: Answer) {
+    setReplyToUsername(comment?.userUsername ?? answer?.username ?? '')
+    setShowReply(true)
     inputRef?.focus()
   }
 
@@ -70,7 +98,7 @@ export function FeedAnswerCommentGroup(props: {
   }, [answerElementId, router.asPath])
 
   return (
-    <Col className={'flex-1 gap-2'}>
+    <Col className={'relative flex-1 gap-2'}>
       <Modal open={open} setOpen={setOpen}>
         <AnswerBetPanel
           answer={answer}
@@ -113,7 +141,7 @@ export function FeedAnswerCommentGroup(props: {
                     className={
                       'text-xs font-bold text-gray-500 hover:underline'
                     }
-                    onClick={() => setShowReplyAndFocus(true)}
+                    onClick={() => scrollAndOpenReplyInput(undefined, answer)}
                   >
                     Reply
                   </button>
@@ -143,7 +171,7 @@ export function FeedAnswerCommentGroup(props: {
             <div className={'justify-initial hidden sm:block'}>
               <button
                 className={'text-xs font-bold text-gray-500 hover:underline'}
-                onClick={() => setShowReplyAndFocus(true)}
+                onClick={() => scrollAndOpenReplyInput(undefined, answer)}
               >
                 Reply
               </button>
@@ -151,36 +179,31 @@ export function FeedAnswerCommentGroup(props: {
           )}
         </Col>
       </Row>
-
-      {items.map((item, index) => (
-        <div
-          key={item.id}
-          className={clsx(
-            'relative ml-8',
-            index !== items.length - 1 && 'pb-4'
-          )}
-        >
-          {index !== items.length - 1 ? (
-            <span
-              className="absolute top-5 left-5 -ml-px h-[calc(100%-1rem)] w-0.5 bg-gray-200"
-              aria-hidden="true"
-            />
-          ) : null}
-          <div className="relative flex items-start space-x-3">
-            <FeedItem item={item} />
-          </div>
-        </div>
-      ))}
+      <CommentRepliesList
+        contract={contract}
+        commentsList={commentsList}
+        betsByUserId={betsByUserId}
+        smallAvatar={true}
+        truncate={false}
+        bets={bets}
+        scrollAndOpenReplyInput={scrollAndOpenReplyInput}
+        treatFirstIndexEqually={true}
+      />
 
       {showReply && (
-        <div className={'ml-8 pt-4'}>
+        <div className={'ml-6 pt-4'}>
+          <span
+            className="absolute -ml-[1px] mt-[0.8rem] h-2 w-0.5 rotate-90 bg-gray-200"
+            aria-hidden="true"
+          />
           <CommentInput
             contract={contract}
-            betsByCurrentUser={betsByCurrentUser ?? []}
-            commentsByCurrentUser={commentsByCurrentUser ?? []}
-            answerOutcome={answer.number + ''}
-            replyToUsername={answer.username}
+            betsByCurrentUser={betsByCurrentUser}
+            commentsByCurrentUser={commentsByCurrentUser}
+            answerOutcome={answer.number.toString()}
+            replyToUsername={replyToUsername}
             setRef={setInputRef}
+            onSubmitComment={() => setShowReply(false)}
           />
         </div>
       )}

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -488,7 +488,7 @@ export function CommentInput(props: {
               {!user && (
                 <button
                   className={
-                    'btn btn-outline btn-sm text-transform: capitalize'
+                    'btn btn-outline btn-sm text-transform:capitalize mt-2'
                   }
                   onClick={() => submitComment(id)}
                 >

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -54,7 +54,7 @@ export function FeedCommentThread(props: {
     if (showReply && inputRef) inputRef.focus()
   }, [inputRef, showReply])
   return (
-    <div className={'flex-col pr-1'}>
+    <div className={'w-full flex-col pr-1'}>
       {commentsList.map((comment, commentIdx) => (
         <div
           key={comment.id}
@@ -373,73 +373,46 @@ export function CommentInput(props: {
                 )}
             </div>
 
-            <Row className="grid grid-cols-8 gap-1.5 text-gray-700">
-              <Col
+            <Row className="gap-1.5 text-gray-700">
+              <Textarea
+                ref={setRef}
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
                 className={clsx(
-                  'col-span-8 sm:col-span-6',
-                  !user && 'col-span-8'
+                  'textarea textarea-bordered w-full resize-none'
                 )}
-              >
-                <Textarea
-                  ref={setRef}
-                  value={comment}
-                  onChange={(e) => setComment(e.target.value)}
-                  className={clsx('textarea textarea-bordered resize-none')}
-                  placeholder={
-                    parentComment || answerOutcome
-                      ? 'Write a reply... '
-                      : 'Write a comment...'
+                placeholder={
+                  parentComment || answerOutcome
+                    ? 'Write a reply... '
+                    : 'Write a comment...'
+                }
+                autoFocus={focused}
+                rows={focused ? 3 : 1}
+                onFocus={() => setFocused(true)}
+                onBlur={() =>
+                  shouldCollapseAfterClickOutside && setFocused(false)
+                }
+                maxLength={MAX_COMMENT_LENGTH}
+                disabled={isSubmitting}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                    e.preventDefault()
+                    submitComment(id)
+                    e.currentTarget.blur()
                   }
-                  autoFocus={focused}
-                  rows={focused ? 3 : 1}
-                  onFocus={() => setFocused(true)}
-                  onBlur={() =>
-                    shouldCollapseAfterClickOutside && setFocused(false)
-                  }
-                  maxLength={MAX_COMMENT_LENGTH}
-                  disabled={isSubmitting}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
-                      e.preventDefault()
-                      submitComment(id)
-                      e.currentTarget.blur()
-                    }
-                  }}
-                />
-              </Col>
-              {!user && (
-                <Col
-                  className={clsx(
-                    'col-span-8 sm:col-span-2',
-                    focused ? 'justify-end' : 'justify-center'
-                  )}
-                >
-                  <button
-                    className={
-                      'btn btn-outline btn-sm text-transform: capitalize'
-                    }
-                    onClick={() => submitComment(id)}
-                  >
-                    Sign in to Comment
-                  </button>
-                </Col>
-              )}
+                }}
+              />
 
-              <Col
-                className={clsx(
-                  'col-span-1 sm:col-span-2',
-                  focused ? 'justify-end' : 'justify-center'
-                )}
-              >
+              <Col className={clsx(focused ? 'justify-end' : 'justify-center')}>
                 {user && !isSubmitting && (
                   <button
                     className={clsx(
                       'btn btn-ghost btn-sm block flex flex-row capitalize',
                       'absolute bottom-4 right-1 col-span-1',
-                      parentComment ? ' bottom-6 right-2.5' : '',
-                      'sm:relative sm:bottom-0 sm:right-0 sm:col-span-2',
+                      // parentComment ? ' bottom-4 right-2.5' : '',
+                      // 'sm:relative sm:bottom-0 sm:right-0 sm:col-span-2',
                       focused && comment
-                        ? 'sm:btn-outline'
+                        ? ''
                         : 'pointer-events-none text-gray-500'
                     )}
                     onClick={() => {
@@ -449,12 +422,9 @@ export function CommentInput(props: {
                       }
                     }}
                   >
-                    <span className={'hidden sm:block'}>
-                      {parentComment || answerOutcome ? 'Reply' : 'Comment'}
-                    </span>
                     {focused && (
                       <PaperAirplaneIcon
-                        className={'m-0 min-w-[22px] rotate-90 p-0 sm:hidden'}
+                        className={'m-0 min-w-[22px] rotate-90 p-0 '}
                         height={25}
                       />
                     )}
@@ -464,6 +434,18 @@ export function CommentInput(props: {
                   <LoadingIndicator spinnerClassName={'border-gray-500'} />
                 )}
               </Col>
+            </Row>
+            <Row>
+              {!user && (
+                <button
+                  className={
+                    'btn btn-outline btn-sm text-transform: capitalize'
+                  }
+                  onClick={() => submitComment(id)}
+                >
+                  Sign in to Comment
+                </button>
+              )}
             </Row>
           </div>
         </div>


### PR DESCRIPTION
- Flattened responses to FR answer replies into 1 level.
- Only the most recent bet on a free response market is given a comment input (other open comment inputs are hidden)
- Comment inputs are only as large as the number of lines in a comment. 
- The submit button is always an arrow inside the comment input box now. 
- Abstracted the replies code into a component that comment threads and fr comment threads share. It could be more condensed but would take a lot more work for not too much gain yet.

<img width="678" alt="Screen Shot 2022-06-07 at 3 30 52 PM" src="https://user-images.githubusercontent.com/23196210/172486246-86eb765e-f8ee-42d0-bbd5-f224f6ef8d75.png">
 