### PR TITLE
Move comment-bet association code into comment creation trigger

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -102,6 +102,20 @@
     },
     {
       "collectionGroup": "comments",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdTime",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "comments",
       "queryScope": "COLLECTION_GROUP",
       "fields": [
         {

--- a/web/components/comment-input.tsx
+++ b/web/components/comment-input.tsx
@@ -16,17 +16,11 @@ export function CommentInput(props: {
   parentAnswerOutcome?: string
   // Reply to another comment
   parentCommentId?: string
-  onSubmitComment?: (editor: Editor, betId: string | undefined) => void
+  onSubmitComment?: (editor: Editor) => void
   className?: string
-  presetId?: string
 }) {
-  const {
-    parentAnswerOutcome,
-    parentCommentId,
-    replyToUser,
-    onSubmitComment,
-    presetId,
-  } = props
+  const { parentAnswerOutcome, parentCommentId, replyToUser, onSubmitComment } =
+    props
   const user = useUser()
 
   const { editor, upload } = useTextEditor({
@@ -40,10 +34,10 @@ export function CommentInput(props: {
 
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  async function submitComment(betId: string | undefined) {
+  async function submitComment() {
     if (!editor || editor.isEmpty || isSubmitting) return
     setIsSubmitting(true)
-    onSubmitComment?.(editor, betId)
+    onSubmitComment?.(editor)
     setIsSubmitting(false)
   }
 
@@ -65,7 +59,6 @@ export function CommentInput(props: {
           user={user}
           submitComment={submitComment}
           isSubmitting={isSubmitting}
-          presetId={presetId}
         />
       </div>
     </Row>
@@ -77,25 +70,17 @@ export function CommentInputTextArea(props: {
   replyToUser?: { id: string; username: string }
   editor: Editor | null
   upload: Parameters<typeof TextEditor>[0]['upload']
-  submitComment: (id?: string) => void
+  submitComment: () => void
   isSubmitting: boolean
-  presetId?: string
 }) {
-  const {
-    user,
-    editor,
-    upload,
-    submitComment,
-    presetId,
-    isSubmitting,
-    replyToUser,
-  } = props
+  const { user, editor, upload, submitComment, isSubmitting, replyToUser } =
+    props
   useEffect(() => {
     editor?.setEditable(!isSubmitting)
   }, [isSubmitting, editor])
 
   const submit = () => {
-    submitComment(presetId)
+    submitComment()
     editor?.commands?.clearContent()
   }
 
@@ -151,14 +136,14 @@ export function CommentInputTextArea(props: {
         )}
 
         {isSubmitting && (
-          <LoadingIndicator spinnerClassName={'border-gray-500'} />
+          <LoadingIndicator spinnerClassName="border-gray-500" />
         )}
       </TextEditor>
       <Row>
         {!user && (
           <button
-            className={'btn btn-outline btn-sm mt-2 normal-case'}
-            onClick={() => submitComment(presetId)}
+            className="btn btn-outline btn-sm mt-2 normal-case"
+            onClick={submitComment}
           >
             Add my comment
           </button>

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -59,7 +59,6 @@ export function ContractTabs(props: {
     />
   )
 
-  const generalBets = outcomeType === 'FREE_RESPONSE' ? [] : visibleBets
   const generalComments = comments.filter(
     (comment) =>
       comment.answerOutcome === undefined &&
@@ -71,36 +70,24 @@ export function ContractTabs(props: {
       <>
         <FreeResponseContractCommentsActivity
           contract={contract}
-          betsByCurrentUser={
-            user ? visibleBets.filter((b) => b.userId === user.id) : []
-          }
           comments={comments}
           tips={tips}
-          user={user}
         />
-        <Col className={'mt-8 flex w-full '}>
-          <div className={'text-md mt-8 mb-2 text-left'}>General Comments</div>
-          <div className={'mb-4 w-full border-b border-gray-200'} />
+        <Col className="mt-8 flex w-full">
+          <div className="text-md mt-8 mb-2 text-left">General Comments</div>
+          <div className="mb-4 w-full border-b border-gray-200" />
           <ContractCommentsActivity
             contract={contract}
-            betsByCurrentUser={
-              user ? generalBets.filter((b) => b.userId === user.id) : []
-            }
             comments={generalComments}
             tips={tips}
-            user={user}
           />
         </Col>
       </>
     ) : (
       <ContractCommentsActivity
         contract={contract}
-        betsByCurrentUser={
-          user ? visibleBets.filter((b) => b.userId === user.id) : []
-        }
         comments={comments}
         tips={tips}
-        user={user}
       />
     )
 
@@ -120,7 +107,7 @@ export function ContractTabs(props: {
 
   return (
     <Tabs
-      currentPageForAnalytics={'contract'}
+      currentPageForAnalytics="contract"
       tabs={[
         {
           title: 'Comments',

--- a/web/components/feed/contract-activity.tsx
+++ b/web/components/feed/contract-activity.tsx
@@ -8,7 +8,6 @@ import { FeedBet } from './feed-bets'
 import { FeedLiquidity } from './feed-liquidity'
 import { FeedAnswerCommentGroup } from './feed-answer-comment-group'
 import { FeedCommentThread, ContractCommentInput } from './feed-comments'
-import { User } from 'common/user'
 import { CommentTipMap } from 'web/hooks/use-tip-txns'
 import { LiquidityProvision } from 'common/liquidity-provision'
 import { groupBy, sortBy } from 'lodash'
@@ -72,13 +71,10 @@ export function ContractBetsActivity(props: {
 
 export function ContractCommentsActivity(props: {
   contract: Contract
-  betsByCurrentUser: Bet[]
   comments: ContractComment[]
   tips: CommentTipMap
-  user: User | null | undefined
 }) {
-  const { betsByCurrentUser, contract, comments, user, tips } = props
-  const commentsByUserId = groupBy(comments, (c) => c.userId)
+  const { contract, comments, tips } = props
   const commentsByParentId = groupBy(comments, (c) => c.replyToCommentId ?? '_')
   const topLevelComments = sortBy(
     commentsByParentId['_'] ?? [],
@@ -87,16 +83,10 @@ export function ContractCommentsActivity(props: {
 
   return (
     <>
-      <ContractCommentInput
-        className="mb-5"
-        contract={contract}
-        betsByCurrentUser={betsByCurrentUser}
-        commentsByCurrentUser={(user && commentsByUserId[user.id]) ?? []}
-      />
+      <ContractCommentInput className="mb-5" contract={contract} />
       {topLevelComments.map((parent) => (
         <FeedCommentThread
           key={parent.id}
-          user={user}
           contract={contract}
           parentComment={parent}
           threadComments={sortBy(
@@ -104,8 +94,6 @@ export function ContractCommentsActivity(props: {
             (c) => c.createdTime
           )}
           tips={tips}
-          betsByCurrentUser={betsByCurrentUser}
-          commentsByUserId={commentsByUserId}
         />
       ))}
     </>
@@ -114,18 +102,15 @@ export function ContractCommentsActivity(props: {
 
 export function FreeResponseContractCommentsActivity(props: {
   contract: FreeResponseContract
-  betsByCurrentUser: Bet[]
   comments: ContractComment[]
   tips: CommentTipMap
-  user: User | null | undefined
 }) {
-  const { betsByCurrentUser, contract, comments, user, tips } = props
+  const { contract, comments, tips } = props
 
   const sortedAnswers = sortBy(
     contract.answers,
     (answer) => -getOutcomeProbability(contract, answer.number.toString())
   )
-  const commentsByUserId = groupBy(comments, (c) => c.userId)
   const commentsByOutcome = groupBy(
     comments,
     (c) => c.answerOutcome ?? c.betOutcome ?? '_'
@@ -134,22 +119,19 @@ export function FreeResponseContractCommentsActivity(props: {
   return (
     <>
       {sortedAnswers.map((answer) => (
-        <div key={answer.id} className={'relative pb-4'}>
+        <div key={answer.id} className="relative pb-4">
           <span
             className="absolute top-5 left-5 -ml-px h-[calc(100%-2rem)] w-0.5 bg-gray-200"
             aria-hidden="true"
           />
           <FeedAnswerCommentGroup
             contract={contract}
-            user={user}
             answer={answer}
             answerComments={sortBy(
               commentsByOutcome[answer.number.toString()] ?? [],
               (c) => c.createdTime
             )}
             tips={tips}
-            betsByCurrentUser={betsByCurrentUser}
-            commentsByUserId={commentsByUserId}
           />
         </div>
       ))}

--- a/web/components/feed/feed-answer-comment-group.tsx
+++ b/web/components/feed/feed-answer-comment-group.tsx
@@ -1,5 +1,4 @@
 import { Answer } from 'common/answer'
-import { Bet } from 'common/bet'
 import { FreeResponseContract } from 'common/contract'
 import { ContractComment } from 'common/comment'
 import React, { useEffect, useState } from 'react'
@@ -14,7 +13,6 @@ import {
 } from 'web/components/feed/feed-comments'
 import { CopyLinkDateTimeComponent } from 'web/components/feed/copy-link-date-time'
 import { useRouter } from 'next/router'
-import { Dictionary } from 'lodash'
 import { User } from 'common/user'
 import { useEvent } from 'web/hooks/use-event'
 import { CommentTipMap } from 'web/hooks/use-tip-txns'
@@ -22,22 +20,11 @@ import { UserLink } from 'web/components/user-link'
 
 export function FeedAnswerCommentGroup(props: {
   contract: FreeResponseContract
-  user: User | undefined | null
   answer: Answer
   answerComments: ContractComment[]
   tips: CommentTipMap
-  betsByCurrentUser: Bet[]
-  commentsByUserId: Dictionary<ContractComment[]>
 }) {
-  const {
-    answer,
-    contract,
-    answerComments,
-    tips,
-    betsByCurrentUser,
-    commentsByUserId,
-    user,
-  } = props
+  const { answer, contract, answerComments, tips } = props
   const { username, avatarUrl, name, text } = answer
 
   const [replyToUser, setReplyToUser] =
@@ -47,7 +34,6 @@ export function FeedAnswerCommentGroup(props: {
   const router = useRouter()
 
   const answerElementId = `answer-${answer.id}`
-  const commentsByCurrentUser = (user && commentsByUserId[user.id]) ?? []
 
   const scrollAndOpenReplyInput = useEvent(
     (comment?: ContractComment, answer?: Answer) => {
@@ -133,8 +119,6 @@ export function FeedAnswerCommentGroup(props: {
           />
           <ContractCommentInput
             contract={contract}
-            betsByCurrentUser={betsByCurrentUser}
-            commentsByCurrentUser={commentsByCurrentUser}
             parentAnswerOutcome={answer.number.toString()}
             replyToUser={replyToUser}
             onSubmitComment={() => setShowReply(false)}

--- a/web/lib/firebase/comments.ts
+++ b/web/lib/firebase/comments.ts
@@ -35,17 +35,13 @@ export async function createCommentOnContract(
   contractId: string,
   content: JSONContent,
   user: User,
-  betId?: string,
   answerOutcome?: string,
   replyToCommentId?: string
 ) {
-  const ref = betId
-    ? doc(getCommentsCollection(contractId), betId)
-    : doc(getCommentsCollection(contractId))
+  const ref = doc(getCommentsCollection(contractId))
   const onContract = {
     commentType: 'contract',
     contractId,
-    betId,
     answerOutcome,
   } as OnContract
   return await createComment(


### PR DESCRIPTION
This is attractive because, as you can see by looking at the diff, it means that we don't have to thread down a ton of context about recent bets and recent comments into the comment posting UI, so it substantially simplifies the comment posting UI code and opens the door to further efficiency improvements.

The only functional difference between this code and the previous code is that the previous code would actually create comment documents with the same Firestore ID as their associated bet document (i.e. a comment associated with `contracts/ABC/bets/DEF` would go to document `contracts/ABC/comments/DEF`). This is cute but as far as I know we never made use of this property, and I am not sure why we would use it in the future instead of just querying by ID.