### PR TITLE
Simplify rich text to string parsing logic

### DIFF
--- a/common/util/parse.ts
+++ b/common/util/parse.ts
@@ -23,7 +23,7 @@ import { Mention } from '@tiptap/extension-mention'
 import Iframe from './tiptap-iframe'
 import TiptapTweet from './tiptap-tweet-type'
 import { find } from 'linkifyjs'
-import { cloneDeep, uniq } from 'lodash'
+import { uniq } from 'lodash'
 import { TiptapSpoiler } from './tiptap-spoiler'
 
 /** get first url in text. like "notion.so " -> "http://notion.so"; "notion" -> null */


### PR DESCRIPTION
instead of copy the json, dfs, then pass to `generateText`, we just generate the correct text inside of `generateText`

this is now possible after #1021 since these extensions are just used for the text conversion, so we can customize them just for this.
