### PR TITLE
add bets and user tables per market

### DIFF
--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -16,7 +16,7 @@ import { Avatar } from 'web/components/avatar'
 import { Grid, _ } from 'gridjs-react'
 import 'gridjs/dist/theme/mermaid.css'
 import { useState, useEffect, useRef } from 'react'
-import { maxBy, uniq } from 'lodash'
+import { maxBy } from 'lodash'
 
 export function ContractTabs(props: {
   contract: Contract
@@ -104,9 +104,11 @@ export function ContractTabs(props: {
   const asked = useRef(new Set<string>())
 
   useEffect(() => {
-    uniq(bets.map((bet:Bet) => bet.userId)).filter((uid) => !asked.current.has(uid)).forEach((uid) => {
-      asked.current.add(uid)
-      getUser(uid).then((u) => setUsers((users) => ({...users, [uid]: u})))
+    bets.forEach(({ userId }) => {
+      if (!asked.current.has(userId)) {
+        asked.current.add(userId)
+        getUser(userId).then((u) => setUsers((us) => ({...us, [userId]: u})))
+      }
     })
   }, [bets])
 
@@ -131,21 +133,7 @@ export function ContractTabs(props: {
     {name: "on", id: "createdTime", formatter: (t:number) => dayjs(t).format('YY/MM/DD,hh:mm:ss')},
   ]
 
-  const gridjsstyle = {
-    table: {
-      border: '3px solid #ccc',
-      'text-align': 'center',
-    },
-    th: {
-      'background-color': 'rgba(0, 0, 0, 0.1)',
-      color: '#000',
-      'border-bottom': '3px solid #ccc',
-      'padding': '0',
-    },
-    td: {
-      'padding': '0',
-    }
-  }
+  const gridjsstyle = {th: {padding: 0}, td: {padding: 0}}
 
   const userpositions = {} as {[key: string]: any}
   bets.forEach((bet) => {

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -153,15 +153,17 @@ export function ContractTabs(props: {
     position[bet.outcome] = (position[bet.outcome] || 0) + bet.shares
     userpositions[bet.userId] = {id:id, position:position, mana:(mana + bet.amount)}
   })
-  const gridjsusers = Object.values(userpositions).map((row:any) => ({...row, ['username']: users[row.userId]?.username}))
-
   const argmax = (obj:{[key:string]:number}) => maxBy(Object.keys(obj), (k:string) => obj[k])
+  const gridjsusers = Object.values(userpositions)
+    .map((row:any) => ({...row, ['topout']: argmax(row.position)}))
+    .map((row:any) => ({...row, ['topshr']: row.position[row.topout]}))
+    .map((row:any) => ({...row, ['username']: users[row.userId]?.username}))
 
   const gridjsusercolumns = [
     {name: "User", id: "id", formatter:formatUser},
     {name: "is down", id: "mana", formatter: (i:number) => "M$"+i.toFixed(0)},
-    {name: "and holds", id: "position", formatter: (p:{[key: string]: number}) => p[argmax(p) ?? ""].toFixed(0)},
-    {name: "of", id: "position", formatter: (p:{[key: string]: number}) => argmax(p)},
+    {name: "and holds", id: "topshr", formatter: (i:number) => i.toFixed(0)},
+    {name: "of", id: "topout"},
   ]
 
   return (

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -16,7 +16,7 @@ import { Avatar } from 'web/components/avatar'
 import { Grid, _ } from 'gridjs-react'
 import 'gridjs/dist/theme/mermaid.css'
 import { useState, useEffect, useRef } from 'react'
-import { maxBy } from 'lodash'
+import { maxBy, Dictionary } from 'lodash'
 
 export function ContractTabs(props: {
   contract: Contract
@@ -100,7 +100,7 @@ export function ContractTabs(props: {
     </div>
   )
 
-  const [users, setUsers] = useState({} as {[key: string]: User})
+  const [users, setUsers] = useState({} as Dictionary<User>)
   const asked = useRef(new Set<string>())
 
   useEffect(() => {
@@ -135,13 +135,13 @@ export function ContractTabs(props: {
 
   const gridjsstyle = {th: {padding: 0}, td: {padding: 0}}
 
-  const userpositions = {} as {[key: string]: any}
+  const userpositions = {} as Dictionary<any>
   bets.forEach(({ userId, outcome, shares, amount }) => {
     const {id, position, mana} = userpositions[userId] || {id: userId, position: {}, mana: 0}
     position[outcome] = (position[outcome] || 0) + shares
     userpositions[userId] = {id:id, position:position, mana:(mana + amount)}
   })
-  const argmax = (obj:{[key:string]:number}) => maxBy(Object.keys(obj), (k:string) => obj[k])
+  const argmax = (obj:Dictionary<number>) => maxBy(Object.keys(obj), (k:string) => obj[k])
   const gridjsusers = Object.values(userpositions).map((row:any) => ({...row
     , topout: argmax(row.position)
     , topshr: row.position[argmax(row.position) || ""]

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -15,7 +15,7 @@ import dayjs from 'dayjs'
 import { Avatar } from 'web/components/avatar'
 import { Grid, _ } from 'gridjs-react'
 import 'gridjs/dist/theme/mermaid.css'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { maxBy, uniq } from 'lodash'
 
 export function ContractTabs(props: {
@@ -101,12 +101,12 @@ export function ContractTabs(props: {
   )
 
   const [users, setUsers] = useState({} as {[key: string]: User})
-  const [asked, _setAsked] = useState(new Set<string>())
+  const asked = useRef(new Set<string>())
 
   useEffect(() => {
-    uniq(bets.map((bet:Bet) => bet.userId)).filter((uid) => !asked.has(uid)).forEach((uid) => {
+    uniq(bets.map((bet:Bet) => bet.userId)).filter((uid) => !asked.current.has(uid)).forEach((uid) => {
       console.log("adding",uid)
-      asked.add(uid)
+      asked.current.add(uid)
       getUser(uid).then((u) => setUsers((users) => ({...users, [uid]: u})))
     })
   }, [bets])

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -120,7 +120,7 @@ export function ContractTabs(props: {
     </div>)
   }
 
-  const gridjsbets = bets.map((bet) => ({...bet, ['username']: users[bet.userId]?.username}))
+  const gridjsbets = bets.map((bet) => ({...bet, username: users[bet.userId]?.username}))
   const gridjsbetcolumns = [
     {name: "User", id: "userId", formatter:formatUser},
     {name: "bought", id: "shares", formatter: (i:number) => i.toFixed(0)},
@@ -136,16 +136,16 @@ export function ContractTabs(props: {
   const gridjsstyle = {th: {padding: 0}, td: {padding: 0}}
 
   const userpositions = {} as {[key: string]: any}
-  bets.forEach((bet) => {
-    const {id, position, mana} = userpositions[bet.userId] || {id: bet.userId, position: {}, mana: 0}
-    position[bet.outcome] = (position[bet.outcome] || 0) + bet.shares
-    userpositions[bet.userId] = {id:id, position:position, mana:(mana + bet.amount)}
+  bets.forEach(({ userId, outcome, shares, amount }) => {
+    const {id, position, mana} = userpositions[userId] || {id: userId, position: {}, mana: 0}
+    position[outcome] = (position[outcome] || 0) + shares
+    userpositions[userId] = {id:id, position:position, mana:(mana + amount)}
   })
   const argmax = (obj:{[key:string]:number}) => maxBy(Object.keys(obj), (k:string) => obj[k])
-  const gridjsusers = Object.values(userpositions)
-    .map((row:any) => ({...row, ['topout']: argmax(row.position)}))
-    .map((row:any) => ({...row, ['topshr']: row.position[row.topout]}))
-    .map((row:any) => ({...row, ['username']: users[row.userId]?.username}))
+  const gridjsusers = Object.values(userpositions).map((row:any) => ({...row
+    , topout: argmax(row.position)
+    , topshr: row.position[argmax(row.position) || ""]
+    , username: users[row.userId]?.username}))
 
   const gridjsusercolumns = [
     {name: "User", id: "id", formatter:formatUser},

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -105,7 +105,6 @@ export function ContractTabs(props: {
 
   useEffect(() => {
     uniq(bets.map((bet:Bet) => bet.userId)).filter((uid) => !asked.current.has(uid)).forEach((uid) => {
-      console.log("adding",uid)
       asked.current.add(uid)
       getUser(uid).then((u) => setUsers((users) => ({...users, [uid]: u})))
     })

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -16,7 +16,7 @@ import { Avatar } from 'web/components/avatar'
 import { Grid, _ } from 'gridjs-react'
 import 'gridjs/dist/theme/mermaid.css'
 import { useState, useEffect } from 'react'
-import { maxBy } from 'lodash'
+import { maxBy, uniq } from 'lodash'
 
 export function ContractTabs(props: {
   contract: Contract
@@ -101,15 +101,13 @@ export function ContractTabs(props: {
   )
 
   const [users, setUsers] = useState({} as {[key: string]: User})
-  const [asked, setAsked] = useState({} as {[key: string]: boolean})
+  const [asked, _setAsked] = useState(new Set<string>())
+
   useEffect(() => {
-    bets.map((bet) => {
-      if (!asked[bet.userId]) {
-        getUser(bet.userId).then((user) => {
-          setUsers({ ...users, [bet.userId]: user })
-        })
-        setAsked({ ...asked, [bet.userId]: true })
-      }
+    uniq(bets.map((bet:Bet) => bet.userId)).filter((uid) => !asked.has(uid)).forEach((uid) => {
+      console.log("adding",uid)
+      asked.add(uid)
+      getUser(uid).then((u) => setUsers((users) => ({...users, [uid]: u})))
     })
   }, [bets])
 


### PR DESCRIPTION
So it turns out you can add a bets table that lets the user sort and filter using like one line. Then I added some more lines for formating and styling and another table of each user's position. Feel free to redo any or all of it or give feedback.
![Screenshot from 2022-08-09 02-50-05](https://user-images.githubusercontent.com/1489801/183539466-88b4adb4-ea3f-40f5-9ee4-7ea4f54bd844.png)
![Screenshot from 2022-08-09 02-50-13](https://user-images.githubusercontent.com/1489801/183539463-58a58058-671b-405f-a614-25ee3b73093b.png)
