### PR TITLE
Make Avatar component update when avatarUrl updates

### DIFF
--- a/web/components/avatar.tsx
+++ b/web/components/avatar.tsx
@@ -1,6 +1,6 @@
 import Router from 'next/router'
 import clsx from 'clsx'
-import { MouseEvent, useState } from 'react'
+import { MouseEvent, useEffect, useState } from 'react'
 import { UserCircleIcon, UserIcon, UsersIcon } from '@heroicons/react/solid'
 
 export function Avatar(props: {
@@ -12,6 +12,7 @@ export function Avatar(props: {
 }) {
   const { username, noLink, size, className } = props
   const [avatarUrl, setAvatarUrl] = useState(props.avatarUrl)
+  useEffect(() => setAvatarUrl(props.avatarUrl), [props.avatarUrl])
   const s = size == 'xs' ? 6 : size === 'sm' ? 8 : size || 10
 
   const onClick =


### PR DESCRIPTION
> Now that you mention it, I might have noticed other avatar weirdness elsewhere. Like when I logged in as someone else, the old avatar was still showing. - @jahooma 

I can't reproduce, so I can't test your issue, but I think the ultimate cause is https://github.com/manifoldmarkets/manifold/commit/34e8138e5096e1ad8a4944566328703bd080c645
The moral of the story is don't replicate props as state