### PR TITLE
Efficient user metrics

### DIFF
--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -227,9 +227,9 @@ export const calculateCreatorTraders = (userContracts: Contract[]) => {
 export const calculateNewPortfolioMetrics = (
   user: User,
   contractsById: { [k: string]: Contract },
-  currentBets: Bet[]
+  unresolvedBets: Bet[]
 ) => {
-  const investmentValue = computeInvestmentValue(currentBets, contractsById)
+  const investmentValue = computeInvestmentValue(unresolvedBets, contractsById)
   const newPortfolio = {
     investmentValue: investmentValue,
     balance: user.balance,


### PR DESCRIPTION
Now all the work involving bets in `updateUserMetrics` only needs bets on unresolved markets, instead of all bets ever, so that's a lot better.

- You can only have outstanding loans on unresolved markets.
- We only need to compute the "investment value" for unresolved markets, since the investment value for resolved markets is 0.
- We only need to compute contract metrics for unresolved markets, if we make sure we compute it once at resolution, since they can't change post-resolution.