### PR TITLE
Add resolutionProbability to LiteMarket

### DIFF
--- a/common/contract.ts
+++ b/common/contract.ts
@@ -33,6 +33,7 @@ export type Contract<T extends AnyContractType = AnyContractType> = {
   isResolved: boolean
   resolutionTime?: number // When the contract creator resolved the market
   resolution?: string
+  resolutionProbability?: number,
 
   closeEmailsSent?: number
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -103,6 +103,7 @@ Requires no authorization.
     isResolved: boolean
     resolutionTime?: number
     resolution?: string
+    resolutionProbability?: number  // Used for BINARY markets resolved to MKT
   }
   ```
 

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -36,6 +36,7 @@ export type LiteMarket = {
   isResolved: boolean
   resolution?: string
   resolutionTime?: number
+  resolutionProbability?: number
 }
 
 export type ApiAnswer = Answer & {
@@ -73,6 +74,7 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     isResolved,
     resolution,
     resolutionTime,
+    resolutionProbability,
   } = contract
 
   const { p, totalLiquidity } = contract as any
@@ -106,6 +108,7 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     isResolved,
     resolution,
     resolutionTime,
+    resolutionProbability,
   })
 }
 


### PR DESCRIPTION
Currently, binary markets have their resolution set to YES, NO, or MKT. If they resolve to MKT, there is no way to know via the API what value they resolved to (Issue #524).

This PR exposes `resolutionProbability` to the API via LiteMarket. This is a key step in being able to calculate payouts for markets.