### PR TITLE
Clean up definition of v2 cloud function URLs

### DIFF
--- a/common/envs/dev.ts
+++ b/common/envs/dev.ts
@@ -12,12 +12,7 @@ export const DEV_CONFIG: EnvConfig = {
     appId: '1:134303100058:web:27f9ea8b83347251f80323',
     measurementId: 'G-YJC9E37P37',
   },
-  functionEndpoints: {
-    placebet: 'https://placebet-w3txbmd3ba-uc.a.run.app',
-    sellshares: 'https://sellshares-w3txbmd3ba-uc.a.run.app',
-    sellbet: 'https://sellbet-w3txbmd3ba-uc.a.run.app',
-    createmarket: 'https://createmarket-w3txbmd3ba-uc.a.run.app',
-    creategroup: 'https://creategroup-w3txbmd3ba-uc.a.run.app',
-  },
+  cloudRunId: 'w3txbmd3ba',
+  cloudRunRegion: 'uc',
   amplitudeApiKey: 'fd8cbfd964b9a205b8678a39faae71b3',
 }

--- a/common/envs/prod.ts
+++ b/common/envs/prod.ts
@@ -1,15 +1,12 @@
-export type V2CloudFunction =
-  | 'placebet'
-  | 'sellbet'
-  | 'sellshares'
-  | 'createmarket'
-  | 'creategroup'
-
 export type EnvConfig = {
   domain: string
   firebaseConfig: FirebaseConfig
-  functionEndpoints: Record<V2CloudFunction, string>
   amplitudeApiKey?: string
+
+  // IDs for v2 cloud functions -- find these by deploying a cloud function and
+  // examining the URL, https://[name]-[cloudRunId]-[cloudRunRegion].a.run.app
+  cloudRunId: string
+  cloudRunRegion: string
 
   // Access controls
   adminEmails: string[]
@@ -48,13 +45,8 @@ export const PROD_CONFIG: EnvConfig = {
     appId: '1:128925704902:web:f61f86944d8ffa2a642dc7',
     measurementId: 'G-SSFK1Q138D',
   },
-  functionEndpoints: {
-    placebet: 'https://placebet-nggbo3neva-uc.a.run.app',
-    sellshares: 'https://sellshares-nggbo3neva-uc.a.run.app',
-    sellbet: 'https://sellbet-nggbo3neva-uc.a.run.app',
-    createmarket: 'https://createmarket-nggbo3neva-uc.a.run.app',
-    creategroup: 'https://creategroup-nggbo3neva-uc.a.run.app',
-  },
+  cloudRunId: 'nggbo3neva',
+  cloudRunRegion: 'uc',
   adminEmails: [
     'akrolsmir@gmail.com', // Austin
     'jahooma@gmail.com', // James

--- a/common/envs/theoremone.ts
+++ b/common/envs/theoremone.ts
@@ -12,14 +12,8 @@ export const THEOREMONE_CONFIG: EnvConfig = {
     appId: '1:698012149198:web:b342af75662831aa84b79f',
     measurementId: 'G-Y3EZ1WNT6E',
   },
-  // TODO: fill in real endpoints for T1
-  functionEndpoints: {
-    placebet: 'https://placebet-nggbo3neva-uc.a.run.app',
-    sellshares: 'https://sellshares-nggbo3neva-uc.a.run.app',
-    sellbet: 'https://sellbet-nggbo3neva-uc.a.run.app',
-    createmarket: 'https://createmarket-nggbo3neva-uc.a.run.app',
-    creategroup: 'https://creategroup-nggbo3neva-uc.a.run.app',
-  },
+  cloudRunId: 'nggbo3neva', // TODO: fill in real ID for T1
+  cloudRunRegion: 'uc',
   adminEmails: [...PROD_CONFIG.adminEmails, 'david.glidden@theoremone.co'],
   whitelistEmail: '@theoremone.co',
   moneyMoniker: 'T$',

--- a/web/lib/api/proxy.ts
+++ b/web/lib/api/proxy.ts
@@ -2,7 +2,6 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { promisify } from 'util'
 import { pipeline } from 'stream'
 import { getFunctionUrl } from 'web/lib/firebase/api-call'
-import { V2CloudFunction } from 'common/envs/prod'
 import fetch, { Headers, Response } from 'node-fetch'
 
 function getProxiedRequestHeaders(req: NextApiRequest, whitelist: string[]) {
@@ -33,7 +32,7 @@ function getProxiedResponseHeaders(res: Response, whitelist: string[]) {
   return result
 }
 
-export const fetchBackend = (req: NextApiRequest, name: V2CloudFunction) => {
+export const fetchBackend = (req: NextApiRequest, name: string) => {
   const url = getFunctionUrl(name)
   const headers = getProxiedRequestHeaders(req, [
     'Authorization',

--- a/web/lib/firebase/api-call.ts
+++ b/web/lib/firebase/api-call.ts
@@ -1,6 +1,5 @@
 import { auth } from './users'
 import { ENV_CONFIG } from 'common/envs/constants'
-import { V2CloudFunction } from 'common/envs/prod'
 
 export class APIError extends Error {
   code: number
@@ -41,8 +40,9 @@ export async function call(url: string, method: string, params: any) {
 // app just hit the cloud functions directly -- there's no difference and it's
 // one less hop
 
-export function getFunctionUrl(name: V2CloudFunction) {
-  return ENV_CONFIG.functionEndpoints[name]
+export function getFunctionUrl(name: string) {
+  const { cloudRunId, cloudRunRegion } = ENV_CONFIG
+  return `https://${name}-${cloudRunId}-${cloudRunRegion}.a.run.app`
 }
 
 export function createMarket(params: any) {


### PR DESCRIPTION
It seems clear how these work now, so let's clean this up so that we don't have to keep adding individual v2 cloud functions here when we create them in the future.

(The `uc` region stands for `us-central1`. The ID as far as I can tell is some meaningless hash.)