### PR TITLE
Remove images config from next.config.js

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -9,9 +9,6 @@ module.exports = {
   reactStrictMode: true,
   optimizeFonts: false,
   experimental: {
-    images: {
-      allowFutureImage: true,
-    },
     scrollRestoration: true,
     externalDir: true,
     modularizeImports: {


### PR DESCRIPTION
This is no longer a thing, the future/image component is present by default in 12.3.

https://nextjs.org/blog/next-12-3#nextfutureimage-component-stable