### PR TITLE
Use Typescript project references, improve functions build/deploy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Run Typescript checker on web client
         if: ${{ success() || failure() }}
         working-directory: web
-        run: tsc --pretty --project tsconfig.json --noEmit
+        run: tsc -b -v --pretty
       - name: Run Typescript checker on cloud functions
         if: ${{ success() || failure() }}
         working-directory: functions
-        run: tsc --pretty --project tsconfig.json --noEmit
+        run: tsc -b -v --pretty

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -1,6 +1,5 @@
 # Compiled JavaScript files
-lib/**/*.js
-lib/**/*.js.map
+lib/
 
 # TypeScript v1 declaration files
 typings/

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": "../",
+    "composite": true,
+    "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitReturns": true,
     "outDir": "lib",

--- a/firebase.json
+++ b/firebase.json
@@ -1,8 +1,8 @@
 {
   "functions": {
-    "predeploy": "npm --prefix \"$RESOURCE_DIR\" run build",
+    "predeploy": "cd functions && yarn build",
     "runtime": "nodejs16",
-    "source": "functions"
+    "source": "functions/dist"
   },
   "firestore": {
     "rules": "firestore.rules",

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -2,6 +2,9 @@
 .env*
 .runtimeconfig.json
 
+# GCP deployment artifact
+dist/
+
 # Compiled JavaScript files
 lib/
 

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -3,8 +3,7 @@
 .runtimeconfig.json
 
 # Compiled JavaScript files
-lib/**/*.js
-lib/**/*.js.map
+lib/
 
 # TypeScript v1 declaration files
 typings/

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,7 +5,8 @@
     "firestore": "dev-mantic-markets.appspot.com"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "yarn compile && rm -r dist && mkdir -p dist/functions && cp -R ../common/lib dist/common && cp -R lib/src dist/functions/src && cp ../yarn.lock dist && cp package.json dist",
+    "compile": "tsc -b",
     "watch": "tsc -w",
     "shell": "yarn build && firebase functions:shell",
     "start": "yarn shell",
@@ -18,7 +19,7 @@
     "db:backup-remote": "yarn db:rename-remote-backup-folder && gcloud firestore export gs://$npm_package_config_firestore/firestore_export/",
     "verify": "(cd .. && yarn verify)"
   },
-  "main": "lib/functions/src/index.js",
+  "main": "functions/src/index.js",
   "dependencies": {
     "@amplitude/node": "1.10.0",
     "fetch": "1.1.0",

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "../",
+    "composite": true,
     "module": "commonjs",
     "noImplicitReturns": true,
     "outDir": "lib",
@@ -8,6 +9,11 @@
     "strict": true,
     "target": "es2017"
   },
+  "references": [
+    {
+      "path": "../common"
+    }
+  ],
   "compileOnSave": true,
-  "include": ["src", "../common/**/*.ts"]
+  "include": ["src"]
 }

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -4,6 +4,9 @@ const API_DOCS_URL = 'https://docs.manifold.markets/api'
 module.exports = {
   staticPageGenerationTimeout: 600, // e.g. stats page
   reactStrictMode: true,
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   experimental: {
     externalDir: true,
     optimizeCss: true,

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "composite": true,
     "baseUrl": "../",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -16,10 +17,15 @@
     "jsx": "preserve",
     "incremental": true
   },
+  "references": [
+    {
+      "path": "../common"
+    }
+  ],
 
   "watchOptions": {
     "excludeDirectories": [".next"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "../common/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This is under the "make our deployment not suck" project heading.

1. Using this [project reference](https://www.typescriptlang.org/docs/handbook/project-references.html) Typescript technology lets us do real incremental builds, so we don't have to wait ten or twenty seconds or whatever to compile the Typescript when we deploy the functions.
2. By using a separate `dist` directory to store the deployable function code, we avoid packaging random nonsense that was in the main directory, inflating the container image and wasting time. (Most egregiously, if you had a database export in the main directory.)
3. By putting the `yarn.lock` into that directory, the builder machine can more efficiently fetch dependencies.

This more or less cuts the deployment time for a function in half so far.

The dev server for the site will also be faster probably. (It won't have to recompile the `common` code all the time.) I had to turn off typechecking in `next build` though because it doesn't work right with project references, but that seems fine because we are already doing typechecking in the normal static analysis GitHub workflow.