### PR TITLE
hotfix market grid ssr (wip)

### DIFF
--- a/web/components/editor/tiptap-grid-cards.tsx
+++ b/web/components/editor/tiptap-grid-cards.tsx
@@ -1,11 +1,11 @@
-import { mergeAttributes, Node } from '@tiptap/core'
+import { Node } from '@tiptap/core'
 import React from 'react'
 import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
 import { ContractsGrid } from '../contract/contracts-grid'
-
 import { LoadingIndicator } from '../widgets/loading-indicator'
 import { useContracts } from 'web/hooks/use-contracts'
 import { filterDefined } from 'common/util/array'
+import { DOMAIN } from 'common/envs/constants'
 
 export default Node.create({
   name: 'gridCardsComponent',
@@ -25,11 +25,25 @@ export default Node.create({
       {
         tag: 'grid-cards-component',
       },
+      {
+        tag: `iframe[data-type="${this.name}"]`,
+      },
     ]
   },
 
-  renderHTML({ HTMLAttributes }) {
-    return ['grid-cards-component', mergeAttributes(HTMLAttributes)]
+  // TODO: begone with this godforesaken hack and render the react component instead
+  renderHTML({ HTMLAttributes: { contractIds } }) {
+    const ids = contractIds.split(',')
+
+    return [
+      'iframe',
+      {
+        'data-type': this.name,
+        height: Math.ceil(ids.length / 2) * 200 + 'px',
+        src: `https://${DOMAIN}/embed/grid/${contractIds.split(',').join('/')}`,
+        frameborder: 0,
+      },
+    ]
   },
 
   addNodeView() {

--- a/web/pages/embed/grid/[...slugs]/index.tsx
+++ b/web/pages/embed/grid/[...slugs]/index.tsx
@@ -1,15 +1,21 @@
 import React from 'react'
-import { Contract, getContractFromSlug } from 'web/lib/firebase/contracts'
+import {
+  Contract,
+  getContractFromId,
+  getContractFromSlug,
+} from 'web/lib/firebase/contracts'
 import { ContractsGrid } from 'web/components/contract/contracts-grid'
+import { compact } from 'lodash'
 
 export async function getStaticProps(props: { params: { slugs: string[] } }) {
   const { slugs } = props.params
 
-  const contracts = (await Promise.all(
-    slugs.map((slug) =>
-      getContractFromSlug(slug) != null ? getContractFromSlug(slug) : []
-    )
-  )) as Contract[]
+  const contracts = compact(
+    await Promise.all([
+      ...slugs.map((slug) => getContractFromSlug(slug)),
+      ...slugs.map((id) => getContractFromId(id)),
+    ])
+  )
 
   return {
     props: {
@@ -27,11 +33,9 @@ export default function ContractGridPage(props: { contracts: Contract[] }) {
   const { contracts } = props
 
   return (
-    <>
-      <ContractsGrid
-        contracts={contracts}
-        breakpointColumns={{ default: 2, 650: 1 }}
-      />
-    </>
+    <ContractsGrid
+      contracts={contracts}
+      breakpointColumns={{ default: 2, 650: 1 }}
+    />
   )
 }


### PR DESCRIPTION
renders the market grid as iframe. I am really not happy with this solution

we could merge it if we need to hotfix the world cup dashboard but otherwise I'd hold out on actually figuring out how to render the react node views server side