### PR TITLE
Use `getAll` Firestore technology to improve some code

### DIFF
--- a/functions/src/place-bet.ts
+++ b/functions/src/place-bet.ts
@@ -41,10 +41,7 @@ export const placebet = newEndpoint({}, async (req, auth) => {
     log('Inside main transaction.')
     const contractDoc = firestore.doc(`contracts/${contractId}`)
     const userDoc = firestore.doc(`users/${auth.uid}`)
-    const [contractSnap, userSnap] = await Promise.all([
-      trans.get(contractDoc),
-      trans.get(userDoc),
-    ])
+    const [contractSnap, userSnap] = await trans.getAll(contractDoc, userDoc)
     if (!contractSnap.exists) throw new APIError(400, 'Contract not found.')
     if (!userSnap.exists) throw new APIError(400, 'User not found.')
     log('Loaded user and contract snapshots.')

--- a/functions/src/sell-bet.ts
+++ b/functions/src/sell-bet.ts
@@ -21,11 +21,11 @@ export const sellbet = newEndpoint({}, async (req, auth) => {
     const contractDoc = firestore.doc(`contracts/${contractId}`)
     const userDoc = firestore.doc(`users/${auth.uid}`)
     const betDoc = firestore.doc(`contracts/${contractId}/bets/${betId}`)
-    const [contractSnap, userSnap, betSnap] = await Promise.all([
-      transaction.get(contractDoc),
-      transaction.get(userDoc),
-      transaction.get(betDoc),
-    ])
+    const [contractSnap, userSnap, betSnap] = await transaction.getAll(
+      contractDoc,
+      userDoc,
+      betDoc
+    )
     if (!contractSnap.exists) throw new APIError(400, 'Contract not found.')
     if (!userSnap.exists) throw new APIError(400, 'User not found.')
     if (!betSnap.exists) throw new APIError(400, 'Bet not found.')

--- a/functions/src/sell-shares.ts
+++ b/functions/src/sell-shares.ts
@@ -24,9 +24,8 @@ export const sellshares = newEndpoint({}, async (req, auth) => {
     const contractDoc = firestore.doc(`contracts/${contractId}`)
     const userDoc = firestore.doc(`users/${auth.uid}`)
     const betsQ = contractDoc.collection('bets').where('userId', '==', auth.uid)
-    const [contractSnap, userSnap, userBets] = await Promise.all([
-      transaction.get(contractDoc),
-      transaction.get(userDoc),
+    const [[contractSnap, userSnap], userBets] = await Promise.all([
+      transaction.getAll(contractDoc, userDoc),
       getValues<Bet>(betsQ), // TODO: why is this not in the transaction??
     ])
     if (!contractSnap.exists) throw new APIError(400, 'Contract not found.')


### PR DESCRIPTION
I just didn't know about this when I last touched this code, but now I do. My guess is we can expect this to be slightly quicker than parallel `Promise.all` requests mostly because it's going to be as slow as the latency of the one network request it does, rather than as slow as the max latency of any of the network requests it does.

Kind of weird that the client side Firebase SDK straight up doesn't expose this, but that's Firebase life for you.