### PR TITLE
resetting y axis when changing from profit to portfolio graph zoomed in

### DIFF
--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -32,6 +32,7 @@ export const PortfolioValueSection = memo(
     const onClickNumber = useEvent((mode: GraphMode) => {
       setGraphMode(mode)
       setGraphDisplayNumber(null)
+      setGraphViewYScale(undefined)
     })
     const [graphViewXScale, setGraphViewXScale] =
       useState<ScaleTime<number, number>>()


### PR DESCRIPTION
<img width="832" alt="image" src="https://user-images.githubusercontent.com/46611122/210719490-60119662-85c7-40b7-8e6d-669a7133439c.png">
<img width="820" alt="image" src="https://user-images.githubusercontent.com/46611122/210719507-d103d31f-2f4e-4282-92d7-07eb009a0498.png">
