### PR TITLE
Disable group prefetching from contract links

### DIFF
--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -116,25 +116,6 @@ export function AvatarDetails(props: {
   )
 }
 
-export function AbbrContractDetails(props: {
-  contract: Contract
-  showHotVolume?: boolean
-  showTime?: ShowTime
-}) {
-  const { contract, showHotVolume, showTime } = props
-  return (
-    <Row className="items-center justify-between">
-      <AvatarDetails contract={contract} />
-
-      <MiscDetails
-        contract={contract}
-        showHotVolume={showHotVolume}
-        showTime={showTime}
-      />
-    </Row>
-  )
-}
-
 export function ContractDetails(props: {
   contract: Contract
   disabled?: boolean

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -8,6 +8,7 @@ import {
 import clsx from 'clsx'
 import { Editor } from '@tiptap/react'
 import dayjs from 'dayjs'
+import Link from 'next/link'
 
 import { Row } from '../layout/row'
 import { formatMoney } from 'common/util/format'
@@ -26,7 +27,7 @@ import { Button } from 'web/components/button'
 import { Modal } from 'web/components/layout/modal'
 import { Col } from 'web/components/layout/col'
 import { ContractGroupsList } from 'web/components/groups/contract-groups-list'
-import { SiteLink } from 'web/components/site-link'
+import { linkClass } from 'web/components/site-link'
 import { getGroupLinkToDisplay, groupPath } from 'web/lib/firebase/groups'
 import { insertContent } from '../editor/utils'
 import { contractMetrics } from 'common/contract-details'
@@ -83,12 +84,11 @@ export function MiscDetails(props: {
       )}
 
       {!hideGroupLink && groupToDisplay && (
-        <SiteLink
-          href={groupPath(groupToDisplay.slug)}
-          className="truncate text-sm text-gray-400"
-        >
-          {groupToDisplay.name}
-        </SiteLink>
+        <Link prefetch={false} href={groupPath(groupToDisplay.slug)}>
+          <a className={clsx(linkClass, 'truncate text-sm text-gray-400')}>
+            {groupToDisplay.name}
+          </a>
+        </Link>
       )}
     </Row>
   )
@@ -143,12 +143,12 @@ export function ContractDetails(props: {
         isMobile ? 'max-w-[140px]' : 'max-w-[250px]'
       )}
     >
-      <SiteLink href={groupPath(groupToDisplay.slug)} className={'truncate'}>
-        <Row>
+      <Link prefetch={false} href={groupPath(groupToDisplay.slug)}>
+        <a className={clsx(linkClass, 'flex flex-row truncate')}>
           <UserGroupIcon className="mx-1 inline h-5 w-5 shrink-0" />
           <span className="items-center truncate">{groupToDisplay.name}</span>
-        </Row>
-      </SiteLink>
+        </a>
+      </Link>
     </Row>
   ) : (
     <Button

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -137,19 +137,18 @@ export function ContractDetails(props: {
   const isMobile = (width ?? 0) < 600
   const groupToDisplay = getGroupLinkToDisplay(contract)
   const groupInfo = groupToDisplay ? (
-    <Row
-      className={clsx(
-        'items-center pr-0 sm:pr-2',
-        isMobile ? 'max-w-[140px]' : 'max-w-[250px]'
-      )}
-    >
-      <Link prefetch={false} href={groupPath(groupToDisplay.slug)}>
-        <a className={clsx(linkClass, 'flex flex-row truncate')}>
-          <UserGroupIcon className="mx-1 inline h-5 w-5 shrink-0" />
-          <span className="items-center truncate">{groupToDisplay.name}</span>
-        </a>
-      </Link>
-    </Row>
+    <Link prefetch={false} href={groupPath(groupToDisplay.slug)}>
+      <a
+        className={clsx(
+          linkClass,
+          'flex flex-row items-center truncate pr-0 sm:pr-2',
+          isMobile ? 'max-w-[140px]' : 'max-w-[250px]'
+        )}
+      >
+        <UserGroupIcon className="mx-1 inline h-5 w-5 shrink-0" />
+        <span className="items-center truncate">{groupToDisplay.name}</span>
+      </a>
+    </Link>
   ) : (
     <Button
       size={'xs'}


### PR DESCRIPTION
I wasn't able to convince James to disable most prefetching, but at least we compromised to not prefetch groups on contracts for as long as those groups are really expensive to prefetch (i.e. right now they load all their members, etc. etc.) since this is a particularly gross thing in the way of making the home/contract user flow better.