### PR TITLE
Remove `volume7Days` precomputed metric

### DIFF
--- a/common/contract.ts
+++ b/common/contract.ts
@@ -50,7 +50,6 @@ export type Contract<T extends AnyContractType = AnyContractType> = {
 
   volume: number
   volume24Hours: number
-  volume7Days: number
   elasticity: number
 
   collectedFees: Fees

--- a/common/new-contract.ts
+++ b/common/new-contract.ts
@@ -74,7 +74,6 @@ export function getNewContract(
 
     volume: 0,
     volume24Hours: 0,
-    volume7Days: 0,
     elasticity:
       propsByOutcomeType.mechanism === 'cpmm-1'
         ? computeBinaryCpmmElasticityFromAnte(ante)

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -123,7 +123,6 @@ Requires no authorization.
       "outcomeType":"BINARY",
       "mechanism":"cpmm-1",
       "volume":241,
-      "volume7Days":0,
       "volume24Hours":0,
       "isResolved":true,
       "resolution":"YES",
@@ -170,7 +169,6 @@ Requires no authorization.
     isLogScale?: bool // PSEUDO_NUMERIC markets only, if true `number = (max - min + 1)^probability + minstart - 1`, otherwise `number = min + (max - min) * probability`
 
     volume: number
-    volume7Days: number
     volume24Hours: number
 
     isResolved: boolean
@@ -214,7 +212,6 @@ Requires no authorization.
     "outcomeType": "FREE_RESPONSE",
     "mechanism": "dpm-2",
     "volume": 112,
-    "volume7Days": 212,
     "volume24Hours": 0,
     "isResolved": true,
     "resolution": "MKT",

--- a/functions/src/update-contract-metrics.ts
+++ b/functions/src/update-contract-metrics.ts
@@ -114,7 +114,6 @@ export async function updateContractMetrics() {
 
       const update = {
         volume24Hours: computeVolume(descendingBets, yesterday),
-        volume7Days: computeVolume(descendingBets, weekAgo),
         elasticity: computeElasticity(unfilledBets, contract),
         uniqueBettors24Hours,
         uniqueBettors7Days,

--- a/twitch-bot/common/types/manifold-api-types.ts
+++ b/twitch-bot/common/types/manifold-api-types.ts
@@ -28,7 +28,6 @@ export type LiteMarket = {
   totalLiquidity?: number;
 
   volume: number;
-  volume7Days: number;
   volume24Hours: number;
 
   isResolved: boolean;

--- a/twitch-bot/common/types/manifold-internal-types.ts
+++ b/twitch-bot/common/types/manifold-internal-types.ts
@@ -139,7 +139,6 @@ export type Contract<T extends AnyContractType = AnyContractType> = {
 
   volume: number;
   volume24Hours: number;
-  volume7Days: number;
   elasticity: number;
 
   collectedFees: Fees;

--- a/web/hooks/use-contracts.ts
+++ b/web/hooks/use-contracts.ts
@@ -4,7 +4,6 @@ import {
   Contract,
   listenForContracts,
   listenForHotContracts,
-  listenForInactiveContracts,
   getUserBetContracts,
   getUserBetContractsQuery,
   listAllContracts,
@@ -111,16 +110,6 @@ export const getCachedContracts = async () =>
   q.fetchQuery(['contracts'], () => listAllContracts(10000), {
     staleTime: Infinity,
   })
-
-export const useInactiveContracts = () => {
-  const [contracts, setContracts] = useState<Contract[] | undefined>()
-
-  useEffect(() => {
-    return listenForInactiveContracts(setContracts)
-  }, [])
-
-  return contracts
-}
 
 export const useHotContracts = () => {
   const [hotContracts, setHotContracts] = useState<Contract[] | undefined>()

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -199,7 +199,7 @@ export function listenForInactiveContracts(
 const newContractsQuery = query(
   contracts,
   where('isResolved', '==', false),
-  where('volume7Days', '==', 0),
+  where('volume', '==', 0),
   where('createdTime', '>', Date.now() - 7 * DAY_MS)
 )
 

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -19,7 +19,6 @@ import { coll, getValues, listenForValue, listenForValues } from './utils'
 import { BinaryContract, Contract } from 'common/contract'
 import { chooseRandomSubset } from 'common/util/random'
 import { formatMoney, formatPercent } from 'common/util/format'
-import { DAY_MS } from 'common/util/time'
 import { ENV_CONFIG } from 'common/envs/constants'
 import { getBinaryProb } from 'common/contract-details'
 import { getLiquidity } from 'common/calculate-cpmm-multi'
@@ -176,37 +175,6 @@ export function getUserBetContractsQuery(userId: string) {
     where('uniqueBettorIds', 'array-contains', userId),
     limit(MAX_USER_BET_CONTRACTS_LOADED)
   ) as Query<Contract>
-}
-
-const inactiveContractsQuery = query(
-  contracts,
-  where('isResolved', '==', false),
-  where('closeTime', '>', Date.now()),
-  where('visibility', '==', 'public'),
-  where('volume24Hours', '==', 0)
-)
-
-export function getInactiveContracts() {
-  return getValues<Contract>(inactiveContractsQuery)
-}
-
-export function listenForInactiveContracts(
-  setContracts: (contracts: Contract[]) => void
-) {
-  return listenForValues<Contract>(inactiveContractsQuery, setContracts)
-}
-
-const newContractsQuery = query(
-  contracts,
-  where('isResolved', '==', false),
-  where('volume', '==', 0),
-  where('createdTime', '>', Date.now() - 7 * DAY_MS)
-)
-
-export function listenForNewContracts(
-  setContracts: (contracts: Contract[]) => void
-) {
-  return listenForValues<Contract>(newContractsQuery, setContracts)
 }
 
 export function listenForLiveContracts(

--- a/web/pages/api/v0/_types.ts
+++ b/web/pages/api/v0/_types.ts
@@ -34,7 +34,6 @@ export type LiteMarket = {
   totalLiquidity?: number
 
   volume: number
-  volume7Days: number
   volume24Hours: number
 
   isResolved: boolean
@@ -89,7 +88,6 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     outcomeType,
     mechanism,
     volume,
-    volume7Days,
     volume24Hours,
     isResolved,
     resolution,
@@ -129,7 +127,6 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     outcomeType,
     mechanism,
     volume,
-    volume7Days,
     volume24Hours,
     isResolved,
     resolution,

--- a/web/pages/contract-search-firestore.tsx
+++ b/web/pages/contract-search-firestore.tsx
@@ -44,6 +44,7 @@ export default function ContractSearchFirestore(props: {
   } else if (sort === 'resolve-date') {
     matches = sortBy(matches, (contract) => -1 * (contract.resolutionTime ?? 0))
   } else if (sort === 'close-date') {
+    // Use lodash for stable sort, so previous sort breaks all ties.
     matches = sortBy(matches, ({ volume24Hours }) => -1 * volume24Hours)
     matches = sortBy(matches, (contract) => contract.closeTime ?? Infinity)
   } else if (sort === 'most-traded') {
@@ -51,8 +52,6 @@ export default function ContractSearchFirestore(props: {
   } else if (sort === 'score') {
     matches.sort((a, b) => (b.popularityScore ?? 0) - (a.popularityScore ?? 0))
   } else if (sort === '24-hour-vol') {
-    // Use lodash for stable sort, so previous sort breaks all ties.
-    matches = sortBy(matches, ({ volume7Days }) => -1 * volume7Days)
     matches = sortBy(matches, ({ volume24Hours }) => -1 * volume24Hours)
   }
 


### PR DESCRIPTION
I'm going to claim we don't need this for anything, and once I replace the "unique bettors in time interval" and "probability change over time" metric computations to be more efficient (both of which I plan to do), then we will no longer need to load as many bets in `updateContractMetrics`.