### PR TITLE
Fix prefetching to not populate useless state

### DIFF
--- a/web/hooks/use-contracts.ts
+++ b/web/hooks/use-contracts.ts
@@ -11,6 +11,7 @@ import {
   listenForNewContracts,
   getUserBetContractsQuery,
 } from 'web/lib/firebase/contracts'
+import { QueryClient } from 'react-query'
 
 export const useContracts = () => {
   const [contracts, setContracts] = useState<Contract[] | undefined>()
@@ -91,6 +92,13 @@ export const useUpdatedContracts = (contracts: Contract[] | undefined) => {
     ? contracts.map((c) => contractDict.current[c.id])
     : undefined
 }
+
+const queryClient = new QueryClient()
+
+export const prefetchUserBetContracts = (userId: string) =>
+  queryClient.prefetchQuery(['contracts', 'bets', userId], () =>
+    getUserBetContractsQuery(userId)
+  )
 
 export const useUserBetContracts = (userId: string) => {
   const result = useFirestoreQueryData(

--- a/web/hooks/use-prefetch.ts
+++ b/web/hooks/use-prefetch.ts
@@ -1,11 +1,11 @@
-import { useUserBetContracts } from './use-contracts'
-import { usePortfolioHistory } from './use-portfolio-history'
-import { useUserBets } from './use-user-bets'
+import { prefetchUserBetContracts } from './use-contracts'
+import { prefetchPortfolioHistory } from './use-portfolio-history'
+import { prefetchUserBets } from './use-user-bets'
 
 export function usePrefetch(userId: string | undefined) {
   const maybeUserId = userId ?? ''
 
-  useUserBets(maybeUserId)
-  useUserBetContracts(maybeUserId)
-  usePortfolioHistory(maybeUserId, 'weekly')
+  prefetchUserBets(maybeUserId)
+  prefetchUserBetContracts(maybeUserId)
+  prefetchPortfolioHistory(maybeUserId, 'weekly')
 }

--- a/web/hooks/use-user-bets.ts
+++ b/web/hooks/use-user-bets.ts
@@ -1,3 +1,4 @@
+import { QueryClient } from 'react-query'
 import { useFirestoreQueryData } from '@react-query-firebase/firestore'
 import { useEffect, useState } from 'react'
 import {
@@ -5,6 +6,11 @@ import {
   getUserBetsQuery,
   listenForUserContractBets,
 } from 'web/lib/firebase/bets'
+
+const queryClient = new QueryClient()
+
+export const prefetchUserBets = (userId: string) =>
+  queryClient.prefetchQuery(['bets', userId], () => getUserBetsQuery(userId))
 
 export const useUserBets = (userId: string) => {
   const result = useFirestoreQueryData(


### PR DESCRIPTION
Since we (maybe?) have some reason to believe that this prefetching is hurting us due to increased memory pressure, let's at least not copy the prefetched data into state for no reason.