### PR TITLE
Add `/comments` endpoint for querying comments by contract

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -701,6 +701,17 @@ Parameters:
 - `html`: The comment to post, formatted as an HTML string, OR
 - `markdown`: The comment to post, formatted as a markdown string.
 
+### `GET /v0/comments`
+
+Gets a list of comments for a contract, ordered by creation date descending.
+
+Parameters:
+
+- `contractId`: Optional. Which contract to read comments for. Either an ID or slug must be specified.
+- `contractSlug`: Optional.
+
+Requires no authorization.
+
 ### `GET /v0/bets`
 
 Gets a list of bets, ordered by creation date descending.

--- a/web/pages/api/v0/comments.ts
+++ b/web/pages/api/v0/comments.ts
@@ -1,0 +1,61 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { Comment, listAllComments } from 'web/lib/firebase/comments'
+import { getContractFromSlug } from 'web/lib/firebase/contracts'
+import { ApiError, ValidationError } from './_types'
+import { z } from 'zod'
+import { validate } from './_validate'
+
+const queryParams = z
+  .object({
+    contractId: z.string().optional(),
+    contractSlug: z.string().optional(),
+    limit: z
+      .number()
+      .default(1000)
+      .or(z.string().regex(/\d+/).transform(Number))
+      .refine((n) => n >= 0 && n <= 1000, 'Limit must be between 0 and 1000'),
+    before: z.string().optional(),
+  })
+  .strict()
+
+const getContractId = async (params: z.infer<typeof queryParams>) => {
+  if (params.contractId) {
+    return params.contractId
+  }
+  if (params.contractSlug) {
+    const contract = await getContractFromSlug(params.contractSlug)
+    if (contract) {
+      return contract.id
+    } else {
+      throw new Error('Contract not found.')
+    }
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Comment[] | ValidationError | ApiError>
+) {
+  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+
+  let params: z.infer<typeof queryParams>
+  try {
+    params = validate(queryParams, req.query)
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      return res.status(400).json(e)
+    }
+    console.error(`Unknown error during validation: ${e}`)
+    return res.status(500).json({ error: 'Unknown error during validation' })
+  }
+
+  const contractId = await getContractId(params)
+  if (!contractId) {
+    return res.status(400).json({ error: 'You must specify a contract.' })
+  }
+  const comments = await listAllComments(contractId)
+
+  res.setHeader('Cache-Control', 'max-age=15, public')
+  return res.status(200).json(comments)
+}


### PR DESCRIPTION
Like https://github.com/manifoldmarkets/manifold/pull/1181, this is important so that people can query market data without getting a firehose of bets and comments.