### PR TITLE
Make type styles more consistent

### DIFF
--- a/web/components/activity-log.tsx
+++ b/web/components/activity-log.tsx
@@ -178,11 +178,7 @@ export const CommentLog = memo(function FeedComment(props: {
           <RelativeTimestamp time={createdTime} />
         </div>
       </Row>
-      <Content
-        className="text-greyscale-7 grow text-[14px]"
-        content={content || text}
-        smallImage
-      />
+      <Content size="sm" className="grow" content={content || text} />
     </Col>
   )
 })

--- a/web/components/comments/comment-input.tsx
+++ b/web/components/comments/comment-input.tsx
@@ -45,7 +45,7 @@ export function CommentInput(props: {
 
   const editor = useTextEditor({
     key,
-    simple: true,
+    size: 'sm',
     max: MAX_COMMENT_LENGTH,
     placeholder:
       !!parentCommentId || !!parentAnswerOutcome

--- a/web/components/comments/comments-list.tsx
+++ b/web/components/comments/comments-list.tsx
@@ -114,7 +114,7 @@ function ProfileComment(props: { comment: ContractComment }) {
           />{' '}
           <RelativeTimestamp time={createdTime} />
         </p>
-        <Content content={content || text} smallImage />
+        <Content content={content || text} size="sm" />
       </div>
     </Row>
   )

--- a/web/components/editor/mention.tsx
+++ b/web/components/editor/mention.tsx
@@ -4,7 +4,6 @@ import {
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from '@tiptap/react'
-import clsx from 'clsx'
 import { Linkify } from '../widgets/linkify'
 import { mentionSuggestion } from './mention-suggestion'
 
@@ -12,7 +11,7 @@ const name = 'mention-component'
 
 const MentionComponent = (props: any) => {
   return (
-    <NodeViewWrapper className={clsx(name, 'not-prose text-indigo-700')}>
+    <NodeViewWrapper className={name}>
       <Linkify text={'@' + props.node.attrs.label} />
     </NodeViewWrapper>
   )

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -151,11 +151,7 @@ export const ParentFeedComment = memo(function ParentFeedComment(props: {
       </Col>
       <Col className="z-20 w-full">
         <FeedCommentHeader comment={comment} contract={contract} />
-        <Content
-          className="text-greyscale-7 mt-2 grow text-[14px]"
-          content={content || text}
-          smallImage
-        />
+        <Content size="sm" content={content || text} />
         <Row className="justify-between">
           <ReplyToggle
             seeReplies={seeReplies}
@@ -267,11 +263,7 @@ export const FeedComment = memo(function FeedComment(props: {
       </Col>
       <Col className="z-20 w-full">
         <FeedCommentHeader comment={comment} contract={contract} />
-        <Content
-          className="text-greyscale-7 mt-2 grow text-[14px]"
-          content={content || text}
-          smallImage
-        />
+        <Content className="mt-2 grow" size="sm" content={content || text} />
         <CommentActions
           onReplyClick={onReplyClick}
           comment={comment}

--- a/web/components/posts/create-post.tsx
+++ b/web/components/posts/create-post.tsx
@@ -22,6 +22,7 @@ export function CreatePostForm(props: { group?: Group }) {
 
   const editor = useTextEditor({
     key: `post ${group?.id || ''}`,
+    size: 'lg',
   })
 
   const isValid =

--- a/web/components/posts/post-comments.tsx
+++ b/web/components/posts/post-comments.tsx
@@ -153,11 +153,7 @@ export function PostComment(props: {
             elementId={comment.id}
           />
         </div>
-        <Content
-          className="mt-2 text-[15px] text-gray-700"
-          content={content || text}
-          smallImage
-        />
+        <Content className="mt-2" size="sm" content={content || text} />
         <Row className="mt-2 items-center gap-6 text-xs text-gray-500">
           {onReplyClick && (
             <button

--- a/web/components/widgets/linkify.tsx
+++ b/web/components/widgets/linkify.tsx
@@ -3,12 +3,8 @@ import { Fragment } from 'react'
 import { SiteLink } from './site-link'
 
 // Return a JSX span, linkifying @username, and https://...
-export function Linkify(props: {
-  text: string
-  className?: string
-  gray?: boolean
-}) {
-  const { text, className, gray } = props
+export function Linkify(props: { text: string; className?: string }) {
+  const { text, className } = props
   // Replace "m1234" with "ϻ1234"
   // const mRegex = /(\W|^)m(\d+)/g
   // text = text.replace(mRegex, (_, pre, num) => `${pre}ϻ${num}`)
@@ -30,10 +26,7 @@ export function Linkify(props: {
     return (
       <>
         {whitespace}
-        <SiteLink
-          className={gray ? 'text-gray-500' : 'text-indigo-700'}
-          href={href}
-        >
+        <SiteLink className="text-indigo-700" href={href}>
           {symbol}
           {tag}
         </SiteLink>

--- a/web/pages/date-docs/[username].tsx
+++ b/web/pages/date-docs/[username].tsx
@@ -140,7 +140,7 @@ export function DateDocPost(props: {
       {user && user.id === creator.id ? (
         <RichEditPost post={post} />
       ) : (
-        <Content content={content} />
+        <Content size="lg" content={content} />
       )}
       {contractSlug && (
         <div className="mt-4 w-full max-w-lg self-center rounded-xl bg-gradient-to-r from-blue-200 via-purple-200 to-indigo-300 p-3">

--- a/web/pages/post/[...slugs]/index.tsx
+++ b/web/pages/post/[...slugs]/index.tsx
@@ -5,7 +5,7 @@ import { Post } from 'common/post'
 import { Title } from 'web/components/widgets/title'
 import { Spacer } from 'web/components/layout/spacer'
 import {
-  PostContent,
+  Content,
   TextEditor,
   useTextEditor,
 } from 'web/components/widgets/editor'
@@ -133,7 +133,7 @@ export default function PostPage(props: {
             {user && user.id === post.creatorId ? (
               <RichEditPost post={post} />
             ) : (
-              <PostContent content={post.content} />
+              <Content size="lg" content={post.content} />
             )}
           </div>
         </div>
@@ -214,7 +214,7 @@ export function RichEditPost(props: { post: Post }) {
     </>
   ) : (
     <Col>
-      <PostContent content={post.content} />
+      <Content size="lg" content={post.content} />
       <Row className="place-content-end">
         <Button
           color="gray-white"

--- a/web/pages/swipe/index.tsx
+++ b/web/pages/swipe/index.tsx
@@ -5,7 +5,7 @@ import { richTextToString } from 'common/util/parse'
 import { useMemo, useState } from 'react'
 import TinderCard from 'react-tinder-card'
 import { Avatar } from 'web/components/widgets/avatar'
-import { RichContent } from 'web/components/widgets/editor'
+import { Content } from 'web/components/widgets/editor'
 
 import { useWindowSize } from 'web/hooks/use-window-size'
 import { placeBet } from 'web/lib/firebase/api'
@@ -192,11 +192,7 @@ const Peek = (props: { contract: BinaryContract; onClose: () => void }) => {
         <h1 className="mb-8 text-lg font-semibold text-indigo-700">
           {question}
         </h1>
-        <RichContent
-          proseClassName="prose-sm"
-          content={description}
-          smallImage
-        />
+        <Content size="sm" content={description} />
       </div>
     </section>
   )


### PR DESCRIPTION
- comments in old format (string) vs json are now the same size (14px)
- @mention and link now are now the same font weight (300px)
- post editor now has between-paragraph space, just like posts
- comment editor now same font size as comments

@ingawei I don't feel opinionated about any of these changes, I just think it should be consistent. To change the styles just change the `proseClass` function in editor.tsx. Previously the styles were split across multiple components in some cases but now its more consolidated

This adds a size property to `Content` and `useTextEditor` to make styling easier and more consistent.
@mantikoros now posts are just `Content` with `size='lg'` rather than `PostContent`
