### PR TITLE
Hack up brush rendering to fix possible Chrome bug

### DIFF
--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -150,7 +150,13 @@ export const SVGChart = <X, Y>(props: {
           justSelected.current = false
         }
       })
-      select(overlayRef.current).call(brush)
+      // mqp: shape-rendering null overrides the default d3-brush shape-rendering
+      // of `crisp-edges`, which seems to cause graphical glitches on Chrome
+      // (i.e. the bug where the area fill flickers white)
+      select(overlayRef.current)
+        .call(brush)
+        .select('.selection')
+        .attr('shape-rendering', 'null')
     }
   }, [innerW, innerH, onSelect])
 


### PR DESCRIPTION
This may fix the "white chart area" bug that people were reporting to me, where part of the chart turns white while selecting a time range with the brush. I was able to reproduce a similar phenomenon using Chrome on my Linux ThinkPad and this fixed it.

I don't really have any hypothesis for what might be going wrong, I suspect it's probably some difficult-to-fathom Chrome bug. It certainly doesn't make any logical sense that this brush rectangle could have something to do with the entire fill of the chart path.