### PR TITLE
Enable source maps in production

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -4,6 +4,7 @@ const ABOUT_PAGE_URL = 'https://docs.manifold.markets/$how-to'
 
 /** @type {import('next').NextConfig} */
 module.exports = {
+  productionBrowserSourceMaps: true,
   staticPageGenerationTimeout: 600, // e.g. stats page
   reactStrictMode: true,
   optimizeFonts: false,


### PR DESCRIPTION
https://nextjs.org/docs/advanced-features/source-maps

We don't really care about build time and it's frequently a pain in the ass not to be able to debug and profile the production site properly.