### PR TITLE
Web: Fix N/A resolution button for numeric markets

### DIFF
--- a/web/components/numeric-resolution-panel.tsx
+++ b/web/components/numeric-resolution-panel.tsx
@@ -109,7 +109,7 @@ export function NumericResolutionPanel(props: {
           color={outcomeMode === 'CANCEL' ? 'yellow' : 'indigo'}
           label={outcomeMode === 'CANCEL' ? 'N/A' : String(value)}
           marketTitle={question}
-          disabled={outcomeMode === undefined || value === undefined}
+          disabled={outcomeMode === undefined || (value === undefined && outcomeMode !== 'CANCEL')}
         />
       </div>
       {!!error && <div className="text-scarlet-500">{error}</div>}

--- a/web/components/numeric-resolution-panel.tsx
+++ b/web/components/numeric-resolution-panel.tsx
@@ -109,7 +109,10 @@ export function NumericResolutionPanel(props: {
           color={outcomeMode === 'CANCEL' ? 'yellow' : 'indigo'}
           label={outcomeMode === 'CANCEL' ? 'N/A' : String(value)}
           marketTitle={question}
-          disabled={outcomeMode === undefined || (value === undefined && outcomeMode !== 'CANCEL')}
+          disabled={
+            outcomeMode === undefined ||
+            (value === undefined && outcomeMode !== 'CANCEL')
+          }
         />
       </div>
       {!!error && <div className="text-scarlet-500">{error}</div>}


### PR DESCRIPTION
This fixes [bug #1083](https://discord.com/channels/915138780216823849/943628693958459462/1059514377532887090) by not disabling the "Resolve" button if the user has selected to cancel the market.