### PR TITLE
Fix some broken stuff on the homepage contract search routing

### DIFF
--- a/web/hooks/use-sort-and-query-params.tsx
+++ b/web/hooks/use-sort-and-query-params.tsx
@@ -82,7 +82,7 @@ export function useUpdateQueryAndSort(props: {
   const setSort = (sort: Sort | undefined) => {
     if (sort !== router.query.s) {
       router.query.s = sort
-      router.push({ query: { ...router.query, s: sort } }, undefined, {
+      router.replace({ query: { ...router.query, s: sort } }, undefined, {
         shallow: true,
       })
       if (shouldLoadFromStorage) {
@@ -102,7 +102,7 @@ export function useUpdateQueryAndSort(props: {
         } else {
           delete router.query.q
         }
-        router.push({ query: router.query }, undefined, {
+        router.replace({ query: router.query }, undefined, {
           shallow: true,
         })
         track('search', { query })

--- a/web/hooks/use-sort-and-query-params.tsx
+++ b/web/hooks/use-sort-and-query-params.tsx
@@ -53,9 +53,12 @@ export function useInitialQueryAndSort(options?: {
         console.log('ready loading from storage ', sort ?? defaultSort)
         const localSort = getSavedSort()
         if (localSort) {
-          router.query.s = localSort
           // Use replace to not break navigating back.
-          router.replace(router, undefined, { shallow: true })
+          router.replace(
+            { query: { ...router.query, s: localSort } },
+            undefined,
+            { shallow: true }
+          )
         }
         setInitialSort(localSort ?? defaultSort)
       } else {
@@ -79,7 +82,9 @@ export function useUpdateQueryAndSort(props: {
   const setSort = (sort: Sort | undefined) => {
     if (sort !== router.query.s) {
       router.query.s = sort
-      router.push(router, undefined, { shallow: true })
+      router.push({ query: { ...router.query, s: sort } }, undefined, {
+        shallow: true,
+      })
       if (shouldLoadFromStorage) {
         localStorage.setItem(MARKETS_SORT, sort || '')
       }
@@ -97,7 +102,9 @@ export function useUpdateQueryAndSort(props: {
         } else {
           delete router.query.q
         }
-        router.push(router, undefined, { shallow: true })
+        router.push({ query: router.query }, undefined, {
+          shallow: true,
+        })
         track('search', { query })
       }, 500),
     [router]


### PR DESCRIPTION
I'm not saying this is all completely working now, but:

- It doesn't spam warnings in the console from the fact that we are passing the whole router object into `router.push` and then trying to call URL formatting methods on it. I am slightly amazed it even worked at all -- nothing in the [documentation](https://nextjs.org/docs/api-reference/next/router#routerpush) suggests that using it like this is reasonable.
- It doesn't create a zillion history frames for each letter you type (these history frames didn't even "work", in that if you navigate back it wouldn't present the correct query.) This was really bad!