### PR TITLE
Allow unspecfied outcome as input to `sellshares`

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -581,12 +581,12 @@ $ curl https://manifold.markets/api/v0/market/{marketId}/resolve -X POST \
 
 ### `POST /v0/market/[marketId]/sell`
 
-Sells some quantity of shares in a market on behalf of the authorized user.
+Sells some quantity of shares in a binary market on behalf of the authorized user.
 
 Parameters:
 
-- `outcome`: Required. One of `YES`, `NO`, or a `number` indicating the numeric
-  bucket ID, depending on the market type.
+- `outcome`: Optional. One of `YES`, or `NO`. If you leave it off, and you only
+  own one kind of shares, you will sell that kind of shares.
 - `shares`: Optional. The amount of shares to sell of the outcome given
   above. If not provided, all the shares you own will be sold.
 

--- a/functions/src/sell-shares.ts
+++ b/functions/src/sell-shares.ts
@@ -9,7 +9,7 @@ import { getCpmmSellBetInfo } from '../../common/sell-bet'
 import { addObjects, removeUndefinedProps } from '../../common/util/object'
 import { getValues, log } from './utils'
 import { Bet } from '../../common/bet'
-import { floatingLesserEqual } from '../../common/util/math'
+import { floatingEqual, floatingLesserEqual } from '../../common/util/math'
 import { getUnfilledBetsQuery, updateMakers } from './place-bet'
 import { FieldValue } from 'firebase-admin/firestore'
 import { redeemShares } from './redeem-shares'
@@ -56,8 +56,11 @@ export const sellshares = newEndpoint({}, async (req, auth) => {
       chosenOutcome = outcome
     } else {
       const nonzeroShares = Object.entries(sharesByOutcome).filter(
-        ([_k, v]) => v
+        ([_k, v]) => !floatingEqual(0, v)
       )
+      if (nonzeroShares.length == 0) {
+        throw new APIError(400, "You don't own any shares in this market.")
+      }
       if (nonzeroShares.length > 1) {
         throw new APIError(
           400,


### PR DESCRIPTION
This is particularly useful in the case of bots, where users may already know how they have bet, regardless of whether the bot knows, and want a very succinct command to sell all their shares.