### PR TITLE
Properly replicate collection groups of stuff into Supabase

### DIFF
--- a/common/transaction-log.ts
+++ b/common/transaction-log.ts
@@ -24,7 +24,8 @@ export type TLEntry<T extends WriteDocument = WriteDocument> = {
   docKind: DocumentKind
   writeKind: WriteKind
   docId: string
-  parent: string
+  parentId: string | null
+  path: string
   data: T | null
   ts: number
 }

--- a/common/transaction-log.ts
+++ b/common/transaction-log.ts
@@ -1,6 +1,7 @@
 export type DocumentKind =
   | 'user'
   | 'userFollow'
+  | 'userReaction'
   | 'contract'
   | 'contractAnswer'
   | 'contractBet'

--- a/common/transaction-log.ts
+++ b/common/transaction-log.ts
@@ -1,6 +1,6 @@
 export type DocumentKind =
   | 'user'
-  | 'userFollower'
+  | 'userFollow'
   | 'contract'
   | 'contractAnswer'
   | 'contractBet'

--- a/functions/src/log-writes.ts
+++ b/functions/src/log-writes.ts
@@ -45,9 +45,9 @@ function logger(path: string, docKind: DocumentKind) {
 }
 
 export const logUsers = logger('users/{id}', 'user')
-export const logUserFollowers = logger(
-  'users/{parent}/followers/{id}',
-  'userFollower'
+export const logUserFollows = logger(
+  'users/{parent}/follows/{id}',
+  'userFollow'
 )
 export const logContracts = logger('contracts/{id}', 'contract')
 export const logContractAnswers = logger(

--- a/functions/src/log-writes.ts
+++ b/functions/src/log-writes.ts
@@ -49,6 +49,10 @@ export const logUserFollows = logger(
   'users/{parent}/follows/{id}',
   'userFollow'
 )
+export const logUserReactions = logger(
+  'users/{parent}/reactions/{id}',
+  'userReaction'
+)
 export const logContracts = logger('contracts/{id}', 'contract')
 export const logContractAnswers = logger(
   'contracts/{parent}/answers/{id}',

--- a/functions/src/scripts/supabase-import.ts
+++ b/functions/src/scripts/supabase-import.ts
@@ -34,6 +34,7 @@ function getWriteRow(
     doc_kind: docKind,
     write_kind: 'create',
     doc_id: snap.id,
+    parent_id: snap.ref.parent.parent?.id,
     data: snap.data(),
     ts: ts.toISOString(),
   }

--- a/functions/src/scripts/supabase-import.ts
+++ b/functions/src/scripts/supabase-import.ts
@@ -115,6 +115,14 @@ async function importDatabase(kinds?: string[]) {
       (c) => c.ref.parent.parent?.parent.path == '/users',
       5000
     )
+  if (shouldImport('userReaction'))
+    await importCollectionGroup(
+      client,
+      firestore.collectionGroup('reactions'),
+      'userReaction',
+      (_) => true,
+      2500
+    )
   if (shouldImport('contract'))
     await importCollection(
       client,

--- a/functions/src/scripts/supabase-import.ts
+++ b/functions/src/scripts/supabase-import.ts
@@ -107,13 +107,13 @@ async function importDatabase(kinds?: string[]) {
 
   if (shouldImport('user'))
     await importCollection(client, firestore.collection('users'), 'user', 500)
-  if (shouldImport('userFollower'))
+  if (shouldImport('userFollow'))
     await importCollectionGroup(
       client,
-      firestore.collectionGroup('followers'),
-      'userFollower',
-      (_) => true,
-      500
+      firestore.collectionGroup('follows'),
+      'userFollow',
+      (c) => c.ref.parent.parent?.parent.path == '/users',
+      5000
     )
   if (shouldImport('contract'))
     await importCollection(
@@ -151,8 +151,8 @@ async function importDatabase(kinds?: string[]) {
       client,
       firestore.collectionGroup('follows'),
       'contractFollow',
-      (_) => true,
-      2500
+      (c) => c.ref.parent.parent?.parent.path == '/contracts',
+      5000
     )
   if (shouldImport('contractLiquidity'))
     await importCollectionGroup(
@@ -170,7 +170,7 @@ async function importDatabase(kinds?: string[]) {
       firestore.collectionGroup('groupContracts'),
       'groupContract',
       (_) => true,
-      500
+      5000
     )
   if (shouldImport('groupMember'))
     await importCollectionGroup(
@@ -178,7 +178,7 @@ async function importDatabase(kinds?: string[]) {
       firestore.collectionGroup('groupMembers'),
       'groupMember',
       (_) => true,
-      2500
+      5000
     )
   if (shouldImport('txn'))
     await importCollection(client, firestore.collection('txns'), 'txn', 2500)

--- a/functions/src/scripts/supabase-import.ts
+++ b/functions/src/scripts/supabase-import.ts
@@ -112,7 +112,7 @@ async function importDatabase(kinds?: string[]) {
       client,
       firestore.collectionGroup('follows'),
       'userFollow',
-      (c) => c.ref.parent.parent?.parent.path == '/users',
+      (c) => c.ref.parent.parent?.parent.path === 'users',
       5000
     )
   if (shouldImport('userReaction'))
@@ -159,7 +159,7 @@ async function importDatabase(kinds?: string[]) {
       client,
       firestore.collectionGroup('follows'),
       'contractFollow',
-      (c) => c.ref.parent.parent?.parent.path == '/contracts',
+      (c) => c.ref.parent.parent?.parent.path == 'contracts',
       5000
     )
   if (shouldImport('contractLiquidity'))

--- a/supabase-replicator/src/replicate-writes.ts
+++ b/supabase-replicator/src/replicate-writes.ts
@@ -55,6 +55,7 @@ export async function replicateWrites(
         event_id: e.eventId,
         doc_kind: e.docKind,
         write_kind: e.writeKind,
+        parent_id: e.parentId,
         doc_id: e.docId,
         data: e.data,
         ts: new Date(e.ts).toISOString(),

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -56,25 +56,25 @@ drop policy if exists "public read" on contract_answers;
 create policy "public read" on contract_answers for select using (true);
 create index concurrently if not exists contract_answers_data_gin on contract_answers using GIN (data);
 
-create table if not exists bets (
+create table if not exists contract_bets (
     id text not null primary key,
     data jsonb not null,
     fs_updated_time timestamp not null
 );
-alter table bets enable row level security;
-drop policy if exists "public read" on bets;
-create policy "public read" on bets for select using (true);
-create index concurrently if not exists bets_data_gin on bets using GIN (data);
+alter table contract_bets enable row level security;
+drop policy if exists "public read" on contract_bets;
+create policy "public read" on contract_bets for select using (true);
+create index concurrently if not exists contract_bets_data_gin on contract_bets using GIN (data);
 
-create table if not exists comments (
+create table if not exists contract_comments (
     id text not null primary key,
     data jsonb not null,
     fs_updated_time timestamp not null
 );
-alter table comments enable row level security;
-drop policy if exists "public read" on comments;
-create policy "public read" on comments for select using (true);
-create index concurrently if not exists comments_data_gin on comments using GIN (data);
+alter table contract_comments enable row level security;
+drop policy if exists "public read" on contract_comments;
+create policy "public read" on contract_comments for select using (true);
+create index concurrently if not exists contract_comments_data_gin on contract_comments using GIN (data);
 
 create table if not exists contract_follows (
     id text not null primary key,
@@ -173,14 +173,14 @@ begin;
   alter publication supabase_realtime add table user_followers;
   alter publication supabase_realtime add table contracts;
   alter publication supabase_realtime add table contract_answers;
+  alter publication supabase_realtime add table contract_bets;
+  alter publication supabase_realtime add table contract_comments;
   alter publication supabase_realtime add table contract_follows;
   alter publication supabase_realtime add table contract_liquidity;
   alter publication supabase_realtime add table groups;
   alter publication supabase_realtime add table group_contracts;
   alter publication supabase_realtime add table group_members;
   alter publication supabase_realtime add table txns;
-  alter publication supabase_realtime add table bets;
-  alter publication supabase_realtime add table comments;
   alter publication supabase_realtime add table manalinks;
   alter publication supabase_realtime add table posts;
   alter publication supabase_realtime add table test;
@@ -209,8 +209,8 @@ begin
     when 'userFollower' then 'user_followers'
     when 'contract' then 'contracts'
     when 'contractAnswer' then 'contract_answers'
-    when 'contractBet' then 'bets'
-    when 'contractComment' then 'comments'
+    when 'contractBet' then 'contract_bets'
+    when 'contractComment' then 'contract_comments'
     when 'contractFollow' then 'contract_follows'
     when 'contractLiquidity' then 'contract_liquidity'
     when 'group' then 'groups'

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -1,5 +1,5 @@
 /* GIN trigram indexes */
-create extension pg_trgm;
+create extension if not exists pg_trgm;
 
 /* enable `explain` via the HTTP API for convenience */
 alter role authenticator set pgrst.db_plan_enabled to true;
@@ -24,12 +24,14 @@ create index concurrently if not exists users_data_gin on users using GIN (data)
 /* indexes supporting @-mention autocomplete */
 create index concurrently if not exists users_name_gin on users using GIN ((data->>'name') gin_trgm_ops);
 create index concurrently if not exists users_username_gin on users using GIN ((data->>'username') gin_trgm_ops);
-create index concurrently if not exists users_follower_count_cached on users (to_jsonb(data->'followerCountCached') desc)
+create index concurrently if not exists users_follower_count_cached on users ((to_jsonb(data->'followerCountCached')) desc);
 
 create table if not exists user_followers (
-    id text not null primary key,
+    user_id text not null,
+    follower_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(user_id, follower_id)
 );
 alter table user_followers enable row level security;
 drop policy if exists "public read" on user_followers;
@@ -47,9 +49,11 @@ create policy "public read" on contracts for select using (true);
 create index concurrently if not exists contracts_data_gin on contracts using GIN (data);
 
 create table if not exists contract_answers (
-    id text not null primary key,
+    contract_id text not null,
+    answer_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(contract_id, answer_id)
 );
 alter table contract_answers enable row level security;
 drop policy if exists "public read" on contract_answers;
@@ -57,9 +61,11 @@ create policy "public read" on contract_answers for select using (true);
 create index concurrently if not exists contract_answers_data_gin on contract_answers using GIN (data);
 
 create table if not exists contract_bets (
-    id text not null primary key,
+    contract_id text not null,
+    bet_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(contract_id, bet_id)
 );
 alter table contract_bets enable row level security;
 drop policy if exists "public read" on contract_bets;
@@ -67,9 +73,11 @@ create policy "public read" on contract_bets for select using (true);
 create index concurrently if not exists contract_bets_data_gin on contract_bets using GIN (data);
 
 create table if not exists contract_comments (
-    id text not null primary key,
+    contract_id text not null,
+    comment_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(contract_id, comment_id)
 );
 alter table contract_comments enable row level security;
 drop policy if exists "public read" on contract_comments;
@@ -77,9 +85,11 @@ create policy "public read" on contract_comments for select using (true);
 create index concurrently if not exists contract_comments_data_gin on contract_comments using GIN (data);
 
 create table if not exists contract_follows (
-    id text not null primary key,
+    contract_id text not null,
+    follower_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(contract_id, follower_id)
 );
 alter table contract_follows enable row level security;
 drop policy if exists "public read" on contract_follows;
@@ -87,9 +97,11 @@ create policy "public read" on contract_follows for select using (true);
 create index concurrently if not exists contract_follows_data_gin on contract_follows using GIN (data);
 
 create table if not exists contract_liquidity (
-    id text not null primary key,
+    contract_id text not null,
+    liquidity_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(contract_id, liquidity_id)
 );
 alter table contract_liquidity enable row level security;
 drop policy if exists "public read" on contract_liquidity;
@@ -107,9 +119,11 @@ create policy "public read" on groups for select using (true);
 create index concurrently if not exists groups_data_gin on groups using GIN (data);
 
 create table if not exists group_contracts (
-    id text not null primary key,
+    group_id text not null,
+    contract_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(group_id, contract_id)
 );
 alter table group_contracts enable row level security;
 drop policy if exists "public read" on group_contracts;
@@ -117,9 +131,11 @@ create policy "public read" on group_contracts for select using (true);
 create index concurrently if not exists group_contracts_data_gin on group_contracts using GIN (data);
 
 create table if not exists group_members (
-    id text not null primary key,
+    group_id text not null,
+    member_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null
+    fs_updated_time timestamp not null,
+    primary key(group_id, member_id)
 );
 alter table group_members enable row level security;
 drop policy if exists "public read" on group_members;
@@ -191,6 +207,7 @@ create table if not exists incoming_writes (
   event_id text null, /* can be null for writes generated by manual import */
   doc_kind text not null,
   write_kind text not null,
+  parent_id text null, /* null for top-level collections */
   doc_id text not null,
   data jsonb null, /* can be null on deletes */
   ts timestamp not null
@@ -198,28 +215,32 @@ create table if not exists incoming_writes (
 alter table incoming_writes enable row level security;
 create index if not exists incoming_writes_ts on incoming_writes (ts desc);
 
-create or replace function get_document_table(doc_kind text)
-  returns text
+drop function if exists get_document_table_spec;
+drop type if exists table_spec;
+create type table_spec as (table_name text, parent_id_col_name text, id_col_name text);
+
+create or replace function get_document_table_spec(doc_kind text)
+  returns table_spec
   language plpgsql
 as
 $$
 begin
   return case doc_kind
-    when 'user' then 'users'
-    when 'userFollower' then 'user_followers'
-    when 'contract' then 'contracts'
-    when 'contractAnswer' then 'contract_answers'
-    when 'contractBet' then 'contract_bets'
-    when 'contractComment' then 'contract_comments'
-    when 'contractFollow' then 'contract_follows'
-    when 'contractLiquidity' then 'contract_liquidity'
-    when 'group' then 'groups'
-    when 'groupContract' then 'group_contracts'
-    when 'groupMember' then 'group_members'
-    when 'txn' then 'txns'
-    when 'manalink' then 'manalinks'
-    when 'post' then 'posts'
-    when 'test' then 'test'
+    when 'user' then cast(('users', null, 'id') as table_spec)
+    when 'userFollower' then cast(('users', 'user_id', 'follower_id') as table_spec)
+    when 'contract' then cast(('contracts', null, 'id') as table_spec)
+    when 'contractAnswer' then cast(('contract_answers', 'contract_id', 'answer_id') as table_spec)
+    when 'contractBet' then cast(('contract_bets', 'contract_id', 'bet_id') as table_spec)
+    when 'contractComment' then cast(('contract_comments', 'contract_id', 'comment_id') as table_spec)
+    when 'contractFollow' then cast(('contract_follows', 'contract_id', 'follower_id') as table_spec)
+    when 'contractLiquidity' then cast(('contract_liquidity', 'contract_id', 'liquidity_id') as table_spec)
+    when 'group' then cast(('groups', null, 'id') as table_spec)
+    when 'groupContract' then cast(('group_contracts', 'group_id', 'contract_id') as table_spec)
+    when 'groupMember' then cast(('group_members', 'group_id', 'member_id') as table_spec)
+    when 'txn' then cast(('txns', null, 'id') as table_spec)
+    when 'manalink' then cast(('manalinks', null, 'id') as table_spec)
+    when 'post' then cast(('posts', null, 'id') as table_spec)
+    when 'test' then cast(('test', null, 'id') as table_spec)
     else null
   end;
 end
@@ -230,26 +251,45 @@ create or replace function replicate_writes_process_one(r incoming_writes)
   language plpgsql
 as
 $$
-declare dest_table text;
+declare dest_table table_spec;
 begin
-  dest_table = get_document_table(r.doc_kind);
-  if dest_table = null then
+  dest_spec = get_document_table_spec(r.doc_kind);
+  if dest_spec = null then
     raise warning 'Invalid document kind.';
     return false;
   end if;
   if r.write_kind = 'create' or r.write_kind = 'update' then
-    execute format(
-      'insert into %1$I (id, data, fs_updated_time) values (%2$L, %3$L, %4$L)
-       on conflict (id) do update set data = %3$L, fs_updated_time = %4$L
-       where %1$I.fs_updated_time <= %4$L
-       returning id;',
-      dest_table, r.doc_id, r.data, r.ts
-    );
+    if dest_spec.parent_id_col_name != null then
+      execute format(
+        'insert into %1$I (%2$I, %3$I, data, fs_updated_time) values (%4$L, %5$L, %6$L, %7$L)
+         on conflict (%2$I, %3$I) do update set data = %6$L, fs_updated_time = %7$L
+         where %1$I.fs_updated_time <= %7$L;',
+        dest_spec.table_name, dest_spec.parent_id_col_name, dest_spec.id_col_name,
+        r.parent_id, r.doc_id, r.data, r.ts
+      );
+    else
+      execute format(
+        'insert into %1$I (%2$I, data, fs_updated_time) values (%3$L, %4$L, %5$L)
+         on conflict (%2$I) do update set data = %4$L, fs_updated_time = %5$L
+         where %1$I.fs_updated_time <= %5$L;',
+        dest_spec.table_name, dest_spec.id_col_name,
+        r.doc_id, r.data, r.ts
+      );
+    end if;
   elsif r.write_kind = 'delete' then
-    execute format(
-      'delete from %1$I where id = %2$L and fs_updated_time <= %3$L',
-      dest_table, r.doc_id, r.ts
-    );
+    if dest_spec.parent_id_col_name != null then
+      execute format(
+        'delete from %1$I where %2$I = %4$L and %3$I = %5$L and fs_updated_time <= %6$L',
+        dest_spec.table_name, dest_spec.parent_id_col_name, dest_spec.id_col_name,
+        r.parent_id, r.doc_id, r.ts
+      );
+    else
+      execute format(
+        'delete from %1$I where %2$I = %3$L and fs_updated_time <= %4$L',
+        dest_spec.table_name, dest_spec.id_col_name,
+        r.doc_id, r.ts
+      );
+    end if;
   else
     raise warning 'Invalid write kind.';
     return false;
@@ -274,7 +314,7 @@ begin
   return query select r.id, replicate_writes_process_one(r) as succeeded
   from incoming_writes as r
   where r.ts >= since
-  order by r.doc_id;
+  order by r.parent_id, r.doc_id;
 end
 $$;
 
@@ -286,7 +326,7 @@ $$
 begin
   perform r.id, replicate_writes_process_one(r) as succeeded
   from new_table as r
-  order by r.doc_id;
+  order by r.parent_id, r.doc_id;
   return null;
 end
 $$;


### PR DESCRIPTION
Problem: We have numerous documents in Firestore at paths like `/groups/{groupId}/groupMembers/{memberId}`, which have two properties:

1. Important information (the group ID) is encoded in the parent path segment of the document, which isn't necessarily present in the document contents.
2. The document ID is not unique in Firestore; rather, the (parent ID, document ID) pair is unique.

Solution: Supabase will now represent these in tables with a composite primary key, e.g. `(group_id, member_id)`. The importing and replication is all fixed up to do this.