### PR TITLE
Make portfolio graph loading more efficient

### DIFF
--- a/web/components/portfolio/portfolio-value-graph.tsx
+++ b/web/components/portfolio/portfolio-value-graph.tsx
@@ -1,7 +1,6 @@
 import { ResponsiveLine } from '@nivo/line'
 import { PortfolioMetrics } from 'common/user'
 import { formatMoney } from 'common/util/format'
-import { DAY_MS } from 'common/util/time'
 import { last } from 'lodash'
 import { memo } from 'react'
 import { useWindowSize } from 'web/hooks/use-window-size'
@@ -10,28 +9,12 @@ import { formatTime } from 'web/lib/util/time'
 export const PortfolioValueGraph = memo(function PortfolioValueGraph(props: {
   portfolioHistory: PortfolioMetrics[]
   height?: number
-  period?: string
+  includeTime?: boolean
 }) {
-  const { portfolioHistory, height, period } = props
-
+  const { portfolioHistory, height, includeTime } = props
   const { width } = useWindowSize()
 
-  const portfolioHistoryFiltered = portfolioHistory.filter((p) => {
-    switch (period) {
-      case 'daily':
-        return p.timestamp > Date.now() - 1 * DAY_MS
-      case 'weekly':
-        return p.timestamp > Date.now() - 7 * DAY_MS
-      case 'monthly':
-        return p.timestamp > Date.now() - 30 * DAY_MS
-      case 'allTime':
-        return true
-      default:
-        return true
-    }
-  })
-
-  const points = portfolioHistoryFiltered.map((p) => {
+  const points = portfolioHistory.map((p) => {
     return {
       x: new Date(p.timestamp),
       y: p.balance + p.investmentValue,
@@ -41,7 +24,6 @@ export const PortfolioValueGraph = memo(function PortfolioValueGraph(props: {
   const numXTickValues = !width || width < 800 ? 2 : 5
   const numYTickValues = 4
   const endDate = last(points)?.x
-  const includeTime = period === 'daily'
   return (
     <div
       className="w-full overflow-hidden"
@@ -66,7 +48,7 @@ export const PortfolioValueGraph = memo(function PortfolioValueGraph(props: {
         colors={{ datum: 'color' }}
         axisBottom={{
           tickValues: numXTickValues,
-          format: (time) => formatTime(+time, includeTime),
+          format: (time) => formatTime(+time, !!includeTime),
         }}
         pointBorderColor="#fff"
         pointSize={points.length > 100 ? 0 : 6}

--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -23,11 +23,8 @@ const periodToCutoff = (now: number, period: Period) => {
 }
 
 export const PortfolioValueSection = memo(
-  function PortfolioValueSection(props: {
-    userId: string
-    disableSelector?: boolean
-  }) {
-    const { disableSelector, userId } = props
+  function PortfolioValueSection(props: { userId: string }) {
+    const { userId } = props
 
     const [portfolioPeriod, setPortfolioPeriod] = useState<Period>('weekly')
     const [portfolioHistory, setUsersPortfolioHistory] = useState<
@@ -48,9 +45,7 @@ export const PortfolioValueSection = memo(
       <div>
         <Row className="gap-8">
           <div className="mb-4 w-full">
-            <Col
-              className={disableSelector ? 'items-center justify-center' : ''}
-            >
+            <Col className="items-center justify-center">
               <div className="text-sm text-gray-500">Portfolio value</div>
               <div className="text-lg">
                 {formatMoney(
@@ -60,20 +55,18 @@ export const PortfolioValueSection = memo(
               </div>
             </Col>
           </div>
-          {!disableSelector && (
-            <select
-              className="select select-bordered self-start"
-              value={portfolioPeriod}
-              onChange={(e) => {
-                setPortfolioPeriod(e.target.value as Period)
-              }}
-            >
-              <option value="allTime">All time</option>
-              <option value="weekly">Last 7d</option>
-              {/* Note: 'daily' seems to be broken? */}
-              {/* <option value="daily">Last 24h</option> */}
-            </select>
-          )}
+          <select
+            className="select select-bordered self-start"
+            value={portfolioPeriod}
+            onChange={(e) => {
+              setPortfolioPeriod(e.target.value as Period)
+            }}
+          >
+            <option value="allTime">All time</option>
+            <option value="weekly">Last 7d</option>
+            {/* Note: 'daily' seems to be broken? */}
+            {/* <option value="daily">Last 24h</option> */}
+          </select>
         </Row>
         <PortfolioValueGraph
           portfolioHistory={portfolioHistory}

--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -41,20 +41,16 @@ export const PortfolioValueSection = memo(
       return <></>
     }
 
+    const { balance, investmentValue } = lastPortfolioMetrics
+    const totalValue = balance + investmentValue
+
     return (
-      <div>
+      <>
         <Row className="gap-8">
-          <div className="mb-4 w-full">
-            <Col className="items-center justify-center">
-              <div className="text-sm text-gray-500">Portfolio value</div>
-              <div className="text-lg">
-                {formatMoney(
-                  lastPortfolioMetrics.balance +
-                    lastPortfolioMetrics.investmentValue
-                )}
-              </div>
-            </Col>
-          </div>
+          <Col className="flex-1 justify-center">
+            <div className="text-sm text-gray-500">Portfolio value</div>
+            <div className="text-lg">{formatMoney(totalValue)}</div>
+          </Col>
           <select
             className="select select-bordered self-start"
             value={portfolioPeriod}
@@ -72,7 +68,7 @@ export const PortfolioValueSection = memo(
           portfolioHistory={portfolioHistory}
           includeTime={portfolioPeriod == 'daily'}
         />
-      </div>
+      </>
     )
   }
 )

--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -60,8 +60,7 @@ export const PortfolioValueSection = memo(
           >
             <option value="allTime">All time</option>
             <option value="weekly">Last 7d</option>
-            {/* Note: 'daily' seems to be broken? */}
-            {/* <option value="daily">Last 24h</option> */}
+            <option value="daily">Last 24h</option>
           </select>
         </Row>
         <PortfolioValueGraph

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -252,11 +252,12 @@ export async function unfollow(userId: string, unfollowedUserId: string) {
   await deleteDoc(followDoc)
 }
 
-export async function getPortfolioHistory(userId: string) {
+export async function getPortfolioHistory(userId: string, since: number) {
   return getValues<PortfolioMetrics>(
     query(
       collectionGroup(db, 'portfolioHistory'),
       where('userId', '==', userId),
+      where('timestamp', '>=', since),
       orderBy('timestamp', 'asc')
     )
   )


### PR DESCRIPTION
Since the default view period is a week, it sucked to pull down the whole history.

Note that the old code sort of implied that there might be history for prior to June, but in the actual database it seems that history was removed. There was no mechanism for filtering stuff only past June, and at a glance, it seems like the history collections I can find don't contain pre-June data points. So e.g. the code that was showing the "since June" label was never doing anything.

I also re-enabled the "daily" option. Austin claimed in [this commit](https://github.com/manifoldmarkets/manifold/commit/258b2a318fa626df536ca31ce178ec6ea6af4919) that it's "broken" but I see zero evidence of that. I'm guessing he got confused by the thing where the metrics update job was busted for a few days due to OOM.