### PR TITLE
Some changes to make auth better

### DIFF
--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -103,11 +103,9 @@ export function AuthProvider(props: {
   }, [setAuthUser])
 
   const uid = authUser?.user.id
-  const username = authUser?.user.username
   useEffect(() => {
-    if (uid && username) {
+    if (uid) {
       identifyUser(uid)
-      setUserProperty('username', username)
       const userListener = listenForUser(uid, (user) => {
         setAuthUser((currAuthUser) =>
           currAuthUser && user ? { ...currAuthUser, user } : null
@@ -123,7 +121,14 @@ export function AuthProvider(props: {
         privateUserListener()
       }
     }
-  }, [uid, username, setAuthUser])
+  }, [uid, setAuthUser])
+
+  const username = authUser?.user.username
+  useEffect(() => {
+    if (username != null) {
+      setUserProperty('username', username)
+    }
+  }, [username])
 
   return (
     <AuthContext.Provider value={authUser}>{children}</AuthContext.Provider>

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -102,17 +102,15 @@ export function AuthProvider(props: {
     if (uid && username) {
       identifyUser(uid)
       setUserProperty('username', username)
-      const userListener = listenForUser(uid, (user) =>
-        setAuthUser((authUser) => {
-          /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-          return { ...authUser!, user: user! }
-        })
-      )
+      const userListener = listenForUser(uid, (user) => {
+        setAuthUser((currAuthUser) =>
+          currAuthUser && user ? { ...currAuthUser, user } : null
+        )
+      })
       const privateUserListener = listenForPrivateUser(uid, (privateUser) => {
-        setAuthUser((authUser) => {
-          /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-          return { ...authUser!, privateUser: privateUser! }
-        })
+        setAuthUser((currAuthUser) =>
+          currAuthUser && privateUser ? { ...currAuthUser, privateUser } : null
+        )
       })
       return () => {
         userListener()

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -68,6 +68,16 @@ export function AuthProvider(props: {
   }, [setAuthUser, serverUser])
 
   useEffect(() => {
+    if (authUser != null) {
+      // Persist to local storage, to reduce login blink next time.
+      // Note: Cap on localStorage size is ~5mb
+      localStorage.setItem(CACHED_USER_KEY, JSON.stringify(authUser))
+    } else {
+      localStorage.removeItem(CACHED_USER_KEY)
+    }
+  }, [authUser])
+
+  useEffect(() => {
     return onIdTokenChanged(
       auth,
       async (fbUser) => {
@@ -80,14 +90,10 @@ export function AuthProvider(props: {
             setCachedReferralInfoForUser(current.user)
           }
           setAuthUser(current)
-          // Persist to local storage, to reduce login blink next time.
-          // Note: Cap on localStorage size is ~5mb
-          localStorage.setItem(CACHED_USER_KEY, JSON.stringify(current))
         } else {
           // User logged out; reset to null
           setUserCookie(undefined)
           setAuthUser(null)
-          localStorage.removeItem(CACHED_USER_KEY)
         }
       },
       (e) => {

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -77,12 +77,12 @@ export function AuthProvider(props: {
           if (!current.user || !current.privateUser) {
             const deviceToken = ensureDeviceToken()
             current = (await createUser({ deviceToken })) as UserAndPrivateUser
+            setCachedReferralInfoForUser(current.user)
           }
           setAuthUser(current)
           // Persist to local storage, to reduce login blink next time.
           // Note: Cap on localStorage size is ~5mb
           localStorage.setItem(CACHED_USER_KEY, JSON.stringify(current))
-          setCachedReferralInfoForUser(current.user)
         } else {
           // User logged out; reset to null
           setUserCookie(undefined)


### PR DESCRIPTION
A variety of small things:

1. The `listenForUser` and `listenForPrivateUser` subscriptions that keep track of the current logged in user docs weren't handling the case where (surprisingly) they can't find the user by ID. But this case actually was coming up in the case where you (e.g. on your local dev server) have a cached user object for prod, and then log into dev, and now you have one with an invalid dev database ID. The consequence is that it would mysteriously explode on the first page load and make a scary message. Now we handle this much more gracefully.

2. Those subscriptions also weren't updating the local storage blob when your user info changes, which they should.

3. It was really weird that we called the `setCachedReferralInfoForUser` on every login even though it only matters when you create a user. Maybe someone can explain to me why this code was the way it was but I have no idea.

4. We no longer mix together the "listen for user stuff" and "update analytics username" in the same `useEffect`, so it makes more sense and doesn't do extra work when you change your username.