### PR TITLE
Make popularity score based on 7 day window so we don't have to load all bets

### DIFF
--- a/functions/src/score-contracts.ts
+++ b/functions/src/score-contracts.ts
@@ -38,7 +38,9 @@ async function scoreContractsInternal() {
   log(`Found ${contracts.length} contracts to score`)
 
   for (const contract of contracts) {
-    const popularityScore = contract.uniqueBettors7Days ?? 1
+    const popularityScore =
+      (contract.uniqueBettors7Days ?? 0) / 10 +
+      (contract.uniqueBettors24Hours ?? 0)
     const wasCreatedToday = contract.createdTime > dayAgo
 
     let dailyScore: number | undefined


### PR DESCRIPTION
@jahooma do you think this is reasonable? If not, we can add a 3-day metric for unique bettors on the contract. But I figure maybe 7 days is just as good for this purpose anyway.