### PR TITLE
Don't `setQuery` on group selector component during initial render

### DIFF
--- a/web/components/groups/group-selector.tsx
+++ b/web/components/groups/group-selector.tsx
@@ -53,9 +53,8 @@ export function GroupSelector(props: {
         nullable={true}
         className={'text-sm'}
       >
-        {({ open }) => (
+        {() => (
           <>
-            {!open && setQuery('')}
             <Combobox.Label className="label justify-start gap-2 text-base">
               Add to Group
               <InfoTooltip text="Question will be displayed alongside the other questions in the group." />


### PR DESCRIPTION
This makes React mad because the rendering of the `ComboBox` component is setting state upstream in the `GroupSelector` component.

I don't see any reason to do it... why would it matter what the filter is when the box is closed and the filtered groups aren't showing? I can't observe any difference in behavior.