### PR TITLE
Remove precomputed user profit rank, clean up leaderboards code

### DIFF
--- a/common/user.ts
+++ b/common/user.ts
@@ -26,13 +26,6 @@ export type User = {
     allTime: number
   }
 
-  profitRankCached?: {
-    daily: number
-    weekly: number
-    monthly: number
-    allTime: number
-  }
-
   creatorTraders: {
     daily: number
     weekly: number

--- a/functions/src/create-user.ts
+++ b/functions/src/create-user.ts
@@ -70,7 +70,6 @@ export const createuser = newEndpoint(opts, async (req, auth) => {
     totalDeposits: balance,
     createdTime: Date.now(),
     profitCached: { daily: 0, weekly: 0, monthly: 0, allTime: 0 },
-    profitRankCached: { daily: 0, weekly: 0, monthly: 0, allTime: 0 },
     nextLoanCached: 0,
     followerCountCached: 0,
     followedCategories: DEFAULT_CATEGORIES,

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -17,7 +17,6 @@ import {
 import { batchedWaitAll } from '../../common/util/promise'
 import { hasChanges } from '../../common/util/object'
 import { newEndpointNoAuth } from './api'
-import { HOUSE_BOT_USERNAME } from '../../common/envs/constants'
 
 const BAD_RESOLUTION_THRESHOLD = 0.1
 
@@ -154,11 +153,8 @@ export async function updateUserMetrics() {
     }),
     100
   )
-  const userUpdatesMinusBot = userUpdates.filter(
-    (update) => HOUSE_BOT_USERNAME !== update.user.username
-  )
 
-  for (const { user, fields } of userUpdatesMinusBot) {
+  for (const { user, fields } of userUpdates) {
     if (hasChanges(user, fields)) {
       writer.update(firestore.collection('users').doc(user.id), fields)
     }

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -14,6 +14,7 @@ import {
   updateDoc,
   where,
   startAfter,
+  getCountFromServer,
 } from 'firebase/firestore'
 import { getAuth, GoogleAuthProvider, signInWithPopup } from 'firebase/auth'
 import { app, db } from './init'
@@ -243,11 +244,17 @@ export async function listAllUsers(
   return snapshot.docs.map((doc) => doc.data())
 }
 
+export async function getProfitRank(profit: number, period: Period) {
+  const resp = await getCountFromServer(
+    query(users, where(`profitCached.${period}`, '>', profit))
+  )
+  return resp.data().count + 1
+}
+
 export function getTopTraders(period: Period) {
   const topTraders = query(
     users,
-    orderBy('profitRankCached.' + period, 'asc'),
-    where('profitRankCached.' + period, '>', 0),
+    orderBy('profitCached.' + period, 'desc'),
     limit(20)
   )
 

--- a/web/pages/leaderboards.tsx
+++ b/web/pages/leaderboards.tsx
@@ -20,15 +20,6 @@ import { BETTORS } from 'common/user'
 import { useUser } from 'web/hooks/use-user'
 
 export async function getStaticProps() {
-  const props = await fetchProps()
-
-  return {
-    props,
-    revalidate: 60, // regenerate after a minute
-  }
-}
-
-const fetchProps = async () => {
   const [allTime, monthly, weekly, daily] = await Promise.all([
     queryLeaderboardUsers('allTime'),
     queryLeaderboardUsers('monthly'),
@@ -36,13 +27,15 @@ const fetchProps = async () => {
     queryLeaderboardUsers('daily'),
   ])
   const topFollowed = await getTopFollowed()
-
   return {
-    allTime,
-    monthly,
-    weekly,
-    daily,
-    topFollowed,
+    props: {
+      allTime,
+      monthly,
+      weekly,
+      daily,
+      topFollowed,
+    },
+    revalidate: 60, // regenerate after a minute
   }
 }
 
@@ -62,23 +55,18 @@ type leaderboard = {
   topCreators: User[]
 }
 
-export default function Leaderboards(_props: {
+export default function Leaderboards(props: {
   allTime: leaderboard
   monthly: leaderboard
   weekly: leaderboard
   daily: leaderboard
   topFollowed: User[]
 }) {
-  const [props, setProps] = useState<Parameters<typeof Leaderboards>[0]>(_props)
   const [myRanks, setMyRanks] = useState<
     Record<Period, number | undefined> | undefined
   >()
 
   const user = useUser()
-
-  useEffect(() => {
-    fetchProps().then(setProps)
-  }, [])
 
   useEffect(() => {
     if (!user?.profitCached) {


### PR DESCRIPTION
Motivation: trying to eliminate complicated and expensive batch job work. Profit rank is almost guaranteed to change for ~every user ~every time we update, so it makes us update every user doc every 15 minutes for sure.

- We no longer need to precompute the profit rank in `updateUserMetrics`.
- The leaderboards page no longer re-downloads the static props for no obvious reason.
- We no longer censor our bot from the leaderboard. (Actually, we previously didn't bother to do any metrics updates on our bot, which is pretty bizarre. It just had a bunch of out of date info in there.) If someone really loves this I can put it back in. We will need to add a field in the database like `isEligibleForLeaderboard`. I think it's much better to have it on the leaderboard.