### PR TITLE
More flexible bet filter machinery, use it everywhere

### DIFF
--- a/web/components/activity-log.tsx
+++ b/web/components/activity-log.tsx
@@ -59,15 +59,16 @@ export function ActivityLog(props: { count: number; showPills: boolean }) {
   const blockedUserIds = privateUser?.blockedUserIds ?? []
 
   const { count, showPills } = props
-  const rawBets = useLiveBets(count * 3 + 20)
+  const rawBets = useLiveBets(count * 3 + 20, {
+    filterRedemptions: true,
+    filterAntes: true,
+  })
   const bets = (rawBets ?? []).filter(
     (bet) =>
       !blockedContractIds.includes(bet.contractId) &&
       !blockedUserIds.includes(bet.userId) &&
       !BOT_USERNAMES.includes(bet.userUsername) &&
-      !EXTRA_USERNAMES_TO_EXCLUDE.includes(bet.userUsername) &&
-      !bet.isRedemption &&
-      !bet.isAnte
+      !EXTRA_USERNAMES_TO_EXCLUDE.includes(bet.userUsername)
   )
   const rawComments = useLiveComments(count * 3)
   const comments = (rawComments ?? []).filter(

--- a/web/components/bet/bets-list.tsx
+++ b/web/components/bet/bets-list.tsx
@@ -74,10 +74,7 @@ export function BetsList(props: { user: User }) {
   // Hide bets before 06-01-2022 if this isn't your own profile
   // NOTE: This means public profits also begin on 06-01-2022 as well.
   const bets = useMemo(
-    () =>
-      userBets?.filter(
-        (bet) => !bet.isAnte && bet.createdTime >= (hideBetsBefore ?? 0)
-      ),
+    () => userBets?.filter((bet) => bet.createdTime >= (hideBetsBefore ?? 0)),
     [userBets, hideBetsBefore]
   )
 

--- a/web/hooks/use-bets.ts
+++ b/web/hooks/use-bets.ts
@@ -1,11 +1,9 @@
 import { useEffect, useState } from 'react'
-import { Contract } from 'common/contract'
 import {
   Bet,
   BetFilter,
   listenForBets,
   listenForUnfilledBets,
-  withoutAnteBets,
 } from 'web/lib/firebase/bets'
 import { LimitBet } from 'common/bet'
 import { inMemoryStore, usePersistentState } from './use-persistent-state'
@@ -19,22 +17,6 @@ export const useBets = (options?: BetFilter) => {
   useEffectCheckEquality(() => {
     return listenForBets(setBets, options)
   }, [options])
-
-  return bets
-}
-
-export const useBetsWithoutAntes = (contract: Contract, initialBets: Bet[]) => {
-  const [bets, setBets] = useState<Bet[]>(
-    withoutAnteBets(contract, initialBets)
-  )
-  useEffect(() => {
-    return listenForBets(
-      (bets) => {
-        setBets(withoutAnteBets(contract, bets).sort((b) => b.createdTime))
-      },
-      { contractId: contract.id }
-    )
-  }, [contract])
 
   return bets
 }

--- a/web/hooks/use-bets.ts
+++ b/web/hooks/use-bets.ts
@@ -4,7 +4,6 @@ import {
   Bet,
   BetFilter,
   listenForBets,
-  listenForLiveBets,
   listenForUnfilledBets,
   withoutAnteBets,
 } from 'web/lib/firebase/bets'
@@ -18,9 +17,7 @@ import { filterDefined } from 'common/util/array'
 export const useBets = (options?: BetFilter) => {
   const [bets, setBets] = useState<Bet[] | undefined>()
   useEffectCheckEquality(() => {
-    return listenForBets((bets) => {
-      setBets(bets.sort((b) => b.createdTime))
-    }, options)
+    return listenForBets(setBets, options)
   }, [options])
 
   return bets
@@ -63,15 +60,14 @@ export const useUnfilledBetsAndBalanceByUserId = (contractId: string) => {
   return { unfilledBets, balanceByUserId }
 }
 
-export const useLiveBets = (count: number) => {
+export const useLiveBets = (count: number, options?: BetFilter) => {
   const [bets, setBets] = usePersistentState<Bet[] | undefined>(undefined, {
     store: inMemoryStore(),
     key: `liveBets-${count}`,
   })
-
-  useEffect(() => {
-    return listenForLiveBets(count, setBets)
-  }, [count, setBets])
+  useEffectCheckEquality(() => {
+    return listenForBets(setBets, { limit: count, order: 'desc', ...options })
+  }, [count, setBets, options])
 
   return bets
 }

--- a/web/hooks/use-bets.ts
+++ b/web/hooks/use-bets.ts
@@ -15,18 +15,13 @@ import { useUsersById } from './use-user'
 import { uniq } from 'lodash'
 import { filterDefined } from 'common/util/array'
 
-export const useBets = (contractId: string, options?: BetFilter) => {
+export const useBets = (options?: BetFilter) => {
   const [bets, setBets] = useState<Bet[] | undefined>()
   useEffectCheckEquality(() => {
-    if (contractId)
-      return listenForBets(
-        contractId,
-        (bets) => {
-          setBets(bets.sort((b) => b.createdTime))
-        },
-        options
-      )
-  }, [contractId, options])
+    return listenForBets((bets) => {
+      setBets(bets.sort((b) => b.createdTime))
+    }, options)
+  }, [options])
 
   return bets
 }
@@ -36,9 +31,12 @@ export const useBetsWithoutAntes = (contract: Contract, initialBets: Bet[]) => {
     withoutAnteBets(contract, initialBets)
   )
   useEffect(() => {
-    return listenForBets(contract.id, (bets) => {
-      setBets(withoutAnteBets(contract, bets).sort((b) => b.createdTime))
-    })
+    return listenForBets(
+      (bets) => {
+        setBets(withoutAnteBets(contract, bets).sort((b) => b.createdTime))
+      },
+      { contractId: contract.id }
+    )
   }, [contract])
 
   return bets

--- a/web/hooks/use-user-bets.ts
+++ b/web/hooks/use-user-bets.ts
@@ -37,11 +37,10 @@ export const useUserContractBets = (
 
   useEffect(() => {
     if (userId && contractId)
-      return listenForBets(
-        contractId,
-        (bets) => setBets(bets.sort((b) => b.createdTime)),
-        { userId: userId }
-      )
+      return listenForBets((bets) => setBets(bets.sort((b) => b.createdTime)), {
+        contractId: contractId,
+        userId: userId,
+      })
   }, [userId, contractId])
 
   return bets

--- a/web/hooks/use-user-bets.ts
+++ b/web/hooks/use-user-bets.ts
@@ -3,9 +3,10 @@ import { useFirestoreQueryData } from '@react-query-firebase/firestore'
 import { useEffect, useState } from 'react'
 import {
   Bet,
+  USER_BET_FILTER,
   getSwipes,
-  getUserBets,
-  getUserBetsQuery,
+  getBetsQuery,
+  listBets,
   listenForBets,
 } from 'web/lib/firebase/bets'
 import { MINUTE_MS, sleep } from 'common/util/time'
@@ -16,7 +17,7 @@ export const usePrefetchUserBets = (userId: string) => {
   const queryClient = useQueryClient()
   return queryClient.prefetchQuery(
     ['bets', userId],
-    () => sleep(1000).then(() => getUserBets(userId)),
+    () => sleep(1000).then(() => listBets({ userId, ...USER_BET_FILTER })),
     { staleTime: 15 * MINUTE_MS }
   )
 }
@@ -24,7 +25,7 @@ export const usePrefetchUserBets = (userId: string) => {
 export const useUserBets = (userId: string) => {
   const result = useFirestoreQueryData(
     ['bets', userId],
-    getUserBetsQuery(userId)
+    getBetsQuery({ userId, ...USER_BET_FILTER })
   )
   return result.data
 }
@@ -37,7 +38,7 @@ export const useUserContractBets = (
 
   useEffect(() => {
     if (userId && contractId)
-      return listenForBets((bets) => setBets(bets.sort((b) => b.createdTime)), {
+      return listenForBets(setBets, {
         contractId: contractId,
         userId: userId,
       })

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -43,10 +43,6 @@ export type BetFilter = {
   limit?: number
 }
 
-function getBetsCollection(contractId: string) {
-  return collection(db, 'contracts', contractId, 'bets')
-}
-
 export const getBetsQuery = (options?: BetFilter) => {
   let q = query(
     collectionGroup(db, 'bets') as Query<Bet>,

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -4,6 +4,7 @@ import {
   query,
   where,
   orderBy,
+  OrderByDirection,
   QueryConstraint,
   limit,
   startAfter,
@@ -30,6 +31,7 @@ export type BetFilter = {
   filterRedemptions?: boolean
   filterAntes?: boolean
   afterTime?: number
+  order?: OrderByDirection
   limit?: number
 }
 
@@ -37,8 +39,11 @@ function getBetsCollection(contractId: string) {
   return collection(db, 'contracts', contractId, 'bets')
 }
 
-const getBetsQuery = (options?: BetFilter) => {
-  let q = query(collectionGroup(db, 'bets'), orderBy('createdTime'))
+export const getBetsQuery = (options?: BetFilter) => {
+  let q = query(
+    collectionGroup(db, 'bets'),
+    orderBy('createdTime', options?.order)
+  )
   if (options?.contractId) {
     q = query(q, where('contractId', '==', options.contractId))
   }
@@ -57,7 +62,6 @@ const getBetsQuery = (options?: BetFilter) => {
   if (options?.filterRedemptions) {
     q = query(q, where('isRedemption', '==', false))
   }
-  q = query(q, orderBy('createdTime'))
   if (options?.limit) {
     q = query(q, limit(options.limit))
   }

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -30,6 +30,7 @@ export type BetFilter = {
   filterRedemptions?: boolean
   filterAntes?: boolean
   afterTime?: number
+  limit?: number
 }
 
 function getBetsCollection(contractId: string) {
@@ -37,7 +38,7 @@ function getBetsCollection(contractId: string) {
 }
 
 const getBetsQuery = (options?: BetFilter) => {
-  let q = query(collectionGroup(db, 'bets'))
+  let q = query(collectionGroup(db, 'bets'), orderBy('createdTime'))
   if (options?.contractId) {
     q = query(q, where('contractId', '==', options.contractId))
   }
@@ -57,15 +58,13 @@ const getBetsQuery = (options?: BetFilter) => {
     q = query(q, where('isRedemption', '==', false))
   }
   q = query(q, orderBy('createdTime'))
+  if (options?.limit) {
+    q = query(q, limit(options.limit))
+  }
   return q
 }
 
-export async function listFirstNBets(n: number, options?: BetFilter) {
-  const q = query(getBetsQuery(options), orderBy('createdTime'), limit(n))
-  return await getValues<Bet>(q)
-}
-
-export async function listAllBets(options?: BetFilter) {
+export async function listBets(options?: BetFilter) {
   return await getValues<Bet>(getBetsQuery(options))
 }
 

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -18,7 +18,6 @@ import { uniq } from 'lodash'
 
 import { db } from './init'
 import { Bet, LimitBet } from 'common/bet'
-import { Contract } from 'common/contract'
 import { getValues, listenForValues } from './utils'
 import { getContractFromId } from './contracts'
 import { filterDefined } from 'common/util/array'
@@ -140,21 +139,6 @@ export function listenForUnfilledBets(
     orderBy('createdTime', 'desc')
   )
   return listenForValues<LimitBet>(betsQuery, setBets)
-}
-
-export function withoutAnteBets(contract: Contract, bets?: Bet[]) {
-  const { createdTime } = contract
-
-  if (
-    bets &&
-    bets.length >= 2 &&
-    bets[0].createdTime === createdTime &&
-    bets[1].createdTime === createdTime
-  ) {
-    return bets.slice(2)
-  }
-
-  return bets?.filter((bet) => !bet.isAnte) ?? []
 }
 
 export async function getSwipes(userId: string) {

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -53,7 +53,7 @@ import {
   UserContractMetrics,
 } from 'web/lib/firebase/contract-metrics'
 
-const CONTRACT_BET_LOADING_OPTS = {
+const CONTRACT_BET_FILTER = {
   filterRedemptions: true,
   filterChallenges: true,
 }
@@ -66,7 +66,7 @@ export async function getStaticPropz(props: {
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
   const bets = contractId
-    ? await listFirstNBets(contractId, 2500, CONTRACT_BET_LOADING_OPTS)
+    ? await listFirstNBets(2500, { contractId, ...CONTRACT_BET_FILTER })
     : []
   const comments = contractId ? await listAllComments(contractId, 100) : []
 
@@ -152,15 +152,17 @@ export function ContractPageContent(
 
   // static props load bets in ascending order by time
   const lastBetTime = last(props.bets)?.createdTime
-  const newBets = useBets(contract.id, {
-    ...CONTRACT_BET_LOADING_OPTS,
+  const newBets = useBets({
+    contractId: contract.id,
     afterTime: lastBetTime,
+    ...CONTRACT_BET_FILTER,
   })
   const bets = props.bets.concat(newBets ?? [])
 
   const creator = useUserById(contract.creatorId) ?? null
 
-  const userBets = useBets(contract.id, {
+  const userBets = useBets({
+    contractId: contract.id,
     userId: user?.id ?? '_',
     filterAntes: true,
   })

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -15,7 +15,7 @@ import {
 } from 'web/lib/firebase/contracts'
 import { SEO } from 'web/components/SEO'
 import { Page } from 'web/components/layout/page'
-import { Bet, listFirstNBets } from 'web/lib/firebase/bets'
+import { Bet, listBets } from 'web/lib/firebase/bets'
 import Custom404 from '../404'
 import { AnswersPanel } from 'web/components/answers/answers-panel'
 import { fromPropz, usePropz } from 'web/hooks/use-propz'
@@ -66,7 +66,7 @@ export async function getStaticPropz(props: {
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
   const bets = contractId
-    ? await listFirstNBets(2500, { contractId, ...CONTRACT_BET_FILTER })
+    ? await listBets({ contractId, limit: 2500, ...CONTRACT_BET_FILTER })
     : []
   const comments = contractId ? await listAllComments(contractId, 100) : []
 

--- a/web/pages/api/v0/market/[id]/index.ts
+++ b/web/pages/api/v0/market/[id]/index.ts
@@ -11,13 +11,11 @@ export default async function handler(
   await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
   const { id } = req.query
   const contractId = id as string
-
   const contract = await getContractFromId(contractId)
   if (!contract) {
     res.status(404).json({ error: 'Contract not found' })
     return
   }
-
   res.setHeader('Cache-Control', marketCacheStrategy)
   return res.status(200).json(toFullMarket(contract))
 }

--- a/web/pages/api/v0/user/[username]/bets/index.ts
+++ b/web/pages/api/v0/user/[username]/bets/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
-import { Bet, getUserBets } from 'web/lib/firebase/bets'
+import { Bet, listBets } from 'web/lib/firebase/bets'
 import { getUserByUsername } from 'web/lib/firebase/users'
 import { ApiError } from '../../../_types'
 
@@ -18,9 +18,13 @@ export default async function handler(
     return
   }
 
-  const bets = await getUserBets(user.id)
-  const visibleBets = bets.filter((b) => !b.isRedemption && !b.isAnte)
+  const bets = await listBets({
+    userId: user.id,
+    filterAntes: true,
+    filterRedemptions: true,
+    order: 'desc',
+  })
 
   res.setHeader('Cache-Control', 'max-age=0')
-  return res.status(200).json(visibleBets)
+  return res.status(200).json(bets)
 }

--- a/web/pages/challenges/[username]/[contractSlug]/[challengeSlug].tsx
+++ b/web/pages/challenges/[username]/[contractSlug]/[challengeSlug].tsx
@@ -23,7 +23,7 @@ import { BinaryOutcomeLabel } from 'web/components/outcome-label'
 import { formatMoney } from 'common/util/format'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
 import { useWindowSize } from 'web/hooks/use-window-size'
-import { Bet, listAllBets } from 'web/lib/firebase/bets'
+import { Bet, listBets } from 'web/lib/firebase/bets'
 import { SEO } from 'web/components/SEO'
 import Custom404 from 'web/pages/404'
 import { useSaveReferral } from 'web/hooks/use-save-referral'
@@ -39,9 +39,7 @@ export async function getStaticProps(props: {
   const { username, contractSlug, challengeSlug } = props.params
   const contract = (await getContractFromSlug(contractSlug)) || null
   const user = (await getUserByUsername(username)) || null
-  const bets = contract?.id
-    ? await listAllBets({ contractId: contract.id })
-    : []
+  const bets = contract?.id ? await listBets({ contractId: contract.id }) : []
   const challenge = contract?.id
     ? await getChallenge(challengeSlug, contract.id)
     : null

--- a/web/pages/challenges/[username]/[contractSlug]/[challengeSlug].tsx
+++ b/web/pages/challenges/[username]/[contractSlug]/[challengeSlug].tsx
@@ -39,7 +39,9 @@ export async function getStaticProps(props: {
   const { username, contractSlug, challengeSlug } = props.params
   const contract = (await getContractFromSlug(contractSlug)) || null
   const user = (await getUserByUsername(username)) || null
-  const bets = contract?.id ? await listAllBets(contract.id) : []
+  const bets = contract?.id
+    ? await listAllBets({ contractId: contract.id })
+    : []
   const challenge = contract?.id
     ? await getChallenge(challengeSlug, contract.id)
     : null

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -18,7 +18,7 @@ import { Spacer } from 'web/components/layout/spacer'
 import { SiteLink } from 'web/components/widgets/site-link'
 import { useMeasureSize } from 'web/hooks/use-measure-size'
 import { fromPropz, usePropz } from 'web/hooks/use-propz'
-import { listAllBets } from 'web/lib/firebase/bets'
+import { listBets } from 'web/lib/firebase/bets'
 import { contractPath, getContractFromSlug } from 'web/lib/firebase/contracts'
 import Custom404 from '../../404'
 import { track } from 'web/lib/service/analytics'
@@ -39,7 +39,7 @@ export async function getStaticPropz(props: {
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
   const bets = contractId
-    ? await listAllBets({ contractId, ...CONTRACT_BET_LOADING_OPTS })
+    ? await listBets({ contractId, ...CONTRACT_BET_LOADING_OPTS })
     : []
 
   return {

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -39,7 +39,7 @@ export async function getStaticPropz(props: {
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
   const bets = contractId
-    ? await listAllBets(contractId, CONTRACT_BET_LOADING_OPTS)
+    ? await listAllBets({ contractId, ...CONTRACT_BET_LOADING_OPTS })
     : []
 
   return {
@@ -63,8 +63,9 @@ export default function ContractEmbedPage(props: {
 
   // static props load bets in ascending order by time
   const lastBetTime = last(props.bets)?.createdTime
-  const newBets = useBets(contract?.id ?? '', {
+  const newBets = useBets({
     ...CONTRACT_BET_LOADING_OPTS,
+    contractId: contract?.id ?? '',
     afterTime: lastBetTime,
   })
   const bets = props.bets.concat(newBets ?? [])


### PR DESCRIPTION
Now more places can use the `BetFilter` query stuff to filter out (typically) redemptions and antes in the query (e.g. the API, the activity feed, the user profile.)