### PR TITLE
Fix issues with chart y-axis zooming

### DIFF
--- a/web/components/charts/generic-charts.tsx
+++ b/web/components/charts/generic-charts.tsx
@@ -343,13 +343,13 @@ export const SingleValueHistoryChart = <P extends HistoryPoint>(props: {
       setViewXScale(() => newViewXScale)
 
       const bisect = bisector((p: P) => p.x)
-      const iMin = bisect.left(data, xMin)
+      const iMin = bisect.right(data, xMin)
       const iMax = bisect.left(data, xMax)
-      const visibleYs = range(iMin - 1, iMax).map((i) => data[i].y)
-      const [yMin, yMax] = extent(visibleYs) as [number, number]
 
       // don't zoom axis if they selected an area with only one value
-      if (yMin != yMax) {
+      if (iMin != iMax) {
+        const visibleYs = range(iMin - 1, iMax).map((i) => data[i].y)
+        const [yMin, yMax] = extent(visibleYs) as [number, number]
         // adds a little padding to the top and bottom of the selection
         const padding = (yMax - yMin) * 0.1
         setViewYScale(() =>

--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -96,6 +96,7 @@ export const PortfolioValueSection = memo(
         <SizedContainer fullHeight={200} mobileHeight={100}>
           {(width, height) => (
             <PortfolioGraph
+              key={graphMode} // we need to reset axis scale state if mode changes
               mode={graphMode}
               history={portfolioHistory}
               width={width}


### PR DESCRIPTION
This was super suspicious before -- because it was mutating props without using React state, there were weird interaction bugs.

Now it's pretty decent, really the only problem is that we should write some clever formatting code so that the y-axis displays an appropriate amount of significant figures on the ticks for the range of values being displayed. (EDIT: I just addressed this by making it so that you can't zoom in tighter than 4% on percentage graphs or 10 bucks on portfolio graphs.)