### PR TITLE
Ameliorate homepage search spam

### DIFF
--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -116,8 +116,8 @@ export function ContractSearch(props: {
     showCategorySelector,
     mode,
     Object.values(additionalFilter ?? {}).join(','),
-    followedCategories?.join(','),
-    follows?.join(','),
+    (followedCategories ?? []).join(','),
+    (follows ?? []).join(','),
   ])
 
   const indexName = `${indexPrefix}contracts-${sort}`

--- a/web/hooks/use-sort-and-query-params.tsx
+++ b/web/hooks/use-sort-and-query-params.tsx
@@ -20,6 +20,16 @@ export function checkAgainstQuery(query: string, corpus: string) {
   return queryWords.every((word) => corpus.toLowerCase().includes(word))
 }
 
+export function getSavedSort() {
+  // TODO: this obviously doesn't work with SSR, common sense would suggest
+  // that we should save things like this in cookies so the server has them
+  if (typeof window !== 'undefined') {
+    return localStorage.getItem(MARKETS_SORT) as Sort | null
+  } else {
+    return null
+  }
+}
+
 export function useInitialQueryAndSort(options?: {
   defaultSort: Sort
   shouldLoadFromStorage?: boolean
@@ -45,7 +55,7 @@ export function useInitialQueryAndSort(options?: {
 
       if (!sort && shouldLoadFromStorage) {
         console.log('ready loading from storage ', sort ?? defaultSort)
-        const localSort = localStorage.getItem(MARKETS_SORT) as Sort
+        const localSort = getSavedSort()
         if (localSort) {
           router.query.s = localSort
           // Use replace to not break navigating back.

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -5,6 +5,7 @@ import { PlusSmIcon } from '@heroicons/react/solid'
 import { Page } from 'web/components/page'
 import { Col } from 'web/components/layout/col'
 import { useUser } from 'web/hooks/use-user'
+import { getSavedSort } from 'web/hooks/use-sort-and-query-params'
 import { ContractSearch } from 'web/components/contract-search'
 import { Contract } from 'common/contract'
 import { ContractPageContent } from './[username]/[contractSlug]'
@@ -17,7 +18,6 @@ const Home = () => {
   const [contract, setContract] = useContractPage()
 
   const router = useRouter()
-
   useTracking('view home')
 
   if (user === null) {
@@ -32,7 +32,7 @@ const Home = () => {
           <ContractSearch
             querySortOptions={{
               shouldLoadFromStorage: true,
-              defaultSort: '24-hour-vol',
+              defaultSort: getSavedSort() ?? '24-hour-vol',
             }}
             showCategorySelector
             onContractClick={(c) => {


### PR DESCRIPTION
The status quo ante: When you load the homepage it does at least three (probably more in some cases) search queries to Algolia before you even touch the UI, each pulling JSON results with thousands of contracts over the wire, and maybe rendering janky search results that disappear afterward.

Two fixes to try to stem the bleeding:

1. Don't treat `undefined` lists of `followedCategories` and `follows` different than empty lists. Previously, it would do a new search every time these came in, even if it was going to be the same search. Now it will only do a new search if you actually have follows or if you filtered the categories. That still kind of sucks but at least we are fixing it for many users.

2. Don't wait a long time to load the saved search sort from local storage. Previously, we would wait until the router is ready to look at both the URL sort/query parameters and also the local storage sort/query from the last usage. This meant that if anyone ever changed it from the default, it was guaranteed to do a search with the default first, and then have to do another search when the saved sort was loaded. Now it loads the saved sort immediately and uses it as the default, so they will only have to do another search if the URL query parameters disagree with the saved sort.

This code still seems kind of unfortunate (it's just incredibly confusing to me, and the design where we do one "default search" that we are going to throw away 500ms later as soon as we load the `follows` etc. from the DB seems not good) but this seems like an 80/20 fix.
