### PR TITLE
Clean up additional mana options, add to modal

### DIFF
--- a/web/components/add-funds-modal.tsx
+++ b/web/components/add-funds-modal.tsx
@@ -5,6 +5,10 @@ import { checkoutURL } from 'web/lib/service/stripe'
 import { Button } from './buttons/button'
 import { Modal } from './layout/modal'
 import { FundsSelector } from './bet/yes-no-selector'
+import { getNativePlatform } from 'web/lib/native/is-native'
+import { Title } from './widgets/title'
+import { OtherWaysToGetMana } from './native/add-funds-ios'
+import { ControlledTabs, Tabs, UncontrolledTabs } from './layout/tabs'
 
 export function AddFundsModal(props: {
   open: boolean
@@ -12,19 +16,53 @@ export function AddFundsModal(props: {
 }) {
   const { open, setOpen } = props
 
+  const { isNative, platform } = getNativePlatform() ?? {}
+  const hidePayment = isNative && platform === 'ios'
+
+  return (
+    <Modal open={open} setOpen={setOpen} className="rounded-md bg-white p-8">
+      {hidePayment ? (
+        <>
+          <Title text="Get Mana" />
+          <OtherWaysToGetMana includeBuyNote />
+        </>
+      ) : (
+        <Tabs
+          currentPageForAnalytics="buy modal"
+          tabs={[
+            {
+              title: 'Buy Mana',
+              content: <BuyManaTab />,
+            },
+            {
+              title: "I'm Broke",
+              content: (
+                <>
+                  <div className="mt-6 mb-4">
+                    Here are some other ways to get mana:
+                  </div>
+                  <OtherWaysToGetMana />
+                </>
+              ),
+            },
+          ]}
+        />
+      )}
+    </Modal>
+  )
+}
+
+function BuyManaTab() {
   const user = useUser()
 
   const [amountSelected, setAmountSelected] = useState<1000 | 2500 | 10000>(
     2500
   )
-
   return (
-    <Modal open={open} setOpen={setOpen} className="rounded-md bg-white p-8">
-      <div className="mb-6 text-xl text-indigo-700">Get Mana</div>
-
-      <div className="mb-6 text-gray-700">
-        Buy mana (M$) to trade in your favorite markets. <br /> (Not redeemable
-        for cash.)
+    <>
+      <div className="mt-6 mb-4">
+        Buy mana (M$) to trade in your favorite markets.
+        <div className="italic">Not redeemable for cash.</div>
       </div>
 
       <div className="mb-2 text-sm text-gray-500">Amount</div>
@@ -35,8 +73,8 @@ export function AddFundsModal(props: {
         <div className="text-xl">{manaToUSD(amountSelected)}</div>
       </div>
 
-      <div className="flex">
-        <Button color="gray-white" onClick={() => setOpen(false)}>
+      <div className="mt-2 flex gap-2">
+        <Button color="gray" onClick={() => setOpen(false)}>
           Back
         </Button>
 
@@ -53,6 +91,6 @@ export function AddFundsModal(props: {
           </Button>
         </form>
       </div>
-    </Modal>
+    </>
   )
 }

--- a/web/components/add-funds-modal.tsx
+++ b/web/components/add-funds-modal.tsx
@@ -8,7 +8,7 @@ import { FundsSelector } from './bet/yes-no-selector'
 import { getNativePlatform } from 'web/lib/native/is-native'
 import { Title } from './widgets/title'
 import { OtherWaysToGetMana } from './native/add-funds-ios'
-import { ControlledTabs, Tabs, UncontrolledTabs } from './layout/tabs'
+import { Tabs } from './layout/tabs'
 
 export function AddFundsModal(props: {
   open: boolean
@@ -32,7 +32,7 @@ export function AddFundsModal(props: {
           tabs={[
             {
               title: 'Buy Mana',
-              content: <BuyManaTab />,
+              content: <BuyManaTab onClose={() => setOpen(false)} />,
             },
             {
               title: "I'm Broke",
@@ -52,7 +52,8 @@ export function AddFundsModal(props: {
   )
 }
 
-function BuyManaTab() {
+function BuyManaTab(props: { onClose: () => void }) {
+  const { onClose } = props
   const user = useUser()
 
   const [amountSelected, setAmountSelected] = useState<1000 | 2500 | 10000>(
@@ -74,7 +75,7 @@ function BuyManaTab() {
       </div>
 
       <div className="mt-2 flex gap-2">
-        <Button color="gray" onClick={() => setOpen(false)}>
+        <Button color="gray" onClick={onClose}>
           Back
         </Button>
 

--- a/web/components/native/add-funds-ios.tsx
+++ b/web/components/native/add-funds-ios.tsx
@@ -1,5 +1,3 @@
-import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
-import { useTracking } from 'web/hooks/use-tracking'
 import { Page } from 'web/components/layout/page'
 import { SEO } from 'web/components/SEO'
 import { Col } from 'web/components/layout/col'

--- a/web/components/native/add-funds-ios.tsx
+++ b/web/components/native/add-funds-ios.tsx
@@ -5,7 +5,6 @@ import { SEO } from 'web/components/SEO'
 import { Col } from 'web/components/layout/col'
 import { Title } from 'web/components/widgets/title'
 import React from 'react'
-import { Row } from 'web/components/layout/row'
 import { PAST_BET } from 'common/user'
 import {
   BETTING_STREAK_BONUS_MAX,
@@ -14,11 +13,9 @@ import {
 } from 'common/economy'
 import { formatMoney } from 'common/util/format'
 import { Card } from 'web/components/widgets/card'
+import Link from 'next/link'
 
 export function AddFundsIOS() {
-  useRedirectIfSignedOut()
-  useTracking('view add funds')
-
   return (
     <Page>
       <SEO
@@ -30,88 +27,70 @@ export function AddFundsIOS() {
       <Col className="items-center">
         <Col className="h-full rounded bg-white p-4 py-8 sm:p-8 sm:shadow-md">
           <Title className="!mt-0" text="Get Mana" />
-          <img
-            className="mb-6 block self-center"
-            src="/welcome/manipurple.png"
-            width={200}
-            height={158}
-          />
-          <div className="mb-6 text-indigo-700">
-            These are the best ways to get mana (M$): <br />
+          <div className="mb-4 text-indigo-700">
+            These are the best ways to get mana (M$):
           </div>
-          {OtherWaysToGetMana(true)}
+          <OtherWaysToGetMana includeBuyNote />
         </Col>
       </Col>
     </Page>
   )
 }
 
-export const OtherWaysToGetMana = (includeBuyingNote?: boolean) => {
-  const cardClass = 'p-2 shadow-md'
+export const OtherWaysToGetMana = (props: { includeBuyNote?: boolean }) => {
+  const { includeBuyNote } = props
   return (
-    <Col className={'text-md gap-y-4 text-gray-700'}>
-      <Card className={cardClass}>
-        <Row>
-          - Add a helpful comment to a market or post to earn tips from other
-          users.
-        </Row>
-      </Card>
-      <Card className={cardClass}>
-        <span>
-          - Place a {PAST_BET} once per day to get your streak bonus. (up to
-          <span className={'mx-1 inline-block text-indigo-700'}>
-            {formatMoney(BETTING_STREAK_BONUS_MAX)}
-          </span>
-          per day!).
+    <ul className="space-y-2 text-sm">
+      <Item>
+        Add a helpful comment to a market or post to earn tips from other users
+      </Item>
+      <Item>
+        Place your first {PAST_BET} of the day to get your streak bonus (up to
+        <span className={'mx-1 font-bold'}>
+          {formatMoney(BETTING_STREAK_BONUS_MAX)}
         </span>
-      </Card>
-      <Card className={cardClass}>
-        <span>
-          - Refer a friend and get
-          <span className={'mx-1 inline-block text-indigo-700'}>
-            {formatMoney(REFERRAL_AMOUNT)}
-          </span>
-          per signup.
+        per day!)
+      </Item>
+      <Item url="/referrals">
+        Refer a friend and get
+        <span className={'mx-1 font-bold'}>{formatMoney(REFERRAL_AMOUNT)}</span>
+        per signup
+      </Item>
+      <Item url="/create">
+        Make a market and get
+        <span className={'mx-1 font-bold'}>
+          {formatMoney(UNIQUE_BETTOR_BONUS_AMOUNT)}
         </span>
-      </Card>
-      <Card className={cardClass}>
-        <span>
-          - Make a market and get
-          <span className={'mx-1 inline-block text-indigo-700'}>
-            {formatMoney(UNIQUE_BETTOR_BONUS_AMOUNT)}
-          </span>
-          per unique trader.
-        </span>
-      </Card>
-      <Card className={cardClass}>
-        <span>
-          - Come by our
-          <a
-            className={'mx-1 text-indigo-700'}
-            href={'https://discord.gg/3Zuth9792G'}
-          >
-            discord
-          </a>
-          and ask nicely - we pay new users for sharing their experience!
-        </span>
-      </Card>
-      <Card className={cardClass}>
-        <span>
-          - Contribute to our{' '}
-          <a
-            className={'text-indigo-700'}
-            href={'https://github.com/manifoldmarkets/manifold'}
-          >
-            codebase
-          </a>
-          , even something simple, and we'll pay you a bounty.
-        </span>
-      </Card>
-      {includeBuyingNote && (
-        <Card className={cardClass}>
-          - Visit our website in your browser to buy mana with a credit card.
-        </Card>
+        per unique trader
+      </Item>
+      <Item url="https://discord.gg/3Zuth9792G">
+        Come by our discord and ask nicely. We pay new users for sharing their
+        experience!
+      </Item>
+      <Item url="https://github.com/manifoldmarkets/manifold">
+        Contribute to our codebase, even something simple, and we'll pay you a
+        bounty
+      </Item>
+      {includeBuyNote && (
+        <Item>
+          Visit our website in your browser to buy mana with a credit card.
+        </Item>
       )}
-    </Col>
+    </ul>
+  )
+}
+
+const Item = (props: { children: React.ReactNode; url?: string }) => {
+  const { children, url } = props
+  return (
+    <li>
+      {url ? (
+        <Link href={url}>
+          <Card className="p-2">{children}</Card>
+        </Link>
+      ) : (
+        <Card className="pointer-events-none cursor-auto p-2">{children}</Card>
+      )}
+    </li>
   )
 }

--- a/web/pages/add-funds.tsx
+++ b/web/pages/add-funds.tsx
@@ -42,16 +42,10 @@ export default function AddFundsPage() {
       <Col className="items-center">
         <Col className="h-full rounded bg-white p-4 py-8 sm:p-8 sm:shadow-md">
           <Title className="!mt-0" text="Get Mana" />
-          <img
-            className="mb-6 block self-center"
-            src="/welcome/manipurple.png"
-            width={200}
-            height={158}
-          />
 
-          <div className="mb-6 text-gray-500">
-            Buy mana (M$) to trade in your favorite markets. <br />{' '}
-            <i>Not redeemable for cash.</i>
+          <div className="mb-6">
+            Buy mana (M$) to trade in your favorite markets.
+            <div className="italic">Not redeemable for cash.</div>
           </div>
 
           <div className="mb-2 text-sm text-gray-500">Amount</div>
@@ -84,10 +78,10 @@ export default function AddFundsPage() {
             </Button>
           </form>
 
-          <div className="mb-6 mt-12 text-gray-500">
-            Short on USD?. Here are some other ways to get mana: <br />{' '}
+          <div className="mb-4 mt-12">
+            Short on cash? Here are some other ways to get mana:
           </div>
-          {OtherWaysToGetMana(false)}
+          <OtherWaysToGetMana />
         </Col>
       </Col>
     </Page>


### PR DESCRIPTION
- Now clicking on the cards redirects you (if that makes sense)
- The options have also been added to the add funds modal on a separate tab
  - Add funds modal is adjusted on iOS, similar to add funds page
<img width="463" alt="Screen Shot 2022-11-04 at 9 40 19 PM" src="https://user-images.githubusercontent.com/18368938/200101416-64a3b171-df80-482e-af4d-1051772ed9e4.png">
<img width="459" alt="Screen Shot 2022-11-04 at 9 40 32 PM" src="https://user-images.githubusercontent.com/18368938/200101417-b580473b-5415-43e5-8284-0a0bfed3119c.png">
erate tab