### PR TITLE
Make `RelativeTimestamp` a little more efficient

### DIFF
--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -83,12 +83,10 @@ export function MiscDetails(props: {
       {!hideGroupLink && groupLinks && groupLinks.length > 0 && (
         <SiteLink
           href={groupPath(groupLinks[0].slug)}
-          className="text-sm text-gray-400"
+          className="line-clamp-1 text-sm text-gray-400"
         >
-          <Row className={'line-clamp-1 flex-wrap items-center '}>
-            <UserGroupIcon className="mx-1 mb-0.5 inline h-4 w-4 shrink-0" />
-            {groupLinks[0].name}
-          </Row>
+          <UserGroupIcon className="mx-1 mb-0.5 inline h-4 w-4 shrink-0" />
+          {groupLinks[0].name}
         </SiteLink>
       )}
     </Row>
@@ -211,7 +209,7 @@ export function ContractDetails(props: {
             <>
               <DateTimeTooltip
                 text="Market resolved:"
-                time={contract.resolutionTime}
+                time={dayjs(contract.resolutionTime)}
               >
                 {resolvedDate}
               </DateTimeTooltip>
@@ -267,13 +265,16 @@ function EditableCloseDate(props: {
 }) {
   const { closeTime, contract, isCreator } = props
 
+  const dayJsCloseTime = dayjs(closeTime)
+  const dayJsNow = dayjs()
+
   const [isEditingCloseTime, setIsEditingCloseTime] = useState(false)
   const [closeDate, setCloseDate] = useState(
-    closeTime && dayjs(closeTime).format('YYYY-MM-DDTHH:mm')
+    closeTime && dayJsCloseTime.format('YYYY-MM-DDTHH:mm')
   )
 
-  const isSameYear = dayjs(closeTime).isSame(dayjs(), 'year')
-  const isSameDay = dayjs(closeTime).isSame(dayjs(), 'day')
+  const isSameYear = dayJsCloseTime.isSame(dayJsNow, 'year')
+  const isSameDay = dayJsCloseTime.isSame(dayJsNow, 'day')
 
   const onSave = () => {
     const newCloseTime = dayjs(closeDate).valueOf()
@@ -314,11 +315,11 @@ function EditableCloseDate(props: {
       ) : (
         <DateTimeTooltip
           text={closeTime > Date.now() ? 'Trading ends:' : 'Trading ended:'}
-          time={closeTime}
+          time={dayJsCloseTime}
         >
           {isSameYear
-            ? dayjs(closeTime).format('MMM D')
-            : dayjs(closeTime).format('MMM D, YYYY')}
+            ? dayJsCloseTime.format('MMM D')
+            : dayJsCloseTime.format('MMM D, YYYY')}
           {isSameDay && <> ({fromNow(closeTime)})</>}
         </DateTimeTooltip>
       )}

--- a/web/components/datetime-tooltip.tsx
+++ b/web/components/datetime-tooltip.tsx
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
 import advanced from 'dayjs/plugin/advancedFormat'
@@ -9,14 +9,14 @@ dayjs.extend(timezone)
 dayjs.extend(advanced)
 
 export function DateTimeTooltip(props: {
-  time: number
+  time: Dayjs
   text?: string
   children?: React.ReactNode
   noTap?: boolean
 }) {
   const { time, text, noTap } = props
 
-  const formattedTime = dayjs(time).format('MMM DD, YYYY hh:mm a z')
+  const formattedTime = time.format('MMM DD, YYYY hh:mm a z')
   const toolTip = text ? `${text} ${formattedTime}` : formattedTime
 
   return (

--- a/web/components/datetime-tooltip.tsx
+++ b/web/components/datetime-tooltip.tsx
@@ -11,16 +11,17 @@ dayjs.extend(advanced)
 export function DateTimeTooltip(props: {
   time: Dayjs
   text?: string
+  className?: string
   children?: React.ReactNode
   noTap?: boolean
 }) {
-  const { time, text, noTap } = props
+  const { className, time, text, noTap } = props
 
   const formattedTime = time.format('MMM DD, YYYY hh:mm a z')
   const toolTip = text ? `${text} ${formattedTime}` : formattedTime
 
   return (
-    <Tooltip text={toolTip} noTap={noTap}>
+    <Tooltip className={className} text={toolTip} noTap={noTap}>
       {props.children}
     </Tooltip>
   )

--- a/web/components/feed/copy-link-date-time.tsx
+++ b/web/components/feed/copy-link-date-time.tsx
@@ -7,6 +7,7 @@ import { fromNow } from 'web/lib/util/time'
 import { ToastClipboard } from 'web/components/toast-clipboard'
 import { LinkIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
+import dayjs from 'dayjs'
 
 export function CopyLinkDateTimeComponent(props: {
   prefix: string
@@ -17,6 +18,7 @@ export function CopyLinkDateTimeComponent(props: {
 }) {
   const { prefix, slug, elementId, createdTime, className } = props
   const [showToast, setShowToast] = useState(false)
+  const time = dayjs(createdTime)
 
   function copyLinkToComment(
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -30,7 +32,7 @@ export function CopyLinkDateTimeComponent(props: {
   }
   return (
     <div className={clsx('inline', className)}>
-      <DateTimeTooltip time={createdTime} noTap>
+      <DateTimeTooltip time={time} noTap>
         <Link href={`/${prefix}/${slug}#${elementId}`} passHref={true}>
           <a
             onClick={(event) => copyLinkToComment(event)}

--- a/web/components/relative-timestamp.tsx
+++ b/web/components/relative-timestamp.tsx
@@ -1,13 +1,14 @@
 import { DateTimeTooltip } from './datetime-tooltip'
-import { fromNow } from 'web/lib/util/time'
+import dayjs from 'dayjs'
 import React from 'react'
 
 export function RelativeTimestamp(props: { time: number }) {
   const { time } = props
+  const dayJsTime = dayjs(time)
   return (
-    <DateTimeTooltip time={time}>
+    <DateTimeTooltip time={dayJsTime}>
       <span className="ml-1 whitespace-nowrap text-gray-400">
-        {fromNow(time)}
+        {dayJsTime.fromNow()}
       </span>
     </DateTimeTooltip>
   )

--- a/web/components/relative-timestamp.tsx
+++ b/web/components/relative-timestamp.tsx
@@ -6,10 +6,11 @@ export function RelativeTimestamp(props: { time: number }) {
   const { time } = props
   const dayJsTime = dayjs(time)
   return (
-    <DateTimeTooltip time={dayJsTime}>
-      <span className="ml-1 whitespace-nowrap text-gray-400">
-        {dayJsTime.fromNow()}
-      </span>
+    <DateTimeTooltip
+      className="ml-1 whitespace-nowrap text-gray-400"
+      time={dayJsTime}
+    >
+      {dayJsTime.fromNow()}
     </DateTimeTooltip>
   )
 }


### PR DESCRIPTION
These timestamps are most of the cost of rendering a big feed of comments or bets. I think basically the real culprit here is the tooltip code, which is doing a ton of work to compute where the tooltip should be, but might as well fix the easy stuff.

`dayjs(...)` isn't that expensive -- it's constructing a few objects and calling a few different things -- but it's expensive enough that we shouldn't call it thousands of extra times per render just for fun.