### PR TITLE
Notif ux improvements

### DIFF
--- a/functions/src/on-update-contract.ts
+++ b/functions/src/on-update-contract.ts
@@ -14,13 +14,25 @@ export const onUpdateContract = functions.firestore
 
     const previousValue = change.before.data() as Contract
     if (previousValue.isResolved !== contract.isResolved) {
+      let resolutionText = contract.resolution ?? contract.question
+      if (contract.outcomeType === 'FREE_RESPONSE') {
+        const answerText = contract.answers.find(
+          (answer) => answer.id === contract.resolution
+        )?.text
+        if (answerText) resolutionText = answerText
+      } else if (contract.outcomeType === 'BINARY') {
+        if (resolutionText === 'MKT' && contract.resolutionProbability)
+          resolutionText = `${contract.resolutionProbability}%`
+        else if (resolutionText === 'MKT') resolutionText = 'PROB'
+      }
+
       await createNotification(
         contract.id,
         'contract',
         'resolved',
         contractUpdater,
         eventId,
-        contract.resolution ?? contract.question,
+        resolutionText,
         contract
       )
     } else if (

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -685,7 +685,7 @@ function NotificationItem(props: {
                       sourceUpdateType,
                       contract
                     )}
-                    <span className={'mx-1 font-bold hover:underline'}>
+                    <span className={'mx-1 font-bold'}>
                       {contract?.question || sourceContractTitle}
                     </span>
                   </div>
@@ -762,14 +762,8 @@ function NotificationTextLabel(props: {
         )
       if (sourceText === 'CANCEL') return <CancelLabel />
       if (sourceText === 'MKT' || sourceText === 'PROB') return <MultiLabel />
-      return (
-        <span
-          style={{ wordBreak: 'break-word' }}
-          className={clsx('whitespace-pre-line break-words', className)}
-        >
-          {sourceText}
-        </span>
-      )
+      // Show free response answer text
+      return <span>{sourceText}</span>
     } else if (contract?.resolution) {
       if (contract.outcomeType === 'FREE_RESPONSE') {
         return (

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -30,8 +30,12 @@ import { UsersIcon } from '@heroicons/react/solid'
 import { RelativeTimestamp } from 'web/components/relative-timestamp'
 import { Linkify } from 'web/components/linkify'
 import {
+  BinaryOutcomeLabel,
+  CancelLabel,
   FreeResponseOutcomeLabel,
+  MultiLabel,
   OutcomeLabel,
+  ProbPercentLabel,
 } from 'web/components/outcome-label'
 import {
   groupNotifications,
@@ -681,7 +685,7 @@ function NotificationItem(props: {
                       sourceUpdateType,
                       contract
                     )}
-                    <span className={'mx-1 font-bold'}>
+                    <span className={'mx-1 font-bold hover:underline'}>
                       {contract?.question || sourceContractTitle}
                     </span>
                   </div>
@@ -746,26 +750,45 @@ function NotificationTextLabel(props: {
       sourceType,
       sourceUpdateType,
       contract
-    ) &&
-    contract?.resolution
+    )
   ) {
-    if (contract.outcomeType === 'FREE_RESPONSE') {
+    if (sourceText) {
+      if (sourceText === 'YES' || sourceText == 'NO') {
+        return <BinaryOutcomeLabel outcome={sourceText as any} />
+      }
+      if (sourceText.includes('%'))
+        return (
+          <ProbPercentLabel prob={parseFloat(sourceText.replace('%', ''))} />
+        )
+      if (sourceText === 'CANCEL') return <CancelLabel />
+      if (sourceText === 'MKT' || sourceText === 'PROB') return <MultiLabel />
       return (
-        <FreeResponseOutcomeLabel
+        <span
+          style={{ wordBreak: 'break-word' }}
+          className={clsx('whitespace-pre-line break-words', className)}
+        >
+          {sourceText}
+        </span>
+      )
+    } else if (contract?.resolution) {
+      if (contract.outcomeType === 'FREE_RESPONSE') {
+        return (
+          <FreeResponseOutcomeLabel
+            contract={contract}
+            resolution={contract.resolution}
+            truncate={'long'}
+            answerClassName={className}
+          />
+        )
+      }
+      return (
+        <OutcomeLabel
           contract={contract}
-          resolution={contract.resolution}
+          outcome={contract.resolution}
           truncate={'long'}
-          answerClassName={className}
         />
       )
-    }
-    return (
-      <OutcomeLabel
-        contract={contract}
-        outcome={contract.resolution}
-        truncate={'long'}
-      />
-    )
+    } else return <div />
   } else if (sourceType === 'contract') {
     return (
       <div className={clsx('text-indigo-700 hover:underline', className)}>


### PR DESCRIPTION
Allow user to click on a title to visit that page. Add timestamp for follows. Stop unnecessarily loading contract for notification groups. Don't repeat contract title in contract updates.