### PR TITLE
[Fix] Clear suggested FR answer after submission

### DIFF
--- a/web/components/answers/create-answer-panel.tsx
+++ b/web/components/answers/create-answer-panel.tsx
@@ -58,6 +58,7 @@ export function CreateAnswerPanel(props: { contract: FreeResponseContract }) {
         setText('')
         setBetAmount(10)
         setAmountError(undefined)
+        setPossibleDuplicateAnswer(undefined)
       } else setAmountError(result.message)
     }
   }


### PR DESCRIPTION
Fixes a small bug with #581 where if you submit a FR answer that had a potential duplicate, the potential duplicate message is not cleared upon submission.