### PR TITLE
add to queue rather than invoking sprig object directly, as it's still being setup

### DIFF
--- a/web/lib/service/sprig.ts
+++ b/web/lib/service/sprig.ts
@@ -25,9 +25,9 @@ try {
 }
 
 export function setUserId(userId: string): void {
-  window.Sprig.setUserId(userId)
+  window.Sprig('setUserId', userId)
 }
 
 export function setAttributes(attributes: Record<string, unknown>): void {
-  window.Sprig.setAttributes(attributes)
+  window.Sprig('setAttributes', attributes)
 }


### PR DESCRIPTION
didn't read our own docs carefully enough and forgot about this issue

it's causing the initial "identify the user with their id/email" call to fail
<img width="1066" alt="Screen Shot 2022-09-27 at 10 10 55 AM" src="https://user-images.githubusercontent.com/6895446/192592880-752de688-9f4e-4fe4-9ace-52cbeb578eea.png">

see the "html script tag" variation here https://docs.sprig.com/docs/web-javascript#values
