### PR TITLE
Add `yarn regen-types` script for Supabase type generation

### DIFF
--- a/supabase-replicator/package.json
+++ b/supabase-replicator/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "nodemon src/index.ts",
     "build": "yarn compile && rm -rf dist && mkdir -p dist/supabase-replicator && cp -R ../common/lib dist/common && cp -R lib/src dist/supabase-replicator/src && cp ../yarn.lock dist && cp package.json dist",
+    "regen-types": "supabase gen types typescript --project-id pxidrgkatumlvfqaxcll --schema public > ../common/supabase/schema.ts",
     "compile": "tsc -b",
     "watch": "tsc -w"
   },


### PR DESCRIPTION
It's convenient to have this so that I don't have to remember the Supabase project ID or anything.