### PR TITLE
removal of totalLiquidity

### DIFF
--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -26,7 +26,6 @@ export type LiteMarket = {
   pool: number
   probability?: number
   p?: number
-  totalLiquidity?: number
 
   volume: number
   volume7Days: number
@@ -69,7 +68,7 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     resolutionTime,
   } = contract
 
-  const { p, totalLiquidity } = contract as any
+  const { p } = contract as any
 
   const probability =
     contract.outcomeType === 'BINARY' ? getProbability(contract) : undefined
@@ -91,7 +90,6 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     pool: pool.YES + pool.NO,
     probability,
     p,
-    totalLiquidity,
     outcomeType,
     mechanism,
     volume,


### PR DESCRIPTION
The "totalLiquidity" field is confusing. It only contains information for binary markets and contains the info which is supposed to be under "Pool" (as in the market info page).

It can be removed after completion of #503.
This is a seperate PR since it needs to be discussed whether this is a breaking change.