### PR TITLE
Add knockout stage markets to worldcup tournament page

### DIFF
--- a/web/pages/worldcup.tsx
+++ b/web/pages/worldcup.tsx
@@ -49,7 +49,21 @@ const general_markets = [
   'will-we-have-a-messi-vs-ronaldo-fin',
 ] as string[]
 
-const round_of_16 = [] as string[]
+const round_of_16 = [
+  // Sat 3rd
+  'will-the-netherlands-beat-the-usa',
+  'who-will-be-man-of-the-match-in-the',
+  'will-argentina-beat-australia',
+  'who-will-be-man-of-the-match-in-arg',
+
+  // Sun 4th
+  'will-france-beat-poland',
+  'who-will-be-man-of-the-match-in-fra',
+  'will-england-beat-senegal',
+  'who-will-be-man-of-the-match-in-eng',
+  // Mon 5th TBD
+  // Tue 6h TBD
+] as string[]
 const quarter_finals = [] as string[]
 const semifinals = [] as string[]
 const final = [] as string[]

--- a/web/pages/worldcup.tsx
+++ b/web/pages/worldcup.tsx
@@ -127,7 +127,13 @@ export default function WorldCup(props: {
   playerRatings: Contract[]
   generalMarkets: Contract[]
 }) {
-  const { groupWinners, groupRunnerups, playerRatings, generalMarkets } = props
+  const {
+    groupWinners,
+    groupRunnerups,
+    roundOf16,
+    playerRatings,
+    generalMarkets,
+  } = props
 
   const isMobile = useIsMobile()
 
@@ -185,33 +191,25 @@ export default function WorldCup(props: {
 
           {/* Might want to put an image or something here. */}
 
-          {/*
-          <div className="mb-2  text-3xl text-indigo-500">
-            Market of the Day
-          </div>
-
-          <div className="mb-4 text-base text-gray-500">
-            Every day we will feature a market that we think is interesting.
-            These markets will only last for 24 hours, so make sure to get your
-            bets in!
-          </div>
-
-          <div className="flex items-center justify-center">
-            {dailyMarkets.map((contract) => (
+          <div className="mb-2 text-3xl text-indigo-700">Round of 16</div>
+          <Spacer h={4} />
+          <Masonry
+            breakpointCols={{ default: 2, 768: 1 }}
+            className="-ml-4 flex w-auto"
+            columnClassName="pl-4 bg-clip-padding"
+          >
+            {roundOf16.map((contract) => (
               <ContractCard
-                className={isMobile ? 'w-full' : 'w-1/2'}
                 key={contract.slug}
                 contract={contract}
+                hideDetails={false}
                 showImage={true}
-                hideDetails={true}
+                className="mb-4"
               />
             ))}
-          </div>
+          </Masonry>
 
-          <Spacer h={4} />
-          <Divider />
-
-          <Spacer h={8} />*/}
+          <Spacer h={8} />
 
           <div className="mb-2 text-3xl text-indigo-700">Group Stage </div>
           {isMobile && (


### PR DESCRIPTION
I've added two markets for each match, who will win and who will be man of the match (free response to guess the best player of the game).

I've posted the game chronologically and added dates which might be useful to add as subheaders on the site.