### PR TITLE
Fix some rendering issues on contract page

### DIFF
--- a/web/components/amount-input.tsx
+++ b/web/components/amount-input.tsx
@@ -5,7 +5,7 @@ import { formatMoney } from 'common/util/format'
 import { Col } from './layout/col'
 import { SiteLink } from './site-link'
 import { ENV_CONFIG } from 'common/envs/constants'
-import { useWindowSize } from 'web/hooks/use-window-size'
+import { useIsMobile } from 'web/hooks/use-is-mobile'
 
 export function AmountInput(props: {
   amount: number | undefined
@@ -34,8 +34,7 @@ export function AmountInput(props: {
     const isInvalid = !str || isNaN(amount)
     onChange(isInvalid ? undefined : amount)
   }
-  const { width } = useWindowSize()
-  const isMobile = (width ?? 0) < 768
+  const isMobile = useIsMobile(768)
   return (
     <Col className={className}>
       <label className="input-group mb-4">

--- a/web/components/bets-list.tsx
+++ b/web/components/bets-list.tsx
@@ -610,18 +610,24 @@ function BetRow(props: {
   const isNumeric = outcomeType === 'NUMERIC'
   const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
 
-  const saleAmount = saleBet?.sale?.amount
+  // calculateSaleAmount is very slow right now so that's why we memoized this
+  const payout = useMemo(() => {
+    const saleBetAmount = saleBet?.sale?.amount
+    if (saleBetAmount) {
+      return saleBetAmount
+    } else if (contract.isResolved) {
+      return resolvedPayout(contract, bet)
+    } else {
+      return calculateSaleAmount(contract, bet, unfilledBets)
+    }
+  }, [contract, bet, saleBet, unfilledBets])
 
   const saleDisplay = isAnte ? (
     'ANTE'
-  ) : saleAmount !== undefined ? (
-    <>{formatMoney(saleAmount)} (sold)</>
+  ) : saleBet ? (
+    <>{formatMoney(payout)} (sold)</>
   ) : (
-    formatMoney(
-      isResolved
-        ? resolvedPayout(contract, bet)
-        : calculateSaleAmount(contract, bet, unfilledBets)
-    )
+    formatMoney(payout)
   )
 
   const payoutIfChosenDisplay =

--- a/web/hooks/use-is-mobile.ts
+++ b/web/hooks/use-is-mobile.ts
@@ -1,7 +1,13 @@
-import { useWindowSize } from 'web/hooks/use-window-size'
+import { useEffect, useState } from 'react'
 
-// matches talwind sm breakpoint
 export function useIsMobile() {
-  const { width } = useWindowSize()
-  return (width ?? 0) < 640
+  const [isMobile, setIsMobile] = useState<boolean>()
+  useEffect(() => {
+    // matches tailwind sm breakpoint
+    const onResize = () => setIsMobile(window.innerWidth < 640)
+    onResize()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+  return isMobile
 }

--- a/web/hooks/use-is-mobile.ts
+++ b/web/hooks/use-is-mobile.ts
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react'
 
-export function useIsMobile() {
+export function useIsMobile(threshold?: number) {
   const [isMobile, setIsMobile] = useState<boolean>()
   useEffect(() => {
-    // matches tailwind sm breakpoint
-    const onResize = () => setIsMobile(window.innerWidth < 640)
+    // 640 matches tailwind sm breakpoint
+    const onResize = () => setIsMobile(window.innerWidth < (threshold ?? 640))
     onResize()
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
-  }, [])
+  }, [threshold])
   return isMobile
 }


### PR DESCRIPTION
These are random things that were causing re-rendering on window resize, so they were very unpleasant. Now re-rendering on resize doesn't happen unless something actually needs to be re-rendered (e.g. layout transitions between mobile and desktop, or recommended contracts column count changes), **_except_** for the probability graph, which re-renders on every resize and makes everything feel laggy and slow. But I'm going to rewrite the whole graph shortly so I'm not going to bother fixing that.