### PR TITLE
Don't download 300 notifications to display notifications icon

### DIFF
--- a/web/components/notifications-icon.tsx
+++ b/web/components/notifications-icon.tsx
@@ -4,7 +4,7 @@ import { Row } from 'web/components/layout/row'
 import { useEffect, useState } from 'react'
 import { usePrivateUser } from 'web/hooks/use-user'
 import { useRouter } from 'next/router'
-import { useUnseenNotificationCount } from 'web/hooks/use-notifications'
+import { useGroupedUnseenNotifications } from 'web/hooks/use-notifications'
 import { PrivateUser } from 'common/user'
 import { NOTIFICATIONS_PER_PAGE } from './notifications/notification-helpers'
 
@@ -29,7 +29,7 @@ function UnseenNotificationsBubble(props: { privateUser: PrivateUser }) {
     }
   }, [isReady, pathname])
 
-  const unseenCount = useUnseenNotificationCount(privateUser)
+  const unseenCount = (useGroupedUnseenNotifications(privateUser) ?? []).length
   if (!unseenCount || seen) {
     return null
   }

--- a/web/components/notifications/notification-helpers.tsx
+++ b/web/components/notifications/notification-helpers.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
 import { getSourceUrl, Notification } from 'common/notification'
-import { doc, updateDoc } from 'firebase/firestore'
 import Link from 'next/link'
 import { ReactNode } from 'react'
 import { Col } from 'web/components/layout/col'
@@ -8,7 +7,6 @@ import { Avatar } from 'web/components/widgets/avatar'
 import { Linkify } from 'web/components/widgets/linkify'
 import { SiteLink } from 'web/components/widgets/site-link'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
-import { db } from 'web/lib/firebase/init'
 import { track } from 'web/lib/service/analytics'
 import { Row } from '../layout/row'
 import { RelativeTimestamp } from '../relative-timestamp'
@@ -271,29 +269,6 @@ export function NotificationFrame(props: {
       {frameEnd}
     </Row>
   )
-}
-
-export const markNotificationsAsSeen = async (
-  notifications: Notification[]
-) => {
-  const unseenNotifications = notifications.filter((n) => !n.isSeen)
-  return await Promise.all(
-    unseenNotifications.map((n) => {
-      return markNotificationAsSeen(n)
-    })
-  )
-}
-
-export async function markNotificationAsSeen(notification: Notification) {
-  const notificationDoc = doc(
-    db,
-    `users/${notification.userId}/notifications/`,
-    notification.id
-  )
-  return updateDoc(notificationDoc, {
-    isSeen: true,
-    viewTime: new Date(),
-  })
 }
 
 export function ParentNotificationHeader(props: {

--- a/web/hooks/use-notifications.ts
+++ b/web/hooks/use-notifications.ts
@@ -2,7 +2,10 @@ import { Notification } from 'common/notification'
 import { PrivateUser } from 'common/user'
 import { groupBy, map } from 'lodash'
 import { useMemo } from 'react'
-import { listenForNotifications } from 'web/lib/firebase/notifications'
+import {
+  listenForNotifications,
+  listenForUnseenNotifications,
+} from 'web/lib/firebase/notifications'
 import { useStore } from './use-store'
 
 export type NotificationGroup = {
@@ -18,6 +21,12 @@ function useNotifications(privateUser: PrivateUser) {
   })
 }
 
+function useUnseenNotifications(privateUser: PrivateUser) {
+  return useStore(privateUser.id, listenForUnseenNotifications, {
+    prefix: 'unseen-notifications',
+  })
+}
+
 export function useGroupedNotifications(privateUser: PrivateUser) {
   const notifications = useNotifications(privateUser)
   return useMemo(() => {
@@ -25,12 +34,10 @@ export function useGroupedNotifications(privateUser: PrivateUser) {
   }, [notifications])
 }
 
-export function useUnseenNotificationCount(privateUser: PrivateUser) {
-  const notifications = useNotifications(privateUser)
+export function useGroupedUnseenNotifications(privateUser: PrivateUser) {
+  const notifications = useUnseenNotifications(privateUser)
   return useMemo(() => {
-    if (!notifications) return undefined
-    const unseen = notifications.filter((n) => !n.isSeen)
-    return groupNotifications(unseen).length
+    return notifications ? groupNotifications(notifications) : undefined
   }, [notifications])
 }
 

--- a/web/lib/firebase/notifications.ts
+++ b/web/lib/firebase/notifications.ts
@@ -3,6 +3,7 @@ import {
   deleteField,
   doc,
   limit,
+  getDocs,
   orderBy,
   query,
   updateDoc,
@@ -93,4 +94,17 @@ export function listenForUnseenNotifications(
     limit(NOTIFICATIONS_PER_PAGE * 10)
   )
   return listenForValues<Notification>(q, setNotifictions)
+}
+
+export const markAllNotificationsAsSeen = async (userId: string) => {
+  const notifsCollection = collection(db, `/users/${userId}/notifications`)
+  const unseenNotifications = await getDocs(
+    query(notifsCollection, where('isSeen', '==', false))
+  )
+  const now = new Date()
+  return await Promise.all(
+    unseenNotifications.docs.map((d) => {
+      return updateDoc(d.ref, { isSeen: true, viewTime: now })
+    })
+  )
 }

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -12,13 +12,13 @@ import { NotificationSettings } from 'web/components/notification-settings'
 import { combineAndSumIncomeNotifications } from 'web/components/notifications/income-summary-notifications'
 import {
   combineReactionNotifications,
-  markNotificationsAsSeen,
   NOTIFICATIONS_PER_PAGE,
   NUM_SUMMARY_LINES,
   ParentNotificationHeader,
   PARENT_NOTIFICATION_STYLE,
   QuestionOrGroupLink,
 } from 'web/components/notifications/notification-helpers'
+import { markAllNotificationsAsSeen } from 'web/lib/firebase/notifications'
 import { NotificationItem } from 'web/components/notifications/notification-types'
 import { PushNotificationsModal } from 'web/components/push-notifications-modal'
 import { SEO } from 'web/components/SEO'
@@ -161,13 +161,9 @@ function NotificationsList(props: { privateUser: PrivateUser }) {
   // Mark all notifications as seen.
   useEffect(() => {
     if (isPageVisible && allGroupedNotifications) {
-      const notifications = allGroupedNotifications
-        .flat()
-        .flatMap((g) => g.notifications)
-
-      markNotificationsAsSeen(notifications)
+      markAllNotificationsAsSeen(privateUser.id)
     }
-  }, [isPageVisible, allGroupedNotifications])
+  }, [privateUser.id, isPageVisible, allGroupedNotifications])
 
   if (!paginatedGroupedNotifications || !allGroupedNotifications)
     return <LoadingIndicator />


### PR DESCRIPTION
We still download your unseen ones, which sucks, but I guess at least we don't download all your unseen ones too. Sigh.

Please don't write code that fetches hundreds of documents on every page load in order to show a little number in a bubble! I believe in you!