### PR TITLE
Bump memory on all v2 functions to 2GB

### DIFF
--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -110,6 +110,7 @@ export const validate = <T extends z.ZodTypeAny>(schema: T, val: unknown) => {
 
 const DEFAULT_OPTS: HttpsOptions = {
   minInstances: 1,
+  memory: '2GiB',
   cors: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
 }
 

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -111,6 +111,7 @@ export const validate = <T extends z.ZodTypeAny>(schema: T, val: unknown) => {
 const DEFAULT_OPTS: HttpsOptions = {
   minInstances: 1,
   memory: '2GiB',
+  cpu: 1,
   cors: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
 }
 

--- a/functions/src/api.ts
+++ b/functions/src/api.ts
@@ -110,6 +110,7 @@ export const validate = <T extends z.ZodTypeAny>(schema: T, val: unknown) => {
 
 const DEFAULT_OPTS: HttpsOptions = {
   minInstances: 1,
+  concurrency: 100,
   memory: '2GiB',
   cpu: 1,
   cors: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],


### PR DESCRIPTION
The Firebase CLI has a secret feature. The feature is that it [ignores](https://github.com/firebase/firebase-tools/blob/466bdaa86de353eb090dc40006d5a1a9414de9da/src/deploy/functions/release/fabricator.ts#L340) your `concurrency` setting on functions if they have less than [2GB](https://github.com/firebase/firebase-tools/blob/466bdaa86de353eb090dc40006d5a1a9414de9da/src/deploy/functions/backend.ts#L189) of memory. So I hypothesize that upping the memory might make v2 functions scale the way I expect them to.

(I thought they already had 1 vCPU by default according to the docs, but the CLI complained that you can't have 2GB of memory without 1 vCPU...so maybe I am also upgrading the CPU?)