### PR TITLE
Invalidate contract page props on description and question changes

### DIFF
--- a/functions/src/on-update-contract.ts
+++ b/functions/src/on-update-contract.ts
@@ -27,8 +27,15 @@ export const onUpdateContract = functions.firestore
       await handleUpdatedCloseTime(previousContract, contract, eventId)
     }
 
-    // maybe we should do this more often, but at least if someone bets
-    if (previousContract.volume !== contract.volume) {
+    // mqp: if you are here trying to figure out why the contract page is
+    // showing random incorrect data, it's probably because we don't do this on
+    // every contract change, and only do it sometimes instead.  complain to
+    // james because he's the one who has made all the decisions about this
+    if (
+      previousContract.volume !== contract.volume ||
+      previousContract.question !== contract.question ||
+      previousContract.description !== contract.description
+    ) {
       await revalidateStaticProps(getContractPath(contract))
     }
   })


### PR DESCRIPTION
This broken invalidation surely causes many bugs, but it seems one of the worst bugs is with the description editor, which doesn't correctly handle the case where the description changes after loading the page. As a result everyone on Discord is mad, because they will change a description and the change basically won't work until someone bets.

I don't want to deal with trying to fix the bug in that editor right now, so I am doing the simplest thing that I think will make people less mad.