### PR TITLE
create market mention on paste manifold link

### DIFF
--- a/web/components/editor/contract-mention.tsx
+++ b/web/components/editor/contract-mention.tsx
@@ -1,6 +1,7 @@
 import Mention from '@tiptap/extension-mention'
 import {
   mergeAttributes,
+  nodePasteRule,
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from '@tiptap/react'
@@ -9,12 +10,27 @@ import { useContract } from 'web/hooks/use-contract'
 import { ContractMention } from 'web/components/contract/contract-mention'
 import Link from 'next/link'
 import { contractMentionSuggestion } from './contract-mention-suggestion'
+import { getContractFromSlug } from 'web/lib/firebase/contracts'
+import { useEffect, useState } from 'react'
 
 const name = 'contract-mention-component'
 
 const ContractMentionComponent = (props: any) => {
   const { label, id } = props.node.attrs
-  const contract = useContract(id)
+  const idContract = useContract(id ?? ' ')
+  const [contract, setContract] = useState(idContract)
+
+  useEffect(() => {
+    ;(async () => {
+      if (!id) {
+        const contract = await getContractFromSlug(label.split('/')[1])
+        if (contract) {
+          setContract(contract)
+          props.id = contract.id
+        }
+      }
+    })()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <NodeViewWrapper className={clsx(name, 'not-prose inline')}>
@@ -43,4 +59,13 @@ export const DisplayContractMention = Mention.extend({
   parseHTML: () => [{ tag: name }],
   renderHTML: ({ HTMLAttributes }) => [name, mergeAttributes(HTMLAttributes)],
   addNodeView: () => ReactNodeViewRenderer(ContractMentionComponent),
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: /^(?:https?:\/\/)?manifold\.markets\/(?:(?!group|post|charity|date-docs))(\w*\/[\w-]*)(?:\?[\w&=]*)?$/g,
+        type: this.type,
+        getAttributes: (match) => ({ label: match[1] }),
+      }),
+    ]
+  },
 }).configure({ suggestion: contractMentionSuggestion })


### PR DESCRIPTION
would fix MAN-65

this mostly works, issue is that we don't store the id in the label. I didn't figure out how to modify the underlying JSON of the mention to add the id attribute once the contract has been found...
this causes the mention to flicker and re-fetch the contract if you edit text around it :(