### PR TITLE
Add internal Style page

### DIFF
--- a/web/components/buttons/button.tsx
+++ b/web/components/buttons/button.tsx
@@ -41,9 +41,9 @@ export function buttonClass(size: SizeType, color: ColorType | 'override') {
     color === 'gray' &&
       'bg-greyscale-1 text-greyscale-6 hover:bg-greyscale-2 disabled:opacity-50',
     color === 'gray-outline' &&
-      'ring-2 ring-greyscale-5 text-greyscale-5 hover:bg-greyscale-5 hover:text-white disabled:opacity-50',
+      'ring-2 ring-greyscale-5 text-greyscale-5 enabled:hover:bg-greyscale-5 enabled:hover:text-white disabled:opacity-50',
     color === 'gradient' &&
-      'disabled:bg-greyscale-2 bg-gradient-to-r from-indigo-500 to-blue-500 text-white hover:from-indigo-700 hover:to-blue-700',
+      'disabled:bg-greyscale-2 enabled:bg-gradient-to-r from-indigo-500 to-blue-500 text-white hover:from-indigo-700 hover:to-blue-700',
     color === 'gray-white' &&
       'text-greyscale-6 hover:bg-greyscale-2 shadow-none disabled:opacity-50'
   )
@@ -77,7 +77,12 @@ export function Button(props: {
       disabled={disabled || loading}
       onClick={onClick}
     >
-      {loading && <LoadingIndicator className={'mr-2 border-gray-500'} />}
+      {loading && (
+        <LoadingIndicator
+          className="mr-2 w-fit self-stretch"
+          spinnerClassName="!h-full !w-[unset] aspect-square"
+        />
+      )}
       {children}
     </button>
   )

--- a/web/pages/styles.tsx
+++ b/web/pages/styles.tsx
@@ -1,5 +1,9 @@
+import { FC } from 'react'
 import { Button } from 'web/components/buttons/button'
 import { Page } from 'web/components/layout/page'
+import { TextEditor, useTextEditor } from 'web/components/widgets/editor'
+import { ExpandingInput } from 'web/components/widgets/expanding-input'
+import { Input } from 'web/components/widgets/input'
 import { Title } from 'web/components/widgets/title'
 
 export default function StylePage() {
@@ -10,7 +14,7 @@ export default function StylePage() {
         A reference for all the common widgets we use on our site. For instance,
         the component above is <code>Title</code>.
       </div>
-      <h2 className="mt-6 mb-4 text-2xl text-indigo-700">Buttons</h2>
+      <Sub>Buttons</Sub>
       <div className="mb-4 flex flex-wrap gap-2">
         <Button>indigo</Button>
         <Button color="gradient">gradient</Button>
@@ -79,6 +83,31 @@ export default function StylePage() {
           2xl
         </Button>
       </div>
+      <Sub>Inputs</Sub>
+      TODO: number input
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Input placeholder="Input" />
+        <Input disabled placeholder="Input disabled=true" />
+        <Input error placeholder="Input error=true" />
+      </div>
+      <ExpandingInput
+        className="mb-4 w-full"
+        placeholder="ExpandingInput (try typing a lot)"
+      />
+      <EditorExample />
+      <Sub>Other stuff</Sub>
+      TODO
     </Page>
   )
+}
+
+const Sub: FC<any> = ({ children }) => (
+  <h2 className="mt-6 mb-4 text-2xl text-indigo-700">{children}</h2>
+)
+
+function EditorExample() {
+  const editor = useTextEditor({
+    defaultValue: 'Rich text editor from editor.tsx',
+  })
+  return <TextEditor editor={editor} />
 }

--- a/web/pages/styles.tsx
+++ b/web/pages/styles.tsx
@@ -1,0 +1,84 @@
+import { Button } from 'web/components/buttons/button'
+import { Page } from 'web/components/layout/page'
+import { Title } from 'web/components/widgets/title'
+
+export default function StylePage() {
+  return (
+    <Page>
+      <Title>Design System</Title>
+      <div>
+        A reference for all the common widgets we use on our site. For instance,
+        the component above is <code>Title</code>.
+      </div>
+      <h2 className="mt-6 mb-4 text-2xl text-indigo-700">Buttons</h2>
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Button>indigo</Button>
+        <Button color="gradient">gradient</Button>
+        <Button color="blue">blue</Button>
+        <Button color="gray">gray</Button>
+        <Button color="gray-outline">gray-outline</Button>
+        <Button color="gray-white">gray-white</Button>
+        <Button color="green">green</Button>
+        <Button color="yellow">yellow</Button>
+        <Button color="red">red</Button>
+      </div>
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Button disabled>indigo</Button>
+        <Button disabled color="gradient">
+          gradient
+        </Button>
+        <Button disabled color="blue">
+          blue
+        </Button>
+        <Button disabled color="gray">
+          gray
+        </Button>
+        <Button disabled color="gray-outline">
+          gray-outline
+        </Button>
+        <Button disabled color="gray-white">
+          gray-white
+        </Button>
+        <Button disabled color="green">
+          green
+        </Button>
+        <Button disabled color="yellow">
+          yellow
+        </Button>
+        <Button disabled color="red">
+          red
+        </Button>
+      </div>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Button size="2xs">2xs</Button>
+        <Button size="xs">xs</Button>
+        <Button size="sm">sm</Button>
+        <Button>md</Button>
+        <Button size="lg">lg</Button>
+        <Button size="xl">xl</Button>
+        <Button size="2xl">2xl</Button>
+      </div>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <Button loading size="2xs">
+          2xs
+        </Button>
+        <Button loading size="xs">
+          xs
+        </Button>
+        <Button loading size="sm">
+          sm
+        </Button>
+        <Button loading> md</Button>
+        <Button loading size="lg">
+          lg
+        </Button>
+        <Button loading size="xl">
+          xl
+        </Button>
+        <Button loading size="2xl">
+          2xl
+        </Button>
+      </div>
+    </Page>
+  )
+}


### PR DESCRIPTION
Adds a `/styles` page with all of our widgets (well, just buttons and inputs for now)

https://prod-g62bqjmme-mantic.vercel.app/styles

I had this at one of my previous companies and it made debugging widgets easier and was also just good documentation. It's kinda like Storybook, but easier to maintain