### PR TITLE
Fix some small bugs mostly related to stats charts

### DIFF
--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -31,14 +31,15 @@ const getBetPoints = (bets: Bet[]) => {
 }
 
 const BinaryChartTooltip = (props: TooltipProps<Date, HistoryPoint<Bet>>) => {
-  const { data, x, xScale } = props
+  const { prev, x, xScale } = props
   const [start, end] = xScale.domain()
   const d = xScale.invert(x)
+  if (!prev) return null
   return (
     <Row className="items-center gap-2">
-      {data.obj && <Avatar size="xs" avatarUrl={data.obj.userAvatarUrl} />}
+      {prev.obj && <Avatar size="xs" avatarUrl={prev.obj.userAvatarUrl} />}
       <span className="font-semibold">{formatDateInRange(d, start, end)}</span>
-      <span className="text-greyscale-6">{formatPct(data.y)}</span>
+      <span className="text-greyscale-6">{formatPct(prev.y)}</span>
     </Row>
   )
 }

--- a/web/components/charts/contract/choice.tsx
+++ b/web/components/charts/contract/choice.tsx
@@ -149,11 +149,12 @@ export const ChoiceContractChart = (props: {
 
   const ChoiceTooltip = useMemo(
     () => (props: TooltipProps<Date, MultiPoint<Bet>>) => {
-      const { data, x, xScale } = props
+      const { prev, x, xScale } = props
       const [start, end] = xScale.domain()
       const d = xScale.invert(x)
+      if (!prev) return null
       const legendItems = sortBy(
-        data.y.map((p, i) => ({
+        prev.y.map((p, i) => ({
           color: CHOICE_ALL_COLORS[i],
           label: i === CHOICE_ANSWER_COLORS.length ? 'Other' : answers[i].text,
           value: formatPct(p),
@@ -164,8 +165,8 @@ export const ChoiceContractChart = (props: {
       return (
         <>
           <Row className="items-center gap-2">
-            {data.obj && (
-              <Avatar size="xxs" avatarUrl={data.obj.userAvatarUrl} />
+            {prev.obj && (
+              <Avatar size="xxs" avatarUrl={prev.obj.userAvatarUrl} />
             )}
             <span className="text-semibold text-base">
               {formatDateInRange(d, start, end)}

--- a/web/components/charts/contract/numeric.tsx
+++ b/web/components/charts/contract/numeric.tsx
@@ -26,12 +26,13 @@ const getNumericChartData = (contract: NumericContract) => {
 const NumericChartTooltip = (
   props: TooltipProps<number, DistributionPoint>
 ) => {
-  const { data, x, xScale } = props
+  const { prev, x, xScale } = props
   const amount = xScale.invert(x)
+  if (!prev) return null
   return (
     <>
       <span className="text-semibold mr-2">{formatLargeNumber(amount)}</span>
-      <span className="text-greyscale-6">{formatPct(data.y, 2)}</span>
+      <span className="text-greyscale-6">{formatPct(prev.y, 2)}</span>
     </>
   )
 }

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -45,14 +45,15 @@ const getBetPoints = (bets: Bet[], scaleP: (p: number) => number) => {
 const PseudoNumericChartTooltip = (
   props: TooltipProps<Date, HistoryPoint<Bet>>
 ) => {
-  const { data, x, xScale } = props
+  const { prev, x, xScale } = props
   const [start, end] = xScale.domain()
   const d = xScale.invert(x)
+  if (!prev) return null
   return (
     <Row className="items-center gap-2">
-      {data.obj && <Avatar size="xs" avatarUrl={data.obj.userAvatarUrl} />}
+      {prev.obj && <Avatar size="xs" avatarUrl={prev.obj.userAvatarUrl} />}
       <span className="font-semibold">{formatDateInRange(d, start, end)}</span>
-      <span className="text-greyscale-6">{formatLargeNumber(data.y)}</span>
+      <span className="text-greyscale-6">{formatLargeNumber(prev.y)}</span>
     </Row>
   )
 }

--- a/web/components/charts/generic-charts.tsx
+++ b/web/components/charts/generic-charts.tsx
@@ -120,7 +120,8 @@ const dataAtPointSelector = <X, Y, P extends Point<X, Y>>(
     const i = bisect.left(data, x)
     const prev = data[i - 1] as P | undefined
     const next = data[i] as P | undefined
-    return { prev, next, x: posX }
+    const nearest = data[bisect.center(data, x)]
+    return { prev, next, nearest, x: posX }
   }
 }
 
@@ -158,7 +159,7 @@ export const DistributionChart = <P extends DistributionPoint>(props: {
     const p = selector(mouseX)
     props.onMouseOver?.(p.prev)
     if (p.prev) {
-      setTTParams({ x: mouseX, y: mouseY, data: p.prev })
+      setTTParams({ ...p, x: mouseX, y: mouseY })
     } else {
       setTTParams(undefined)
     }
@@ -260,7 +261,7 @@ export const MultiValueHistoryChart = <P extends MultiPoint>(props: {
     const p = selector(mouseX)
     props.onMouseOver?.(p.prev)
     if (p.prev) {
-      setTTParams({ x: mouseX, y: mouseY, data: p.prev })
+      setTTParams({ ...p, x: mouseX, y: mouseY })
     } else {
       setTTParams(undefined)
     }
@@ -368,13 +369,7 @@ export const SingleValueHistoryChart = <P extends HistoryPoint>(props: {
       const y0 = yScale(p.prev.y)
       const y1 = p.next ? yScale(p.next.y) : y0
       const markerY = interpolateY(curve, mouseX, x0, x1, y0, y1)
-      setMouse({
-        x: mouseX,
-        y: markerY,
-        y0: py0,
-        y1: markerY,
-        data: p.prev,
-      })
+      setMouse({ ...p, x: mouseX, y: markerY, y0: py0, y1: markerY })
     } else {
       setMouse(undefined)
     }
@@ -429,9 +424,7 @@ export const SingleValueHistoryChart = <P extends HistoryPoint>(props: {
       margin={margin}
       xAxis={xAxis}
       yAxis={yAxis}
-      ttParams={
-        mouse ? { x: mouse.x, y: mouse.y, data: mouse.data } : undefined
-      }
+      ttParams={mouse}
       onSelect={onSelect}
       onMouseOver={onMouseOver}
       onMouseLeave={onMouseLeave}

--- a/web/components/charts/generic-charts.tsx
+++ b/web/components/charts/generic-charts.tsx
@@ -58,12 +58,18 @@ const interpolateY = (
   y1: number
 ) => {
   if (curve === curveLinear) {
-    const p = (x - x0) / (x1 - x0)
-    return y0 * (1 - p) + y1 * p
+    if (x1 == x0) {
+      return y0
+    } else {
+      const p = (x - x0) / (x1 - x0)
+      return y0 * (1 - p) + y1 * p
+    }
   } else if (curve === curveStepAfter) {
     return y0
   } else if (curve === curveStepBefore) {
     return y1
+  } else {
+    return 0
   }
 }
 
@@ -356,12 +362,12 @@ export const SingleValueHistoryChart = <P extends HistoryPoint>(props: {
   const onMouseOver = useEvent((mouseX: number) => {
     const p = selector(mouseX)
     props.onMouseOver?.(p.prev)
-    const x0 = p.prev ? xScale(p.prev.x) : xScale.range()[0]
-    const x1 = p.next ? xScale(p.next.x) : xScale.range()[1]
-    const y0 = p.prev ? yScale(p.prev.y) : yScale.range()[0]
-    const y1 = p.next ? yScale(p.next.y) : yScale.range()[1]
-    const markerY = interpolateY(curve, mouseX, x0, x1, y0, y1)
-    if (p.prev && markerY) {
+    if (p.prev) {
+      const x0 = xScale(p.prev.x)
+      const x1 = p.next ? xScale(p.next.x) : x0
+      const y0 = yScale(p.prev.y)
+      const y1 = p.next ? yScale(p.next.y) : y0
+      const markerY = interpolateY(curve, mouseX, x0, x1, y0, y1)
       setMouse({
         x: mouseX,
         y: markerY,

--- a/web/components/charts/generic-charts.tsx
+++ b/web/components/charts/generic-charts.tsx
@@ -389,7 +389,7 @@ export const SingleValueHistoryChart = <P extends HistoryPoint>(props: {
 
       const bisect = bisector((p: P) => p.x)
       const iMin = bisect.right(data, xMin)
-      const iMax = bisect.left(data, xMax)
+      const iMax = bisect.right(data, xMax)
 
       // don't zoom axis if they selected an area with only one value
       if (iMin != iMax) {

--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -251,12 +251,7 @@ export const SVGChart = <X, TT>(props: {
             isMobile ?? false
           )}
         >
-          <Tooltip
-            xScale={xAxis.scale()}
-            x={ttParams.x}
-            y={ttParams.y}
-            data={ttParams.data}
-          />
+          <Tooltip xScale={xAxis.scale()} {...ttParams} />
         </TooltipContainer>
       )}
       <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`}>
@@ -329,7 +324,13 @@ export const getTooltipPosition = (
   return { left, bottom }
 }
 
-export type TooltipParams<T> = { x: number; y: number; data: T }
+export type TooltipParams<T> = {
+  x: number
+  y: number
+  prev: T | undefined
+  next: T | undefined
+  nearest: T
+}
 export type TooltipProps<X, T> = TooltipParams<T> & {
   xScale: ContinuousScale<X>
 }

--- a/web/components/charts/stats.tsx
+++ b/web/components/charts/stats.tsx
@@ -22,23 +22,21 @@ const getPoints = (startDate: number, dailyValues: number[]) => {
 }
 
 const DailyCountTooltip = (props: TooltipProps<Date, HistoryPoint>) => {
-  const { data, x, xScale } = props
-  const d = xScale.invert(x)
+  const { nearest } = props
   return (
     <Row className="items-center gap-2">
-      <span className="font-semibold">{dayjs(d).format('MMM DD')}</span>
-      <span className="text-greyscale-6">{data.y}</span>
+      <span className="font-semibold">{dayjs(nearest.x).format('MMM DD')}</span>
+      <span className="text-greyscale-6">{nearest.y}</span>
     </Row>
   )
 }
 
 const DailyPercentTooltip = (props: TooltipProps<Date, HistoryPoint>) => {
-  const { data, x, xScale } = props
-  const d = xScale.invert(x)
+  const { nearest } = props
   return (
     <Row className="items-center gap-2">
-      <span className="font-semibold">{dayjs(d).format('MMM DD')}</span>
-      <span className="text-greyscale-6">{formatPercent(data.y)}</span>
+      <span className="font-semibold">{dayjs(nearest.x).format('MMM DD')}</span>
+      <span className="text-greyscale-6">{formatPercent(nearest.y)}</span>
     </Row>
   )
 }


### PR DESCRIPTION
As context, the stats chart is unusual because the last data point is exactly at the end of the chart range. We don't extend the chart out to "now."

1. The tooltip code wasn't working right when you hovered over a data point that was at the very right edge, because `interpolateY` wasn't handling the case where `x0 === x1`.
2. The y-axis scale-on-zoom code wasn't correctly taking the last data point into account when you zoomed into a time range including the last data point.
3. For most of our charts, it makes conceptual sense for the tooltip to show the "last data point that happened before time T." But this works very poorly on the stats charts, since the data points are the metric computations, and they aren't actually happening at the time they are for. It's also very hard to see the last data point in the tooltip since it's only at the very right edge! It makes more sense on the stats chart, when you hover over it, to show the nearest data point to time T.