### PR TITLE
added yaboi as trustworthy

### DIFF
--- a/common/envs/constants.ts
+++ b/common/envs/constants.ts
@@ -114,6 +114,7 @@ export const CHECK_USERNAMES = [
   'NcyRocks',
   'MichaelWheatley',
   'dglid',
+  'yaboi69',
 ]
 
 export const HOUSE_BOT_USERNAME = 'acc'


### PR DESCRIPTION
can't have the og destiny user not be trustworthy (also needed more people to edit group tags for destiny markets)