### PR TITLE
Add two more of my bots

### DIFF
--- a/common/envs/constants.ts
+++ b/common/envs/constants.ts
@@ -79,6 +79,8 @@ export const BOT_USERNAMES = [
   'Catnee',
   'JeremyK',
   'Botmageddon',
+  'SmartBot',
+  'ShifraGazsi',
 ]
 
 export const CORE_USERNAMES = [


### PR DESCRIPTION
The goal of @Botmageddon is to try and scam the bots out of Manifold tokens.

The reason I need multiple accounts is to create the illusion of momentum.

These two accounts are my partners in crime.

In the meantime, I have exploited the unique trader bonus on the accounts which I know goes against the [Community Guidelines](https://help.manifold.markets/community-guidelines). I have donated all of the bonuses [here](https://manifold.markets/charity/ai-impacts). Feel free to remove the donations if you wish to.

So, in summary, please don't ban me and add these two bots to the list.