### PR TITLE
Reorganize verify scripts

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "verify": "(cd .. && yarn verify)"
+    "verify": "(cd .. && yarn verify)",
+    "verify:dir": "npx eslint . --max-warnings 0"
   },
   "sideEffects": false,
   "dependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,8 @@
     "db:backup-local": "firebase emulators:export --force ./firestore_export",
     "db:rename-remote-backup-folder": "gsutil mv gs://$npm_package_config_firestore/firestore_export gs://$npm_package_config_firestore/firestore_export_$(date +%d-%m-%Y-%H-%M)",
     "db:backup-remote": "yarn db:rename-remote-backup-folder && gcloud firestore export gs://$npm_package_config_firestore/firestore_export/",
-    "verify": "(cd .. && yarn verify)"
+    "verify": "(cd .. && yarn verify)",
+    "verify:dir": "npx eslint . --max-warnings 0; tsc -b -v --pretty"
   },
   "main": "functions/src/index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "web"
   ],
   "scripts": {
-    "verify": "(cd web && npx prettier --check .; yarn lint --max-warnings 0; tsc --pretty --project tsconfig.json --noEmit); (cd common && npx eslint . --max-warnings 0); (cd functions && npx eslint . --max-warnings 0; tsc --pretty --project tsconfig.json --noEmit)"
+    "verify": "(cd web && npx prettier --check .; yarn lint --max-warnings 0; tsc --pretty --project tsconfig.json --noEmit); (cd common && npx eslint . --max-warnings 0); (cd functions && npx eslint . --max-warnings 0; tsc -b -v --pretty)"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "web"
   ],
   "scripts": {
-    "verify": "(cd web && npx prettier --check .; yarn lint --max-warnings 0; tsc --pretty --project tsconfig.json --noEmit); (cd common && npx eslint . --max-warnings 0); (cd functions && npx eslint . --max-warnings 0; tsc -b -v --pretty)"
+    "verify": "(cd web && yarn verify:dir); (cd functions && yarn verify:dir)"
   },
   "dependencies": {},
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
     "lint": "next lint",
     "format": "npx prettier --write .",
     "postbuild": "next-sitemap",
-    "verify": "(cd .. && yarn verify)"
+    "verify": "(cd .. && yarn verify)",
+    "verify:dir": "npx prettier --check .; yarn lint --max-warnings 0; tsc --pretty --project tsconfig.json --noEmit"
   },
   "dependencies": {
     "@amplitude/analytics-browser": "0.4.1",


### PR DESCRIPTION
On #378, @mqp suggested
> I think it would be better if the verify scripts in each subdirectory did all the verify work for that subproject, and then in the root directory it recursed on all the subdirectories. To me that would be the ideal version. But I like this better than the status quo. Maybe someone can improve it later.

This is my attempt to have it work like that, while preventing the possibility of running `verify` in a subdirectory and thinking you'd run it for the whole project.

Also updates the one for `functions` to match the change to the github workflow made in #586.