### PR TITLE
New design for Homepage

### DIFF
--- a/common/calculate.ts
+++ b/common/calculate.ts
@@ -261,6 +261,29 @@ export function getTopAnswer(
   return top?.answer
 }
 
+export function getTopNSortedAnswers(
+  contract: FreeResponseContract | MultipleChoiceContract,
+  n: number
+) {
+  const { answers, resolution, resolutions } = contract
+
+  const [winningAnswers, losingAnswers] = partition(
+    answers,
+    (answer) =>
+      answer.id === resolution || (resolutions && resolutions[answer.id])
+  )
+  const sortedAnswers = [
+    ...sortBy(winningAnswers, (answer) =>
+      resolutions ? -1 * resolutions[answer.id] : 0
+    ),
+    ...sortBy(
+      losingAnswers,
+      (answer) => -1 * getDpmOutcomeProbability(contract.totalShares, answer.id)
+    ),
+  ].slice(0, n)
+  return sortedAnswers
+}
+
 export function getLargestPosition(contract: Contract, userBets: Bet[]) {
   let yesFloorShares = 0,
     yesShares = 0,

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -143,12 +143,11 @@ export function QuickBet(props: {
     <Row
       className={clsx(
         className,
-        'relative min-w-[5.5rem]  items-center justify-between   align-middle'
+        'relative min-w-[5.5rem] items-center justify-between align-middle'
         // Use this for colored QuickBet panes
         // `bg-opacity-10 bg-${color}`
       )}
     >
-      {/* Up bet triangle */}
       <div>
         <div
           className="peer absolute bottom-0 top-0 left-0 w-[50%]"
@@ -161,10 +160,10 @@ export function QuickBet(props: {
           <TriangleLeftFillIcon
             className={clsx(
               'mx-auto h-6 w-6',
-              downHover ? 'text-red-400' : 'text-indigo-500'
+              downHover ? 'text-indigo-700' : 'text-indigo-500'
             )}
           />
-          <span className={textColor}>NO </span>
+          <span className="text-greyscale-6">{downHover ? 'M$10' : ''} </span>
         </Row>
       </div>
 
@@ -173,7 +172,6 @@ export function QuickBet(props: {
       {/* Down bet triangle */}
       {outcomeType !== 'BINARY' && outcomeType !== 'PSEUDO_NUMERIC' ? (
         <div>
-          <div className="peer absolute bottom-0 left-0 right-0 h-[50%] cursor-default"></div>
           <TriangleLeftFillIcon
             className={clsx('mx-auto h-6 w-6 text-gray-200')}
           />
@@ -187,12 +185,14 @@ export function QuickBet(props: {
             onClick={() => placeQuickBet('UP')}
           />
 
-          <Row className=" flex items-center text-gray-500">
-            <span className={textColor}>YES </span>
+          <Row className="text-gray-500">
+            <span className={clsx({ textColor }, upHover ? '' : 'hidden')}>
+              {upHover ? 'M$10' : ''}
+            </span>
             <TriangleRightFillIcon
               className={clsx(
                 'mx-auto h-6 w-6',
-                upHover ? 'text-green-400' : 'text-indigo-500'
+                upHover ? 'text-indigo-700' : 'text-indigo-500'
               )}
             />
           </Row>
@@ -210,17 +210,17 @@ export function ProbBar(props: { contract: Contract; previewProb?: number }) {
     <>
       <div
         className={clsx(
-          'absolute right-0 bottom-0 top-0 -z-10 w-1.5 transition-all',
+          'absolute right-0 bottom-0 top-0 -z-10 w-1.5 rounded-r-lg transition-all',
           `bg-${unfilledColor}`
         )}
         style={{ width: `${100 * (1 - prob)}%` }}
       />
       <div
         className={clsx(
-          ' absolute left-0 bottom-0 top-0 -z-10 w-1.5 transition-all',
+          ' absolute left-0 bottom-0 top-0 -z-10 w-1.5 rounded-l-lg transition-all',
           `bg-${filledColor}`,
           // If we're showing the full bar, also round the top
-          prob === 1 ? 'rounded-tr-md' : ''
+          prob === 1 ? 'rounded-r-lg' : ''
         )}
         style={{ width: `${100 * prob}%` }}
       />
@@ -287,24 +287,28 @@ export function QuickOutcomeView(props: {
     }
   }
 
+  if (outcomeType != 'FREE_RESPONSE') {
+    return (
+      <>
+        <div className="absolute left-1/2">
+          <div className="relative -left-1/2">
+            {contract.resolution ?? override ?? display}
+            {caption && <div className="text-base">{caption}</div>}
+          </div>
+        </div>
+        <ProbBar contract={contract} previewProb={previewProb} />
+      </>
+    )
+  }
   return (
-    <Row
-      className={clsx(
-        'items-center justify-center gap-2 py-1 text-xl',
-        textColor
-      )}
-    >
-      {outcomeType == 'FREE_RESPONSE' && (
-        <>
-          <FreeResponseTopAnswer contract={contract} className="text-xs" />
-          {override ?? display}
-        </>
-      )}
-      {outcomeType != 'FREE_RESPONSE' &&
-        (contract.resolution ?? override ?? display)}
-      {caption && <div className="text-base">{caption}</div>}
+    <>
+      <div className="absolute">
+        <FreeResponseTopAnswer contract={contract} className="text-xs" />
+        {override ?? display}
+        {caption && <div className="text-base">{caption}</div>}
+      </div>
       <ProbBar contract={contract} previewProb={previewProb} />
-    </Row>
+    </>
   )
 }
 

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -6,10 +6,7 @@ import {
   getTopAnswer,
   getTopNSortedAnswers,
 } from 'common/calculate'
-import {
-  getDpmOutcomeProbability,
-  getExpectedValue,
-} from 'common/calculate-dpm'
+import { getExpectedValue } from 'common/calculate-dpm'
 import { User } from 'common/user'
 import {
   BinaryContract,
@@ -40,8 +37,6 @@ import { formatNumericProbability } from 'common/pseudo-numeric'
 import { useUnfilledBetsAndBalanceByUserId } from 'web/hooks/use-bets'
 import { getBinaryProb } from 'common/contract-details'
 import { Row } from '../layout/row'
-import { FreeResponseTopAnswer } from '../contract/contract-card'
-import { Tooltip } from '../widgets/tooltip'
 import { Col } from '../layout/col'
 import { Answer } from 'common/answer'
 import { AnswerLabel } from '../outcome-label'
@@ -56,7 +51,7 @@ export function QuickBet(props: {
   className?: string
 }) {
   const { contract, user, className } = props
-  const { mechanism, outcomeType } = contract
+  const { mechanism } = contract
   const isCpmm = mechanism === 'cpmm-1'
 
   const userBets = useUserContractBets(user.id, contract.id)
@@ -69,7 +64,6 @@ export function QuickBet(props: {
 
   const [upHover, setUpHover] = useState(false)
   const [downHover, setDownHover] = useState(false)
-  const textColor = `text-${getTextColor(contract)}`
 
   let previewProb = undefined
   try {
@@ -284,14 +278,20 @@ export function QuickOutcomeView(props: {
     )
   }
 
-  const answers = getTopNSortedAnswers(contract, 3)
-  if (answers.length === 0) {
-    return <div>No answers yet...</div>
-  }
+  return <ContractCardAnswers contract={contract} />
+}
 
+export function ContractCardAnswers(props: {
+  contract: FreeResponseContract | MultipleChoiceContract
+}) {
+  const { contract } = props
+  const answers = getTopNSortedAnswers(contract, 3)
   const answersArray = useChartAnswers(contract).map(
     (answer, _index) => answer.text
   )
+  if (answers.length === 0) {
+    return <div>No answers yet...</div>
+  }
   return (
     <Col className="gap-2">
       {answers.map((answer) => (

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -35,6 +35,7 @@ import { useUnfilledBetsAndBalanceByUserId } from 'web/hooks/use-bets'
 import { getBinaryProb } from 'common/contract-details'
 import { Row } from '../layout/row'
 import { FreeResponseTopAnswer } from '../contract/contract-card'
+import { Tooltip } from '../widgets/tooltip'
 
 const BET_SIZE = 10
 
@@ -140,91 +141,60 @@ export function QuickBet(props: {
   }
 
   return (
-    <Row
-      className={clsx(
-        className,
-        'relative min-w-[5.5rem] items-center justify-between align-middle'
-        // Use this for colored QuickBet panes
-        // `bg-opacity-10 bg-${color}`
-      )}
-    >
-      <div>
-        <div
-          className="peer absolute bottom-0 top-0 left-0 w-[50%]"
+    <div className="mx-y relative">
+      <Row
+        className={clsx(
+          className,
+          'py-auto absolute w-full items-center justify-between align-middle'
+          // Use this for colored QuickBet panes
+          // `bg-opacity-10 bg-${color}`
+        )}
+      >
+        <Row
+          className="items-center pr-4"
           onMouseEnter={() => setDownHover(true)}
           onMouseLeave={() => setDownHover(false)}
           onClick={() => placeQuickBet('DOWN')}
-        ></div>
-
-        <Row className=" flex items-center text-gray-500">
+        >
           <TriangleLeftFillIcon
             className={clsx(
               'mx-auto h-6 w-6',
               downHover ? 'text-indigo-700' : 'text-indigo-500'
             )}
           />
-          <span className="text-greyscale-6">{downHover ? 'M$10' : ''} </span>
+          <span
+            className={clsx(
+              'text-greyscale-6 text-sm font-light transition-opacity',
+              downHover ? 'opacity-100' : 'opacity-0 '
+            )}
+          >
+            M$10
+          </span>
         </Row>
-      </div>
-
+        <Row
+          className="items-center pl-4"
+          onMouseEnter={() => setUpHover(true)}
+          onMouseLeave={() => setUpHover(false)}
+          onClick={() => placeQuickBet('UP')}
+        >
+          <span
+            className={clsx(
+              'text-greyscale-6 transition- text-sm font-light',
+              upHover ? 'opacity-100' : 'opacity-0 '
+            )}
+          >
+            M$10
+          </span>
+          <TriangleRightFillIcon
+            className={clsx(
+              'mx-auto h-6 w-6',
+              upHover ? 'text-indigo-700' : 'text-indigo-500'
+            )}
+          />
+        </Row>
+      </Row>
       <QuickOutcomeView contract={contract} previewProb={previewProb} />
-
-      {/* Down bet triangle */}
-      {outcomeType !== 'BINARY' && outcomeType !== 'PSEUDO_NUMERIC' ? (
-        <div>
-          <TriangleLeftFillIcon
-            className={clsx('mx-auto h-6 w-6 text-gray-200')}
-          />
-        </div>
-      ) : (
-        <div>
-          <div
-            className="peer absolute top-0 bottom-0 right-0 w-[50%]"
-            onMouseEnter={() => setUpHover(true)}
-            onMouseLeave={() => setUpHover(false)}
-            onClick={() => placeQuickBet('UP')}
-          />
-
-          <Row className="text-gray-500">
-            <span className={clsx({ textColor }, upHover ? '' : 'hidden')}>
-              {upHover ? 'M$10' : ''}
-            </span>
-            <TriangleRightFillIcon
-              className={clsx(
-                'mx-auto h-6 w-6',
-                upHover ? 'text-indigo-700' : 'text-indigo-500'
-              )}
-            />
-          </Row>
-        </div>
-      )}
-    </Row>
-  )
-}
-
-export function ProbBar(props: { contract: Contract; previewProb?: number }) {
-  const { contract, previewProb } = props
-  const [filledColor, unfilledColor] = getProbBarColors(contract)
-  const prob = previewProb ?? getProb(contract)
-  return (
-    <>
-      <div
-        className={clsx(
-          'absolute right-0 bottom-0 top-0 -z-10 w-1.5 rounded-r-lg transition-all',
-          `bg-${unfilledColor}`
-        )}
-        style={{ width: `${100 * (1 - prob)}%` }}
-      />
-      <div
-        className={clsx(
-          ' absolute left-0 bottom-0 top-0 -z-10 w-1.5 rounded-l-lg transition-all',
-          `bg-${filledColor}`,
-          // If we're showing the full bar, also round the top
-          prob === 1 ? 'rounded-r-lg' : ''
-        )}
-        style={{ width: `${100 * prob}%` }}
-      />
-    </>
+    </div>
   )
 }
 
@@ -255,6 +225,7 @@ export function QuickOutcomeView(props: {
   const { contract, previewProb, caption } = props
   const { outcomeType } = contract
   const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
+  const prob = previewProb ?? getProb(contract)
 
   // If there's a preview prob, display that instead of the current prob
   const override =
@@ -286,29 +257,28 @@ export function QuickOutcomeView(props: {
       break
     }
   }
-
-  if (outcomeType != 'FREE_RESPONSE') {
-    return (
-      <>
-        <div className="absolute left-1/2">
-          <div className="relative -left-1/2">
-            {contract.resolution ?? override ?? display}
-            {caption && <div className="text-base">{caption}</div>}
-          </div>
-        </div>
-        <ProbBar contract={contract} previewProb={previewProb} />
-      </>
-    )
-  }
   return (
-    <>
-      <div className="absolute">
-        <FreeResponseTopAnswer contract={contract} className="text-xs" />
-        {override ?? display}
-        {caption && <div className="text-base">{caption}</div>}
-      </div>
-      <ProbBar contract={contract} previewProb={previewProb} />
-    </>
+    <Row
+      className="justify-between rounded-lg px-4 transition-all"
+      style={{
+        background: `linear-gradient(to right, ${getColor(contract)} ${
+          100 * prob
+        }%, #F4F4FB ${100 * prob}%)`,
+      }}
+    >
+      {outcomeType != 'FREE_RESPONSE' && (
+        <div className="mx-auto font-semibold">
+          {contract.resolution ?? override ?? display}
+        </div>
+      )}
+      {outcomeType === 'FREE_RESPONSE' && (
+        <>
+          <FreeResponseTopAnswer contract={contract} className="text-xs" />
+          <div className="font-semibold">{override ?? display}</div>
+        </>
+      )}
+      {caption && <div className="text-base">{caption}</div>}
+    </Row>
   )
 }
 
@@ -338,24 +308,24 @@ function getNumericScale(contract: NumericContract) {
 }
 
 const OUTCOME_TO_COLOR = {
-  YES: 'teal',
-  NO: 'scarlet',
-  CANCEL: 'yellow',
-  MKT: 'blue',
+  YES: '#5eead4',
+  NO: '#FFA799',
+  CANCEL: '#fde68a',
+  MKT: '#7dd3fc',
 }
 
 export function getColor(contract: Contract) {
   const { resolution } = contract
 
   if (resolution) {
-    return OUTCOME_TO_COLOR[resolution as resolution] ?? 'indigo'
+    return OUTCOME_TO_COLOR[resolution as resolution] ?? '#c7d2fe'
   }
 
   if ((contract.closeTime ?? Infinity) < Date.now()) {
-    return 'gray'
+    return '#B1B1C7'
   }
 
-  return 'indigo'
+  return '#c7d2fe'
 }
 
 export function getTextColor(contract: Contract) {
@@ -373,28 +343,4 @@ export function getTextColor(contract: Contract) {
         return `${color}-600`
     }
   }
-}
-
-export function getProbBarColors(contract: Contract): [string, string] {
-  const color = getColor(contract)
-
-  if (color) {
-    switch (color) {
-      case 'teal':
-        return [`${color}-100`, `${color}-50`]
-      case 'scarlet':
-        return [`${color}-300`, `${color}-50`]
-      case 'yellow':
-        return [`${color}-400`, `${color}-50`]
-      case 'blue':
-        return [`${color}-100`, `${color}-50`]
-      case 'indigo':
-        return [`${color}-200`, `${color}-50`]
-      case 'gray':
-        return [`${color}-200`, `${color}-50`]
-      default:
-        return [`${color}-400`, `${color}-50`]
-    }
-  }
-  return ['indigo-400', 'indigo-50']
 }

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -145,9 +145,7 @@ export function QuickBet(props: {
       <Row
         className={clsx(
           className,
-          'py-auto absolute w-full items-center justify-between align-middle'
-          // Use this for colored QuickBet panes
-          // `bg-opacity-10 bg-${color}`
+          'absolute my-auto mt-0.5 w-full items-center justify-between align-middle'
         )}
       >
         <Row
@@ -164,7 +162,7 @@ export function QuickBet(props: {
           />
           <span
             className={clsx(
-              'text-greyscale-6 text-sm font-light transition-opacity',
+              'text-sm font-light text-indigo-500 transition-opacity',
               downHover ? 'opacity-100' : 'opacity-0 '
             )}
           >
@@ -179,7 +177,7 @@ export function QuickBet(props: {
         >
           <span
             className={clsx(
-              'text-greyscale-6 transition- text-sm font-light',
+              'transition- text-sm font-light text-indigo-500',
               upHover ? 'opacity-100' : 'opacity-0 '
             )}
           >
@@ -235,7 +233,7 @@ export function QuickOutcomeView(props: {
       ? formatNumericProbability(previewProb, contract)
       : formatPercent(previewProb)
 
-  const textColor = `text-${getTextColor(contract)}`
+  const textColor = getTextColor(contract)
 
   let display: string | undefined
   switch (outcomeType) {
@@ -259,22 +257,24 @@ export function QuickOutcomeView(props: {
   }
   return (
     <Row
-      className="justify-between rounded-lg px-4 transition-all"
+      className="justify-between rounded-md px-4 py-0.5 transition-all"
       style={{
-        background: `linear-gradient(to right, ${getColor(contract)} ${
+        background: `linear-gradient(to right, ${getBarColor(contract)} ${
           100 * prob
-        }%, #F4F4FB ${100 * prob}%)`,
+        }%, ${getBgColor(contract)} ${100 * prob}%)`,
       }}
     >
       {outcomeType != 'FREE_RESPONSE' && (
-        <div className="mx-auto font-semibold">
+        <div className={`mx-auto font-semibold ${textColor}`}>
           {contract.resolution ?? override ?? display}
         </div>
       )}
       {outcomeType === 'FREE_RESPONSE' && (
         <>
           <FreeResponseTopAnswer contract={contract} className="text-xs" />
-          <div className="font-semibold">{override ?? display}</div>
+          <div className={`font-semibold ${textColor}`}>
+            {override ?? display}
+          </div>
         </>
       )}
       {caption && <div className="text-base">{caption}</div>}
@@ -307,40 +307,65 @@ function getNumericScale(contract: NumericContract) {
   return (ev - min) / (max - min)
 }
 
-const OUTCOME_TO_COLOR = {
-  YES: '#5eead4',
+const OUTCOME_TO_COLOR_BAR = {
+  YES: '#99f6e4',
   NO: '#FFA799',
-  CANCEL: '#fde68a',
-  MKT: '#7dd3fc',
+  CANCEL: '#F4F4FB',
+  MKT: '#bae6fd',
 }
 
-export function getColor(contract: Contract) {
+export function getBarColor(contract: Contract) {
   const { resolution } = contract
 
   if (resolution) {
-    return OUTCOME_TO_COLOR[resolution as resolution] ?? '#c7d2fe'
+    return OUTCOME_TO_COLOR_BAR[resolution as resolution] ?? '#c7d2fe'
   }
 
   if ((contract.closeTime ?? Infinity) < Date.now()) {
-    return '#B1B1C7'
+    return '#D8D8EB'
   }
 
   return '#c7d2fe'
 }
 
-export function getTextColor(contract: Contract) {
-  // this is a bit of a hack, for some reason some tailwind color classes don't work
-  // so im working around it
-  const color = getColor(contract)
-  if (color) {
-    switch (color) {
-      case 'teal':
-      case 'blue':
-        return `${color}-500`
-      case 'yellow':
-        return 'yellow-700'
-      default:
-        return `${color}-600`
-    }
+const OUTCOME_TO_COLOR_BACKGROUND = {
+  YES: '#ccfbf1',
+  NO: '#FFD3CC',
+  CANCEL: '#F4F4FB',
+  MKT: '#e0f2fe',
+}
+
+export function getBgColor(contract: Contract) {
+  const { resolution } = contract
+
+  if (resolution) {
+    return OUTCOME_TO_COLOR_BACKGROUND[resolution as resolution] ?? '#F4F4FB'
   }
+
+  if ((contract.closeTime ?? Infinity) < Date.now()) {
+    return '#F4F4FB'
+  }
+
+  return '#F4F4FB'
+}
+
+const OUTCOME_TO_COLOR_TEXT = {
+  YES: 'text-teal-600',
+  NO: 'text-scarlet-600',
+  CANCEL: 'text-greyscale-4',
+  MKT: 'text-sky-600',
+}
+
+export function getTextColor(contract: Contract) {
+  const { resolution } = contract
+
+  if (resolution) {
+    return OUTCOME_TO_COLOR_TEXT[resolution as resolution] ?? '#c7d2fe'
+  }
+
+  if ((contract.closeTime ?? Infinity) < Date.now()) {
+    return 'text-greyscale-6'
+  }
+
+  return 'text-greyscale-7'
 }

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -78,7 +78,7 @@ export function ContractCard(props: {
   const marketClosed =
     (contract.closeTime || Infinity) < Date.now() || !!resolution
 
-  const showQuickBet =
+  const showBinaryQuickBet =
     user &&
     !marketClosed &&
     (outcomeType === 'BINARY' || outcomeType === 'PSEUDO_NUMERIC') &&
@@ -99,7 +99,7 @@ export function ContractCard(props: {
         />
         {/* overlay question on image */}
         {contract.coverImageUrl && showImage && (
-          <div className="relative">
+          <div className="relative mb-2">
             <img
               className="h-80 w-full object-cover "
               src={contract.coverImageUrl}
@@ -117,9 +117,9 @@ export function ContractCard(props: {
           </div>
         )}
 
-        <div className="mt-2 px-4">
-          {/* question is here if not overlaid on image */}
-          {(!contract.coverImageUrl || !showImage) && (
+        <div className="px-4">
+          {/* question is here if not overlaid on an image */}
+          {(!showImage || !contract.coverImageUrl) && (
             <div
               className={clsx(
                 'break-anywhere pb-2 font-semibold text-indigo-700 group-hover:underline group-hover:decoration-indigo-400 group-hover:decoration-2',
@@ -129,15 +129,13 @@ export function ContractCard(props: {
               {question}
             </div>
           )}
-          {showQuickBet ? (
+          {showBinaryQuickBet ? (
             <QuickBet contract={contract} user={user} className="z-10" />
           ) : (
-            <div className="relative z-10">
-              <QuickOutcomeView contract={contract} />
-            </div>
+            <QuickOutcomeView contract={contract} />
           )}
         </div>
-        <Row className={clsx('gap-1 truncate px-2')}>
+        <Row className={clsx('mt-2 gap-1 truncate px-2')}>
           <MiscDetails
             contract={contract}
             showTime={showTime}

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -97,14 +97,13 @@ export function ContractCard(props: {
           className={'hidden pl-2 md:inline-flex'}
           noLink={noLinkAvatar}
         />
-        {showImage && (
+        {contract.coverImageUrl && showImage && (
           <img
             className="h-60 w-full object-cover "
-            src={
-              'https://firebasestorage.googleapis.com/v0/b/mantic-markets.appspot.com/o/dream%2FykU5KOeiSQ.png?alt=media&token=f7c69a0f-8f71-4758-996c-0b6411d16875'
-            }
+            src={contract.coverImageUrl}
           />
         )}
+
         <div className="px-2">
           <div
             className={clsx(
@@ -403,12 +402,10 @@ export function ContractCardProbChange(props: {
         className={'px-2 pt-4'}
         noLink={noLinkAvatar}
       />
-      {showImage && (
+      {contract.coverImageUrl && showImage && (
         <img
           className="mt-2 h-60 w-full object-cover "
-          src={
-            'https://firebasestorage.googleapis.com/v0/b/mantic-markets.appspot.com/o/dream%2FykU5KOeiSQ.png?alt=media&token=f7c69a0f-8f71-4758-996c-0b6411d16875'
-          }
+          src={contract.coverImageUrl}
         />
       )}
       <Row className={clsx('items-start justify-between gap-4 ', className)}>

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -91,7 +91,7 @@ export function ContractCard(props: {
         className
       )}
     >
-      <Col className="relative flex-1 gap-1 py-2 pb-12 ">
+      <Col className="relative flex-1 gap-1 py-2">
         <AvatarDetails
           contract={contract}
           className={'pl-2'}
@@ -135,20 +135,19 @@ export function ContractCard(props: {
             </div>
           )}
         </div>
+        <Row
+          className={clsx(
+            'gap-2 truncate px-2 md:gap-0'
+            // showQuickBet ? 'w-[85%]' : 'w-full'
+          )}
+        >
+          <MiscDetails
+            contract={contract}
+            showTime={showTime}
+            hideGroupLink={hideGroupLink}
+          />
+        </Row>
       </Col>
-
-      <Row
-        className={clsx(
-          'absolute bottom-3 gap-2 truncate px-2 md:gap-0',
-          showQuickBet ? 'w-[85%]' : 'w-full'
-        )}
-      >
-        <MiscDetails
-          contract={contract}
-          showTime={showTime}
-          hideGroupLink={hideGroupLink}
-        />
-      </Row>
 
       {/* Add click layer */}
       {onClick ? (
@@ -247,9 +246,9 @@ export function FreeResponseTopAnswer(props: {
 
   return topAnswer ? (
     <AnswerLabel
-      className="!text-gray-600"
+      className="!text-greyscale-7 text-md"
       answer={topAnswer}
-      truncate="long"
+      truncate="medium"
     />
   ) : null
 }

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -87,32 +87,46 @@ export function ContractCard(props: {
   return (
     <Card
       className={clsx(
-        'font-readex-pro group relative flex gap-3 leading-normal',
+        'font-readex-pro group relative flex leading-normal',
         className
       )}
     >
-      <Col className="relative flex-1 gap-3 py-4 pb-12 ">
+      <Col className="relative flex-1 gap-1 py-2 pb-12 ">
         <AvatarDetails
           contract={contract}
-          className={'hidden pl-2 md:inline-flex'}
+          className={'pl-2'}
           noLink={noLinkAvatar}
         />
         {contract.coverImageUrl && showImage && (
-          <img
-            className="h-60 w-full object-cover "
-            src={contract.coverImageUrl}
-          />
+          <div className="relative">
+            <img
+              className="h-80 w-full object-cover "
+              src={contract.coverImageUrl}
+            />
+            <div className="absolute bottom-0">
+              <div
+                className={clsx(
+                  'break-anywhere bg-gradient-to-t from-slate-900 px-2 pb-2 pt-12 text-xl font-semibold text-white',
+                  questionClass
+                )}
+              >
+                {question}
+              </div>
+            </div>
+          </div>
         )}
 
-        <div className="px-2">
-          <div
-            className={clsx(
-              'break-anywhere pb-2 font-semibold text-indigo-700 group-hover:underline group-hover:decoration-indigo-400 group-hover:decoration-2',
-              questionClass
-            )}
-          >
-            {question}
-          </div>
+        <div className="mt-2 px-4">
+          {(!contract.coverImageUrl || !showImage) && (
+            <div
+              className={clsx(
+                'break-anywhere pb-2 font-semibold text-indigo-700 group-hover:underline group-hover:decoration-indigo-400 group-hover:decoration-2',
+                questionClass
+              )}
+            >
+              {question}
+            </div>
+          )}
           {showQuickBet ? (
             <QuickBet contract={contract} user={user} className="z-10" />
           ) : (
@@ -129,12 +143,6 @@ export function ContractCard(props: {
           showQuickBet ? 'w-[85%]' : 'w-full'
         )}
       >
-        <AvatarDetails
-          contract={contract}
-          short={true}
-          className="md:hidden"
-          noLink={noLinkAvatar}
-        />
         <MiscDetails
           contract={contract}
           showTime={showTime}

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -97,13 +97,14 @@ export function ContractCard(props: {
           className={'pl-2'}
           noLink={noLinkAvatar}
         />
+        {/* overlay question on image */}
         {contract.coverImageUrl && showImage && (
           <div className="relative">
             <img
               className="h-80 w-full object-cover "
               src={contract.coverImageUrl}
             />
-            <div className="absolute bottom-0">
+            <div className="absolute bottom-0 w-full">
               <div
                 className={clsx(
                   'break-anywhere bg-gradient-to-t from-slate-900 px-2 pb-2 pt-12 text-xl font-semibold text-white',
@@ -117,6 +118,7 @@ export function ContractCard(props: {
         )}
 
         <div className="mt-2 px-4">
+          {/* question is here if not overlaid on image */}
           {(!contract.coverImageUrl || !showImage) && (
             <div
               className={clsx(
@@ -135,12 +137,7 @@ export function ContractCard(props: {
             </div>
           )}
         </div>
-        <Row
-          className={clsx(
-            'gap-2 truncate px-2 md:gap-0'
-            // showQuickBet ? 'w-[85%]' : 'w-full'
-          )}
-        >
+        <Row className={clsx('gap-1 truncate px-2')}>
           <MiscDetails
             contract={contract}
             showTime={showTime}

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -109,12 +109,12 @@ export function AvatarDetails(props: {
 
   return (
     <Row
-      className={clsx('items-center gap-2 text-sm text-gray-400', className)}
+      className={clsx('text-greyscale-4 items-center gap-2 text-sm', className)}
     >
       <Avatar
         username={creatorUsername}
         avatarUrl={creatorAvatarUrl}
-        size={6}
+        size={4}
         noLink={noLink}
       />
       <UserLink

--- a/web/components/contract/contract-mention.tsx
+++ b/web/components/contract/contract-mention.tsx
@@ -5,13 +5,13 @@ import Link from 'next/link'
 import { contractPath, getBinaryProbPercent } from 'web/lib/firebase/contracts'
 import { fromNow } from 'web/lib/util/time'
 import { BinaryContractOutcomeLabel } from '../outcome-label'
-import { getColor } from '../bet/quick-bet'
+import { getTextColor } from '../bet/quick-bet'
 import { useIsClient } from 'web/hooks/use-is-client'
 
 export function ContractMention(props: { contract: Contract }) {
   const { contract } = props
   const { outcomeType, resolution } = contract
-  const probTextColor = `text-${getColor(contract)}`
+  const probTextColor = getTextColor(contract)
   const isClient = useIsClient()
 
   return (

--- a/web/components/contract/contracts-grid.tsx
+++ b/web/components/contract/contracts-grid.tsx
@@ -31,6 +31,7 @@ export function ContractsGrid(props: {
   highlightOptions?: CardHighlightOptions
   trackingPostfix?: string
   breakpointColumns?: { [key: string]: number }
+  showImageOnTopContract?: boolean
 }) {
   const {
     contracts,
@@ -40,6 +41,7 @@ export function ContractsGrid(props: {
     cardUIOptions,
     highlightOptions,
     trackingPostfix,
+    showImageOnTopContract,
   } = props
   const { hideQuickBet, hideGroupLink, noLinkAvatar, showProbChange } =
     cardUIOptions || {}
@@ -76,18 +78,20 @@ export function ContractsGrid(props: {
         className="-ml-4 flex w-auto"
         columnClassName="pl-4 bg-clip-padding"
       >
-        {contracts.map((contract) =>
+        {contracts.map((contract, index) =>
           showProbChange && contract.mechanism === 'cpmm-1' ? (
             <ContractCardProbChange
               key={contract.id}
               contract={contract as CPMMBinaryContract}
               showPosition
+              showImage={showImageOnTopContract && index == 0}
             />
           ) : (
             <ContractCard
               contract={contract}
               key={contract.id}
               showTime={showTime}
+              showImage={showImageOnTopContract && index == 0}
               onClick={
                 onContractClick ? () => onContractClick(contract) : undefined
               }

--- a/web/components/contract/prob-change-table.tsx
+++ b/web/components/contract/prob-change-table.tsx
@@ -3,11 +3,11 @@ import { sortBy } from 'lodash'
 import { filterDefined } from 'common/util/array'
 import { ContractMetrics } from 'common/calculate-metrics'
 import { CPMMBinaryContract, CPMMContract } from 'common/contract'
-import { formatPercent } from 'common/util/format'
 import { Col } from '../layout/col'
 import { LoadingIndicator } from '../widgets/loading-indicator'
 import { ContractCardProbChange } from './contract-card'
-import { formatNumericProbability } from 'common/pseudo-numeric'
+import { QuickBet } from '../bet/quick-bet'
+import { User } from 'common/user'
 
 export function ProfitChangeTable(props: {
   contracts: CPMMBinaryContract[]
@@ -122,28 +122,30 @@ export function ProbChangeTable(props: {
 
 export function ProbOrNumericChange(props: {
   contract: CPMMContract
+  user?: User | null
+
   className?: string
 }) {
-  const { contract, className } = props
+  const { contract, className, user } = props
   const {
-    prob,
     probChanges: { day: change },
   } = contract
-  const number =
-    contract.outcomeType === 'PSEUDO_NUMERIC'
-      ? formatNumericProbability(prob, contract)
-      : null
 
   const color = change >= 0 ? 'text-teal-500' : 'text-scarlet-400'
 
   return (
-    <Col className={clsx('flex flex-col items-end', className)}>
-      <div className="mb-0.5 mr-0.5 text-2xl">
-        {number ? number : formatPercent(Math.round(100 * prob) / 100)}
-      </div>
-      <div className={clsx('text-base', color)}>
-        {(change > 0 ? '+' : '') + (change * 100).toFixed(0) + '%'}
-      </div>
+    <Col className={clsx('flex flex-col ', className)}>
+      {user && <QuickBet contract={contract} user={user} className="z-10" />}
+      <Col className={clsx('flex items-end pt-2 text-base', color)}>
+        <div
+          className={clsx(
+            'mr-1 flex  items-center justify-center rounded-full bg-teal-100 px-2 py-1 text-xs font-bold ',
+            change > 0 ? 'bg-teal-100' : 'bg-scarlet-100'
+          )}
+        >
+          {(change > 0 ? '+' : '') + (change * 100).toFixed(0) + '%'}
+        </div>
+      </Col>
     </Col>
   )
 }

--- a/web/components/contract/prob-change-table.tsx
+++ b/web/components/contract/prob-change-table.tsx
@@ -140,7 +140,7 @@ export function ProbOrNumericChange(props: {
         <div
           className={clsx(
             'mr-1 flex  items-center justify-center rounded-full bg-teal-100 px-2 py-1 text-xs font-bold ',
-            change > 0 ? 'bg-teal-100' : 'bg-scarlet-100'
+            change >= 0 ? 'bg-teal-100' : 'bg-scarlet-100'
           )}
         >
           {(change > 0 ? '+' : '') + (change * 100).toFixed(0) + '%'}

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -142,7 +142,7 @@ export function AnswerNumberLabel(props: { number: string }) {
 
 export function AnswerLabel(props: {
   answer: Answer
-  truncate: 'short' | 'long' | 'none'
+  truncate: 'short' | 'medium' | 'long' | 'none'
   className?: string
 }) {
   const { answer, truncate, className } = props
@@ -151,6 +151,8 @@ export function AnswerLabel(props: {
   let truncated = text
   if (truncate === 'short' && text.length > 20) {
     truncated = text.slice(0, 10) + '...' + text.slice(-10)
+  } else if (truncate === 'medium' && text.length > 30) {
+    truncated = text.slice(0, 20) + '...' + text.slice(-10)
   } else if (truncate === 'long' && text.length > 75) {
     truncated = text.slice(0, 75) + '...'
   }

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -98,13 +98,6 @@ export function FreeResponseOutcomeLabel(props: {
   )
 }
 
-export const OUTCOME_TO_COLOR = {
-  YES: 'teal-500',
-  NO: 'scarlet-300',
-  CANCEL: 'yellow-400',
-  MKT: 'blue-400',
-}
-
 export function YesLabel() {
   return <span className="text-teal-500">YES</span>
 }

--- a/web/components/portfolio/portfolio-value-graph.tsx
+++ b/web/components/portfolio/portfolio-value-graph.tsx
@@ -61,6 +61,7 @@ export const PortfolioGraph = (props: {
     const maxValue = max(data.map((d) => d.y))!
     return { data, minDate, maxDate, minValue, maxValue }
   }, [mode, history])
+  console.log('MIN DATE', minDate)
 
   return (
     <SingleValueHistoryChart

--- a/web/lib/icons/triangle-left-fill-icon.tsx
+++ b/web/lib/icons/triangle-left-fill-icon.tsx
@@ -1,0 +1,15 @@
+// Icon from Bootstrap: https://icons.getbootstrap.com/
+export default function TriangleLeftFillIcon(props: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      className={props.className}
+      viewBox="0 0 16 16"
+    >
+      <path d="m3.86 8.753 5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z" />
+    </svg>
+  )
+}

--- a/web/lib/icons/triangle-right-fill-icon.tsx
+++ b/web/lib/icons/triangle-right-fill-icon.tsx
@@ -1,0 +1,15 @@
+// Icon from Bootstrap: https://icons.getbootstrap.com/
+export default function TriangleLeftFillIcon(props: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      className={props.className}
+      viewBox="0 0 16 16"
+    >
+      <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z" />
+    </svg>
+  )
+}

--- a/web/pages/home/index.tsx
+++ b/web/pages/home/index.tsx
@@ -389,7 +389,11 @@ function SearchSection(props: {
         label={label}
         href={`/search?s=${sort}${pill ? `&p=${pill}` : ''}`}
       />
-      <ContractsGrid contracts={contracts} cardUIOptions={{ showProbChange }} />
+      <ContractsGrid
+        contracts={contracts}
+        cardUIOptions={{ showProbChange }}
+        showImageOnTopContract={true}
+      />
     </Col>
   )
 }


### PR DESCRIPTION
<img width="846" alt="image" src="https://user-images.githubusercontent.com/6242616/198044424-750c37cd-faac-4e64-a752-6502f8ce8de2.png">

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/6242616/198044487-cfd3be1c-7961-4b45-bebd-95f5d2c89c7b.png">

<img width="424" alt="image" src="https://user-images.githubusercontent.com/6242616/198044592-d49507b4-bbc2-432b-a5ef-e816303ac3e2.png">

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/6242616/198044659-c32c4786-90bf-43c8-872f-e523abd2252a.png">

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/6242616/198044743-c9cbeba0-4325-4fde-96fb-48443d62e01c.png">

Remaining launch blocking tasks:
- @ingawei to add in extra design polish.
- Find and fix and new bugs/design issues introduced
- Fix the secrets management issue, so coverImgUrls start being stored, and use that instead of the random stock image.
- Daily mover profit/position should update when a quick bet happens.

Non launch blocking:
- Free Response markets don't yet match the figma 
- Show quickbetting arrows even when signed out, but they just redirect to the login dialog