### PR TITLE
Fix the "warning, you are making a big bet" UI to be less error-prone

### DIFF
--- a/web/components/buttons/confirmation-button.tsx
+++ b/web/components/buttons/confirmation-button.tsx
@@ -17,6 +17,7 @@ export function ConfirmationButton(props: {
   cancelBtn?: {
     label?: string
     color?: ColorType
+    disabled?: boolean
   }
   submitBtn?: {
     label?: string
@@ -56,6 +57,7 @@ export function ConfirmationButton(props: {
             <Button
               color={cancelBtn?.color ?? 'gray-white'}
               onClick={() => updateOpen(false)}
+              disabled={cancelBtn?.disabled}
             >
               {cancelBtn?.label ?? 'Cancel'}
             </Button>

--- a/web/components/buttons/warning-confirmation-button.tsx
+++ b/web/components/buttons/warning-confirmation-button.tsx
@@ -62,6 +62,7 @@ export function WarningConfirmationButton(props: {
       cancelBtn={{
         label: 'Cancel',
         color: 'yellow',
+        disabled: isSubmitting,
       }}
       submitBtn={{
         label: 'Submit',

--- a/web/components/buttons/warning-confirmation-button.tsx
+++ b/web/components/buttons/warning-confirmation-button.tsx
@@ -66,6 +66,7 @@ export function WarningConfirmationButton(props: {
       submitBtn={{
         label: 'Submit',
         color: 'indigo',
+        isSubmitting,
       }}
       onSubmit={onSubmit}
     >

--- a/web/components/buttons/warning-confirmation-button.tsx
+++ b/web/components/buttons/warning-confirmation-button.tsx
@@ -65,7 +65,7 @@ export function WarningConfirmationButton(props: {
       }}
       submitBtn={{
         label: 'Submit',
-        color: 'gray',
+        color: 'indigo',
       }}
       onSubmit={onSubmit}
     >


### PR DESCRIPTION
This addresses two concerns:
1. Having the main action button be gray on gray while "cancel" is yellow is totally bizarre, e.g. it made gwillen think that it might be disabled. Now it's blue like our normal buttons. Still not a fan of the yellow but whatever.
2. It's important that you can't click the "submit" button twice and accidentally make your bet twice.