### PR TITLE
Use points instead of bets on binary & pseudonumeric graphs (inlcuding embeds). Always include user in contract leaderboards

### DIFF
--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -3,7 +3,6 @@ import { last, sortBy } from 'lodash'
 import { scaleTime, scaleLinear } from 'd3-scale'
 import { curveStepAfter } from 'd3-shape'
 
-import { Bet } from 'common/bet'
 import { getProbability, getInitialProbability } from 'common/calculate'
 import { BinaryContract } from 'common/contract'
 import { DAY_MS } from 'common/util/time'
@@ -16,28 +15,29 @@ import {
 } from '../helpers'
 import { HistoryPoint, SingleValueHistoryChart } from '../generic-charts'
 import { Row } from 'web/components/layout/row'
-import { Avatar } from 'web/components/widgets/avatar'
+import { BetPoint } from 'web/pages/[username]/[contractSlug]'
 
 const MARGIN = { top: 20, right: 40, bottom: 20, left: 10 }
 const MARGIN_X = MARGIN.left + MARGIN.right
 const MARGIN_Y = MARGIN.top + MARGIN.bottom
 
-const getBetPoints = (bets: Bet[]) => {
-  return sortBy(bets, (b) => b.createdTime).map((b) => ({
-    x: new Date(b.createdTime),
-    y: b.probAfter,
+const getBetPoints = (bets: BetPoint[]) => {
+  return sortBy(bets, (b) => b.x).map((b) => ({
+    x: new Date(b.x),
+    y: b.y,
     obj: b,
   }))
 }
 
-const BinaryChartTooltip = (props: TooltipProps<Date, HistoryPoint<Bet>>) => {
+const BinaryChartTooltip = (
+  props: TooltipProps<Date, HistoryPoint<BetPoint>>
+) => {
   const { prev, x, xScale } = props
   const [start, end] = xScale.domain()
   const d = xScale.invert(x)
   if (!prev) return null
   return (
     <Row className="items-center gap-2">
-      {prev.obj && <Avatar size="xs" avatarUrl={prev.obj.userAvatarUrl} />}
       <span className="font-semibold">{formatDateInRange(d, start, end)}</span>
       <span className="text-gray-600">{formatPct(prev.y)}</span>
     </Row>
@@ -46,17 +46,20 @@ const BinaryChartTooltip = (props: TooltipProps<Date, HistoryPoint<Bet>>) => {
 
 export const BinaryContractChart = (props: {
   contract: BinaryContract
-  bets: Bet[]
+  betPoints: BetPoint[]
   width: number
   height: number
   color?: string
-  onMouseOver?: (p: HistoryPoint<Bet> | undefined) => void
+  onMouseOver?: (p: HistoryPoint<BetPoint> | undefined) => void
 }) => {
-  const { contract, bets, width, height, onMouseOver, color } = props
+  const { contract, width, height, onMouseOver, color } = props
   const [start, end] = getDateRange(contract)
   const startP = getInitialProbability(contract)
   const endP = getProbability(contract)
-  const betPoints = useMemo(() => getBetPoints(bets), [bets])
+  const betPoints = useMemo(
+    () => getBetPoints(props.betPoints),
+    [props.betPoints]
+  )
   const data = useMemo(() => {
     return [
       { x: new Date(start), y: startP },

--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -16,6 +16,7 @@ import {
 import { HistoryPoint, SingleValueHistoryChart } from '../generic-charts'
 import { Row } from 'web/components/layout/row'
 import { BetPoint } from 'web/pages/[username]/[contractSlug]'
+import { Avatar } from 'web/components/widgets/avatar'
 
 const MARGIN = { top: 20, right: 40, bottom: 20, left: 10 }
 const MARGIN_X = MARGIN.left + MARGIN.right
@@ -38,6 +39,9 @@ const BinaryChartTooltip = (
   if (!prev) return null
   return (
     <Row className="items-center gap-2">
+      {prev.obj?.bet?.userAvatarUrl && (
+        <Avatar size="xs" avatarUrl={prev.obj.bet?.userAvatarUrl} />
+      )}
       <span className="font-semibold">{formatDateInRange(d, start, end)}</span>
       <span className="text-gray-600">{formatPct(prev.y)}</span>
     </Row>

--- a/web/components/charts/contract/index.tsx
+++ b/web/components/charts/contract/index.tsx
@@ -9,22 +9,15 @@ import { BetPoint } from 'web/pages/[username]/[contractSlug]'
 export const ContractChart = (props: {
   contract: Contract
   bets: Bet[]
-  betPoints?: BetPoint[] // required for binary charts
+  betPoints: BetPoint[] // used in binary & numeric charts
   width: number
   height: number
   color?: string
 }) => {
-  const { contract, betPoints } = props
+  const { contract } = props
   switch (contract.outcomeType) {
     case 'BINARY':
-      return betPoints ? (
-        <BinaryContractChart
-          {...{ ...props, contract }}
-          betPoints={betPoints}
-        />
-      ) : (
-        <div />
-      )
+      return <BinaryContractChart {...{ ...props, contract }} />
     case 'PSEUDO_NUMERIC':
       return <PseudoNumericContractChart {...{ ...props, contract }} />
     case 'FREE_RESPONSE':

--- a/web/components/charts/contract/index.tsx
+++ b/web/components/charts/contract/index.tsx
@@ -4,10 +4,12 @@ import { BinaryContractChart } from './binary'
 import { PseudoNumericContractChart } from './pseudo-numeric'
 import { ChoiceContractChart } from './choice'
 import { NumericContractChart } from './numeric'
+import { BetPoint } from 'web/pages/[username]/[contractSlug]'
 
 export const ContractChart = (props: {
   contract: Contract
   bets: Bet[]
+  betPoints: BetPoint[]
   width: number
   height: number
   color?: string

--- a/web/components/charts/contract/index.tsx
+++ b/web/components/charts/contract/index.tsx
@@ -9,15 +9,22 @@ import { BetPoint } from 'web/pages/[username]/[contractSlug]'
 export const ContractChart = (props: {
   contract: Contract
   bets: Bet[]
-  betPoints: BetPoint[]
+  betPoints?: BetPoint[] // required for binary charts
   width: number
   height: number
   color?: string
 }) => {
-  const { contract } = props
+  const { contract, betPoints } = props
   switch (contract.outcomeType) {
     case 'BINARY':
-      return <BinaryContractChart {...{ ...props, contract }} />
+      return betPoints ? (
+        <BinaryContractChart
+          {...{ ...props, contract }}
+          betPoints={betPoints}
+        />
+      ) : (
+        <div />
+      )
     case 'PSEUDO_NUMERIC':
       return <PseudoNumericContractChart {...{ ...props, contract }} />
     case 'FREE_RESPONSE':

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -3,7 +3,6 @@ import { last, sortBy } from 'lodash'
 import { scaleTime, scaleLog, scaleLinear } from 'd3-scale'
 import { curveStepAfter } from 'd3-shape'
 
-import { Bet } from 'common/bet'
 import { DAY_MS } from 'common/util/time'
 import { getInitialProbability, getProbability } from 'common/calculate'
 import { formatLargeNumber } from 'common/util/format'
@@ -18,6 +17,7 @@ import {
 import { HistoryPoint, SingleValueHistoryChart } from '../generic-charts'
 import { Row } from 'web/components/layout/row'
 import { Avatar } from 'web/components/widgets/avatar'
+import { BetPoint } from 'web/pages/[username]/[contractSlug]'
 
 const MARGIN = { top: 20, right: 40, bottom: 20, left: 10 }
 const MARGIN_X = MARGIN.left + MARGIN.right
@@ -34,16 +34,16 @@ const getScaleP = (min: number, max: number, isLogScale: boolean) => {
       : p * (max - min) + min
 }
 
-const getBetPoints = (bets: Bet[], scaleP: (p: number) => number) => {
-  return sortBy(bets, (b) => b.createdTime).map((b) => ({
-    x: new Date(b.createdTime),
-    y: scaleP(b.probAfter),
+const getBetPoints = (bets: BetPoint[], scaleP: (p: number) => number) => {
+  return sortBy(bets, (b) => b.x).map((b) => ({
+    x: new Date(b.x),
+    y: scaleP(b.y),
     obj: b,
   }))
 }
 
 const PseudoNumericChartTooltip = (
-  props: TooltipProps<Date, HistoryPoint<Bet>>
+  props: TooltipProps<Date, HistoryPoint<BetPoint>>
 ) => {
   const { prev, x, xScale } = props
   const [start, end] = xScale.domain()
@@ -51,7 +51,9 @@ const PseudoNumericChartTooltip = (
   if (!prev) return null
   return (
     <Row className="items-center gap-2">
-      {prev.obj && <Avatar size="xs" avatarUrl={prev.obj.userAvatarUrl} />}
+      {prev.obj?.bet?.userAvatarUrl && (
+        <Avatar size="xs" avatarUrl={prev.obj.bet?.userAvatarUrl} />
+      )}{' '}
       <span className="font-semibold">{formatDateInRange(d, start, end)}</span>
       <span className="text-gray-600">{formatLargeNumber(prev.y)}</span>
     </Row>
@@ -60,13 +62,13 @@ const PseudoNumericChartTooltip = (
 
 export const PseudoNumericContractChart = (props: {
   contract: PseudoNumericContract
-  bets: Bet[]
+  betPoints: BetPoint[]
   width: number
   height: number
   color?: string
-  onMouseOver?: (p: HistoryPoint<Bet> | undefined) => void
+  onMouseOver?: (p: HistoryPoint<BetPoint> | undefined) => void
 }) => {
-  const { contract, bets, width, height, color, onMouseOver } = props
+  const { contract, width, height, color, onMouseOver } = props
   const { min, max, isLogScale } = contract
   const [start, end] = getDateRange(contract)
   const scaleP = useMemo(
@@ -75,7 +77,10 @@ export const PseudoNumericContractChart = (props: {
   )
   const startP = scaleP(getInitialProbability(contract))
   const endP = scaleP(getProbability(contract))
-  const betPoints = useMemo(() => getBetPoints(bets, scaleP), [bets, scaleP])
+  const betPoints = useMemo(
+    () => getBetPoints(props.betPoints, scaleP),
+    [props.betPoints, scaleP]
+  )
   const data = useMemo(
     () => [
       { x: new Date(start), y: startP },

--- a/web/components/contract/contract-leaderboard.tsx
+++ b/web/components/contract/contract-leaderboard.tsx
@@ -2,29 +2,30 @@ import { formatMoney } from 'common/util/format'
 
 import { Leaderboard } from '../leaderboard'
 import { BETTORS, User } from 'common/user'
-import { useEffect, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 import { ContractMetric } from 'common/contract-metric'
 import { getProfitRankForContract } from 'web/lib/firebase/contract-metrics'
 import { removeUndefinedProps } from 'common/util/object'
+import { useUserContractMetric } from 'web/hooks/use-user-contract-metric'
 
-export const ContractLeaderboard = function ContractLeaderboard(props: {
+export const ContractLeaderboard = memo(function ContractLeaderboard(props: {
   topContractMetrics: ContractMetric[]
-  currentUserMetrics?: ContractMetric
   currentUser: User | undefined | null
   contractId: string
 }) {
-  const { topContractMetrics, currentUserMetrics, currentUser, contractId } =
-    props
+  const { topContractMetrics, currentUser, contractId } = props
+  const currentUserMetrics = useUserContractMetric(currentUser?.id, contractId)
   const [yourRank, setYourRank] = useState<number | undefined>(undefined)
   const userIsAlreadyRanked =
     currentUser &&
     topContractMetrics.map((m) => m.userId).includes(currentUser.id)
 
   useEffect(() => {
-    if (currentUserMetrics?.profit && !yourRank)
+    if (currentUserMetrics?.profit && !yourRank) {
       getProfitRankForContract(currentUserMetrics.profit, contractId).then(
         (rank) => setYourRank(rank)
       )
+    }
   }, [currentUserMetrics?.profit, yourRank, contractId])
 
   const allMetrics =
@@ -72,4 +73,4 @@ export const ContractLeaderboard = function ContractLeaderboard(props: {
       highlightUsername={currentUser?.username}
     />
   ) : null
-}
+})

--- a/web/components/contract/contract-leaderboard.tsx
+++ b/web/components/contract/contract-leaderboard.tsx
@@ -57,7 +57,10 @@ export const ContractLeaderboard = memo(function ContractLeaderboard(props: {
   })
   const top = Object.values(userProfits)
     .filter((p) => p.total > 0)
-    .slice(0, userIsAlreadyRanked ? 5 : 6)
+    .slice(
+      0,
+      !currentUser || userIsAlreadyRanked || !currentUserMetrics ? 5 : 6
+    )
 
   return top && top.length > 0 ? (
     <Leaderboard

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -49,7 +49,7 @@ const SizedContractChart = (props: {
   bets: Bet[]
   fullHeight: number
   mobileHeight: number
-  betPoints?: BetPoint[]
+  betPoints: BetPoint[]
 }) => {
   const { fullHeight, betPoints, mobileHeight, contract, bets } = props
   return (
@@ -90,6 +90,7 @@ const NumericOverview = (props: { contract: NumericContract; bets: Bet[] }) => {
         bets={bets}
         fullHeight={250}
         mobileHeight={150}
+        betPoints={[]}
       />
     </Col>
   )
@@ -164,6 +165,7 @@ const ChoiceOverview = (props: {
           bets={bets}
           fullHeight={350}
           mobileHeight={250}
+          betPoints={[]}
         />
       )}
     </Col>
@@ -173,8 +175,9 @@ const ChoiceOverview = (props: {
 const PseudoNumericOverview = (props: {
   contract: PseudoNumericContract
   bets: Bet[]
+  betPoints: BetPoint[]
 }) => {
-  const { contract, bets } = props
+  const { contract, bets, betPoints } = props
   return (
     <Col className="gap-1 md:gap-2">
       <Col className="gap-3 px-2 sm:gap-4">
@@ -202,6 +205,7 @@ const PseudoNumericOverview = (props: {
         bets={bets}
         fullHeight={250}
         mobileHeight={150}
+        betPoints={betPoints}
       />
     </Col>
   )
@@ -210,20 +214,24 @@ const PseudoNumericOverview = (props: {
 export const ContractOverview = (props: {
   contract: Contract
   bets: Bet[]
-  betPoints?: BetPoint[]
+  betPoints: BetPoint[]
 }) => {
   const { betPoints, contract, bets } = props
   switch (contract.outcomeType) {
     case 'BINARY':
-      return betPoints ? (
+      return (
         <BinaryOverview betPoints={betPoints} contract={contract} bets={bets} />
-      ) : (
-        <div />
       )
     case 'NUMERIC':
       return <NumericOverview contract={contract} bets={bets} />
     case 'PSEUDO_NUMERIC':
-      return <PseudoNumericOverview contract={contract} bets={bets} />
+      return (
+        <PseudoNumericOverview
+          contract={contract}
+          bets={bets}
+          betPoints={betPoints}
+        />
+      )
     case 'FREE_RESPONSE':
     case 'MULTIPLE_CHOICE':
       return <ChoiceOverview contract={contract} bets={bets} />

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -49,7 +49,7 @@ const SizedContractChart = (props: {
   bets: Bet[]
   fullHeight: number
   mobileHeight: number
-  betPoints: BetPoint[]
+  betPoints?: BetPoint[]
 }) => {
   const { fullHeight, betPoints, mobileHeight, contract, bets } = props
   return (
@@ -67,12 +67,8 @@ const SizedContractChart = (props: {
   )
 }
 
-const NumericOverview = (props: {
-  contract: NumericContract
-  bets: Bet[]
-  betPoints: BetPoint[]
-}) => {
-  const { contract, bets, betPoints } = props
+const NumericOverview = (props: { contract: NumericContract; bets: Bet[] }) => {
+  const { contract, bets } = props
   return (
     <Col className="gap-1 md:gap-2">
       <Col className="gap-3 px-2 sm:gap-4">
@@ -94,7 +90,6 @@ const NumericOverview = (props: {
         bets={bets}
         fullHeight={250}
         mobileHeight={150}
-        betPoints={betPoints}
       />
     </Col>
   )
@@ -141,9 +136,8 @@ const BinaryOverview = (props: {
 const ChoiceOverview = (props: {
   contract: FreeResponseContract | MultipleChoiceContract
   bets: Bet[]
-  betPoints: BetPoint[]
 }) => {
-  const { contract, bets, betPoints } = props
+  const { contract, bets } = props
   const { question, resolution, slug } = contract
 
   // TODO(James): Remove hideGraph once market is resolved.
@@ -170,7 +164,6 @@ const ChoiceOverview = (props: {
           bets={bets}
           fullHeight={350}
           mobileHeight={250}
-          betPoints={betPoints}
         />
       )}
     </Col>
@@ -180,9 +173,8 @@ const ChoiceOverview = (props: {
 const PseudoNumericOverview = (props: {
   contract: PseudoNumericContract
   bets: Bet[]
-  betPoints: BetPoint[]
 }) => {
-  const { contract, bets, betPoints } = props
+  const { contract, bets } = props
   return (
     <Col className="gap-1 md:gap-2">
       <Col className="gap-3 px-2 sm:gap-4">
@@ -210,7 +202,6 @@ const PseudoNumericOverview = (props: {
         bets={bets}
         fullHeight={250}
         mobileHeight={150}
-        betPoints={betPoints}
       />
     </Col>
   )
@@ -219,34 +210,22 @@ const PseudoNumericOverview = (props: {
 export const ContractOverview = (props: {
   contract: Contract
   bets: Bet[]
-  betPoints: BetPoint[]
+  betPoints?: BetPoint[]
 }) => {
   const { betPoints, contract, bets } = props
   switch (contract.outcomeType) {
     case 'BINARY':
-      return (
+      return betPoints ? (
         <BinaryOverview betPoints={betPoints} contract={contract} bets={bets} />
+      ) : (
+        <div />
       )
     case 'NUMERIC':
-      return (
-        <NumericOverview
-          contract={contract}
-          bets={bets}
-          betPoints={betPoints}
-        />
-      )
+      return <NumericOverview contract={contract} bets={bets} />
     case 'PSEUDO_NUMERIC':
-      return (
-        <PseudoNumericOverview
-          contract={contract}
-          bets={bets}
-          betPoints={betPoints}
-        />
-      )
+      return <PseudoNumericOverview contract={contract} bets={bets} />
     case 'FREE_RESPONSE':
     case 'MULTIPLE_CHOICE':
-      return (
-        <ChoiceOverview contract={contract} bets={bets} betPoints={betPoints} />
-      )
+      return <ChoiceOverview contract={contract} bets={bets} />
   }
 }

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -24,6 +24,7 @@ import {
 import { ContractDetails } from './contract-details'
 import { ContractReportResolution } from './contract-report-resolution'
 import { SizedContainer } from 'web/components/sized-container'
+import { BetPoint } from 'web/pages/[username]/[contractSlug]'
 
 const OverviewQuestion = (props: { text: string }) => (
   <Linkify className="text-lg text-indigo-700 sm:text-2xl" text={props.text} />
@@ -48,8 +49,9 @@ const SizedContractChart = (props: {
   bets: Bet[]
   fullHeight: number
   mobileHeight: number
+  betPoints: BetPoint[]
 }) => {
-  const { fullHeight, mobileHeight, contract, bets } = props
+  const { fullHeight, betPoints, mobileHeight, contract, bets } = props
   return (
     <SizedContainer fullHeight={fullHeight} mobileHeight={mobileHeight}>
       {(width, height) => (
@@ -58,14 +60,19 @@ const SizedContractChart = (props: {
           height={height}
           contract={contract}
           bets={bets}
+          betPoints={betPoints}
         />
       )}
     </SizedContainer>
   )
 }
 
-const NumericOverview = (props: { contract: NumericContract; bets: Bet[] }) => {
-  const { contract, bets } = props
+const NumericOverview = (props: {
+  contract: NumericContract
+  bets: Bet[]
+  betPoints: BetPoint[]
+}) => {
+  const { contract, bets, betPoints } = props
   return (
     <Col className="gap-1 md:gap-2">
       <Col className="gap-3 px-2 sm:gap-4">
@@ -87,13 +94,18 @@ const NumericOverview = (props: { contract: NumericContract; bets: Bet[] }) => {
         bets={bets}
         fullHeight={250}
         mobileHeight={150}
+        betPoints={betPoints}
       />
     </Col>
   )
 }
 
-const BinaryOverview = (props: { contract: BinaryContract; bets: Bet[] }) => {
-  const { contract, bets } = props
+const BinaryOverview = (props: {
+  contract: BinaryContract
+  bets: Bet[]
+  betPoints: BetPoint[]
+}) => {
+  const { contract, bets, betPoints } = props
   return (
     <Col className="gap-1 md:gap-2">
       <Col className="gap-1 px-2">
@@ -115,6 +127,7 @@ const BinaryOverview = (props: { contract: BinaryContract; bets: Bet[] }) => {
         bets={bets}
         fullHeight={250}
         mobileHeight={150}
+        betPoints={betPoints}
       />
       <Row className="items-center justify-between gap-4 xl:hidden">
         {tradingAllowed(contract) && (
@@ -128,8 +141,9 @@ const BinaryOverview = (props: { contract: BinaryContract; bets: Bet[] }) => {
 const ChoiceOverview = (props: {
   contract: FreeResponseContract | MultipleChoiceContract
   bets: Bet[]
+  betPoints: BetPoint[]
 }) => {
-  const { contract, bets } = props
+  const { contract, bets, betPoints } = props
   const { question, resolution, slug } = contract
 
   // TODO(James): Remove hideGraph once market is resolved.
@@ -156,6 +170,7 @@ const ChoiceOverview = (props: {
           bets={bets}
           fullHeight={350}
           mobileHeight={250}
+          betPoints={betPoints}
         />
       )}
     </Col>
@@ -165,8 +180,9 @@ const ChoiceOverview = (props: {
 const PseudoNumericOverview = (props: {
   contract: PseudoNumericContract
   bets: Bet[]
+  betPoints: BetPoint[]
 }) => {
-  const { contract, bets } = props
+  const { contract, bets, betPoints } = props
   return (
     <Col className="gap-1 md:gap-2">
       <Col className="gap-3 px-2 sm:gap-4">
@@ -194,6 +210,7 @@ const PseudoNumericOverview = (props: {
         bets={bets}
         fullHeight={250}
         mobileHeight={150}
+        betPoints={betPoints}
       />
     </Col>
   )
@@ -202,17 +219,34 @@ const PseudoNumericOverview = (props: {
 export const ContractOverview = (props: {
   contract: Contract
   bets: Bet[]
+  betPoints: BetPoint[]
 }) => {
-  const { contract, bets } = props
+  const { betPoints, contract, bets } = props
   switch (contract.outcomeType) {
     case 'BINARY':
-      return <BinaryOverview contract={contract} bets={bets} />
+      return (
+        <BinaryOverview betPoints={betPoints} contract={contract} bets={bets} />
+      )
     case 'NUMERIC':
-      return <NumericOverview contract={contract} bets={bets} />
+      return (
+        <NumericOverview
+          contract={contract}
+          bets={bets}
+          betPoints={betPoints}
+        />
+      )
     case 'PSEUDO_NUMERIC':
-      return <PseudoNumericOverview contract={contract} bets={bets} />
+      return (
+        <PseudoNumericOverview
+          contract={contract}
+          bets={bets}
+          betPoints={betPoints}
+        />
+      )
     case 'FREE_RESPONSE':
     case 'MULTIPLE_CHOICE':
-      return <ChoiceOverview contract={contract} bets={bets} />
+      return (
+        <ChoiceOverview contract={contract} bets={bets} betPoints={betPoints} />
+      )
   }
 }

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -174,14 +174,12 @@ const BinaryUserPositionsTabContent = memo(
       outcome: 'YES' | 'NO'
     }) {
       const { position, outcome } = props
-      const { totalShares, userName, userUsername, userAvatarUrl, userId } =
-        position
+      const { totalShares, userName, userUsername, userAvatarUrl } = position
       const shares = totalShares[outcome] ?? 0
       const isMobile = useIsMobile(800)
 
       return (
         <Row
-          key={userId + outcome}
           className={clsx(
             'items-center justify-between gap-2 rounded-sm border-b p-2',
             currentUser?.id === position.userId && 'bg-amber-100',
@@ -228,7 +226,13 @@ const BinaryUserPositionsTabContent = memo(
               <span>YES shares</span>
             </Row>
             {visibleYesPositions.map((position) => {
-              return <PositionRow outcome={'YES'} position={position} />
+              return (
+                <PositionRow
+                  key={position.userId + '-YES'}
+                  outcome={'YES'}
+                  position={position}
+                />
+              )
             })}
           </Col>
           <Col className={'w-full max-w-sm gap-2'}>
@@ -236,7 +240,13 @@ const BinaryUserPositionsTabContent = memo(
               <span>NO shares</span>
             </Row>
             {visibleNoPositions.map((position) => {
-              return <PositionRow position={position} outcome={'NO'} />
+              return (
+                <PositionRow
+                  key={position.userId + '-NO'}
+                  position={position}
+                  outcome={'NO'}
+                />
+              )
             })}
           </Col>
         </Row>
@@ -375,7 +385,7 @@ const BetsTabContent = memo(function BetsTabContent(props: {
   const items = [
     ...visibleBets.map((bet) => ({
       type: 'bet' as const,
-      id: bet.id + '-' + bet.isSold,
+      id: bet.id + '-' + (bet.isSold ? 'sold' : 'unsold'),
       bet,
     })),
     ...visibleLps.map((lp) => ({

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -54,6 +54,7 @@ export function ContractTabs(props: {
   blockedUserIds: string[]
   activeIndex: number
   setActiveIndex: (i: number) => void
+  totalBets: number
 }) {
   const {
     contract,
@@ -64,6 +65,7 @@ export function ContractTabs(props: {
     blockedUserIds,
     activeIndex,
     setActiveIndex,
+    totalBets,
   } = props
 
   const contractComments = useComments(contract.id) ?? props.comments
@@ -78,7 +80,7 @@ export function ContractTabs(props: {
   const commentTitle =
     comments.length === 0 ? 'Comments' : `${comments.length} Comments`
 
-  const betsTitle = bets.length === 0 ? 'Trades' : `${bets.length} Trades`
+  const betsTitle = totalBets === 0 ? 'Trades' : `${totalBets} Trades`
 
   const visibleUserBets = userBets.filter(
     (bet) => bet.amount !== 0 && !bet.isRedemption
@@ -115,7 +117,7 @@ export function ContractTabs(props: {
             />
           ),
         },
-        bets.length > 0 && {
+        totalBets > 0 && {
           title: betsTitle,
           content: (
             <Col className={'gap-4'}>

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -55,6 +55,7 @@ export function ContractTabs(props: {
   activeIndex: number
   setActiveIndex: (i: number) => void
   totalBets: number
+  totalPositions: number
 }) {
   const {
     contract,
@@ -66,6 +67,7 @@ export function ContractTabs(props: {
     activeIndex,
     setActiveIndex,
     totalBets,
+    totalPositions,
   } = props
 
   const contractComments = useComments(contract.id) ?? props.comments
@@ -92,7 +94,6 @@ export function ContractTabs(props: {
   const positions =
     useContractMetrics(contract.id, 500, outcomes) ??
     props.userPositionsByOutcome
-  const totalPositions = positions.NO?.length + positions.YES?.length ?? 0
   const positionsTitle =
     totalPositions === 0 ? 'Users' : totalPositions + ' Users'
 

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -92,7 +92,7 @@ export function ContractTabs(props: {
 
   const outcomes = ['YES', 'NO']
   const positions =
-    useContractMetrics(contract.id, 500, outcomes) ??
+    useContractMetrics(contract.id, 100, outcomes) ??
     props.userPositionsByOutcome
   const positionsTitle =
     totalPositions === 0 ? 'Users' : totalPositions + ' Users'

--- a/web/hooks/use-user-contract-metric.ts
+++ b/web/hooks/use-user-contract-metric.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import { listenForValue } from 'web/lib/firebase/utils'
+import { collection, doc } from 'firebase/firestore'
+import { db } from 'web/lib/firebase/init'
+
+import { ContractMetric } from 'common/contract-metric'
+
+export const useUserContractMetric = (
+  userId: string | null | undefined,
+  contractId: string
+) => {
+  const [contractMetrics, setContractMetrics] = useState<
+    ContractMetric | undefined | null
+  >()
+
+  useEffect(() => {
+    if (!userId) return
+    return listenForUserContractMetric(userId, contractId, setContractMetrics)
+  }, [userId, contractId])
+
+  return contractMetrics
+}
+
+// If you want shares sorted in descending order you have to make a new index for that outcome.
+// You can still get all users with contract-metrics and shares without the index and sort them in the client
+export function listenForUserContractMetric(
+  userId: string,
+  contractId: string,
+  setMetrics: (metrics: ContractMetric | null) => void
+) {
+  const q = collection(db, `users/${userId}/contract-metrics/`)
+
+  return listenForValue<ContractMetric>(doc(q, contractId), setMetrics)
+}

--- a/web/hooks/use-user-contract-metric.ts
+++ b/web/hooks/use-user-contract-metric.ts
@@ -21,8 +21,6 @@ export const useUserContractMetric = (
   return contractMetrics
 }
 
-// If you want shares sorted in descending order you have to make a new index for that outcome.
-// You can still get all users with contract-metrics and shares without the index and sort them in the client
 export function listenForUserContractMetric(
   userId: string,
   contractId: string,

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -80,7 +80,8 @@ export async function getTotalBetCount(contractId: string) {
   const betsRef = query(
     collection(db, `contracts/${contractId}/bets`),
     where('isChallenge', '==', false),
-    where('isRedemption', '==', false)
+    where('isRedemption', '==', false),
+    where('isAnte', '==', false)
   )
   const snap = await getCountFromServer(betsRef)
   return snap.data().count

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -77,7 +77,11 @@ export async function listBets(options?: BetFilter) {
 }
 
 export async function getTotalBetCount(contractId: string) {
-  const betsRef = collection(db, `contracts/${contractId}/bets`)
+  const betsRef = query(
+    collection(db, `contracts/${contractId}/bets`),
+    where('isChallenge', '==', false),
+    where('isRedemption', '==', false)
+  )
   const snap = await getCountFromServer(betsRef)
   return snap.data().count
 }

--- a/web/lib/firebase/bets.ts
+++ b/web/lib/firebase/bets.ts
@@ -13,6 +13,7 @@ import {
   getDoc,
   DocumentSnapshot,
   Query,
+  getCountFromServer,
 } from 'firebase/firestore'
 import { uniq } from 'lodash'
 
@@ -73,6 +74,12 @@ export const getBetsQuery = (options?: BetFilter) => {
 
 export async function listBets(options?: BetFilter) {
   return await getValues<Bet>(getBetsQuery(options))
+}
+
+export async function getTotalBetCount(contractId: string) {
+  const betsRef = collection(db, `contracts/${contractId}/bets`)
+  const snap = await getCountFromServer(betsRef)
+  return snap.data().count
 }
 
 export function listenForBets(

--- a/web/lib/firebase/contract-metrics.ts
+++ b/web/lib/firebase/contract-metrics.ts
@@ -8,6 +8,7 @@ import {
   where,
   collectionGroup,
   getDocs,
+  getCountFromServer,
 } from 'firebase/firestore'
 import { db } from './init'
 import { ContractMetric } from 'common/contract-metric'
@@ -60,4 +61,43 @@ export async function getBinaryContractUserContractMetrics(
   }
 
   return outcomeToDetails
+}
+
+export async function getTopContractMetrics(contractId: string, count: number) {
+  const snap = await getDocs(
+    query(
+      collectionGroup(db, 'contract-metrics'),
+      where('contractId', '==', contractId),
+      orderBy('profit', 'desc'),
+      limit(count)
+    )
+  )
+  const cms = snap.docs.map((doc) => doc.data() as ContractMetrics)
+
+  return cms
+}
+
+export async function getProfitRankForContract(
+  profit: number,
+  contractId: string
+) {
+  const resp = await getCountFromServer(
+    query(
+      collectionGroup(db, 'contract-metrics'),
+      where('contractId', '==', contractId),
+      where('profit', '>', profit)
+    )
+  )
+  return resp.data().count + 1
+}
+
+export async function getTotalContractMetricsCount(contractId: string) {
+  const resp = await getCountFromServer(
+    query(
+      collectionGroup(db, 'contract-metrics'),
+      where('contractId', '==', contractId),
+      where('hasShares', '==', true)
+    )
+  )
+  return resp.data().count
 }

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -192,7 +192,7 @@ export function ContractPageContent(
     true
   )
 
-  // static props load bets in ascending order by time
+  // Static props load bets in descending order by time
   const lastBetTime = first(props.bets)?.createdTime
   const newBets = useBets({
     contractId: contract.id,

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -54,7 +54,6 @@ import {
 import { OrderByDirection } from 'firebase/firestore'
 import { removeUndefinedProps } from 'common/util/object'
 import { ContractMetric } from 'common/contract-metric'
-import { useSavedContractMetrics } from 'web/hooks/use-saved-contract-metrics'
 import { HOUSE_BOT_USERNAME } from 'common/lib/envs/constants'
 
 const CONTRACT_BET_FILTER = {
@@ -213,7 +212,6 @@ export function ContractPageContent(
     userId: user?.id ?? '_',
     filterAntes: true,
   })
-  const metrics = useSavedContractMetrics(contract, bets)
 
   const { isResolved, question, outcomeType } = contract
 
@@ -321,7 +319,6 @@ export function ContractPageContent(
                 (metric) => metric.userUsername !== HOUSE_BOT_USERNAME
               )}
               contractId={contract.id}
-              currentUserMetrics={metrics}
               currentUser={user}
             />
             <Spacer h={12} />

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -99,7 +99,7 @@ export async function getStaticPropz(props: {
 
   const userPositionsByOutcome =
     contractId && contract?.outcomeType === 'BINARY'
-      ? await getBinaryContractUserContractMetrics(contractId, 500)
+      ? await getBinaryContractUserContractMetrics(contractId, 100)
       : {}
   const topContractMetrics = contractId
     ? await getTopContractMetrics(contractId, 10)

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -54,7 +54,7 @@ import {
 import { OrderByDirection } from 'firebase/firestore'
 import { removeUndefinedProps } from 'common/util/object'
 import { ContractMetric } from 'common/contract-metric'
-import { HOUSE_BOT_USERNAME } from 'common/lib/envs/constants'
+import { HOUSE_BOT_USERNAME } from 'common/envs/constants'
 
 const CONTRACT_BET_FILTER = {
   filterRedemptions: true,

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -70,10 +70,10 @@ export async function getStaticPropz(props: {
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
   const totalBets = contractId ? await getTotalBetCount(contractId) : 0
-  // Prioritize newer bets via descending order
   const useBetPoints =
     contract?.outcomeType === 'BINARY' ||
     contract?.outcomeType === 'PSEUDO_NUMERIC'
+  // Prioritize newer bets via descending order
   const bets = contractId
     ? await listBets({
         contractId,

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -2,7 +2,7 @@ import { Bet } from 'common/bet'
 import { Contract } from 'common/contract'
 import { DOMAIN } from 'common/envs/constants'
 import { useEffect } from 'react'
-import { last } from 'lodash'
+import { first } from 'lodash'
 import {
   BinaryResolutionOrChance,
   ContractCard,
@@ -25,6 +25,7 @@ import { useBets } from 'web/hooks/use-bets'
 import { useRouter } from 'next/router'
 import { Avatar } from 'web/components/widgets/avatar'
 import { BetPoint } from 'web/pages/[username]/[contractSlug]'
+import { OrderByDirection } from 'firebase/firestore'
 
 const CONTRACT_BET_LOADING_OPTS = {
   filterRedemptions: true,
@@ -38,16 +39,32 @@ export async function getStaticPropz(props: {
   const { contractSlug } = props.params
   const contract = (await getContractFromSlug(contractSlug)) || null
   const contractId = contract?.id
+  const useBetPoints =
+    contract?.outcomeType === 'BINARY' ||
+    contract?.outcomeType === 'PSEUDO_NUMERIC'
+  // Prioritize newer bets via descending order
   const bets = contractId
-    ? await listBets({ contractId, ...CONTRACT_BET_LOADING_OPTS })
+    ? await listBets({
+        contractId,
+        ...CONTRACT_BET_LOADING_OPTS,
+        limit: 10000,
+        order: 'desc' as OrderByDirection,
+      })
     : []
-  const betPoints = bets.map((bet) => ({
-    x: bet.createdTime,
-    y: bet.probAfter,
-  }))
+  // We could include avatars in the embed, but not sure it's worth it
+  const betPoints = useBetPoints
+    ? bets.map((bet) => ({
+        x: bet.createdTime,
+        y: bet.probAfter,
+      }))
+    : []
 
   return {
-    props: { contract, bets: bets.slice(0, 100), betPoints },
+    props: {
+      contract,
+      bets: useBetPoints ? bets.slice(0, 100) : bets,
+      betPoints,
+    },
     revalidate: 60, // regenerate after a minute
   }
 }
@@ -70,15 +87,24 @@ export default function ContractEmbedPage(props: {
 
   const contract = useContract(props.contract?.id) ?? props.contract
 
-  // static props load bets in ascending order by time
-  const lastBetTime = last(props.bets)?.createdTime
+  // Static props load bets in descending order by time
+  const lastBetTime = first(props.bets)?.createdTime
   const newBets = useBets({
     ...CONTRACT_BET_LOADING_OPTS,
     contractId: contract?.id ?? '',
     afterTime: lastBetTime,
   })
   const bets = props.bets.concat(newBets ?? [])
-
+  const betPoints = props.betPoints.concat(
+    newBets?.map(
+      (bet) =>
+        ({
+          x: bet.createdTime,
+          y: bet.probAfter,
+          bet: { userAvatarUrl: bet.userAvatarUrl },
+        } as BetPoint)
+    ) ?? []
+  )
   if (!contract) {
     return <Custom404 />
   }
@@ -91,7 +117,7 @@ export default function ContractEmbedPage(props: {
     bets,
     graphColor,
     textColor,
-    betPoints: props.betPoints,
+    betPoints,
   }
 
   return <ContractEmbed {...embedProps} />


### PR DESCRIPTION
It looks like this halves the large graphs' (e.g. will donald trump tweet, will destiny get to 600k subs) data from ~4mb to ~1.5mb. We lose the avatar url on the graph tooltip but the probability that you see an avatar you know is probably ~1% anyways so this seems fine. This works great for embeds bc you don't likely know the avatars either.