### PR TITLE
💭 Make notifications public on your user page?

### DIFF
--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -177,7 +177,7 @@ const setNotificationsAsSeen = (notifications: Notification[]) => {
   return notifications
 }
 
-function NotificationGroupItem(props: {
+export function NotificationGroupItem(props: {
   notificationGroup: NotificationGroup
   className?: string
 }) {
@@ -510,7 +510,7 @@ function isNotificationAboutContractResolution(
   )
 }
 
-function NotificationItem(props: {
+export function NotificationItem(props: {
   notification: Notification
   justSummary?: boolean
 }) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/856034/173512847-71d69f78-ffa6-4502-9418-b8ea2067ccff.png)

Very experimental; inspired by musings here: https://manifold.markets/Austin/will-you-be-able-to-dm-someone-thro#eTNos8mZe3TjFJHmHWir

Notifications make even less sense to show on a user profile than a hypothetical "DM inbox", but it's kind of fun to think about notification-stalking people!

Further extension: maybe you should be able to login as any other person and see what they see on a read-only view...?