### PR TITLE
Make `onCreateBet` trigger more efficient

### DIFF
--- a/functions/src/helpers/handle-referral.ts
+++ b/functions/src/helpers/handle-referral.ts
@@ -50,22 +50,15 @@ export async function handleReferral(user: User, eventId: string) {
     }
     console.log(`referredByGroup: ${referredByGroup}`)
 
-    const txns = (
-      await firestore
+    const txns = await transaction.get(
+      firestore
         .collection('txns')
         .where('toId', '==', referredByUserId)
         .where('category', '==', 'REFERRAL')
-        .get()
-    ).docs.map((txn) => txn.ref)
-    if (txns.length > 0) {
-      const referralTxns = await transaction.getAll(...txns).catch((err) => {
-        console.error('error getting txns:', err)
-        throw err
-      })
+    )
+    if (txns.size > 0) {
       // If the referring user already has a referral txn due to referring this user, halt
-      if (
-        referralTxns.map((txn) => txn.data()?.description).includes(user.id)
-      ) {
+      if (txns.docs.map((txn) => txn.data()?.description).includes(user.id)) {
         console.log('found referral txn with the same details, aborting')
         return
       }

--- a/functions/src/on-create-bet.ts
+++ b/functions/src/on-create-bet.ts
@@ -249,14 +249,10 @@ const updateUniqueBettorsAndGiveCreatorBonus = async (
   const fromUserId = isProd()
     ? HOUSE_LIQUIDITY_PROVIDER_ID
     : DEV_HOUSE_LIQUIDITY_PROVIDER_ID
-  const fromSnap = await firestore.doc(`users/${fromUserId}`).get()
-  if (!fromSnap.exists) throw new APIError(400, 'From user not found.')
-
-  const fromUser = fromSnap.data() as User
 
   const result = await firestore.runTransaction(async (trans) => {
     const bonusTxn: TxnData = {
-      fromId: fromUser.id,
+      fromId: fromUserId,
       fromType: 'BANK',
       toId: oldContract.creatorId,
       toType: 'USER',

--- a/functions/src/on-create-bet.ts
+++ b/functions/src/on-create-bet.ts
@@ -32,7 +32,6 @@ import {
   DEV_HOUSE_LIQUIDITY_PROVIDER_ID,
   HOUSE_LIQUIDITY_PROVIDER_ID,
 } from '../../common/antes'
-import { APIError } from '../../common/api'
 import { User } from '../../common/user'
 import { DAY_MS } from '../../common/util/time'
 import { BettingStreakBonusTxn, UniqueBettorBonusTxn } from '../../common/txn'

--- a/functions/src/on-create-bet.ts
+++ b/functions/src/on-create-bet.ts
@@ -193,11 +193,10 @@ const updateUniqueBettorsAndGiveCreatorBonus = async (
       const contractDoc = firestore.collection(`contracts`).doc(oldContract.id)
       const contract = (await trans.get(contractDoc)).data() as Contract
       let previousUniqueBettorIds = contract.uniqueBettorIds
-
-      const betsSnap = await trans.get(
-        firestore.collection(`contracts/${contract.id}/bets`)
-      )
       if (!previousUniqueBettorIds) {
+        const betsSnap = await trans.get(
+          firestore.collection(`contracts/${contract.id}/bets`)
+        )
         const contractBets = betsSnap.docs.map((doc) => doc.data() as Bet)
 
         if (contractBets.length === 0) {


### PR DESCRIPTION
I don't think this is the worst problem we have, but clearly this bet loading was performing totally needless carnage on our Firestore reads.