### PR TITLE
Don't show the 'New' chip on resolved markets

### DIFF
--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -24,6 +24,7 @@ import NewContractBadge from '../new-contract-badge'
 import { CATEGORY_LIST } from 'common/categories'
 import { TagsList } from '../tags-list'
 import { UserFollowButton } from '../follow-button'
+import { DAY_MS } from 'common/util/time'
 
 export function MiscDetails(props: {
   contract: Contract
@@ -31,11 +32,13 @@ export function MiscDetails(props: {
   showCloseTime?: boolean
 }) {
   const { contract, showHotVolume, showCloseTime } = props
-  const { volume, volume24Hours, closeTime, tags, isResolved } = contract
+  const { volume, volume24Hours, closeTime, tags, isResolved, createdTime } =
+    contract
   // Show at most one category that this contract is tagged by
   const categories = CATEGORY_LIST.filter((category) =>
     tags.map((t) => t.toLowerCase()).includes(category)
   ).slice(0, 1)
+  const isNew = createdTime > Date.now() - DAY_MS && !isResolved
 
   return (
     <Row className="items-center gap-3 text-sm text-gray-400">
@@ -49,7 +52,7 @@ export function MiscDetails(props: {
           {(closeTime || 0) < Date.now() ? 'Closed' : 'Closes'}{' '}
           {fromNow(closeTime || 0)}
         </Row>
-      ) : volume > 0 || isResolved ? (
+      ) : volume > 0 || !isNew ? (
         <Row>{contractPool(contract)} pool</Row>
       ) : (
         <NewContractBadge />

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -31,7 +31,7 @@ export function MiscDetails(props: {
   showCloseTime?: boolean
 }) {
   const { contract, showHotVolume, showCloseTime } = props
-  const { volume, volume24Hours, closeTime, tags } = contract
+  const { volume, volume24Hours, closeTime, tags, isResolved } = contract
   // Show at most one category that this contract is tagged by
   const categories = CATEGORY_LIST.filter((category) =>
     tags.map((t) => t.toLowerCase()).includes(category)
@@ -49,7 +49,7 @@ export function MiscDetails(props: {
           {(closeTime || 0) < Date.now() ? 'Closed' : 'Closes'}{' '}
           {fromNow(closeTime || 0)}
         </Row>
-      ) : volume > 0 ? (
+      ) : volume > 0 || isResolved ? (
         <Row>{contractPool(contract)} pool</Row>
       ) : (
         <NewContractBadge />

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -109,10 +109,11 @@ export function FeedQuestion(props: {
     outcomeType,
     volume,
     createdTime,
+    isResolved,
   } = contract
   const { volumeLabel } = contractMetrics(contract)
   const isBinary = outcomeType === 'BINARY'
-  const isNew = createdTime > Date.now() - DAY_MS
+  const isNew = createdTime > Date.now() - DAY_MS && !isResolved
 
   return (
     <div className={'flex gap-2'}>


### PR DESCRIPTION
I noticed that resolved markets which haven't been traded on still show the "New" chip. This PR removes the "New" chip for resolved markets

Old:
<img width="430" alt="Screen Shot 2022-06-16 at 7 40 24 AM" src="https://user-images.githubusercontent.com/706257/174095265-4645995e-054f-441d-91fc-2f6147efbcc0.png">

New:
<img width="451" alt="Screen Shot 2022-06-16 at 7 39 24 AM" src="https://user-images.githubusercontent.com/706257/174095095-23d5a297-4568-4710-907b-98812b2d6f69.png">
 