### PR TITLE
fix: let useUserById accept undefined userId

### DIFF
--- a/web/hooks/use-user.ts
+++ b/web/hooks/use-user.ts
@@ -46,7 +46,7 @@ export const usePrivateUser = (userId?: string) => {
   return privateUser
 }
 
-export const useUserById = (userId: string) => {
+export const useUserById = (userId = '_') => {
   const result = useFirestoreDocumentData<DocumentData, User>(
     ['users', userId],
     doc(users, userId),

--- a/web/pages/link/[slug].tsx
+++ b/web/pages/link/[slug].tsx
@@ -17,7 +17,7 @@ export default function ClaimPage() {
   const [claiming, setClaiming] = useState(false)
   const [error, setError] = useState<string | undefined>(undefined)
 
-  const fromUser = useUserById(manalink?.fromId ?? '_loading')
+  const fromUser = useUserById(manalink?.fromId)
   if (!manalink) {
     return <></>
   }


### PR DESCRIPTION
As long as we never have a user with the id of "_" this should be fine 😬 
I can't think of a better way to fix this because of react's hook rules prevent us from simply returning early if the input is undefined