### PR TITLE
web/components: only show notification subtitle if user invested

### DIFF
--- a/web/components/notifications/notification-types.tsx
+++ b/web/components/notifications/notification-types.tsx
@@ -303,18 +303,22 @@ function MarketResolvedNotification(props: {
   } = notification
   const { userInvestment, userPayout } = (data as ContractResolutionData) ?? {}
   const profit = userPayout - userInvestment
-  const profitable = profit >= 0
-  const subtitle =
-    sourceText === 'CANCEL' ? (
-      <>Your {formatMoney(userInvestment)} invested has been returned to you</>
-    ) : profitable ? (
-      <>
-        Your {formatMoney(userInvestment)} investment won{' '}
-        <span className="text-teal-600">+{formatMoney(profit)}</span> in profit!
-      </>
-    ) : (
-      <>You lost {formatMoney(Math.abs(profit))} ... Better luck next time!</>
-    )
+  const profitable = profit >= 0 
+  let subtitle = <>;
+  if (userInvestment > 0) {
+    if (sourceText === 'CANCEL') {
+      subtitle = <>Your {formatMoney(userInvestment)} invested has been returned to you</>
+    } else {
+      if (profitable) {
+        subtitle = <>
+          Your {formatMoney(userInvestment)} investment won{' '}
+          <span className="text-teal-600">+{formatMoney(profit)}</span> in profit!
+          </>
+      } else {
+        subtitle = <>You lost {formatMoney(Math.abs(profit))} ... Better luck next time!</>
+      }
+    }
+  }
 
   const resolutionDescription = () => {
     if (!sourceText) return <div />


### PR DESCRIPTION
I got a notification for a market that I'd commented on but not bet anything, that said my $0 received a $0 profit, which is a bit misleading. Instead anly show notifications for markets where there's an investment.