### PR TITLE
Add HTTP method checking to API routes

### DIFF
--- a/web/lib/api/validation.ts
+++ b/web/lib/api/validation.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+// Asserts that the request is using the specified HTTP method.
+// Writes appropriate error response if an unexpected method is set.
+export function assertHTTPMethod(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  method: string
+): boolean {
+  if (req.method !== method) {
+    res.setHeader('Allow', [method])
+    res.status(405).end(`Method ${req.method} Not Allowed`)
+    return false
+  }
+  return true
+}

--- a/web/pages/api/v0/bet/index.ts
+++ b/web/pages/api/v0/bet/index.ts
@@ -4,11 +4,16 @@ import {
   CORS_ORIGIN_LOCALHOST,
 } from 'common/envs/constants'
 import { applyCorsHeaders } from 'web/lib/api/cors'
+import { assertHTTPMethod } from 'web/lib/api/validation'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: false } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
+  if (!assertHTTPMethod(req, res, 'POST')) {
+    return
+  }
+
   await applyCorsHeaders(req, res, {
     origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
     methods: 'POST',

--- a/web/pages/api/v0/market/[id].ts
+++ b/web/pages/api/v0/market/[id].ts
@@ -3,12 +3,17 @@ import { Bet, listAllBets } from 'web/lib/firebase/bets'
 import { listAllComments } from 'web/lib/firebase/comments'
 import { getContractFromId } from 'web/lib/firebase/contracts'
 import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { assertHTTPMethod } from 'web/lib/api/validation'
 import { FullMarket, ApiError, toLiteMarket } from '../_types'
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<FullMarket | ApiError>
 ) {
+  if (!assertHTTPMethod(req, res, 'GET')) {
+    return
+  }
+
   await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
   const { id } = req.query
   const contractId = id as string

--- a/web/pages/api/v0/market/index.ts
+++ b/web/pages/api/v0/market/index.ts
@@ -4,11 +4,16 @@ import {
   CORS_ORIGIN_LOCALHOST,
 } from 'common/envs/constants'
 import { applyCorsHeaders } from 'web/lib/api/cors'
+import { assertHTTPMethod } from 'web/lib/api/validation'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: false } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
+  if (!assertHTTPMethod(req, res, 'POST')) {
+    return
+  }
+
   await applyCorsHeaders(req, res, {
     origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
     methods: 'POST',

--- a/web/pages/api/v0/markets.ts
+++ b/web/pages/api/v0/markets.ts
@@ -3,11 +3,16 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { listAllContracts } from 'web/lib/firebase/contracts'
 import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
 import { toLiteMarket } from './_types'
+import { assertHTTPMethod } from 'web/lib/api/validation'
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  if (!assertHTTPMethod(req, res, 'GET')) {
+    return
+  }
+
   await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
   let before: string | undefined
   let limit: number | undefined

--- a/web/pages/api/v0/slug/[slug].ts
+++ b/web/pages/api/v0/slug/[slug].ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { assertHTTPMethod } from 'web/lib/api/validation'
 import { Bet, listAllBets } from 'web/lib/firebase/bets'
 import { listAllComments } from 'web/lib/firebase/comments'
 import { getContractFromSlug } from 'web/lib/firebase/contracts'
@@ -9,6 +10,10 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<FullMarket | ApiError>
 ) {
+  if (!assertHTTPMethod(req, res, 'GET')) {
+    return
+  }
+
   await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
   const { slug } = req.query
 


### PR DESCRIPTION
Resolves https://github.com/manifoldmarkets/manifold/issues/507

Adds validation to the public API routes so they only respond to the HTTP methods they were intended for