### PR TITLE
Refactor loan code a little bit

### DIFF
--- a/common/loans.ts
+++ b/common/loans.ts
@@ -1,4 +1,4 @@
-import { Dictionary, groupBy, sumBy, minBy } from 'lodash'
+import { Dictionary, sumBy, minBy } from 'lodash'
 import { Bet } from './bet'
 import { getContractBetMetrics } from './calculate'
 import {
@@ -7,7 +7,7 @@ import {
   FreeResponseContract,
   MultipleChoiceContract,
 } from './contract'
-import { PortfolioMetrics, User } from './user'
+import { PortfolioMetrics } from './user'
 import { filterDefined } from './util/array'
 
 const LOAN_DAILY_RATE = 0.02
@@ -19,46 +19,18 @@ const calculateNewLoan = (investedValue: number, loanTotal: number) => {
 
 export const getUserLoanUpdates = (
   betsByContractId: { [contractId: string]: Bet[] },
-  contractsById: { [contractId: string]: Contract },
-  portfolio?: PortfolioMetrics | undefined
+  contractsById: { [contractId: string]: Contract }
 ) => {
-  if (isUserEligibleForLoan(portfolio)) {
-    const updates = calculateLoanBetUpdates(
-      betsByContractId,
-      contractsById
-    ).betUpdates
-    return { updates, payout: sumBy(updates, (update) => update.newLoan) }
-  } else {
-    return undefined
-  }
+  const updates = calculateLoanBetUpdates(
+    betsByContractId,
+    contractsById
+  ).betUpdates
+  return { updates, payout: sumBy(updates, (update) => update.newLoan) }
 }
 
-export const getLoanUpdates = (
-  users: User[],
-  contractsById: { [contractId: string]: Contract },
-  portfolioByUser: { [userId: string]: PortfolioMetrics | undefined },
-  betsByUser: { [userId: string]: Bet[] }
+export const isUserEligibleForLoan = (
+  portfolio: PortfolioMetrics | undefined
 ) => {
-  const userUpdates = filterDefined(
-    users.map((user) => {
-      const result = getUserLoanUpdates(
-        groupBy(betsByUser[user.id] ?? [], (b) => b.contractId),
-        contractsById,
-        portfolioByUser[user.id]
-      )
-      return result ? { user, result } : undefined
-    })
-  )
-  return {
-    betUpdates: userUpdates.map((u) => u.result.updates).flat(),
-    userPayouts: userUpdates.map(({ user, result: { payout } }) => ({
-      user,
-      payout,
-    })),
-  }
-}
-
-const isUserEligibleForLoan = (portfolio: PortfolioMetrics | undefined) => {
   if (!portfolio) return true
 
   const { balance, investmentValue } = portfolio

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -7,7 +7,7 @@ import { Bet } from '../../common/bet'
 import { Contract } from '../../common/contract'
 import { PortfolioMetrics, User } from '../../common/user'
 import { DAY_MS } from '../../common/util/time'
-import { getUserLoanUpdates } from '../../common/loans'
+import { getUserLoanUpdates, isUserEligibleForLoan } from '../../common/loans'
 import {
   calculateCreatorVolume,
   calculateNewPortfolioMetrics,
@@ -112,11 +112,9 @@ export async function updateUserMetrics() {
           (userContracts.length - badResolutions.length) / userContracts.length
       }
 
-      const nextLoanPayout = getUserLoanUpdates(
-        betsByContractId,
-        contractsById,
-        newPortfolio
-      )?.payout
+      const nextLoanPayout = isUserEligibleForLoan(newPortfolio)
+        ? getUserLoanUpdates(betsByContractId, contractsById).payout
+        : undefined
 
       return {
         user,


### PR DESCRIPTION
This is just some cleanup subsequent to the changes I made in #1100. There's no efficiency advantage for the code in `loans.ts` to run the loan computations in a batch, so it's cleaner for its interface to not be batched.