### PR TITLE
Fix broken `useBets` filter implementation

### DIFF
--- a/web/hooks/use-bets.ts
+++ b/web/hooks/use-bets.ts
@@ -14,21 +14,22 @@ export const useBets = (
   options?: { filterChallenges: boolean; filterRedemptions: boolean }
 ) => {
   const [bets, setBets] = useState<Bet[] | undefined>()
-
+  const filterChallenges = !!options?.filterChallenges
+  const filterRedemptions = !!options?.filterRedemptions
   useEffect(() => {
     if (contractId)
       return listenForBets(contractId, (bets) => {
-        if (options)
+        if (filterChallenges || filterRedemptions)
           setBets(
             bets.filter(
               (bet) =>
-                (options.filterChallenges ? !bet.challengeSlug : true) &&
-                (options.filterRedemptions ? !bet.isRedemption : true)
+                (filterChallenges ? !bet.challengeSlug : true) &&
+                (filterRedemptions ? !bet.isRedemption : true)
             )
           )
         else setBets(bets)
       })
-  }, [contractId, options])
+  }, [contractId, filterChallenges, filterRedemptions])
 
   return bets
 }


### PR DESCRIPTION
This was basically causing an infinite database-spam-and-render loop on the contract page (the only place where we use the filter option is the `ContractActivity` component on that page) because the filter option was an object literal defined in the parent component. So it would call this, this would run and set the bets, it would re-render, creating a new options object, so this would run and set the bets again, and so on.