### PR TITLE
Make `updateUserMetrics` only consider bets on unresolved markets

### DIFF
--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -230,9 +230,9 @@ export const calculateCreatorTraders = (userContracts: Contract[]) => {
 export const calculateNewPortfolioMetrics = (
   user: User,
   contractsById: { [k: string]: Contract },
-  currentBets: Bet[]
+  unresolvedBets: Bet[]
 ) => {
-  const investmentValue = computeInvestmentValue(currentBets, contractsById)
+  const investmentValue = computeInvestmentValue(unresolvedBets, contractsById)
   const newPortfolio = {
     investmentValue: investmentValue,
     balance: user.balance,

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -184,9 +184,10 @@ const loadUserContractBets = async (userId: string, contractIds: string[]) => {
   const betDocs = await batchedWaitAll(
     contractIds.map((c) => async () => {
       return await firestore
-        .collectionGroup('bets')
+        .collection('contracts')
+        .doc(c)
+        .collection('bets')
         .where('userId', '==', userId)
-        .where('contractId', '==', c)
         .get()
     }),
     100

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -51,7 +51,6 @@ export async function updateUserMetrics() {
   const contractsById = Object.fromEntries(contracts.map((c) => [c.id, c]))
   log(`Loaded ${contracts.length} contracts.`)
 
-  log('Computing metric updates...')
   const now = Date.now()
   const monthAgo = now - DAY_MS * 30
   const writer = firestore.bulkWriter({ throttling: false })
@@ -61,7 +60,9 @@ export async function updateUserMetrics() {
   const metricEligibleContracts = contracts.filter(
     (c) => c.resolutionTime == null || c.resolutionTime > monthAgo
   )
+  log(`${metricEligibleContracts.length} contracts need metrics updates.`)
 
+  log('Computing metric updates...')
   const userUpdates = await batchedWaitAll(
     users.map((user) => async () => {
       const userContracts = contractsByCreator[user.id] ?? []

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -90,13 +90,13 @@ export async function updateUserMetrics() {
 
       const newProfit = calculateNewProfit(portfolioHistory, newPortfolio)
 
-      const unresolvedBetsByContractId = groupBy(
+      const metricRelevantBetsByContract = groupBy(
         metricRelevantBets,
         (b) => b.contractId
       )
 
       const metricsByContract = calculateMetricsByContract(
-        unresolvedBetsByContractId,
+        metricRelevantBetsByContract,
         contractsById
       )
 
@@ -125,7 +125,7 @@ export async function updateUserMetrics() {
       }
 
       const nextLoanPayout = isUserEligibleForLoan(newPortfolio)
-        ? getUserLoanUpdates(unresolvedBetsByContractId, contractsById).payout
+        ? getUserLoanUpdates(metricRelevantBetsByContract, contractsById).payout
         : undefined
 
       const userDoc = firestore.collection('users').doc(user.id)

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -57,13 +57,13 @@ export async function updateUserMetrics() {
   const userUpdates = await batchedWaitAll(
     users.map((user) => async () => {
       const userContracts = contractsByCreator[user.id] ?? []
-      const currentBets = (
-        await firestore
-          .collectionGroup('bets')
-          .where('userId', '==', user.id)
-          .get()
-      ).docs.map((d) => d.data() as Bet)
-      const betsByContractId = groupBy(currentBets, (b) => b.contractId)
+      const unresolvedBetContracts = contracts.filter(
+        (c) => !c.isResolved && c.uniqueBettorIds?.includes(user.id)
+      )
+      const unresolvedBets = await loadUserContractBets(
+        user.id,
+        unresolvedBetContracts.map((c) => c.id)
+      )
       const portfolioHistory = await loadPortfolioHistory(user.id, now)
       const newCreatorVolume = calculateCreatorVolume(userContracts)
       const newCreatorTraders = calculateCreatorTraders(userContracts)
@@ -71,7 +71,7 @@ export async function updateUserMetrics() {
       const newPortfolio = calculateNewPortfolioMetrics(
         user,
         contractsById,
-        currentBets
+        unresolvedBets
       )
       const currPortfolio = portfolioHistory.current
       const didPortfolioChange =
@@ -82,8 +82,13 @@ export async function updateUserMetrics() {
 
       const newProfit = calculateNewProfit(portfolioHistory, newPortfolio)
 
+      const unresolvedBetsByContractId = groupBy(
+        unresolvedBets,
+        (b) => b.contractId
+      )
+
       const metricsByContract = calculateMetricsByContract(
-        betsByContractId,
+        unresolvedBetsByContractId,
         contractsById
       )
 
@@ -112,7 +117,7 @@ export async function updateUserMetrics() {
       }
 
       const nextLoanPayout = isUserEligibleForLoan(newPortfolio)
-        ? getUserLoanUpdates(betsByContractId, contractsById).payout
+        ? getUserLoanUpdates(unresolvedBetsByContractId, contractsById).payout
         : undefined
 
       const userDoc = firestore.collection('users').doc(user.id)
@@ -173,6 +178,23 @@ export async function updateUserMetrics() {
 
   await revalidateStaticProps('/leaderboards')
   log('Done.')
+}
+
+const loadUserContractBets = async (userId: string, contractIds: string[]) => {
+  const betDocs = await batchedWaitAll(
+    contractIds.map((c) => async () => {
+      return await firestore
+        .collectionGroup('bets')
+        .where('userId', '==', userId)
+        .where('contractId', '==', c)
+        .get()
+    }),
+    100
+  )
+  return betDocs
+    .map((d) => d.docs)
+    .flat()
+    .map((d) => d.data() as Bet)
 }
 
 const loadPortfolioHistory = async (userId: string, now: number) => {


### PR DESCRIPTION
GitHub won't let me reopen https://github.com/manifoldmarkets/manifold/pull/1171 but here it is!

Now all the work involving bets in `updateUserMetrics` only needs bets on unresolved markets, instead of all bets ever, so that's a lot better.

- You can only have outstanding loans on unresolved markets.
- We only need to compute the "investment value" for unresolved markets, since the investment value for resolved markets is 0.
- We only need to compute contract metrics for unresolved markets, if we make sure we compute it once at resolution, since they can't change post-resolution.
