### PR TITLE
Include market URL in createmarket response

### DIFF
--- a/common/contract.ts
+++ b/common/contract.ts
@@ -12,6 +12,7 @@ export type AnyContractType =
 export type Contract<T extends AnyContractType = AnyContractType> = {
   id: string
   slug: string // auto-generated; must be unique
+  url: string
 
   creatorId: string
   creatorName: string

--- a/common/new-contract.ts
+++ b/common/new-contract.ts
@@ -15,6 +15,7 @@ import { removeUndefinedProps } from './util/object'
 export function getNewContract(
   id: string,
   slug: string,
+  url: string,
   creator: User,
   question: string,
   outcomeType: outcomeType,
@@ -44,6 +45,7 @@ export function getNewContract(
   const contract: Contract = removeUndefinedProps({
     id,
     slug,
+    url,
     ...propsByOutcomeType,
 
     creatorId: creator.id,

--- a/functions/src/create-contract.ts
+++ b/functions/src/create-contract.ts
@@ -13,6 +13,7 @@ import {
 } from '../../common/contract'
 import { slugify } from '../../common/util/slugify'
 import { randomString } from '../../common/util/random'
+import { DOMAIN } from '../../common/envs/constants'
 
 import { chargeUser } from './utils'
 import { APIError, newEndpoint, validate, zTimestamp } from './api'
@@ -101,10 +102,12 @@ export const createmarket = newEndpoint(['POST'], async (req, auth) => {
   )
 
   const slug = await getSlug(question)
+  const url = `https://${DOMAIN}/${user.username}/${slug}`
   const contractRef = firestore.collection('contracts').doc()
   const contract = getNewContract(
     contractRef.id,
     slug,
+    url,
     user,
     question,
     outcomeType,

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -3,6 +3,7 @@ import { getProbability } from 'common/calculate'
 import { Comment } from 'common/comment'
 import { Contract } from 'common/contract'
 import { removeUndefinedProps } from 'common/util/object'
+import { DOMAIN } from '../../../../common/envs/constants'
 
 export type LiteMarket = {
   // Unique identifer for this market
@@ -87,7 +88,7 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     question,
     description,
     tags,
-    url: `https://manifold.markets/${creatorUsername}/${slug}`,
+    url: `https://${DOMAIN}/${creatorUsername}/${slug}`,
     pool: pool.YES + pool.NO,
     probability,
     p,


### PR DESCRIPTION
My intention with this is to resolve https://github.com/manifoldmarkets/manifold/issues/508.

I'm not sure how to test this, since the relevant change is to the backend Firebase function