### PR TITLE
Bump Cloud Functions Node version from 12 -> 16

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "predeploy": "npm --prefix \"$RESOURCE_DIR\" run build",
-    "runtime": "nodejs12",
+    "runtime": "nodejs16",
     "source": "functions"
   },
   "firestore": {


### PR DESCRIPTION
I don't know of any particular reason why this is important, but keeping these on such an old version of Node is really spooky in terms of "the documentation and local development environment matching production", so let's get it as up to date as possible.

These can be redeployed in place. I currently have dev `placebet` running Node 16 as a test. When I deploy the rest I'll be keeping an eye on the dashboard to see if any errors crop up.

By the way, Vercel is on Node 14. I'll probably bump it to 16 too so that everything makes more sense.