### PR TITLE
Clean up markup in CopyLinkDateTimeComponent

### DIFF
--- a/web/components/feed/copy-link-date-time.tsx
+++ b/web/components/feed/copy-link-date-time.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link'
 import { fromNow } from 'web/lib/util/time'
 import { ToastClipboard } from 'web/components/toast-clipboard'
 import { LinkIcon } from '@heroicons/react/outline'
-import clsx from 'clsx'
 
 export function CopyLinkDateTimeComponent(props: {
   prefix: string
@@ -29,26 +28,19 @@ export function CopyLinkDateTimeComponent(props: {
     setTimeout(() => setShowToast(false), 2000)
   }
   return (
-    <div className={clsx('inline', className)}>
-      <DateTimeTooltip time={createdTime} noTap>
-        <Link href={`/${prefix}/${slug}#${elementId}`} passHref={true}>
-          <a
-            onClick={(event) => copyLinkToComment(event)}
-            className={'mx-1 cursor-pointer'}
-          >
-            <span className="whitespace-nowrap rounded-sm px-1 text-gray-400 hover:bg-gray-100 ">
-              {fromNow(createdTime)}
-              {showToast && (
-                <ToastClipboard className={'left-24 sm:-left-16'} />
-              )}
-              <LinkIcon
-                className="ml-1 mb-0.5 inline-block text-gray-400"
-                height={13}
-              />
-            </span>
-          </a>
-        </Link>
-      </DateTimeTooltip>
-    </div>
+    <DateTimeTooltip className={className} time={createdTime} noTap>
+      <Link href={`/${prefix}/${slug}#${elementId}`} passHref={true}>
+        <a
+          onClick={copyLinkToComment}
+          className={
+            'mx-1 whitespace-nowrap rounded-sm px-1 text-gray-400 hover:bg-gray-100'
+          }
+        >
+          {fromNow(createdTime)}
+          {showToast && <ToastClipboard className={'left-24 sm:-left-16'} />}
+          <LinkIcon className="ml-1 mb-0.5 inline" height={13} />
+        </a>
+      </Link>
+    </DateTimeTooltip>
   )
 }


### PR DESCRIPTION
Just fixing up tiny stuff I noticed.