### PR TITLE
Split contract metrics and positions into separate docs

### DIFF
--- a/common/calculate-metrics.ts
+++ b/common/calculate-metrics.ts
@@ -9,13 +9,13 @@ import {
   DPMContract,
 } from './contract'
 import { PortfolioMetrics, User } from './user'
+import { ContractMetric } from './contract-metric'
 import { DAY_MS } from './util/time'
 import { getBinaryCpmmBetInfo, getNewMultiBetInfo } from './new-bet'
 import { getCpmmProbability } from './calculate-cpmm'
 import { removeUndefinedProps } from './util/object'
 import { buy, getProb, shortSell } from './calculate-cpmm-multi'
 import { average } from './util/math'
-import { ContractMetric } from 'common/contract-metric'
 
 const computeInvestmentValue = (
   bets: Bet[],
@@ -257,8 +257,7 @@ export const calculateNewProfit = (
 
 export const calculateMetricsByContract = (
   betsByContractId: Dictionary<Bet[]>,
-  contractsById: Dictionary<Contract>,
-  user: User
+  contractsById: Dictionary<Contract>
 ) => {
   return Object.entries(betsByContractId).map(([contractId, bets]) => {
     const contract = contractsById[contractId]
@@ -279,17 +278,9 @@ export const calculateMetricsByContract = (
       contractId,
       ...current,
       from: periodMetrics,
-      userName: user.name,
-      userId: user.id,
-      userUsername: user.username,
-      userAvatarUrl: user.avatarUrl,
-    } as ContractMetric)
+    }) as ContractMetric
   })
 }
-
-export type ContractMetrics = ReturnType<
-  typeof calculateMetricsByContract
->[number]
 
 const calculatePeriodProfit = (
   contract: CPMMBinaryContract,

--- a/common/contract-metric.ts
+++ b/common/contract-metric.ts
@@ -11,18 +11,10 @@ export type ContractMetric = {
         }
       }
     | undefined
-  hasNoShares: boolean
-  hasShares: boolean
-  hasYesShares: boolean
   invested: number
-  loan: number
-  maxSharesOutcome: string | null
   payout: number
   profit: number
   profitPercent: number
-  totalShares: {
-    [outcome: string]: number
-  }
   userId: string
   userUsername: string
   userName: string

--- a/common/contract-positions.ts
+++ b/common/contract-positions.ts
@@ -1,0 +1,15 @@
+export type ContractPositions = {
+  contractId: string
+  hasNoShares: boolean
+  hasShares: boolean
+  hasYesShares: boolean
+  loan: number
+  maxSharesOutcome: string | null
+  totalShares: {
+    [outcome: string]: number
+  }
+  userId: string
+  userUsername: string
+  userName: string
+  userAvatarUrl: string
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -57,6 +57,10 @@ service cloud.firestore {
       allow read;
     }
 
+    match /{somePath=**}/contract-positions/{contractId} {
+      allow read;
+    }
+
     match /{somePath=**}/challenges/{challengeId}{
       allow read;
     }
@@ -97,7 +101,7 @@ service cloud.firestore {
                          .hasOnly(['blockedByUserIds'])
                        && request.resource.data.blockedByUserIds.toSet().difference(resource.data.blockedByUserIds.toSet()).hasOnly([request.auth.uid]);
 
-      allow delete: if (userId == request.auth.uid || isAdmin());              
+      allow delete: if (userId == request.auth.uid || isAdmin());
     }
 
     match /private-users/{userId}/views/{viewId} {

--- a/functions/src/change-user-info.ts
+++ b/functions/src/change-user-info.ts
@@ -19,6 +19,7 @@ import { removeUndefinedProps } from '../../common/util/object'
 import { Answer } from '../../common/answer'
 import { APIError, newEndpoint, validate } from './api'
 import { ContractMetric } from '../../common/contract-metric'
+import { ContractPositions } from '../../common/contract-positions'
 
 type ChoiceContract = FreeResponseContract | MultipleChoiceContract
 
@@ -113,6 +114,17 @@ export const changeUser = async (
     userAvatarUrl: update.avatarUrl,
   })
 
+  const contractPositionsSnap = await firestore
+    .collection(`users/${user.id}/contract-positions`)
+    .get()
+
+  const contractPositionsUpdate: Partial<ContractPositions> =
+    removeUndefinedProps({
+      userName: update.name,
+      userUsername: update.username,
+      userAvatarUrl: update.avatarUrl,
+    })
+
   const bulkWriter = firestore.bulkWriter()
   const userRef = firestore.collection('users').doc(user.id)
   bulkWriter.update(userRef, removeUndefinedProps(update))
@@ -121,6 +133,9 @@ export const changeUser = async (
   betsSnap.docs.forEach((d) => bulkWriter.update(d.ref, betsUpdate))
   contractMetricsSnap.docs.forEach((d) =>
     bulkWriter.update(d.ref, contractMetricsUpdate)
+  )
+  contractPositionsSnap.docs.forEach((d) =>
+    bulkWriter.update(d.ref, contractPositionsUpdate)
   )
 
   const answerSnap = await firestore

--- a/functions/src/on-create-comment-on-contract.ts
+++ b/functions/src/on-create-comment-on-contract.ts
@@ -141,7 +141,7 @@ export const onCreateCommentOnContract = functions
       })
     }
 
-    const position = getLargestPosition(contract, priorUserBets)
+    const position = getLargestPosition(priorUserBets)
     if (position) {
       const fields: { [k: string]: unknown } = {
         commenterPositionShares: position.shares,

--- a/functions/src/scripts/backfill-comment-position-data.ts
+++ b/functions/src/scripts/backfill-comment-position-data.ts
@@ -62,7 +62,6 @@ async function denormalize() {
         (b) => b.createdTime < comment.createdTime
       )
       const position = getLargestPosition(
-        contract,
         previousBets.filter((b) => b.userId === comment.userId && !b.isAnte)
       )
       if (position) {

--- a/functions/src/update-contract-metrics.ts
+++ b/functions/src/update-contract-metrics.ts
@@ -154,7 +154,7 @@ async function getBetsAroundTime(contractId: string, when: number) {
 async function getUniqueBettors(contractId: string, since: number) {
   return (
     await firestore
-      .collectionGroup('contract-metrics')
+      .collectionGroup('contract-positions')
       .where('contractId', '==', contractId)
       .where('lastBetTime', '>', since)
       .count()

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -5,6 +5,7 @@ import { groupBy } from 'lodash'
 import { getValues, invokeFunction, log, revalidateStaticProps } from './utils'
 import { Bet } from '../../common/bet'
 import { Contract } from '../../common/contract'
+import { ContractMetric } from '../../common/contract-metric'
 import { PortfolioMetrics, User } from '../../common/user'
 import { DAY_MS } from '../../common/util/time'
 import { getUserLoanUpdates, isUserEligibleForLoan } from '../../common/loans'
@@ -101,8 +102,7 @@ export async function updateUserMetrics() {
 
       const metricsByContract = calculateMetricsByContract(
         metricRelevantBetsByContract,
-        contractsById,
-        user
+        contractsById
       )
 
       const contractRatios = userContracts
@@ -140,7 +140,14 @@ export async function updateUserMetrics() {
 
       const contractMetricsCollection = userDoc.collection('contract-metrics')
       for (const metrics of metricsByContract) {
-        writer.set(contractMetricsCollection.doc(metrics.contractId), metrics)
+        const update = {
+          ...metrics,
+          userId: user.id,
+          userName: user.name,
+          userUsername: user.username,
+          userAvatarUrl: user.avatarUrl,
+        } as ContractMetric
+        writer.set(contractMetricsCollection.doc(metrics.contractId), update)
       }
 
       return {

--- a/web/components/bet/bet-summary.tsx
+++ b/web/components/bet/bet-summary.tsx
@@ -9,7 +9,7 @@ import { YesLabel, NoLabel } from '../outcome-label'
 import { getProbability } from 'common/calculate'
 import { InfoTooltip } from '../widgets/info-tooltip'
 import { ProfitBadge } from '../profit-badge'
-import { useSavedContractMetrics } from 'web/hooks/use-saved-contract-metrics'
+import { useSavedContractInfo } from 'web/hooks/use-saved-contract-metrics'
 import { ENV_CONFIG } from 'common/envs/constants'
 
 export function BetsSummary(props: {
@@ -22,11 +22,12 @@ export function BetsSummary(props: {
   const isBinary = outcomeType === 'BINARY'
 
   const bets = props.userBets?.filter((b) => !b.isAnte)
-  const metrics = useSavedContractMetrics(contract, bets)
+  const [metrics, positions] = useSavedContractInfo(contract, bets)
 
-  if (!metrics) return <></>
+  if (!metrics || !positions) return <></>
 
-  const { profitPercent, payout, profit, invested, totalShares } = metrics
+  const { profitPercent, payout, profit, invested } = metrics
+  const { totalShares } = positions
 
   const yesWinnings = totalShares.YES ?? 0
   const noWinnings = totalShares.NO ?? 0

--- a/web/components/bet/bets-list.tsx
+++ b/web/components/bet/bets-list.tsx
@@ -28,9 +28,11 @@ import { SiteLink } from '../widgets/site-link'
 import {
   calculatePayout,
   getOutcomeProbability,
-  getContractBetMetrics,
   resolvedPayout,
+  getContractBetMetrics,
   getContractBetNullMetrics,
+  getContractPositions,
+  getContractNullPositions,
 } from 'common/calculate'
 import { DPMContract, NumericContract } from 'common/contract'
 import { formatNumericProbability } from 'common/pseudo-numeric'
@@ -125,6 +127,12 @@ export function BetsList(props: { user: User }) {
     return getContractBetMetrics(contract, bets)
   })
 
+  const contractsPositions = mapValues(contractBets, (bets, contractId) => {
+    const contract = contractsById[contractId]
+    if (!contract) return getContractNullPositions()
+    return getContractPositions(bets)
+  })
+
   const FILTERS: Record<BetFilter, (c: Contract) => boolean> = {
     resolved: (c) => !!c.resolutionTime,
     closed: (c) =>
@@ -151,7 +159,7 @@ export function BetsList(props: { user: User }) {
     .filter((c) => {
       if (filter === 'all') return true
 
-      const { hasShares } = contractsMetrics[c.id]
+      const { hasShares } = contractsPositions[c.id]
 
       if (filter === 'sold') return !hasShares
       if (filter === 'limit_bet')
@@ -174,7 +182,7 @@ export function BetsList(props: { user: User }) {
     unsettled,
     (c) => contractsMetrics[c.id].payout
   )
-  const currentLoan = sumBy(unsettled, (c) => contractsMetrics[c.id].loan)
+  const currentLoan = sumBy(unsettled, (c) => contractsPositions[c.id].loan)
 
   const investedProfitPercent =
     ((currentBetsValue - currentInvested) / (currentInvested + 0.1)) * 100

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -43,9 +43,10 @@ import { memo, ReactNode } from 'react'
 import { useUserContractBets } from 'web/hooks/use-user-bets'
 import { ProbOrNumericChange } from './prob-change-table'
 import { Spacer } from '../layout/spacer'
-import { useSavedContractMetrics } from 'web/hooks/use-saved-contract-metrics'
+import { useSavedContractInfo } from 'web/hooks/use-saved-contract-metrics'
 import { DAY_MS } from 'common/util/time'
-import { ContractMetrics } from 'common/calculate-metrics'
+import { ContractMetric } from 'common/contract-metric'
+import { ContractPositions } from 'common/contract-positions'
 
 export const ContractCard = memo(function ContractCard(props: {
   contract: Contract
@@ -421,12 +422,13 @@ export function ContractMetricsFooter(props: {
 
   const user = useUser()
   const userBets = useUserContractBets(user?.id, contract.id)
-  const metrics = useSavedContractMetrics(contract, userBets)
+  const [metrics, positions] = useSavedContractInfo(contract, userBets)
 
-  return user && metrics && metrics.hasShares ? (
+  return user && metrics && positions && positions.hasShares ? (
     <LoadedMetricsFooter
       contract={contract}
       metrics={metrics}
+      positions={positions}
       showDailyProfit={showDailyProfit}
     />
   ) : (
@@ -436,11 +438,13 @@ export function ContractMetricsFooter(props: {
 
 function LoadedMetricsFooter(props: {
   contract: CPMMContract
-  metrics: ContractMetrics
+  metrics: ContractMetric
+  positions: ContractPositions
   showDailyProfit?: boolean
 }) {
-  const { contract, metrics, showDailyProfit } = props
-  const { totalShares, maxSharesOutcome, from } = metrics
+  const { contract, metrics, positions, showDailyProfit } = props
+  const { totalShares, maxSharesOutcome } = positions
+  const { from } = metrics
   const { YES: yesShares, NO: noShares } = totalShares
   const dailyProfit = from ? from.day.profit : 0
   const profit = showDailyProfit ? dailyProfit : metrics.profit

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -34,21 +34,21 @@ import { safeLocalStorage } from 'web/lib/util/local'
 import TriangleDownFillIcon from 'web/lib/icons/triangle-down-fill-icon'
 import { Answer } from 'common/answer'
 import { track } from 'web/lib/service/analytics'
-import { ContractMetricsByOutcome } from 'web/lib/firebase/contract-metrics'
+import { ContractPositionsByOutcome } from 'web/lib/firebase/contract-positions'
 import { UserLink } from 'web/components/widgets/user-link'
 import { Avatar } from 'web/components/widgets/avatar'
 import clsx from 'clsx'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
 import { useFollows } from 'web/hooks/use-follows'
-import { ContractMetric } from 'common/contract-metric'
-import { useContractMetrics } from 'web/hooks/use-contract-metrics'
+import { ContractPositions } from 'common/contract-positions'
+import { useContractPositions } from 'web/hooks/use-contract-positions'
 
 export function ContractTabs(props: {
   contract: Contract
   bets: Bet[]
   userBets: Bet[]
   comments: ContractComment[]
-  userPositionsByOutcome: ContractMetricsByOutcome
+  userPositionsByOutcome: ContractPositionsByOutcome
   answerResponse?: Answer | undefined
   onCancelAnswerResponse?: () => void
   blockedUserIds: string[]
@@ -88,7 +88,7 @@ export function ContractTabs(props: {
 
   const outcomes = ['YES', 'NO']
   const positions =
-    useContractMetrics(contract.id, 500, outcomes) ??
+    useContractPositions(contract.id, 500, outcomes) ??
     props.userPositionsByOutcome
   const totalPositions = positions.NO?.length + positions.YES?.length ?? 0
   const positionsTitle =
@@ -142,7 +142,7 @@ export function ContractTabs(props: {
 
 const BinaryUserPositionsTabContent = memo(
   function BinaryUserPositionsTabContent(props: {
-    positions: ContractMetricsByOutcome
+    positions: ContractPositionsByOutcome
   }) {
     const { positions } = props
 
@@ -167,7 +167,7 @@ const BinaryUserPositionsTabContent = memo(
         : noPositionsSorted.length
 
     const PositionRow = memo(function PositionRow(props: {
-      position: ContractMetric
+      position: ContractPositions
       outcome: 'YES' | 'NO'
     }) {
       const { position, outcome } = props

--- a/web/components/contract/prob-change-table.tsx
+++ b/web/components/contract/prob-change-table.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { sortBy } from 'lodash'
 import { filterDefined } from 'common/util/array'
-import { ContractMetrics } from 'common/calculate-metrics'
+import { ContractMetric } from 'common/contract-metric'
 import { CPMMBinaryContract, CPMMContract } from 'common/contract'
 import { Col } from '../layout/col'
 import { LoadingIndicator } from '../widgets/loading-indicator'
@@ -10,7 +10,7 @@ import { User } from 'common/user'
 
 export function ProfitChangeTable(props: {
   contracts: CPMMBinaryContract[]
-  metrics: ContractMetrics[]
+  metrics: ContractMetric[]
   maxRows?: number
 }) {
   const { contracts, metrics, maxRows } = props

--- a/web/lib/firebase/contract-metrics.ts
+++ b/web/lib/firebase/contract-metrics.ts
@@ -1,4 +1,3 @@
-import { ContractMetrics } from 'common/calculate-metrics'
 import {
   query,
   limit,
@@ -6,15 +5,9 @@ import {
   collection,
   orderBy,
   where,
-  collectionGroup,
-  getDocs,
 } from 'firebase/firestore'
 import { db } from './init'
 import { ContractMetric } from 'common/contract-metric'
-
-export const CONTRACT_METRICS_SORTED_INDICES = ['YES', 'NO']
-
-export type ContractMetricsByOutcome = Record<string, ContractMetric[]>
 
 export function getUserContractMetricsQuery(
   userId: string,
@@ -26,38 +19,5 @@ export function getUserContractMetricsQuery(
     where('from.day.profit', sort === 'desc' ? '>' : '<', 0),
     orderBy('from.day.profit', sort),
     limit(count)
-  ) as Query<ContractMetrics>
-}
-
-// If you want shares sorted in descending order you have to make a new index for that outcome.
-// You can still get all users with contract-metrics and shares without the index and sort them afterwards
-// See use-contract-metrics.ts to extend this for more outcomes
-export async function getBinaryContractUserContractMetrics(
-  contractId: string,
-  count: number
-) {
-  const yesSnap = await getDocs(
-    query(
-      collectionGroup(db, 'contract-metrics'),
-      where('contractId', '==', contractId),
-      where('hasYesShares', '==', true),
-      orderBy('totalShares.YES', 'desc'),
-      limit(count)
-    )
-  )
-  const noSnap = await getDocs(
-    query(
-      collectionGroup(db, 'contract-metrics'),
-      where('contractId', '==', contractId),
-      where('hasNoShares', '==', true),
-      orderBy('totalShares.NO', 'desc'),
-      limit(count)
-    )
-  )
-  const outcomeToDetails = {
-    YES: yesSnap.docs.map((doc) => doc.data() as ContractMetrics),
-    NO: noSnap.docs.map((doc) => doc.data() as ContractMetrics),
-  }
-
-  return outcomeToDetails
+  ) as Query<ContractMetric[]>
 }

--- a/web/lib/firebase/contract-positions.ts
+++ b/web/lib/firebase/contract-positions.ts
@@ -1,0 +1,47 @@
+import {
+  query,
+  limit,
+  orderBy,
+  where,
+  collectionGroup,
+  getDocs,
+} from 'firebase/firestore'
+import { db } from './init'
+import { ContractPositions } from 'common/contract-positions'
+
+export const CONTRACT_POSITIONS_SORTED_INDICES = ['YES', 'NO']
+
+export type ContractPositionsByOutcome = Record<string, ContractPositions[]>
+
+// If you want shares sorted in descending order you have to make a new index for that outcome.
+// You can still get all users with contract-positions and shares without the index and sort them afterwards
+// See use-contract-positions.ts to extend this for more outcomes
+export async function getBinaryContractUserContractPositions(
+  contractId: string,
+  count: number
+) {
+  const yesSnap = await getDocs(
+    query(
+      collectionGroup(db, 'contract-positions'),
+      where('contractId', '==', contractId),
+      where('hasYesShares', '==', true),
+      orderBy('totalShares.YES', 'desc'),
+      limit(count)
+    )
+  )
+  const noSnap = await getDocs(
+    query(
+      collectionGroup(db, 'contract-positions'),
+      where('contractId', '==', contractId),
+      where('hasNoShares', '==', true),
+      orderBy('totalShares.NO', 'desc'),
+      limit(count)
+    )
+  )
+  const outcomeToDetails = {
+    YES: yesSnap.docs.map((doc) => doc.data() as ContractPositions),
+    NO: noSnap.docs.map((doc) => doc.data() as ContractPositions),
+  }
+
+  return outcomeToDetails
+}

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -46,9 +46,9 @@ import { CreatorSharePanel } from 'web/components/contract/creator-share-panel'
 import { useContract } from 'web/hooks/use-contracts'
 import { BAD_CREATOR_THRESHOLD } from 'web/components/contract/contract-details'
 import {
-  getBinaryContractUserContractMetrics,
-  ContractMetricsByOutcome,
-} from 'web/lib/firebase/contract-metrics'
+  getBinaryContractUserContractPositions,
+  ContractPositionsByOutcome,
+} from 'web/lib/firebase/contract-positions'
 
 const CONTRACT_BET_FILTER = {
   filterRedemptions: true,
@@ -69,7 +69,7 @@ export async function getStaticPropz(props: {
 
   const userPositionsByOutcome =
     contractId && contract?.outcomeType === 'BINARY'
-      ? await getBinaryContractUserContractMetrics(contractId, 500)
+      ? await getBinaryContractUserContractPositions(contractId, 500)
       : {}
 
   return {
@@ -91,7 +91,7 @@ export default function ContractPage(props: {
   contract: Contract | null
   bets: Bet[]
   comments: ContractComment[]
-  userPositionsByOutcome: ContractMetricsByOutcome
+  userPositionsByOutcome: ContractPositionsByOutcome
 }) {
   props = usePropz(props, getStaticPropz) ?? {
     contract: null,

--- a/web/pages/home/index.tsx
+++ b/web/pages/home/index.tsx
@@ -28,7 +28,7 @@ import { Button, buttonClass } from 'web/components/buttons/button'
 import { Row } from 'web/components/layout/row'
 import { ProfitChangeTable } from 'web/components/contract/prob-change-table'
 import { getGroup, joinGroup, leaveGroup } from 'web/lib/firebase/groups'
-import { ContractMetrics } from 'common/calculate-metrics'
+import { ContractMetric } from 'common/contract-metric'
 import { ContractsGrid } from 'web/components/contract/contracts-grid'
 import { PillButton } from 'web/components/buttons/pill-button'
 import { filterDefined } from 'common/util/array'
@@ -321,7 +321,7 @@ export function renderSections(
   dailyMovers:
     | {
         contracts: CPMMBinaryContract[]
-        metrics: ContractMetrics[]
+        metrics: ContractMetric[]
       }
     | undefined
 ) {
@@ -582,7 +582,7 @@ export const DailyMoversSection = memo(function DailyMoversSection(props: {
   data:
     | {
         contracts: CPMMBinaryContract[]
-        metrics: ContractMetrics[]
+        metrics: ContractMetric[]
       }
     | undefined
 }) {


### PR DESCRIPTION
Still kind of WIP, I probably made some mistake and I haven't tested yet. It's also a bit of a mess. I also need to write a backfill script.

Now `users/{userId}/contract-positions/{contractId}` contains real-time updated information on user share balances on contracts, whereas `users/{userId}/contract-metrics/{contractId}` contains the traditional batch information that is computed every 15 minutes.