### PR TITLE
Upgrade `firebase-functions` SDK, eliminate unnecessary proxy functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -40,7 +40,7 @@
     "expo-server-sdk": "3.6.0",
     "express": "4.18.1",
     "firebase-admin": "11.2.0",
-    "firebase-functions": "3.21.2",
+    "firebase-functions": "4.1.0",
     "lodash": "4.17.21",
     "mailgun-js": "0.22.0",
     "marked": "4.1.1",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,10 +9,10 @@ export * from './on-create-user'
 export * from './on-create-bet'
 export * from './on-create-comment-on-contract'
 export * from './on-create-comment-on-post'
-export { scheduleUpdateContractMetrics } from './update-contract-metrics'
-export { scheduleUpdateUserMetrics } from './update-user-metrics'
-export { scheduleUpdateGroupMetrics } from './update-group-metrics'
-export { scheduleUpdateLoans } from './update-loans'
+export * from './update-contract-metrics'
+export * from './update-user-metrics'
+export * from './update-group-metrics'
+export * from './update-loans'
 export * from './update-stats'
 export * from './backup-db'
 export * from './market-close-notifications'
@@ -80,10 +80,6 @@ import { getcurrentuser } from './get-current-user'
 import { acceptchallenge } from './accept-challenge'
 import { createpost } from './create-post'
 import { savetwitchcredentials } from './save-twitch-credentials'
-import { updatecontractmetrics } from './update-contract-metrics'
-import { updateusermetrics } from './update-user-metrics'
-import { updategroupmetrics } from './update-group-metrics'
-import { updateloans } from './update-loans'
 import { addsubsidy } from './add-subsidy'
 import { testscheduledfunction } from './test-scheduled-function'
 import { validateiap } from './validate-iap'
@@ -115,10 +111,6 @@ const acceptChallenge = toCloudFunction(acceptchallenge)
 const createPostFunction = toCloudFunction(createpost)
 const saveTwitchCredentials = toCloudFunction(savetwitchcredentials)
 const testScheduledFunction = toCloudFunction(testscheduledfunction)
-const updateContractMetricsFunction = toCloudFunction(updatecontractmetrics)
-const updateUserMetricsFunction = toCloudFunction(updateusermetrics)
-const updateGroupMetricsFunction = toCloudFunction(updategroupmetrics)
-const updateLoansFunction = toCloudFunction(updateloans)
 const validateIAPFunction = toCloudFunction(validateiap)
 
 export {
@@ -146,9 +138,5 @@ export {
   saveTwitchCredentials as savetwitchcredentials,
   createCommentFunction as createcomment,
   testScheduledFunction as testscheduledfunction,
-  updateContractMetricsFunction as updatecontractmetrics,
-  updateUserMetricsFunction as updateusermetrics,
-  updateGroupMetricsFunction as updategroupmetrics,
-  updateLoansFunction as updateloans,
   validateIAPFunction as validateiap,
 }

--- a/functions/src/update-group-metrics.ts
+++ b/functions/src/update-group-metrics.ts
@@ -1,34 +1,24 @@
-import * as functions from 'firebase-functions'
+import { onSchedule } from 'firebase-functions/v2/scheduler'
 import * as admin from 'firebase-admin'
 import { groupBy, sumBy, mapValues, uniq } from 'lodash'
 
 import { log } from './utils'
 import { Contract } from '../../common/contract'
 import { batchedWaitAll } from '../../common/util/promise'
-import { newEndpointNoAuth } from './api'
-import { invokeFunction } from './utils'
-const firestore = admin.firestore()
 
-export const scheduleUpdateGroupMetrics = functions.pubsub
-  .schedule('every 15 minutes')
-  .onRun(async () => {
-    try {
-      console.log(await invokeFunction('updategroupmetrics'))
-    } catch (e) {
-      console.error(e)
-    }
-  })
-
-export const updategroupmetrics = newEndpointNoAuth(
-  { timeoutSeconds: 2000, memory: '8GiB', minInstances: 0 },
-  async (_req) => {
-    await updateGroupMetrics()
-    return { success: true }
-  }
+export const updategroupmetrics = onSchedule(
+  {
+    schedule: 'every 15 minutes',
+    timeoutSeconds: 2000,
+    memory: '8GiB',
+    minInstances: 0,
+  },
+  updateGroupMetrics
 )
 
 export async function updateGroupMetrics() {
   log('Loading groups...')
+  const firestore = admin.firestore()
   const groups = await firestore.collection('groups').select().get()
   log(`Loaded ${groups.size} groups.`)
 
@@ -112,6 +102,7 @@ async function scoreTraders(contractIds: string[]) {
 }
 
 async function scoreUsersByContract(contractId: string) {
+  const firestore = admin.firestore()
   const userContractMetrics = await firestore
     .collectionGroup('contract-metrics')
     .where('contractId', '==', contractId)
@@ -144,6 +135,7 @@ const topUserScores = (scores: { [userId: string]: number }) => {
 }
 
 async function loadContracts(contractIds: string[]) {
+  const firestore = admin.firestore()
   const refs = contractIds.map((c) => firestore.collection('contracts').doc(c))
   const contractDocs = await firestore.getAll(...refs)
   return contractDocs.map((d) => d.data() as Contract)

--- a/functions/src/update-loans.ts
+++ b/functions/src/update-loans.ts
@@ -1,41 +1,30 @@
-import * as functions from 'firebase-functions'
+import { onSchedule } from 'firebase-functions/v2/scheduler'
 import * as admin from 'firebase-admin'
 import { groupBy, keyBy, sortBy } from 'lodash'
-import { getValues, invokeFunction, log, payUser, writeAsync } from './utils'
+import { getValues, log, payUser, writeAsync } from './utils'
 import { Bet } from '../../common/bet'
 import { Contract } from '../../common/contract'
 import { PortfolioMetrics, User } from '../../common/user'
 import { getUserLoanUpdates, isUserEligibleForLoan } from '../../common/loans'
 import { createLoanIncomeNotification } from './create-notification'
 import { filterDefined } from '../../common/util/array'
-import { newEndpointNoAuth } from './api'
 import { batchedWaitAll } from '../../common/util/promise'
 
-const firestore = admin.firestore()
-
-export const scheduleUpdateLoans = functions.pubsub
-  // Run every day at midnight.
-  .schedule('0 0 * * *')
-  .timeZone('America/Los_Angeles')
-  .onRun(async () => {
-    try {
-      console.log(await invokeFunction('updateloans'))
-    } catch (e) {
-      console.error(e)
-    }
-  })
-
-export const updateloans = newEndpointNoAuth(
-  { timeoutSeconds: 2000, memory: '8GiB', minInstances: 0 },
-  async (_req) => {
-    await updateLoansCore()
-    return { success: true }
-  }
+export const updateloans = onSchedule(
+  {
+    schedule: '0 0 * * *', // Run every day at midnight.
+    timeZone: 'America/Los_Angeles',
+    timeoutSeconds: 2000,
+    memory: '8GiB',
+    minInstances: 0,
+  },
+  updateLoansCore
 )
 
 async function updateLoansCore() {
   log('Updating loans...')
 
+  const firestore = admin.firestore()
   const [users, contracts] = await Promise.all([
     getValues<User>(firestore.collection('users')),
     getValues<Contract>(

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -1,8 +1,8 @@
-import * as functions from 'firebase-functions'
+import { onSchedule } from 'firebase-functions/v2/scheduler'
 import * as admin from 'firebase-admin'
 import { groupBy } from 'lodash'
 
-import { getValues, invokeFunction, log, revalidateStaticProps } from './utils'
+import { getValues, log, revalidateStaticProps } from './utils'
 import { Bet } from '../../common/bet'
 import { Contract } from '../../common/contract'
 import { PortfolioMetrics, User } from '../../common/user'
@@ -16,37 +16,23 @@ import {
 } from '../../common/calculate-metrics'
 import { batchedWaitAll } from '../../common/util/promise'
 import { hasChanges } from '../../common/util/object'
-import { newEndpointNoAuth } from './api'
 
 const BAD_RESOLUTION_THRESHOLD = 0.1
 
-const firestore = admin.firestore()
-
-export const scheduleUpdateUserMetrics = functions.pubsub
-  .schedule('every 15 minutes')
-  .onRun(async () => {
-    try {
-      console.log(await invokeFunction('updateusermetrics'))
-    } catch (e) {
-      console.error(e)
-    }
-  })
-
-export const updateusermetrics = newEndpointNoAuth(
+export const updateusermetrics = onSchedule(
   {
+    schedule: 'every 15 minutes',
     timeoutSeconds: 2000,
     memory: '16GiB',
     minInstances: 0,
     secrets: ['API_SECRET'],
   },
-  async (_req) => {
-    await updateUserMetrics()
-    return { success: true }
-  }
+  updateUserMetrics
 )
 
 export async function updateUserMetrics() {
   log('Loading users...')
+  const firestore = admin.firestore()
   const users = await getValues<User>(firestore.collection('users'))
   log(`Loaded ${users.length} users.`)
 
@@ -164,12 +150,12 @@ export async function updateUserMetrics() {
 
   log('Committing writes...')
   await writer.close()
-
   await revalidateStaticProps('/leaderboards')
   log('Done.')
 }
 
 const loadUserContractBets = async (userId: string, contractIds: string[]) => {
+  const firestore = admin.firestore()
   const betDocs = await batchedWaitAll(
     contractIds.map((c) => async () => {
       return await firestore
@@ -188,6 +174,7 @@ const loadUserContractBets = async (userId: string, contractIds: string[]) => {
 }
 
 const loadPortfolioHistory = async (userId: string, now: number) => {
+  const firestore = admin.firestore()
   const query = firestore
     .collection('users')
     .doc(userId)

--- a/functions/src/utils.ts
+++ b/functions/src/utils.ts
@@ -15,7 +15,6 @@ import { Contract } from '../../common/contract'
 import { PrivateUser, User } from '../../common/user'
 import { Group } from '../../common/group'
 import { Post } from '../../common/post'
-import { getFunctionUrl } from '../../common/api'
 
 export const log = (...args: unknown[]) => {
   console.log(`[${new Date().toISOString()}]`, ...args)
@@ -30,25 +29,6 @@ export const logMemory = () => {
 
 export function htmlToRichText(html: string) {
   return generateJSON(html, stringParseExts)
-}
-
-export const invokeFunction = async (name: string, body?: unknown) => {
-  const response = await fetch(getFunctionUrl(name), {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    body: JSON.stringify(body ?? {}),
-  })
-
-  const json = await response.json()
-  if (response.ok) {
-    return json
-  } else {
-    throw new Error(
-      `${response.status} invoking ${name}: ${JSON.stringify(json)}`
-    )
-  }
 }
 
 export const revalidateStaticProps = async (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3847,16 +3847,15 @@ firebase-functions-test@0.3.3:
     "@types/lodash" "^4.14.104"
     lodash "^4.17.5"
 
-firebase-functions@3.21.2:
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-3.21.2.tgz#53dde54cdcb2a645b4cdc3e3cbb7480dd46c9293"
-  integrity sha512-XZOSv7mLnd8uIzNA+rc+n+oM/g2Nn4rtUkOKeTMccYiWOMdMMUwhzuqRnE28mB65bveU12aTHkaJY6p3Pk6MUw==
+firebase-functions@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-4.1.0.tgz#4d8780a2c0aee6f362b3a632af293911427ec597"
+  integrity sha512-brbww5lGQVm8+d4KFmHF+O8wJBthws1NGXgphy7UDguMbUoW0fq6bL0NI442w+3nDE8IYUbnR4p3U8/cLAhnOA==
   dependencies:
     "@types/cors" "^2.8.5"
     "@types/express" "4.17.3"
     cors "^2.8.5"
     express "^4.17.1"
-    lodash "^4.17.14"
     node-fetch "^2.6.7"
 
 firebase@9.13.0:


### PR DESCRIPTION
The new `firebase-functions` SDK makes it easy to make scheduled v2 functions, so we don't need to do the weird thing where we have a v1 proxy function invoking a v2 function anymore.