### PR TITLE
Make comments with bet outcome but no answer outcome appear

### DIFF
--- a/web/components/feed/contract-activity.tsx
+++ b/web/components/feed/contract-activity.tsx
@@ -126,7 +126,10 @@ export function FreeResponseContractCommentsActivity(props: {
     (answer) => -getOutcomeProbability(contract, answer.number.toString())
   )
   const commentsByUserId = groupBy(comments, (c) => c.userId)
-  const commentsByOutcome = groupBy(comments, (c) => c.answerOutcome ?? '_')
+  const commentsByOutcome = groupBy(
+    comments,
+    (c) => c.answerOutcome ?? c.betOutcome ?? '_'
+  )
 
   return (
     <>


### PR DESCRIPTION
Not sure what the deal with this is, but there are comments in the DB associated with a bet for outcome X, but which have no `answerOutcome` field. They should definitely be in the thread for that bet's answer.