### PR TITLE
Pass page props user to auth provider if present

### DIFF
--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect } from 'react'
+import { ReactNode, createContext, useEffect } from 'react'
 import { User } from 'common/user'
 import { onIdTokenChanged } from 'firebase/auth'
 import {
@@ -28,11 +28,11 @@ const ensureDeviceToken = () => {
   return deviceToken
 }
 
-export const AuthContext = createContext<AuthUser>(null)
+export const AuthContext = createContext<AuthUser>(undefined)
 
-export function AuthProvider({ children }: any) {
-  const [authUser, setAuthUser] = useStateCheckEquality<AuthUser>(undefined)
-
+export function AuthProvider(props: { children: ReactNode; user?: AuthUser }) {
+  const { children, user } = props
+  const [authUser, setAuthUser] = useStateCheckEquality<AuthUser>(user)
   useEffect(() => {
     const cachedUser = localStorage.getItem(CACHED_USER_KEY)
     setAuthUser(cachedUser && JSON.parse(cachedUser))

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -37,9 +37,11 @@ export function AuthProvider(props: {
   const { children, serverUser } = props
   const [authUser, setAuthUser] = useStateCheckEquality<AuthUser>(serverUser)
   useEffect(() => {
-    const cachedUser = localStorage.getItem(CACHED_USER_KEY)
-    setAuthUser(cachedUser && JSON.parse(cachedUser))
-  }, [setAuthUser])
+    if (serverUser === undefined) {
+      const cachedUser = localStorage.getItem(CACHED_USER_KEY)
+      setAuthUser(cachedUser && JSON.parse(cachedUser))
+    }
+  }, [setAuthUser, serverUser])
 
   useEffect(() => {
     return onIdTokenChanged(auth, async (fbUser) => {

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -30,9 +30,12 @@ const ensureDeviceToken = () => {
 
 export const AuthContext = createContext<AuthUser>(undefined)
 
-export function AuthProvider(props: { children: ReactNode; user?: AuthUser }) {
-  const { children, user } = props
-  const [authUser, setAuthUser] = useStateCheckEquality<AuthUser>(user)
+export function AuthProvider(props: {
+  children: ReactNode
+  serverUser?: AuthUser
+}) {
+  const { children, serverUser } = props
+  const [authUser, setAuthUser] = useStateCheckEquality<AuthUser>(serverUser)
   useEffect(() => {
     const cachedUser = localStorage.getItem(CACHED_USER_KEY)
     setAuthUser(cachedUser && JSON.parse(cachedUser))

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -79,7 +79,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
       </Head>
-      <AuthProvider user={pageProps.user}>
+      <AuthProvider serverUser={pageProps.user}>
         <QueryClientProvider client={queryClient}>
           <Welcome {...pageProps} />
           <Component {...pageProps} />

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -79,7 +79,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           content="width=device-width, initial-scale=1, maximum-scale=1"
         />
       </Head>
-      <AuthProvider>
+      <AuthProvider user={pageProps.user}>
         <QueryClientProvider client={queryClient}>
           <Welcome {...pageProps} />
           <Component {...pageProps} />


### PR DESCRIPTION
This establishes a special magic prop, `user`, which if it's present in the page props (e.g. because we wrote a `getServerSideProps` that returns it), will be the initial value in the page `AuthContext`. This will save a re-render on the client when we load the user later from either local storage and/or from the actual Firebase SDK (assuming those things don't disagree with the version that came down from the server.) It will also kind of make the server side rendering more "useful" because it will actually be able to render using the authed user.