### PR TITLE
Optimize `updateContractMetrics`

### DIFF
--- a/functions/src/update-contract-metrics.ts
+++ b/functions/src/update-contract-metrics.ts
@@ -29,12 +29,12 @@ export const updateContractMetrics = functions.pubsub
   })
 
 const computeVolumes = async (contractId: string, durationsMs: number[]) => {
-  const longestDurationMs = max(durationsMs)
-  /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const longestDurationMs = max(durationsMs)!
   const allBets = await getValues<Bet>(
     firestore
       .collection(`contracts/${contractId}/bets`)
-      .where('createdTime', '>', Date.now() - longestDurationMs!)
+      .where('createdTime', '>', Date.now() - longestDurationMs)
   )
   return durationsMs.map((duration) => {
     const cutoff = Date.now() - duration


### PR DESCRIPTION
I don't know if this is moving the needle on cost, but it's easier to just fix stuff to be better and look at what happens rather than try to discern it by thinking.

I guess this does half as many database queries as the previous version and reads way less data, so that should be good.