### PR TITLE
Fix tooltip popping up when modal is opened

### DIFF
--- a/web/components/tooltip.tsx
+++ b/web/components/tooltip.tsx
@@ -6,7 +6,6 @@ import {
   Placement,
   shift,
   useFloating,
-  useFocus,
   useHover,
   useInteractions,
   useRole,
@@ -48,7 +47,6 @@ export function Tooltip(props: {
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useHover(context, { mouseOnly: noTap }),
-    useFocus(context),
     useRole(context, { role: 'tooltip' }),
   ])
   // which side of tooltip arrow is on. like: if tooltip is top-left, arrow is on bottom of tooltip
@@ -64,7 +62,6 @@ export function Tooltip(props: {
       <div
         className={clsx('inline-block', className)}
         ref={reference}
-        tabIndex={noTap ? undefined : 0}
         {...getReferenceProps()}
       >
         {children}


### PR DESCRIPTION
Headless UI's Modal component autofocuses the first focusable item inside it when opened. This is [by design for accessibility reasons](https://headlessui.com/react/dialog#managing-initial-focus). 

Ironically this means we'll have to remove keyboard focus for tooltips because this causes the tooltips to pop up unnecessarily for all users whenever the dialog is opened.
Doing this in an accessible way would involve is managing focus manually for several dialogs, which may not be possible yet as some of our modals lack a sensible element to focus by default. Or maybe disabling the autofocus unless the modal is opened via the keyboard (maybe complicated?)

I'm somewhat unhappy with this but I think doing it the unaccessible way is the right thing to do, in a utilitarian sense.