### PR TITLE
Don't include an extra copy of Tailwind in our app

### DIFF
--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,4 +1,3 @@
-import 'tailwindcss/tailwind.css'
 import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
 import Head from 'next/head'


### PR DESCRIPTION
Inga introduced a globals.css file that imports Tailwind in #1197 but forgot to delete this import.