### PR TITLE
Implement really obvious optimizations on `placebet`, `sellbet`, `sellshares`

### DIFF
--- a/functions/src/create-contract.ts
+++ b/functions/src/create-contract.ts
@@ -27,6 +27,7 @@ import {
 import { getNoneAnswer } from '../../common/answer'
 import { getNewContract } from '../../common/new-contract'
 import { NUMERIC_BUCKET_COUNT } from '../../common/numeric-constants'
+import { User } from '../../common/user'
 
 const bodySchema = z.object({
   question: z.string().min(1).max(MAX_QUESTION_LENGTH),
@@ -48,7 +49,7 @@ const numericSchema = z.object({
   max: z.number(),
 })
 
-export const createmarket = newEndpoint(['POST'], async (req, [user, _]) => {
+export const createmarket = newEndpoint(['POST'], async (req, auth) => {
   const { question, description, tags, closeTime, outcomeType } = validate(
     bodySchema,
     req.body
@@ -70,9 +71,15 @@ export const createmarket = newEndpoint(['POST'], async (req, [user, _]) => {
     freeMarketResetTime = freeMarketResetTime - 24 * 60 * 60 * 1000
   }
 
+  const userDoc = await firestore.collection('users').doc(auth.uid).get()
+  if (!userDoc.exists) {
+    throw new APIError(400, 'No user exists with the authenticated user ID.')
+  }
+  const user = userDoc.data() as User
+
   const userContractsCreatedTodaySnapshot = await firestore
     .collection(`contracts`)
-    .where('creatorId', '==', user.id)
+    .where('creatorId', '==', auth.uid)
     .where('createdTime', '>=', freeMarketResetTime)
     .get()
   console.log('free market reset time: ', freeMarketResetTime)

--- a/functions/src/health.ts
+++ b/functions/src/health.ts
@@ -1,11 +1,8 @@
 import { newEndpoint } from './api'
 
-export const health = newEndpoint(['GET'], async (_req, [user, _]) => {
+export const health = newEndpoint(['GET'], async (_req, auth) => {
   return {
     message: 'Server is working.',
-    user: {
-      id: user.id,
-      username: user.username,
-    },
+    uid: auth.uid,
   }
 })

--- a/functions/src/place-bet.ts
+++ b/functions/src/place-bet.ts
@@ -32,11 +32,11 @@ const numericSchema = z.object({
   value: z.number(),
 })
 
-export const placebet = newEndpoint(['POST'], async (req, [bettor, _]) => {
+export const placebet = newEndpoint(['POST'], async (req, auth) => {
   const { amount, contractId } = validate(bodySchema, req.body)
 
   const result = await firestore.runTransaction(async (trans) => {
-    const userDoc = firestore.doc(`users/${bettor.id}`)
+    const userDoc = firestore.doc(`users/${auth.uid}`)
     const userSnap = await trans.get(userDoc)
     if (!userSnap.exists) throw new APIError(400, 'User not found.')
     const user = userSnap.data() as User
@@ -110,7 +110,7 @@ export const placebet = newEndpoint(['POST'], async (req, [bettor, _]) => {
     return { betId: betDoc.id }
   })
 
-  await redeemShares(bettor.id, contractId)
+  await redeemShares(auth.uid, contractId)
   return result
 })
 

--- a/functions/src/sell-bet.ts
+++ b/functions/src/sell-bet.ts
@@ -18,26 +18,27 @@ export const sellbet = newEndpoint(['POST'], async (req, auth) => {
 
   // run as transaction to prevent race conditions
   return await firestore.runTransaction(async (transaction) => {
-    const userDoc = firestore.doc(`users/${auth.uid}`)
-    const userSnap = await transaction.get(userDoc)
-    if (!userSnap.exists) throw new APIError(400, 'User not found.')
-    const user = userSnap.data() as User
-
     const contractDoc = firestore.doc(`contracts/${contractId}`)
-    const contractSnap = await transaction.get(contractDoc)
+    const userDoc = firestore.doc(`users/${auth.uid}`)
+    const betDoc = firestore.doc(`contracts/${contractId}/bets/${betId}`)
+    const [contractSnap, userSnap, betSnap] = await Promise.all([
+      transaction.get(contractDoc),
+      transaction.get(userDoc),
+      transaction.get(betDoc),
+    ])
     if (!contractSnap.exists) throw new APIError(400, 'Contract not found.')
+    if (!userSnap.exists) throw new APIError(400, 'User not found.')
+    if (!betSnap.exists) throw new APIError(400, 'Bet not found.')
+
     const contract = contractSnap.data() as Contract
+    const user = userSnap.data() as User
+    const bet = betSnap.data() as Bet
 
     const { closeTime, mechanism, collectedFees, volume } = contract
     if (mechanism !== 'dpm-2')
       throw new APIError(400, 'You can only sell bets on DPM-2 contracts.')
     if (closeTime && Date.now() > closeTime)
       throw new APIError(400, 'Trading is closed.')
-
-    const betDoc = firestore.doc(`contracts/${contractId}/bets/${betId}`)
-    const betSnap = await transaction.get(betDoc)
-    if (!betSnap.exists) throw new APIError(400, 'Bet not found.')
-    const bet = betSnap.data() as Bet
 
     if (auth.uid !== bet.userId)
       throw new APIError(400, 'The specified bet does not belong to you.')

--- a/functions/src/sell-shares.ts
+++ b/functions/src/sell-shares.ts
@@ -1,4 +1,4 @@
-import { partition, sumBy } from 'lodash'
+import { sumBy } from 'lodash'
 import * as admin from 'firebase-admin'
 import { z } from 'zod'
 
@@ -44,17 +44,9 @@ export const sellshares = newEndpoint(['POST'], async (req, auth) => {
 
     const prevLoanAmount = sumBy(userBets, (bet) => bet.loanAmount ?? 0)
 
-    const [yesBets, noBets] = partition(
-      userBets ?? [],
-      (bet) => bet.outcome === 'YES'
-    )
+    const outcomeBets = userBets.filter((bet) => bet.outcome == outcome)
+    const maxShares = sumBy(outcomeBets, (bet) => bet.shares)
 
-    const [yesShares, noShares] = [
-      sumBy(yesBets, (bet) => bet.shares),
-      sumBy(noBets, (bet) => bet.shares),
-    ]
-
-    const maxShares = outcome === 'YES' ? yesShares : noShares
     if (shares > maxShares + 0.000000000001)
       throw new APIError(400, `You can only sell up to ${maxShares} shares.`)
 


### PR DESCRIPTION
Just picking the lowest possible hanging fruit here. After this `placebet` (e.g.) will basically be doing what looks like a conceptually reasonable thing from a performance standpoint, so then we can take a look at the graphs, see where we stand, and judge whether we want to spend more effort.

- It turns out that most API endpoints that want user info are gonna want it in a transaction anyway, so looking it up in the auth flow is not a good idea because it's wasted work.
- There was no reason for `redeemShares` to be happening in a separate transaction and re-looking-up stuff that was already looked up.