### PR TITLE
Improve visibility of `updateFooMetrics` functions behavior

### DIFF
--- a/functions/src/scripts/update-metrics.ts
+++ b/functions/src/scripts/update-metrics.ts
@@ -1,0 +1,16 @@
+import { initAdmin } from './script-init'
+initAdmin()
+
+import { updateContractMetricsCore } from '../update-contract-metrics'
+import { updateUserMetricsCore } from '../update-user-metrics'
+
+async function updateMetrics() {
+  console.log('Updating contract metrics...')
+  await updateContractMetricsCore()
+  console.log('Updating user metrics...')
+  await updateUserMetricsCore()
+}
+
+if (require.main === module) {
+  updateMetrics().then(() => process.exit())
+}

--- a/functions/src/scripts/update-metrics.ts
+++ b/functions/src/scripts/update-metrics.ts
@@ -1,13 +1,15 @@
 import { initAdmin } from './script-init'
 initAdmin()
 
+import { log, logMemory } from '../utils'
 import { updateContractMetricsCore } from '../update-contract-metrics'
 import { updateUserMetricsCore } from '../update-user-metrics'
 
 async function updateMetrics() {
-  console.log('Updating contract metrics...')
+  logMemory()
+  log('Updating contract metrics...')
   await updateContractMetricsCore()
-  console.log('Updating user metrics...')
+  log('Updating user metrics...')
   await updateUserMetricsCore()
 }
 

--- a/functions/src/update-contract-metrics.ts
+++ b/functions/src/update-contract-metrics.ts
@@ -2,7 +2,7 @@ import * as functions from 'firebase-functions'
 import * as admin from 'firebase-admin'
 import { max, sumBy } from 'lodash'
 
-import { getValues } from './utils'
+import { getValues, log, logMemory } from './utils'
 import { Bet } from '../../common/bet'
 import { batchedWaitAll } from '../../common/util/promise'
 
@@ -27,6 +27,8 @@ const computeVolumes = async (contractId: string, durationsMs: number[]) => {
 
 export const updateContractMetricsCore = async () => {
   const contractDocs = await firestore.collection('contracts').listDocuments()
+  log(`Loaded ${contractDocs.length} contract IDs.`)
+  logMemory()
   await batchedWaitAll(
     contractDocs.map((doc) => async () => {
       const [volume24Hours, volume7Days] = await computeVolumes(doc.id, [
@@ -39,6 +41,7 @@ export const updateContractMetricsCore = async () => {
       })
     })
   )
+  log(`Updated metrics for ${contractDocs.length} contracts.`)
 }
 
 export const updateContractMetrics = functions

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -2,7 +2,7 @@ import * as functions from 'firebase-functions'
 import * as admin from 'firebase-admin'
 import { groupBy, sum, sumBy } from 'lodash'
 
-import { getValues } from './utils'
+import { getValues, log, logMemory } from './utils'
 import { Contract } from '../../common/contract'
 import { Bet } from '../../common/bet'
 import { User } from '../../common/user'
@@ -44,6 +44,10 @@ export const updateUserMetricsCore = async () => {
     getValues<Contract>(firestore.collection('contracts')),
     firestore.collectionGroup('bets').get(),
   ])
+  log(
+    `Loaded ${users.length} users, ${contracts.length} contracts, and ${bets.docs.length} bets.`
+  )
+  logMemory()
 
   const contractsDict = Object.fromEntries(
     contracts.map((contract) => [contract.id, contract])
@@ -70,6 +74,7 @@ export const updateUserMetricsCore = async () => {
       })
     })
   )
+  log(`Updated metrics for ${users.length} users.`)
 }
 
 export const updateUserMetrics = functions

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -1,5 +1,6 @@
 import * as admin from 'firebase-admin'
 
+import { chunk } from 'lodash'
 import { Contract } from '../../common/contract'
 import { PrivateUser, User } from '../../common/user'
 
@@ -12,6 +13,20 @@ export const logMemory = () => {
   for (const [k, v] of Object.entries(used)) {
     log(`${k} ${Math.round((v / 1024 / 1024) * 100) / 100} MB`)
   }
+}
+
+export const mapAsync = async <T, U>(
+  xs: T[],
+  fn: (x: T) => Promise<U>,
+  concurrency = 100
+) => {
+  const results = []
+  const chunks = chunk(xs, concurrency)
+  for (let i = 0; i < chunks.length; i++) {
+    log(`${i * concurrency}/${xs.length} processed...`)
+    results.push(...(await Promise.all(chunks[i].map(fn))))
+  }
+  return results
 }
 
 export const isProd =

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -3,6 +3,17 @@ import * as admin from 'firebase-admin'
 import { Contract } from '../../common/contract'
 import { PrivateUser, User } from '../../common/user'
 
+export const log = (...args: unknown[]) => {
+  console.log(`[${new Date().toISOString()}]`, ...args)
+}
+
+export const logMemory = () => {
+  const used = process.memoryUsage()
+  for (const [k, v] of Object.entries(used)) {
+    log(`${k} ${Math.round((v / 1024 / 1024) * 100) / 100} MB`)
+  }
+}
+
 export const isProd =
   admin.instanceId().app.options.projectId === 'mantic-markets'
 


### PR DESCRIPTION
Basically I wanted to add a bunch of logging so that I can see what's going on in these functions, and add a script to test it.

Based on looking at graphs so far, I think these will be our new cost culprits after `updateFeed`, and we can easily continue to make them more efficient with minimal effort. For example, if we put these two functions together it's basically going to do all the work in the same amount of time, and we aren't taking advantage of Firebase's batched update functionality either. Probably I am going to do this if it saves e.g. twenty bucks per day. (These guys basically scale linearly with the number of things in the DB, so they are only going to get more expensive.)

But I'm getting tired of feeling like I am in the dark while I am changing stuff so I am gonna start lighting things up.