### PR TITLE
Simplify and fix inefficiencies in contract search component

### DIFF
--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -13,7 +13,8 @@ import {
   ContractsGrid,
 } from './contract/contracts-grid'
 import { Row } from './layout/row'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useRef, useMemo, useState } from 'react'
+import { unstable_batchedUpdates } from 'react-dom'
 import { ENV, IS_PRIVATE_MANIFOLD } from 'common/envs/constants'
 import { useFollows } from 'web/hooks/use-follows'
 import { track, trackCallback } from 'web/lib/service/analytics'
@@ -21,7 +22,7 @@ import ContractSearchFirestore from 'web/pages/contract-search-firestore'
 import { useMemberGroups } from 'web/hooks/use-group'
 import { Group, NEW_USER_GROUP_SLUGS } from 'common/group'
 import { PillButton } from './buttons/pill-button'
-import { range, sortBy } from 'lodash'
+import { sortBy } from 'lodash'
 import { DEFAULT_CATEGORY_GROUPS } from 'common/categories'
 import { Col } from './layout/col'
 import clsx from 'clsx'
@@ -111,7 +112,8 @@ export function ContractSearch(props: {
 
   const selectPill = (pill: string | undefined) => () => {
     setPillFilter(pill)
-    setPage(0)
+    setPages([])
+    setNumPages(1)
     track('select search category', { category: pill ?? 'all' })
   }
 
@@ -167,80 +169,65 @@ export function ContractSearch(props: {
     [searchIndexName]
   )
 
-  const [page, setPage] = useState(0)
   const [numPages, setNumPages] = useState(1)
-  const [hitsByPage, setHitsByPage] = useState<{ [page: string]: Contract[] }>(
-    {}
-  )
+  const [pages, setPages] = useState<Contract[][]>([])
+  const requestId = useRef(0)
 
-  useEffect(() => {
-    let wasMostRecentQuery = true
-    const algoliaIndex = query ? searchIndex : index
-
-    algoliaIndex
-      .search(query, {
+  const queryNextPage = async () => {
+    const id = ++requestId.current
+    if (pages.length < numPages) {
+      const algoliaIndex = query ? searchIndex : index
+      const results = await algoliaIndex.search(query, {
         facetFilters,
         numericFilters,
-        page,
+        page: pages.length,
         hitsPerPage: 20,
       })
-      .then((results) => {
-        if (!wasMostRecentQuery) return
-
-        if (page === 0) {
-          setHitsByPage({
-            [0]: results.hits as any as Contract[],
-          })
-        } else {
-          setHitsByPage((hitsByPage) => ({
-            ...hitsByPage,
-            [page]: results.hits,
-          }))
-        }
-        setNumPages(results.nbPages)
-      })
-    return () => {
-      wasMostRecentQuery = false
+      // if there's a more recent request, forget about this one
+      if (id === requestId.current) {
+        // this spooky looking function is the easiest way to get react to
+        // batch this and not do two renders. we can throw it out in react 18.
+        // see https://github.com/reactwg/react-18/discussions/21
+        unstable_batchedUpdates(() => {
+          setPages((pages) => [...pages, results.hits as any as Contract[]])
+          setNumPages(results.nbPages)
+        })
+      }
     }
-    // Note numeric filters are unique based on current time, so can't compare
-    // them by value.
-  }, [query, page, index, searchIndex, JSON.stringify(facetFilters), filter])
-
-  const loadMore = () => {
-    if (page >= numPages - 1) return
-
-    const haveLoadedCurrentPage = hitsByPage[page]
-    if (haveLoadedCurrentPage) setPage(page + 1)
   }
 
-  const hits = range(0, page + 1)
-    .map((p) => hitsByPage[p] ?? [])
-    .flat()
+  useEffect(() => {
+    if (pages.length === 0) {
+      queryNextPage()
+    }
+  }, [pages])
 
-  const contracts = hits.filter(
-    (c) => !additionalFilter?.excludeContractIds?.includes(c.id)
-  )
+  const contracts = pages
+    .flat()
+    .filter((c) => !additionalFilter?.excludeContractIds?.includes(c.id))
 
   const showTime =
     sort === 'close-date' || sort === 'resolve-date' ? sort : undefined
 
   const updateQuery = (newQuery: string) => {
     setQuery(newQuery)
-    setPage(0)
+    setPages([])
+    setNumPages(1)
   }
 
   const selectFilter = (newFilter: filter) => {
     if (newFilter === filter) return
     setFilter(newFilter)
-    setPage(0)
+    setPages([])
+    setNumPages(1)
     track('select search filter', { filter: newFilter })
   }
 
   const selectSort = (newSort: Sort) => {
     if (newSort === sort) return
-
-    setPage(0)
     setSort(newSort)
+    setPages([])
+    setNumPages(1)
     track('select search sort', { sort: newSort })
   }
 
@@ -345,8 +332,8 @@ export function ContractSearch(props: {
         <>You're not following anyone, nor in any of your own groups yet.</>
       ) : (
         <ContractsGrid
-          contracts={hitsByPage[0] === undefined ? undefined : contracts}
-          loadMore={loadMore}
+          contracts={pages.length === 0 ? undefined : contracts}
+          loadMore={queryNextPage}
           showTime={showTime}
           onContractClick={onContractClick}
           overrideGridClassName={overrideGridClassName}

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -197,6 +197,8 @@ export function ContractSearch(props: {
   }
 
   useEffect(() => {
+    // if there are no search results yet (not even an empty page), that means
+    // we should do an initial search to populate a first page.
     if (pages.length === 0) {
       queryNextPage()
     }

--- a/web/package.json
+++ b/web/package.json
@@ -67,6 +67,7 @@
     "@types/lodash": "4.14.178",
     "@types/node": "16.11.11",
     "@types/react": "17.0.43",
+    "@types/react-dom": "17.0.2",
     "@types/string-similarity": "^4.0.0",
     "autoprefixer": "10.2.6",
     "critters": "0.0.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,6 +3386,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/react-dom@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.2.tgz#35654cf6c49ae162d5bc90843d5437dc38008d43"
+  integrity sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-router-config@*":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-router-config/-/react-router-config-5.0.6.tgz#87c5c57e72d241db900d9734512c50ccec062451"


### PR DESCRIPTION
Previously, when you (for example) scrolled to the bottom of the contract search grid, this would happen:

1. The `loadMore` callback would be called.
2. It would call `setPage`, triggering a re-render of the grid. (This is obviously fishy since visually, absolutely nothing changed.)
3. The change in the `page` prop would trigger an effect that is looking at many dependencies and performs a new search query.
4. Later, your query would produce results.
5. `setHitsByPage` and `setNumPages` would be called. This would actually trigger two re-renders, because in React <18, state changes that aren't directly inside the React render code aren't batched.

Now:

1. The `loadMore` callback is called.
2. It directly invokes `queryNextPage`, instead of changing state, so no re-render happens.
3. Later, your query would produce results.
4. `setPages` and `setNumPages` are called, but we use a special React API to batch them, so this causes one re-render.

That's the useful change. Other than that, it just got a little simpler all around. `Contract[][]` is an easier data structure to work with than `{ [page: string]: Contract[] }`, and I changed the "superseding in-flight requests with new queries" logic slightly so that it doesn't have to rely on `useEffect` as the only interface to invoking the query machinery.