### PR TITLE
Refinement of LiteMarket

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -95,14 +95,21 @@ Requires no authorization.
     description: string
     tags: string[]
     url: string
+    outcomeType: string
+    mechanism: string
 
     pool: number
-    probability: number
+    probability?: number
+    p?: number
+    totalShares?: number
+
+    volume: number
     volume7Days: number
     volume24Hours: number
+
     isResolved: boolean
-    resolutionTime?: number
     resolution?: string
+    resolutionTime?: number
   }
   ```
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -101,7 +101,6 @@ Requires no authorization.
     pool: number
     probability?: number
     p?: number
-    totalShares?: number
 
     volume: number
     volume7Days: number

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -57,11 +57,17 @@ export function contractMetrics(contract: Contract) {
 }
 
 export function contractPool(contract: Contract) {
+  return contractPoolValue(contract) === 0
+    ? 'Empty Pool'
+    : formatMoney(contractPoolValue(contract))
+}
+
+export function contractPoolValue(contract: Contract) {
   return contract.mechanism === 'cpmm-1'
-    ? formatMoney(contract.totalLiquidity)
+    ? contract.totalLiquidity
     : contract.mechanism === 'dpm-2'
-    ? formatMoney(sum(Object.values(contract.pool)))
-    : 'Empty pool'
+    ? sum(Object.values(contract.pool))
+    : 0
 }
 
 export function getBinaryProb(contract: BinaryContract) {

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -57,12 +57,12 @@ export function contractMetrics(contract: Contract) {
 }
 
 export function contractPool(contract: Contract) {
-  return contractPoolValue(contract) === 0
+  return getPoolValue(contract) === 0
     ? 'Empty Pool'
-    : formatMoney(contractPoolValue(contract))
+    : formatMoney(getPoolValue(contract))
 }
 
-export function contractPoolValue(contract: Contract) {
+export function getPoolValue(contract: Contract) {
   return contract.mechanism === 'cpmm-1'
     ? contract.totalLiquidity
     : contract.mechanism === 'dpm-2'

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -92,7 +92,6 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     pool: getPoolValue(contract),
     probability,
     p,
-    totalShares: getTotalShares(contract),
     outcomeType,
     mechanism,
     volume,
@@ -102,11 +101,4 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     resolution,
     resolutionTime,
   })
-}
-
-function getTotalShares(contract: Contract): number {
-  const shares =
-    contract.mechanism === 'dpm-2' ? contract.totalShares : contract.pool
-
-  return sum(Object.values(shares))
 }


### PR DESCRIPTION
@wasabipesto noticed inconsistencies in the market data the api returns.

I've taken a look at LiteMarket, my suggestions are in this PR.
There is more data for non-binary markets now and hopefully it's clearer what the values mean.
The total number of shares in the liquidity pool which was written to "pool" before seems to have been a relic from dpm binary markets and is not in the API anymore.

### Details
* pool: set in the same way as in the "Market Overview" from contract-info-dialog.tsx now
* removal of totalLiquidity: was only set for binary markets and its value was identical to the new totalShares in that case

This does not need to be merged right away but can serve as basis for discussion.
