### PR TITLE
Clean up a bunch of markup and CSS on contract cards

### DIFF
--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -68,48 +68,41 @@ export function ContractCard(props: {
   return (
     <Row
       className={clsx(
-        'relative gap-3 self-start rounded-lg bg-white py-4 pl-6 pr-5 shadow-md hover:cursor-pointer hover:bg-gray-100',
+        'relative gap-3 self-start rounded-lg bg-white shadow-md hover:cursor-pointer hover:bg-gray-100',
         className
       )}
     >
-      <Col className="relative flex-1 gap-3">
-        <div
-          className={clsx(
-            'peer absolute -left-6 -top-4 -bottom-4 z-10',
-            hideQuickBet ? '-right-20' : 'right-0'
-          )}
-        >
-          {onClick ? (
-            <a
-              className="absolute top-0 left-0 right-0 bottom-0"
-              href={contractPath(contract)}
-              onClick={(e) => {
-                // Let the browser handle the link click (opens in new tab).
-                if (e.ctrlKey || e.metaKey) return
+      <Col className="group relative flex-1 gap-3 py-4 pl-6">
+        {onClick ? (
+          <a
+            className="absolute top-0 left-0 right-0 bottom-0"
+            href={contractPath(contract)}
+            onClick={(e) => {
+              // Let the browser handle the link click (opens in new tab).
+              if (e.ctrlKey || e.metaKey) return
 
-                e.preventDefault()
-                track('click market card', {
-                  slug: contract.slug,
-                  contractId: contract.id,
-                })
-                onClick()
-              }}
+              e.preventDefault()
+              track('click market card', {
+                slug: contract.slug,
+                contractId: contract.id,
+              })
+              onClick()
+            }}
+          />
+        ) : (
+          <Link href={contractPath(contract)}>
+            <a
+              onClick={trackCallback('click market card', {
+                slug: contract.slug,
+                contractId: contract.id,
+              })}
+              className="absolute top-0 left-0 right-0 bottom-0"
             />
-          ) : (
-            <Link href={contractPath(contract)}>
-              <a
-                onClick={trackCallback('click market card', {
-                  slug: contract.slug,
-                  contractId: contract.id,
-                })}
-                className="absolute top-0 left-0 right-0 bottom-0"
-              />
-            </Link>
-          )}
-        </div>
+          </Link>
+        )}
         <AvatarDetails contract={contract} />
         <p
-          className="break-words font-semibold text-indigo-700 peer-hover:underline peer-hover:decoration-indigo-400 peer-hover:decoration-2"
+          className="break-words font-semibold text-indigo-700 group-hover:underline group-hover:decoration-indigo-400 group-hover:decoration-2"
           style={{ /* For iOS safari */ wordBreak: 'break-word' }}
         >
           {question}
@@ -140,21 +133,21 @@ export function ContractCard(props: {
         <>
           {outcomeType === 'BINARY' && (
             <BinaryResolutionOrChance
-              className="items-center self-center"
+              className="items-center self-center pr-5"
               contract={contract}
             />
           )}
 
           {outcomeType === 'PSEUDO_NUMERIC' && (
             <PseudoNumericResolutionOrExpectation
-              className="items-center self-center"
+              className="items-center self-center pr-5"
               contract={contract}
             />
           )}
 
           {outcomeType === 'NUMERIC' && (
             <NumericResolutionOrExpectation
-              className="items-center self-center"
+              className="items-center self-center pr-5"
               contract={contract}
             />
           )}
@@ -162,7 +155,7 @@ export function ContractCard(props: {
           {(outcomeType === 'FREE_RESPONSE' ||
             outcomeType === 'MULTIPLE_CHOICE') && (
             <FreeResponseResolutionOrChance
-              className="items-center self-center text-gray-600"
+              className="items-center self-center pr-5 text-gray-600"
               contract={contract}
               truncate="long"
             />

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -137,24 +137,24 @@ export function ContractCard(props: {
       {showQuickBet ? (
         <QuickBet contract={contract} user={user} />
       ) : (
-        <Col className="m-auto pl-2">
+        <>
           {outcomeType === 'BINARY' && (
             <BinaryResolutionOrChance
-              className="items-center"
+              className="items-center self-center"
               contract={contract}
             />
           )}
 
           {outcomeType === 'PSEUDO_NUMERIC' && (
             <PseudoNumericResolutionOrExpectation
-              className="items-center"
+              className="items-center self-center"
               contract={contract}
             />
           )}
 
           {outcomeType === 'NUMERIC' && (
             <NumericResolutionOrExpectation
-              className="items-center"
+              className="items-center self-center"
               contract={contract}
             />
           )}
@@ -162,13 +162,13 @@ export function ContractCard(props: {
           {(outcomeType === 'FREE_RESPONSE' ||
             outcomeType === 'MULTIPLE_CHOICE') && (
             <FreeResponseResolutionOrChance
-              className="self-end text-gray-600"
+              className="items-center self-center text-gray-600"
               contract={contract}
               truncate="long"
             />
           )}
           <ProbBar contract={contract} />
-        </Col>
+        </>
       )}
     </Row>
   )

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -66,115 +66,111 @@ export function ContractCard(props: {
     !hideQuickBet
 
   return (
-    <div>
-      <Col
-        className={clsx(
-          'relative gap-3 rounded-lg bg-white py-4 pl-6 pr-5 shadow-md hover:cursor-pointer hover:bg-gray-100',
-          className
-        )}
-      >
-        <Row>
-          <Col className="relative flex-1 gap-3 pr-1">
-            <div
-              className={clsx(
-                'peer absolute -left-6 -top-4 -bottom-4 z-10',
-                hideQuickBet ? '-right-20' : 'right-0'
-              )}
-            >
-              {onClick ? (
-                <a
-                  className="absolute top-0 left-0 right-0 bottom-0"
-                  href={contractPath(contract)}
-                  onClick={(e) => {
-                    // Let the browser handle the link click (opens in new tab).
-                    if (e.ctrlKey || e.metaKey) return
-
-                    e.preventDefault()
-                    track('click market card', {
-                      slug: contract.slug,
-                      contractId: contract.id,
-                    })
-                    onClick()
-                  }}
-                />
-              ) : (
-                <Link href={contractPath(contract)}>
-                  <a
-                    onClick={trackCallback('click market card', {
-                      slug: contract.slug,
-                      contractId: contract.id,
-                    })}
-                    className="absolute top-0 left-0 right-0 bottom-0"
-                  />
-                </Link>
-              )}
-            </div>
-            <AvatarDetails contract={contract} />
-            <p
-              className="break-words font-semibold text-indigo-700 peer-hover:underline peer-hover:decoration-indigo-400 peer-hover:decoration-2"
-              style={{ /* For iOS safari */ wordBreak: 'break-word' }}
-            >
-              {question}
-            </p>
-
-            {(outcomeType === 'FREE_RESPONSE' ||
-              outcomeType === 'MULTIPLE_CHOICE') &&
-              (resolution ? (
-                <FreeResponseOutcomeLabel
-                  contract={contract}
-                  resolution={resolution}
-                  truncate={'long'}
-                />
-              ) : (
-                <FreeResponseTopAnswer contract={contract} truncate="long" />
-              ))}
-
-            <MiscDetails
-              contract={contract}
-              showHotVolume={showHotVolume}
-              showTime={showTime}
-              hideGroupLink={hideGroupLink}
-            />
-          </Col>
-          {showQuickBet ? (
-            <QuickBet contract={contract} user={user} />
-          ) : (
-            <Col className="m-auto pl-2">
-              {outcomeType === 'BINARY' && (
-                <BinaryResolutionOrChance
-                  className="items-center"
-                  contract={contract}
-                />
-              )}
-
-              {outcomeType === 'PSEUDO_NUMERIC' && (
-                <PseudoNumericResolutionOrExpectation
-                  className="items-center"
-                  contract={contract}
-                />
-              )}
-
-              {outcomeType === 'NUMERIC' && (
-                <NumericResolutionOrExpectation
-                  className="items-center"
-                  contract={contract}
-                />
-              )}
-
-              {(outcomeType === 'FREE_RESPONSE' ||
-                outcomeType === 'MULTIPLE_CHOICE') && (
-                <FreeResponseResolutionOrChance
-                  className="self-end text-gray-600"
-                  contract={contract}
-                  truncate="long"
-                />
-              )}
-              <ProbBar contract={contract} />
-            </Col>
+    <Row
+      className={clsx(
+        'relative gap-3 self-start rounded-lg bg-white py-4 pl-6 pr-5 shadow-md hover:cursor-pointer hover:bg-gray-100',
+        className
+      )}
+    >
+      <Col className="relative flex-1 gap-3">
+        <div
+          className={clsx(
+            'peer absolute -left-6 -top-4 -bottom-4 z-10',
+            hideQuickBet ? '-right-20' : 'right-0'
           )}
-        </Row>
+        >
+          {onClick ? (
+            <a
+              className="absolute top-0 left-0 right-0 bottom-0"
+              href={contractPath(contract)}
+              onClick={(e) => {
+                // Let the browser handle the link click (opens in new tab).
+                if (e.ctrlKey || e.metaKey) return
+
+                e.preventDefault()
+                track('click market card', {
+                  slug: contract.slug,
+                  contractId: contract.id,
+                })
+                onClick()
+              }}
+            />
+          ) : (
+            <Link href={contractPath(contract)}>
+              <a
+                onClick={trackCallback('click market card', {
+                  slug: contract.slug,
+                  contractId: contract.id,
+                })}
+                className="absolute top-0 left-0 right-0 bottom-0"
+              />
+            </Link>
+          )}
+        </div>
+        <AvatarDetails contract={contract} />
+        <p
+          className="break-words font-semibold text-indigo-700 peer-hover:underline peer-hover:decoration-indigo-400 peer-hover:decoration-2"
+          style={{ /* For iOS safari */ wordBreak: 'break-word' }}
+        >
+          {question}
+        </p>
+
+        {(outcomeType === 'FREE_RESPONSE' ||
+          outcomeType === 'MULTIPLE_CHOICE') &&
+          (resolution ? (
+            <FreeResponseOutcomeLabel
+              contract={contract}
+              resolution={resolution}
+              truncate={'long'}
+            />
+          ) : (
+            <FreeResponseTopAnswer contract={contract} truncate="long" />
+          ))}
+
+        <MiscDetails
+          contract={contract}
+          showHotVolume={showHotVolume}
+          showTime={showTime}
+          hideGroupLink={hideGroupLink}
+        />
       </Col>
-    </div>
+      {showQuickBet ? (
+        <QuickBet contract={contract} user={user} />
+      ) : (
+        <Col className="m-auto pl-2">
+          {outcomeType === 'BINARY' && (
+            <BinaryResolutionOrChance
+              className="items-center"
+              contract={contract}
+            />
+          )}
+
+          {outcomeType === 'PSEUDO_NUMERIC' && (
+            <PseudoNumericResolutionOrExpectation
+              className="items-center"
+              contract={contract}
+            />
+          )}
+
+          {outcomeType === 'NUMERIC' && (
+            <NumericResolutionOrExpectation
+              className="items-center"
+              contract={contract}
+            />
+          )}
+
+          {(outcomeType === 'FREE_RESPONSE' ||
+            outcomeType === 'MULTIPLE_CHOICE') && (
+            <FreeResponseResolutionOrChance
+              className="self-end text-gray-600"
+              contract={contract}
+              truncate="long"
+            />
+          )}
+          <ProbBar contract={contract} />
+        </Col>
+      )}
+    </Row>
   )
 }
 

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -83,12 +83,10 @@ export function MiscDetails(props: {
       {!hideGroupLink && groupLinks && groupLinks.length > 0 && (
         <SiteLink
           href={groupPath(groupLinks[0].slug)}
-          className="text-sm text-gray-400"
+          className="line-clamp-1 text-sm text-gray-400"
         >
-          <Row className={'line-clamp-1 flex-wrap items-center '}>
-            <UserGroupIcon className="mx-1 mb-0.5 inline h-4 w-4 shrink-0" />
-            {groupLinks[0].name}
-          </Row>
+          <UserGroupIcon className="mx-1 mb-0.5 inline h-4 w-4 shrink-0" />
+          {groupLinks[0].name}
         </SiteLink>
       )}
     </Row>

--- a/web/components/contract/quick-bet.tsx
+++ b/web/components/contract/quick-bet.tsx
@@ -138,7 +138,7 @@ export function QuickBet(props: {
   return (
     <Col
       className={clsx(
-        'relative -my-4 -mr-5 min-w-[5.5rem] justify-center gap-2 pr-5 pl-1 align-middle'
+        'relative min-w-[5.5rem] justify-center gap-2 pr-5 pl-1 align-middle'
         // Use this for colored QuickBet panes
         // `bg-opacity-10 bg-${color}`
       )}


### PR DESCRIPTION
Rendering the contract cards is surprisingly expensive, so just cleaning up obviously unnecessary layers of cruft that has accumulated on them. Should be no visible changes.