### PR TITLE
⚡ Cache user bets tab with react query!! 

### DIFF
--- a/functions/src/scripts/backfill-unique-bettors.ts
+++ b/functions/src/scripts/backfill-unique-bettors.ts
@@ -1,0 +1,39 @@
+import * as admin from 'firebase-admin'
+import { initAdmin } from './script-init'
+import { getValues, log, writeAsync } from '../utils'
+import { Bet } from '../../../common/bet'
+import { groupBy, mapValues, sortBy, uniq } from 'lodash'
+
+initAdmin()
+const firestore = admin.firestore()
+
+const getBettorsByContractId = async () => {
+  const bets = await getValues<Bet>(firestore.collectionGroup('bets'))
+  log(`Loaded ${bets.length} bets.`)
+  const betsByContractId = groupBy(bets, 'contractId')
+  return mapValues(betsByContractId, (bets) =>
+    uniq(sortBy(bets, 'createdTime').map((bet) => bet.userId))
+  )
+}
+
+const updateUniqueBettors = async () => {
+  const bettorsByContractId = await getBettorsByContractId()
+
+  const updates = Object.entries(bettorsByContractId).map(
+    ([contractId, userIds]) => {
+      const update = {
+        uniqueBettorIds: userIds,
+        uniqueBettorCount: userIds.length,
+      }
+      const docRef = firestore.collection('contracts').doc(contractId)
+      return { doc: docRef, fields: update }
+    }
+  )
+  log(`Updating ${updates.length} contracts.`)
+  await writeAsync(firestore, updates)
+  log(`Updated all contracts.`)
+}
+
+if (require.main === module) {
+  updateUniqueBettors()
+}

--- a/web/components/bets-list.tsx
+++ b/web/components/bets-list.tsx
@@ -72,7 +72,7 @@ export function BetsList(props: { user: User }) {
   const signedInUser = useUser()
   const isYourBets = user.id === signedInUser?.id
   const hideBetsBefore = isYourBets ? 0 : JUNE_1_2022
-  const userBets = useUserBets(user.id, { includeRedemptions: true })
+  const userBets = useUserBets(user.id)
   const [contractsById, setContractsById] = useState<
     Dictionary<Contract> | undefined
   >()
@@ -80,7 +80,10 @@ export function BetsList(props: { user: User }) {
   // Hide bets before 06-01-2022 if this isn't your own profile
   // NOTE: This means public profits also begin on 06-01-2022 as well.
   const bets = useMemo(
-    () => userBets?.filter((bet) => bet.createdTime >= (hideBetsBefore ?? 0)),
+    () =>
+      userBets?.filter(
+        (bet) => !bet.isAnte && bet.createdTime >= (hideBetsBefore ?? 0)
+      ),
     [userBets, hideBetsBefore]
   )
 

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -317,7 +317,7 @@ function GroupsList(props: { currentPage: string; memberItems: Item[] }) {
         {memberItems.map((item) => (
           <a
             href={item.href}
-            key={item.name}
+            key={item.href}
             onClick={trackCallback('click sidebar group', { name: item.name })}
             className={clsx(
               'cursor-pointer truncate',

--- a/web/hooks/use-contracts.ts
+++ b/web/hooks/use-contracts.ts
@@ -1,3 +1,4 @@
+import { useFirestoreQueryData } from '@react-query-firebase/firestore'
 import { isEqual } from 'lodash'
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -8,6 +9,7 @@ import {
   listenForHotContracts,
   listenForInactiveContracts,
   listenForNewContracts,
+  getUserBetContractsQuery,
 } from 'web/lib/firebase/contracts'
 
 export const useContracts = () => {
@@ -88,4 +90,16 @@ export const useUpdatedContracts = (contracts: Contract[] | undefined) => {
   return contracts && Object.keys(contractDict.current).length > 0
     ? contracts.map((c) => contractDict.current[c.id])
     : undefined
+}
+
+export const useUserBetContracts = (userId: string) => {
+  const result = useFirestoreQueryData(
+    ['contracts', 'bets', userId],
+    getUserBetContractsQuery(userId),
+    { subscribe: true, includeMetadataChanges: true },
+    // Temporary workaround for react-query bug:
+    // https://github.com/invertase/react-query-firebase/issues/25
+    { refetchOnMount: 'always' }
+  )
+  return result.data
 }

--- a/web/hooks/use-notifications.ts
+++ b/web/hooks/use-notifications.ts
@@ -20,8 +20,9 @@ function useNotifications(privateUser: PrivateUser) {
     { subscribe: true, includeMetadataChanges: true },
     // Temporary workaround for react-query bug:
     // https://github.com/invertase/react-query-firebase/issues/25
-    { cacheTime: 0 }
+    { refetchOnMount: 'always' }
   )
+
   const notifications = useMemo(() => {
     if (!result.data) return undefined
     const notifications = result.data as Notification[]

--- a/web/hooks/use-portfolio-history.ts
+++ b/web/hooks/use-portfolio-history.ts
@@ -1,0 +1,32 @@
+import { useFirestoreQueryData } from '@react-query-firebase/firestore'
+import { DAY_MS, HOUR_MS } from 'common/util/time'
+import { getPortfolioHistoryQuery, Period } from 'web/lib/firebase/users'
+
+export const usePortfolioHistory = (userId: string, period: Period) => {
+  const nowRounded = Math.round(Date.now() / HOUR_MS) * HOUR_MS
+  const cutoff = periodToCutoff(nowRounded, period).valueOf()
+
+  const result = useFirestoreQueryData(
+    ['portfolio-history', userId, cutoff],
+    getPortfolioHistoryQuery(userId, cutoff),
+    { subscribe: true, includeMetadataChanges: true },
+    // Temporary workaround for react-query bug:
+    // https://github.com/invertase/react-query-firebase/issues/25
+    { refetchOnMount: 'always' }
+  )
+  return result.data
+}
+
+const periodToCutoff = (now: number, period: Period) => {
+  switch (period) {
+    case 'daily':
+      return now - 1 * DAY_MS
+    case 'weekly':
+      return now - 7 * DAY_MS
+    case 'monthly':
+      return now - 30 * DAY_MS
+    case 'allTime':
+    default:
+      return new Date(0)
+  }
+}

--- a/web/hooks/use-prefetch.ts
+++ b/web/hooks/use-prefetch.ts
@@ -1,0 +1,11 @@
+import { useUserBetContracts } from './use-contracts'
+import { usePortfolioHistory } from './use-portfolio-history'
+import { useUserBets } from './use-user-bets'
+
+export function usePrefetch(userId: string | undefined) {
+  const maybeUserId = userId ?? ''
+
+  useUserBets(maybeUserId)
+  useUserBetContracts(maybeUserId)
+  usePortfolioHistory(maybeUserId, 'weekly')
+}

--- a/web/hooks/use-user-bets.ts
+++ b/web/hooks/use-user-bets.ts
@@ -1,22 +1,21 @@
-import { uniq } from 'lodash'
+import { useFirestoreQueryData } from '@react-query-firebase/firestore'
 import { useEffect, useState } from 'react'
 import {
   Bet,
-  listenForUserBets,
+  getUserBetsQuery,
   listenForUserContractBets,
 } from 'web/lib/firebase/bets'
 
-export const useUserBets = (
-  userId: string | undefined,
-  options: { includeRedemptions: boolean }
-) => {
-  const [bets, setBets] = useState<Bet[] | undefined>(undefined)
-
-  useEffect(() => {
-    if (userId) return listenForUserBets(userId, setBets, options)
-  }, [userId])
-
-  return bets
+export const useUserBets = (userId: string) => {
+  const result = useFirestoreQueryData(
+    ['bets', userId],
+    getUserBetsQuery(userId),
+    { subscribe: true, includeMetadataChanges: true },
+    // Temporary workaround for react-query bug:
+    // https://github.com/invertase/react-query-firebase/issues/25
+    { cacheTime: 0 }
+  )
+  return result.data
 }
 
 export const useUserContractBets = (
@@ -31,36 +30,6 @@ export const useUserContractBets = (
   }, [userId, contractId])
 
   return bets
-}
-
-export const useUserBetContracts = (
-  userId: string | undefined,
-  options: { includeRedemptions: boolean }
-) => {
-  const [contractIds, setContractIds] = useState<string[] | undefined>()
-
-  useEffect(() => {
-    if (userId) {
-      const key = `user-bet-contractIds-${userId}`
-
-      const userBetContractJson = localStorage.getItem(key)
-      if (userBetContractJson) {
-        setContractIds(JSON.parse(userBetContractJson))
-      }
-
-      return listenForUserBets(
-        userId,
-        (bets) => {
-          const contractIds = uniq(bets.map((bet) => bet.contractId))
-          setContractIds(contractIds)
-          localStorage.setItem(key, JSON.stringify(contractIds))
-        },
-        options
-      )
-    }
-  }, [userId])
-
-  return contractIds
 }
 
 export const useGetUserBetContractIds = (userId: string | undefined) => {

--- a/web/hooks/use-user-bets.ts
+++ b/web/hooks/use-user-bets.ts
@@ -13,7 +13,7 @@ export const useUserBets = (userId: string) => {
     { subscribe: true, includeMetadataChanges: true },
     // Temporary workaround for react-query bug:
     // https://github.com/invertase/react-query-firebase/issues/25
-    { cacheTime: 0 }
+    { refetchOnMount: 'always' }
   )
   return result.data
 }

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -11,6 +11,7 @@ import {
   getDocs,
   getDoc,
   DocumentSnapshot,
+  Query,
 } from 'firebase/firestore'
 import { uniq } from 'lodash'
 
@@ -131,24 +132,12 @@ export async function getContractsOfUserBets(userId: string) {
   return filterDefined(contracts)
 }
 
-export function listenForUserBets(
-  userId: string,
-  setBets: (bets: Bet[]) => void,
-  options: { includeRedemptions: boolean }
-) {
-  const { includeRedemptions } = options
-  const userQuery = query(
+export function getUserBetsQuery(userId: string) {
+  return query(
     collectionGroup(db, 'bets'),
     where('userId', '==', userId),
     orderBy('createdTime', 'desc')
-  )
-  return listenForValues<Bet>(userQuery, (bets) => {
-    setBets(
-      bets.filter(
-        (bet) => (includeRedemptions || !bet.isRedemption) && !bet.isAnte
-      )
-    )
-  })
+  ) as Query<Bet>
 }
 
 export function listenForUserContractBets(

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -6,6 +6,7 @@ import {
   getDocs,
   limit,
   orderBy,
+  Query,
   query,
   setDoc,
   startAfter,
@@ -154,6 +155,13 @@ export function listenForUserContracts(
     orderBy('createdTime', 'desc')
   )
   return listenForValues<Contract>(q, setContracts)
+}
+
+export function getUserBetContractsQuery(userId: string) {
+  return query(
+    contracts,
+    where('uniqueBettorIds', 'array-contains', userId)
+  ) as Query<Contract>
 }
 
 const activeContractsQuery = query(

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -12,6 +12,7 @@ import {
   deleteDoc,
   collectionGroup,
   onSnapshot,
+  Query,
 } from 'firebase/firestore'
 import { getAuth } from 'firebase/auth'
 import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth'
@@ -252,15 +253,13 @@ export async function unfollow(userId: string, unfollowedUserId: string) {
   await deleteDoc(followDoc)
 }
 
-export async function getPortfolioHistory(userId: string, since: number) {
-  return getValues<PortfolioMetrics>(
-    query(
-      collectionGroup(db, 'portfolioHistory'),
-      where('userId', '==', userId),
-      where('timestamp', '>=', since),
-      orderBy('timestamp', 'asc')
-    )
-  )
+export function getPortfolioHistoryQuery(userId: string, since: number) {
+  return query(
+    collectionGroup(db, 'portfolioHistory'),
+    where('userId', '==', userId),
+    where('timestamp', '>=', since),
+    orderBy('timestamp', 'asc')
+  ) as Query<PortfolioMetrics>
 }
 
 export function listenForFollows(

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -42,6 +42,7 @@ import {
 } from 'web/components/contract/contract-leaderboard'
 import { ContractsGrid } from 'web/components/contract/contracts-grid'
 import { Title } from 'web/components/title'
+import { usePrefetch } from 'web/hooks/use-prefetch'
 
 export const getStaticProps = fromPropz(getStaticPropz)
 export async function getStaticPropz(props: {
@@ -157,6 +158,7 @@ export function ContractPageContent(
   const { backToHome, comments, user } = props
 
   const contract = useContractWithPreload(props.contract) ?? props.contract
+  usePrefetch(user?.id)
 
   useTracking('view market', {
     slug: contract.slug,

--- a/web/pages/home.tsx
+++ b/web/pages/home.tsx
@@ -15,6 +15,7 @@ import { track } from 'web/lib/service/analytics'
 import { authenticateOnServer } from 'web/lib/firebase/server-auth'
 import { useSaveReferral } from 'web/hooks/use-save-referral'
 import { GetServerSideProps } from 'next'
+import { usePrefetch } from 'web/hooks/use-prefetch'
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const creds = await authenticateOnServer(ctx)
@@ -30,6 +31,7 @@ const Home = (props: { auth: { user: User } | null }) => {
   useTracking('view home')
 
   useSaveReferral()
+  usePrefetch(user?.id)
 
   return (
     <>


### PR DESCRIPTION
From the insight that NextJS does client-side navigation when clicking Links, it means we can cache data in-memory.

This PR caches all the user bet data, including portfolio history, user bets, and the contracts corresponding to your bets using react query.

Further, we call these hooks on home and the market page to "precache" the data so that it will load instantly when navigating your user page bets tab.

To make this work, I backfilled the `uniqueBettorIds` in every contract so that we can query all the contracts you have bet on in one go.