### PR TITLE
Fix notification for updated questions and descriptions

### DIFF
--- a/functions/src/on-update-contract.ts
+++ b/functions/src/on-update-contract.ts
@@ -2,6 +2,7 @@ import * as functions from 'firebase-functions'
 import { getUser } from './utils'
 import { createNotification } from './create-notification'
 import { Contract } from '../../common/contract'
+import { isEqual } from 'lodash'
 
 export const onUpdateContract = functions.firestore
   .document('contracts/{contractId}')
@@ -40,19 +41,19 @@ export const onUpdateContract = functions.firestore
       )
     } else if (
       previousValue.closeTime !== contract.closeTime ||
-      previousValue.description !== contract.description
+      previousValue.question !== contract.question ||
+      !isEqual(previousValue.description, contract.description)
     ) {
       let sourceText = ''
-      if (previousValue.closeTime !== contract.closeTime && contract.closeTime)
+      if (
+        previousValue.closeTime !== contract.closeTime &&
+        contract.closeTime
+      ) {
         sourceText = contract.closeTime.toString()
-      else {
-        const oldTrimmedDescription = previousValue.description.trim()
-        const newTrimmedDescription = contract.description.trim()
-        if (oldTrimmedDescription === '') sourceText = newTrimmedDescription
-        else
-          sourceText = newTrimmedDescription
-            .split(oldTrimmedDescription)[1]
-            .trim()
+      } else if (previousValue.question !== contract.question) {
+        sourceText = contract.question
+      } else {
+        sourceText = 'the market description'
       }
 
       await createNotification(

--- a/functions/src/on-update-contract.ts
+++ b/functions/src/on-update-contract.ts
@@ -2,7 +2,6 @@ import * as functions from 'firebase-functions'
 import { getUser } from './utils'
 import { createNotification } from './create-notification'
 import { Contract } from '../../common/contract'
-import { isEqual } from 'lodash'
 
 export const onUpdateContract = functions.firestore
   .document('contracts/{contractId}')
@@ -41,8 +40,7 @@ export const onUpdateContract = functions.firestore
       )
     } else if (
       previousValue.closeTime !== contract.closeTime ||
-      previousValue.question !== contract.question ||
-      !isEqual(previousValue.description, contract.description)
+      previousValue.question !== contract.question
     ) {
       let sourceText = ''
       if (
@@ -52,8 +50,6 @@ export const onUpdateContract = functions.firestore
         sourceText = contract.closeTime.toString()
       } else if (previousValue.question !== contract.question) {
         sourceText = contract.question
-      } else {
-        sourceText = 'the market description'
       }
 
       await createNotification(


### PR DESCRIPTION
Since descriptions are now rich text and not append-only, the previous way of calculating the changes will not work, and there isn't a simple way to fix it. For now, we just say that the market description changed without saying what in it changed.