### PR TITLE
always include current username in share-market-URLs

### DIFF
--- a/common/util/share.ts
+++ b/common/util/share.ts
@@ -3,7 +3,5 @@ import { ENV_CONFIG } from 'common/envs/constants'
 
 export const getShareUrl = (contract: Contract, username: string | undefined) =>
   `https://${ENV_CONFIG.domain}/${contract.creatorUsername}/${contract.slug}${
-    username && contract.creatorUsername !== username
-      ? '?referrer=' + username
-      : ''
+    username ? '?referrer=' + username : ''
   }`


### PR DESCRIPTION
Fixes #1161, if that's regarded as a bug worth fixing! If not, feel free to ignore this.

Testing:

- Before: ![Screenshot from 2022-11-25 22-52-56](https://user-images.githubusercontent.com/1899701/204076516-021b35e6-10c4-486b-8ea2-11451f80a457.png)

- After: ![Screenshot from 2022-11-25 22-53-04](https://user-images.githubusercontent.com/1899701/204076535-f109eb60-bbfb-4bf9-83e4-81ec4d8fc594.png)

(If you'd like unit tests for this, I'd be happy to add them! But I'll need a pointer about where to put them.)