### PR TITLE
Change tabs to keep all individual tab components in the DOM

### DIFF
--- a/web/components/layout/tabs.tsx
+++ b/web/components/layout/tabs.tsx
@@ -28,7 +28,6 @@ export function ControlledTabs(props: TabProps & { activeIndex: number }) {
     className,
     currentPageForAnalytics,
   } = props
-  const activeTab = tabs[activeIndex] as Tab | undefined // can be undefined in weird case
   return (
     <>
       <nav
@@ -64,7 +63,11 @@ export function ControlledTabs(props: TabProps & { activeIndex: number }) {
           </a>
         ))}
       </nav>
-      {activeTab?.content}
+      {tabs.map((tab, i) => (
+        <div key={i} className={i === activeIndex ? 'block' : 'hidden'}>
+          {tab.content}
+        </div>
+      ))}
     </>
   )
 }


### PR DESCRIPTION
This is important for two reasons:

1. It means that DOM state doesn't get reset when you switch tabs. As a simple but important example, the comment input in the "comments" tab on contracts doesn't get cleared if you switch to the bets tab and back.
2. It means that we can store per-tab React state that doesn't get reset when you switch tabs. For example, on the contract page, we can load the bets list inside the bets tab component without having it have to reload every time you switch to the bets tab. So we will be able to make the user and contract pages load faster by pushing down more tab-specific state in this way.

This approach has a downside, which is that all the tabs will render in advance of viewing them. However, we can and should make rendering fast; for example, the really big tabs we have, like the contract bets list, we should paginate. The benefits above seem worth it. If rendering performance becomes a problem, we could address it by only lazily producing each tab the first time you view it.