### PR TITLE
Add posts tab, change icon for comments tab

### DIFF
--- a/web/components/user-page.tsx
+++ b/web/components/user-page.tsx
@@ -1,5 +1,6 @@
 import {
   DocumentIcon,
+  ChatIcon,
   FolderIcon,
   PencilIcon,
   ScaleIcon,
@@ -278,37 +279,41 @@ export function UserPage(props: { user: User; posts: Post[] }) {
               },
               {
                 title: 'Comments',
+                stackedTabIcon: <ChatIcon className="h-5" />,
+                content: (
+                  <>
+                    <Col>
+                      <UserCommentsList user={user} />
+                    </Col>
+                  </>
+                ),
+              },
+              {
+                title: 'Posts',
                 stackedTabIcon: <DocumentIcon className="h-5" />,
                 content: (
                   <>
-                    {userPosts.length > 0 && (
-                      <>
-                        <Spacer h={4} />
-
-                        <Row className="flex items-center justify-between">
-                          <SectionHeader label={'Posts'} href={''} />
-
-                          {isCurrentUser && (
-                            <Link
-                              className={clsx(
-                                'mb-3',
-                                buttonClass('md', 'indigo')
-                              )}
-                              href={'/create-post'}
-                              onClick={() => track('profile click create post')}
-                            >
-                              Create Post
-                            </Link>
-                          )}
-                        </Row>
-
-                        <PostCardList posts={userPosts} limit={6} />
-                        <Spacer h={4} />
-                        <SectionHeader label={'Comments'} href={''} />
-                      </>
-                    )}
                     <Col>
-                      <UserCommentsList user={user} />
+                      {isCurrentUser && (
+                        <p className="mt-4 flex items-center justify-between">
+                          <Link
+                            className={clsx(
+                              'mb-3',
+                              buttonClass('md', 'indigo')
+                            )}
+                            href={'/create-post'}
+                            onClick={() => track('profile click create post')}
+                          >
+                            Create Post
+                          </Link>
+                        </p>
+                      )}
+
+                      {!isCurrentUser && userPosts.length == 0 && (
+                        <p className="mt-4 text-gray-500">No posts yet</p>
+                      )}
+
+                      <PostCardList posts={userPosts} limit={6} />
                     </Col>
                   </>
                 ),


### PR DESCRIPTION
This PR aims to address https://github.com/manifoldmarkets/manifold/issues/1363. This was inspired by [this comment thread](https://manifold.markets/MattCWilson/do-you-think-creating-trading-in-an#D4st3ITRUqEl8fVQUmzx).

I did notice that new users are prohibited from creating posts for the first 30 days of use. This PR changes nothing there, although I did wonder if making the posts feature less discoverable was intentional for this reason.

I also followed the [Contributing](https://manifold.markets/MattCWilson/do-you-think-creating-trading-in-an#D4st3ITRUqEl8fVQUmzx) section as best I could. I didn't see anywhere to add or extend UI tests, so I just manually tested these four cases:

    Viewing a user with existing Posts (@ian)
    Viewing a user with no existing Posts (@ACX_Bot)
    Viewing my own user account
    Attempting to create a post as a new user

Everything looks great, no obvious signs of anything breaking.

One other note - it looks like PostCardList is used a number of places, so rather than extending it to do the "no posts yet" capability, I just instead inlined that into the new Posts tab alone. Wanted to go for minimally invasive, but if it's preferable to have that in the component (as it is for UserCommentsList), happy to adjust.

Excited to potentially contribute back to the community! Thanks for your consideration!