### PR TITLE
Throttle writes in `update-*-metrics`

### DIFF
--- a/functions/src/update-contract-metrics.ts
+++ b/functions/src/update-contract-metrics.ts
@@ -43,7 +43,7 @@ export async function updateContractMetrics() {
   const weekAgo = now - 7 * DAY_MS
   const monthAgo = now - 30 * DAY_MS
 
-  const writer = firestore.bulkWriter({ throttling: false })
+  const writer = firestore.bulkWriter()
   await batchedWaitAll(
     contracts.map((contract) => async () => {
       const yesterdayBets = await getValues<Bet>(

--- a/functions/src/update-group-metrics.ts
+++ b/functions/src/update-group-metrics.ts
@@ -55,7 +55,7 @@ export async function updateGroupMetrics() {
   log(`Loaded ${contractIds.length} contracts.`)
 
   log('Computing metric updates...')
-  const writer = firestore.bulkWriter({ throttling: false })
+  const writer = firestore.bulkWriter()
   await batchedWaitAll(
     groups.docs.map((doc) => async () => {
       const contractIds = contractIdsByGroupId[doc.id] ?? []

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -58,7 +58,7 @@ export async function updateUserMetrics() {
 
   const now = Date.now()
   const monthAgo = now - DAY_MS * 30
-  const writer = firestore.bulkWriter({ throttling: false })
+  const writer = firestore.bulkWriter()
 
   // we need to update metrics for contracts that resolved up through a month ago,
   // for the purposes of computing the daily/weekly/monthly profit on them


### PR DESCRIPTION
Ramping these up more slowly will give time for the write triggers and replication to spin up new Cloud Run instances to handle the writes.