### PR TITLE
Denormalize some contract comment fields

### DIFF
--- a/common/comment.ts
+++ b/common/comment.ts
@@ -20,4 +20,6 @@ export type Comment = {
   userName: string
   userUsername: string
   userAvatarUrl?: string
+  contractSlug?: string
+  contractQuestion?: string
 }

--- a/common/util/array.ts
+++ b/common/util/array.ts
@@ -1,3 +1,5 @@
+import { isEqual } from 'lodash'
+
 export function filterDefined<T>(array: (T | null | undefined)[]) {
   return array.filter((item) => item !== null && item !== undefined) as T[]
 }
@@ -26,7 +28,7 @@ export function groupConsecutive<T, U>(xs: T[], key: (x: T) => U) {
   let curr = { key: key(xs[0]), items: [xs[0]] }
   for (const x of xs.slice(1)) {
     const k = key(x)
-    if (k !== curr.key) {
+    if (!isEqual(key, curr.key)) {
       result.push(curr)
       curr = { key: k, items: [x] }
     } else {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -498,6 +498,28 @@
     },
     {
       "collectionGroup": "comments",
+      "fieldPath": "contractId",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "comments",
       "fieldPath": "createdTime",
       "indexes": [
         {

--- a/functions/src/on-create-comment-on-contract.ts
+++ b/functions/src/on-create-comment-on-contract.ts
@@ -24,6 +24,11 @@ export const onCreateCommentOnContract = functions
     if (!contract)
       throw new Error('Could not find contract corresponding with comment')
 
+    await change.ref.update({
+      contractSlug: contract.slug,
+      contractQuestion: contract.question,
+    })
+
     const comment = change.data() as Comment
     const lastCommentTime = comment.createdTime
 

--- a/functions/src/scripts/denormalize-comment-contract-data.ts
+++ b/functions/src/scripts/denormalize-comment-contract-data.ts
@@ -1,0 +1,70 @@
+// Filling in the contract-based fields on comments.
+
+import * as admin from 'firebase-admin'
+import { initAdmin } from './script-init'
+import {
+  DocumentCorrespondence,
+  findDiffs,
+  describeDiff,
+  applyDiff,
+} from './denormalize'
+import { DocumentSnapshot, Transaction } from 'firebase-admin/firestore'
+
+initAdmin()
+const firestore = admin.firestore()
+
+async function getContractsById(transaction: Transaction) {
+  const contracts = await transaction.get(firestore.collection('contracts'))
+  const results = Object.fromEntries(contracts.docs.map((doc) => [doc.id, doc]))
+  console.log(`Found ${contracts.size} contracts.`)
+  return results
+}
+
+async function getCommentsByContractId(transaction: Transaction) {
+  const comments = await transaction.get(
+    firestore.collectionGroup('comments').where('contractId', '!=', null)
+  )
+  const results = new Map<string, DocumentSnapshot[]>()
+  comments.forEach((doc) => {
+    const contractId = doc.get('contractId')
+    const contractComments = results.get(contractId) || []
+    contractComments.push(doc)
+    results.set(contractId, contractComments)
+  })
+  console.log(`Found ${comments.size} comments on ${results.size} contracts.`)
+  return results
+}
+
+async function denormalize() {
+  let hasMore = true
+  while (hasMore) {
+    hasMore = await admin.firestore().runTransaction(async (transaction) => {
+      const [contractsById, commentsByContractId] = await Promise.all([
+        getContractsById(transaction),
+        getCommentsByContractId(transaction),
+      ])
+      const mapping = Object.entries(contractsById).map(
+        ([id, doc]): DocumentCorrespondence => {
+          return [doc, commentsByContractId.get(id) || []]
+        }
+      )
+      const slugDiffs = findDiffs(mapping, 'slug', 'contractSlug')
+      const qDiffs = findDiffs(mapping, 'question', 'contractQuestion')
+      console.log(`Found ${slugDiffs.length} comments with mismatched slugs.`)
+      console.log(`Found ${qDiffs.length} comments with mismatched questions.`)
+      const diffs = slugDiffs.concat(qDiffs)
+      diffs.slice(0, 500).forEach((d) => {
+        console.log(describeDiff(d))
+        applyDiff(transaction, d)
+      })
+      if (diffs.length > 500) {
+        console.log(`Applying first 500 because of Firestore limit...`)
+      }
+      return diffs.length > 500
+    })
+  }
+}
+
+if (require.main === module) {
+  denormalize().catch((e) => console.error(e))
+}

--- a/web/components/comments-list.tsx
+++ b/web/components/comments-list.tsx
@@ -23,8 +23,9 @@ type ContractComment = Comment & {
 }
 
 function contractPath(slug: string) {
-  // in honor of austin, who insists that contract URLs are prefixed with a username
-  return `/Austin/${slug}`
+  // by convention this includes the contract creator username, but we don't
+  // have that handy, so we just put /market/
+  return `/market/${slug}`
 }
 
 export function UserCommentsList(props: { user: User }) {


### PR DESCRIPTION
Now we have a `contractSlug` and `contractQuestion`.

This is a big deal for the user profile, because otherwise we have to load the contract doc for every comment. Now we don't.