### PR TITLE
Tweak recommendation SQL to be a little better

### DIFF
--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -425,16 +425,14 @@ create or replace function dot(
   crf contract_recommendation_features
 ) returns real
 immutable parallel safe
-language plpgsql as $$
-begin
-  return (
+language sql as $$
+  select (
     urf.f0 * crf.f0 +
     urf.f1 * crf.f1 +
     urf.f2 * crf.f2 +
     urf.f3 * crf.f3 +
     urf.f4 * crf.f4
   );
-end;
 $$;
 
 -- Use cached tables of user and contract features to computed the top scoring

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -439,7 +439,7 @@ $$;
 
 -- Use cached tables of user and contract features to computed the top scoring
 -- markets for a user.
-create or replace function get_recommended_contract_ids(uid text, count int)
+create or replace function get_recommended_contract_ids(uid text)
 returns table (contract_id text)
 immutable parallel safe
 language sql
@@ -462,7 +462,6 @@ as $$
     and user_seen_markets.contract_id = crf.contract_id
   )
   order by dot(urf, crf) desc
-  limit count
 $$;
 
 create or replace function get_recommended_contracts(uid text, count int)

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -446,7 +446,7 @@ language sql
 as $$
   select crf.contract_id
   from user_recommendation_features as urf
-  left join contract_recommendation_features as crf on true
+  cross join contract_recommendation_features as crf
   where user_id = uid
   -- That has not been viewed.
   and not exists (

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -66,6 +66,8 @@ alter table user_events enable row level security;
 drop policy if exists "public read" on user_events;
 create policy "public read" on user_events for select using (true);
 create index if not exists user_events_data_gin on user_events using GIN (data);
+create index if not exists user_events_user_id_name
+    on user_events (user_id, (to_jsonb(data)->>'name'));
 
 create table if not exists user_seen_markets (
     user_id text not null,


### PR DESCRIPTION
1. I didn't appreciate this until now, but it seems that if you are writing a small function that you are going to call a lot in SQL, it's good for it to be `language sql`, because then it's eligible for inlining. There's a great Stack Overflow answer explaining some differences between `language sql` and `language plpgsql` [here](https://stackoverflow.com/a/24771561).
2. Added an index on `user_events` by `user_id` and `name` to accelerate "have I viewed this market" query and because it just seems like an obviously useful index to have.

Together these changes bring the performance of the thing from about 80ms to about 30ms for my user.

I also fixed a bug, which is that if you asked for `get_recommended_contracts('myid', 10)` you wouldn't actually get 10, because it was first getting the top 10 scores, and then filtering those down to valid recommendations (i.e. open markets.) Now it will get the top 10 valid recommendations, like you asked for.