### PR TITLE
Twitch no resolution emails

### DIFF
--- a/common/contract.ts
+++ b/common/contract.ts
@@ -71,6 +71,7 @@ export type Contract<T extends AnyContractType = AnyContractType> = {
   openCommentBounties?: number
   unlistedById?: string
   featuredLabel?: string
+  isTwitchContract?: boolean
 
   coverImageUrl?: string
 } & T

--- a/common/new-contract.ts
+++ b/common/new-contract.ts
@@ -37,7 +37,10 @@ export function getNewContract(
 
   // for multiple choice
   answers: string[],
-  visibility: visibility
+  visibility: visibility,
+
+  // twitch
+  isTwitchContract: boolean | undefined
 ) {
   const createdTime = Date.now()
 
@@ -84,6 +87,8 @@ export function getNewContract(
       liquidityFee: 0,
       platformFee: 0,
     },
+
+    isTwitchContract,
   })
 
   return contract as Contract

--- a/functions/src/create-market.ts
+++ b/functions/src/create-market.ts
@@ -74,6 +74,7 @@ const bodySchema = z.object({
   outcomeType: z.enum(OUTCOME_TYPES),
   groupId: z.string().min(1).max(MAX_ID_LENGTH).optional(),
   visibility: z.enum(VISIBILITIES).optional(),
+  isTwitchContract: z.boolean().optional(),
 })
 
 const binarySchema = z.object({
@@ -112,6 +113,7 @@ export async function createMarketHelper(body: any, auth: AuthedUser) {
     outcomeType,
     groupId,
     visibility = 'public',
+    isTwitchContract,
   } = validate(bodySchema, body)
 
   let min, max, initialProb, isLogScale, answers
@@ -240,7 +242,8 @@ export async function createMarketHelper(body: any, auth: AuthedUser) {
     max ?? 0,
     isLogScale ?? false,
     answers ?? [],
-    visibility
+    visibility,
+    isTwitchContract ? true : undefined
   )
 
   await contractRef.create(contract)

--- a/functions/src/create-notification.ts
+++ b/functions/src/create-notification.ts
@@ -1011,7 +1011,7 @@ export const createContractResolvedNotifications = async (
     }
 
     // Emails notifications
-    if (sendToEmail)
+    if (sendToEmail && !contract.isTwitchContract)
       await sendMarketResolutionEmail(
         reason,
         privateUser,

--- a/twitch-bot/server/src/manifold-api.ts
+++ b/twitch-bot/server/src/manifold-api.ts
@@ -132,6 +132,7 @@ export async function createBinaryMarket(
     initialProb: initialProb_percent,
     ...(groupID && { groupId: groupID }),
     visibility,
+    isTwitchContract: true,
   };
   return <Promise<ManifoldAPITypes.LiteMarket>>(await post(`${MANIFOLD_API_BASE_URL}market`, APIKey, requestData)).json();
 }


### PR DESCRIPTION
Prevent contracts created through Twitch (either the dock or directly from chat) from sending market resolution emails.