### PR TITLE
Spell `max-age` correctly in `/bets` API cache headers

### DIFF
--- a/web/pages/api/v0/bets.ts
+++ b/web/pages/api/v0/bets.ts
@@ -61,6 +61,6 @@ export default async function handler(
 
   const bets = await getBets({ userId, contractId, limit, before })
 
-  res.setHeader('Cache-Control', 'maxage=15, public')
+  res.setHeader('Cache-Control', 'max-age=15, public')
   return res.status(200).json(bets)
 }


### PR DESCRIPTION
Self-explanatory.