### PR TITLE
Stop producing AI-generated market groups

### DIFF
--- a/functions/src/create-market.ts
+++ b/functions/src/create-market.ts
@@ -32,7 +32,7 @@ import { NUMERIC_BUCKET_COUNT } from '../../common/numeric-constants'
 import { User } from '../../common/user'
 import { Group, GroupLink, MAX_ID_LENGTH } from '../../common/group'
 import { getPseudoProbability } from '../../common/pseudo-numeric'
-import { getCloseDate, getGroupForMarket } from './helpers/openai-utils'
+import { getCloseDate } from './helpers/openai-utils'
 import { marked } from 'marked'
 import { mintAndPoolCert } from './helpers/cert-txns'
 import { Bet } from 'common/bet'
@@ -172,9 +172,6 @@ export async function createMarketHelper(body: any, auth: AuthedUser) {
         'User must be a member/creator of the group or group must be open to add markets to it.'
       )
     }
-  } else {
-    // generate group using AI
-    group = (await getGroupForMarket(question)) ?? null
   }
 
   const slug = await getSlug(question)


### PR DESCRIPTION
Reasons I think this is ridiculous:

1. It's mixing up valuable, accurate information that we can use for recommendations or UI (groups that informed humans assigned to markets) with trash-quality information, thereby ruining the signal of the accurate information.
2. People constantly complain about the poor quality of the suggestions on Discord and I have yet to hear that someone liked it.
3. The implementation makes it impossible to intentionally create a market with no group, which is a reasonable action to be able to do.
4. The implementation performs poorly (it downloads the whole groups DB to send the names to OpenAI, which is a few dozen megabytes, and then it waits on the response from OpenAI, all serially), degrading the user experience of an operation that's critical to the product (creating a new market.)
5. The implementation is half-assed in other ways (e.g. the prompt looks very naive, what's happening is totally opaque to users, it doesn't log errors...)

All in all I think this feature is substantially net negative and we should reflect on why it stayed live for this long.

If someone is really addicted to the idea of trying to leverage AI to improve group categorization quality, I suggest making a feature that generates group suggestions on the client for markets without any group and presents them in the UI, such that users can then choose to accept them if they think they are good suggestions. That would mostly fix the serious problems listed above.