### PR TITLE
Use v2 scheduled function

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -41,7 +41,7 @@
     "expo-server-sdk": "3.6.0",
     "express": "4.18.1",
     "firebase-admin": "11.2.0",
-    "firebase-functions": "4.1.0",
+    "firebase-functions": "4.1.1",
     "lodash": "4.17.21",
     "mailgun-js": "0.22.0",
     "marked": "4.1.1",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -90,7 +90,7 @@ import { swapcert } from './swap-cert'
 import { dividendcert } from './dividend-cert'
 
 // v2
-export { updateusermetrics2 } from './update-user-metrics'
+export { updateusermetrics } from './update-user-metrics'
 
 const toCloudFunction = ({ opts, handler }: EndpointDefinition) => {
   return onRequest(opts, handler as any)

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,7 +10,6 @@ export * from './on-create-bet'
 export * from './on-create-comment-on-contract'
 export * from './on-create-comment-on-post'
 export { scheduleUpdateContractMetrics } from './update-contract-metrics'
-export { scheduleUpdateUserMetrics } from './update-user-metrics'
 export { scheduleUpdateGroupMetrics } from './update-group-metrics'
 export { scheduleUpdateLoans } from './update-loans'
 export * from './update-stats'
@@ -82,7 +81,6 @@ import { acceptchallenge } from './accept-challenge'
 import { createpost } from './create-post'
 import { savetwitchcredentials } from './save-twitch-credentials'
 import { updatecontractmetrics } from './update-contract-metrics'
-import { updateusermetrics } from './update-user-metrics'
 import { updategroupmetrics } from './update-group-metrics'
 import { updateloans } from './update-loans'
 import { addsubsidy } from './add-subsidy'
@@ -90,6 +88,9 @@ import { testscheduledfunction } from './test-scheduled-function'
 import { validateiap } from './validate-iap'
 import { swapcert } from './swap-cert'
 import { dividendcert } from './dividend-cert'
+
+// v2
+export { updateusermetrics2 } from './update-user-metrics'
 
 const toCloudFunction = ({ opts, handler }: EndpointDefinition) => {
   return onRequest(opts, handler as any)
@@ -119,7 +120,6 @@ const createPostFunction = toCloudFunction(createpost)
 const saveTwitchCredentials = toCloudFunction(savetwitchcredentials)
 const testScheduledFunction = toCloudFunction(testscheduledfunction)
 const updateContractMetricsFunction = toCloudFunction(updatecontractmetrics)
-const updateUserMetricsFunction = toCloudFunction(updateusermetrics)
 const updateGroupMetricsFunction = toCloudFunction(updategroupmetrics)
 const updateLoansFunction = toCloudFunction(updateloans)
 const validateIAPFunction = toCloudFunction(validateiap)
@@ -152,7 +152,6 @@ export {
   createCommentFunction as createcomment,
   testScheduledFunction as testscheduledfunction,
   updateContractMetricsFunction as updatecontractmetrics,
-  updateUserMetricsFunction as updateusermetrics,
   updateGroupMetricsFunction as updategroupmetrics,
   updateLoansFunction as updateloans,
   validateIAPFunction as validateiap,

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -1,11 +1,10 @@
-import * as functions from 'firebase-functions'
+import { onSchedule } from 'firebase-functions/v2/scheduler'
 import * as admin from 'firebase-admin'
 import { groupBy } from 'lodash'
 
 import {
   getUser,
   getValues,
-  invokeFunction,
   loadPaginated,
   log,
   revalidateStaticProps,
@@ -23,33 +22,23 @@ import {
 } from '../../common/calculate-metrics'
 import { batchedWaitAll } from '../../common/util/promise'
 import { hasChanges } from '../../common/util/object'
-import { newEndpointNoAuth } from './api'
 import { CollectionReference } from 'firebase-admin/firestore'
 
 const BAD_RESOLUTION_THRESHOLD = 0.1
 
 const firestore = admin.firestore()
 
-export const scheduleUpdateUserMetrics = functions.pubsub
-  .schedule('every 15 minutes')
-  .onRun(async () => {
-    try {
-      console.log(await invokeFunction('updateusermetrics'))
-    } catch (e) {
-      console.error(e)
-    }
-  })
-
-export const updateusermetrics = newEndpointNoAuth(
+export const updateusermetrics2 = onSchedule(
   {
+    schedule: 'every 15 minutes',
     timeoutSeconds: 2000,
     memory: '16GiB',
     minInstances: 0,
     secrets: ['API_SECRET'],
   },
-  async (_req) => {
+  async (e) => {
+    console.log('Running scheduled job', e.jobName)
     await updateUserMetrics()
-    return { success: true }
   }
 )
 

--- a/functions/src/update-user-metrics.ts
+++ b/functions/src/update-user-metrics.ts
@@ -28,7 +28,7 @@ const BAD_RESOLUTION_THRESHOLD = 0.1
 
 const firestore = admin.firestore()
 
-export const updateusermetrics2 = onSchedule(
+export const updateusermetrics = onSchedule(
   {
     schedule: 'every 15 minutes',
     timeoutSeconds: 2000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,7 +2600,7 @@
     satori "0.0.43"
     yoga-wasm-web "0.1.2"
 
-"@xmldom/xmldom@0.8.5","@xmldom/xmldom@^0.8.5":
+"@xmldom/xmldom@0.8.5", "@xmldom/xmldom@^0.8.5":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.5.tgz#7f4b797cfda39355b512b4cfcc66b49b5d93d5f3"
   integrity sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==
@@ -4616,10 +4616,10 @@ firebase-admin@11.2.0:
     "@google-cloud/firestore" "^6.4.0"
     "@google-cloud/storage" "^6.5.2"
 
-firebase-functions@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-4.1.0.tgz#4d8780a2c0aee6f362b3a632af293911427ec597"
-  integrity sha512-brbww5lGQVm8+d4KFmHF+O8wJBthws1NGXgphy7UDguMbUoW0fq6bL0NI442w+3nDE8IYUbnR4p3U8/cLAhnOA==
+firebase-functions@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-4.1.1.tgz#47c39a40d6cdaad9a46cb7ee3b9ffbb9bcaa7f2c"
+  integrity sha512-D0fhHO7m3OfZp5TpbO+ClsEo6vmr8uaR4kt7sePhQgcF1OCRI6YT5dEa9szaQekGKoao/YeZ+C5HVxEGsLxD9Q==
   dependencies:
     "@types/cors" "^2.8.5"
     "@types/express" "4.17.3"


### PR DESCRIPTION
I'd merge this but deploying the scheduled function leads to an unexpected error lol:
Edit: downgrading to the previous version of firebase-tools just leads to no error but nothing happening. It doesn't deploy this scheduled function... 

```
=== Deploying to 'mantic-markets'...

i  deploying functions
Running command: cd functions && yarn build
yarn run v1.22.19
$ yarn compile && rm -rf dist && mkdir -p dist/functions && cp -R ../common/lib dist/common && cp -R lib/src dist/functions/src && cp ../yarn.lock dist && cp package.json dist && cp .env.prod dist && cp .env.dev dist
$ tsc -b
✨  Done in 0.66s.
✔  functions: Finished running predeploy script.
i  functions: preparing codebase default for deployment
i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
i  functions: ensuring required API cloudbuild.googleapis.com is enabled...
i  artifactregistry: ensuring required API artifactregistry.googleapis.com is enabled...
✔  functions: required API cloudbuild.googleapis.com is enabled
✔  functions: required API cloudfunctions.googleapis.com is enabled
✔  artifactregistry: required API artifactregistry.googleapis.com is enabled

Error: An unexpected error has occurred.
```