### PR TITLE
Fix portfolio link in sidebar

### DIFF
--- a/web/components/nav/nav-bar.tsx
+++ b/web/components/nav/nav-bar.tsx
@@ -24,7 +24,7 @@ function getNavigation(username: string) {
     { name: 'Home', href: '/home', icon: HomeIcon },
     {
       name: 'Portfolio',
-      href: `/${username}/bets`,
+      href: `/${username}?tab=bets`,
       icon: PresentationChartLineIcon,
     },
     {

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -47,7 +47,7 @@ function getNavigation(username: string) {
     { name: 'Home', href: '/home', icon: HomeIcon },
     {
       name: 'Portfolio',
-      href: `/${username}/bets`,
+      href: `/${username}?tab=bets`,
       icon: PresentationChartLineIcon,
     },
     {


### PR DESCRIPTION
It appears that, e.g., https://manifold.markets/Forrest/bets is now a 404 (and the portfolio page is now at https://manifold.markets/Forrest?tab=bets), but the Portfolio link in the sidebar still points to it. This PR is intended to fix that.