### PR TITLE
Load additional bets on broken embeds after initial load

### DIFF
--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -52,6 +52,7 @@ const getContractBetsQuery = (contractId: string, options?: BetFilter) => {
   if (options?.filterRedemptions) {
     q = query(q, where('isRedemption', '==', false))
   }
+  q = query(q, orderBy('createdTime'))
   return q
 }
 
@@ -60,11 +61,7 @@ export async function listFirstNBets(
   n: number,
   options?: BetFilter
 ) {
-  const q = query(
-    getContractBetsQuery(contractId, options),
-    orderBy('createdTime'),
-    limit(n)
-  )
+  const q = query(getContractBetsQuery(contractId, options), limit(n))
   return await getValues<Bet>(q)
 }
 


### PR DESCRIPTION
This is necessary to support "embeds pointing to the main contract page", which load the contract page static props (only including a prefix of bets) and then render the embed view afterward. Otherwise, embeds with more than 2.5k bets will just show a wrong chart forever. You can see an example on the Donald Trump market shown at https://astralcodexten.substack.com/p/mantic-monday-twitter-chaos-edition.