### PR TITLE
dpm fix multi resolution

### DIFF
--- a/common/calculate-dpm.ts
+++ b/common/calculate-dpm.ts
@@ -363,13 +363,10 @@ function calculateMktDpmPayout(contract: DPMContract, bet: Bet) {
             )
           }
         )
-      : (probs[outcome] * shares) / weightedShareTotal
+      : (shares / totalShares[outcome]) * probs[outcome]
 
   const totalPool = sum(Object.values(pool))
-  const winnings =
-    outcomeType === 'NUMERIC'
-      ? poolFrac * totalPool
-      : (shares / totalShares[outcome]) * probs[outcome] * totalPool
+  const winnings = poolFrac * totalPool
 
   return deductDpmFees(amount, winnings)
 }

--- a/common/calculate-dpm.ts
+++ b/common/calculate-dpm.ts
@@ -367,7 +367,6 @@ function calculateMktDpmPayout(contract: DPMContract, bet: Bet) {
 
   const totalPool = sum(Object.values(pool))
   const winnings = poolFrac * totalPool
-
   return deductDpmFees(amount, winnings)
 }
 

--- a/common/calculate-dpm.ts
+++ b/common/calculate-dpm.ts
@@ -363,7 +363,7 @@ function calculateMktDpmPayout(contract: DPMContract, bet: Bet) {
             )
           }
         )
-      : (shares / totalShares[outcome]) * probs[outcome]
+      : (probs[outcome] * shares) / totalShares[outcome]
 
   const totalPool = sum(Object.values(pool))
   const winnings = poolFrac * totalPool

--- a/common/calculate-dpm.ts
+++ b/common/calculate-dpm.ts
@@ -366,7 +366,11 @@ function calculateMktDpmPayout(contract: DPMContract, bet: Bet) {
       : (probs[outcome] * shares) / weightedShareTotal
 
   const totalPool = sum(Object.values(pool))
-  const winnings = poolFrac * totalPool
+  const winnings =
+    outcomeType === 'NUMERIC'
+      ? poolFrac * totalPool
+      : (shares / totalShares[outcome]) * probs[outcome] * totalPool
+
   return deductDpmFees(amount, winnings)
 }
 


### PR DESCRIPTION
With the current implementation the pool is split among all "winning" shares with the respective probability.
That means an answer with twice the shares gets assigned twice the winnings.

Correct would be to split the pool amongst the "winning" answers and then equally among shares for each answer.

Left old, right new
![image](https://user-images.githubusercontent.com/61841994/172680658-7e70cdd8-884b-4054-ae09-b849c757e702.png)
