### PR TITLE
Clean up chart tooltip handling

### DIFF
--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -32,7 +32,8 @@ const getBetPoints = (bets: Bet[]) => {
 }
 
 const BinaryChartTooltip = (props: SingleValueHistoryTooltipProps<Bet>) => {
-  const { x, y, xScale, datum } = props
+  const { p, xScale } = props
+  const { x, y, datum } = p
   const [start, end] = xScale.domain()
   return (
     <Row className="items-center gap-2 text-sm">

--- a/web/components/charts/contract/choice.tsx
+++ b/web/components/charts/contract/choice.tsx
@@ -162,7 +162,8 @@ export const ChoiceContractChart = (props: {
 
   const ChoiceTooltip = useMemo(
     () => (props: MultiValueHistoryTooltipProps<Bet>) => {
-      const { x, y, xScale, datum } = props
+      const { p, xScale } = props
+      const { x, y, datum } = p
       const [start, end] = xScale.domain()
       const legendItems = sortBy(
         y.map((p, i) => ({

--- a/web/components/charts/contract/numeric.tsx
+++ b/web/components/charts/contract/numeric.tsx
@@ -25,7 +25,8 @@ const getNumericChartData = (contract: NumericContract) => {
 }
 
 const NumericChartTooltip = (props: SingleValueDistributionTooltipProps) => {
-  const { x, y } = props
+  const { p } = props
+  const { x, y } = p
   return (
     <span className="text-sm">
       <strong>{formatPct(y, 2)}</strong> {formatLargeNumber(x)}

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -46,7 +46,8 @@ const getBetPoints = (bets: Bet[], scaleP: (p: number) => number) => {
 const PseudoNumericChartTooltip = (
   props: SingleValueHistoryTooltipProps<Bet>
 ) => {
-  const { x, y, xScale, datum } = props
+  const { p, xScale } = props
+  const { x, y, datum } = p
   const [start, end] = xScale.domain()
   return (
     <Row className="items-center gap-2 text-sm">


### PR DESCRIPTION
Now that we moved the tooltip rendering logic out (#958), `SVGChart` can do all the tooltip display logic for charts and the different charts in `generic-charts` don't have to reimplement it for themselves.