### PR TITLE
Update metrics for resolved contracts also

### DIFF
--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -238,11 +238,7 @@ export const calculateMetricsByContract = (
   betsByContractId: Dictionary<Bet[]>,
   contractsById: Dictionary<Contract>
 ) => {
-  const unresolvedContracts = Object.keys(betsByContractId)
-    .map((cid) => contractsById[cid])
-    .filter((c) => c && !c.isResolved)
-
-  return unresolvedContracts.map((c) => {
+  return Object.values(contractsById).map((c) => {
     const bets = betsByContractId[c.id] ?? []
     const current = getContractBetMetrics(c, bets)
 


### PR DESCRIPTION
This is necessary for a variety of future work, incl. #1122.

It would be better for it to only update metrics for resolved contracts exactly once, after resolution; we will probably add this complication soon.