### PR TITLE
Fix up importing events related stuff

### DIFF
--- a/functions/src/scripts/supabase-import.ts
+++ b/functions/src/scripts/supabase-import.ts
@@ -128,7 +128,7 @@ async function importDatabase(kinds?: string[]) {
       client,
       firestore.collectionGroup('events'),
       'userEvent',
-      (_) => true,
+      (c) => c.ref.parent.parent?.parent.path === 'users',
       2500
     )
   if (shouldImport('userSeenMarket'))

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -1,5 +1,8 @@
 -- noinspection SqlNoDataSourceInspectionForFile
 
+/* allow our backend to have a long statement timeout */
+alter role service_role set statement_timeout = '120s';
+
 /* GIN trigram indexes */
 create extension if not exists pg_trgm;
 


### PR DESCRIPTION
There are ~10 million user events right now so it's good to import them efficiently. Also, don't import the old fake user events in `private-users`.