### PR TITLE
Kill counts of comments and trades on contract page

### DIFF
--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -47,9 +47,7 @@ export function ContractTabs(props: {
       l.amount > 0
   )
 
-  // Load comments here, so the badge count will be correct
-  const updatedComments = useComments(contract.id)
-  const comments = updatedComments ?? props.comments
+  const comments = useComments(contract.id) ?? props.comments
 
   const betActivity = lps != null && (
     <ContractBetsActivity
@@ -107,18 +105,10 @@ export function ContractTabs(props: {
 
   return (
     <Tabs
-      currentPageForAnalytics="contract"
+      currentPageForAnalytics={'contract'}
       tabs={[
-        {
-          title: 'Comments',
-          content: commentActivity,
-          badge: `${comments.length}`,
-        },
-        {
-          title: capitalize(PAST_BETS),
-          content: betActivity,
-          badge: `${visibleBets.length + visibleLps.length}`,
-        },
+        { title: 'Comments', content: commentActivity },
+        { title: capitalize(PAST_BETS), content: betActivity },
         ...(!user || !userBets?.length
           ? []
           : [


### PR DESCRIPTION
It's pretty bad to have to load all comments and bets to get these counts; it means we have to load everything without pagination, and means we can't render the tab control until the counts are in. (As opposed to if we leave the counts out, we can render the comments tab as soon as comments are in, and the bets tab as soon as the bets are in.) I plan on making changes shortly to contract page loading that are incompatible with having these counts.

If we really wanted these numbers, we could make some complicated triggers that track them, but I don't think they are important, so that seems like more work than it's worth.