### PR TITLE
Don't load redemption bets in `updateContractMetrics`

### DIFF
--- a/functions/src/update-contract-metrics.ts
+++ b/functions/src/update-contract-metrics.ts
@@ -55,6 +55,7 @@ export async function updateContractMetrics() {
           .collection('bets')
           .orderBy('createdTime', 'desc')
           .where('createdTime', '>=', monthAgo)
+          .where('isRedemption', '==', false)
       )
       const unfilledBets = await getValues<LimitBet>(
         firestore


### PR DESCRIPTION
Redemptions shouldn't affect the probability, volume, or unique bettors, so they are useless to consider in these metrics.