### PR TITLE
Remove surprising 2 minute edge caching for API market data

### DIFF
--- a/web/pages/api/v0/market/[id].ts
+++ b/web/pages/api/v0/market/[id].ts
@@ -24,7 +24,6 @@ export default async function handler(
     return
   }
 
-  // Cache on Vercel edge servers for 2min
-  res.setHeader('Cache-Control', 'max-age=0, s-maxage=120')
+  res.setHeader('Cache-Control', 'max-age=0')
   return res.status(200).json(toFullMarket(contract, comments, bets))
 }

--- a/web/pages/api/v0/slug/[slug].ts
+++ b/web/pages/api/v0/slug/[slug].ts
@@ -24,7 +24,6 @@ export default async function handler(
     listAllComments(contract.id),
   ])
 
-  // Cache on Vercel edge servers for 2min
-  res.setHeader('Cache-Control', 'max-age=0, s-maxage=120')
+  res.setHeader('Cache-Control', 'max-age=0')
   return res.status(200).json(toFullMarket(contract, comments, bets))
 }


### PR DESCRIPTION
Self-explanatory. I don't see any virtue to this cache and it makes it totally impossible to make anything resembling a trading bot.