### PR TITLE
Mark scripts as modules to avoid global name collision

### DIFF
--- a/functions/src/scripts/contest/bulk-add-liquidity.ts
+++ b/functions/src/scripts/contest/bulk-add-liquidity.ts
@@ -50,3 +50,5 @@ async function main() {
   }
 }
 main()
+
+export {}

--- a/functions/src/scripts/contest/bulk-resolve-markets.ts
+++ b/functions/src/scripts/contest/bulk-resolve-markets.ts
@@ -61,3 +61,5 @@ async function main() {
   }
 }
 main()
+
+export {}


### PR DESCRIPTION
@akrolsmir randomly checked this in busted and broke the build.