### PR TITLE
Update FR comment prob and input after bet

### DIFF
--- a/web/components/feed/feed-answer-comment-group.tsx
+++ b/web/components/feed/feed-answer-comment-group.tsx
@@ -54,7 +54,6 @@ export function FeedAnswerCommentGroup(props: {
   )
   const commentsList = answerComments.concat(commentReplies)
   const thisAnswerProbOnMount = useRef<number>()
-  // get most recent bet on this answer to find probability
   const thisAnswerProb = bets
     .filter((bet) => bet.outcome === answer.number.toString())
     .sort((a, b) => b.createdTime - a.createdTime)[0].probAfter

--- a/web/components/feed/feed-answer-comment-group.tsx
+++ b/web/components/feed/feed-answer-comment-group.tsx
@@ -64,6 +64,7 @@ export function FeedAnswerCommentGroup(props: {
 
   useEffect(() => {
     thisAnswerProbOnMount.current = thisAnswerProb.valueOf()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
Updates fr answers in the comments section in realtime after a bet is placed. Also only scrolls user to an input field for their bet if they made a bet while on the page, (not for previous commentable bets).