### PR TITLE
Don't re-create visibility observer for no reason

### DIFF
--- a/web/components/visibility-observer.tsx
+++ b/web/components/visibility-observer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useEvent } from '../hooks/use-event'
 
 export function VisibilityObserver(props: {
@@ -8,17 +8,18 @@ export function VisibilityObserver(props: {
   const { className } = props
   const [elem, setElem] = useState<HTMLElement | null>(null)
   const onVisibilityUpdated = useEvent(props.onVisibilityUpdated)
-
-  useEffect(() => {
-    const hasIOSupport = !!window.IntersectionObserver
-    if (!hasIOSupport || !elem) return
-
-    const observer = new IntersectionObserver(([entry]) => {
+  const observer = useRef(
+    new IntersectionObserver(([entry]) => {
       onVisibilityUpdated(entry.isIntersecting)
     }, {})
-    observer.observe(elem)
-    return () => observer.disconnect()
-  }, [elem, onVisibilityUpdated])
+  ).current
+
+  useEffect(() => {
+    if (elem) {
+      observer.observe(elem)
+      return () => observer.disconnect()
+    }
+  }, [elem, observer])
 
   return <div ref={setElem} className={className}></div>
 }

--- a/web/components/visibility-observer.tsx
+++ b/web/components/visibility-observer.tsx
@@ -17,7 +17,7 @@ export function VisibilityObserver(props: {
   useEffect(() => {
     if (elem) {
       observer.observe(elem)
-      return () => observer.disconnect()
+      return () => observer.unobserve(elem)
     }
   }, [elem, observer])
 


### PR DESCRIPTION
I don't think this was causing any actual problem, but it was just obviously silly to re-create the `IntersectionObserver` object whenever the ref changes.