### PR TITLE
Migrate stripeWebhook and createCheckoutSession to v2

### DIFF
--- a/functions/src/stripe.ts
+++ b/functions/src/stripe.ts
@@ -1,4 +1,4 @@
-import * as functions from 'firebase-functions'
+import { onRequest } from 'firebase-functions/v2/https'
 import * as admin from 'firebase-admin'
 import Stripe from 'stripe'
 
@@ -42,9 +42,9 @@ const manticDollarStripePrice = isProd()
       10000: 'price_1K8bEiGdoFKoCJW7Us4UkRHE',
     }
 
-export const createCheckoutSession = functions
-  .runWith({ minInstances: 1, secrets: ['STRIPE_APIKEY'] })
-  .https.onRequest(async (req, res) => {
+export const createcheckoutsession = onRequest(
+  { minInstances: 1, secrets: ['STRIPE_APIKEY'] },
+  async (req, res) => {
     const userId = req.query.userId?.toString()
 
     const manticDollarQuantity = req.query.manticDollarQuantity?.toString()
@@ -86,14 +86,15 @@ export const createCheckoutSession = functions
     })
 
     res.redirect(303, session.url || '')
-  })
+  }
+)
 
-export const stripeWebhook = functions
-  .runWith({
+export const stripewebhook = onRequest(
+  {
     minInstances: 1,
     secrets: ['MAILGUN_KEY', 'STRIPE_APIKEY', 'STRIPE_WEBHOOKSECRET'],
-  })
-  .https.onRequest(async (req, res) => {
+  },
+  async (req, res) => {
     const stripe = initStripe()
     let event
 
@@ -115,7 +116,8 @@ export const stripeWebhook = functions
     }
 
     res.status(200).send('success')
-  })
+  }
+)
 
 const issueMoneys = async (session: StripeSession) => {
   const { id: sessionId } = session

--- a/web/lib/firebase/api-call.ts
+++ b/web/lib/firebase/api-call.ts
@@ -53,6 +53,7 @@ export function getFunctionUrl(name: string) {
 export function createAnswer(params: any) {
   return call(getFunctionUrl('createanswer'), 'POST', params)
 }
+
 export function changeUserInfo(params: any) {
   return call(getFunctionUrl('changeuserinfo'), 'POST', params)
 }

--- a/web/lib/service/stripe.ts
+++ b/web/lib/service/stripe.ts
@@ -1,12 +1,11 @@
-import { PROJECT_ID } from 'common/envs/constants'
+import { getFunctionUrl } from 'web/lib/firebase/api-call'
 
 export const checkoutURL = (
   userId: string,
   manticDollarQuantity: number,
   referer = ''
 ) => {
-  const endpoint = `https://us-central1-${PROJECT_ID}.cloudfunctions.net/createCheckoutSession`
-
+  const endpoint = getFunctionUrl('createcheckoutsession')
   return `${endpoint}?userId=${userId}&manticDollarQuantity=${manticDollarQuantity}&referer=${encodeURIComponent(
     referer
   )}`


### PR DESCRIPTION
Straightforward, but we will have to go into the Stripe dashboard and change the webhook URL after deploying this, so I'm marking it as a draft until I have access to do that.

(Background: I want to migrate our remaining v1 onCall functions to v2 because there is no reason not to and because it will be easier to then do further general backend changes, like deploying them in a single express app and making hot reloading of server code work.)
