### PR TITLE
Don't accidentally make meaningless zero bets

### DIFF
--- a/functions/src/redeem-shares.ts
+++ b/functions/src/redeem-shares.ts
@@ -21,6 +21,9 @@ export const redeemShares = async (userId: string, contractId: string) => {
     const betsSnap = await trans.get(betsColl.where('userId', '==', userId))
     const bets = betsSnap.docs.map((doc) => doc.data() as Bet)
     const { shares, loanPayment, netAmount } = getRedeemableAmount(bets)
+    if (netAmount === 0) {
+      return { status: 'success' }
+    }
     const [yesBet, noBet] = getRedemptionBets(shares, loanPayment, contract)
 
     const userDoc = firestore.doc(`users/${userId}`)


### PR DESCRIPTION
Oops, I messed this up in #614 by removing where it was doing this early return. Unfortunately this means there are some weird bets for zero shares now in our DB that do nothing. I don't think that should cause any concrete problems, though.