### PR TITLE
Be parsimonious with contract page revalidation

### DIFF
--- a/functions/src/on-create-bet.ts
+++ b/functions/src/on-create-bet.ts
@@ -3,14 +3,7 @@ import * as admin from 'firebase-admin'
 import { keyBy, uniq } from 'lodash'
 
 import { Bet, LimitBet } from '../../common/bet'
-import {
-  getContractPath,
-  getUser,
-  getValues,
-  isProd,
-  log,
-  revalidateStaticProps,
-} from './utils'
+import { getUser, getValues, isProd, log } from './utils'
 import {
   createBadgeAwardedNotification,
   createBetFillNotification,
@@ -90,8 +83,6 @@ export const onCreateBet = functions
     await notifyFills(bet, contract, eventId, bettor)
     await processReferralBonus(bettor, eventId)
     await updateBettingStreak(bettor, bet, contract, eventId)
-
-    await revalidateStaticProps(getContractPath(contract))
   })
 
 const processReferralBonus = async (user: User, eventId: string) => {

--- a/functions/src/on-update-contract.ts
+++ b/functions/src/on-update-contract.ts
@@ -1,5 +1,10 @@
 import * as functions from 'firebase-functions'
-import { getUser, getValues } from './utils'
+import {
+  getUser,
+  getValues,
+  getContractPath,
+  revalidateStaticProps,
+} from './utils'
 import {
   createBadgeAwardedNotification,
   createCommentOrAnswerOrUpdatedContractNotification,
@@ -22,6 +27,11 @@ export const onUpdateContract = functions.firestore
     const previousContract = change.before.data() as Contract
     const { eventId } = context
     const { closeTime, question } = contract
+
+    // maybe we should do this more often, but at least if someone bets
+    if (previousContract.volume !== contract.volume) {
+      await revalidateStaticProps(getContractPath(contract))
+    }
 
     if (!previousContract.isResolved && contract.isResolved) {
       // No need to notify users of resolution, that's handled in resolve-market

--- a/functions/src/on-update-contract.ts
+++ b/functions/src/on-update-contract.ts
@@ -28,21 +28,25 @@ export const onUpdateContract = functions.firestore
     const { eventId } = context
     const { closeTime, question } = contract
 
-    // maybe we should do this more often, but at least if someone bets
-    if (previousContract.volume !== contract.volume) {
-      await revalidateStaticProps(getContractPath(contract))
+    if (previousContract.groupSlugs !== contract.groupSlugs) {
+      await handleContractGroupUpdated(previousContract, contract)
     }
 
-    if (!previousContract.isResolved && contract.isResolved) {
-      // No need to notify users of resolution, that's handled in resolve-market
-      return await handleResolvedContract(contract)
-    } else if (previousContract.groupSlugs !== contract.groupSlugs) {
-      await handleContractGroupUpdated(previousContract, contract)
-    } else if (
+    if (
       previousContract.closeTime !== closeTime ||
       previousContract.question !== question
     ) {
       await handleUpdatedCloseTime(previousContract, contract, eventId)
+    }
+
+    if (!previousContract.isResolved && contract.isResolved) {
+      // No need to notify users of resolution, that's handled in resolve-market
+      await handleResolvedContract(contract)
+    }
+
+    // maybe we should do this more often, but at least if someone bets
+    if (previousContract.volume !== contract.volume) {
+      await revalidateStaticProps(getContractPath(contract))
     }
   })
 


### PR DESCRIPTION
Currently, we were revalidating in `onCreateBet`, but when you place a bet sometimes it creates a bunch of bet documents, due to filling limit orders. It's much better to only revalidate once for all of those. So now it revalidates in `onUpdateContract` if the volume went up.