### PR TITLE
Dynamically choose outcome in Position tooltip

### DIFF
--- a/web/components/bet-summary.tsx
+++ b/web/components/bet-summary.tsx
@@ -25,10 +25,8 @@ export function BetsSummary(props: {
   const isBinary = outcomeType === 'BINARY'
 
   const bets = props.userBets.filter((b) => !b.isAnte)
-  const { profitPercent, payout, profit, invested } = getContractBetMetrics(
-    contract,
-    bets
-  )
+  const { profitPercent, payout, profit, invested, hasShares } =
+    getContractBetMetrics(contract, bets)
 
   const excludeSales = bets.filter((b) => !b.isSold && !b.sale)
   const yesWinnings = sumBy(excludeSales, (bet) =>
@@ -39,6 +37,7 @@ export function BetsSummary(props: {
   )
 
   const position = yesWinnings - noWinnings
+  const outcome = hasShares ? (position > 0 ? 'YES' : 'NO') : undefined
 
   const prob = isBinary ? getProbability(contract) : 0
   const expectation = prob * yesWinnings + (1 - prob) * noWinnings
@@ -60,7 +59,9 @@ export function BetsSummary(props: {
           <Col>
             <div className="whitespace-nowrap text-sm text-gray-500">
               Position{' '}
-              <InfoTooltip text="Number of shares you own on net. 1 YES share = M$1 if the market resolves YES." />
+              <InfoTooltip
+                text={`Number of shares you own on net. 1 ${outcome} share = M$1 if the market resolves ${outcome}.`}
+              />
             </div>
             <div className="whitespace-nowrap">
               {position > 1e-7 ? (


### PR DESCRIPTION
This is a test PR to see if Linear is updating the corresponding issue automatically based on the branch name.

It's working! https://linear.app/manifoldmarkets/issue/MAN-16/position-tooltip-change-based-on-outcome-you-hold