### PR TITLE
Convert tags to groups on demand

### DIFF
--- a/functions/src/create-group.ts
+++ b/functions/src/create-group.ts
@@ -21,6 +21,7 @@ const bodySchema = z.object({
 })
 
 export const creategroup = newEndpoint({}, async (req, auth) => {
+  const firestore = admin.firestore()
   const { name, about, memberIds, anyoneCanJoin } = validate(
     bodySchema,
     req.body
@@ -67,7 +68,7 @@ export const creategroup = newEndpoint({}, async (req, auth) => {
   return { status: 'success', group: group }
 })
 
-const getSlug = async (name: string) => {
+export const getSlug = async (name: string) => {
   const proposedSlug = slugify(name)
 
   const preexistingGroup = await getGroupFromSlug(proposedSlug)
@@ -75,9 +76,8 @@ const getSlug = async (name: string) => {
   return preexistingGroup ? proposedSlug + '-' + randomString() : proposedSlug
 }
 
-const firestore = admin.firestore()
-
 export async function getGroupFromSlug(slug: string) {
+  const firestore = admin.firestore()
   const snap = await firestore
     .collection('groups')
     .where('slug', '==', slug)

--- a/functions/src/scripts/convert-tag-to-group.ts
+++ b/functions/src/scripts/convert-tag-to-group.ts
@@ -1,0 +1,66 @@
+// Takes a tag and makes a new group with all the contracts in it.
+
+import * as admin from 'firebase-admin'
+import { initAdmin } from './script-init'
+import { isProd, log } from '../utils'
+import { getSlug } from '../create-group'
+import { Group } from '../../../common/group'
+
+const getTaggedContractIds = async (tag: string) => {
+  const firestore = admin.firestore()
+  const results = await firestore
+    .collection('contracts')
+    .where('lowercaseTags', 'array-contains', tag.toLowerCase())
+    .get()
+  return results.docs.map((d) => d.id)
+}
+
+const createGroup = async (
+  name: string,
+  about: string,
+  contractIds: string[]
+) => {
+  const firestore = admin.firestore()
+  const creatorId = isProd()
+    ? 'IPTOzEqrpkWmEzh6hwvAyY9PqFb2'
+    : '94YYTk1AFWfbWMpfYcvnnwI1veP2'
+
+  const slug = await getSlug(name)
+  const groupRef = firestore.collection('groups').doc()
+  const now = Date.now()
+  const group: Group = {
+    id: groupRef.id,
+    creatorId,
+    slug,
+    name,
+    about,
+    createdTime: now,
+    mostRecentActivityTime: now,
+    contractIds: contractIds,
+    anyoneCanJoin: true,
+    memberIds: [],
+  }
+  return await groupRef.create(group)
+}
+
+const convertTagToGroup = async (tag: string, groupName: string) => {
+  log(`Looking up contract IDs with tag ${tag}...`)
+  const contractIds = await getTaggedContractIds(tag)
+  log(`${contractIds.length} contracts found.`)
+  if (contractIds.length > 0) {
+    log(`Creating group ${groupName}...`)
+    const about = `Contracts that used to be tagged ${tag}.`
+    const result = await createGroup(groupName, about, contractIds)
+    log(`Done. Group: `, result)
+  }
+}
+
+if (require.main === module) {
+  initAdmin()
+  const args = process.argv.slice(2)
+  if (args.length != 2) {
+    console.log('Usage: convert-tag-to-group [tag] [group-name]')
+  } else {
+    convertTagToGroup(args[0], args[1]).catch((e) => console.error(e))
+  }
+}


### PR DESCRIPTION
There are some old tags that people liked, so it's good to make groups out of them so that people can enjoy the fruits of their effort categorizing the old contracts.

P.S. there was some stuff busted on dev by trying to use the wrong Manifold user ID, like notification generation. Whatever.