### PR TITLE
[Leaderboards][Work in Progress] Added period toggle for leaderboards

### DIFF
--- a/common/user.ts
+++ b/common/user.ts
@@ -15,8 +15,18 @@ export type User = {
 
   balance: number
   totalDeposits: number
-  totalPnLCached: number
-  creatorVolumeCached: number
+  totalPnLCached: {
+    daily: number
+    weekly: number
+    monthly: number
+    allTime: number
+  }
+  creatorVolumeCached: {
+    daily: number
+    weekly: number
+    monthly: number
+    allTime: number
+  }
 
   followedCategories?: string[]
 }

--- a/functions/src/create-user.ts
+++ b/functions/src/create-user.ts
@@ -67,8 +67,8 @@ export const createUser = functions
       balance,
       totalDeposits: balance,
       createdTime: Date.now(),
-      totalPnLCached: 0,
-      creatorVolumeCached: 0,
+      totalPnLCached: { daily: 0, weekly: 0, monthly: 0, allTime: 0 },
+      creatorVolumeCached: { daily: 0, weekly: 0, monthly: 0, allTime: 0 },
     }
 
     await firestore.collection('users').doc(userId).create(user)

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -9,10 +9,12 @@ import { User } from '../../common/user'
 import { calculatePayout } from '../../common/calculate'
 
 const firestore = admin.firestore()
+const DAY_MS = 24 * 60 * 60 * 1000
 
 const computeInvestmentValue = (
   bets: Bet[],
-  contractsDict: { [k: string]: Contract }
+  contractsDict: { [k: string]: Contract },
+  startTime: number = 0
 ) => {
   return sumBy(bets, (bet) => {
     const contract = contractsDict[bet.contractId]
@@ -20,16 +22,21 @@ const computeInvestmentValue = (
     if (bet.sale || bet.isSold) return 0
 
     const payout = calculatePayout(contract, bet, 'MKT')
+    const betTime = bet.createdTime ?? 0
+    if (betTime < startTime || betTime >= Date.now()) return 0
+
     return payout - (bet.loanAmount ?? 0)
   })
 }
 
 const computeTotalPool = (
   user: User,
-  contractsDict: { [k: string]: Contract }
+  contractsDict: { [k: string]: Contract },
+  startTime: number = 0
 ) => {
   const creatorContracts = Object.values(contractsDict).filter(
-    (contract) => contract.creatorId === user.id
+    (contract) =>
+      contract.creatorId === user.id && contract.createdTime >= startTime
   )
   const pools = creatorContracts.map((contract) =>
     sum(Object.values(contract.pool))
@@ -58,19 +65,94 @@ export const updateUserMetricsCore = async () => {
   )
 
   await mapAsync(users, async (user) => {
-    const investmentValue = computeInvestmentValue(
-      betsByUser[user.id] ?? [],
-      contractsDict
+    const currentBets = betsByUser[user.id] ?? []
+    const calculatedValues = calculateValuesForUser(
+      user,
+      contractsDict,
+      currentBets
     )
-    const creatorVolume = computeTotalPool(user, contractsDict)
-    const totalValue = user.balance + investmentValue
-    const totalPnL = totalValue - user.totalDeposits
-    return await firestore.collection('users').doc(user.id).update({
-      totalPnLCached: totalPnL,
-      creatorVolumeCached: creatorVolume,
-    })
+
+    return await firestore
+      .collection('users')
+      .doc(user.id)
+      .update({
+        totalPnLCached: {
+          daily: calculatedValues.dailyInvestmentValue,
+          weekly: calculatedValues.weeklyInvestmentValue,
+          monthly: calculatedValues.monthlyInvestmentValue,
+          allTime:
+            calculatedValues.allTimeInvestmentValue +
+            user.balance -
+            user.totalDeposits,
+        },
+        creatorVolumeCached: {
+          daily: calculatedValues.dailyCreatorVolume,
+          weekly: calculatedValues.weeklyCreatorVolume,
+          monthly: calculatedValues.monthlyCreatorVolume,
+          allTime: calculatedValues.allTimeCreatorVolume,
+        },
+      })
   })
   log(`Updated metrics for ${users.length} users.`)
+}
+
+const calculateValuesForUser = (
+  user: User,
+  contractsDict: { [k: string]: Contract },
+  currentBets: Bet[]
+) => {
+  const allTimeInvestmentValue = computeInvestmentValue(
+    currentBets,
+    contractsDict,
+    0
+  )
+
+  const dailyInvestmentValue = computeInvestmentValue(
+    currentBets,
+    contractsDict,
+    Date.now() - 1 * DAY_MS
+  )
+
+  const monthlyInvestmentValue = computeInvestmentValue(
+    currentBets,
+    contractsDict,
+    Date.now() - 30 * DAY_MS
+  )
+
+  const weeklyInvestmentValue = computeInvestmentValue(
+    currentBets,
+    contractsDict,
+    Date.now() - 7 * DAY_MS
+  )
+
+  const allTimeCreatorVolume = computeTotalPool(user, contractsDict, 0)
+  const monthlyCreatorVolume = computeTotalPool(
+    user,
+    contractsDict,
+    Date.now() - 30 * DAY_MS
+  )
+  const weeklyCreatorVolume = computeTotalPool(
+    user,
+    contractsDict,
+    Date.now() - 7 * DAY_MS
+  )
+
+  const dailyCreatorVolume = computeTotalPool(
+    user,
+    contractsDict,
+    Date.now() - 1 * DAY_MS
+  )
+
+  return {
+    allTimeInvestmentValue,
+    dailyInvestmentValue,
+    monthlyInvestmentValue,
+    weeklyInvestmentValue,
+    allTimeCreatorVolume,
+    monthlyCreatorVolume,
+    weeklyCreatorVolume,
+    dailyCreatorVolume,
+  }
 }
 
 export const updateUserMetrics = functions

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -32,8 +32,11 @@ import { feed } from 'common/feed'
 import { CATEGORY_LIST } from 'common/categories'
 import { safeLocalStorage } from '../util/local'
 import { filterDefined } from 'common/util/array'
+import { Leaderboard } from 'web/components/leaderboard'
 
 export type { User }
+
+export type LeaderboardPeriod = 'daily' | 'weekly' | 'monthly' | 'allTime'
 
 const db = getFirestore(app)
 export const auth = getAuth(app)
@@ -178,25 +181,23 @@ export function listenForPrivateUsers(
   listenForValues(q, setUsers)
 }
 
-const topTradersQuery = query(
-  collection(db, 'users'),
-  orderBy('totalPnLCached', 'desc'),
-  limit(21)
-)
+export function getTopTraders(period: LeaderboardPeriod) {
+  const topTraders = query(
+    collection(db, 'users'),
+    orderBy('totalPnLCached.' + period, 'desc'),
+    limit(20)
+  )
 
-export async function getTopTraders() {
-  const users = await getValues<User>(topTradersQuery)
-  return users.slice(0, 20)
+  return getValues(topTraders)
 }
 
-const topCreatorsQuery = query(
-  collection(db, 'users'),
-  orderBy('creatorVolumeCached', 'desc'),
-  limit(20)
-)
-
-export function getTopCreators() {
-  return getValues<User>(topCreatorsQuery)
+export function getTopCreators(period: LeaderboardPeriod) {
+  const topCreators = query(
+    collection(db, 'users'),
+    orderBy('creatorVolumeCached.' + period, 'desc'),
+    limit(20)
+  )
+  return getValues(topCreators)
 }
 
 export function getUsers() {

--- a/web/pages/leaderboards.tsx
+++ b/web/pages/leaderboards.tsx
@@ -1,23 +1,33 @@
 import { Col } from 'web/components/layout/col'
 import { Leaderboard } from 'web/components/leaderboard'
 import { Page } from 'web/components/page'
-import { getTopCreators, getTopTraders, User } from 'web/lib/firebase/users'
+import {
+  getTopCreators,
+  getTopTraders,
+  LeaderboardPeriod,
+  User,
+} from 'web/lib/firebase/users'
 import { formatMoney } from 'common/util/format'
 import { fromPropz, usePropz } from 'web/hooks/use-propz'
+import { useEffect, useState } from 'react'
+import { LoadingIndicator } from 'web/components/loading-indicator'
+import { Spacer } from 'web/components/layout/spacer'
+import { Title } from 'web/components/title'
 
 export const getStaticProps = fromPropz(getStaticPropz)
 export async function getStaticPropz() {
+  return queryTopCreators('weekly')
+}
+const queryTopCreators = async (period: LeaderboardPeriod) => {
   const [topTraders, topCreators] = await Promise.all([
-    getTopTraders().catch(() => {}),
-    getTopCreators().catch(() => {}),
+    getTopTraders(period).catch(() => {}),
+    getTopCreators(period).catch(() => {}),
   ])
-
   return {
     props: {
       topTraders,
       topCreators,
     },
-
     revalidate: 60, // regenerate after a minute
   }
 }
@@ -30,31 +40,69 @@ export default function Leaderboards(props: {
     topTraders: [],
     topCreators: [],
   }
-  const { topTraders, topCreators } = props
+
+  const [topTradersState, setTopTraders] = useState(props.topTraders)
+  const [topCreatorsState, setTopCreators] = useState(props.topCreators)
+  const [isLoading, setLoading] = useState(false)
+  const [period, setPeriod] = useState<LeaderboardPeriod>('weekly')
+
+  useEffect(() => {
+    setLoading(true)
+    queryTopCreators(period).then((res) => {
+      setTopTraders(res.props.topTraders as User[])
+      setTopCreators(res.props.topCreators as User[])
+      setLoading(false)
+    })
+  }, [period])
 
   return (
     <Page margin>
+      <Title text={'Leaderboards'} className={'hidden md:block'} />
+      <Col className="gap-4 text-center">
+        <select
+          onChange={async (e) => {
+            setPeriod(e.target.value as LeaderboardPeriod)
+          }}
+          value={period}
+          className="!select !select-bordered max-w-xs"
+        >
+          <option value="allTime">All Time</option>
+          <option value="monthly">Monthly</option>
+          <option value="weekly">Weekly</option>
+          <option value="daily">Daily</option>
+        </select>
+      </Col>
+      <Spacer h={4} />
+
       <Col className="items-center gap-10 lg:flex-row">
-        <Leaderboard
-          title="🏅 Top bettors"
-          users={topTraders}
-          columns={[
-            {
-              header: 'Total profit',
-              renderCell: (user) => formatMoney(user.totalPnLCached),
-            },
-          ]}
-        />
-        <Leaderboard
-          title="🏅 Top creators"
-          users={topCreators}
-          columns={[
-            {
-              header: 'Total bet',
-              renderCell: (user) => formatMoney(user.creatorVolumeCached),
-            },
-          ]}
-        />
+        {!isLoading ? (
+          <>
+            <Leaderboard
+              title="🏅 Top bettors"
+              users={topTradersState}
+              columns={[
+                {
+                  header: 'Total profit',
+                  renderCell: (user) =>
+                    formatMoney(user.totalPnLCached[period]),
+                },
+              ]}
+            />
+            <Leaderboard
+              title="🏅 Top creators"
+              users={topCreatorsState}
+              columns={[
+                {
+                  header: 'Total bet',
+                  renderCell: (user) =>
+                    formatMoney(user.creatorVolumeCached[period]),
+                },
+              ]}
+            />
+          </>
+        ) : (
+          <LoadingIndicator spinnerClassName={'border-gray-500'} />
+        )}
       </Col>
     </Page>
   )


### PR DESCRIPTION
@akrolsmir  @jahooma @jahooma Hey guys, thought I'd share the progress so far with a pull request. 

This is what it looks like let me if you'd like any changes to the design. 
[Click for Video](https://user-images.githubusercontent.com/6242616/173882715-f9280126-a2c4-42bb-984f-82db44ad88be.mov
)
1. Changed how firestore stores the relevant data. It used to be number fields in the 'user' collection, they are now maps that store the info for each period. They are still cached every 15mins by the update-user-metrics scheduled cloud function.

Assumption: My first idea here was to store the data in a last30daysVolume[30] array, and calculate the duration when querying. I decided against that as it seems that firebase is very limited when querying array fields. 

2. Updated the methods that compute the user's bettingProfits and creatorVolume in update-user-metrics. They can now take a startTime as a param. updateUserMetricsCore() now uses those methods to store the information for all the relevant time periods (daily,weekly,monthly,alltime). 

Note: Seems like Marshall deleted updateUserMetrics yesterday and moved all scheduled jobs into a new single file, so I'll need to update this. 

3. Updated the relevant queries to take a period parameter.

4. Updated the frontend to show the new UX. 
Note: I used getStaticProps to prebuild the default "weekly" view, but whenever the user selects something else in the toggle (i.e monthly, allTime, daily), I'm fetching the query again with the new period, dynamically. I haven't worked with Jamstack/serverless before, is this bad practice in this context? Should I just pre-fetch all the data in getStaticProps, and just swap what gets rendered when the user selects smth in the toggle?

**Important: There are some merge conflicts with @mqp's 4f96b9ef6342456bf7c9f30f7e90924f6abc8dfe, I'll fix those tomorrow, we can't land this until then.**