### PR TITLE
[Regression] Fix feature-breaking bug in Group Leaderboards

### DIFF
--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -104,7 +104,7 @@ export async function listContracts(creatorId: string): Promise<Contract[]> {
   return snapshot.docs.map((doc) => doc.data())
 }
 
-export const contractsByGroupSlugQuery = (slug: string) =>
+export const tournamentContractsByGroupSlugQuery = (slug: string) =>
   query(
     contracts,
     where('groupSlugs', 'array-contains', slug),
@@ -115,7 +115,8 @@ export const contractsByGroupSlugQuery = (slug: string) =>
 export async function listContractsByGroupSlug(
   slug: string
 ): Promise<Contract[]> {
-  const snapshot = await getDocs(contractsByGroupSlugQuery(slug))
+  const q = query(contracts, where('groupSlugs', 'array-contains', slug))
+  const snapshot = await getDocs(q)
   return snapshot.docs.map((doc) => doc.data())
 }
 

--- a/web/pages/tournaments/index.tsx
+++ b/web/pages/tournaments/index.tsx
@@ -14,7 +14,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Page } from 'web/components/page'
 import { SEO } from 'web/components/SEO'
-import { contractsByGroupSlugQuery } from 'web/lib/firebase/contracts'
+import { tournamentContractsByGroupSlugQuery } from 'web/lib/firebase/contracts'
 import { getGroup, groupPath } from 'web/lib/firebase/groups'
 import elon_pic from './_cspi/Will_Elon_Buy_Twitter.png'
 import china_pic from './_cspi/Chinese_Military_Action_against_Taiwan.png'
@@ -222,7 +222,7 @@ const ImageCarousel = (props: { images: MarketImage[]; url: string }) => {
 
 const MarketCarousel = (props: { slug: string }) => {
   const { slug } = props
-  const q = contractsByGroupSlugQuery(slug)
+  const q = tournamentContractsByGroupSlugQuery(slug)
   const { allItems, getNext } = usePagination({ q, pageSize: 6 })
   const items = allItems()
 


### PR DESCRIPTION
https://github.com/manifoldmarkets/manifold/pull/832 broke group leaderboards. The changes to contracts.ts made it so only not-resolved contracts where pulled up to build the leaderboards, which broke the Top Trader group leaderboard (every item shows 0 profit).

Example:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/6242616/188644420-af49dd20-5393-4182-bbbc-e1e7dd501981.png">


I'm not going to wait for a review as the changes are trivial and this should be fixed immediately. 