### PR TITLE
Rewrite `useQueryAndSortParams` machinery to be faster/simpler/better

### DIFF
--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -20,7 +20,7 @@ import ContractSearchFirestore from 'web/pages/contract-search-firestore'
 import { useMemberGroups } from 'web/hooks/use-group'
 import { NEW_USER_GROUP_SLUGS } from 'common/group'
 import { PillButton } from './buttons/pill-button'
-import { sortBy } from 'lodash'
+import { debounce, sortBy } from 'lodash'
 import { DEFAULT_CATEGORY_GROUPS } from 'common/categories'
 import { Col } from './layout/col'
 import { safeLocalStorage } from 'web/lib/util/local'
@@ -147,6 +147,12 @@ export function ContractSearch(props: {
     }
   }
 
+  const onSearchParametersChanged = useRef(
+    debounce((params) => {
+      searchParameters.current = params
+      performQuery(true)
+    }, 100)
+  )
   const contracts = pages
     .flat()
     .filter((c) => !additionalFilter?.excludeContractIds?.includes(c.id))
@@ -166,10 +172,7 @@ export function ContractSearch(props: {
         useQuerySortLocalStorage={useQuerySortLocalStorage}
         useQuerySortUrlParams={useQuerySortUrlParams}
         user={user}
-        onSearchParametersChanged={(params) => {
-          searchParameters.current = params
-          performQuery(true)
-        }}
+        onSearchParametersChanged={onSearchParametersChanged.current}
       />
       <ContractsGrid
         contracts={pages.length === 0 ? undefined : contracts}

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -152,7 +152,8 @@ export function ContractSearch(props: {
       searchParameters.current = params
       performQuery(true)
     }, 100)
-  )
+  ).current
+
   const contracts = pages
     .flat()
     .filter((c) => !additionalFilter?.excludeContractIds?.includes(c.id))
@@ -172,7 +173,7 @@ export function ContractSearch(props: {
         useQuerySortLocalStorage={useQuerySortLocalStorage}
         useQuerySortUrlParams={useQuerySortUrlParams}
         user={user}
-        onSearchParametersChanged={onSearchParametersChanged.current}
+        onSearchParametersChanged={onSearchParametersChanged}
       />
       <ContractsGrid
         contracts={pages.length === 0 ? undefined : contracts}
@@ -212,8 +213,9 @@ function ContractSearchControls(props: {
 
   const savedSort = useQuerySortLocalStorage ? getSavedSort() : null
   const initialSort = savedSort ?? defaultSort ?? 'score'
-  const [sort, setSort] = useSort(initialSort, !!useQuerySortUrlParams)
-  const [query, setQuery] = useQuery('', !!useQuerySortUrlParams)
+  const querySortOpts = { useUrl: !!useQuerySortUrlParams }
+  const [sort, setSort] = useSort(initialSort, querySortOpts)
+  const [query, setQuery] = useQuery('', querySortOpts)
   const [filter, setFilter] = useState<filter>(defaultFilter ?? 'open')
   const [pillFilter, setPillFilter] = useState<string | undefined>(undefined)
 

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -4,11 +4,7 @@ import { SearchOptions } from '@algolia/client-search'
 
 import { Contract } from 'common/contract'
 import { User } from 'common/user'
-import {
-  QuerySortOptions,
-  Sort,
-  useQueryAndSortParams,
-} from '../hooks/use-sort-and-query-params'
+import { Sort, useQuery, useSort } from '../hooks/use-sort-and-query-params'
 import {
   ContractHighlightOptions,
   ContractsGrid,
@@ -27,7 +23,21 @@ import { PillButton } from './buttons/pill-button'
 import { sortBy } from 'lodash'
 import { DEFAULT_CATEGORY_GROUPS } from 'common/categories'
 import { Col } from './layout/col'
+import { safeLocalStorage } from 'web/lib/util/local'
 import clsx from 'clsx'
+
+// TODO: this obviously doesn't work with SSR, common sense would suggest
+// that we should save things like this in cookies so the server has them
+
+const MARKETS_SORT = 'markets_sort'
+
+function setSavedSort(s: Sort) {
+  safeLocalStorage()?.setItem(MARKETS_SORT, s)
+}
+
+function getSavedSort() {
+  return safeLocalStorage()?.getItem(MARKETS_SORT) as Sort | null | undefined
+}
 
 const searchClient = algoliasearch(
   'GJQPAYENIF',
@@ -47,7 +57,6 @@ const sortOptions = [
   { label: 'Close date', value: 'close-date' },
   { label: 'Resolve date', value: 'resolve-date' },
 ]
-export const DEFAULT_SORT = 'score'
 
 type filter = 'personal' | 'open' | 'closed' | 'resolved' | 'all'
 
@@ -68,7 +77,8 @@ type AdditionalFilter = {
 
 export function ContractSearch(props: {
   user?: User | null
-  querySortOptions?: { defaultFilter?: filter } & QuerySortOptions
+  defaultSort?: Sort
+  defaultFilter?: filter
   additionalFilter?: AdditionalFilter
   highlightOptions?: ContractHighlightOptions
   onContractClick?: (contract: Contract) => void
@@ -79,10 +89,13 @@ export function ContractSearch(props: {
     hideQuickBet?: boolean
   }
   headerClassName?: string
+  useQuerySortLocalStorage?: boolean
+  useQuerySortUrlParams?: boolean
 }) {
   const {
     user,
-    querySortOptions,
+    defaultSort,
+    defaultFilter,
     additionalFilter,
     onContractClick,
     overrideGridClassName,
@@ -90,6 +103,8 @@ export function ContractSearch(props: {
     cardHideOptions,
     highlightOptions,
     headerClassName,
+    useQuerySortLocalStorage,
+    useQuerySortUrlParams,
   } = props
 
   const [numPages, setNumPages] = useState(1)
@@ -137,21 +152,19 @@ export function ContractSearch(props: {
     .filter((c) => !additionalFilter?.excludeContractIds?.includes(c.id))
 
   if (IS_PRIVATE_MANIFOLD || process.env.NEXT_PUBLIC_FIREBASE_EMULATE) {
-    return (
-      <ContractSearchFirestore
-        querySortOptions={querySortOptions}
-        additionalFilter={additionalFilter}
-      />
-    )
+    return <ContractSearchFirestore additionalFilter={additionalFilter} />
   }
 
   return (
     <Col className="h-full">
       <ContractSearchControls
         className={headerClassName}
+        defaultSort={defaultSort}
+        defaultFilter={defaultFilter}
         additionalFilter={additionalFilter}
         hideOrderSelector={hideOrderSelector}
-        querySortOptions={querySortOptions}
+        useQuerySortLocalStorage={useQuerySortLocalStorage}
+        useQuerySortUrlParams={useQuerySortUrlParams}
         user={user}
         onSearchParametersChanged={(params) => {
           searchParameters.current = params
@@ -173,23 +186,39 @@ export function ContractSearch(props: {
 
 function ContractSearchControls(props: {
   className?: string
+  defaultSort?: Sort
+  defaultFilter?: filter
   additionalFilter?: AdditionalFilter
   hideOrderSelector?: boolean
   onSearchParametersChanged: (params: SearchParameters) => void
-  querySortOptions?: { defaultFilter?: filter } & QuerySortOptions
+  useQuerySortLocalStorage?: boolean
+  useQuerySortUrlParams?: boolean
   user?: User | null
 }) {
   const {
     className,
+    defaultSort,
+    defaultFilter,
     additionalFilter,
     hideOrderSelector,
     onSearchParametersChanged,
-    querySortOptions,
+    useQuerySortLocalStorage,
+    useQuerySortUrlParams,
     user,
   } = props
 
-  const { query, setQuery, sort, setSort } =
-    useQueryAndSortParams(querySortOptions)
+  const savedSort = useQuerySortLocalStorage ? getSavedSort() : null
+  const initialSort = savedSort ?? defaultSort ?? 'score'
+  const [sort, setSort] = useSort(initialSort, !!useQuerySortUrlParams)
+  const [query, setQuery] = useQuery('', !!useQuerySortUrlParams)
+  const [filter, setFilter] = useState<filter>(defaultFilter ?? 'open')
+  const [pillFilter, setPillFilter] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (useQuerySortLocalStorage) {
+      setSavedSort(sort)
+    }
+  }, [sort])
 
   const follows = useFollows(user?.id)
   const memberGroups = (useMemberGroups(user?.id) ?? []).filter(
@@ -207,12 +236,6 @@ function ContractSearchControls(props: {
 
   const pillGroups: { name: string; slug: string }[] =
     memberPillGroups.length > 0 ? memberPillGroups : DEFAULT_CATEGORY_GROUPS
-
-  const [filter, setFilter] = useState<filter>(
-    querySortOptions?.defaultFilter ?? 'open'
-  )
-
-  const [pillFilter, setPillFilter] = useState<string | undefined>(undefined)
 
   const additionalFilters = [
     additionalFilter?.creatorId

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -106,11 +106,8 @@ export function CreatorContractsList(props: {
   return (
     <ContractSearch
       user={user}
-      querySortOptions={{
-        defaultSort: 'newest',
-        defaultFilter: 'all',
-        shouldLoadFromStorage: false,
-      }}
+      defaultSort="newest"
+      defaultFilter="all"
       additionalFilter={{
         creatorId: creator.id,
       }}

--- a/web/components/editor/market-modal.tsx
+++ b/web/components/editor/market-modal.tsx
@@ -69,7 +69,6 @@ export function MarketModal(props: {
               'flex grid grid-cols-1 sm:grid-cols-2 flex-col gap-3 p-1'
             }
             cardHideOptions={{ hideGroupLink: true, hideQuickBet: true }}
-            querySortOptions={{ disableQueryString: true }}
             highlightOptions={{
               contractIds: contracts.map((c) => c.id),
               highlightClassName:

--- a/web/hooks/use-sort-and-query-params.tsx
+++ b/web/hooks/use-sort-and-query-params.tsx
@@ -1,9 +1,5 @@
-import { debounce } from 'lodash'
-import { useRouter } from 'next/router'
-import { useEffect, useMemo, useState } from 'react'
-import { DEFAULT_SORT } from 'web/components/contract-search'
-
-const MARKETS_SORT = 'markets_sort'
+import { useState } from 'react'
+import { NextRouter, useRouter } from 'next/router'
 
 export type Sort =
   | 'newest'
@@ -15,92 +11,51 @@ export type Sort =
   | 'last-updated'
   | 'score'
 
-export function getSavedSort() {
-  // TODO: this obviously doesn't work with SSR, common sense would suggest
-  // that we should save things like this in cookies so the server has them
-  if (typeof window !== 'undefined') {
-    return localStorage.getItem(MARKETS_SORT) as Sort | null
-  } else {
-    return null
+type NewQueryParams = { [k: string]: string | null | undefined }
+
+function withURLParams(params: NewQueryParams) {
+  const newParams = new URLSearchParams(window.location.search)
+  for (const [k, v] of Object.entries(params)) {
+    if (!v) {
+      newParams.delete(k)
+    } else {
+      newParams.set(k, v)
+    }
   }
+  const newUrl = new URL(window.location.href)
+  newUrl.search = newParams.toString()
+  return newUrl
 }
 
-export interface QuerySortOptions {
-  defaultSort?: Sort
-  shouldLoadFromStorage?: boolean
-  /** Use normal react state instead of url query string */
-  disableQueryString?: boolean
+function updateURL(params: NewQueryParams) {
+  const url = withURLParams(params).toString()
+  const updatedState = { ...window.history.state, as: url, url }
+  window.history.replaceState(updatedState, '', url)
 }
 
-export function useQueryAndSortParams({
-  defaultSort = DEFAULT_SORT,
-  shouldLoadFromStorage = true,
-  disableQueryString,
-}: QuerySortOptions = {}) {
+function getStringURLParam(router: NextRouter, k: string) {
+  const v = router.query[k]
+  return typeof v === 'string' ? v : null
+}
+
+export function useQuery(defaultQuery: string, useUrl: boolean) {
   const router = useRouter()
-
-  const { s: sort, q: query } = router.query as {
-    q?: string
-    s?: Sort
+  const initialQuery = useUrl ? getStringURLParam(router, 'q') : null
+  const [query, setQuery] = useState(initialQuery ?? defaultQuery)
+  if (!useUrl) {
+    return [query, setQuery] as const
+  } else {
+    return [query, (q: string) => (setQuery(q), updateURL({ q }))] as const
   }
+}
 
-  const setSort = (sort: Sort | undefined) => {
-    router.replace({ query: { ...router.query, s: sort } }, undefined, {
-      shallow: true,
-    })
-    if (shouldLoadFromStorage) {
-      localStorage.setItem(MARKETS_SORT, sort || '')
-    }
-  }
-
-  const [queryState, setQueryState] = useState(query)
-
-  useEffect(() => {
-    setQueryState(query)
-  }, [query])
-
-  // Debounce router query update.
-  const pushQuery = useMemo(
-    () =>
-      debounce((query: string | undefined) => {
-        const queryObj = { ...router.query, q: query }
-        if (!query) delete queryObj.q
-        router.replace({ query: queryObj }, undefined, {
-          shallow: true,
-        })
-      }, 100),
-    [router]
-  )
-
-  const setQuery = (query: string | undefined) => {
-    setQueryState(query)
-    if (!disableQueryString) {
-      pushQuery(query)
-    }
-  }
-
-  useEffect(() => {
-    // If there's no sort option, then set the one from localstorage
-    if (router.isReady && !sort && shouldLoadFromStorage) {
-      const localSort = localStorage.getItem(MARKETS_SORT) as Sort
-      if (localSort && localSort !== defaultSort) {
-        // Use replace to not break navigating back.
-        router.replace(
-          { query: { ...router.query, s: localSort } },
-          undefined,
-          { shallow: true }
-        )
-      }
-    }
-  })
-
-  // use normal state if querydisableQueryString
-  const [sortState, setSortState] = useState(defaultSort)
-
-  return {
-    sort: disableQueryString ? sortState : sort ?? defaultSort,
-    query: queryState ?? '',
-    setSort: disableQueryString ? setSortState : setSort,
-    setQuery,
+export function useSort(defaultSort: Sort, useUrl: boolean) {
+  const router = useRouter()
+  const initialSort = useUrl ? (getStringURLParam(router, 's') as Sort) : null
+  const [sort, setSort] = useState(initialSort ?? defaultSort)
+  if (!useUrl) {
+    return [sort, setSort] as const
+  } else {
+    return [sort, (s: Sort) => (setSort(s), updateURL({ s }))] as const
   }
 }

--- a/web/hooks/use-sort-and-query-params.tsx
+++ b/web/hooks/use-sort-and-query-params.tsx
@@ -12,6 +12,7 @@ export type Sort =
   | 'score'
 
 type UpdatedQueryParams = { [k: string]: string }
+type QuerySortOpts = { useUrl: boolean }
 
 function withURLParams(location: Location, params: UpdatedQueryParams) {
   const newParams = new URLSearchParams(location.search)
@@ -39,7 +40,8 @@ function getStringURLParam(router: NextRouter, k: string) {
   return typeof v === 'string' ? v : null
 }
 
-export function useQuery(defaultQuery: string, useUrl: boolean) {
+export function useQuery(defaultQuery: string, opts?: QuerySortOpts) {
+  const useUrl = opts?.useUrl ?? false
   const router = useRouter()
   const initialQuery = useUrl ? getStringURLParam(router, 'q') : null
   const [query, setQuery] = useState(initialQuery ?? defaultQuery)
@@ -50,7 +52,8 @@ export function useQuery(defaultQuery: string, useUrl: boolean) {
   }
 }
 
-export function useSort(defaultSort: Sort, useUrl: boolean) {
+export function useSort(defaultSort: Sort, opts?: QuerySortOpts) {
+  const useUrl = opts?.useUrl ?? false
   const router = useRouter()
   const initialSort = useUrl ? (getStringURLParam(router, 's') as Sort) : null
   const [sort, setSort] = useState(initialSort ?? defaultSort)

--- a/web/hooks/use-sort-and-query-params.tsx
+++ b/web/hooks/use-sort-and-query-params.tsx
@@ -11,10 +11,10 @@ export type Sort =
   | 'last-updated'
   | 'score'
 
-type NewQueryParams = { [k: string]: string | null | undefined }
+type UpdatedQueryParams = { [k: string]: string }
 
-function withURLParams(params: NewQueryParams) {
-  const newParams = new URLSearchParams(window.location.search)
+function withURLParams(location: Location, params: UpdatedQueryParams) {
+  const newParams = new URLSearchParams(location.search)
   for (const [k, v] of Object.entries(params)) {
     if (!v) {
       newParams.delete(k)
@@ -22,13 +22,14 @@ function withURLParams(params: NewQueryParams) {
       newParams.set(k, v)
     }
   }
-  const newUrl = new URL(window.location.href)
+  const newUrl = new URL(location.href)
   newUrl.search = newParams.toString()
   return newUrl
 }
 
-function updateURL(params: NewQueryParams) {
-  const url = withURLParams(params).toString()
+function updateURL(params: UpdatedQueryParams) {
+  // see relevant discussion here https://github.com/vercel/next.js/discussions/18072
+  const url = withURLParams(window.location, params).toString()
   const updatedState = { ...window.history.state, as: url, url }
   window.history.replaceState(updatedState, '', url)
 }

--- a/web/pages/contract-search-firestore.tsx
+++ b/web/pages/contract-search-firestore.tsx
@@ -3,16 +3,11 @@ import { searchInAny } from 'common/util/parse'
 import { sortBy } from 'lodash'
 import { ContractsGrid } from 'web/components/contract/contracts-grid'
 import { useContracts } from 'web/hooks/use-contracts'
-import {
-  QuerySortOptions,
-  Sort,
-  useQueryAndSortParams,
-} from 'web/hooks/use-sort-and-query-params'
+import { Sort, useQuery, useSort } from 'web/hooks/use-sort-and-query-params'
 
 const MAX_CONTRACTS_RENDERED = 100
 
 export default function ContractSearchFirestore(props: {
-  querySortOptions?: QuerySortOptions
   additionalFilter?: {
     creatorId?: string
     tag?: string
@@ -21,10 +16,10 @@ export default function ContractSearchFirestore(props: {
   }
 }) {
   const contracts = useContracts()
-  const { querySortOptions, additionalFilter } = props
+  const { additionalFilter } = props
 
-  const { query, setQuery, sort, setSort } =
-    useQueryAndSortParams(querySortOptions)
+  const [query, setQuery] = useQuery('', true)
+  const [sort, setSort] = useSort('score', true)
 
   let matches = (contracts ?? []).filter((c) =>
     searchInAny(

--- a/web/pages/contract-search-firestore.tsx
+++ b/web/pages/contract-search-firestore.tsx
@@ -17,9 +17,8 @@ export default function ContractSearchFirestore(props: {
 }) {
   const contracts = useContracts()
   const { additionalFilter } = props
-
-  const [query, setQuery] = useQuery('', true)
-  const [sort, setSort] = useSort('score', true)
+  const [query, setQuery] = useQuery('', { useUrl: true })
+  const [sort, setSort] = useSort('score', { useUrl: true })
 
   let matches = (contracts ?? []).filter((c) =>
     searchInAny(

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -31,7 +31,6 @@ import { CreateQuestionButton } from 'web/components/create-question-button'
 import React, { useState } from 'react'
 import { LoadingIndicator } from 'web/components/loading-indicator'
 import { Modal } from 'web/components/layout/modal'
-import { getSavedSort } from 'web/hooks/use-sort-and-query-params'
 import { ChoicesToggleGroup } from 'web/components/choices-toggle-group'
 import { toast } from 'react-hot-toast'
 import { useCommentsOnGroup } from 'web/hooks/use-comments'
@@ -196,11 +195,8 @@ export default function GroupPage(props: {
   const questionsTab = (
     <ContractSearch
       user={user}
-      querySortOptions={{
-        shouldLoadFromStorage: true,
-        defaultSort: getSavedSort() ?? 'newest',
-        defaultFilter: 'open',
-      }}
+      defaultSort={'newest'}
+      defaultFilter={'open'}
       additionalFilter={{ groupSlug: group.slug }}
     />
   )

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -4,8 +4,7 @@ import { PlusSmIcon } from '@heroicons/react/solid'
 
 import { Page } from 'web/components/page'
 import { Col } from 'web/components/layout/col'
-import { getSavedSort } from 'web/hooks/use-sort-and-query-params'
-import { ContractSearch, DEFAULT_SORT } from 'web/components/contract-search'
+import { ContractSearch } from 'web/components/contract-search'
 import { Contract } from 'common/contract'
 import { User } from 'common/user'
 import { ContractPageContent } from './[username]/[contractSlug]'
@@ -35,10 +34,8 @@ const Home = (props: { auth: { user: User } }) => {
         <Col className="mx-auto w-full p-2">
           <ContractSearch
             user={user}
-            querySortOptions={{
-              shouldLoadFromStorage: true,
-              defaultSort: getSavedSort() ?? DEFAULT_SORT,
-            }}
+            useQuerySortLocalStorage={true}
+            useQuerySortUrlParams={true}
             onContractClick={(c) => {
               // Show contract without navigating to contract page.
               setContract(c)

--- a/web/pages/tag/[tag].tsx
+++ b/web/pages/tag/[tag].tsx
@@ -15,11 +15,8 @@ export default function TagPage() {
       <Title text={`#${tag}`} />
       <ContractSearch
         user={user}
-        querySortOptions={{
-          defaultSort: 'newest',
-          defaultFilter: 'all',
-          shouldLoadFromStorage: true,
-        }}
+        defaultSort="newest"
+        defaultFilter="all"
         additionalFilter={{ tag }}
       />
     </Page>


### PR DESCRIPTION
OK, so the previous state of affairs looked like this:

1. There existed a hook called `useQueryAndSortParams` which served the query box and "sort" dropdown on contract grid search areas.
2. It's hard to explain exactly what it did because it had a bunch of flags, but basically, it would maintain some combination of React state, URL query string state, and local storage state corresponding to the most recent query and sort you did, and handed that back to the caller along with setters.
3. One problem with this code is that it was confusing.
4. Another problem was that it used the Next.js `Router.replace` API, which does a [ton of work](https://github.com/vercel/next.js/blob/canary/packages/next/shared/lib/router/router.ts#L952), including but not limited to re-rendering the page root. This is fine in many cases, but it's really not fine when you are typing into a search box at 100 WPM.
5. Another problem is that someone noticed problem number 4, and their solution was to debounce the query string updating, but this is literally debouncing the updates to the letters you type in the box, which is really bad. (Try mashing the keyboard and you will see that it doesn't catch all the stuff you typed.)
6. Another problem was that the way our application used this code didn't make sense to me. For example, the 'adding markets to a group' box and the 'user profile page market list' would fiddle with the URL parameters and use the saved sort from the homepage, which seems foolish.

So I rewrote this into something that seems better:

1. There exist hooks called `useQuery` and `useSort` which are a `useState` that optionally load their state from the URL parameters and keep those URL parameters updated with the state.
2. We do local storage management from outside.
3. It's fast because we just use the browser history API instead of the Next.js machinery.
4. Instead of debouncing the state update, we just debounce the actual queries to Algolia.
5. I changed all the different places that render a contract search widget so that none of them except the home page dick around with the URL or with local storage at all.

Now the typing responsiveness when you use the search box is very good. The only problem is the noticeable hiccup when it actually re-renders a new list of contracts on the screen, since rendering 20 contracts takes a decent chunk of time. Probably I can make future improvements to make that less bad.
