### PR TITLE
Add userId to bets API

### DIFF
--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -38,7 +38,7 @@ export type LiteMarket = {
 }
 
 export type FullMarket = LiteMarket & {
-  allBets: Bet[]
+  bets: Bet[]
   comments: Comment[]
 }
 

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -38,7 +38,7 @@ export type LiteMarket = {
 }
 
 export type FullMarket = LiteMarket & {
-  bets: Bet[]
+  allBets: Bet[]
   comments: Comment[]
 }
 

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -38,7 +38,7 @@ export type LiteMarket = {
 }
 
 export type FullMarket = LiteMarket & {
-  bets: Exclude<Bet, 'userId'>[]
+  bets: Bet[]
   comments: Comment[]
 }
 

--- a/web/pages/api/v0/market/[id].ts
+++ b/web/pages/api/v0/market/[id].ts
@@ -13,7 +13,7 @@ export default async function handler(
   const { id } = req.query
   const contractId = id as string
 
-  const [contract, allBets, comments] = await Promise.all([
+  const [contract, bets, comments] = await Promise.all([
     getContractFromId(contractId),
     listAllBets(contractId),
     listAllComments(contractId),
@@ -28,7 +28,7 @@ export default async function handler(
   res.setHeader('Cache-Control', 'max-age=0, s-maxage=120')
   return res.status(200).json({
     ...toLiteMarket(contract),
-    allBets,
+    bets,
     comments,
   })
 }

--- a/web/pages/api/v0/market/[id].ts
+++ b/web/pages/api/v0/market/[id].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { Bet, listAllBets } from 'web/lib/firebase/bets'
+import { listAllBets } from 'web/lib/firebase/bets'
 import { listAllComments } from 'web/lib/firebase/comments'
 import { getContractFromId } from 'web/lib/firebase/contracts'
 import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
@@ -19,11 +19,6 @@ export default async function handler(
     listAllComments(contractId),
   ])
 
-  const bets = allBets.map(({ userId, ...bet }) => bet) as Exclude<
-    Bet,
-    'userId'
-  >[]
-
   if (!contract) {
     res.status(404).json({ error: 'Contract not found' })
     return
@@ -33,7 +28,7 @@ export default async function handler(
   res.setHeader('Cache-Control', 'max-age=0, s-maxage=120')
   return res.status(200).json({
     ...toLiteMarket(contract),
-    bets,
+    allBets,
     comments,
   })
 }

--- a/web/pages/api/v0/slug/[slug].ts
+++ b/web/pages/api/v0/slug/[slug].ts
@@ -19,7 +19,7 @@ export default async function handler(
     return
   }
 
-  const [allBets, comments] = await Promise.all([
+  const [bets, comments] = await Promise.all([
     listAllBets(contract.id),
     listAllComments(contract.id),
   ])
@@ -28,7 +28,7 @@ export default async function handler(
   res.setHeader('Cache-Control', 'max-age=0, s-maxage=120')
   return res.status(200).json({
     ...toLiteMarket(contract),
-    allBets,
+    bets,
     comments,
   })
 }

--- a/web/pages/api/v0/slug/[slug].ts
+++ b/web/pages/api/v0/slug/[slug].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
-import { Bet, listAllBets } from 'web/lib/firebase/bets'
+import { listAllBets } from 'web/lib/firebase/bets'
 import { listAllComments } from 'web/lib/firebase/comments'
 import { getContractFromSlug } from 'web/lib/firebase/contracts'
 import { FullMarket, ApiError, toLiteMarket } from '../_types'
@@ -24,16 +24,11 @@ export default async function handler(
     listAllComments(contract.id),
   ])
 
-  const bets = allBets.map(({ userId, ...bet }) => bet) as Exclude<
-    Bet,
-    'userId'
-  >[]
-
   // Cache on Vercel edge servers for 2min
   res.setHeader('Cache-Control', 'max-age=0, s-maxage=120')
   return res.status(200).json({
     ...toLiteMarket(contract),
-    bets,
+    allBets,
     comments,
   })
 }


### PR DESCRIPTION
This PR simply reverts [this commit](https://github.com/manifoldmarkets/manifold/commit/42f88766b37895d3b39026c6d16c7a6541332311). It does not directly reveal bettor usernames, though we aren't making too much of an effort to hide them at the moment.

With this data I plan to create the following analytics:
- Histogram: Total bets made, per user (possibly M$ bet per user?)
- Histogram: Total profit, per user
- Histogram: Average Brier score, based on final position in market

When we have the ability to correlate `userId` to username, I'm looking into creating the following:
- Leaderboard: Most bets
- Leaderboard: Total profit (replica of official leaderboard)
- Leaderboard: Highest profit/loss ratio
- Leaderboard: Highest average (median?) bet amount