### PR TITLE
Try to make auth cookie smaller

### DIFF
--- a/common/firebase-auth.ts
+++ b/common/firebase-auth.ts
@@ -6,6 +6,33 @@ import {
   User as FirebaseUser,
 } from 'firebase/auth'
 
+// The Firebase SDK doesn't really support persisting the logged-in state between
+// devices, or anything like that. To get it from the client to the server:
+//
+// 1. We pack up the user by calling (the undocumented) User.toJSON(). This is the
+//    same way the Firebase SDK saves it to disk, so it's gonna have the right stuff.
+//
+// 2. We put it into a cookie and read the cookie out here.
+//
+// 3. We use the Firebase "persistence manager" to write the cookie value into the persistent
+//    store on the server (an in-memory store), just as if the SDK had saved the user itself.
+//
+// 4. We ask the persistence manager for the current user, which reads what we just wrote,
+//    and creates a real puffed-up internal user object from the serialized user.
+//
+// 5. We set that user to be the current Firebase user in the SDK.
+//
+// 6. We ask for the ID token, which will refresh it if necessary (i.e. if this cookie
+//    is from an old browser session), so that we know the SDK is prepared to do real
+//    Firebase queries.
+//
+// This strategy should be robust, since it's repurposing Firebase's internal persistence
+// machinery, but the details may eventually need updating for new versions of the SDK.
+//
+// References:
+// Persistence manager: https://github.com/firebase/firebase-js-sdk/blob/39f4635ebc07316661324145f1b8c27f9bd7aedb/packages/auth/src/core/persistence/persistence_user_manager.ts#L64
+// Token manager: https://github.com/firebase/firebase-js-sdk/blob/39f4635ebc07316661324145f1b8c27f9bd7aedb/packages/auth/src/core/user/token_manager.ts#L76
+
 export interface FirebaseAuthInternal extends FirebaseAuth {
   persistenceManager: {
     fullUserKey: string

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -1,4 +1,5 @@
 import { createContext, ReactNode, useEffect } from 'react'
+import { pickBy } from 'lodash'
 import { onIdTokenChanged } from 'firebase/auth'
 import {
   auth,
@@ -43,14 +44,25 @@ const ensureDeviceToken = () => {
   return deviceToken
 }
 
-export const setUserCookie = (cookie: string | undefined) => {
-  const data = setCookie(AUTH_COOKIE_NAME, cookie ?? '', [
+const stripUserData = (data: string) => {
+  // there's some risk that this cookie could be too big for some clients,
+  // so strip it down to only the keys that the server auth actually needs
+  // in order to auth to the firebase SDK
+  const whitelist = ['uid', 'emailVerified', 'isAnonymous', 'stsTokenManager']
+  const user = JSON.parse(data)
+  const stripped = pickBy(user, (_v, k) => whitelist.includes(k))
+  return JSON.stringify(stripped)
+}
+
+export const setUserCookie = (data: string | undefined) => {
+  const stripped = data ? stripUserData(data) : ''
+  const cookie = setCookie(AUTH_COOKIE_NAME, stripped, [
     ['path', '/'],
-    ['max-age', (cookie === undefined ? 0 : TEN_YEARS_SECS).toString()],
+    ['max-age', (data === undefined ? 0 : TEN_YEARS_SECS).toString()],
     ['samesite', 'lax'],
     ['secure'],
   ])
-  document.cookie = data
+  document.cookie = cookie
 }
 
 export const AuthContext = createContext<AuthUser>(undefined)
@@ -61,6 +73,7 @@ export function AuthProvider(props: {
   const { children, serverUser } = props
   const [authUser, setAuthUser] = useStateCheckEquality<AuthUser>(serverUser)
 
+  console.log(serverUser)
   useEffect(() => {
     if (serverUser === undefined) {
       const cachedUser = localStorage.getItem(CACHED_USER_KEY)

--- a/web/lib/firebase/server-auth.ts
+++ b/web/lib/firebase/server-auth.ts
@@ -18,33 +18,6 @@ type RequestContext = {
   res: ServerResponse
 }
 
-// The Firebase SDK doesn't really support persisting the logged-in state between
-// devices, or anything like that. To get it from the client to the server:
-//
-// 1. We pack up the user by calling (the undocumented) User.toJSON(). This is the
-//    same way the Firebase SDK saves it to disk, so it's gonna have the right stuff.
-//
-// 2. We put it into a cookie and read the cookie out here.
-//
-// 3. We use the Firebase "persistence manager" to write the cookie value into the persistent
-//    store on the server (an in-memory store), just as if the SDK had saved the user itself.
-//
-// 4. We ask the persistence manager for the current user, which reads what we just wrote,
-//    and creates a real puffed-up internal user object from the serialized user.
-//
-// 5. We set that user to be the current Firebase user in the SDK.
-//
-// 6. We ask for the ID token, which will refresh it if necessary (i.e. if this cookie
-//    is from an old browser session), so that we know the SDK is prepared to do real
-//    Firebase queries.
-//
-// This strategy should be robust, since it's repurposing Firebase's internal persistence
-// machinery, but the details may eventually need updating for new versions of the SDK.
-//
-// References:
-// Persistence manager: https://github.com/firebase/firebase-js-sdk/blob/39f4635ebc07316661324145f1b8c27f9bd7aedb/packages/auth/src/core/persistence/persistence_user_manager.ts#L64
-// Token manager: https://github.com/firebase/firebase-js-sdk/blob/39f4635ebc07316661324145f1b8c27f9bd7aedb/packages/auth/src/core/user/token_manager.ts#L76
-
 export const authenticateOnServer = async (ctx: RequestContext) => {
   const user = getCookies(ctx.req.headers.cookie ?? '')[AUTH_COOKIE_NAME]
   if (user == null) {


### PR DESCRIPTION
On my box, this drops it from 2.2kB to 1.7kB. But based on Nonrival's screenshot it looks like he was running into the cookie size limit of 4Kb, perhaps due to different attributes of his Google account. So let's try to make it as small as possible and see if it fixes his problem.