### PR TITLE
Native market embeds

### DIFF
--- a/common/util/parse.ts
+++ b/common/util/parse.ts
@@ -58,7 +58,7 @@ export const stringParseExts = [
       '[embed]' + node.attrs.src ? `(${node.attrs.src})` : '',
   }),
   skippableComponent('gridCardsComponent', '[markets]'),
-  skippableComponent('staticReactEmbedComponent', '[map]'),
+  skippableComponent('market-embed', '[market]'),
   TiptapTweet.extend({ renderText: () => '[tweet]' }),
   TiptapSpoiler.extend({ renderHTML: () => ['span', '[spoiler]', 0] }),
 ]

--- a/web/components/buttons/share-embed-button.tsx
+++ b/web/components/buttons/share-embed-button.tsx
@@ -9,19 +9,10 @@ import { copyToClipboard } from 'web/lib/util/copy'
 import { track } from 'web/lib/service/analytics'
 import { Button } from './button'
 
-export function embedContractCode(contract: Contract) {
+function embedContractCode(contract: Contract) {
   const title = contract.question
   const src = `https://${DOMAIN}/embed${contractPath(contract)}`
   return `<iframe src="${src}" title="${title}" frameborder="0"></iframe>`
-}
-
-// TODO: move this function elsewhere
-export function embedContractGridCode(contracts: Contract[]) {
-  const height = (contracts.length - (contracts.length % 2)) * 100 + 'px'
-  const src = `https://${DOMAIN}/embed/grid/${contracts
-    .map((c) => c.slug)
-    .join('/')}`
-  return `<iframe height="${height}" src="${src}" title="Grid of contracts" frameborder="0"></iframe>`
 }
 
 export function ShareEmbedButton(props: { contract: Contract }) {

--- a/web/components/editor/market-modal.tsx
+++ b/web/components/editor/market-modal.tsx
@@ -1,7 +1,6 @@
 import { Editor } from '@tiptap/react'
 import { Contract } from 'common/contract'
 import { SelectMarketsModal } from '../contract-select-modal'
-import { embedContractCode } from '../buttons/share-embed-button'
 import { insertContent } from './utils'
 
 export function MarketModal(props: {
@@ -13,7 +12,7 @@ export function MarketModal(props: {
 
   function onSubmit(contracts: Contract[]) {
     if (contracts.length == 1) {
-      insertContent(editor, embedContractCode(contracts[0]))
+      insertContent(editor, `<market-embed contractId=${contracts[0].id} />`)
     } else if (contracts.length > 1) {
       insertContent(
         editor,

--- a/web/components/editor/tiptap-grid-cards.tsx
+++ b/web/components/editor/tiptap-grid-cards.tsx
@@ -43,7 +43,7 @@ function GridComponent(attrs: any) {
   const loaded = contracts.every((c) => c !== undefined)
 
   return (
-    <div className=" not-prose font-normal">
+    <div className="not-prose font-normal">
       {loaded ? (
         <ContractsGrid
           contracts={filterDefined(contracts)}

--- a/web/components/editor/tiptap-market-embed.tsx
+++ b/web/components/editor/tiptap-market-embed.tsx
@@ -1,0 +1,17 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { LoadableContractEmbed } from 'web/pages/embed/[username]/[contractSlug]'
+
+export default Node.create({
+  name: 'market-embed',
+  group: 'block',
+  atom: true,
+
+  addAttributes: () => ({ contractId: '' }),
+  parseHTML: () => [{ tag: 'market-embed ' }],
+  renderHTML: ({ HTMLAttributes }) => [
+    'market-embed',
+    mergeAttributes(HTMLAttributes),
+  ],
+
+  renderReact: (attrs: any) => <LoadableContractEmbed {...attrs} />,
+})

--- a/web/components/widgets/editor.tsx
+++ b/web/components/widgets/editor.tsx
@@ -17,6 +17,7 @@ import React, { ReactNode, useCallback, useMemo } from 'react'
 import { DisplayContractMention } from '../editor/contract-mention'
 import { DisplayMention } from '../editor/mention'
 import GridComponent from '../editor/tiptap-grid-cards'
+import MarketEmbed from '../editor/tiptap-market-embed'
 import { Linkify } from './linkify'
 import { linkClass } from './site-link'
 import Iframe from 'common/util/tiptap-iframe'
@@ -61,6 +62,7 @@ export const editorExtensions = (simple = false): Extensions =>
     DisplayMention,
     DisplayContractMention,
     GridComponent,
+    MarketEmbed,
     Iframe,
     DisplayTweet,
     TiptapSpoiler.configure({ class: 'rounded-sm bg-gray-200' }),
@@ -200,6 +202,7 @@ function RichContent(props: {
         DisplayMention,
         DisplayContractMention,
         GridComponent,
+        MarketEmbed,
         Iframe,
         DisplayTweet,
         DisplaySpoiler,


### PR DESCRIPTION
Use react instead of iframes for the markets. Resolves MAN-86

I'm not sure if this is actually faster. There's no static props so each market loads its bets client-side. At least like the iframes there isn't any CLS because I gave it a fixed height.