### PR TITLE
Add Statistics link to sidebar

### DIFF
--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -6,6 +6,7 @@ import {
   CashIcon,
   HeartIcon,
   PresentationChartLineIcon,
+  PresentationChartBarIcon,
   SparklesIcon,
   NewspaperIcon,
   TrendingUpIcon,
@@ -73,6 +74,7 @@ function getMoreNavigation(user?: User | null) {
     { name: 'Blog', href: 'https://news.manifold.markets' },
     { name: 'Discord', href: 'https://discord.gg/eHQBNBqXuh' },
     { name: 'Twitter', href: 'https://twitter.com/ManifoldMarkets' },
+    { name: 'Statistics', href: '/stats' },
     { name: 'About', href: 'https://docs.manifold.markets/$how-to' },
     { name: 'Sign out', href: '#', onClick: () => firebaseLogout() },
   ]
@@ -102,6 +104,11 @@ const signedOutMobileNavigation = [
     name: 'Twitter',
     href: 'https://twitter.com/ManifoldMarkets',
     icon: IconFromUrl('/twitter-logo.svg'),
+  },
+  { 
+    name: 'Statistics', 
+    href: '/stats',
+    icon: PresentationChartBarIcon,
   },
   {
     name: 'About',

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -105,8 +105,8 @@ const signedOutMobileNavigation = [
     href: 'https://twitter.com/ManifoldMarkets',
     icon: IconFromUrl('/twitter-logo.svg'),
   },
-  { 
-    name: 'Statistics', 
+  {
+    name: 'Statistics',
     href: '/stats',
     icon: PresentationChartBarIcon,
   },


### PR DESCRIPTION
There's currently no user-discoverable link to https://manifold.markets/stats (previously https://manifold.markets/analytics). 