### PR TITLE
Apply `useDeferredValue` on computation of SVG chart paths

### DIFF
--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -1,4 +1,12 @@
-import { ReactNode, SVGProps, memo, useId, useRef, useEffect } from 'react'
+import {
+  ReactNode,
+  SVGProps,
+  useDeferredValue,
+  useId,
+  useMemo,
+  useRef,
+  useEffect,
+} from 'react'
 import { pointer, select } from 'd3-selection'
 import { Axis, AxisScale } from 'd3-axis'
 import { brushX, D3BrushEvent } from 'd3-brush'
@@ -59,7 +67,7 @@ export const YAxis = <Y,>(props: { w: number; h: number; axis: Axis<Y> }) => {
   return <g ref={axisRef} />
 }
 
-const LinePathInternal = <P,>(
+export const LinePath = <P,>(
   props: {
     data: P[]
     px: number | ((p: P) => number)
@@ -67,14 +75,17 @@ const LinePathInternal = <P,>(
     curve: CurveFactory
   } & SVGProps<SVGPathElement>
 ) => {
-  const { data, px, py, curve, ...rest } = props
-  const d3Line = line<P>(px, py).curve(curve)
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return <path {...rest} fill="none" d={d3Line(data)!} />
+  const { px, py, curve, ...rest } = props
+  const data = useDeferredValue(props.data)
+  const d = useMemo(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    () => line<P>(px, py).curve(curve)(data)!,
+    [px, py, curve, data]
+  )
+  return <path {...rest} fill="none" d={d} />
 }
-export const LinePath = memo(LinePathInternal) as typeof LinePathInternal
 
-const AreaPathInternal = <P,>(
+export const AreaPath = <P,>(
   props: {
     data: P[]
     px: number | ((p: P) => number)
@@ -83,12 +94,15 @@ const AreaPathInternal = <P,>(
     curve: CurveFactory
   } & SVGProps<SVGPathElement>
 ) => {
-  const { data, px, py0, py1, curve, ...rest } = props
-  const d3Area = area<P>(px, py0, py1).curve(curve)
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return <path {...rest} d={d3Area(data)!} />
+  const { px, py0, py1, curve, ...rest } = props
+  const data = useDeferredValue(props.data)
+  const d = useMemo(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    () => area<P>(px, py0, py1).curve(curve)(data)!,
+    [px, py0, py1, curve, data]
+  )
+  return <path {...rest} d={d} />
 }
-export const AreaPath = memo(AreaPathInternal) as typeof AreaPathInternal
 
 export const AreaWithTopStroke = <P,>(props: {
   data: P[]


### PR DESCRIPTION
Computing the path segments is basically the expensive operation of rendering a chart (it may plausibly take up to a few dozen milliseconds if you have a market with a few thousand data points and a slow computer), so by applying `useDeferredValue` to it, we make sure that the UI stays responsive if the chart is rendering (for example, it could be rendering because the contract metadata was changed, or a bet was made, or you just zoomed it.)

It's not a big deal because the charts are pretty fast, but this may help get pinch to zoom working in a satisfying way and is a good idea anyway.