### PR TITLE
Don't load bets we don't need on contract page

### DIFF
--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -184,10 +184,7 @@ const BetsTabContent = memo(function BetsTabContent(props: {
   const end = start + ITEMS_PER_PAGE
 
   const lps = useLiquidity(contract.id) ?? []
-  const visibleBets = bets.filter(
-    (bet) => !bet.isAnte && !bet.isRedemption && bet.amount !== 0
-  )
-
+  const visibleBets = bets.filter((bet) => !bet.isAnte)
   const visibleLps = lps.filter(
     (l) =>
       !l.isAnte &&

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -184,7 +184,7 @@ const BetsTabContent = memo(function BetsTabContent(props: {
   const end = start + ITEMS_PER_PAGE
 
   const lps = useLiquidity(contract.id) ?? []
-  const visibleBets = bets.filter((bet) => !bet.isAnte)
+  const visibleBets = bets.filter((bet) => !bet.isAnte) // on top of main contract page bet filters
   const visibleLps = lps.filter(
     (l) =>
       !l.isAnte &&

--- a/web/hooks/use-bets.ts
+++ b/web/hooks/use-bets.ts
@@ -12,10 +12,11 @@ import {
 import { LimitBet } from 'common/bet'
 import { getUser } from 'web/lib/firebase/users'
 import { inMemoryStore, usePersistentState } from './use-persistent-state'
+import { useEffectCheckEquality } from 'web/hooks/use-effect-check-equality'
 
 export const useBets = (contractId: string, options?: BetFilter) => {
   const [bets, setBets] = useState<Bet[] | undefined>()
-  useEffect(() => {
+  useEffectCheckEquality(() => {
     if (contractId)
       return listenForBets(
         contractId,

--- a/web/hooks/use-bets.ts
+++ b/web/hooks/use-bets.ts
@@ -21,7 +21,15 @@ export const useBets = (contractId: string, options?: BetFilter) => {
       return listenForBets(
         contractId,
         (bets) => {
-          setBets(bets.sort((b) => b.createdTime))
+          // we can't do this stuff in firestore because we can't query for
+          // when a field doesn't exist
+          const filteredBets = bets.filter(
+            (b) =>
+              (!options?.filterChallenges || !b.challengeSlug) &&
+              (!options?.filterAntes || !b.isAnte) &&
+              (!options?.filterRedemptions || !b.isRedemption)
+          )
+          setBets(filteredBets.sort((b) => b.createdTime))
         },
         options
       )

--- a/web/hooks/use-user-bets.ts
+++ b/web/hooks/use-user-bets.ts
@@ -5,7 +5,7 @@ import {
   Bet,
   getUserBets,
   getUserBetsQuery,
-  listenForUserContractBets,
+  listenForBets,
 } from 'web/lib/firebase/bets'
 import { MINUTE_MS, sleep } from 'common/util/time'
 
@@ -34,7 +34,11 @@ export const useUserContractBets = (
 
   useEffect(() => {
     if (userId && contractId)
-      return listenForUserContractBets(userId, contractId, setBets)
+      return listenForBets(
+        contractId,
+        (bets) => setBets(bets.sort((b) => b.createdTime)),
+        { userId: userId }
+      )
   }, [userId, contractId])
 
   return bets

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -43,15 +43,6 @@ const getContractBetsQuery = (contractId: string, options?: BetFilter) => {
   if (options?.filterZeroes) {
     q = query(q, where('amount', '!=', 0))
   }
-  if (options?.filterChallenges) {
-    q = query(q, where('challengeSlug', '==', null))
-  }
-  if (options?.filterAntes) {
-    q = query(q, where('isAnte', '==', false))
-  }
-  if (options?.filterRedemptions) {
-    q = query(q, where('isRedemption', '==', false))
-  }
   return q
 }
 
@@ -62,7 +53,14 @@ export async function listAllBets(
 ) {
   const q = getContractBetsQuery(contractId, options)
   const limitedQ = maxCount ? query(q, limit(maxCount)) : q
-  return await getValues<Bet>(limitedQ)
+  const bets = await getValues<Bet>(limitedQ)
+  const filteredBets = bets.filter(
+    (b) =>
+      (!options?.filterChallenges || !b.challengeSlug) &&
+      (!options?.filterAntes || !b.isAnte) &&
+      (!options?.filterRedemptions || !b.isRedemption)
+  )
+  return filteredBets
 }
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef, useState } from 'react'
+import React, { memo, useEffect, useRef, useState } from 'react'
 
 import { ContractOverview } from 'web/components/contract/contract-overview'
 import { BetPanel } from 'web/components/bet/bet-panel'
@@ -49,6 +49,12 @@ import { needsAdminToResolve } from 'web/lib/util/admin'
 import { CreatorSharePanel } from 'web/components/contract/creator-share-panel'
 import { useContract } from 'web/hooks/use-contracts'
 
+const CONTRACT_BET_LOADING_OPTS = {
+  filterRedemptions: true,
+  filterChallenges: true,
+  filterZeroes: true,
+}
+
 export const getStaticProps = fromPropz(getStaticPropz)
 export async function getStaticPropz(props: {
   params: { username: string; contractSlug: string }
@@ -56,12 +62,9 @@ export async function getStaticPropz(props: {
   const { contractSlug } = props.params
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
-  const opts = {
-    filterRedemptions: true,
-    filterChallenges: true,
-    filterZeroes: true,
-  }
-  const bets = contractId ? await listAllBets(contractId, opts, 2500) : []
+  const bets = contractId
+    ? await listAllBets(contractId, CONTRACT_BET_LOADING_OPTS, 2500)
+    : []
   const comments = contractId ? await listAllComments(contractId, 100) : []
 
   return {
@@ -123,18 +126,11 @@ export function ContractPageContent(
     true
   )
 
-  const betOpts = useRef({
-    filterRedemptions: true,
-    filterChallenges: true,
-    filterZeroes: true,
-  }).current
-  const bets = useBets(contract.id, betOpts) ?? props.bets
+  const bets = useBets(contract.id, CONTRACT_BET_LOADING_OPTS) ?? props.bets
+  console.log(props.bets)
 
-  const userBetOpts = useMemo(
-    () => ({ userId: user?.id ?? '_', filterAntes: true }),
-    [user?.id]
-  )
-  const userBets = useBets(contract.id, userBetOpts) ?? []
+  const userBets =
+    useBets(contract.id, { userId: user?.id ?? '_', filterAntes: true }) ?? []
 
   const [showConfetti, setShowConfetti] = useState(false)
 

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -31,8 +31,12 @@ export async function getStaticPropz(props: {
   const { contractSlug } = props.params
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
-
-  const bets = contractId ? await listAllBets(contractId, 5000) : []
+  const opts = {
+    filterRedemptions: true,
+    filterChallenges: true,
+    filterZeroes: true,
+  }
+  const bets = contractId ? await listAllBets(contractId, opts) : []
 
   return {
     props: { contract, bets },


### PR DESCRIPTION
WIP. There are actually many many redemption bets and zero bets (limit orders with no fills, cancelled or otherwise, can be zero.) These bets have no relevance to the chart, the contract leaderboard, or the trades tab, but we are downloading them anyway. For example, on one Elon Musk market these are half of all bets. So it's a big difference.