### PR TITLE
Remove txns from charity page static props

### DIFF
--- a/web/pages/charity/index.tsx
+++ b/web/pages/charity/index.tsx
@@ -49,7 +49,6 @@ export async function getStaticProps() {
       totalRaised,
       charities: sortedCharities,
       matches,
-      txns,
       numDonors,
       mostRecentDonor,
       mostRecentCharity,
@@ -94,7 +93,6 @@ export default function Charity(props: {
   totalRaised: number
   charities: CharityType[]
   matches: { [charityId: string]: number }
-  txns: Txn[]
   numDonors: number
   mostRecentDonor?: User | null
   mostRecentCharity?: string


### PR DESCRIPTION
When you put stuff in the static props of a page in the sidebar, it gets downloaded on every page load everywhere, so it really needs to not have a bunch of junk.