### PR TITLE
Turn off Next.js font inlining

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -4,6 +4,7 @@ const API_DOCS_URL = 'https://docs.manifold.markets/api'
 module.exports = {
   staticPageGenerationTimeout: 600, // e.g. stats page
   reactStrictMode: true,
+  optimizeFonts: false,
   experimental: {
     externalDir: true,
     optimizeCss: true,


### PR DESCRIPTION
This will probably fix our weird font loading problem, which I haven't exactly pinned down what the deal with is yet. See for reference:

- https://nextjs.org/docs/basic-features/font-optimization
- https://github.com/vercel/next.js/blob/canary/packages/next/pages/_document.tsx