### PR TITLE
Make write replayer not fail if there are too many writes

### DIFF
--- a/functions/src/replication/transaction-log.ts
+++ b/functions/src/replication/transaction-log.ts
@@ -108,7 +108,7 @@ export const replicatelogtosupabase = onMessagePublished<TLEntry>(
 )
 
 export const replayFailedSupabaseWrites = functions
-  .runWith({ secrets: ['SUPABASE_KEY'] })
+  .runWith({ secrets: ['SUPABASE_KEY'], timeoutSeconds: 540 })
   .pubsub.schedule('every 1 minutes')
   .onRun(async () => {
     const firestore = admin.firestore()


### PR DESCRIPTION
Now it can handle arbitrary sized sets of failed writes without blowing up due to OOM or timeout.* Also `processPaginated` will be useful elsewhere.

*If there are really a lot, it could time out, but that's fine since it processed lots of them and it will get back to work in a minute processing more.