### PR TITLE
Add comment type field to comments

### DIFF
--- a/common/comment.ts
+++ b/common/comment.ts
@@ -4,6 +4,8 @@ import type { JSONContent } from '@tiptap/core'
 // They're uniquely identified by the pair contractId/betId.
 export type Comment = {
   id: string
+  commentType: 'contract' | 'group'
+
   contractId?: string
   groupId?: string
   betId?: string

--- a/functions/src/scripts/backfill-comment-types.ts
+++ b/functions/src/scripts/backfill-comment-types.ts
@@ -1,0 +1,31 @@
+// Comment types were introduced in August 2022.
+
+import { initAdmin } from './script-init'
+import { log, writeAsync } from '../utils'
+
+if (require.main === module) {
+  const app = initAdmin()
+  const firestore = app.firestore()
+  const commentsRef = firestore.collectionGroup('comments')
+  commentsRef.get().then(async (commentsSnaps) => {
+    log(`Loaded ${commentsSnaps.size} contracts.`)
+    const needsFilling = commentsSnaps.docs.filter((ct) => {
+      return !('commentType' in ct.data())
+    })
+    log(`Found ${needsFilling.length} comments to update.`)
+    const updates = needsFilling.map((d) => {
+      const comment = d.data()
+      const fields: { [k: string]: unknown } = {}
+      if (comment.contractId != null && comment.groupId == null) {
+        fields.commentType = 'contract'
+      } else if (comment.groupId != null && comment.contractId == null) {
+        fields.commentType = 'group'
+      } else {
+        log(`Invalid comment ${comment}; not touching it.`)
+      }
+      return { doc: d.ref, fields, info: comment }
+    })
+    await writeAsync(firestore, updates)
+    log(`Updated all comments.`)
+  })
+}

--- a/web/lib/firebase/comments.ts
+++ b/web/lib/firebase/comments.ts
@@ -33,6 +33,7 @@ export async function createCommentOnContract(
     : doc(getCommentsCollection(contractId))
   const comment: Comment = removeUndefinedProps({
     id: ref.id,
+    commentType: 'contract',
     contractId,
     userId: commenter.id,
     content: content,
@@ -61,6 +62,7 @@ export async function createCommentOnGroup(
   const ref = doc(getCommentsOnGroupCollection(groupId))
   const comment: Comment = removeUndefinedProps({
     id: ref.id,
+    commentType: 'group',
     groupId,
     userId: user.id,
     content: content,


### PR DESCRIPTION
This is going to be helpful both for Typescript purposes (type narrowing on the comment will work well, like it does on contracts) and for database querying purposes (e.g. in the user profile page, where we want all contract comments.)

You might think that it's equally good to do a query like `query(comments, where('contractId', '!=', null))` instead of `query(comments, where('commentType', '==', 'contract'))`, but it's not, because `!= null` qualifies as a "range comparison" in [these docs](https://firebase.google.com/docs/firestore/query-data/order-limit-data#limitations) -- they don't say so, but I tried it -- and it prevents you from doing arbitrary sorts on other query fields.