### PR TITLE
Implement server-assisted "mark notifications as seen" functionality

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -90,6 +90,7 @@ import { testscheduledfunction } from './test-scheduled-function'
 import { validateiap } from './validate-iap'
 import { swapcert } from './swap-cert'
 import { dividendcert } from './dividend-cert'
+import { markallnotifications } from './mark-all-notifications'
 
 const toCloudFunction = ({ opts, handler }: EndpointDefinition) => {
   return onRequest(opts, handler as any)
@@ -125,6 +126,7 @@ const updateLoansFunction = toCloudFunction(updateloans)
 const validateIAPFunction = toCloudFunction(validateiap)
 const swapCertFunction = toCloudFunction(swapcert)
 const dividendCertFunction = toCloudFunction(dividendcert)
+const markAllNotificationsFunction = toCloudFunction(markallnotifications)
 
 export {
   healthFunction as health,
@@ -158,4 +160,5 @@ export {
   validateIAPFunction as validateiap,
   swapCertFunction as swapcert,
   dividendCertFunction as dividendcert,
+  markAllNotificationsFunction as markallnotifications,
 }

--- a/functions/src/mark-all-notifications.ts
+++ b/functions/src/mark-all-notifications.ts
@@ -1,0 +1,27 @@
+import * as admin from 'firebase-admin'
+import { z } from 'zod'
+import { FieldValue } from 'firebase-admin/firestore'
+import { newEndpoint, validate } from './api'
+
+const bodySchema = z.object({
+  seen: z.boolean(),
+})
+
+export const markallnotifications = newEndpoint({}, async (req, auth) => {
+  const { seen } = validate(bodySchema, req.body)
+  const firestore = admin.firestore()
+  const notifsColl = firestore
+    .collection('users')
+    .doc(auth.uid)
+    .collection('notifications')
+  const notifs = await notifsColl.where('isSeen', '==', !seen).select().get()
+  const writer = firestore.bulkWriter()
+  for (const doc of notifs.docs) {
+    writer.update(doc.ref, {
+      isSeen: seen,
+      viewTime: FieldValue.serverTimestamp(),
+    })
+  }
+  await writer.close()
+  return { success: true, n: notifs.size }
+})

--- a/functions/src/serve.ts
+++ b/functions/src/serve.ts
@@ -32,6 +32,7 @@ import { createpost } from './create-post'
 import { savetwitchcredentials } from './save-twitch-credentials'
 import { testscheduledfunction } from './test-scheduled-function'
 import { validateiap } from 'functions/src/validate-iap'
+import { markallnotifications } from 'functions/src/mark-all-notifications'
 
 type Middleware = (req: Request, res: Response, next: NextFunction) => void
 const app = express()
@@ -77,6 +78,7 @@ addEndpointRoute('/stripewebhook', stripewebhook, express.raw())
 addEndpointRoute('/createpost', createpost)
 addEndpointRoute('/testscheduledfunction', testscheduledfunction)
 addJsonEndpointRoute('/validateIap', validateiap)
+addJsonEndpointRoute('/markallnotifications', markallnotifications)
 
 app.listen(PORT)
 console.log(`Serving functions on port ${PORT}.`)

--- a/web/lib/firebase/api.ts
+++ b/web/lib/firebase/api.ts
@@ -110,3 +110,7 @@ export function createPost(params: {
 export function validateIapReceipt(params: any) {
   return call(getFunctionUrl('validateiap'), 'POST', params)
 }
+
+export function markAllNotifications(params: any) {
+  return call(getFunctionUrl('markallnotifications'), 'POST', params)
+}

--- a/web/lib/firebase/notifications.ts
+++ b/web/lib/firebase/notifications.ts
@@ -3,7 +3,6 @@ import {
   deleteField,
   doc,
   limit,
-  getDocs,
   orderBy,
   query,
   updateDoc,
@@ -95,17 +94,4 @@ export function listenForUnseenNotifications(
     limit(NOTIFICATIONS_PER_PAGE * 10)
   )
   return listenForValues<Notification>(q, setNotifictions)
-}
-
-export const markAllNotificationsAsSeen = async (userId: string) => {
-  const notifsCollection = collection(db, `/users/${userId}/notifications`)
-  const unseenNotifications = await getDocs(
-    query(notifsCollection, where('isSeen', '==', false))
-  )
-  const now = new Date()
-  return await Promise.all(
-    unseenNotifications.docs.map((d) => {
-      return updateDoc(d.ref, { isSeen: true, viewTime: now })
-    })
-  )
 }

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -195,10 +195,10 @@ function NotificationsList(props: { privateUser: PrivateUser }) {
 
   // Mark all notifications as seen.
   useEffect(() => {
-    if (isPageVisible && allGroupedNotifications) {
+    if (isPageVisible) {
       markAllNotifications({ seen: true })
     }
-  }, [privateUser.id, isPageVisible, allGroupedNotifications])
+  }, [privateUser.id, isPageVisible])
 
   if (!paginatedGroupedNotifications || !allGroupedNotifications)
     return <LoadingIndicator />

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -18,7 +18,7 @@ import {
   PARENT_NOTIFICATION_STYLE,
   QuestionOrGroupLink,
 } from 'web/components/notifications/notification-helpers'
-import { markAllNotificationsAsSeen } from 'web/lib/firebase/notifications'
+import { markAllNotifications } from 'web/lib/firebase/api'
 import { NotificationItem } from 'web/components/notifications/notification-types'
 import { PushNotificationsModal } from 'web/components/push-notifications-modal'
 import { SEO } from 'web/components/SEO'
@@ -196,7 +196,7 @@ function NotificationsList(props: { privateUser: PrivateUser }) {
   // Mark all notifications as seen.
   useEffect(() => {
     if (isPageVisible && allGroupedNotifications) {
-      markAllNotificationsAsSeen(privateUser.id)
+      markAllNotifications({ seen: true })
     }
   }, [privateUser.id, isPageVisible, allGroupedNotifications])
 


### PR DESCRIPTION
The previous version of this was very bad in the case that someone had a lot (e.g. thousands) of unread notifications, because it would load them all as a prereq to marking any of them as seen. This version is much more efficient (since on the server we can load the document refs without the data) and it still works once you trigger it even if you navigate away from the page, as opposed to "never getting to" the part where it actually marks them as seen.