### PR TITLE
Use masonry on contract cards, sorted correctly

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -39,6 +39,7 @@
     "lodash": "4.17.21",
     "mailgun-js": "0.22.0",
     "module-alias": "2.2.2",
+    "react-masonry-css": "1.0.16",
     "stripe": "8.194.0",
     "zod": "3.17.2"
   },

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -83,7 +83,7 @@ export function ContractSearch(props: {
   highlightOptions?: ContractHighlightOptions
   onContractClick?: (contract: Contract) => void
   hideOrderSelector?: boolean
-  overrideGridClassName?: string
+  gridClassName?: string
   cardHideOptions?: {
     hideGroupLink?: boolean
     hideQuickBet?: boolean
@@ -98,7 +98,7 @@ export function ContractSearch(props: {
     defaultFilter,
     additionalFilter,
     onContractClick,
-    overrideGridClassName,
+    gridClassName,
     hideOrderSelector,
     cardHideOptions,
     highlightOptions,
@@ -181,7 +181,7 @@ export function ContractSearch(props: {
         loadMore={performQuery}
         showTime={showTime}
         onContractClick={onContractClick}
-        overrideGridClassName={overrideGridClassName}
+        gridClassName={gridClassName}
         highlightOptions={highlightOptions}
         cardHideOptions={cardHideOptions}
       />

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -83,7 +83,6 @@ export function ContractSearch(props: {
   highlightOptions?: ContractHighlightOptions
   onContractClick?: (contract: Contract) => void
   hideOrderSelector?: boolean
-  gridClassName?: string
   cardHideOptions?: {
     hideGroupLink?: boolean
     hideQuickBet?: boolean
@@ -98,7 +97,6 @@ export function ContractSearch(props: {
     defaultFilter,
     additionalFilter,
     onContractClick,
-    gridClassName,
     hideOrderSelector,
     cardHideOptions,
     highlightOptions,
@@ -181,7 +179,6 @@ export function ContractSearch(props: {
         loadMore={performQuery}
         showTime={showTime}
         onContractClick={onContractClick}
-        gridClassName={gridClassName}
         highlightOptions={highlightOptions}
         cardHideOptions={cardHideOptions}
       />

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -21,7 +21,6 @@ export function ContractsGrid(props: {
   loadMore?: () => void
   showTime?: ShowTime
   onContractClick?: (contract: Contract) => void
-  gridClassName?: string
   cardHideOptions?: {
     hideQuickBet?: boolean
     hideGroupLink?: boolean
@@ -33,7 +32,6 @@ export function ContractsGrid(props: {
     showTime,
     loadMore,
     onContractClick,
-    gridClassName,
     cardHideOptions,
     highlightOptions,
   } = props

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -9,6 +9,7 @@ import { useCallback } from 'react'
 import clsx from 'clsx'
 import { LoadingIndicator } from '../loading-indicator'
 import { VisibilityObserver } from '../visibility-observer'
+import Masonry from 'react-masonry-css'
 
 export type ContractHighlightOptions = {
   contractIds?: string[]
@@ -61,50 +62,14 @@ export function ContractsGrid(props: {
       </p>
     )
   }
-  // Reorganize the contracts so that the masonry layout shows them in the original order
-  // E.g. from [0, 1, 2, 3] => [0, 2, 1, 3]
-  // E.g. from [0, 1, 2, 3, 4, 5, 6] => [0, 2, 4, 1, 3, 5, 6]
-  const halfway = Math.floor(contracts.length / 2)
-  function reorder(i: number) {
-    return i < halfway
-      ? i * 2
-      : Math.min((i - halfway) * 2 + 1, (contracts?.length ?? 1) - 1)
-  }
-  const twoColContracts = Array.from(
-    { length: contracts.length },
-    (_, i) => contracts[reorder(i)]
-  )
 
   return (
     <Col className="gap-8">
-      <div
-        className={clsx(
-          'hidden w-full gap-4 space-y-4 md:block md:columns-2',
-          gridClassName
-        )}
-      >
-        {twoColContracts.map((contract) => (
-          <ContractCard
-            contract={contract}
-            key={contract.id}
-            showTime={showTime}
-            onClick={
-              onContractClick ? () => onContractClick(contract) : undefined
-            }
-            hideQuickBet={hideQuickBet}
-            hideGroupLink={hideGroupLink}
-            className={clsx(
-              'break-inside-avoid-column',
-              contractIds?.includes(contract.id) && highlightClassName
-            )}
-          />
-        ))}
-      </div>
-      <div
-        className={clsx(
-          'w-full columns-1 gap-4 space-y-4 md:hidden',
-          gridClassName
-        )}
+      <Masonry
+        // Show only 1 column on tailwind md = 768px
+        breakpointCols={{ default: 2, 768: 1 }}
+        className="-ml-4 flex w-auto"
+        columnClassName="pl-4 bg-clip-padding"
       >
         {contracts.map((contract) => (
           <ContractCard
@@ -117,12 +82,12 @@ export function ContractsGrid(props: {
             hideQuickBet={hideQuickBet}
             hideGroupLink={hideGroupLink}
             className={clsx(
-              'break-inside-avoid-column',
+              'mb-4 break-inside-avoid-column',
               contractIds?.includes(contract.id) && highlightClassName
             )}
           />
         ))}
-      </div>
+      </Masonry>
       <VisibilityObserver
         onVisibilityUpdated={onVisibilityUpdated}
         className="relative -top-96 h-1"

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -20,7 +20,7 @@ export function ContractsGrid(props: {
   loadMore?: () => void
   showTime?: ShowTime
   onContractClick?: (contract: Contract) => void
-  overrideGridClassName?: string
+  gridClassName?: string
   cardHideOptions?: {
     hideQuickBet?: boolean
     hideGroupLink?: boolean
@@ -32,7 +32,7 @@ export function ContractsGrid(props: {
     showTime,
     loadMore,
     onContractClick,
-    overrideGridClassName,
+    gridClassName,
     cardHideOptions,
     highlightOptions,
   } = props
@@ -66,9 +66,8 @@ export function ContractsGrid(props: {
     <Col className="gap-8">
       <ul
         className={clsx(
-          overrideGridClassName
-            ? overrideGridClassName
-            : 'grid w-full grid-cols-1 gap-4 md:grid-cols-2'
+          'w-full columns-1 gap-4 space-y-4 md:columns-2',
+          gridClassName
         )}
       >
         {contracts.map((contract) => (
@@ -81,11 +80,10 @@ export function ContractsGrid(props: {
             }
             hideQuickBet={hideQuickBet}
             hideGroupLink={hideGroupLink}
-            className={
-              contractIds?.includes(contract.id)
-                ? highlightClassName
-                : undefined
-            }
+            className={clsx(
+              'break-inside-avoid-column',
+              contractIds?.includes(contract.id) && highlightClassName
+            )}
           />
         ))}
       </ul>

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -79,12 +79,34 @@ export function ContractsGrid(props: {
     <Col className="gap-8">
       <div
         className={clsx(
-          'w-full columns-1 gap-4 space-y-4 md:columns-2',
+          'hidden w-full gap-4 space-y-4 md:block md:columns-2',
           gridClassName
         )}
       >
-        {/* TODO: When columns-1, don't reorder the contracts */}
         {twoColContracts.map((contract) => (
+          <ContractCard
+            contract={contract}
+            key={contract.id}
+            showTime={showTime}
+            onClick={
+              onContractClick ? () => onContractClick(contract) : undefined
+            }
+            hideQuickBet={hideQuickBet}
+            hideGroupLink={hideGroupLink}
+            className={clsx(
+              'break-inside-avoid-column',
+              contractIds?.includes(contract.id) && highlightClassName
+            )}
+          />
+        ))}
+      </div>
+      <div
+        className={clsx(
+          'w-full columns-1 gap-4 space-y-4 md:hidden',
+          gridClassName
+        )}
+      >
+        {contracts.map((contract) => (
           <ContractCard
             contract={contract}
             key={contract.id}

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -61,16 +61,30 @@ export function ContractsGrid(props: {
       </p>
     )
   }
+  // Reorganize the contracts so that the masonry layout shows them in the original order
+  // E.g. from [0, 1, 2, 3] => [0, 2, 1, 3]
+  // E.g. from [0, 1, 2, 3, 4, 5, 6] => [0, 2, 4, 1, 3, 5, 6]
+  const halfway = Math.floor(contracts.length / 2)
+  function reorder(i: number) {
+    return i < halfway
+      ? i * 2
+      : Math.min((i - halfway) * 2 + 1, (contracts?.length ?? 1) - 1)
+  }
+  const twoColContracts = Array.from(
+    { length: contracts.length },
+    (_, i) => contracts[reorder(i)]
+  )
 
   return (
     <Col className="gap-8">
-      <ul
+      <div
         className={clsx(
           'w-full columns-1 gap-4 space-y-4 md:columns-2',
           gridClassName
         )}
       >
-        {contracts.map((contract) => (
+        {/* TODO: When columns-1, don't reorder the contracts */}
+        {twoColContracts.map((contract) => (
           <ContractCard
             contract={contract}
             key={contract.id}
@@ -86,7 +100,7 @@ export function ContractsGrid(props: {
             )}
           />
         ))}
-      </ul>
+      </div>
       <VisibilityObserver
         onVisibilityUpdated={onVisibilityUpdated}
         className="relative -top-96 h-1"

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -66,7 +66,7 @@ export function ContractsGrid(props: {
   return (
     <Col className="gap-8">
       <Masonry
-        // Show only 1 column on tailwind md = 768px
+        // Show only 1 column on tailwind's md breakpoint (768px)
         breakpointCols={{ default: 2, 768: 1 }}
         className="-ml-4 flex w-auto"
         columnClassName="pl-4 bg-clip-padding"

--- a/web/components/editor/market-modal.tsx
+++ b/web/components/editor/market-modal.tsx
@@ -65,7 +65,6 @@ export function MarketModal(props: {
           <ContractSearch
             hideOrderSelector
             onContractClick={addContract}
-            gridClassName="gap-3 space-y-3"
             cardHideOptions={{ hideGroupLink: true, hideQuickBet: true }}
             highlightOptions={{
               contractIds: contracts.map((c) => c.id),

--- a/web/components/editor/market-modal.tsx
+++ b/web/components/editor/market-modal.tsx
@@ -65,9 +65,7 @@ export function MarketModal(props: {
           <ContractSearch
             hideOrderSelector
             onContractClick={addContract}
-            overrideGridClassName={
-              'flex grid grid-cols-1 sm:grid-cols-2 flex-col gap-3 p-1'
-            }
+            gridClassName="gap-3 space-y-3"
             cardHideOptions={{ hideGroupLink: true, hideQuickBet: true }}
             highlightOptions={{
               contractIds: contracts.map((c) => c.id),

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -607,9 +607,7 @@ function AddContractButton(props: { group: Group; user: User }) {
               user={user}
               hideOrderSelector={true}
               onContractClick={addContractToCurrentGroup}
-              overrideGridClassName={
-                'flex grid grid-cols-1 sm:grid-cols-2 flex-col gap-3 p-1'
-              }
+              gridClassName="gap-3 space-y-3"
               cardHideOptions={{ hideGroupLink: true, hideQuickBet: true }}
               additionalFilter={{ excludeContractIds: group.contractIds }}
               highlightOptions={{

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -607,7 +607,6 @@ function AddContractButton(props: { group: Group; user: User }) {
               user={user}
               hideOrderSelector={true}
               onContractClick={addContractToCurrentGroup}
-              gridClassName="gap-3 space-y-3"
               cardHideOptions={{ hideGroupLink: true, hideQuickBet: true }}
               additionalFilter={{ excludeContractIds: group.contractIds }}
               highlightOptions={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -9947,6 +9947,11 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+react-masonry-css@1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/react-masonry-css/-/react-masonry-css-1.0.16.tgz#72b28b4ae3484e250534700860597553a10f1a2c"
+  integrity sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==
+
 react-motion@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"


### PR DESCRIPTION
This is actually kind of a huge pain to get exactly right...
- The Tailwind `columns-2` solution doesn't order them in the ideal left-to-right ordering. But [`order-[x]`](https://tailwindcss.com/docs/order#class-reference) doesn't work either
- Firefox has support for Masonry https://stackoverflow.com/a/45200955/1222351
- MaterialUI has this implemented https://github.com/mui/material-ui/pull/27439

So here's this somewhat hacky solution, which seems to work okay.

TODO: Have to fix the 1-column version - unfortunately, detecting whether we're in md: breakpoint in React/JS seems to be annoying too