### PR TITLE
Make `updateGroupMetrics` use precomputed contract metrics

### DIFF
--- a/common/scoring.ts
+++ b/common/scoring.ts
@@ -1,52 +1,9 @@
-import { groupBy, sumBy, mapValues, keyBy, sortBy } from 'lodash'
+import { keyBy, sortBy } from 'lodash'
 
 import { Bet } from './bet'
-import { getContractBetMetrics, resolvedPayout } from './calculate'
+import { resolvedPayout } from './calculate'
 import { Contract } from './contract'
 import { ContractComment } from './comment'
-
-export function scoreCreators(contracts: Contract[]) {
-  const creatorScore = mapValues(
-    groupBy(contracts, ({ creatorId }) => creatorId),
-    (contracts) =>
-      sumBy(
-        contracts.map((contract) => {
-          return contract.volume
-        })
-      )
-  )
-
-  return creatorScore
-}
-
-export function scoreTraders(contracts: Contract[], bets: Bet[][]) {
-  const userScoresByContract = contracts.map((contract, index) =>
-    scoreUsersByContract(contract, bets[index])
-  )
-  const userScores: { [userId: string]: number } = {}
-  for (const scores of userScoresByContract) {
-    addUserScores(scores, userScores)
-  }
-  return userScores
-}
-
-export function scoreUsersByContract(contract: Contract, bets: Bet[]) {
-  const betsByUser = groupBy(bets, (bet) => bet.userId)
-  return mapValues(
-    betsByUser,
-    (bets) => getContractBetMetrics(contract, bets).profit
-  )
-}
-
-export function addUserScores(
-  src: { [userId: string]: number },
-  dest: { [userId: string]: number }
-) {
-  for (const [userId, score] of Object.entries(src)) {
-    if (dest[userId] === undefined) dest[userId] = 0
-    dest[userId] += score
-  }
-}
 
 export function scoreCommentorsAndBettors(
   contract: Contract,


### PR DESCRIPTION
WIP. Now `updateGroupMetrics` doesn't have to load all bets, so it's basically good enough for now.