### PR TITLE
Clean up font loading and see if it fixes our problem

### DIFF
--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -6,16 +6,15 @@ export default function Document() {
     <Html data-theme="mantic" className="min-h-screen">
       <Head>
         <link rel="icon" href={ENV_CONFIG.faviconPath} />
-
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
-          crossOrigin="true"
+          crossOrigin="anonymous"
         />
         <link
           href="https://fonts.googleapis.com/css2?family=Major+Mono+Display&family=Readex+Pro:wght@300;400;600;700&display=swap"
           rel="stylesheet"
+          crossOrigin="anonymous"
         />
         <link
           rel="stylesheet"
@@ -24,7 +23,6 @@ export default function Document() {
           crossOrigin="anonymous"
         />
       </Head>
-
       <body className="font-readex-pro bg-base-200 min-h-screen">
         <Main />
         <NextScript />


### PR DESCRIPTION
There's some kind of issue where the Google Fonts request for our custom fonts is not getting processed in some cases. It seems like our stuff here is rather sloppy:

- There's no reason to preconnect to the thing we are connecting to immediately afterward.
- The preconnect had no `crossOrigin` attribute, so it probably wasn't working.
- `true` is [not a valid option](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) for `crossOrigin`. We meant to write `anonymous`.
- The actual stylesheet connection had no `crossOrigin` attribute either, which is kind of weird.

So I'm just fixing it up to look right and then I will continue debugging from there if it's still broken.