### PR TITLE
fixed liked

### DIFF
--- a/web/components/notifications/notification-types.tsx
+++ b/web/components/notifications/notification-types.tsx
@@ -742,7 +742,7 @@ function UserLikeNotification(props: {
       {reactorsText && <PrimaryNotificationLink text={reactorsText} />} liked
       your
       {sourceType === 'comment_like' ? ' comment on ' : ' market '}
-      <QuestionOrGroupLink notification={notification} />
+      {!isChildOfGroup && <QuestionOrGroupLink notification={notification} />}
       <MultiUserReactionModal
         similarNotifications={relatedNotifications}
         modalLabel={'Who dunnit?'}


### PR DESCRIPTION
<img width="425" alt="image" src="https://user-images.githubusercontent.com/46611122/207468743-52150f06-66ed-49d1-a078-23de68869de5.png">
got rid of market description when nested