### PR TITLE
Correctly proxy GET and HEAD requests instead of dying

### DIFF
--- a/web/lib/api/proxy.ts
+++ b/web/lib/api/proxy.ts
@@ -41,7 +41,9 @@ export const fetchBackend = (req: NextApiRequest, name: V2CloudFunction) => {
     'Content-Type',
     'Origin',
   ])
-  return fetch(url, { headers, method: req.method, body: req })
+  const hasBody = req.method != 'HEAD' && req.method != 'GET'
+  const opts = { headers, method: req.method, body: hasBody ? req : undefined }
+  return fetch(url, opts)
 }
 
 export const forwardResponse = async (


### PR DESCRIPTION
This fixes an issue noted [here](https://github.com/manifoldmarkets/manifold/pull/518#discussion_r899643978) because node-fetch throws an error on the client if you try to ever `fetch` using `GET` or `HEAD` with a non-null `body`, so it was never making it to Firebase.

Now trying to call the write APIs with invalid methods produces a correct 405 via Firebase.