### PR TITLE
Adds investmentValue to group leaderboard calculation

### DIFF
--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -11,14 +11,18 @@ const computeInvestmentValue = (
 ) => {
   return sumBy(bets, (bet) => {
     const contract = contractsDict[bet.contractId]
-    if (!contract || contract.isResolved) return 0
-    if (bet.sale || bet.isSold) return 0
-
-    const payout = calculatePayout(contract, bet, 'MKT')
-    const value = payout - (bet.loanAmount ?? 0)
-    if (isNaN(value)) return 0
-    return value
+    return computeInvestmentValueForBet(bet, contract)
   })
+}
+
+export const computeInvestmentValueForBet = (bet: Bet, contract: Contract) => {
+  if (!contract || contract.isResolved) return 0
+  if (bet.sale || bet.isSold) return 0
+
+  const payout = calculatePayout(contract, bet, 'MKT')
+  const value = payout - (bet.loanAmount ?? 0)
+  if (isNaN(value)) return 0
+  return value
 }
 
 const computeTotalPool = (userContracts: Contract[], startTime = 0) => {

--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -11,18 +11,14 @@ const computeInvestmentValue = (
 ) => {
   return sumBy(bets, (bet) => {
     const contract = contractsDict[bet.contractId]
-    return computeInvestmentValueForBet(bet, contract)
+    if (!contract || contract.isResolved) return 0
+    if (bet.sale || bet.isSold) return 0
+
+    const payout = calculatePayout(contract, bet, 'MKT')
+    const value = payout - (bet.loanAmount ?? 0)
+    if (isNaN(value)) return 0
+    return value
   })
-}
-
-export const computeInvestmentValueForBet = (bet: Bet, contract: Contract) => {
-  if (!contract || contract.isResolved) return 0
-  if (bet.sale || bet.isSold) return 0
-
-  const payout = calculatePayout(contract, bet, 'MKT')
-  const value = payout - (bet.loanAmount ?? 0)
-  if (isNaN(value)) return 0
-  return value
 }
 
 const computeTotalPool = (userContracts: Contract[], startTime = 0) => {

--- a/common/scoring.ts
+++ b/common/scoring.ts
@@ -34,17 +34,11 @@ export function scoreUsersByContract(contract: Contract, bets: Bet[]) {
   const profits = bets.map((bet) => {
     const { userId } = bet
     const payout = getContractBetMetrics(contract, [bet]).profit
-    console.log({
-      userId: userId,
-      metrics: getContractBetMetrics(contract, [bet]),
-    })
-    return { userId: userId, payout: payout }
+    return { userId, payout }
   })
 
-  const netPayouts = [...profits]
-
   const userScore = mapValues(
-    groupBy(netPayouts, (payout) => payout.userId),
+    groupBy(profits, (payout) => payout.userId),
     (payouts) => sumBy(payouts, ({ payout }) => payout)
   )
 

--- a/common/scoring.ts
+++ b/common/scoring.ts
@@ -31,18 +31,8 @@ export function scoreTraders(contracts: Contract[], bets: Bet[][]) {
 }
 
 export function scoreUsersByContract(contract: Contract, bets: Bet[]) {
-  const profits = bets.map((bet) => {
-    const { userId } = bet
-    const payout = getContractBetMetrics(contract, [bet]).profit
-    return { userId, payout }
-  })
-
-  const userScore = mapValues(
-    groupBy(profits, (payout) => payout.userId),
-    (payouts) => sumBy(payouts, ({ payout }) => payout)
-  )
-
-  return userScore
+  const betsByUser = groupBy(bets, bet => bet.userId)
+  return mapValues(betsByUser, bets => getContractBetMetrics(contract, bets).profit)
 }
 
 export function addUserScores(

--- a/common/scoring.ts
+++ b/common/scoring.ts
@@ -1,6 +1,7 @@
 import { groupBy, sumBy, mapValues, partition } from 'lodash'
 
 import { Bet } from './bet'
+import { computeInvestmentValueForBet } from './calculate-metrics'
 import { Contract } from './contract'
 import { getPayouts } from './payouts'
 
@@ -62,7 +63,18 @@ export function scoreUsersByContract(contract: Contract, bets: Bet[]) {
       return { userId, payout }
     })
 
-  const netPayouts = [...resolvePayouts, ...salePayouts, ...investments]
+  const investmentValues = openBets.map((bet) => {
+    const { userId } = bet
+    const investmentValue = computeInvestmentValueForBet(bet, contract)
+    return { userId, payout: investmentValue }
+  })
+
+  const netPayouts = [
+    ...resolvePayouts,
+    ...salePayouts,
+    ...investments,
+    ...investmentValues,
+  ]
 
   const userScore = mapValues(
     groupBy(netPayouts, (payout) => payout.userId),

--- a/common/scoring.ts
+++ b/common/scoring.ts
@@ -1,7 +1,7 @@
 import { groupBy, sumBy, mapValues, partition } from 'lodash'
 
 import { Bet } from './bet'
-import { computeInvestmentValueForBet } from './calculate-metrics'
+import { getContractBetMetrics } from './calculate'
 import { Contract } from './contract'
 import { getPayouts } from './payouts'
 
@@ -63,17 +63,24 @@ export function scoreUsersByContract(contract: Contract, bets: Bet[]) {
       return { userId, payout }
     })
 
-  const investmentValues = openBets.map((bet) => {
+  const profits = openBets.map((bet) => {
     const { userId } = bet
-    const investmentValue = computeInvestmentValueForBet(bet, contract)
-    return { userId, payout: investmentValue }
+    if (contract.isResolved) {
+      return { userId: userId, payout: 0 }
+    }
+    const payout = getContractBetMetrics(contract, [bet]).payout
+    console.log({
+      userId: userId,
+      metrics: getContractBetMetrics(contract, [bet]),
+    })
+    return { userId: userId, payout: payout }
   })
 
   const netPayouts = [
     ...resolvePayouts,
     ...salePayouts,
     ...investments,
-    ...investmentValues,
+    ...profits,
   ]
 
   const userScore = mapValues(


### PR DESCRIPTION
Relevant task: https://www.notion.so/manifoldmarkets/Change-group-leaderboard-to-update-based-on-bet-value-in-unresolved-markets-1a55b41650a04d468225212bb49a11e7

@jahooma Please help me validate whether the math here is correct. 

Sanity-checking on Localhost seems to work. I printed out the values of investmentValues for each user, and it's what I expect. For any given contract, they match the sum of these two values, which I believe is what's expected:

<img width="368" alt="image" src="https://user-images.githubusercontent.com/6242616/188664809-88818143-e85c-45ce-9b4d-5830e28e19e0.png">

Looking at some example group leaderboards, it seems to be correct as well. For the group that contains the contract from the last image (the only one I bet on):

<img width="457" alt="image" src="https://user-images.githubusercontent.com/6242616/188665034-aefc52a4-bb01-4972-a98c-293c8d7b10a2.png">







