### PR TITLE
Move search controls into separate component

### DIFF
--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -22,7 +22,7 @@ import { useFollows } from 'web/hooks/use-follows'
 import { track, trackCallback } from 'web/lib/service/analytics'
 import ContractSearchFirestore from 'web/pages/contract-search-firestore'
 import { useMemberGroups } from 'web/hooks/use-group'
-import { Group, NEW_USER_GROUP_SLUGS } from 'common/group'
+import { NEW_USER_GROUP_SLUGS } from 'common/group'
 import { PillButton } from './buttons/pill-button'
 import { sortBy } from 'lodash'
 import { DEFAULT_CATEGORY_GROUPS } from 'common/categories'
@@ -204,10 +204,8 @@ function ContractSearchControls(props: {
     (group) => group.contractIds.length
   ).reverse()
 
-  const defaultPillGroups = DEFAULT_CATEGORY_GROUPS as Group[]
-
-  const pillGroups =
-    memberPillGroups.length > 0 ? memberPillGroups : defaultPillGroups
+  const pillGroups: { name: string; slug: string }[] =
+    memberPillGroups.length > 0 ? memberPillGroups : DEFAULT_CATEGORY_GROUPS
 
   const [filter, setFilter] = useState<filter>(
     querySortOptions?.defaultFilter ?? 'open'

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import algoliasearch from 'algoliasearch/lite'
+import algoliasearch, { SearchIndex } from 'algoliasearch/lite'
+import { SearchOptions } from '@algolia/client-search'
 
 import { Contract } from 'common/contract'
 import { User } from 'common/user'
@@ -12,6 +13,7 @@ import {
   ContractHighlightOptions,
   ContractsGrid,
 } from './contract/contracts-grid'
+import { ShowTime } from './contract/contract-details'
 import { Row } from './layout/row'
 import { useEffect, useRef, useMemo, useState } from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
@@ -49,15 +51,25 @@ export const DEFAULT_SORT = 'score'
 
 type filter = 'personal' | 'open' | 'closed' | 'resolved' | 'all'
 
+type SearchParameters = {
+  index: SearchIndex
+  query: string
+  numericFilters: SearchOptions['numericFilters']
+  facetFilters: SearchOptions['facetFilters']
+  showTime?: ShowTime
+}
+
+type AdditionalFilter = {
+  creatorId?: string
+  tag?: string
+  excludeContractIds?: string[]
+  groupSlug?: string
+}
+
 export function ContractSearch(props: {
   user?: User | null
   querySortOptions?: { defaultFilter?: filter } & QuerySortOptions
-  additionalFilter?: {
-    creatorId?: string
-    tag?: string
-    excludeContractIds?: string[]
-    groupSlug?: string
-  }
+  additionalFilter?: AdditionalFilter
   highlightOptions?: ContractHighlightOptions
   onContractClick?: (contract: Contract) => void
   hideOrderSelector?: boolean
@@ -80,6 +92,105 @@ export function ContractSearch(props: {
     headerClassName,
   } = props
 
+  const [numPages, setNumPages] = useState(1)
+  const [pages, setPages] = useState<Contract[][]>([])
+  const [showTime, setShowTime] = useState<ShowTime | undefined>()
+
+  const searchParameters = useRef<SearchParameters | undefined>()
+  const requestId = useRef(0)
+
+  const performQuery = async (freshQuery?: boolean) => {
+    if (searchParameters.current == null) {
+      return
+    }
+    const params = searchParameters.current
+    const id = ++requestId.current
+    const requestedPage = freshQuery ? 0 : pages.length
+    if (freshQuery || requestedPage < numPages) {
+      const results = await params.index.search(params.query, {
+        facetFilters: params.facetFilters,
+        numericFilters: params.numericFilters,
+        page: requestedPage,
+        hitsPerPage: 20,
+      })
+      // if there's a more recent request, forget about this one
+      if (id === requestId.current) {
+        const newPage = results.hits as any as Contract[]
+        // this spooky looking function is the easiest way to get react to
+        // batch this and not do multiple renders. we can throw it out in react 18.
+        // see https://github.com/reactwg/react-18/discussions/21
+        unstable_batchedUpdates(() => {
+          setShowTime(params.showTime)
+          setNumPages(results.nbPages)
+          if (freshQuery) {
+            setPages([newPage])
+          } else {
+            setPages((pages) => [...pages, newPage])
+          }
+        })
+      }
+    }
+  }
+
+  const contracts = pages
+    .flat()
+    .filter((c) => !additionalFilter?.excludeContractIds?.includes(c.id))
+
+  if (IS_PRIVATE_MANIFOLD || process.env.NEXT_PUBLIC_FIREBASE_EMULATE) {
+    return (
+      <ContractSearchFirestore
+        querySortOptions={querySortOptions}
+        additionalFilter={additionalFilter}
+      />
+    )
+  }
+
+  return (
+    <Col className="h-full">
+      <ContractSearchControls
+        className={headerClassName}
+        hideOrderSelector={hideOrderSelector}
+        querySortOptions={querySortOptions}
+        user={user}
+        onSearchParametersChanged={(params) => {
+          searchParameters.current = params
+          performQuery(true)
+        }}
+      />
+      <ContractsGrid
+        contracts={pages.length === 0 ? undefined : contracts}
+        loadMore={performQuery}
+        showTime={showTime}
+        onContractClick={onContractClick}
+        overrideGridClassName={overrideGridClassName}
+        highlightOptions={highlightOptions}
+        cardHideOptions={cardHideOptions}
+      />
+    </Col>
+  )
+}
+
+function ContractSearchControls(props: {
+  className?: string
+  additionalFilter?: AdditionalFilter
+  hideOrderSelector?: boolean
+  onSearchParametersChanged: (params: SearchParameters) => void
+  querySortOptions?: { defaultFilter?: filter } & QuerySortOptions
+  user?: User | null
+}) {
+  const {
+    className,
+    additionalFilter,
+    hideOrderSelector,
+    onSearchParametersChanged,
+    querySortOptions,
+    user,
+  } = props
+
+  const { query, setQuery, sort, setSort } =
+    useQueryAndSortParams(querySortOptions)
+
+  const follows = useFollows(user?.id)
   const memberGroups = (useMemberGroups(user?.id) ?? []).filter(
     (group) => !NEW_USER_GROUP_SLUGS.includes(group.slug)
   )
@@ -98,22 +209,11 @@ export function ContractSearch(props: {
   const pillGroups =
     memberPillGroups.length > 0 ? memberPillGroups : defaultPillGroups
 
-  const follows = useFollows(user?.id)
-
-  const { query, setQuery, sort, setSort } =
-    useQueryAndSortParams(querySortOptions)
-
   const [filter, setFilter] = useState<filter>(
     querySortOptions?.defaultFilter ?? 'open'
   )
-  const pillsEnabled = !additionalFilter && !query
 
   const [pillFilter, setPillFilter] = useState<string | undefined>(undefined)
-
-  const selectPill = (pill: string | undefined) => () => {
-    setPillFilter(pill)
-    track('select search category', { category: pill ?? 'all' })
-  }
 
   const additionalFilters = [
     additionalFilter?.creatorId
@@ -160,56 +260,10 @@ export function ContractSearch(props: {
         filter === 'closed' ? `closeTime <= ${Date.now()}` : '',
       ].filter((f) => f)
 
-  const indexName = `${indexPrefix}contracts-${sort}`
-  const index = useMemo(() => searchClient.initIndex(indexName), [indexName])
-  const searchIndex = useMemo(
-    () => searchClient.initIndex(searchIndexName),
-    [searchIndexName]
-  )
-
-  const [numPages, setNumPages] = useState(1)
-  const [pages, setPages] = useState<Contract[][]>([])
-  const requestId = useRef(0)
-
-  const performQuery = async (freshQuery?: boolean) => {
-    const id = ++requestId.current
-    const requestedPage = freshQuery ? 0 : pages.length
-    if (freshQuery || requestedPage < numPages) {
-      const algoliaIndex = query ? searchIndex : index
-      const results = await algoliaIndex.search(query, {
-        facetFilters,
-        numericFilters,
-        page: requestedPage,
-        hitsPerPage: 20,
-      })
-      // if there's a more recent request, forget about this one
-      if (id === requestId.current) {
-        const newPage = results.hits as any as Contract[]
-        // this spooky looking function is the easiest way to get react to
-        // batch this and not do two renders. we can throw it out in react 18.
-        // see https://github.com/reactwg/react-18/discussions/21
-        unstable_batchedUpdates(() => {
-          setNumPages(results.nbPages)
-          if (freshQuery) {
-            setPages([newPage])
-          } else {
-            setPages((pages) => [...pages, newPage])
-          }
-        })
-      }
-    }
+  const selectPill = (pill: string | undefined) => () => {
+    setPillFilter(pill)
+    track('select search category', { category: pill ?? 'all' })
   }
-
-  useEffect(() => {
-    performQuery(true)
-  }, [query, index, searchIndex, filter, JSON.stringify(facetFilters)])
-
-  const contracts = pages
-    .flat()
-    .filter((c) => !additionalFilter?.excludeContractIds?.includes(c.id))
-
-  const showTime =
-    sort === 'close-date' || sort === 'resolve-date' ? sort : undefined
 
   const updateQuery = (newQuery: string) => {
     setQuery(newQuery)
@@ -227,115 +281,103 @@ export function ContractSearch(props: {
     track('select search sort', { sort: newSort })
   }
 
-  if (IS_PRIVATE_MANIFOLD || process.env.NEXT_PUBLIC_FIREBASE_EMULATE) {
-    return (
-      <ContractSearchFirestore
-        querySortOptions={querySortOptions}
-        additionalFilter={additionalFilter}
-      />
-    )
-  }
+  const indexName = `${indexPrefix}contracts-${sort}`
+  const index = useMemo(() => searchClient.initIndex(indexName), [indexName])
+  const searchIndex = useMemo(
+    () => searchClient.initIndex(searchIndexName),
+    [searchIndexName]
+  )
+
+  useEffect(() => {
+    onSearchParametersChanged({
+      index: query ? searchIndex : index,
+      query: query,
+      numericFilters: numericFilters,
+      facetFilters: facetFilters,
+      showTime:
+        sort === 'close-date' || sort === 'resolve-date' ? sort : undefined,
+    })
+  }, [query, index, searchIndex, filter, JSON.stringify(facetFilters)])
 
   return (
-    <Col className="h-full">
-      <Col
-        className={clsx(
-          'bg-base-200 sticky top-0 z-20 gap-3 pb-3',
-          headerClassName
-        )}
-      >
-        <Row className="gap-1 sm:gap-2">
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => updateQuery(e.target.value)}
-            onBlur={trackCallback('search', { query })}
-            placeholder={'Search'}
-            className="input input-bordered w-full"
-          />
-          {!query && (
-            <select
-              className="select select-bordered"
-              value={filter}
-              onChange={(e) => selectFilter(e.target.value as filter)}
-            >
-              <option value="open">Open</option>
-              <option value="closed">Closed</option>
-              <option value="resolved">Resolved</option>
-              <option value="all">All</option>
-            </select>
-          )}
-          {!hideOrderSelector && !query && (
-            <select
-              className="select select-bordered"
-              value={sort}
-              onChange={(e) => selectSort(e.target.value as Sort)}
-            >
-              {sortOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          )}
-        </Row>
-
-        {pillsEnabled && (
-          <Row className="scrollbar-hide items-start gap-2 overflow-x-auto">
-            <PillButton
-              key={'all'}
-              selected={pillFilter === undefined}
-              onSelect={selectPill(undefined)}
-            >
-              All
-            </PillButton>
-            <PillButton
-              key={'personal'}
-              selected={pillFilter === 'personal'}
-              onSelect={selectPill('personal')}
-            >
-              {user ? 'For you' : 'Featured'}
-            </PillButton>
-
-            {user && (
-              <PillButton
-                key={'your-bets'}
-                selected={pillFilter === 'your-bets'}
-                onSelect={selectPill('your-bets')}
-              >
-                Your bets
-              </PillButton>
-            )}
-
-            {pillGroups.map(({ name, slug }) => {
-              return (
-                <PillButton
-                  key={slug}
-                  selected={pillFilter === slug}
-                  onSelect={selectPill(slug)}
-                >
-                  {name}
-                </PillButton>
-              )
-            })}
-          </Row>
-        )}
-      </Col>
-
-      {filter === 'personal' &&
-      (follows ?? []).length === 0 &&
-      memberGroupSlugs.length === 0 ? (
-        <>You're not following anyone, nor in any of your own groups yet.</>
-      ) : (
-        <ContractsGrid
-          contracts={pages.length === 0 ? undefined : contracts}
-          loadMore={performQuery}
-          showTime={showTime}
-          onContractClick={onContractClick}
-          overrideGridClassName={overrideGridClassName}
-          highlightOptions={highlightOptions}
-          cardHideOptions={cardHideOptions}
+    <Col
+      className={clsx('bg-base-200 sticky top-0 z-20 gap-3 pb-3', className)}
+    >
+      <Row className="gap-1 sm:gap-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => updateQuery(e.target.value)}
+          onBlur={trackCallback('search', { query })}
+          placeholder={'Search'}
+          className="input input-bordered w-full"
         />
+        {!query && (
+          <select
+            className="select select-bordered"
+            value={filter}
+            onChange={(e) => selectFilter(e.target.value as filter)}
+          >
+            <option value="open">Open</option>
+            <option value="closed">Closed</option>
+            <option value="resolved">Resolved</option>
+            <option value="all">All</option>
+          </select>
+        )}
+        {!hideOrderSelector && !query && (
+          <select
+            className="select select-bordered"
+            value={sort}
+            onChange={(e) => selectSort(e.target.value as Sort)}
+          >
+            {sortOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        )}
+      </Row>
+
+      {!additionalFilter && !query && (
+        <Row className="scrollbar-hide items-start gap-2 overflow-x-auto">
+          <PillButton
+            key={'all'}
+            selected={pillFilter === undefined}
+            onSelect={selectPill(undefined)}
+          >
+            All
+          </PillButton>
+          <PillButton
+            key={'personal'}
+            selected={pillFilter === 'personal'}
+            onSelect={selectPill('personal')}
+          >
+            {user ? 'For you' : 'Featured'}
+          </PillButton>
+
+          {user && (
+            <PillButton
+              key={'your-bets'}
+              selected={pillFilter === 'your-bets'}
+              onSelect={selectPill('your-bets')}
+            >
+              Your bets
+            </PillButton>
+          )}
+
+          {pillGroups.map(({ name, slug }) => {
+            return (
+              <PillButton
+                key={slug}
+                selected={pillFilter === slug}
+                onSelect={selectPill(slug)}
+              >
+                {name}
+              </PillButton>
+            )
+          })}
+        </Row>
       )}
     </Col>
   )

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -149,6 +149,7 @@ export function ContractSearch(props: {
     <Col className="h-full">
       <ContractSearchControls
         className={headerClassName}
+        additionalFilter={additionalFilter}
         hideOrderSelector={hideOrderSelector}
         querySortOptions={querySortOptions}
         user={user}

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -100,7 +100,7 @@ export function ContractSearch(props: {
   const requestId = useRef(0)
 
   const performQuery = async (freshQuery?: boolean) => {
-    if (searchParameters.current == null) {
+    if (searchParameters.current === undefined) {
       return
     }
     const params = searchParameters.current


### PR DESCRIPTION
I think this change is good because typing in the search bar needs to be responsive for the search to feel good, so it sucks if that typing triggers a re-render on the whole grid of loaded contracts. Anyway, it's nice to put things in components.

The diff looks scary, but I didn't change much -- basically I just uprooted all the "figure out what search to do" code into a separate component that calls an `onSearchParametersChanged` callback to do the search with the new parameters.

(P.S. The search still isn't perfectly snappy yet. The main thing I need to fix next to make it snappy is the `useQueryAndSort` machinery, which A) literally throws out characters you type B) basically triggers re-renders on the whole page when the query parameter is updated.)

(P.P.S. I might make some additional components here later, like breaking out the pill stuff into a component. But probably not because it's important for efficiency, just because I think it would be a little tidier.)