### PR TITLE
Fix market card for resolved pseudonumeric markets

### DIFF
--- a/common/pseudo-numeric.ts
+++ b/common/pseudo-numeric.ts
@@ -1,4 +1,4 @@
-import { BinaryContract, PseudoNumericContract } from './contract'
+import { Contract, PseudoNumericContract } from './contract'
 import { formatLargeNumber, formatPercent } from './util/format'
 
 export function formatNumericProbability(
@@ -10,8 +10,8 @@ export function formatNumericProbability(
 }
 
 export const getMappedValue =
-  (contract: PseudoNumericContract | BinaryContract) => (p: number) => {
-    if (contract.outcomeType === 'BINARY') return p
+  (contract: Contract) => (p: number) => {
+    if (contract.outcomeType !== 'PSEUDO_NUMERIC') return p
 
     const { min, max, isLogScale } = contract
 
@@ -24,8 +24,8 @@ export const getMappedValue =
   }
 
 export const getFormattedMappedValue =
-  (contract: PseudoNumericContract | BinaryContract) => (p: number) => {
-    if (contract.outcomeType === 'BINARY') return formatPercent(p)
+  (contract: Contract) => (p: number) => {
+    if (contract.outcomeType !== 'PSEUDO_NUMERIC') return formatPercent(p)
 
     const value = getMappedValue(contract)(p)
     return formatLargeNumber(value)

--- a/common/pseudo-numeric.ts
+++ b/common/pseudo-numeric.ts
@@ -9,27 +9,25 @@ export function formatNumericProbability(
   return formatLargeNumber(value)
 }
 
-export const getMappedValue =
-  (contract: Contract) => (p: number) => {
-    if (contract.outcomeType !== 'PSEUDO_NUMERIC') return p
+export const getMappedValue = (contract: Contract) => (p: number) => {
+  if (contract.outcomeType !== 'PSEUDO_NUMERIC') return p
 
-    const { min, max, isLogScale } = contract
+  const { min, max, isLogScale } = contract
 
-    if (isLogScale) {
-      const logValue = p * Math.log10(max - min + 1)
-      return 10 ** logValue + min - 1
-    }
-
-    return p * (max - min) + min
+  if (isLogScale) {
+    const logValue = p * Math.log10(max - min + 1)
+    return 10 ** logValue + min - 1
   }
 
-export const getFormattedMappedValue =
-  (contract: Contract) => (p: number) => {
-    if (contract.outcomeType !== 'PSEUDO_NUMERIC') return formatPercent(p)
+  return p * (max - min) + min
+}
 
-    const value = getMappedValue(contract)(p)
-    return formatLargeNumber(value)
-  }
+export const getFormattedMappedValue = (contract: Contract) => (p: number) => {
+  if (contract.outcomeType !== 'PSEUDO_NUMERIC') return formatPercent(p)
+
+  const value = getMappedValue(contract)(p)
+  return formatLargeNumber(value)
+}
 
 export const getPseudoProbability = (
   value: number,

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -36,7 +36,7 @@ import {
   getCpmmProbabilityAfterSale,
 } from 'common/calculate-cpmm'
 import { track } from 'web/lib/service/analytics'
-import { formatNumericProbability } from 'common/pseudo-numeric'
+import { formatNumericProbability, getFormattedMappedValue } from 'common/pseudo-numeric'
 import { useUnfilledBetsAndBalanceByUserId } from 'web/hooks/use-bets'
 import { getBinaryProb } from 'common/contract-details'
 import { Row } from '../layout/row'
@@ -346,7 +346,7 @@ function cardText(contract: Contract, previewProb?: number) {
       return (
         <>
           <span className="my-auto text-sm font-normal">resolved as</span>
-          {formatPercent(resolutionProbability)}
+          {getFormattedMappedValue(contract)(resolutionProbability)}
         </>
       )
     }
@@ -362,9 +362,7 @@ function cardText(contract: Contract, previewProb?: number) {
   }
 
   if (previewProb) {
-    return outcomeType === 'PSEUDO_NUMERIC'
-      ? formatNumericProbability(previewProb, contract)
-      : formatPercent(previewProb)
+    return getFormattedMappedValue(contract)(previewProb)
   }
 
   switch (outcomeType) {

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -36,7 +36,10 @@ import {
   getCpmmProbabilityAfterSale,
 } from 'common/calculate-cpmm'
 import { track } from 'web/lib/service/analytics'
-import { formatNumericProbability, getFormattedMappedValue } from 'common/pseudo-numeric'
+import {
+  formatNumericProbability,
+  getFormattedMappedValue,
+} from 'common/pseudo-numeric'
 import { useUnfilledBetsAndBalanceByUserId } from 'web/hooks/use-bets'
 import { getBinaryProb } from 'common/contract-details'
 import { Row } from '../layout/row'

--- a/web/components/feed/feed-bets.tsx
+++ b/web/components/feed/feed-bets.tsx
@@ -6,10 +6,10 @@ import { useUser } from 'web/hooks/use-user'
 import { Row } from 'web/components/layout/row'
 import { Avatar, EmptyAvatar } from 'web/components/widgets/avatar'
 import clsx from 'clsx'
-import { formatMoney, formatPercent } from 'common/util/format'
+import { formatMoney } from 'common/util/format'
 import { OutcomeLabel } from 'web/components/outcome-label'
 import { RelativeTimestamp } from 'web/components/relative-timestamp'
-import { formatNumericProbability } from 'common/pseudo-numeric'
+import { getFormattedMappedValue } from 'common/pseudo-numeric'
 import { SiteLink } from 'web/components/widgets/site-link'
 import { getChallenge, getChallengeUrl } from 'web/lib/firebase/challenges'
 import { Challenge } from 'common/challenge'
@@ -85,21 +85,13 @@ export function BetStatusText(props: {
 
   const fromProb =
     hadPoolMatch || isFreeResponse
-      ? isPseudoNumeric
-        ? formatNumericProbability(bet.probBefore, contract)
-        : formatPercent(bet.probBefore)
-      : isPseudoNumeric
-      ? formatNumericProbability(bet.limitProb ?? bet.probBefore, contract)
-      : formatPercent(bet.limitProb ?? bet.probBefore)
+      ? getFormattedMappedValue(contract)(bet.probBefore)
+      : getFormattedMappedValue(contract)(bet.limitProb ?? bet.probBefore)
 
   const toProb =
     hadPoolMatch || isFreeResponse
-      ? isPseudoNumeric
-        ? formatNumericProbability(bet.probAfter, contract)
-        : formatPercent(bet.probAfter)
-      : isPseudoNumeric
-      ? formatNumericProbability(bet.limitProb ?? bet.probAfter, contract)
-      : formatPercent(bet.limitProb ?? bet.probAfter)
+      ? getFormattedMappedValue(contract)(bet.probAfter)
+      : getFormattedMappedValue(contract)(bet.limitProb ?? bet.probAfter)
 
   return (
     <div className={clsx('text-sm text-gray-500', className)}>

--- a/web/components/feed/feed-bets.tsx
+++ b/web/components/feed/feed-bets.tsx
@@ -57,7 +57,6 @@ export function BetStatusText(props: {
   const { bet, contract, hideUser, className } = props
   const { outcomeType } = contract
   const self = useUser()
-  const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
   const isFreeResponse = outcomeType === 'FREE_RESPONSE'
   const { amount, outcome, createdTime, challengeSlug } = bet
   const [challenge, setChallenge] = React.useState<Challenge>()


### PR DESCRIPTION
The market cards for resolved pseudonumeric markets were displaying "Resolved as X%" instead of "Resolved as Y".

This PR fixes this, and also cleans up related code in bet feed (Please don't nest so many ternaries! :scream: Especially when there already is a helper function that does exactly that)