### PR TITLE
Inga/multiple colors

### DIFF
--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -215,7 +215,7 @@ function OpenAnswer(props: {
         <Row className="z-20 -mb-1 justify-between gap-2 py-2 px-3">
           <Row>
             <Avatar
-              className="mr-2 inline h-5 w-5 border border-transparent transition-transform hover:border-none"
+              className="mt-0.5 mr-2 inline h-5 w-5 border border-transparent transition-transform hover:border-none"
               username={username}
               avatarUrl={avatarUrl}
             />

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -210,7 +210,7 @@ function OpenAnswer(props: {
       </Modal>
 
       <Col
-        className="hover:bg-greyscale-1.5 bg-greyscale-1 relative w-full rounded-lg transition-colors"
+        className="bg-greyscale-1 relative w-full rounded-lg drop-shadow-sm transition-all hover:drop-shadow-md"
         onClick={() => setOpen(true)}
       >
         <Row className="z-20 -mb-1 justify-between py-2 px-3">
@@ -223,16 +223,20 @@ function OpenAnswer(props: {
               />
             </span>
             <Linkify
-              className="text-md cursor-pointer whitespace-pre-line"
+              className={clsx(
+                'text-md cursor-pointer whitespace-pre-line',
+                tradingAllowed(contract)
+                  ? 'text-greyscale-7'
+                  : 'text-greyscale-6'
+              )}
               text={text}
             />
           </div>
           <div
             className={clsx(
-              'my-auto text-xl '
-              // tradingAllowed(contract) ? 'text-greyscale-7' : 'text-gray-500'
+              'my-auto text-xl ',
+              tradingAllowed(contract) ? 'text-greyscale-7' : 'text-greyscale-6'
             )}
-            color={color}
           >
             {probPercent}
           </div>
@@ -243,16 +247,6 @@ function OpenAnswer(props: {
           style={{ width: `${100 * Math.max(prob, 0.01)}%` }}
         />
       </Col>
-      {/* <Row className="align-items justify-end gap-4">
-          <Button
-            className={clsx(tradingAllowed(contract) ? '' : '!hidden')}
-            color="gray"
-            size="xs"
-            onClick={() => setOpen(true)}
-          >
-            Buy
-          </Button>
-        </Row> */}
     </Col>
   )
 }

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -209,35 +209,33 @@ function OpenAnswer(props: {
       <Col
         className={clsx(
           'bg-greyscale-1 relative w-full rounded-lg transition-all',
-          tradingAllowed(contract)
-            ? 'text-greyscale-7'
-            : 'text-greyscale-5 pointer-events-none'
+          tradingAllowed(contract) ? 'text-greyscale-7' : 'text-greyscale-5'
         )}
       >
         <Row className="z-20 -mb-1 justify-between gap-2 py-2 px-3">
-          <div>
-            <span>
-              <Avatar
-                className="mr-2 inline h-5 w-5 border border-transparent transition-transform hover:border-none"
-                username={username}
-                avatarUrl={avatarUrl}
-              />
-            </span>
+          <Row>
+            <Avatar
+              className="mr-2 inline h-5 w-5 border border-transparent transition-transform hover:border-none"
+              username={username}
+              avatarUrl={avatarUrl}
+            />
             <Linkify
               className="text-md cursor-pointer whitespace-pre-line"
               text={text}
             />
-          </div>
+          </Row>
           <Row className="gap-2">
             <div className="my-auto text-xl">{probPercent}</div>
-            <Button
-              size="2xs"
-              color="gray-outline"
-              onClick={() => setOpen(true)}
-              className="my-auto"
-            >
-              BUY
-            </Button>
+            {tradingAllowed(contract) && (
+              <Button
+                size="2xs"
+                color="gray-outline"
+                onClick={() => setOpen(true)}
+                className="my-auto"
+              >
+                BUY
+              </Button>
+            )}
           </Row>
         </Row>
         <hr

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -207,7 +207,12 @@ function OpenAnswer(props: {
       </Modal>
 
       <Col
-        className="bg-greyscale-1 relative w-full rounded-lg drop-shadow-sm transition-all hover:drop-shadow-md"
+        className={clsx(
+          'bg-greyscale-1 relative w-full rounded-lg transition-all',
+          tradingAllowed(contract)
+            ? 'text-greyscale-7 drop-shadow-sm hover:drop-shadow-md'
+            : 'text-greyscale-5 pointer-events-none'
+        )}
         onClick={() => setOpen(true)}
       >
         <Row className="z-20 -mb-1 justify-between py-2 px-3">
@@ -220,23 +225,11 @@ function OpenAnswer(props: {
               />
             </span>
             <Linkify
-              className={clsx(
-                'text-md cursor-pointer whitespace-pre-line',
-                tradingAllowed(contract)
-                  ? 'text-greyscale-7'
-                  : 'text-greyscale-6'
-              )}
+              className="text-md cursor-pointer whitespace-pre-line"
               text={text}
             />
           </div>
-          <div
-            className={clsx(
-              'my-auto text-xl ',
-              tradingAllowed(contract) ? 'text-greyscale-7' : 'text-greyscale-6'
-            )}
-          >
-            {probPercent}
-          </div>
+          <div className="my-auto text-xl">{probPercent}</div>
         </Row>
         <hr
           color={color}

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -198,7 +198,7 @@ function OpenAnswer(props: {
     colorIndex != undefined ? CATEGORY_COLORS[colorIndex] : '#B1B1C7'
 
   return (
-    <>
+    <Col className="my-1 px-2">
       <Modal open={open} setOpen={setOpen} position="center">
         <AnswerBetPanel
           answer={answer}
@@ -210,31 +210,26 @@ function OpenAnswer(props: {
       </Modal>
 
       <Col
-        className="hover:bg-greyscale-1.5 w-full rounded-lg py-1 px-4"
+        className="hover:bg-greyscale-1.5 bg-greyscale-1 relative w-full rounded-lg transition-colors"
         onClick={() => setOpen(true)}
       >
-        <Row className="-mb-1 pr-[60px]">
-          <Avatar
-            className="mt-1 mr-2 h-4 w-4"
-            username={username}
-            avatarUrl={avatarUrl}
-          />
-          <Linkify
-            className="text-md whitespace-pre-line md:text-lg"
-            text={text}
-          />
-        </Row>
-        <Row className="gap-2">
-          {/* <div className="relative h-3 w-[calc(100%-60px)]"> */}
-          {/* <hr className="border-greyscale-2 absolute z-0 mt-2 h-3 w-full rounded-full border bg-white" /> */}
-          <hr
-            color={color}
-            className="mt-1 h-3 w-full rounded-l-full border-none"
-            style={{ width: `${100 * Math.max(prob, 0.01)}%` }}
-          />
+        <Row className="z-20 -mb-1 justify-between py-2 px-3">
+          <div>
+            <span>
+              <Avatar
+                className="mr-2 inline h-5 w-5 border border-transparent transition-transform hover:border-none"
+                username={username}
+                avatarUrl={avatarUrl}
+              />
+            </span>
+            <Linkify
+              className="text-md cursor-pointer whitespace-pre-line"
+              text={text}
+            />
+          </div>
           <div
             className={clsx(
-              'md:text-md my-auto text-sm'
+              'my-auto text-xl '
               // tradingAllowed(contract) ? 'text-greyscale-7' : 'text-gray-500'
             )}
             color={color}
@@ -242,6 +237,11 @@ function OpenAnswer(props: {
             {probPercent}
           </div>
         </Row>
+        <hr
+          color={color}
+          className="absolute z-0 h-full w-full rounded-l-lg border-none opacity-30"
+          style={{ width: `${100 * Math.max(prob, 0.01)}%` }}
+        />
       </Col>
       {/* <Row className="align-items justify-end gap-4">
           <Button
@@ -253,6 +253,6 @@ function OpenAnswer(props: {
             Buy
           </Button>
         </Row> */}
-    </>
+    </Col>
   )
 }

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -20,13 +20,11 @@ import { AnswerBetPanel } from 'web/components/answers/answer-bet-panel'
 import { Row } from 'web/components/layout/row'
 import { Avatar } from 'web/components/avatar'
 import { Linkify } from 'web/components/linkify'
-import { BuyButton } from 'web/components/yes-no-selector'
-import { UserLink } from 'web/components/user-link'
 import { Button } from 'web/components/button'
 import { useAdmin } from 'web/hooks/use-admin'
 import { needsAdminToResolve } from 'web/pages/[username]/[contractSlug]'
 import { CATEGORY_COLORS } from '../charts/contract/choice'
-import { getChartAnswers } from '../charts/contract/choice'
+import { useChartAnswers } from '../charts/contract/choice'
 
 export function AnswersPanel(props: {
   contract: FreeResponseContract | MultipleChoiceContract
@@ -107,10 +105,9 @@ export function AnswersPanel(props: {
     ? 'checkbox'
     : undefined
 
-  const colorSortedAnswer = getChartAnswers(
-    contract,
-    CATEGORY_COLORS.length
-  ).map((value, index) => value.text)
+  const colorSortedAnswer = useChartAnswers(contract).map(
+    (value, _index) => value.text
+  )
 
   return (
     <Col className="gap-3">
@@ -190,7 +187,7 @@ function OpenAnswer(props: {
   colorIndex: number | undefined
 }) {
   const { answer, contract, colorIndex } = props
-  const { username, avatarUrl, name, text } = answer
+  const { username, avatarUrl, text } = answer
   const prob = getDpmOutcomeProbability(contract.totalShares, answer.id)
   const probPercent = formatPercent(prob)
   const [open, setOpen] = useState(false)

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -210,12 +210,11 @@ function OpenAnswer(props: {
         className={clsx(
           'bg-greyscale-1 relative w-full rounded-lg transition-all',
           tradingAllowed(contract)
-            ? 'text-greyscale-7 drop-shadow-sm hover:drop-shadow-md'
+            ? 'text-greyscale-7'
             : 'text-greyscale-5 pointer-events-none'
         )}
-        onClick={() => setOpen(true)}
       >
-        <Row className="z-20 -mb-1 justify-between py-2 px-3">
+        <Row className="z-20 -mb-1 justify-between gap-2 py-2 px-3">
           <div>
             <span>
               <Avatar
@@ -229,7 +228,17 @@ function OpenAnswer(props: {
               text={text}
             />
           </div>
-          <div className="my-auto text-xl">{probPercent}</div>
+          <Row className="gap-2">
+            <div className="my-auto text-xl">{probPercent}</div>
+            <Button
+              size="2xs"
+              color="gray-outline"
+              onClick={() => setOpen(true)}
+              className="my-auto"
+            >
+              BUY
+            </Button>
+          </Row>
         </Row>
         <hr
           color={color}

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -182,7 +182,7 @@ function OpenAnswer(props: {
   const [open, setOpen] = useState(false)
 
   return (
-    <Col className="border-base-200 bg-base-200 relative flex-1 rounded-md px-2">
+    <>
       <Modal open={open} setOpen={setOpen} position="center">
         <AnswerBetPanel
           answer={answer}
@@ -193,40 +193,46 @@ function OpenAnswer(props: {
         />
       </Modal>
 
-      <div
-        className="pointer-events-none absolute -mx-2 h-full rounded-tl-md bg-green-600 bg-opacity-10"
-        style={{ width: `${100 * Math.max(prob, 0.01)}%` }}
-      />
-
-      <Row className="my-4 gap-3">
-        <Avatar className="mx-1" username={username} avatarUrl={avatarUrl} />
-        <Col className="min-w-0 flex-1 lg:gap-1">
-          <div className="text-sm text-gray-500">
-            <UserLink username={username} name={name} /> answered
+      <Row className="justify-between">
+        <Col className="w-4/5">
+          <Row>
+            <Avatar
+              className="my-auto mr-2 h-5 w-5"
+              username={username}
+              avatarUrl={avatarUrl}
+            />
+            <Linkify
+              className="text-md whitespace-pre-line md:text-lg"
+              text={text}
+            />
+          </Row>
+          <div className="relative h-3">
+            <hr className="bg-greyscale-2 absolute z-0 h-3 w-full rounded-full" />
+            <hr
+              className="absolute z-20 h-3 rounded-l-full bg-green-600 text-green-600"
+              style={{ width: `${100 * Math.max(prob, 0.01)}%` }}
+            />
           </div>
-
-          <Col className="align-items justify-between gap-4 sm:flex-row">
-            <Linkify className="whitespace-pre-line text-lg" text={text} />
-            <Row className="align-items items-center justify-end gap-4">
-              <span
-                className={clsx(
-                  'text-2xl',
-                  tradingAllowed(contract) ? 'text-primary' : 'text-gray-500'
-                )}
-              >
-                {probPercent}
-              </span>
-              <BuyButton
-                className={clsx(
-                  'btn-sm flex-initial !px-6 sm:flex',
-                  tradingAllowed(contract) ? '' : '!hidden'
-                )}
-                onClick={() => setOpen(true)}
-              />
-            </Row>
-          </Col>
         </Col>
+        <Row className="align-items items-center justify-end gap-4">
+          <span
+            className={clsx(
+              'text-2xl',
+              tradingAllowed(contract) ? 'text-greyscale-7' : 'text-gray-500'
+            )}
+          >
+            {probPercent}
+          </span>
+          <Button
+            className={clsx(tradingAllowed(contract) ? '' : '!hidden')}
+            color="indigo"
+            size="xs"
+            onClick={() => setOpen(true)}
+          >
+            Buy
+          </Button>
+        </Row>
       </Row>
-    </Col>
+    </>
   )
 }

--- a/web/components/button.tsx
+++ b/web/components/button.tsx
@@ -10,6 +10,7 @@ export type ColorType =
   | 'indigo'
   | 'yellow'
   | 'gray'
+  | 'gray-outline'
   | 'gradient'
   | 'gray-white'
   | 'highlight-blue'
@@ -63,6 +64,8 @@ export function Button(props: {
           'disabled:bg-greyscale-2 bg-indigo-500 text-white hover:bg-indigo-600',
         color === 'gray' &&
           'bg-greyscale-1 text-greyscale-6 hover:bg-greyscale-2 disabled:opacity-50',
+        color === 'gray-outline' &&
+          'border-greyscale-4 text-greyscale-4 hover:bg-greyscale-4 border-2 hover:text-white disabled:opacity-50',
         color === 'gradient' &&
           'disabled:bg-greyscale-2 border-none bg-gradient-to-r from-indigo-500 to-blue-500 text-white hover:from-indigo-700 hover:to-blue-700',
         color === 'gray-white' &&

--- a/web/components/charts/contract/choice.tsx
+++ b/web/components/charts/contract/choice.tsx
@@ -142,9 +142,8 @@ const Legend = (props: { className?: string; items: LegendItem[] }) => {
   )
 }
 
-export function getChartAnswers(
-  contract: FreeResponseContract | MultipleChoiceContract,
-  length: number
+export function useChartAnswers(
+  contract: FreeResponseContract | MultipleChoiceContract
 ) {
   return useMemo(
     () => getTrackedAnswers(contract, CATEGORY_COLORS.length),
@@ -161,11 +160,7 @@ export const ChoiceContractChart = (props: {
 }) => {
   const { contract, bets, width, height, onMouseOver } = props
   const [start, end] = getDateRange(contract)
-  // const answers = useMemo(
-  //   () => getTrackedAnswers(contract, CATEGORY_COLORS.length),
-  //   [contract]
-  // )
-  const answers = getChartAnswers(contract, CATEGORY_COLORS.length)
+  const answers = useChartAnswers(contract)
   const betPoints = useMemo(() => getBetPoints(answers, bets), [answers, bets])
   const data = useMemo(
     () => [

--- a/web/components/charts/contract/choice.tsx
+++ b/web/components/charts/contract/choice.tsx
@@ -22,7 +22,7 @@ import { Row } from 'web/components/layout/row'
 import { Avatar } from 'web/components/avatar'
 
 // thanks to https://observablehq.com/@jonhelfman/optimal-orders-for-choosing-categorical-colors
-const CATEGORY_COLORS = [
+export const CATEGORY_COLORS = [
   '#00b8dd',
   '#eecafe',
   '#874c62',
@@ -142,6 +142,16 @@ const Legend = (props: { className?: string; items: LegendItem[] }) => {
   )
 }
 
+export function getChartAnswers(
+  contract: FreeResponseContract | MultipleChoiceContract,
+  length: number
+) {
+  return useMemo(
+    () => getTrackedAnswers(contract, CATEGORY_COLORS.length),
+    [contract]
+  )
+}
+
 export const ChoiceContractChart = (props: {
   contract: FreeResponseContract | MultipleChoiceContract
   bets: Bet[]
@@ -151,10 +161,11 @@ export const ChoiceContractChart = (props: {
 }) => {
   const { contract, bets, width, height, onMouseOver } = props
   const [start, end] = getDateRange(contract)
-  const answers = useMemo(
-    () => getTrackedAnswers(contract, CATEGORY_COLORS.length),
-    [contract]
-  )
+  // const answers = useMemo(
+  //   () => getTrackedAnswers(contract, CATEGORY_COLORS.length),
+  //   [contract]
+  // )
+  const answers = getChartAnswers(contract, CATEGORY_COLORS.length)
   const betPoints = useMemo(() => getBetPoints(answers, bets), [answers, bets])
   const data = useMemo(
     () => [

--- a/web/components/yes-no-selector.tsx
+++ b/web/components/yes-no-selector.tsx
@@ -244,7 +244,7 @@ function Button(props: {
       type="button"
       className={clsx(
         'inline-flex flex-1 items-center justify-center rounded-md border border-transparent px-8 py-3 font-medium shadow-sm',
-        color === 'green' && 'bg-teal-500 bg-teal-600 text-white',
+        color === 'green' && 'bg-teal-500 text-white hover:bg-teal-600',
         color === 'red' && 'bg-red-400 text-white hover:bg-red-500',
         color === 'yellow' && 'bg-yellow-400 text-white hover:bg-yellow-500',
         color === 'blue' && 'bg-blue-400 text-white hover:bg-blue-500',

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -18,6 +18,7 @@ module.exports = {
       colors: {
         'red-25': '#FDF7F6',
         'greyscale-1': '#FBFBFF',
+        'greyscale-1.5': '#F4F4FB',
         'greyscale-2': '#E7E7F4',
         'greyscale-3': '#D8D8EB',
         'greyscale-4': '#B1B1C7',


### PR DESCRIPTION
<img width="832" alt="Screen Shot 2022-10-04 at 1 49 20 AM" src="https://user-images.githubusercontent.com/46611122/193776657-ee7db52f-d0ff-4063-bac8-ec9e866e7c3f.png">
<img width="836" alt="Screen Shot 2022-10-04 at 1 49 26 AM" src="https://user-images.githubusercontent.com/46611122/193776659-ad64a009-d4c7-4c54-bf73-25e3a5b6bbf1.png">
<img width="328" alt="Screen Shot 2022-10-04 at 1 49 52 AM" src="https://user-images.githubusercontent.com/46611122/193776661-0926abc2-3563-4eff-a077-96de2fe95f40.png">

when market is closed, there is no drop shadow and nothing is clickable
<img width="833" alt="Screen Shot 2022-10-04 at 2 05 01 AM" src="https://user-images.githubusercontent.com/46611122/193780260-ff585cdc-1e9b-464d-a60c-2c4b5129ac3f.png">


Making multiple choice market options much smoller. I'm trying to make smaller PR's so this is just a part of a bigger change I want to make, where only the top 5 markets are colored and the rest are gray. I've picked lighter colors for @mqp to incorporate, but for now I've just used a lower opacity for the background colors.