### PR TITLE
Make comment position calculation more robust

### DIFF
--- a/common/calculate.ts
+++ b/common/calculate.ts
@@ -257,11 +257,6 @@ export function getTopAnswer(
 }
 
 export function getLargestPosition(contract: Contract, userBets: Bet[]) {
-  let yesFloorShares = 0,
-    yesShares = 0,
-    noShares = 0,
-    noFloorShares = 0
-
   if (userBets.length === 0) {
     return null
   }
@@ -286,12 +281,10 @@ export function getLargestPosition(contract: Contract, userBets: Bet[]) {
   }
 
   const [yesBets, noBets] = partition(userBets, (bet) => bet.outcome === 'YES')
-  yesShares = sumBy(yesBets, (bet) => bet.shares)
-  noShares = sumBy(noBets, (bet) => bet.shares)
-  yesFloorShares = Math.floor(yesShares)
-  noFloorShares = Math.floor(noShares)
-
-  const shares = yesFloorShares || noFloorShares
-  const outcome = yesFloorShares > noFloorShares ? 'YES' : 'NO'
-  return { shares, outcome }
+  const yesShares = sumBy(yesBets, (bet) => bet.shares)
+  const noShares = sumBy(noBets, (bet) => bet.shares)
+  return {
+    shares: Math.abs(yesShares - noShares),
+    outcome: yesShares > noShares ? 'YES' : 'NO',
+  }
 }

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -134,7 +134,7 @@ export function FeedComment(props: {
             commenterPositionProb != null &&
             commenterPositionOutcome != null &&
             commenterPositionShares != null &&
-            commenterPositionShares > 0 &&
+            Math.floor(commenterPositionShares) > 0 &&
             contract.outcomeType !== 'NUMERIC' && (
               <>
                 {'is '}


### PR DESCRIPTION
This fixes three issues with this code:

1. If someone had both YES and NO shares, then it now nets them out instead of only 'seeing' the larger of the two. (This probably shouldn't happen, but there's no reason for this code to break if it does.)
2. If someone has some number of YES shares and `0 - epsilon` NO shares due to floating point error, which is totally possible, the code now works correctly. Previously it would end up always looking at the NO shares, which would get floored to -1, and end up not displaying a position in the UI.
3. The binary branch is now consistent with the free response branch in that it correctly records in the DB the exact number of shares and leaves it up to the client to do rounding or hiding as it chooses, which makes more sense.