### PR TITLE
Introduce `contract-metrics` `lastBetTime`, optimize `updateContractMetrics`

### DIFF
--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -1,4 +1,4 @@
-import { Dictionary, last, partition, sumBy, uniq } from 'lodash'
+import { Dictionary, partition, sumBy, uniq } from 'lodash'
 import { calculatePayout, getContractBetMetrics } from './calculate'
 import { Bet, LimitBet } from './bet'
 import {
@@ -179,35 +179,6 @@ export const computeDpmElasticity = (
   betAmount: number
 ) => {
   return getNewMultiBetInfo('', 2 * betAmount, contract).newBet.probAfter
-}
-
-export const computeVolume = (contractBets: Bet[], since: number) => {
-  return sumBy(contractBets, (b) =>
-    b.createdTime > since && !b.isRedemption && !b.isAnte
-      ? Math.abs(b.amount)
-      : 0
-  )
-}
-
-export const calculateProbChange = (
-  prob: number,
-  descendingBets: Bet[],
-  since: number,
-  resolutionTime: number | undefined
-) => {
-  if (resolutionTime && since >= resolutionTime) return 0
-
-  const newestBet = descendingBets[0]
-  if (!newestBet) return 0
-
-  const betBeforeSince = descendingBets.find((b) => b.createdTime < since)
-
-  if (!betBeforeSince) {
-    const oldestBet = last(descendingBets) ?? newestBet
-    return prob - oldestBet.probBefore
-  }
-
-  return prob - betBeforeSince.probAfter
 }
 
 export const calculateCreatorTraders = (userContracts: Contract[]) => {

--- a/common/calculate.ts
+++ b/common/calculate.ts
@@ -220,7 +220,7 @@ export function getContractBetMetrics(contract: Contract, yourBets: Bet[]) {
   const { YES: yesShares, NO: noShares } = totalShares
   const hasYesShares = yesShares >= 1
   const hasNoShares = noShares >= 1
-
+  const lastBetTime = Math.max(...yourBets.map((b) => b.createdTime))
   const maxSharesOutcome = hasShares
     ? maxBy(Object.keys(totalShares), (outcome) => totalShares[outcome])
     : null
@@ -236,6 +236,7 @@ export function getContractBetMetrics(contract: Contract, yourBets: Bet[]) {
     hasYesShares,
     hasNoShares,
     maxSharesOutcome,
+    lastBetTime,
   }
 }
 
@@ -251,6 +252,7 @@ export function getContractBetNullMetrics() {
     hasYesShares: false,
     hasNoShares: false,
     maxSharesOutcome: null,
+    lastBetTime: null,
   }
 }
 

--- a/functions/src/scripts/update-metrics.ts
+++ b/functions/src/scripts/update-metrics.ts
@@ -7,10 +7,10 @@ import { updateUserMetrics } from '../update-user-metrics'
 import { updateGroupMetrics } from '../update-group-metrics'
 
 async function updateMetrics() {
-  log('Updating contract metrics...')
-  await updateContractMetrics()
   log('Updating user metrics...')
   await updateUserMetrics()
+  log('Updating contract metrics...')
+  await updateContractMetrics()
   log('Updating group metrics...')
   await updateGroupMetrics()
 }


### PR DESCRIPTION
The goal of this field is to make it easy to compute "unique bettors between time T0 and T1." (I intend to remove the contract unique bettor fields entirely in a later PR, but adding this field is the first step.)

Now we don't need to load all the bets from the last month in `updateContractMetrics`; just the bets from the last day, for the purpose of computing daily volume.

Later I may transition to maintaining this field in the `onCreateBet` trigger so that it doesn't have a 15-minute lag time, but for now let's populate it in the same place that we populate the other contract metrics, since that's easy.