### PR TITLE
Make feed updating do much less work

### DIFF
--- a/functions/src/get-feed-data.ts
+++ b/functions/src/get-feed-data.ts
@@ -42,8 +42,8 @@ export async function getTaggedContracts(tag: string) {
   return taggedContracts.filter((c) => (c.closeTime ?? Infinity) > Date.now())
 }
 
-export async function getRecentBetsAndComments(contract: Contract) {
-  const contractDoc = firestore.collection('contracts').doc(contract.id)
+export async function getRecentBetsAndComments(contractId: string) {
+  const contractDoc = firestore.collection('contracts').doc(contractId)
 
   const [recentBets, recentComments] = await Promise.all([
     getValues<Bet>(
@@ -64,7 +64,6 @@ export async function getRecentBetsAndComments(contract: Contract) {
   ])
 
   return {
-    contract,
     recentBets,
     recentComments,
   }


### PR DESCRIPTION
I noticed that feed updating is frequently outright failing because it takes so long it exceeds the Cloud Function runtime limit, and it looked like it was easy to make it much more efficient, so I did that.

Previously, to update each category feed, it was loading all bets and comment data for every contract (likely 75) in the feed of every user in every batch of users (30). But even though the feeds were probably very similar -- they use lots of user-agnostic ranking data -- each user would independently query all the bet and comment data for all their contracts. Now, the batch queries bet and comment data once for the union of the contracts of all the user feeds in the batch, so that might be something not far off from a factor of 30 less queries.

I didn't measure it, but this is by far the majority of the database work done by this computation, so common sense would suggest that it may be the majority of the overall work, so I might expect this to speed up the whole thing by something like an order of magnitude.