### PR TITLE
Don't count ante bet in 24 hour and weekly volume

### DIFF
--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -155,7 +155,9 @@ const computeTotalPool = (userContracts: Contract[], startTime = 0) => {
 
 export const computeVolume = (contractBets: Bet[], since: number) => {
   return sumBy(contractBets, (b) =>
-    b.createdTime > since && !b.isRedemption ? Math.abs(b.amount) : 0
+    b.createdTime > since && !b.isRedemption && !b.isAnte
+      ? Math.abs(b.amount)
+      : 0
   )
 }
 

--- a/functions/src/update-contract-metrics.ts
+++ b/functions/src/update-contract-metrics.ts
@@ -96,8 +96,8 @@ export async function updateContractMetrics() {
       )
 
       writer.update(firestore.collection('contracts').doc(contract.id), {
-        volume24Hours: computeVolume(descendingBets, now - DAY_MS),
-        volume7Days: computeVolume(descendingBets, now - DAY_MS * 7),
+        volume24Hours: computeVolume(descendingBets, yesterday),
+        volume7Days: computeVolume(descendingBets, weekAgo),
         elasticity: computeElasticity(unfilledBets, contract),
         uniqueBettors24Hours,
         uniqueBettors7Days,


### PR DESCRIPTION
You can argue in principle whether this should be included, but there's a really good practical reason not to include it, which is that it isn't included in the contract total `volume` field. So if we include it in the period volume fields, those will be out of sync with the total (e.g. they could be higher than the total which looks ridiculous.)