### PR TITLE
Fix date memoization in charts

### DIFF
--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -49,24 +49,24 @@ export const BinaryContractChart = (props: {
   onMouseOver?: (p: HistoryPoint<Bet> | undefined) => void
 }) => {
   const { contract, bets, onMouseOver } = props
-  const [startDate, endDate] = getDateRange(contract)
+  const [start, end] = getDateRange(contract)
   const startP = getInitialProbability(contract)
   const endP = getProbability(contract)
   const betPoints = useMemo(() => getBetPoints(bets), [bets])
   const data = useMemo(() => {
     return [
-      { x: new Date(startDate), y: startP },
+      { x: new Date(start), y: startP },
       ...betPoints,
-      { x: new Date(endDate ?? Date.now() + DAY_MS), y: endP },
+      { x: new Date(end ?? Date.now() + DAY_MS), y: endP },
     ]
-  }, [startDate, startP, endDate, endP, betPoints])
+  }, [start, startP, end, endP, betPoints])
 
   const rightmostDate = getRightmostVisibleDate(
-    endDate ? new Date(endDate) : null,
-    last(betPoints)?.x,
-    new Date(Date.now())
+    end,
+    last(betPoints)?.x?.getTime(),
+    Date.now()
   )
-  const visibleRange = [startDate, rightmostDate]
+  const visibleRange = [start, rightmostDate]
   const isMobile = useIsMobile(800)
   const containerRef = useRef<HTMLDivElement>(null)
   const width = useElementWidth(containerRef) ?? 0

--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -55,14 +55,14 @@ export const BinaryContractChart = (props: {
   const betPoints = useMemo(() => getBetPoints(bets), [bets])
   const data = useMemo(() => {
     return [
-      { x: startDate, y: startP },
+      { x: new Date(startDate), y: startP },
       ...betPoints,
-      { x: endDate ?? new Date(Date.now() + DAY_MS), y: endP },
+      { x: new Date(endDate ?? Date.now() + DAY_MS), y: endP },
     ]
   }, [startDate, startP, endDate, endP, betPoints])
 
   const rightmostDate = getRightmostVisibleDate(
-    endDate,
+    endDate ? new Date(endDate) : null,
     last(betPoints)?.x,
     new Date(Date.now())
   )

--- a/web/components/charts/contract/choice.tsx
+++ b/web/components/charts/contract/choice.tsx
@@ -136,17 +136,17 @@ export const ChoiceContractChart = (props: {
   const betPoints = useMemo(() => getBetPoints(answers, bets), [answers, bets])
   const data = useMemo(
     () => [
-      { x: start, y: answers.map((_) => 0) },
+      { x: new Date(start), y: answers.map((_) => 0) },
       ...betPoints,
       {
-        x: end ?? new Date(Date.now() + DAY_MS),
+        x: new Date(end ?? Date.now() + DAY_MS),
         y: answers.map((a) => getOutcomeProbability(contract, a.id)),
       },
     ],
     [answers, contract, betPoints, start, end]
   )
   const rightmostDate = getRightmostVisibleDate(
-    end,
+    end ? new Date(end) : null,
     last(betPoints)?.x,
     new Date(Date.now())
   )

--- a/web/components/charts/contract/choice.tsx
+++ b/web/components/charts/contract/choice.tsx
@@ -146,9 +146,9 @@ export const ChoiceContractChart = (props: {
     [answers, contract, betPoints, start, end]
   )
   const rightmostDate = getRightmostVisibleDate(
-    end ? new Date(end) : null,
-    last(betPoints)?.x,
-    new Date(Date.now())
+    end,
+    last(betPoints)?.x?.getTime(),
+    Date.now()
   )
   const visibleRange = [start, rightmostDate]
   const isMobile = useIsMobile(800)

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -62,7 +62,7 @@ export const PseudoNumericContractChart = (props: {
 }) => {
   const { contract, bets, onMouseOver } = props
   const { min, max, isLogScale } = contract
-  const [startDate, endDate] = getDateRange(contract)
+  const [start, end] = getDateRange(contract)
   const scaleP = useMemo(
     () => getScaleP(min, max, isLogScale),
     [min, max, isLogScale]
@@ -72,18 +72,18 @@ export const PseudoNumericContractChart = (props: {
   const betPoints = useMemo(() => getBetPoints(bets, scaleP), [bets, scaleP])
   const data = useMemo(
     () => [
-      { x: new Date(startDate), y: startP },
+      { x: new Date(start), y: startP },
       ...betPoints,
-      { x: new Date(endDate ?? Date.now() + DAY_MS), y: endP },
+      { x: new Date(end ?? Date.now() + DAY_MS), y: endP },
     ],
-    [betPoints, startDate, startP, endDate, endP]
+    [betPoints, start, startP, end, endP]
   )
   const rightmostDate = getRightmostVisibleDate(
-    endDate ? new Date(endDate) : null,
-    last(betPoints)?.x,
-    new Date(Date.now())
+    end,
+    last(betPoints)?.x?.getTime(),
+    Date.now()
   )
-  const visibleRange = [startDate, rightmostDate]
+  const visibleRange = [start, rightmostDate]
   const isMobile = useIsMobile(800)
   const containerRef = useRef<HTMLDivElement>(null)
   const width = useElementWidth(containerRef) ?? 0

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -72,14 +72,14 @@ export const PseudoNumericContractChart = (props: {
   const betPoints = useMemo(() => getBetPoints(bets, scaleP), [bets, scaleP])
   const data = useMemo(
     () => [
-      { x: startDate, y: startP },
+      { x: new Date(startDate), y: startP },
       ...betPoints,
-      { x: endDate ?? new Date(Date.now() + DAY_MS), y: endP },
+      { x: new Date(endDate ?? Date.now() + DAY_MS), y: endP },
     ],
     [betPoints, startDate, startP, endDate, endP]
   )
   const rightmostDate = getRightmostVisibleDate(
-    endDate,
+    endDate ? new Date(endDate) : null,
     last(betPoints)?.x,
     new Date(Date.now())
   )

--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -259,7 +259,7 @@ export const getDateRange = (contract: Contract) => {
   const { createdTime, closeTime, resolutionTime } = contract
   const isClosed = !!closeTime && Date.now() > closeTime
   const endDate = resolutionTime ?? (isClosed ? closeTime : null)
-  return [new Date(createdTime), endDate ? new Date(endDate) : null] as const
+  return [createdTime, endDate ?? null] as const
 }
 
 export const getRightmostVisibleDate = (

--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -263,15 +263,15 @@ export const getDateRange = (contract: Contract) => {
 }
 
 export const getRightmostVisibleDate = (
-  contractEnd: Date | null | undefined,
-  lastActivity: Date | null | undefined,
-  now: Date
+  contractEnd: number | null | undefined,
+  lastActivity: number | null | undefined,
+  now: number
 ) => {
   if (contractEnd != null) {
     return contractEnd
   } else if (lastActivity != null) {
     // client-DB clock divergence may cause last activity to be later than now
-    return new Date(Math.max(lastActivity.getTime(), now.getTime()))
+    return Math.max(lastActivity, now)
   } else {
     return now
   }


### PR DESCRIPTION
TIL that `new Date(1234) !== new Date(1234)`. So we have to keep them as numbers to make `useMemo` work well. This is for the case where some stuff changes in a contract but we don't need to recompute any data points for the chart.