### PR TITLE
Move react-masonry-css dependency to web package.json

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -40,7 +40,6 @@
     "mailgun-js": "0.22.0",
     "module-alias": "2.2.2",
     "node-fetch": "2",
-    "react-masonry-css": "1.0.16",
     "stripe": "8.194.0",
     "zod": "3.17.2"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -58,6 +58,7 @@
     "react-instantsearch-hooks-web": "6.24.1",
     "react-query": "3.39.0",
     "react-twitter-embed": "4.0.4",
+    "react-masonry-css": "1.0.16",
     "string-similarity": "^4.0.4",
     "tippy.js": "6.3.7"
   },


### PR DESCRIPTION
This was just in the wrong one for no particular reason.