### PR TITLE
Somewhat improve `changeuserinfo`

### DIFF
--- a/functions/src/change-user-info.ts
+++ b/functions/src/change-user-info.ts
@@ -54,6 +54,9 @@ export const changeUser = async (
     avatarUrl?: string
   }
 ) => {
+  if (update.username) update.username = cleanUsername(update.username)
+  if (update.name) update.name = cleanDisplayName(update.name)
+
   // Update contracts, comments, and answers outside of a transaction to avoid contention.
   // Using bulkWriter to supports >500 writes at a time
   const contractsRef = firestore
@@ -105,10 +108,6 @@ export const changeUser = async (
 
   // Update the username inside a transaction
   return await firestore.runTransaction(async (transaction) => {
-    if (update.username) update.username = cleanUsername(update.username)
-
-    if (update.name) update.name = cleanDisplayName(update.name)
-
     const userRef = firestore.collection('users').doc(user.id)
     const userUpdate: Partial<User> = removeUndefinedProps(update)
     transaction.update(userRef, userUpdate)

--- a/functions/src/change-user-info.ts
+++ b/functions/src/change-user-info.ts
@@ -99,19 +99,15 @@ export const changeUser = async (
   })
 
   const bulkWriter = firestore.bulkWriter()
+  const userRef = firestore.collection('users').doc(user.id)
+  bulkWriter.update(userRef, removeUndefinedProps(update))
   commentSnap.docs.forEach((d) => bulkWriter.update(d.ref, commentUpdate))
   answerSnap.docs.forEach((d) => bulkWriter.update(d.ref, answerUpdate))
   contracts.docs.forEach((d) => bulkWriter.update(d.ref, contractUpdate))
   betsSnap.docs.forEach((d) => bulkWriter.update(d.ref, betsUpdate))
+
   await bulkWriter.flush()
   console.log('Done writing!')
-
-  // Update the username inside a transaction
-  return await firestore.runTransaction(async (transaction) => {
-    const userRef = firestore.collection('users').doc(user.id)
-    const userUpdate: Partial<User> = removeUndefinedProps(update)
-    transaction.update(userRef, userUpdate)
-  })
 }
 
 const firestore = admin.firestore()

--- a/functions/src/change-user-info.ts
+++ b/functions/src/change-user-info.ts
@@ -49,7 +49,8 @@ export const changeuserinfo = newEndpoint({}, async (req, auth) => {
     })
     return { message: 'Successfully changed user info.' }
   } catch (e) {
-    throw new APIError(400, 'update failed, please revert changes')
+    console.error(e)
+    throw new APIError(500, 'update failed, please revert changes')
   }
 })
 

--- a/functions/src/change-user-info.ts
+++ b/functions/src/change-user-info.ts
@@ -73,7 +73,7 @@ export const changeUser = async (
 
   const commentSnap = await firestore
     .collectionGroup('comments')
-    .where('userUsername', '==', user.username)
+    .where('userId', '==', user.id)
     .select()
     .get()
 
@@ -85,7 +85,7 @@ export const changeUser = async (
 
   const answerSnap = await firestore
     .collectionGroup('answers')
-    .where('username', '==', user.username)
+    .where('userId', '==', user.id)
     .select()
     .get()
   const answerUpdate: Partial<Answer> = removeUndefinedProps(update)


### PR DESCRIPTION
This fixes a bug where people could enter invalid display names and propagate those invalid names across all the denormalized stuff. (It wasn't super obvious because we also sanitize this on the client.) It also fixes gratuitous inefficiency. Note that all this code is still incorrect -- it will race to update denormalized data in any case where you quickly update your info twice in succession. It's just a little less bad.