### PR TITLE
Make `parse.richTextToString` more efficient

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -13,6 +13,7 @@
     "@tiptap/extension-link": "2.0.0-beta.43",
     "@tiptap/extension-mention": "2.0.0-beta.102",
     "@tiptap/starter-kit": "2.0.0-beta.191",
+    "prosemirror-model": "1.18.1",
     "lodash": "4.17.21"
   },
   "devDependencies": {

--- a/common/util/parse.ts
+++ b/common/util/parse.ts
@@ -1,5 +1,12 @@
 import { MAX_TAG_LENGTH } from '../contract'
-import { generateText, JSONContent } from '@tiptap/core'
+import {
+  getText,
+  getTextSerializersFromSchema,
+  getSchema,
+  JSONContent,
+} from '@tiptap/core'
+import { Node as ProseMirrorNode } from 'prosemirror-model'
+
 // Tiptap starter extensions
 import { Blockquote } from '@tiptap/extension-blockquote'
 import { Bold } from '@tiptap/extension-bold'
@@ -90,7 +97,6 @@ export const exhibitExts = [
   Paragraph,
   Strike,
   Text,
-
   Image,
   Link,
   Mention,
@@ -98,6 +104,15 @@ export const exhibitExts = [
   TiptapTweet,
 ]
 
+const exhibitSchema = getSchema(exhibitExts)
+
 export function richTextToString(text?: JSONContent) {
-  return !text ? '' : generateText(text, exhibitExts)
+  if (!text) {
+    return ''
+  }
+  const contentNode = ProseMirrorNode.fromJSON(exhibitSchema, text)
+  return getText(contentNode, {
+    blockSeparator: '\n\n',
+    textSerializers: getTextSerializersFromSchema(exhibitSchema),
+  })
 }


### PR DESCRIPTION
This is necessary for rendering the OG meta description when loading the content page, so it's in the hotspot for the user browsing flow. Profiling suggests that recomputing the ProseMirror schema every time (the behavior of the previous version) may cost on the order of tens of milliseconds. That code is [here](https://github.com/ueberdosis/tiptap/blob/main/packages/core/src/helpers/getSchemaByResolvedExtensions.ts#L23) -- I don't know if I believe the profiler but clearly we should just not do this.

I continue to update in the direction of "ProseMirror may or may not be good, but TipTap is often suspicious." It's kind of ridiculous to me that the `generateText` method they supplied took the extensions instead of the schema as an argument. Not a good design.

EDIT: Before merging this I want to look at some other TipTap code to understand what the deal is with extension resolution. It's also possible that in addition to this code I should just go and add a pre-rendered plaintext copy in the DB, which would be very useful, but it would also bloat our contract docs further, so it kind of sucks too.