### PR TITLE
Recommended markets page [WIP]

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -46,6 +46,7 @@ service cloud.firestore {
                           // && (get(/databases/$(database)/documents/users/$(request.resource.data.referredByUserId)).referredByUserId == resource.data.id);
       match /events/{eventId} {
         allow create: if (request.auth == null && userId == 'NO_USER') || userId == request.auth.uid;
+        allow read: if userId == request.auth.uid;
       }
     }
 

--- a/web/hooks/use-user.ts
+++ b/web/hooks/use-user.ts
@@ -1,8 +1,16 @@
-import { useContext, useRef } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useFirestoreQueryData } from '@react-query-firebase/firestore'
-import { sortBy } from 'lodash'
+import { countBy, sampleSize, shuffle, sortBy, uniq, uniqBy } from 'lodash'
 
-import { doc } from 'firebase/firestore'
+import {
+  collection,
+  doc,
+  limit,
+  orderBy,
+  Query,
+  query,
+  where,
+} from 'firebase/firestore'
 import { listenForUser, users } from 'web/lib/firebase/users'
 import { AuthContext } from 'web/components/auth-context'
 import { ContractMetrics } from 'common/calculate-metrics'
@@ -14,7 +22,9 @@ import { useStore, useStoreItems } from './use-store'
 import { safeLocalStorage } from 'web/lib/util/local'
 import { useEffectCheckEquality } from './use-effect-check-equality'
 import { listenForValue } from 'web/lib/firebase/utils'
-
+import { db } from 'web/lib/firebase/init'
+import { getValues } from 'web/lib/firebase/utils'
+import { ContractMetric } from 'common/contract-metric'
 export const useUser = () => {
   const authUser = useContext(AuthContext)
   return authUser ? authUser.user : authUser
@@ -112,4 +122,234 @@ export const useUserContractMetrics = (userId = '_', contractId: string) => {
   if (userId === '_') return undefined
 
   return data
+}
+
+type ContractView = {
+  name: string
+  slug: string
+  timestamp: number
+  contractId: string
+  creatorId: string
+}
+// Note: we don't filter out blocked contracts/users/groups here like we do in unbet-on contracts
+export const useUserRecommendedMarkets = (userId = '_', count = 500) => {
+  const viewedMarketsQuery = query(
+    collection(db, `users/${userId}/events`),
+    where('name', '==', 'view market'),
+    orderBy('timestamp', 'desc'),
+    limit(count)
+  ) as Query<ContractView>
+  const viewedMarketEvents = useFirestoreQueryData<ContractView>(
+    ['user-viewed-markets', userId, count],
+    viewedMarketsQuery
+  )
+  const recentBetOnContractMetrics = query(
+    collection(db, `users/${userId}/contract-metrics`),
+    orderBy('lastBetTime', 'desc'),
+    limit(count)
+  ) as Query<ContractMetric>
+  const recentContractMetrics = useFirestoreQueryData<ContractMetric>(
+    ['user-recent-contract-markets', userId, count],
+    recentBetOnContractMetrics
+  )
+
+  // TODO: we shouldn't just get unique ids here, but weight them by how many times they've been viewed
+  const contractsRelatedToUser = sampleSize(
+    recentContractMetrics.data?.map((m) => m.contractId) ?? [],
+    10
+  )
+
+  if (contractsRelatedToUser.length < 10) {
+    const allSeenContractIds = uniq(
+      viewedMarketEvents.data?.map((e) => e.contractId) ?? []
+    )
+    contractsRelatedToUser.push(
+      ...sampleSize(allSeenContractIds, 10 - contractsRelatedToUser.length)
+    )
+  }
+  // get recommended contracts with count inversely proportional to the unique contract ids,
+  // with the goal of getting 500 unique contracts
+  const recommendedContracts = useRecommendedContracts(
+    contractsRelatedToUser,
+    userId,
+    500,
+    contractsRelatedToUser
+  )
+
+  return recommendedContracts
+}
+
+const getSimilarBettorsToUserMarkets = async (
+  userId: string,
+  contractsThatAppealToUser?: Contract[]
+) => {
+  const userMarkets =
+    contractsThatAppealToUser ??
+    (await getValues<Contract>(
+      query(
+        collection(db, 'contracts'),
+        where('uniqueBettorIds', 'array-contains', userId),
+        orderBy('createdTime', 'desc'),
+        limit(150)
+      )
+    ))
+  return await getSimilarBettorsMarkets(userId, userMarkets)
+}
+
+const getSimilarBettorIds = (
+  contractsAppealingToUser: Contract[],
+  userId: string
+) => {
+  // get contracts with unique bettor ids
+  if (contractsAppealingToUser.length === 0) return []
+  // count the number of times each unique bettor id appears on those contracts
+  const bettorIdsToCounts = countBy(
+    contractsAppealingToUser.map((contract) => contract.uniqueBettorIds).flat(),
+    (bettorId) => bettorId
+  )
+
+  // sort by number of times they appear with at least 2 appearances
+  const sortedBettorIds = Object.entries(bettorIdsToCounts)
+    .sort((a, b) => b[1] - a[1])
+    .filter((bettorId) => bettorId[1] > 0)
+    .map((entry) => entry[0])
+    .filter((bettorId) => bettorId !== userId)
+
+  // get the top 10 most similar bettors (excluding this user)
+  const similarBettorIds = sortedBettorIds.slice(0, 10)
+  return similarBettorIds
+}
+
+// Gets markets followed by similar bettors and bet on by similar bettors
+const getSimilarBettorsMarkets = async (
+  userId: string,
+  contractsUserHasBetOn: Contract[]
+) => {
+  const similarBettorIds = getSimilarBettorIds(contractsUserHasBetOn, userId)
+  if (similarBettorIds.length === 0) return []
+
+  // get contracts with unique bettor ids with this user
+  const contractsSimilarBettorsHaveBetOn = uniqBy(
+    (
+      await getValues<Contract>(
+        query(
+          collection(db, 'contracts'),
+          where(
+            'uniqueBettorIds',
+            'array-contains-any',
+            similarBettorIds.slice(0, 10)
+          ),
+          orderBy('popularityScore', 'desc'),
+          limit(200)
+        )
+      )
+    ).filter(
+      (contract) =>
+        !contract.uniqueBettorIds?.includes(userId) &&
+        !contractsUserHasBetOn.find((c) => c.id === contract.id)
+    ),
+    (contract) => contract.id
+  )
+
+  // sort the contracts by how many times similar bettor ids are in their unique bettor ids array
+  const sortedContractsInSimilarBettorsBets = contractsSimilarBettorsHaveBetOn
+    .map((contract) => {
+      const appearances = contract.uniqueBettorIds?.filter((bettorId) =>
+        similarBettorIds.includes(bettorId)
+      ).length
+      return [contract, appearances] as [Contract, number]
+    })
+    .sort((a, b) => b[1] - a[1])
+    .map((entry) => entry[0])
+
+  return sortedContractsInSimilarBettorsBets
+}
+
+const useRecommendedContracts = (
+  similarToContractIds: string[],
+  excludeBettorId: string,
+  maxCount: number,
+  excludingContractIds: string[]
+) => {
+  const [recommendedContracts, setRecommendedContracts] = useState<
+    Contract[] | undefined
+  >(undefined)
+  // get creators markets from the user's viewed markets
+  // get markets from groups that the user has viewed
+  // get markets that have similar bettors that the user has viewed
+  const getRecommendedContracts = useCallback(async () => {
+    const contracts = await getValues<Contract>(
+      query(
+        collection(db, 'contracts'),
+        where('id', 'in', similarToContractIds)
+      )
+    )
+    const creatorIds = uniq(contracts.map((contract) => contract.creatorId))
+    const groupSlugs = filterDefined(
+      uniq(contracts.map((contract) => contract.groupSlugs?.[0]))
+    )
+
+    const creatorContractsQuery = query(
+      collection(db, 'contracts'),
+      where('isResolved', '==', false),
+      where('creatorId', 'in', creatorIds),
+      orderBy('popularityScore', 'desc'),
+      limit(maxCount)
+    )
+    const creatorContracts = await getValues<Contract>(creatorContractsQuery)
+    const groupContractsQuery = query(
+      collection(db, 'contracts'),
+      where('groupSlugs', 'array-contains-any', groupSlugs),
+      where('isResolved', '==', false),
+      orderBy('popularityScore', 'desc'),
+      limit(maxCount)
+    )
+    const groupContracts = await getValues<Contract>(groupContractsQuery)
+    const similarBettorsContracts = await getSimilarBettorsToUserMarkets(
+      excludeBettorId,
+      contracts
+    )
+    const filterContracts = (contracts: Contract[]) =>
+      uniqBy(
+        contracts.filter(
+          (contract) =>
+            !contract.uniqueBettorIds?.includes(excludeBettorId) &&
+            !excludingContractIds.includes(contract.id) &&
+            contract.closeTime &&
+            contract.closeTime > Date.now()
+        ),
+        (contract) => contract.id
+      )
+
+    const combined = uniqBy(
+      [
+        ...filterContracts(creatorContracts).slice(0, maxCount / 3),
+        ...filterContracts(groupContracts).slice(0, maxCount / 3),
+        ...filterContracts(similarBettorsContracts).slice(0, maxCount / 3),
+      ],
+      (c) => c.id
+    )
+
+    // sort randomly
+    const chosen = shuffle(combined).slice(0, maxCount)
+    // if (chosen.length < count)
+    //   chosen.push(...chooseRandomSubset(betOnContracts, count - chosen.length))
+    return chosen
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    similarToContractIds.length,
+    maxCount,
+    excludeBettorId,
+    excludingContractIds.length,
+  ])
+
+  useEffect(() => {
+    if (similarToContractIds.length > 0) {
+      getRecommendedContracts().then((recommendedContracts) =>
+        setRecommendedContracts(recommendedContracts)
+      )
+    }
+  }, [getRecommendedContracts, similarToContractIds.length])
+
+  return recommendedContracts
 }

--- a/web/pages/recommended-markets.tsx
+++ b/web/pages/recommended-markets.tsx
@@ -1,0 +1,42 @@
+import { Col } from 'web/components/layout/col'
+import { Row } from 'web/components/layout/row'
+import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import { Page } from 'web/components/layout/page'
+import { Title } from 'web/components/widgets/title'
+import { useTracking } from 'web/hooks/use-tracking'
+import { useUser, useUserRecommendedMarkets } from 'web/hooks/use-user'
+import { DailyProfit } from '../components/daily-stats'
+import { ContractsGrid } from 'web/components/contract/contracts-grid'
+import { memo } from 'react'
+
+export default function RecommendedMarkets() {
+  const user = useUser()
+  useTracking('view recommended markets')
+
+  return (
+    <Page>
+      <Col className="pm:mx-10 gap-4 sm:px-4 sm:pb-4">
+        <Row className="mt-4 items-start justify-between sm:mt-0">
+          <Title
+            className="mx-4 !mb-0 !mt-0 sm:mx-0"
+            text="Your recommended markets"
+          />
+          <DailyProfit user={user} />
+        </Row>
+        {user && <RecommendedMarketsItems userId={user.id} />}
+      </Col>
+    </Page>
+  )
+}
+
+const RecommendedMarketsItems = memo(function RecommendedMarketsItems(props: {
+  userId: string
+}) {
+  const { userId } = props
+
+  const data = useUserRecommendedMarkets(userId)
+
+  if (!data) return <LoadingIndicator />
+
+  return <ContractsGrid contracts={data} />
+})


### PR DESCRIPTION
Result of my hackathon project. Shows recommends markets similar to those you've bet on and viewed (via their contract page), showing 100 markets by similar creators, similar groups, similar bettors' interests, but won't show you markets you've already bet on or viewed. Austin brought up the point that perhaps we shouldn't reshow you markets you've scrolled past too many times. Could be an interesting addition to add. Using this page we could start logging markets you've seen and not show them more than 2/3 times. 

It could go on the homepage and should probably have an infinite scroll.

<img width="813" alt="Screenshot 2022-12-07 at 10 54 42 AM" src="https://user-images.githubusercontent.com/23196210/206241528-a1055039-893a-4d8f-a20c-9dbf49f516a6.png">
