### PR TITLE
Sort markets on tournament pages by %, using ContractSearchFirestore

### DIFF
--- a/web/pages/contract-search-firestore.tsx
+++ b/web/pages/contract-search-firestore.tsx
@@ -61,6 +61,10 @@ export default function ContractSearchFirestore(props: {
     matches = sortBy(matches, (c) =>
       getProbability(c as BinaryContract | PseudoNumericContract)
     ).reverse()
+  } else if (sort === 'lowest-percent') {
+    matches = sortBy(matches, (c) =>
+      getProbability(c as BinaryContract | PseudoNumericContract)
+    )
   }
 
   if (additionalFilter) {
@@ -109,12 +113,13 @@ export default function ContractSearchFirestore(props: {
           value={sort}
           onChange={(e) => setSort(e.target.value)}
         >
-          <option value="highest-percent">Highest %</option>
           <option value="score">Trending</option>
           <option value="newest">Newest</option>
           <option value="most-traded">Most traded</option>
           <option value="24-hour-vol">24h volume</option>
           <option value="close-date">Closing soon</option>
+          <option value="highest-percent">Highest %</option>
+          <option value="lowest-percent">Lowest %</option>
         </select>
       </div>
       <ContractsGrid contracts={matches} showTime={showTime} />

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -227,6 +227,10 @@ export default function GroupPage(props: {
     <ContractSearchFirestore
       additionalFilter={{ groupSlug: group.slug }}
       defaultSort="highest-percent"
+      getContracts={async () => {
+        const contracts = await listContractsByGroupSlug(group.slug)
+        return contracts.filter((c) => !c.isResolved)
+      }}
     />
   ) : (
     <ContractSearch

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -52,6 +52,8 @@ import { Post } from 'common/post'
 import { Spacer } from 'web/components/layout/spacer'
 import { usePost } from 'web/hooks/use-post'
 import { useAdmin } from 'web/hooks/use-admin'
+import { isTournament } from 'web/pages/tournaments'
+import ContractSearchFirestore from 'web/pages/contract-search-firestore'
 
 export const getStaticProps = fromPropz(getStaticPropz)
 export async function getStaticPropz(props: { params: { slugs: string[] } }) {
@@ -220,7 +222,13 @@ export default function GroupPage(props: {
     </Col>
   )
 
-  const questionsTab = (
+  // Use Firestore search for Tournament groups, so they can sort by highest
+  const questionsTab = isTournament(group.id) ? (
+    <ContractSearchFirestore
+      additionalFilter={{ groupSlug: group.slug }}
+      defaultSort="highest-percent"
+    />
+  ) : (
     <ContractSearch
       user={user}
       defaultSort={'newest'}

--- a/web/pages/tournaments/index.tsx
+++ b/web/pages/tournaments/index.tsx
@@ -107,6 +107,10 @@ const tourneys: Tourney[] = [
   // },
 ]
 
+export function isTournament(groupId: string) {
+  return tourneys.map((t) => t.groupId).includes(groupId)
+}
+
 export async function getStaticProps() {
   const groupIds = tourneys
     .map((data) => data.groupId)


### PR DESCRIPTION
This is super hacky and trades off a much longer initial load time, for a better browsing experience... Not sure if this is the right longterm solution but I _think_ it's better for the CEP contest?