### PR TITLE
Revamp a lot of stuff on the user page to make it usably efficient

### DIFF
--- a/common/util/array.ts
+++ b/common/util/array.ts
@@ -17,3 +17,22 @@ export function buildArray<T>(
 
   return array
 }
+
+export function groupConsecutive<T, U>(xs: T[], key: (x: T) => U) {
+  if (!xs.length) {
+    return []
+  }
+  const result = []
+  let curr = { key: key(xs[0]), items: [xs[0]] }
+  for (const x of xs.slice(1)) {
+    const k = key(x)
+    if (k !== curr.key) {
+      result.push(curr)
+      curr = { key: k, items: [x] }
+    } else {
+      curr.items.push(x)
+    }
+  }
+  result.push(curr)
+  return result
+}

--- a/web/components/bets-list.tsx
+++ b/web/components/bets-list.tsx
@@ -86,8 +86,8 @@ export function BetsList(props: { user: User }) {
 
   useEffect(() => {
     if (bets) {
-      const contractIds = uniq(bets.map((b) => getContractFromId(b.contractId)))
-      Promise.all(contractIds).then((contracts) => {
+      const contractIds = uniq(bets.map((b) => b.contractId))
+      Promise.all(contractIds.map(getContractFromId)).then((contracts) => {
         setContractsById(keyBy(filterDefined(contracts), 'id'))
       })
     }

--- a/web/components/comments-list.tsx
+++ b/web/components/comments-list.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Dictionary, groupBy, keyBy, mapValues, uniq } from 'lodash'
+import { Dictionary, keyBy, uniq } from 'lodash'
 
 import { Comment } from 'common/comment'
 import { Contract } from 'common/contract'
@@ -59,7 +59,7 @@ export function UserCommentsList(props: { user: User }) {
       {pageComments.map(({ key, items }, i) => {
         const contract = contracts[key]
         return (
-          <div key={i} className="border-b p-5">
+          <div key={start + i} className="border-b p-5">
             <SiteLink
               className="mb-2 block pb-2 font-medium text-indigo-700"
               href={contractPath(contract)}

--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -5,6 +5,7 @@ import { LinkIcon } from '@heroicons/react/solid'
 import { PencilIcon } from '@heroicons/react/outline'
 
 import { User } from 'web/lib/firebase/users'
+import { useUser } from 'web/hooks/use-user'
 import { CreatorContractsList } from './contract/contracts-grid'
 import { SEO } from './SEO'
 import { Page } from './page'
@@ -50,9 +51,10 @@ export function UserLink(props: {
 
 export const TAB_IDS = ['markets', 'comments', 'bets', 'groups']
 
-export function UserPage(props: { user: User; currentUser?: User }) {
-  const { user, currentUser } = props
+export function UserPage(props: { user: User }) {
+  const { user } = props
   const router = useRouter()
+  const currentUser = useUser()
   const isCurrentUser = user.id === currentUser?.id
   const bannerUrl = user.bannerUrl ?? defaultBannerUrl(user.id)
   const [showConfetti, setShowConfetti] = useState(false)

--- a/web/lib/firebase/server-auth.ts
+++ b/web/lib/firebase/server-auth.ts
@@ -81,7 +81,7 @@ const authAndRefreshTokens = async (ctx: RequestContext) => {
   // step 0: if you have no refresh token you are logged out
   if (refresh == null) {
     console.debug('User is unauthenticated.')
-    return undefined
+    return null
   }
 
   console.debug('User may be authenticated; checking cookies.')
@@ -107,7 +107,7 @@ const authAndRefreshTokens = async (ctx: RequestContext) => {
     } catch (e) {
       // big unexpected problem -- functionally, they are not logged in
       console.error(e)
-      return undefined
+      return null
     }
   }
 
@@ -136,9 +136,10 @@ const authAndRefreshTokens = async (ctx: RequestContext) => {
     } catch (e) {
       // big unexpected problem -- functionally, they are not logged in
       console.error(e)
-      return undefined
+      return null
     }
   }
+  return null
 }
 
 export const authenticateOnServer = async (ctx: RequestContext) => {
@@ -158,7 +159,7 @@ export const authenticateOnServer = async (ctx: RequestContext) => {
     // definitely not supposed to happen, but let's be maximally robust
     console.error(e)
   }
-  return creds
+  return creds ?? null
 }
 
 // note that we might want to define these types more generically if we want better

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -1,48 +1,38 @@
 import { useRouter } from 'next/router'
 import React from 'react'
 
-import { getUserByUsername, User } from 'web/lib/firebase/users'
+import {
+  getUserByUsername,
+  getUserAndPrivateUser,
+  User,
+  UserAndPrivateUser,
+} from 'web/lib/firebase/users'
 import { UserPage } from 'web/components/user-page'
-import { useUser } from 'web/hooks/use-user'
 import Custom404 from '../404'
 import { useTracking } from 'web/hooks/use-tracking'
-import { fromPropz, usePropz } from 'web/hooks/use-propz'
+import { GetServerSideProps } from 'next'
+import { authenticateOnServer } from 'web/lib/firebase/server-auth'
 
-export const getStaticProps = fromPropz(getStaticPropz)
-export async function getStaticPropz(props: { params: { username: string } }) {
-  const { username } = props.params
-  const user = await getUserByUsername(username)
-
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const creds = await authenticateOnServer(ctx)
+  const [auth, user] = (await Promise.all([
+    creds != null ? getUserAndPrivateUser(creds.user.uid) : null,
+    getUserByUsername(ctx.params!.username as string),
+  ])) as [UserAndPrivateUser | null, User | null]
   return {
-    props: {
-      user,
-    },
-
-    revalidate: 60, // regenerate after a minute
+    props: { auth, user },
   }
 }
 
-export async function getStaticPaths() {
-  return { paths: [], fallback: 'blocking' }
-}
-
 export default function UserProfile(props: { user: User | null }) {
-  props = usePropz(props, getStaticPropz) ?? { user: undefined }
   const { user } = props
 
   const router = useRouter()
   const { username } = router.query as {
     username: string
   }
-  const currentUser = useUser()
 
   useTracking('view user profile', { username })
 
-  if (user === undefined) return <div />
-
-  return user ? (
-    <UserPage user={user} currentUser={currentUser || undefined} />
-  ) : (
-    <Custom404 />
-  )
+  return user ? <UserPage user={user} /> : <Custom404 />
 }

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -17,11 +17,9 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const creds = await authenticateOnServer(ctx)
   const [auth, user] = (await Promise.all([
     creds != null ? getUserAndPrivateUser(creds.user.uid) : null,
-    getUserByUsername(ctx.params!.username as string),
+    getUserByUsername(ctx.params!.username as string), // eslint-disable-line @typescript-eslint/no-non-null-assertion
   ])) as [UserAndPrivateUser | null, User | null]
-  return {
-    props: { auth, user },
-  }
+  return { props: { auth, user } }
 }
 
 export default function UserProfile(props: { user: User | null }) {

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -15,9 +15,10 @@ import { authenticateOnServer } from 'web/lib/firebase/server-auth'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const creds = await authenticateOnServer(ctx)
+  const username = ctx.params!.username as string // eslint-disable-line @typescript-eslint/no-non-null-assertion
   const [auth, user] = (await Promise.all([
     creds != null ? getUserAndPrivateUser(creds.user.uid) : null,
-    getUserByUsername(ctx.params!.username as string), // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    getUserByUsername(username),
   ])) as [UserAndPrivateUser | null, User | null]
   return { props: { auth, user } }
 }


### PR DESCRIPTION
Efficiency changes:

1. Changed the user page to be server-side rendered, so that the sidebar loads nicely and re-renders are minimized.
2. Changed the user page tabs to load the data they need inside the tab component, rather than waiting up front for it.
3. Paginated the comments tab to reduce the rendering burden.

Functionality/presentation changes:

1. Removed the number on the tab headers. This number is fine but computing it is expensive so it's not worth doing. If you really like the number, feel free to denormalize it on the user document and then put it back into the UI.
2. Changed the comments list to sort by date, instead of sorting by "date within contract" and always presenting all comments on a single contract together. I think this is better, but it also works in a way that makes more sense with pagination.

The result is that the user page loads much faster, but there's still work to be done:

1. The pagination implementation on these components is very simplistic. It loads all the data up front for every page, and the pagination only controls what is rendered. That's better than nothing, but an obvious next step is to build an "actual pagination" component that loads the data for each page on demand. That will make the comments and bets tabs load much faster.
2. There is still some choppiness on loading and delay clicking around. This is because the comments list, bets list, and portfolio history still render kind of slow. We can still do lots of work here. The main culprit right now is our tooltip component, which can probably use a rewrite.