### PR TITLE
Add "M$" to title of Manalink claim page

### DIFF
--- a/web/pages/link/[slug].tsx
+++ b/web/pages/link/[slug].tsx
@@ -31,7 +31,7 @@ export default function ClaimPage() {
         url="/send"
       />
       <div className="mx-auto max-w-xl">
-        <Title text={`Claim ${manalink.amount} mana`} />
+        <Title text={`Claim M$${manalink.amount} mana`} />
         <ManalinkCard
           defaultMessage={fromUser?.name || 'Enjoy this mana!'}
           info={info}


### PR DESCRIPTION
Nitpick of the Manalink claim page title
<img width="645" alt="Screen Shot 2022-07-01 at 6 57 25 AM" src="https://user-images.githubusercontent.com/706257/176908888-68ba444f-cc09-4107-8ada-da281b627459.png">
