### PR TITLE
Overhaul nav

### DIFF
--- a/common/util/array.ts
+++ b/common/util/array.ts
@@ -1,23 +1,13 @@
-import { isEqual } from 'lodash'
+import { compact, flattenDeep, isEqual } from 'lodash'
 
 export function filterDefined<T>(array: (T | null | undefined)[]) {
   return array.filter((item) => item !== null && item !== undefined) as T[]
 }
 
-export function buildArray<T>(
-  ...params: (T | T[] | false | undefined | null)[]
-) {
-  const array: T[] = []
+type FalseyValueArray<T> = T | false | undefined | null | FalseyValueArray<T>[]
 
-  for (const el of params) {
-    if (Array.isArray(el)) {
-      array.push(...el)
-    } else if (el) {
-      array.push(el)
-    }
-  }
-
-  return array
+export function buildArray<T>(...params: FalseyValueArray<T>[]) {
+  return compact(flattenDeep(params)) as T[]
 }
 
 export function groupConsecutive<T, U>(xs: T[], key: (x: T) => U) {

--- a/common/util/array.ts
+++ b/common/util/array.ts
@@ -4,7 +4,8 @@ export function filterDefined<T>(array: (T | null | undefined)[]) {
   return array.filter((item) => item !== null && item !== undefined) as T[]
 }
 
-type FalseyValueArray<T> = T | false | undefined | null | FalseyValueArray<T>[]
+type Falsey = false | undefined | null | 0 | ''
+type FalseyValueArray<T> = T | Falsey | FalseyValueArray<T>[]
 
 export function buildArray<T>(...params: FalseyValueArray<T>[]) {
   return compact(flattenDeep(params)) as T[]

--- a/web/components/nav/bottom-nav-bar.tsx
+++ b/web/components/nav/bottom-nav-bar.tsx
@@ -194,7 +194,7 @@ export function MobileSidebar(props: {
                 </div>
               </Transition.Child>
               <div className="mx-2 h-0 flex-1 overflow-y-auto">
-                <Sidebar className="pl-2" />
+                <Sidebar className="pl-2" isMobile />
               </div>
             </div>
           </Transition.Child>

--- a/web/components/nav/sidebar-item.tsx
+++ b/web/components/nav/sidebar-item.tsx
@@ -8,21 +8,16 @@ export type Item = {
   name: string
   trackingEventName?: string
   href?: string
-  key?: string
+  onClick?: () => void
   icon?: React.ComponentType<{ className?: string }>
 }
 
-export function SidebarItem(props: {
-  item: Item
-  currentPage: string
-  onClick?: (key: string) => void
-}) {
-  const { item, currentPage, onClick } = props
-  const isCurrentPage =
-    item.href != null ? item.href === currentPage : item.key === currentPage
+export function SidebarItem(props: { item: Item; currentPage?: string }) {
+  const { item, currentPage } = props
+  const isCurrentPage = item.href != null && item.href === currentPage
 
   const sidebarItem = (
-    <a
+    <div
       onClick={trackCallback('sidebar: ' + item.name)}
       className={clsx(
         isCurrentPage
@@ -44,20 +39,16 @@ export function SidebarItem(props: {
         />
       )}
       <span className="truncate">{item.name}</span>
-    </a>
+    </div>
   )
 
   if (item.href) {
     return (
-      <Link href={item.href} key={item.name} legacyBehavior>
+      <Link href={item.href} key={item.name}>
         {sidebarItem}
       </Link>
     )
   } else {
-    return onClick ? (
-      <button onClick={() => onClick(item.key ?? '#')}>{sidebarItem}</button>
-    ) : (
-      <> </>
-    )
+    return <button onClick={item.onClick}>{sidebarItem}</button>
   }
 }

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -3,19 +3,19 @@ import {
   HomeIcon,
   SearchIcon,
   BookOpenIcon,
-  CashIcon,
-  HeartIcon,
+  UsersIcon,
   FlagIcon,
   ChatIcon,
   ChartBarIcon,
+  LogoutIcon,
+  BeakerIcon,
 } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import Router, { useRouter } from 'next/router'
-
 import { useUser } from 'web/hooks/use-user'
-import { firebaseLogout, User } from 'web/lib/firebase/users'
+import { firebaseLogout } from 'web/lib/firebase/users'
 import { ManifoldLogo } from './manifold-logo'
-import { MenuButton, MenuItem } from './menu'
+import { MenuButton } from './menu'
 import { ProfileSummary } from './profile-menu'
 import NotificationsIcon from 'web/components/notifications-icon'
 import { IS_PRIVATE_MANIFOLD } from 'common/envs/constants'
@@ -32,20 +32,16 @@ import { Spacer } from '../layout/spacer'
 export default function Sidebar(props: {
   className?: string
   logoSubheading?: string
+  isMobile?: boolean
 }) {
-  const { className, logoSubheading } = props
+  const { className, logoSubheading, isMobile } = props
   const router = useRouter()
   const currentPage = router.pathname
 
   const user = useUser()
 
-  const desktopNavOptions = !user
-    ? signedOutDesktopNavigation
-    : getDesktopNavigation()
-
-  const mobileNavOptions = !user
-    ? signedOutMobileNavigation
-    : signedInMobileNavigation
+  const navOptions = isMobile ? getMobileNav(!!user) : getDesktopNav(!!user)
+  const bottomNavOptions = bottomNav(!!isMobile, !!user)
 
   const createMarketButton = user && !user.isBannedFromPosting && (
     <CreateQuestionButton />
@@ -54,7 +50,7 @@ export default function Sidebar(props: {
   return (
     <nav
       aria-label="Sidebar"
-      className={clsx('flex max-h-[100vh] flex-col', className)}
+      className={clsx('flex h-screen flex-col', className)}
     >
       <ManifoldLogo className="pt-6" twoLine />
       {logoSubheading && (
@@ -67,35 +63,26 @@ export default function Sidebar(props: {
       {user === undefined && <div className="h-[56px]" />}
       {user === null && <SignInButton className="mb-4" />}
 
-      {user && <ProfileSummary user={user} />}
+      {user && !isMobile && <ProfileSummary user={user} />}
 
-      {/* Mobile navigation */}
-      <div className="flex min-h-0 shrink flex-col gap-1 lg:hidden">
-        {mobileNavOptions.map((item) => (
+      <div className="flex flex-col gap-1">
+        {navOptions.map((item) => (
           <SidebarItem key={item.href} item={item} currentPage={currentPage} />
         ))}
 
-        {user && (
+        {!isMobile && (
           <MenuButton
-            menuItems={getMoreMobileNav()}
+            menuItems={getMoreDesktopNavigation(!!user)}
             buttonContent={<MoreButton />}
           />
         )}
 
         {createMarketButton}
       </div>
-
-      {/* Desktop navigation */}
-      <div className="hidden min-h-0 shrink flex-col items-stretch gap-1 lg:flex ">
-        {desktopNavOptions.map((item) => (
-          <SidebarItem key={item.href} item={item} currentPage={currentPage} />
+      <div className="mt-auto mb-6 flex flex-col gap-1">
+        {bottomNavOptions.map((item) => (
+          <SidebarItem key={item.name} item={item} currentPage={currentPage} />
         ))}
-        <MenuButton
-          menuItems={getMoreDesktopNavigation(user)}
-          buttonContent={<MoreButton />}
-        />
-
-        {createMarketButton}
       </div>
     </nav>
   )
@@ -108,11 +95,11 @@ const logout = async () => {
   await Router.replace(Router.asPath)
 }
 
-function getDesktopNavigation() {
-  return buildArray(
+const getDesktopNav = (loggedIn: boolean) =>
+  buildArray(
     { name: 'Home', href: '/home', icon: HomeIcon },
     { name: 'Search', href: '/search', icon: SearchIcon },
-    {
+    loggedIn && {
       name: 'Notifications',
       href: `/notifications`,
       icon: NotificationsIcon,
@@ -120,110 +107,65 @@ function getDesktopNavigation() {
 
     !IS_PRIVATE_MANIFOLD && [
       { name: 'Midterms', href: '/midterms', icon: FlagIcon },
-      { name: 'Leaderboards', href: '/leaderboards', icon: ChartBarIcon },
-    ]
-  )
-}
-
-function getMoreDesktopNavigation(user?: User | null) {
-  if (IS_PRIVATE_MANIFOLD) {
-    return [
-      { name: 'Leaderboards', href: '/leaderboards', icon: ChartBarIcon },
-      {
-        name: 'Sign out',
-        href: '#',
-        onClick: logout,
+      loggedIn && {
+        name: 'Leaderboards',
+        href: '/leaderboards',
+        icon: ChartBarIcon,
       },
-    ]
-  }
+    ],
 
-  if (!user) {
-    // Signed out "More"
-    return buildArray(
-      { name: 'Tournaments', href: '/tournaments' },
-      { name: 'Leaderboards', href: '/leaderboards' },
-      { name: 'Groups', href: '/groups' },
-      { name: 'Tournaments', href: '/tournaments' },
-      { name: 'Charity', href: '/charity' },
-      { name: 'Labs', href: '/labs' },
-      { name: 'Blog', href: 'https://news.manifold.markets' },
-      { name: 'Discord', href: 'https://discord.gg/eHQBNBqXuh' },
-      { name: 'Twitter', href: 'https://twitter.com/ManifoldMarkets' }
-    )
-  }
-
-  // Signed in "More"
-  return buildArray(
-    { name: 'Tournaments', href: '/tournaments' },
-    { name: 'Get M$', href: '/add-funds', icon: CashIcon },
-    { name: 'Groups', href: '/groups' },
-    { name: 'Refer a friend', href: '/referrals' },
-    { name: 'Charity', href: '/charity' },
-    { name: 'Labs', href: '/labs' },
-    { name: 'Discord', href: 'https://discord.gg/eHQBNBqXuh' },
-    { name: 'Help & About', href: 'https://help.manifold.markets/' },
-    {
-      name: 'Sign out',
-      href: '#',
-      onClick: logout,
+    !loggedIn && {
+      name: 'Help & About',
+      href: 'https://help.manifold.markets/',
+      icon: BookOpenIcon,
     }
   )
+
+function getMoreDesktopNavigation(loggedIn: boolean) {
+  if (IS_PRIVATE_MANIFOLD) {
+    return [{ name: 'Leaderboards', href: '/leaderboards', icon: ChartBarIcon }]
+  }
+
+  return buildArray(
+    { name: 'Tournaments', href: '/tournaments' },
+    // loggedIn && { name: 'Get M$', href: '/add-funds', icon: CashIcon },
+    { name: 'Groups', href: '/groups' },
+    loggedIn && { name: 'Refer a friend', href: '/referrals' },
+    { name: 'Charity', href: '/charity' },
+    { name: 'Labs', href: '/labs' },
+    { name: 'Blog', href: 'https://news.manifold.markets' },
+    { name: 'Discord', href: 'https://discord.gg/eHQBNBqXuh' }
+    // { name: 'Twitter', href: 'https://twitter.com/ManifoldMarkets' },
+  )
 }
 
-const signedOutDesktopNavigation = [
-  { name: 'Home', href: '/', icon: HomeIcon },
-  { name: 'Explore', href: '/search', icon: SearchIcon },
-  { name: 'Midterms', href: '/midterms', icon: FlagIcon },
-  {
-    name: 'Help & About',
-    href: 'https://help.manifold.markets/',
-    icon: BookOpenIcon,
-  },
-]
-
-const signedOutMobileNavigation = [
-  {
-    name: 'Help & About',
-    href: 'https://help.manifold.markets/',
-    icon: BookOpenIcon,
-  },
-  { name: 'Midterms', href: '/midterms', icon: FlagIcon },
-  { name: 'Charity', href: '/charity', icon: HeartIcon },
-  { name: 'Tournaments', href: '/tournaments', icon: TrophyIcon },
-  { name: 'Leaderboards', href: '/leaderboards', icon: ChartBarIcon },
-  { name: 'Discord', href: 'https://discord.gg/eHQBNBqXuh', icon: ChatIcon },
-]
-
-const signedInMobileNavigation = buildArray(
-  { name: 'Search', href: '/search', icon: SearchIcon },
-
-  !IS_PRIVATE_MANIFOLD && [
+const getMobileNav = (loggedIn: boolean) => {
+  if (IS_PRIVATE_MANIFOLD) {
+    return [{ name: 'Leaderboards', href: '/leaderboards', icon: ChartBarIcon }]
+  }
+  return buildArray(
     { name: 'Midterms', href: '/midterms', icon: FlagIcon },
     { name: 'Tournaments', href: '/tournaments', icon: TrophyIcon },
     { name: 'Leaderboards', href: '/leaderboards', icon: ChartBarIcon },
-    { name: 'Get M$', href: '/add-funds', icon: CashIcon },
-  ],
-  {
-    name: 'Help & About',
-    href: 'https://help.manifold.markets/',
-    icon: BookOpenIcon,
-  }
-)
-
-function getMoreMobileNav() {
-  const signOut = {
-    name: 'Sign out',
-    href: '#',
-    onClick: logout,
-  }
-  if (IS_PRIVATE_MANIFOLD) return [signOut]
-
-  return buildArray<MenuItem>(
-    { name: 'Groups', href: '/groups' },
-    { name: 'Refer a friend', href: '/referrals' },
-    { name: 'Charity', href: '/charity' },
-    { name: 'Labs', href: '/labs' },
-    { name: 'Discord', href: 'https://discord.gg/eHQBNBqXuh' },
-    signOut
+    loggedIn && { name: 'Groups', href: '/groups', icon: UsersIcon },
+    // { name: 'Charity', href: '/charity', icon: HeartIcon },
+    // loggedIn && { name: 'Get M$', href: '/add-funds', icon: CashIcon },
+    { name: 'Labs', href: '/labs', icon: BeakerIcon }
   )
 }
+
+const bottomNav = (isMobile: boolean, loggedIn: boolean) =>
+  buildArray(
+    !IS_PRIVATE_MANIFOLD &&
+      isMobile && {
+        name: 'Discord',
+        href: 'https://discord.gg/eHQBNBqXuh',
+        icon: ChatIcon,
+      },
+    {
+      name: 'Help & About',
+      href: 'https://help.manifold.markets/',
+      icon: BookOpenIcon,
+    },
+    loggedIn && { name: 'Sign out', icon: LogoutIcon, onClick: logout }
+  )

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   ChartBarIcon,
   LogoutIcon,
   BeakerIcon,
+  GiftIcon,
 } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import Router, { useRouter } from 'next/router'
@@ -112,13 +113,7 @@ const getDesktopNav = (loggedIn: boolean) =>
         href: '/leaderboards',
         icon: ChartBarIcon,
       },
-    ],
-
-    !loggedIn && {
-      name: 'Help & About',
-      href: 'https://help.manifold.markets/',
-      icon: BookOpenIcon,
-    }
+    ]
   )
 
 function getMoreDesktopNavigation(loggedIn: boolean) {
@@ -128,14 +123,12 @@ function getMoreDesktopNavigation(loggedIn: boolean) {
 
   return buildArray(
     { name: 'Tournaments', href: '/tournaments' },
-    // loggedIn && { name: 'Get M$', href: '/add-funds', icon: CashIcon },
     { name: 'Groups', href: '/groups' },
     loggedIn && { name: 'Refer a friend', href: '/referrals' },
     { name: 'Charity', href: '/charity' },
     { name: 'Labs', href: '/labs' },
     { name: 'Blog', href: 'https://news.manifold.markets' },
     { name: 'Discord', href: 'https://discord.gg/eHQBNBqXuh' }
-    // { name: 'Twitter', href: 'https://twitter.com/ManifoldMarkets' },
   )
 }
 
@@ -148,8 +141,7 @@ const getMobileNav = (loggedIn: boolean) => {
     { name: 'Tournaments', href: '/tournaments', icon: TrophyIcon },
     { name: 'Leaderboards', href: '/leaderboards', icon: ChartBarIcon },
     loggedIn && { name: 'Groups', href: '/groups', icon: UsersIcon },
-    // { name: 'Charity', href: '/charity', icon: HeartIcon },
-    // loggedIn && { name: 'Get M$', href: '/add-funds', icon: CashIcon },
+    loggedIn && { name: 'Refer a friend', href: '/referrals', icon: GiftIcon },
     { name: 'Labs', href: '/labs', icon: BeakerIcon }
   )
 }

--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -288,7 +288,7 @@ function AddFundsButton({ userId }: { userId?: string }) {
         color="gray-outline"
         onClick={() => setOpen(true)}
       >
-        Add {ENV_CONFIG.moneyMoniker}
+        Get more {ENV_CONFIG.moneyMoniker}
       </Button>
       <AddFundsModal open={open} setOpen={setOpen} />
     </>

--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -11,6 +11,10 @@ import { Period } from 'web/lib/firebase/users'
 import { useEvent } from 'web/hooks/use-event'
 import PlaceholderGraph from 'web/lib/icons/placeholder-graph'
 import { ScaleContinuousNumeric, ScaleTime } from 'd3-scale'
+import { AddFundsModal } from '../add-funds-modal'
+import { Button } from '../buttons/button'
+import { ENV_CONFIG } from 'common/envs/constants'
+import { useUser } from 'web/hooks/use-user'
 
 export const PortfolioValueSection = memo(
   function PortfolioValueSection(props: { userId: string }) {
@@ -50,6 +54,7 @@ export const PortfolioValueSection = memo(
     if (!portfolioHistory || !lastPortfolioMetrics) {
       return (
         <PortfolioValueSkeleton
+          userId={userId}
           graphMode={graphMode}
           onClickNumber={onClickNumber}
           currentTimePeriod={currentTimePeriod}
@@ -83,6 +88,7 @@ export const PortfolioValueSection = memo(
     const totalProfit = totalValue - totalDeposits
     return (
       <PortfolioValueSkeleton
+        userId={userId}
         graphMode={graphMode}
         onClickNumber={onClickNumber}
         currentTimePeriod={currentTimePeriod}
@@ -144,6 +150,7 @@ export function PortfolioValueSkeleton(props: {
   profitElement: ReactNode
   valueElement: ReactNode
   graphElement: (width: number, height: number) => ReactNode
+  userId?: string
   disabled?: boolean
 }) {
   const {
@@ -154,42 +161,43 @@ export function PortfolioValueSkeleton(props: {
     profitElement,
     valueElement,
     graphElement,
+    userId,
     disabled,
   } = props
   return (
     <>
-      <Row className="mb-2 justify-between">
-        <Row className="gap-2">
-          <Col
-            className={clsx(
-              'w-24 cursor-pointer sm:w-28 ',
-              graphMode != 'profit'
-                ? 'cursor-pointer opacity-40 hover:opacity-80'
-                : ''
-            )}
-            onClick={() => {
-              onClickNumber('profit')
-            }}
-          >
-            <div className="text-greyscale-6 text-xs sm:text-sm">Profit</div>
-            {profitElement}
-          </Col>
+      <Row className="mb-2 gap-2">
+        <Col
+          className={clsx(
+            'w-24 cursor-pointer sm:w-28 ',
+            graphMode != 'profit'
+              ? 'cursor-pointer opacity-40 hover:opacity-80'
+              : ''
+          )}
+          onClick={() => {
+            onClickNumber('profit')
+          }}
+        >
+          <div className="text-greyscale-6 text-xs sm:text-sm">Profit</div>
+          {profitElement}
+        </Col>
 
-          <Col
-            className={clsx(
-              'w-24 cursor-pointer sm:w-28',
-              graphMode != 'value' ? 'opacity-40 hover:opacity-80' : ''
-            )}
-            onClick={() => {
-              onClickNumber('value')
-            }}
-          >
-            <div className="text-greyscale-6 text-xs sm:text-sm">
-              Portfolio value
-            </div>
-            {valueElement}
-          </Col>
-        </Row>
+        <Col
+          className={clsx(
+            'w-24 cursor-pointer sm:w-28',
+            graphMode != 'value' ? 'opacity-40 hover:opacity-80' : ''
+          )}
+          onClick={() => {
+            onClickNumber('value')
+          }}
+        >
+          <div className="text-greyscale-6 text-xs sm:text-sm">
+            Portfolio value
+          </div>
+          {valueElement}
+        </Col>
+
+        <AddFundsButton userId={userId} />
       </Row>
       <SizedContainer fullHeight={200} mobileHeight={100}>
         {graphElement}
@@ -265,5 +273,24 @@ export function TimeSelectionButton(props: {
     >
       {symbol}
     </button>
+  )
+}
+
+function AddFundsButton({ userId }: { userId?: string }) {
+  const [open, setOpen] = useState(false)
+  const user = useUser()
+  if (!userId || user?.id !== userId) return null
+
+  return (
+    <>
+      <Button
+        className="ml-auto self-start"
+        color="gray-outline"
+        onClick={() => setOpen(true)}
+      >
+        Add {ENV_CONFIG.moneyMoniker}
+      </Button>
+      <AddFundsModal open={open} setOpen={setOpen} />
+    </>
   )
 }

--- a/web/pages/labs/index.tsx
+++ b/web/pages/labs/index.tsx
@@ -24,9 +24,9 @@ export default function LabsPage() {
           columnClassName="pl-4 bg-clip-padding"
         >
           <LabCard
-            title="🇺🇸 US 2022 Midterms"
-            description="See Manifold's state-by-state breakdown of senate and governor races"
-            href="/midterms"
+            title="🫀 Charity"
+            description="Turn your M$ earnings into real donations to causes you care about"
+            href="/charity"
           />
 
           {CHALLENGES_ENABLED && (
@@ -51,7 +51,7 @@ export default function LabsPage() {
 
           <LabCard
             title="📈 Stats"
-            description="Check up on Manifold's usage stats"
+            description="See how Manifold is doing"
             href="/stats"
           />
 


### PR DESCRIPTION
- add bottom section for sign out, help
- remove "Get M$", twitter
  - Get Mana added to profile - which is where people will naturally click on to add money since it has your balance
     <img width="400" alt="image" src="https://user-images.githubusercontent.com/18368938/200108718-06592d1c-0302-4ecd-ba55-0dbb95853b75.png">

- remove from mobile nav: search, profile, charity, refer friend
  - You can still get to refer a friend from add funds modal, or from share link on a market
  - Charity moved to labs
  - Search and profile are already in the bottom nav
- remove metamore so groups and labs won't be jealous

<img width="1512" alt="Screen Shot 2022-11-05 at 12 25 43 AM" src="https://user-images.githubusercontent.com/18368938/200108197-0cf2f34e-3d2c-4298-bc8c-2b5eb42e665f.png">
<img width="1512" alt="Screen Shot 2022-11-05 at 12 26 42 AM" src="https://user-images.githubusercontent.com/18368938/200108200-1108f728-605a-4aea-b3c3-720657f611ca.png">
<img width="1512" alt="Screen Shot 2022-11-05 at 12 26 50 AM" src="https://user-images.githubusercontent.com/18368938/200108201-3072bdbd-c877-4c3a-9b6f-d8de9cbd028a.png">
