### PR TITLE
Make referral stuff not busted

### DIFF
--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -39,6 +39,9 @@ import { filterDefined } from 'common/util/array'
 import { addUserToGroupViaSlug } from 'web/lib/firebase/groups'
 import { removeUndefinedProps } from 'common/util/object'
 import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+dayjs.extend(utc)
+
 import { track } from '@amplitude/analytics-browser'
 
 export const users = coll<User>('users')


### PR DESCRIPTION
`setCachedReferralInfoForUser` uses the dayjs UTC extension, but doesn't initialize it, so this was broken unless some other stuff on the page happened to initialize the UTC extension first. Not sure exactly what cases this entails -- at least it happened to me when I tried to claim a manalink.