### PR TITLE
Apple review fixes

### DIFF
--- a/common/report.ts
+++ b/common/report.ts
@@ -1,0 +1,16 @@
+export type Report = {
+  id: string
+  userId: string
+  createdTime: number
+  contentOwnerId: string
+  contentType: ReportContentTypes
+  contentId: string
+
+  // in case the user would like to say why they reported the content
+  description?: string
+
+  // in the case of a comment, the comment's contract id
+  parentId?: string
+  parentType?: 'contract' | 'post'
+}
+export type ReportContentTypes = 'user' | 'comment' | 'contract'

--- a/common/user.ts
+++ b/common/user.ts
@@ -98,6 +98,7 @@ export type PrivateUser = {
   blockedByUserIds: string[]
   blockedContractIds: string[]
   blockedGroupSlugs: string[]
+  hasSignedEula?: boolean
 }
 
 export type PortfolioMetrics = {

--- a/firestore.rules
+++ b/firestore.rules
@@ -165,6 +165,11 @@ service cloud.firestore {
       allow read;
     }
 
+    match /reports/{reportId} {
+      allow read;
+      allow write: if request.auth.uid == request.resource.data.userId;
+    }
+
     // Note: `resource` = existing doc, `request.resource` = incoming doc
     match /manalinks/{slug} {
       // Anyone can view any manalink

--- a/firestore.rules
+++ b/firestore.rules
@@ -91,7 +91,7 @@ service cloud.firestore {
       allow read: if userId == request.auth.uid || isAdmin();
       allow update: if (userId == request.auth.uid || isAdmin())
                        && request.resource.data.diff(resource.data).affectedKeys()
-                         .hasOnly(['apiKey', 'notificationPreferences', 'twitchInfo', 'pushToken', 'rejectedPushNotificationsOn', 'blockedUserIds', 'blockedContractIds', 'blockedGroupSlugs','interestedInPushNotifications']);
+                         .hasOnly(['apiKey', 'notificationPreferences', 'twitchInfo', 'pushToken', 'rejectedPushNotificationsOn', 'blockedUserIds', 'blockedContractIds', 'blockedGroupSlugs','interestedInPushNotifications', 'hasSignedEula']);
       allow update: if (request.auth != null || isAdmin())
                        && request.resource.data.diff(resource.data).affectedKeys()
                          .hasOnly(['blockedByUserIds'])

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -56,7 +56,9 @@ export const auth = getAuth(app)
 // no other uri works for API requests due to CORS
 // const uri = 'http://localhost:3000/'
 const homeUri =
-  ENV === 'DEV' ? 'https://dev.manifold.markets/' : 'https://manifold.markets/'
+  ENV === 'DEV'
+    ? 'https://3004-181-41-206-68.ngrok.io'
+    : 'https://manifold.markets/'
 
 export default function App() {
   // Init
@@ -107,11 +109,9 @@ export default function App() {
       responseListener.current =
         Notifications.addNotificationResponseReceivedListener((response) => {
           console.log('notification response', response)
-          webview.current?.postMessage(
-            JSON.stringify({
-              type: 'notification',
-              data: response.notification.request.content.data,
-            })
+          communicateWithWebview(
+            'notification',
+            response.notification.request.content.data
           )
         })
     } catch (err) {
@@ -146,12 +146,7 @@ export default function App() {
           queryParams
         )}`
       )
-      webview.current?.postMessage(
-        JSON.stringify({
-          type: 'link',
-          data: path,
-        })
-      )
+      communicateWithWebview('link', path ? path : '/')
       // If we don't clear the url, we won't reopen previously opened links
       const clearUrlCacheEvent = {
         hostname: 'manifold.markets',
@@ -215,12 +210,10 @@ export default function App() {
         finalStatus = status
       }
       if (finalStatus !== 'granted') {
-        webview.current?.postMessage(
-          JSON.stringify({
-            type: 'pushNotificationPermissionStatus',
-            data: { status: finalStatus, userId },
-          })
-        )
+        communicateWithWebview('pushNotificationPermissionStatus', {
+          status: finalStatus,
+          userId,
+        })
         return null
       }
       return await getPushToken()
@@ -246,20 +239,12 @@ export default function App() {
         if (status === 'granted') {
           const token = await getPushToken()
           if (!webview.current) return
-          if (token)
-            webview.current.postMessage(
-              JSON.stringify({
-                type: 'pushToken',
-                data: { token, userId },
-              })
-            )
+          if (token) communicateWithWebview('pushToken', { token, userId })
         } else
-          webview.current?.postMessage(
-            JSON.stringify({
-              type: 'pushNotificationPermissionStatus',
-              data: { status, userId },
-            })
-          )
+          communicateWithWebview('pushNotificationPermissionStatus', {
+            status,
+            userId,
+          })
       })
     } else if (type === 'copyToClipboard') {
       Clipboard.setString(payload)
@@ -267,13 +252,7 @@ export default function App() {
     // User needs to enable push notifications
     else if (type === 'promptEnablePushNotifications') {
       registerForPushNotificationsAsync().then((token) => {
-        if (token)
-          webview.current?.postMessage(
-            JSON.stringify({
-              type: 'pushToken',
-              data: { token, userId },
-            })
-          )
+        if (token) communicateWithWebview('pushToken', { token, userId })
       })
     } else if (type === 'signOut' && (fbUser || auth.currentUser)) {
       console.log('signOut called')
@@ -306,6 +285,20 @@ export default function App() {
     } else {
       console.log('Unhandled nativeEvent.data: ', data)
     }
+  }
+
+  const tellWebviewToSetNativeFlag = () => {
+    if (hasSetNativeFlag) return
+    communicateWithWebview('setNativeFlag', { platform: Platform.OS })
+  }
+
+  const communicateWithWebview = (type: string, data: object | string) => {
+    webview.current?.postMessage(
+      JSON.stringify({
+        type,
+        data,
+      })
+    )
   }
 
   const width = Dimensions.get('window').width //full width
@@ -467,15 +460,7 @@ export default function App() {
             })
           }}
           onTouchStart={() => {
-            if (!hasSetNativeFlag && webview.current) {
-              console.log('setting is native')
-              webview.current.postMessage(
-                JSON.stringify({
-                  type: 'setIsNative',
-                  data: {},
-                })
-              )
-            }
+            tellWebviewToSetNativeFlag()
           }}
           onLoadStart={() => {
             console.log('onLoadStart')
@@ -492,16 +477,7 @@ export default function App() {
                 : currentHostStatus.previousHomeUrl,
               previousUrl: currentHostStatus.url,
             })
-
-            if (!hasSetNativeFlag && webview.current) {
-              console.log('setting is native')
-              webview.current.postMessage(
-                JSON.stringify({
-                  type: 'setIsNative',
-                  data: {},
-                })
-              )
-            }
+            tellWebviewToSetNativeFlag()
           }}
           onMessage={handleMessageFromWebview}
         />

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -55,7 +55,8 @@ export const auth = getAuth(app)
 
 // no other uri works for API requests due to CORS
 // const uri = 'http://localhost:3000/'
-const homeUri = ENV === 'DEV' ? '' : 'https://3004-181-41-206-68.ngrok.io'
+const homeUri =
+  ENV === 'DEV' ? 'https://dev.manifold.markets/' : 'https://manifold.markets/'
 
 export default function App() {
   // Init

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -55,10 +55,7 @@ export const auth = getAuth(app)
 
 // no other uri works for API requests due to CORS
 // const uri = 'http://localhost:3000/'
-const homeUri =
-  ENV === 'DEV'
-    ? 'https://3004-181-41-206-68.ngrok.io'
-    : 'https://manifold.markets/'
+const homeUri = ENV === 'DEV' ? '' : 'https://3004-181-41-206-68.ngrok.io'
 
 export default function App() {
   // Init
@@ -289,7 +286,7 @@ export default function App() {
 
   const tellWebviewToSetNativeFlag = () => {
     if (hasSetNativeFlag) return
-    communicateWithWebview('setNativeFlag', { platform: Platform.OS })
+    communicateWithWebview('setIsNative', { platform: Platform.OS })
   }
 
   const communicateWithWebview = (type: string, data: object | string) => {
@@ -463,7 +460,6 @@ export default function App() {
             tellWebviewToSetNativeFlag()
           }}
           onLoadStart={() => {
-            console.log('onLoadStart')
             setCurrentHostStatus({ ...currentHostStatus, loading: true })
           }}
           onNavigationStateChange={(navState) => {

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -147,8 +147,8 @@ android {
         applicationId 'com.markets.manifold'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 19
-        versionName "2.0.11"
+        versionCode 20
+        versionName "2.0.12"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         if (isNewArchitectureEnabled()) {

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -147,8 +147,8 @@ android {
         applicationId 'com.markets.manifold'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 20
-        versionName "2.0.12"
+        versionCode 21
+        versionName "2.0.13"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         if (isNewArchitectureEnabled()) {

--- a/native/app.json
+++ b/native/app.json
@@ -4,7 +4,7 @@
     "slug": "manifold-markets",
     "owner": "iansp",
     "sdkVersion": "46.0.0",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
     "userInterfaceStyle": "light",
@@ -51,7 +51,7 @@
         "backgroundColor": "#4337C9"
       },
       "package": "com.markets.manifold",
-      "versionCode": 20
+      "versionCode": 21
     },
     "ios": {
       "infoPlist": {
@@ -64,7 +64,7 @@
         "applinks:manifold.markets",
         "webcredentials:manifold.markets"
       ],
-      "buildNumber": "1.0.7",
+      "buildNumber": "1.0.8",
       "runtimeVersion": {
         "policy": "sdkVersion"
       }

--- a/native/app.json
+++ b/native/app.json
@@ -54,6 +54,9 @@
       "versionCode": 20
     },
     "ios": {
+      "infoPlist": {
+        "NSCameraUsageDescription": "Pictures can be attached to the content you create."
+      },
       "supportsTablet": true,
       "usesAppleSignIn": true,
       "bundleIdentifier": "com.markets.manifold",

--- a/native/ios/Manifold/Info.plist
+++ b/native/ios/Manifold/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.12</string>
+    <string>2.0.13</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.0.7</string>
+    <string>1.0.8</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/native/ios/Manifold/Info.plist
+++ b/native/ios/Manifold/Info.plist
@@ -54,6 +54,8 @@
         </dict>
       </dict>
     </dict>
+    <key>NSCameraUsageDescription</key>
+    <string>Pictures can be attached to the content you create.</string>
     <key>UILaunchStoryboardName</key>
     <string>SplashScreen</string>
     <key>UIRequiredDeviceCapabilities</key>

--- a/native/ios/Manifold/Info.plist
+++ b/native/ios/Manifold/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.11</string>
+    <string>2.0.12</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.0.6</string>
+    <string>1.0.7</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/web/components/buttons/block-user-button.tsx
+++ b/web/components/buttons/block-user-button.tsx
@@ -78,10 +78,11 @@ export function BlockUserButton(props: { user: User }) {
             </Button>
             <Row className={'gap-4'}>
               <ReportButton
-                userId={user.id}
-                name={user.name}
+                contentName={user.name}
+                contentOwnerId={user.id}
+                contentId={user.id}
                 noModal={true}
-                label={'user'}
+                contentType={'user'}
               />
               {isBlocked ? (
                 <Button

--- a/web/components/buttons/report-button.tsx
+++ b/web/components/buttons/report-button.tsx
@@ -8,31 +8,64 @@ import { useState } from 'react'
 import { Col } from 'web/components/layout/col'
 import { Title } from 'web/components/widgets/title'
 import { capitalize } from 'lodash'
-import { getIsNative } from 'web/lib/native/is-native'
+import { collection, doc, setDoc } from 'firebase/firestore'
+import { Report, ReportContentTypes } from 'common/report'
+import { db } from 'web/lib/firebase/init'
+import { removeUndefinedProps } from 'common/util/object'
 
 export function ReportButton(props: {
-  userId: string
-  label: 'user' | 'market' | 'comment'
+  contentType: ReportContentTypes
+  contentOwnerId: string
+  contentId: string
+  parentId?: string
+  parentType?: 'post' | 'contract'
+  description?: string
+  contentName?: string
   icon?: React.ReactNode
-  name?: string
   noModal?: boolean
 }) {
-  const { userId, name, noModal, label, icon } = props
+  const {
+    noModal,
+    contentType,
+    icon,
+    contentOwnerId,
+    contentId,
+    parentId,
+    description,
+    contentName,
+    parentType,
+  } = props
   const currentUser = useUser()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isReported, setIsReported] = useState(false)
-  const isNative = getIsNative()
-  if (!currentUser || currentUser.id === userId || !isNative) return null
+  const label = contentType === 'contract' ? 'market' : contentType
+  if (!currentUser || currentUser.id === contentOwnerId) return <div />
   const report = async () => {
-    // TODO: file report
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    // create the report doc in the db
+    const reportDoc = await doc(collection(db, 'reports'))
+    await setDoc(
+      reportDoc,
+      removeUndefinedProps({
+        id: reportDoc.id,
+        userId: currentUser.id,
+        createdTime: Date.now(),
+        contentId,
+        contentOwnerId,
+        parentId,
+        description,
+        contentType,
+        parentType,
+      }) as Report
+    )
     setIsReported(true)
   }
 
   const onReport = async () => {
     await toast.promise(report(), {
       loading: 'Reporting...',
-      success: `${capitalize(label)} reported! Admins will take a look asap.`,
+      success: `${capitalize(
+        label
+      )} reported! Admins will take a look within 24 hours.`,
       error: `Error reporting ${label}`,
     })
   }
@@ -49,11 +82,11 @@ export function ReportButton(props: {
       </Button>
       <Modal open={isModalOpen} setOpen={setIsModalOpen}>
         <Col className={'rounded-md bg-white p-4'}>
-          <Title>Report {name ? name : label}</Title>
+          <Title>Report {contentName ? contentName : label}</Title>
           <span className={'mb-4 text-sm'}>
             {isReported
-              ? `You've reported this ${label}. Administrators wil take a look at them as soon as possible.`
-              : `Report this ${label}`}
+              ? `You've reported this ${label}. Our team will take a look within 24 hours.`
+              : `Report this ${label} for objectionable content that violates our Terms of Service.`}
           </span>
           <Row className={'justify-between'}>
             <Button color={'gray-white'} onClick={() => setIsModalOpen(false)}>
@@ -75,7 +108,7 @@ export function ReportButton(props: {
                 className="my-auto"
                 onClick={withTracking(onReport, 'block')}
               >
-                Report {label}
+                Report {contentType}
               </Button>
             )}
           </Row>

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -99,7 +99,12 @@ export function ContractInfoDialog(props: {
             <Row className={'justify-between'}>
               <Title className="!mt-0 !mb-0" text="This Market" />
               {user && (
-                <ReportButton userId={contract.creatorId} label={'market'} />
+                <ReportButton
+                  contentType={'contract'}
+                  contentOwnerId={contract.creatorId}
+                  contentId={contract.id}
+                  contentName={'market'}
+                />
               )}
               {privateUser && <BlockMarketButton contractId={contract.id} />}
             </Row>

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -26,10 +26,8 @@ import { AwardBountyButton } from 'web/components/buttons/award-bounty-button'
 import { ReplyIcon } from '@heroicons/react/solid'
 import { IconButton } from '../buttons/button'
 import { ReplyToggle } from '../comments/reply-toggle'
-import { Tooltip } from 'web/components/widgets/tooltip'
 import { ReportButton } from 'web/components/buttons/report-button'
 import { FlagIcon } from '@heroicons/react/outline'
-import { getIsNative } from 'web/lib/native/is-native'
 
 export type ReplyTo = { id: string; username: string }
 
@@ -190,7 +188,6 @@ export function CommentActions(props: {
   contract: Contract
 }) {
   const { onReplyClick, comment, showTip, myTip, totalTip, contract } = props
-  const isNative = getIsNative()
 
   return (
     <Row className="grow items-center justify-end">
@@ -205,21 +202,20 @@ export function CommentActions(props: {
       {(contract.openCommentBounties ?? 0) > 0 && (
         <AwardBountyButton comment={comment} contract={contract} />
       )}
-      {isNative && (
-        <Tooltip text={'Report comment'}>
-          <ReportButton
-            userId={comment.userId}
-            label={'comment'}
-            icon={
-              <FlagIcon
-                className={
-                  'disabled:text-greyscale-2 text-greyscale-5 hover:text-greyscale-6 h-5 w-5'
-                }
-              />
+      <ReportButton
+        contentOwnerId={comment.userId}
+        contentId={comment.id}
+        parentId={contract.id}
+        parentType={'contract'}
+        contentType={'comment'}
+        icon={
+          <FlagIcon
+            className={
+              'disabled:text-greyscale-2 text-greyscale-5 hover:text-greyscale-6 h-5 w-5'
             }
           />
-        </Tooltip>
-      )}
+        }
+      />
     </Row>
   )
 }

--- a/web/components/native-message-listener.tsx
+++ b/web/components/native-message-listener.tsx
@@ -23,7 +23,7 @@ export const NativeMessageListener = () => {
     const { type, data } = event
     console.log('Received native event: ', event)
     if (type === 'setIsNative') {
-      setIsNative(true)
+      setIsNative(true, data.platform)
     } else if (type === 'nativeFbUser') {
       await setFirebaseUserViaJson(data, app, true)
     } else if (type === 'pushNotificationPermissionStatus') {

--- a/web/components/native/add-funds-ios.tsx
+++ b/web/components/native/add-funds-ios.tsx
@@ -13,8 +13,9 @@ import {
   UNIQUE_BETTOR_BONUS_AMOUNT,
 } from 'common/economy'
 import { formatMoney } from 'common/lib/util/format'
+import { Card } from 'web/components/widgets/card'
 
-export default function AddFundsIOS() {
+export function AddFundsIOS() {
   useRedirectIfSignedOut()
   useTracking('view add funds')
 
@@ -46,9 +47,16 @@ export default function AddFundsIOS() {
 }
 
 export const OtherWaysToGetMana = (includeBuyingNote?: boolean) => {
+  const cardClass = 'p-2 shadow-md'
   return (
     <Col className={'text-md gap-y-4 text-gray-700'}>
-      <Row>
+      <Card className={cardClass}>
+        <Row>
+          - Add a helpful comment to a market or post to earn tips from other
+          users.
+        </Row>
+      </Card>
+      <Card className={cardClass}>
         <span>
           - Place a {PAST_BET} once per day to get your streak bonus. (up to
           <span className={'mx-1 inline-block text-indigo-700'}>
@@ -56,8 +64,8 @@ export const OtherWaysToGetMana = (includeBuyingNote?: boolean) => {
           </span>
           per day!).
         </span>
-      </Row>
-      <Row>
+      </Card>
+      <Card className={cardClass}>
         <span>
           - Refer a friend and get
           <span className={'mx-1 inline-block text-indigo-700'}>
@@ -65,8 +73,8 @@ export const OtherWaysToGetMana = (includeBuyingNote?: boolean) => {
           </span>
           per signup.
         </span>
-      </Row>
-      <Row>
+      </Card>
+      <Card className={cardClass}>
         <span>
           - Make a market and get
           <span className={'mx-1 inline-block text-indigo-700'}>
@@ -74,8 +82,8 @@ export const OtherWaysToGetMana = (includeBuyingNote?: boolean) => {
           </span>
           per unique trader.
         </span>
-      </Row>
-      <Row>
+      </Card>
+      <Card className={cardClass}>
         <span>
           - Come by our
           <a
@@ -86,11 +94,23 @@ export const OtherWaysToGetMana = (includeBuyingNote?: boolean) => {
           </a>
           and ask nicely - we pay new users for sharing their experience!
         </span>
-      </Row>
+      </Card>
+      <Card className={cardClass}>
+        <span>
+          - Contribute to our{' '}
+          <a
+            className={'text-indigo-700'}
+            href={'https://github.com/manifoldmarkets/manifold'}
+          >
+            codebase
+          </a>
+          , even something simple, and we'll pay you a bounty.
+        </span>
+      </Card>
       {includeBuyingNote && (
-        <Row>
+        <Card className={cardClass}>
           - Visit our website in your browser to buy mana with a credit card.
-        </Row>
+        </Card>
       )}
     </Col>
   )

--- a/web/components/native/add-funds-ios.tsx
+++ b/web/components/native/add-funds-ios.tsx
@@ -12,7 +12,7 @@ import {
   REFERRAL_AMOUNT,
   UNIQUE_BETTOR_BONUS_AMOUNT,
 } from 'common/economy'
-import { formatMoney } from 'common/lib/util/format'
+import { formatMoney } from 'common/util/format'
 import { Card } from 'web/components/widgets/card'
 
 export function AddFundsIOS() {

--- a/web/components/native/add-funds-ios.tsx
+++ b/web/components/native/add-funds-ios.tsx
@@ -1,0 +1,97 @@
+import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
+import { useTracking } from 'web/hooks/use-tracking'
+import { Page } from 'web/components/layout/page'
+import { SEO } from 'web/components/SEO'
+import { Col } from 'web/components/layout/col'
+import { Title } from 'web/components/widgets/title'
+import React from 'react'
+import { Row } from 'web/components/layout/row'
+import { PAST_BET } from 'common/user'
+import {
+  BETTING_STREAK_BONUS_MAX,
+  REFERRAL_AMOUNT,
+  UNIQUE_BETTOR_BONUS_AMOUNT,
+} from 'common/economy'
+import { formatMoney } from 'common/lib/util/format'
+
+export default function AddFundsIOS() {
+  useRedirectIfSignedOut()
+  useTracking('view add funds')
+
+  return (
+    <Page>
+      <SEO
+        title="Get Mana"
+        description="Buy mana to trade in your favorite markets on Manifold"
+        url="/add-funds"
+      />
+
+      <Col className="items-center">
+        <Col className="h-full rounded bg-white p-4 py-8 sm:p-8 sm:shadow-md">
+          <Title className="!mt-0" text="Get Mana" />
+          <img
+            className="mb-6 block self-center"
+            src="/welcome/manipurple.png"
+            width={200}
+            height={158}
+          />
+          <div className="mb-6 text-indigo-700">
+            These are the best ways to get mana (M$): <br />
+          </div>
+          {OtherWaysToGetMana(true)}
+        </Col>
+      </Col>
+    </Page>
+  )
+}
+
+export const OtherWaysToGetMana = (includeBuyingNote?: boolean) => {
+  return (
+    <Col className={'text-md gap-y-4 text-gray-700'}>
+      <Row>
+        <span>
+          - Place a {PAST_BET} once per day to get your streak bonus. (up to
+          <span className={'mx-1 inline-block text-indigo-700'}>
+            {formatMoney(BETTING_STREAK_BONUS_MAX)}
+          </span>
+          per day!).
+        </span>
+      </Row>
+      <Row>
+        <span>
+          - Refer a friend and get
+          <span className={'mx-1 inline-block text-indigo-700'}>
+            {formatMoney(REFERRAL_AMOUNT)}
+          </span>
+          per signup.
+        </span>
+      </Row>
+      <Row>
+        <span>
+          - Make a market and get
+          <span className={'mx-1 inline-block text-indigo-700'}>
+            {formatMoney(UNIQUE_BETTOR_BONUS_AMOUNT)}
+          </span>
+          per unique trader.
+        </span>
+      </Row>
+      <Row>
+        <span>
+          - Come by our
+          <a
+            className={'mx-1 text-indigo-700'}
+            href={'https://discord.gg/3Zuth9792G'}
+          >
+            discord
+          </a>
+          and ask nicely - we pay new users for sharing their experience!
+        </span>
+      </Row>
+      {includeBuyingNote && (
+        <Row>
+          - Visit our website in your browser to buy mana with a credit card.
+        </Row>
+      )}
+    </Col>
+  )
+}

--- a/web/components/onboarding/group-selector-dialog.tsx
+++ b/web/components/onboarding/group-selector-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from 'web/components/buttons/button'
 import { Group } from 'common/group'
 import { LoadingIndicator } from '../widgets/loading-indicator'
 import { withTracking } from 'web/lib/service/analytics'
+import { Row } from 'web/components/layout/row'
 
 export default function GroupSelectorDialog(props: {
   open: boolean
@@ -89,9 +90,11 @@ export default function GroupSelectorDialog(props: {
             ))
           )}
         </div>
-      </Col>
-      <Col>
-        <Button onClick={() => setOpen(false)}>Done</Button>
+        <Row className={'justify-end'}>
+          <Button size={'lg'} onClick={() => setOpen(false)}>
+            Done
+          </Button>
+        </Row>
       </Col>
     </Modal>
   )

--- a/web/lib/native/is-native.ts
+++ b/web/lib/native/is-native.ts
@@ -1,13 +1,27 @@
 import { safeLocalStorage } from 'web/lib/util/local'
 
-export const IS_NATIVE_KEY = 'is-native'
+const IS_NATIVE_KEY = 'is-native'
+const PLATFORM_KEY = 'native-platform'
+
 export const getIsNative = () => {
   if (typeof window === 'undefined') return false
   const local = safeLocalStorage()
   const isNative = local?.getItem(IS_NATIVE_KEY)
   return isNative === 'true'
 }
-export const setIsNative = (isNative: boolean) => {
+
+export const getNativePlatform = () => {
+  if (typeof window === 'undefined') return null
+  const local = safeLocalStorage()
+  const isNative = local?.getItem(IS_NATIVE_KEY)
+  const platform = local?.getItem(PLATFORM_KEY)
+  return { isNative: isNative === 'true', platform }
+}
+
+export const setIsNative = (isNative: boolean, platform: string) => {
   const local = safeLocalStorage()
   local?.setItem(IS_NATIVE_KEY, isNative ? 'true' : 'false')
+  if (platform) {
+    local?.setItem(PLATFORM_KEY, platform)
+  }
 }

--- a/web/pages/add-funds.tsx
+++ b/web/pages/add-funds.tsx
@@ -11,7 +11,8 @@ import { trackCallback } from 'web/lib/service/analytics'
 import { Button } from 'web/components/buttons/button'
 import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
 import { getNativePlatform } from 'web/lib/native/is-native'
-import AddFundsIOS, {
+import {
+  AddFundsIOS,
   OtherWaysToGetMana,
 } from 'web/components/native/add-funds-ios'
 

--- a/web/pages/add-funds.tsx
+++ b/web/pages/add-funds.tsx
@@ -10,6 +10,10 @@ import { useTracking } from 'web/hooks/use-tracking'
 import { trackCallback } from 'web/lib/service/analytics'
 import { Button } from 'web/components/buttons/button'
 import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
+import { getNativePlatform } from 'web/lib/native/is-native'
+import AddFundsIOS, {
+  OtherWaysToGetMana,
+} from 'web/components/native/add-funds-ios'
 
 export default function AddFundsPage() {
   const user = useUser()
@@ -20,6 +24,11 @@ export default function AddFundsPage() {
 
   useRedirectIfSignedOut()
   useTracking('view add funds')
+
+  const { isNative, platform } = getNativePlatform() ?? {}
+  if (isNative && platform === 'ios') {
+    return <AddFundsIOS />
+  }
 
   return (
     <Page>
@@ -73,6 +82,11 @@ export default function AddFundsPage() {
               Checkout
             </Button>
           </form>
+
+          <div className="mb-6 mt-12 text-gray-500">
+            Short on USD?. Here are some other ways to get mana: <br />{' '}
+          </div>
+          {OtherWaysToGetMana(false)}
         </Col>
       </Col>
     </Page>


### PR DESCRIPTION
Reports are now top-level objects in the 'reports' collection.
Iphone native app users can use the 'take a photo' option in the editor now. 
Iphone native app users must agree to the TOS and privacy policy before using the site. 
IPhone native app users can't buy mana in the app :(. 

Perhaps we should make a /reports api to hook up zapier and get discord messages when people report content?