### PR TITLE
Revalidate contract page periodically again

### DIFF
--- a/functions/src/on-update-contract.ts
+++ b/functions/src/on-update-contract.ts
@@ -27,15 +27,8 @@ export const onUpdateContract = functions.firestore
       await handleUpdatedCloseTime(previousContract, contract, eventId)
     }
 
-    // mqp: if you are here trying to figure out why the contract page is
-    // showing random incorrect data, it's probably because we don't do this on
-    // every contract change, and only do it sometimes instead.  complain to
-    // james because he's the one who has made all the decisions about this
-    if (
-      previousContract.volume !== contract.volume ||
-      previousContract.question !== contract.question ||
-      previousContract.description !== contract.description
-    ) {
+    // i.e. if someone made a bet
+    if (previousContract.volume !== contract.volume) {
       await revalidateStaticProps(getContractPath(contract))
     }
   })

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -83,6 +83,7 @@ export async function getStaticPropz(props: {
       comments,
       userPositions,
     },
+    revalidate: 60,
   }
 }
 


### PR DESCRIPTION
Sorry @jahooma but I just can't stand the way it is so I am changing it back.

If you want to change this back, note that my fix in #1232 was wrong because I forgot that contract descriptions are complicated, so we were revalidating too often before. So you will have to write a more complicated version of that fix.