### PR TITLE
Use new React `useId` hook in chart code

### DIFF
--- a/web/components/charts/generic-charts.tsx
+++ b/web/components/charts/generic-charts.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useId, useMemo, useState } from 'react'
 import { bisector } from 'd3-array'
 import { axisBottom, axisLeft } from 'd3-axis'
 import { D3BrushEvent } from 'd3-brush'
@@ -29,7 +29,6 @@ import {
 } from './helpers'
 import { useEvent } from 'web/hooks/use-event'
 import { formatMoney } from 'common/util/format'
-import { nanoid } from 'nanoid'
 
 export type MultiPoint<T = unknown> = Point<Date, number[], T>
 export type HistoryPoint<T = unknown> = Point<Date, number, T>
@@ -349,7 +348,7 @@ export const SingleValueHistoryChart = <P extends HistoryPoint>(props: {
     }
   })
 
-  const gradientId = useMemo(() => nanoid(), [])
+  const gradientId = useId()
   const stops = useMemo(
     () =>
       typeof color !== 'string' ? computeColorStops(data, color, px) : null,

--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -1,9 +1,8 @@
-import { ReactNode, SVGProps, memo, useRef, useEffect, useMemo } from 'react'
+import { ReactNode, SVGProps, memo, useId, useRef, useEffect } from 'react'
 import { pointer, select } from 'd3-selection'
 import { Axis, AxisScale } from 'd3-axis'
 import { brushX, D3BrushEvent } from 'd3-brush'
 import { area, line, CurveFactory } from 'd3-shape'
-import { nanoid } from 'nanoid'
 import dayjs from 'dayjs'
 import clsx from 'clsx'
 
@@ -168,7 +167,7 @@ export const SVGChart = <X, TT>(props: {
   const overlayRef = useRef<SVGGElement>(null)
   const innerW = w - (margin.left + margin.right)
   const innerH = h - (margin.top + margin.bottom)
-  const clipPathId = useMemo(() => nanoid(), [])
+  const clipPathId = useId()
   const isMobile = useIsMobile()
 
   const justSelected = useRef(false)


### PR DESCRIPTION
This is new in React 18 and is a nicer solution than the `nanoid` version. It also works with SSR, which is nice.