### PR TITLE
Make main login/logout buttons reload server side props

### DIFF
--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -41,6 +41,7 @@ export function AuthProvider({ children }: any) {
   useEffect(() => {
     return onIdTokenChanged(auth, async (fbUser) => {
       if (fbUser) {
+        setAuthCookies(await fbUser.getIdToken(), fbUser.refreshToken)
         let user = await getUser(fbUser.uid)
         if (!user) {
           const deviceToken = ensureDeviceToken()
@@ -51,12 +52,11 @@ export function AuthProvider({ children }: any) {
         // Note: Cap on localStorage size is ~5mb
         localStorage.setItem(CACHED_USER_KEY, JSON.stringify(user))
         setCachedReferralInfoForUser(user)
-        setAuthCookies(await fbUser.getIdToken(), fbUser.refreshToken)
       } else {
         // User logged out; reset to null
+        deleteAuthCookies()
         setAuthUser(null)
         localStorage.removeItem(CACHED_USER_KEY)
-        deleteAuthCookies()
       }
     })
   }, [setAuthUser])

--- a/web/components/create-question-button.tsx
+++ b/web/components/create-question-button.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import clsx from 'clsx'
 import { firebaseLogin, User } from 'web/lib/firebase/users'
 import React from 'react'
@@ -16,6 +17,7 @@ export const CreateQuestionButton = (props: {
     'from-indigo-500 to-blue-500 hover:from-indigo-700 hover:to-blue-700'
 
   const { user, overrideText, className, query } = props
+  const router = useRouter()
   return (
     <div className={clsx('flex justify-center', className)}>
       {user ? (
@@ -26,7 +28,12 @@ export const CreateQuestionButton = (props: {
         </Link>
       ) : (
         <button
-          onClick={firebaseLogin}
+          onClick={async () => {
+            // login, and then reload the page, to hit any SSR redirect (e.g.
+            // redirecting from / to /home for logged in users)
+            await firebaseLogin()
+            router.replace(router.asPath)
+          }}
           className={clsx(gradient, createButtonStyle)}
         >
           Sign in

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -11,7 +11,7 @@ import {
 } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import Link from 'next/link'
-import { useRouter } from 'next/router'
+import Router, { useRouter } from 'next/router'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { firebaseLogout, User } from 'web/lib/firebase/users'
 import { ManifoldLogo } from './manifold-logo'
@@ -30,6 +30,13 @@ import { useUnseenPreferredNotifications } from 'web/hooks/use-notifications'
 import { setNotificationsAsSeen } from 'web/pages/notifications'
 import { PrivateUser } from 'common/user'
 import { useWindowSize } from 'web/hooks/use-window-size'
+
+const logout = async () => {
+  // log out, and then reload the page, in case SSR wants to boot them out
+  // of whatever logged-in-only area of the site they might be in
+  await withTracking(firebaseLogout, 'sign out')()
+  await Router.replace(Router.asPath)
+}
 
 function getNavigation() {
   return [
@@ -71,7 +78,7 @@ function getMoreNavigation(user?: User | null) {
     {
       name: 'Sign out',
       href: '#',
-      onClick: withTracking(firebaseLogout, 'sign out'),
+      onClick: logout,
     },
   ]
 }
@@ -122,7 +129,7 @@ function getMoreMobileNav() {
     {
       name: 'Sign out',
       href: '#',
-      onClick: withTracking(firebaseLogout, 'sign out'),
+      onClick: logout,
     },
   ]
 }

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -179,7 +179,7 @@ export async function firebaseLogin() {
 }
 
 export async function firebaseLogout() {
-  auth.signOut()
+  await auth.signOut()
 }
 
 const storage = getStorage(app)

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,6 +1,3 @@
-import React, { useEffect } from 'react'
-import { useRouter } from 'next/router'
-import { useUser } from 'web/hooks/use-user'
 import { Contract, getContractsBySlugs } from 'web/lib/firebase/contracts'
 import { Page } from 'web/components/page'
 import { LandingPagePanel } from 'web/components/landing-page-panel'
@@ -29,18 +26,7 @@ export const getServerSideProps = redirectIfLoggedIn('/home', async (_) => {
 export default function Home(props: { hotContracts: Contract[] }) {
   const { hotContracts } = props
 
-  // for now this redirect in the component is how we handle the case where they are
-  // on this page and they log in -- in the future we will make some cleaner way
-  const user = useUser()
-  const router = useRouter()
-
   useSaveReferral()
-
-  useEffect(() => {
-    if (user != null) {
-      router.replace('/home')
-    }
-  }, [router, user])
 
   return (
     <Page>


### PR DESCRIPTION
That means that if we create server-side redirects, they will trigger the redirects if appropriate (i.e. redirecting from `/` to `/home` if logging in, redirecting from random logged-in-users-only pages to `/` if logging out.) So now we can set up server side redirects when desired and not worry about also doing it on the client side in the React components anymore.