### PR TITLE
Ingawei/man 463 notifications user suggestions

### DIFF
--- a/web/components/comments/dropdown-menu.tsx
+++ b/web/components/comments/dropdown-menu.tsx
@@ -6,14 +6,19 @@ import { Row } from 'web/components/layout/row'
 
 export default function DropdownMenu(props: {
   Items: { name: string; icon: ReactNode; onClick: () => void }[]
+  Icon?: ReactNode
+  MenuWidth?: string
 }) {
-  const { Items } = props
+  const { Items, Icon, MenuWidth } = props
+  const icon = Icon ?? (
+    <DotsHorizontalIcon className="h-5 w-5" aria-hidden="true" />
+  )
   return (
     <Menu as="div" className="relative inline-block text-left">
       <div>
         <Menu.Button className="flex items-center rounded-full text-gray-400 hover:text-gray-600">
           <span className="sr-only">Open options</span>
-          <DotsHorizontalIcon className="h-5 w-5" aria-hidden="true" />
+          {icon}
         </Menu.Button>
       </div>
 
@@ -26,7 +31,12 @@ export default function DropdownMenu(props: {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Menu.Items
+          className={clsx(
+            'absolute right-0 z-10 mt-2 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none',
+            MenuWidth ?? 'w-32'
+          )}
+        >
           <div className="py-1">
             {Items.map((item) => (
               <Menu.Item key={item.name}>
@@ -35,12 +45,12 @@ export default function DropdownMenu(props: {
                     onClick={item.onClick}
                     className={clsx(
                       active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-                      'z-20 block px-4 py-2 text-sm'
+                      'z-20 block w-full px-4 py-2 text-sm'
                     )}
                   >
                     <Row className={'gap-2'}>
-                      {item.icon}
-                      {item.name}
+                      <div className="w-5">{item.icon}</div>
+                      <div className="text-left">{item.name}</div>
                     </Row>
                   </button>
                 )}

--- a/web/components/notifications/income-summary-notifications.tsx
+++ b/web/components/notifications/income-summary-notifications.tsx
@@ -82,16 +82,15 @@ function combineNotificationsByAddingNumericSourceTexts(
 
 export function IncomeNotificationGroupItem(props: {
   notificationGroup: NotificationGroup
-  allMarkedAsRead: boolean
 }) {
-  const { notificationGroup, allMarkedAsRead } = props
+  const { notificationGroup } = props
   const { notifications } = notificationGroup
 
   const combinedNotifs = combineNotificationsByAddingNumericSourceTexts(
     notifications.filter((n) => n.sourceType !== 'betting_streak_bonus')
   )
   const [highlighted, _setHighlighted] = useState(
-    allMarkedAsRead ? !allMarkedAsRead : notifications.some((n) => !n.isSeen)
+    notifications.some((n) => !n.isSeen)
   )
   const totalIncome = sum(
     notifications.map((notification) =>

--- a/web/components/notifications/income-summary-notifications.tsx
+++ b/web/components/notifications/income-summary-notifications.tsx
@@ -82,15 +82,16 @@ function combineNotificationsByAddingNumericSourceTexts(
 
 export function IncomeNotificationGroupItem(props: {
   notificationGroup: NotificationGroup
+  allMarkedAsRead: boolean
 }) {
-  const { notificationGroup } = props
+  const { notificationGroup, allMarkedAsRead } = props
   const { notifications } = notificationGroup
 
   const combinedNotifs = combineNotificationsByAddingNumericSourceTexts(
     notifications.filter((n) => n.sourceType !== 'betting_streak_bonus')
   )
   const [highlighted, setHighlighted] = useState(
-    notifications.some((n) => !n.isSeen)
+    allMarkedAsRead ? !allMarkedAsRead : notifications.some((n) => !n.isSeen)
   )
   const totalIncome = sum(
     notifications.map((notification) =>
@@ -120,18 +121,20 @@ export function IncomeNotificationGroupItem(props: {
   return (
     <NotificationGroupItemComponent
       notifications={combinedNotifs}
-      highlighted={highlighted}
       setHighlighted={setHighlighted}
       header={header}
       isIncomeNotification={true}
+      allMarkedAsRead={allMarkedAsRead}
     />
   )
 }
 
-export function IncomeNotificationItem(props: { notification: Notification }) {
-  const { notification } = props
+export function IncomeNotificationItem(props: {
+  notification: Notification
+  highlighted: boolean
+}) {
+  const { notification, highlighted } = props
   const { sourceType } = notification
-  const [highlighted, _setHighlighted] = useState(!notification.isSeen)
 
   if (sourceType === 'tip' || sourceType === 'tip_and_like') {
     return (

--- a/web/components/notifications/income-summary-notifications.tsx
+++ b/web/components/notifications/income-summary-notifications.tsx
@@ -90,7 +90,7 @@ export function IncomeNotificationGroupItem(props: {
   const combinedNotifs = combineNotificationsByAddingNumericSourceTexts(
     notifications.filter((n) => n.sourceType !== 'betting_streak_bonus')
   )
-  const [highlighted, setHighlighted] = useState(
+  const [highlighted, _setHighlighted] = useState(
     allMarkedAsRead ? !allMarkedAsRead : notifications.some((n) => !n.isSeen)
   )
   const totalIncome = sum(
@@ -121,10 +121,8 @@ export function IncomeNotificationGroupItem(props: {
   return (
     <NotificationGroupItemComponent
       notifications={combinedNotifs}
-      setHighlighted={setHighlighted}
       header={header}
       isIncomeNotification={true}
-      allMarkedAsRead={allMarkedAsRead}
     />
   )
 }
@@ -193,7 +191,7 @@ export function TipIncomeNotification(props: {
       }
       onClick={() => setOpen(true)}
     >
-      <span>
+      <span className="line-clamp-3">
         <IncomeNotificationLabel notification={notification} />{' '}
         {tippersText && <PrimaryNotificationLink text={tippersText} />} tipped
         you on <QuestionOrGroupLink notification={notification} />
@@ -231,7 +229,7 @@ export function BonusIncomeNotification(props: {
       }
       onClick={() => setOpen(true)}
     >
-      <span>
+      <span className="line-clamp-3">
         <IncomeNotificationLabel notification={notification} /> Bonus for{' '}
         <PrimaryNotificationLink
           text={
@@ -242,11 +240,7 @@ export function BonusIncomeNotification(props: {
               : 'unique traders'
           }
         />{' '}
-        on{' '}
-        <QuestionOrGroupLink
-          notification={notification}
-          truncatedLength={'xl'}
-        />
+        on <QuestionOrGroupLink notification={notification} />
       </span>
       <MultiUserTransactionModal
         userInfos={userLinks}
@@ -282,7 +276,7 @@ export function BettingStreakBonusIncomeNotification(props: {
       }
       onClick={() => setOpen(true)}
     >
-      <span>
+      <span className="line-clamp-3">
         <IncomeNotificationLabel notification={notification} />{' '}
         {sourceText && +sourceText === BETTING_STREAK_BONUS_MAX && (
           <span>(max) </span>

--- a/web/components/notifications/notification-helpers.tsx
+++ b/web/components/notifications/notification-helpers.tsx
@@ -1,15 +1,10 @@
-import {
-  CheckCircleIcon,
-  DotsVerticalIcon,
-  MinusCircleIcon,
-} from '@heroicons/react/solid'
+import { DotsVerticalIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
 import { groupPath } from 'common/group'
 import { Notification } from 'common/notification'
 import { doc, updateDoc } from 'firebase/firestore'
-import { set } from 'lodash'
 import Link from 'next/link'
-import { ReactNode, useState } from 'react'
+import { ReactNode } from 'react'
 import { Col } from 'web/components/layout/col'
 import { Avatar } from 'web/components/widgets/avatar'
 import { Linkify } from 'web/components/widgets/linkify'
@@ -19,7 +14,6 @@ import { db } from 'web/lib/firebase/init'
 import EnvelopeClosedIcon from 'web/lib/icons/envelope-closed-icon'
 import EnvelopeOpenIcon from 'web/lib/icons/envelope-open-icon'
 import { track } from 'web/lib/service/analytics'
-import { IconButton } from '../buttons/button'
 import DropdownMenu from '../comments/dropdown-menu'
 import { Row } from '../layout/row'
 import { RelativeTimestamp } from '../relative-timestamp'

--- a/web/components/notifications/notification-helpers.tsx
+++ b/web/components/notifications/notification-helpers.tsx
@@ -242,9 +242,9 @@ export function NotificationFrame(props: {
             {
               name: highlighted ? 'Mark as read' : 'Mark as unread',
               icon: highlighted ? (
-                <EnvelopeClosedIcon className="h-5 w-5" />
-              ) : (
                 <EnvelopeOpenIcon className="h-5 w-5" />
+              ) : (
+                <EnvelopeClosedIcon className="h-5 w-5" />
               ),
               onClick: () => {
                 if (highlighted) {
@@ -254,11 +254,11 @@ export function NotificationFrame(props: {
                 }
               },
             },
-            {
-              name: 'Turn off this kind of notification',
-              icon: <MinusCircleIcon className="h-5 w-5" />,
-              onClick: () => console.log('hi'),
-            },
+            // {
+            //   name: 'Turn off this kind of notification',
+            //   icon: <MinusCircleIcon className="h-5 w-5" />,
+            //   onClick: () => console.log('hi'),
+            // },
           ]}
           Icon={
             <DotsVerticalIcon
@@ -268,7 +268,7 @@ export function NotificationFrame(props: {
               )}
             />
           }
-          MenuWidth="w-52"
+          MenuWidth="w-44"
         />
       </Col>
       <Col className="w-4">

--- a/web/components/notifications/notification-types.tsx
+++ b/web/components/notifications/notification-types.tsx
@@ -6,7 +6,7 @@ import {
   Notification,
 } from 'common/notification'
 import { formatMoney } from 'common/util/format'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { IncomeNotificationItem } from 'web/components/notifications/income-summary-notifications'
@@ -32,15 +32,29 @@ import {
 
 export function NotificationItem(props: {
   notification: Notification
+  markedAsRead: boolean
   isChildOfGroup?: boolean
   isIncomeNotification?: boolean
 }) {
-  const { notification, isChildOfGroup, isIncomeNotification } = props
+  const { notification, isChildOfGroup, isIncomeNotification, markedAsRead } =
+    props
   const { sourceType, reason, sourceUpdateType } = notification
 
-  const [highlighted, _setHighlighted] = useState(!notification.isSeen)
+  const [highlighted, setHighlighted] = useState(!notification.isSeen)
+
+  useEffect(() => {
+    if (markedAsRead && highlighted) {
+      setHighlighted(!markedAsRead)
+    }
+  }, [markedAsRead, highlighted])
+
   if (isIncomeNotification) {
-    return <IncomeNotificationItem notification={notification} />
+    return (
+      <IncomeNotificationItem
+        notification={notification}
+        highlighted={highlighted}
+      />
+    )
   }
 
   // TODO Any new notification should be its own component

--- a/web/components/notifications/notification-types.tsx
+++ b/web/components/notifications/notification-types.tsx
@@ -18,6 +18,7 @@ import {
 } from 'web/components/outcome-label'
 import { UserLink } from 'web/components/widgets/user-link'
 import { useUser } from 'web/hooks/use-user'
+import Notifications from 'web/pages/notifications'
 import { BadgesModal } from '../profile/badges-modal'
 import { Linkify } from '../widgets/linkify'
 import { truncateText } from '../widgets/truncate'
@@ -32,21 +33,13 @@ import {
 
 export function NotificationItem(props: {
   notification: Notification
-  markedAsRead: boolean
   isChildOfGroup?: boolean
   isIncomeNotification?: boolean
 }) {
-  const { notification, isChildOfGroup, isIncomeNotification, markedAsRead } =
-    props
+  const { notification, isChildOfGroup, isIncomeNotification } = props
   const { sourceType, reason, sourceUpdateType } = notification
 
-  const [highlighted, setHighlighted] = useState(!notification.isSeen)
-
-  useEffect(() => {
-    if (markedAsRead && highlighted) {
-      setHighlighted(!markedAsRead)
-    }
-  }, [markedAsRead, highlighted])
+  const highlighted = !notification.isSeen
 
   if (isIncomeNotification) {
     return (
@@ -257,18 +250,14 @@ function BetFillNotification(props: {
       subtitle={subtitle}
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         {description}
         {!isChildOfGroup && (
           <span>
-            on{' '}
-            <PrimaryNotificationLink
-              text={sourceContractTitle}
-              truncatedLength={'xl'}
-            />
+            on <PrimaryNotificationLink text={sourceContractTitle} />
           </span>
         )}
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -413,7 +402,7 @@ function MarketResolvedNotification(props: {
             {' '}
             <PrimaryNotificationLink
               text={sourceContractTitle}
-              truncatedLength="lg"
+              truncatedLength={'xl'}
             />
           </span>
         )}
@@ -430,7 +419,7 @@ function MarketResolvedNotification(props: {
           <span>
             <PrimaryNotificationLink
               text={sourceContractTitle}
-              truncatedLength="lg"
+              truncatedLength={'xl'}
             />
           </span>
         )}{' '}
@@ -476,7 +465,7 @@ function MarketClosedNotification(props: {
       }
       link={getSourceUrl(notification)}
     >
-      <span>
+      <span className="line-clamp-3">
         Please resolve your question
         {!isChildOfGroup && (
           <>
@@ -507,7 +496,7 @@ function NewMarketNotification(props: {
       }
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
@@ -516,7 +505,7 @@ function NewMarketNotification(props: {
         <span>
           asked <PrimaryNotificationLink text={sourceContractTitle} />
         </span>
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -554,7 +543,7 @@ function MarketUpdateNotification(props: {
       subtitle={subtitle}
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
@@ -567,7 +556,7 @@ function MarketUpdateNotification(props: {
           )}
           {isChildOfGroup && <>the question</>}
         </span>
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -589,7 +578,7 @@ function CommentNotification(props: {
     reason === 'reply_to_users_answer' || reason === 'reply_to_users_comment'
       ? 'replied to you '
       : `commented `
-  const comment = truncateText(sourceText, 'xl')
+  const comment = sourceText
   return (
     <NotificationFrame
       notification={notification}
@@ -598,10 +587,18 @@ function CommentNotification(props: {
       icon={
         <AvatarNotificationIcon notification={notification} symbol={'💬'} />
       }
-      subtitle={comment ? <Linkify text={comment} /> : <></>}
+      subtitle={
+        comment ? (
+          <div className="line-clamp-2">
+            <Linkify text={comment} />{' '}
+          </div>
+        ) : (
+          <></>
+        )
+      }
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
@@ -613,7 +610,7 @@ function CommentNotification(props: {
             on <PrimaryNotificationLink text={sourceContractTitle} />
           </span>
         )}
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -638,10 +635,10 @@ function AnswerNotification(props: {
       icon={
         <AvatarNotificationIcon notification={notification} symbol={'🙋'} />
       }
-      subtitle={truncateText(sourceText, 'xl')}
+      subtitle={<div className="line-clamp-2">{sourceText}</div>}
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
@@ -653,7 +650,7 @@ function AnswerNotification(props: {
             on <PrimaryNotificationLink text={sourceContractTitle} />
           </span>
         )}
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -676,7 +673,7 @@ function TaggedUserNotification(props: {
       }
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
@@ -688,7 +685,7 @@ function TaggedUserNotification(props: {
             on <PrimaryNotificationLink text={sourceContractTitle} />
           </span>
         )}
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -751,7 +748,7 @@ function LiquidityNotification(props: {
       }
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
@@ -765,7 +762,7 @@ function LiquidityNotification(props: {
             to <PrimaryNotificationLink text={sourceContractTitle} />
           </span>
         )}
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -787,7 +784,7 @@ function GroupAddNotification(props: {
       }
       link={getSourceUrl(notification)}
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
@@ -797,7 +794,7 @@ function GroupAddNotification(props: {
         <span>
           <PrimaryNotificationLink text={sourceTitle} />
         </span>
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -853,14 +850,14 @@ function UserJoinedNotification(props: {
         )
       }
     >
-      <>
+      <div className="line-clamp-3">
         <UserLink
           name={sourceUserName || ''}
           username={sourceUserUsername || ''}
           className={'relative flex-shrink-0 hover:text-indigo-500'}
         />{' '}
         joined Manifold Markets {reasonBlock}
-      </>
+      </div>
     </NotificationFrame>
   )
 }
@@ -899,7 +896,7 @@ function ChallengeNotification(props: {
             on{' '}
             <PrimaryNotificationLink
               text={sourceContractTitle}
-              truncatedLength="lg"
+              truncatedLength="xl"
             />{' '}
           </span>
         )}

--- a/web/lib/icons/envelope-closed-icon.tsx
+++ b/web/lib/icons/envelope-closed-icon.tsx
@@ -1,0 +1,18 @@
+export default function EnvelopeClosedIcon(props: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={props.className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+      />
+    </svg>
+  )
+}

--- a/web/lib/icons/envelope-open-icon.tsx
+++ b/web/lib/icons/envelope-open-icon.tsx
@@ -1,0 +1,19 @@
+// Icon from Bootstrap: https://icons.getbootstrap.com/
+export default function EnvelopeOpenIcon(props: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={props.className}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21.75 9v.906a2.25 2.25 0 01-1.183 1.981l-6.478 3.488M2.25 9v.906a2.25 2.25 0 001.183 1.981l6.478 3.488m8.839 2.51l-4.66-2.51m0 0l-1.023-.55a2.25 2.25 0 00-2.134 0l-1.022.55m0 0l-4.661 2.51m16.5 1.615a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V8.844a2.25 2.25 0 011.183-1.98l7.5-4.04a2.25 2.25 0 012.134 0l7.5 4.04a2.25 2.25 0 011.183 1.98V19.5z"
+      />
+    </svg>
+  )
+}

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -7,6 +7,7 @@ import { Notification } from 'common/notification'
 import { PrivateUser } from 'common/user'
 import { useRouter } from 'next/router'
 import React, { ReactNode, useEffect, useMemo, useState } from 'react'
+import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
 import { Page } from 'web/components/layout/page'
 import { Row } from 'web/components/layout/row'
@@ -40,6 +41,7 @@ export default function Notifications() {
   const router = useRouter()
   const [navigateToSection, setNavigateToSection] = useState<string>()
   const [activeIndex, setActiveIndex] = useState(0)
+  const [allMarkedAsRead, setAllMarkedAsRead] = useState(false)
 
   useRedirectIfSignedOut()
 
@@ -56,7 +58,19 @@ export default function Notifications() {
   return (
     <Page>
       <div className={'px-2 pt-4 sm:px-4 lg:pt-0'}>
-        <Title text={'Notifications'} className={'hidden md:block'} />
+        <Row className="hidden w-full justify-between md:flex">
+          <Title text={'Notifications'} className="grow" />
+          <div className="my-auto">
+            <Button
+              onClick={() => {
+                setAllMarkedAsRead(true)
+                setTimeout(() => setAllMarkedAsRead(false), 50)
+              }}
+            >
+              Mark all as read
+            </Button>
+          </div>
+        </Row>
         <SEO title="Notifications" description="Manifold user notifications" />
 
         {privateUser && router.isReady && (
@@ -83,7 +97,12 @@ export default function Notifications() {
               tabs={[
                 {
                   title: 'Notifications',
-                  content: <NotificationsList privateUser={privateUser} />,
+                  content: (
+                    <NotificationsList
+                      privateUser={privateUser}
+                      allMarkedAsRead={allMarkedAsRead}
+                    />
+                  ),
                 },
                 {
                   title: 'Settings',
@@ -105,8 +124,9 @@ export default function Notifications() {
 
 function RenderNotificationGroups(props: {
   notificationGroups: NotificationGroup[]
+  allMarkedAsRead: boolean
 }) {
-  const { notificationGroups } = props
+  const { notificationGroups, allMarkedAsRead } = props
   const grayLine = <hr className="mx-auto w-[calc(100%-1rem)] bg-gray-400" />
   return (
     <>
@@ -116,6 +136,7 @@ function RenderNotificationGroups(props: {
             <IncomeNotificationGroupItem
               notificationGroup={notification}
               key={notification.groupedById + notification.timePeriod}
+              allMarkedAsRead={allMarkedAsRead}
             />
             {grayLine}
           </>
@@ -124,6 +145,7 @@ function RenderNotificationGroups(props: {
             <NotificationItem
               notification={notification.notifications[0]}
               key={notification.notifications[0].id}
+              markedAsRead={allMarkedAsRead}
             />
             {grayLine}
           </>
@@ -132,6 +154,7 @@ function RenderNotificationGroups(props: {
             <NotificationGroupItem
               notificationGroup={notification}
               key={notification.groupedById + notification.timePeriod}
+              allMarkedAsRead={allMarkedAsRead}
             />
             {grayLine}
           </>
@@ -141,8 +164,11 @@ function RenderNotificationGroups(props: {
   )
 }
 
-function NotificationsList(props: { privateUser: PrivateUser }) {
-  const { privateUser } = props
+function NotificationsList(props: {
+  privateUser: PrivateUser
+  allMarkedAsRead: boolean
+}) {
+  const { privateUser, allMarkedAsRead } = props
 
   const [page, setPage] = useState(0)
 
@@ -188,6 +214,7 @@ function NotificationsList(props: { privateUser: PrivateUser }) {
 
       <RenderNotificationGroups
         notificationGroups={paginatedGroupedNotifications}
+        allMarkedAsRead={allMarkedAsRead}
       />
       {paginatedGroupedNotifications.length > 0 &&
         allGroupedNotifications.length > NOTIFICATIONS_PER_PAGE && (
@@ -206,8 +233,9 @@ function NotificationsList(props: { privateUser: PrivateUser }) {
 function NotificationGroupItem(props: {
   notificationGroup: NotificationGroup
   className?: string
+  allMarkedAsRead: boolean
 }) {
-  const { notificationGroup } = props
+  const { notificationGroup, allMarkedAsRead } = props
   const { notifications } = notificationGroup
   const { sourceContractTitle } = notifications[0]
   const [highlighted, setHighlighted] = useState(
@@ -235,18 +263,18 @@ function NotificationGroupItem(props: {
   return (
     <NotificationGroupItemComponent
       notifications={notifications}
-      highlighted={highlighted}
       setHighlighted={setHighlighted}
       header={header}
+      allMarkedAsRead={allMarkedAsRead}
     />
   )
 }
 
 export function NotificationGroupItemComponent(props: {
   notifications: Notification[]
-  highlighted: boolean
   setHighlighted: (highlighted: boolean) => void
   header: ReactNode
+  allMarkedAsRead: boolean
   isIncomeNotification?: boolean
   className?: string
 }) {
@@ -255,6 +283,7 @@ export function NotificationGroupItemComponent(props: {
     className,
     setHighlighted,
     header,
+    allMarkedAsRead,
     isIncomeNotification,
   } = props
 
@@ -291,6 +320,7 @@ export function NotificationGroupItemComponent(props: {
                 key={notification.id}
                 isChildOfGroup={true}
                 isIncomeNotification={isIncomeNotification}
+                markedAsRead={allMarkedAsRead}
               />
             )
           })}

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -181,18 +181,18 @@ function NotificationsList(props: {
     return allGroupedNotifications.slice(start, end)
   }, [allGroupedNotifications, page])
 
-  const isPageVisible = useIsPageVisible()
+  // const isPageVisible = useIsPageVisible()
 
   // Mark all notifications as seen.
-  useEffect(() => {
-    if (isPageVisible && allGroupedNotifications) {
-      const notifications = allGroupedNotifications
-        .flat()
-        .flatMap((g) => g.notifications)
+  // useEffect(() => {
+  //   if (isPageVisible && allGroupedNotifications) {
+  //     const notifications = allGroupedNotifications
+  //       .flat()
+  //       .flatMap((g) => g.notifications)
 
-      markNotificationsAsSeen(notifications)
-    }
-  }, [isPageVisible, allGroupedNotifications])
+  //     markNotificationsAsSeen(notifications)
+  //   }
+  // }, [isPageVisible, allGroupedNotifications])
 
   if (!paginatedGroupedNotifications || !allGroupedNotifications)
     return <LoadingIndicator />
@@ -238,9 +238,7 @@ function NotificationGroupItem(props: {
   const { notificationGroup, allMarkedAsRead } = props
   const { notifications } = notificationGroup
   const { sourceContractTitle } = notifications[0]
-  const [highlighted, setHighlighted] = useState(
-    notifications.some((n) => !n.isSeen)
-  )
+  const highlighted = notifications.some((n) => !n.isSeen)
   const header = (
     <ParentNotificationHeader
       header={
@@ -263,7 +261,6 @@ function NotificationGroupItem(props: {
   return (
     <NotificationGroupItemComponent
       notifications={notifications}
-      setHighlighted={setHighlighted}
       header={header}
       allMarkedAsRead={allMarkedAsRead}
     />
@@ -272,7 +269,6 @@ function NotificationGroupItem(props: {
 
 export function NotificationGroupItemComponent(props: {
   notifications: Notification[]
-  setHighlighted: (highlighted: boolean) => void
   header: ReactNode
   allMarkedAsRead: boolean
   isIncomeNotification?: boolean
@@ -281,7 +277,6 @@ export function NotificationGroupItemComponent(props: {
   const {
     notifications,
     className,
-    setHighlighted,
     header,
     allMarkedAsRead,
     isIncomeNotification,
@@ -295,10 +290,6 @@ export function NotificationGroupItemComponent(props: {
     if (event.ctrlKey || event.metaKey) return
     setExpanded(!expanded)
   }
-
-  useEffect(() => {
-    if (expanded) setHighlighted(false)
-  }, [expanded, setHighlighted])
 
   return (
     <div className={clsx(PARENT_NOTIFICATION_STYLE, className)}>


### PR DESCRIPTION
<img width="859" alt="image" src="https://user-images.githubusercontent.com/46611122/205017916-75957da6-4300-45bc-85b5-62b15a750787.png">
<img width="263" alt="image" src="https://user-images.githubusercontent.com/46611122/205018011-ddf0a334-7244-4af2-8c52-2fbb16a7c902.png">

made it so notifications don't automatically become 'read' upon clicking. I think this was bugged anyhow, as it seemed to mark notifications that weren't even visible as read after refresh.

There are 3 ways to mark a notification as read:
1. Mark all as read button
2. click the notification
3. choose to mark it as read in the '...' menu

Setting up this '...' button next to notifications to allow notification settings configuration on notifications page later, but that's for future Inga to worry about