### PR TITLE
Make tabs components better

### DIFF
--- a/web/components/layout/tabs.tsx
+++ b/web/components/layout/tabs.tsx
@@ -9,8 +9,6 @@ type Tab = {
   title: string
   tabIcon?: ReactNode
   content: ReactNode
-  // If set, change the url to this href when the tab is selected
-  href?: string
   // If set, show a badge with this content
   badge?: string
 }
@@ -33,25 +31,21 @@ export function UncontrolledTabs(props: TabProps & { activeIndex: number }) {
     currentPageForAnalytics,
   } = props
   const activeTab = tabs[activeIndex] as Tab | undefined // can be undefined in weird case
-
   return (
     <>
       <div className={clsx('mb-4 border-b border-gray-200', className)}>
         <nav className="-mb-px flex space-x-8" aria-label="Tabs">
           {tabs.map((tab, i) => (
-            <Link href={tab.href ?? '#'} key={tab.title} shallow={!!tab.href}>
+            <Link href="#" key={tab.title} shallow={false}>
               <a
                 id={`tab-${i}`}
                 key={tab.title}
                 onClick={(e) => {
+                  e.preventDefault()
                   track('Clicked Tab', {
                     title: tab.title,
-                    href: tab.href,
                     currentPage: currentPageForAnalytics,
                   })
-                  if (!tab.href) {
-                    e.preventDefault()
-                  }
                   onClick?.(tab.title, i)
                 }}
                 className={clsx(

--- a/web/components/layout/tabs.tsx
+++ b/web/components/layout/tabs.tsx
@@ -1,8 +1,6 @@
 import clsx from 'clsx'
-import Link from 'next/link'
 import { useRouter, NextRouter } from 'next/router'
 import { ReactNode, useState } from 'react'
-import { Row } from './row'
 import { track } from '@amplitude/analytics-browser'
 
 type Tab = {
@@ -33,42 +31,39 @@ export function UncontrolledTabs(props: TabProps & { activeIndex: number }) {
   const activeTab = tabs[activeIndex] as Tab | undefined // can be undefined in weird case
   return (
     <>
-      <div className={clsx('mb-4 border-b border-gray-200', className)}>
-        <nav className="-mb-px flex space-x-8" aria-label="Tabs">
-          {tabs.map((tab, i) => (
-            <Link href="#" key={tab.title} shallow={false}>
-              <a
-                key={tab.title}
-                onClick={(e) => {
-                  e.preventDefault()
-                  track('Clicked Tab', {
-                    title: tab.title,
-                    currentPage: currentPageForAnalytics,
-                  })
-                  onClick?.(tab.title, i)
-                }}
-                className={clsx(
-                  activeIndex === i
-                    ? 'border-indigo-500 text-indigo-600'
-                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
-                  'cursor-pointer whitespace-nowrap border-b-2 py-3 px-1 text-sm font-medium',
-                  labelClassName
-                )}
-                aria-current={activeIndex === i ? 'page' : undefined}
-              >
-                <Row className={'items-center justify-center gap-1'}>
-                  {tab.tabIcon && <span> {tab.tabIcon}</span>}
-                  {tab.badge ? (
-                    <div className="px-0.5 font-bold">{tab.badge}</div>
-                  ) : null}
-                  {tab.title}
-                </Row>
-              </a>
-            </Link>
-          ))}
-        </nav>
-      </div>
-
+      <nav
+        className={clsx('mb-4 space-x-8 border-b border-gray-200', className)}
+        aria-label="Tabs"
+      >
+        {tabs.map((tab, i) => (
+          <a
+            href="#"
+            key={tab.title}
+            onClick={(e) => {
+              e.preventDefault()
+              track('Clicked Tab', {
+                title: tab.title,
+                currentPage: currentPageForAnalytics,
+              })
+              onClick?.(tab.title, i)
+            }}
+            className={clsx(
+              activeIndex === i
+                ? 'border-indigo-500 text-indigo-600'
+                : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+              'inline-flex cursor-pointer flex-row gap-1 whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium',
+              labelClassName
+            )}
+            aria-current={activeIndex === i ? 'page' : undefined}
+          >
+            {tab.tabIcon && <span>{tab.tabIcon}</span>}
+            {tab.badge ? (
+              <span className="px-0.5 font-bold">{tab.badge}</span>
+            ) : null}
+            {tab.title}
+          </a>
+        ))}
+      </nav>
       {activeTab?.content}
     </>
   )

--- a/web/components/layout/tabs.tsx
+++ b/web/components/layout/tabs.tsx
@@ -19,7 +19,7 @@ type TabProps = {
   currentPageForAnalytics?: string
 }
 
-export function UncontrolledTabs(props: TabProps & { activeIndex: number }) {
+export function ControlledTabs(props: TabProps & { activeIndex: number }) {
   const {
     tabs,
     activeIndex,
@@ -69,11 +69,11 @@ export function UncontrolledTabs(props: TabProps & { activeIndex: number }) {
   )
 }
 
-export function ControlledTabs(props: TabProps & { defaultIndex?: number }) {
+export function UncontrolledTabs(props: TabProps & { defaultIndex?: number }) {
   const { defaultIndex, onClick, ...rest } = props
   const [activeIndex, setActiveIndex] = useState(defaultIndex ?? 0)
   return (
-    <UncontrolledTabs
+    <ControlledTabs
       {...rest}
       activeIndex={activeIndex}
       onClick={(title, i) => {
@@ -93,7 +93,7 @@ const isTabSelected = (router: NextRouter, queryParam: string, tab: Tab) => {
   }
 }
 
-export function QueryControlledTabs(
+export function QueryUncontrolledTabs(
   props: TabProps & { defaultIndex?: number }
 ) {
   const { tabs, defaultIndex, onClick, ...rest } = props
@@ -101,7 +101,7 @@ export function QueryControlledTabs(
   const selectedIdx = tabs.findIndex((t) => isTabSelected(router, 'tab', t))
   const activeIndex = selectedIdx !== -1 ? selectedIdx : defaultIndex ?? 0
   return (
-    <UncontrolledTabs
+    <ControlledTabs
       {...rest}
       tabs={tabs}
       activeIndex={activeIndex}
@@ -118,4 +118,4 @@ export function QueryControlledTabs(
 }
 
 // legacy code that didn't know about any other kind of tabs imports this
-export const Tabs = ControlledTabs
+export const Tabs = UncontrolledTabs

--- a/web/components/layout/tabs.tsx
+++ b/web/components/layout/tabs.tsx
@@ -38,7 +38,6 @@ export function UncontrolledTabs(props: TabProps & { activeIndex: number }) {
           {tabs.map((tab, i) => (
             <Link href="#" key={tab.title} shallow={false}>
               <a
-                id={`tab-${i}`}
                 key={tab.title}
                 onClick={(e) => {
                   e.preventDefault()

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -280,9 +280,9 @@ export function UserPage(props: { user: User; currentUser?: User }) {
                 title: 'Markets',
                 content: <CreatorContractsList creator={user} />,
                 tabIcon: (
-                  <div className="px-0.5 font-bold">
+                  <span className="px-0.5 font-bold">
                     {usersContracts.length}
-                  </div>
+                  </span>
                 ),
               },
               {
@@ -295,7 +295,9 @@ export function UserPage(props: { user: User; currentUser?: User }) {
                   />
                 ),
                 tabIcon: (
-                  <div className="px-0.5 font-bold">{usersComments.length}</div>
+                  <span className="px-0.5 font-bold">
+                    {usersComments.length}
+                  </span>
                 ),
               },
               {
@@ -313,7 +315,7 @@ export function UserPage(props: { user: User; currentUser?: User }) {
                     />
                   </div>
                 ),
-                tabIcon: <div className="px-0.5 font-bold">{betCount}</div>,
+                tabIcon: <span className="px-0.5 font-bold">{betCount}</span>,
               },
             ]}
           />

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -22,7 +22,7 @@ import { Linkify } from './linkify'
 import { Spacer } from './layout/spacer'
 import { Row } from './layout/row'
 import { genHash } from 'common/util/random'
-import { QueryControlledTabs } from './layout/tabs'
+import { QueryUncontrolledTabs } from './layout/tabs'
 import { UserCommentsList } from './comments-list'
 import { useWindowSize } from 'web/hooks/use-window-size'
 import { Comment, getUsersComments } from 'web/lib/firebase/comments'
@@ -272,7 +272,7 @@ export function UserPage(props: { user: User; currentUser?: User }) {
         <Spacer h={10} />
 
         {usersContracts !== 'loading' && contractsById && usersComments ? (
-          <QueryControlledTabs
+          <QueryUncontrolledTabs
             currentPageForAnalytics={'profile'}
             labelClassName={'pb-2 pt-1 '}
             tabs={[

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -22,7 +22,7 @@ import { Linkify } from './linkify'
 import { Spacer } from './layout/spacer'
 import { Row } from './layout/row'
 import { genHash } from 'common/util/random'
-import { Tabs } from './layout/tabs'
+import { QueryControlledTabs } from './layout/tabs'
 import { UserCommentsList } from './comments-list'
 import { useWindowSize } from 'web/hooks/use-window-size'
 import { Comment, getUsersComments } from 'web/lib/firebase/comments'
@@ -64,12 +64,8 @@ export function UserLink(props: {
 export const TAB_IDS = ['markets', 'comments', 'bets', 'groups']
 const JUNE_1_2022 = new Date('2022-06-01T00:00:00.000Z').valueOf()
 
-export function UserPage(props: {
-  user: User
-  currentUser?: User
-  defaultTabTitle?: string | undefined
-}) {
-  const { user, currentUser, defaultTabTitle } = props
+export function UserPage(props: { user: User; currentUser?: User }) {
+  const { user, currentUser } = props
   const router = useRouter()
   const isCurrentUser = user.id === currentUser?.id
   const bannerUrl = user.bannerUrl ?? defaultBannerUrl(user.id)
@@ -276,21 +272,9 @@ export function UserPage(props: {
         <Spacer h={10} />
 
         {usersContracts !== 'loading' && contractsById && usersComments ? (
-          <Tabs
+          <QueryControlledTabs
             currentPageForAnalytics={'profile'}
             labelClassName={'pb-2 pt-1 '}
-            defaultIndex={
-              defaultTabTitle ? TAB_IDS.indexOf(defaultTabTitle) : 0
-            }
-            onClick={(tabName) => {
-              const tabId = tabName.toLowerCase()
-              const subpath = tabId === 'markets' ? '' : '?tab=' + tabId
-              // BUG: if you start on `/Bob/bets`, then click on Markets, use-query-and-sort-params
-              // rewrites the url incorrectly to `/Bob/bets` instead of `/Bob`
-              router.push(`/${user.username}${subpath}`, undefined, {
-                shallow: true,
-              })
-            }}
             tabs={[
               {
                 title: 'Markets',

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -31,9 +31,8 @@ export default function UserProfile(props: { user: User | null }) {
   const { user } = props
 
   const router = useRouter()
-  const { username, tab } = router.query as {
+  const { username } = router.query as {
     username: string
-    tab?: string | undefined
   }
   const currentUser = useUser()
 
@@ -42,11 +41,7 @@ export default function UserProfile(props: { user: User | null }) {
   if (user === undefined) return <div />
 
   return user ? (
-    <UserPage
-      user={user}
-      currentUser={currentUser || undefined}
-      defaultTabTitle={tab}
-    />
+    <UserPage user={user} currentUser={currentUser || undefined} />
   ) : (
     <Custom404 />
   )


### PR DESCRIPTION
Previously, our tabs component that we used everywhere had only one mode, which would be normally called "uncontrolled" -- it kept its active index in local React state. This caused at least two problems:

- In some circumstances, a parent component might like to choose which tab is selected in some arbitrary way. But this becomes impossible to do in any principled way. This really bit me when I was making the manalinks page and I wanted to switch tabs to show the manalink you just created. (That particular case got redesigned, but obviously this is a very normal sounding desire.)
- In some circumstances, we are OK with having internal React-managed active tab state, but we want to represent it differently. For example, on the user page, we represent the active tab in the URL query string. This meant that when you changed tabs, it had to re-render everything twice -- once when the tabs component changed its intenal state, and once when outside code changed the query string on its behalf.

Now I split the tab component into three varieties:

- `ControlledTabs`, where you pass the active index in via props and the parent is responsible for setting it (e.g. via the `onClick` handler.
- `UncontrolledTabs`, which wraps `ControlledTabs` and manages an `activeIndex` which it sets in the `onClick` handler. This is synonymous with our existing `Tabs`.
- `QueryUncontrolledTabs`, which wraps `ControlledTabs` and sets the `activeIndex` based on the URL query parameter, which it then sets in the `onClick` handler.

Now the user page uses `QueryUncontrolledTabs`, so it fixes the problem with re-rendering.

Later I will go fix up other tab controls as appropriate.