### PR TITLE
Add Users API endpoint

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -446,8 +446,7 @@ Requires no authorization.
     twitterHandle?: string
     discordHandle?: string
 
-    // Note: the following are fully rederivable from the transaction history.
-    // They are here for convenience only and may be removed in the future.
+    // Note: the following are here for convenience only and may be removed in the future.
     balance: number
     totalDeposits: number
     totalPnLCached: number

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -396,6 +396,66 @@ Requires no authorization.
   ```
 - Response type: A `FullMarket` ; same as above.
 
+### `GET /v0/users`
+
+Lists all users.
+
+Requires no authorization.
+
+- Example request
+  ```
+  https://manifold.markets/api/v0/users
+  ```
+- Example response
+  ```json
+  [
+    {
+      "id":"igi2zGXsfxYPgB0DJTXVJVmwCOr2",
+      "createdTime":1639011767273,
+      "name":"Austin",
+      "username":"Austin",
+      "url":"https://manifold.markets/Austin",
+      "avatarUrl":"https://lh3.googleusercontent.com/a-/AOh14GiZyl1lBehuBMGyJYJhZd-N-mstaUtgE4xdI22lLw=s96-c",
+      "bio":"I build Manifold! Always happy to chat; reach out on Discord or find a time on https://calendly.com/austinchen/manifold!",
+      "bannerUrl":"https://images.unsplash.com/photo-1501523460185-2aa5d2a0f981?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1531&q=80",
+      "website":"https://blog.austn.io",
+      "twitterHandle":"akrolsmir",
+      "discordHandle":"akrolsmir#4125",
+      "balance":9122.607163564959,
+      "totalDeposits":10339.004780544328,
+      "totalPnLCached":9376.601262721899,
+      "creatorVolumeCached":76078.46984199001
+    }
+  ```
+- Response type: Array of `LiteUser`
+
+  ```tsx
+  // Basic information about a user
+  type LiteUser = {
+    id: string // user's unique id
+    createdTime: number
+
+    name: string // display name, may contain spaces
+    username: string // username, used in urls
+    url: string // link to user's profile
+    avatarUrl?: string
+
+    bio?: string
+    bannerUrl?: string
+    website?: string
+    twitterHandle?: string
+    discordHandle?: string
+
+    // Note: the following are fully rederivable from the transaction history.
+    // They are here for convenience only and may be removed in the future.
+    balance: number
+    totalDeposits: number
+    totalPnLCached: number
+    creatorVolumeCached: number
+  }
+  ```
+
+
 ### `POST /v0/bet`
 
 Places a new bet on behalf of the authorized user.

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -5,6 +5,7 @@ import { Comment } from 'common/comment'
 import { Contract } from 'common/contract'
 import { User } from 'common/user'
 import { removeUndefinedProps } from 'common/util/object'
+import { ENV_CONFIG } from 'common/envs/constants'
 
 export type LiteMarket = {
   // Unique identifer for this market
@@ -186,7 +187,7 @@ export function toLiteUser(user: User): LiteUser {
     createdTime,
     name,
     username,
-    url: `https://manifold.markets/${username}`,
+    url: `https://${ENV_CONFIG.domain}/${username}`,
     avatarUrl,
     bio,
     bannerUrl,

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -3,6 +3,7 @@ import { Answer } from 'common/answer'
 import { getOutcomeProbability, getProbability } from 'common/calculate'
 import { Comment } from 'common/comment'
 import { Contract } from 'common/contract'
+import { User } from 'common/user'
 import { removeUndefinedProps } from 'common/util/object'
 
 export type LiteMarket = {
@@ -139,4 +140,62 @@ function augmentAnswerWithProbability(
     ...answer,
     probability,
   }
+}
+
+export type LiteUser = {
+  id: string
+  createdTime: number
+
+  name: string
+  username: string
+  url: string
+  avatarUrl?: string
+
+  bio?: string
+  bannerUrl?: string
+  website?: string
+  twitterHandle?: string
+  discordHandle?: string
+
+  balance: number
+  totalDeposits: number
+  totalPnLCached: number
+  creatorVolumeCached: number
+}
+
+export function toLiteUser(user: User): LiteUser {
+  const {
+    id,
+    createdTime,
+    name,
+    username,
+    avatarUrl,
+    bio,
+    bannerUrl,
+    website,
+    twitterHandle,
+    discordHandle,
+    balance,
+    totalDeposits,
+    totalPnLCached,
+    creatorVolumeCached,
+  } = user
+
+  return removeUndefinedProps({
+    id,
+    createdTime,
+    name,
+    username,
+    url: `https://manifold.markets/${username}`,
+    avatarUrl,
+    bio,
+    bannerUrl,
+    website,
+    twitterHandle,
+    discordHandle,
+    balance,
+    totalDeposits,
+    totalPnLCached,
+    creatorVolumeCached,
+  })
 }

--- a/web/pages/api/v0/users.ts
+++ b/web/pages/api/v0/users.ts
@@ -1,0 +1,17 @@
+// Next.js API route support: https://vercel.com/docs/concepts/functions/serverless-functions
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { listAllUsers } from 'web/lib/firebase/users'
+import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { toLiteUser } from './_types'
+
+type Data = any[]
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  const users = await listAllUsers()
+  res.setHeader('Cache-Control', 'max-age=0')
+  res.status(200).json(users.map(toLiteUser))
+}


### PR DESCRIPTION
This is a first swing at adding a `users` endpoint to the API. It's read-only, exposing basic account info and cached values.

Basic uses at this stage include:
- Getting current balance for intelligent betting via API
- Getting total market volume for leaderboard placement
- Getting username and avatar for rendering bets

Future plans may include:
- Exposing extended data in FullUser, akin to FullMarket
  - `Markets[]`, a list of all markets a user has created
  - `Comments[]`, a list of all comments a user has made
  - `Bets[]`, a list of all bets a user has made
- List of followers and followed accounts
- Amount received via tips
- Groups(?)

I would love feedback on styling, layout, etc. We may want to move some of this out of `_types` if we plan on adding much more. We may also want pagination here, right now the response on prod is a little over 1MB but it'll grow quickly.

Once we're set on how we want to implement this, I'll also do up some docs. 