### PR TITLE
Check in config for fly.io Grafana agent process

### DIFF
--- a/supabase-grafana-agent/Dockerfile
+++ b/supabase-grafana-agent/Dockerfile
@@ -1,0 +1,6 @@
+FROM grafana/agent
+COPY agent.yaml /etc/agent/
+COPY run.sh /run.sh
+RUN chmod +x /run.sh
+USER root
+ENTRYPOINT ["/run.sh"]

--- a/supabase-grafana-agent/README.md
+++ b/supabase-grafana-agent/README.md
@@ -1,0 +1,7 @@
+# supabase-grafana-agent
+
+Configuration for our fly.io Grafana agent host that is responsible for scraping
+the Supabase Prometheus endpoint and sending metrics to Grafana Cloud so we can
+look at them on https://manifoldmarkets.grafana.net/.
+
+Mostly thanks to https://github.com/supabase/grafana-agent-fly-example.

--- a/supabase-grafana-agent/agent.yaml
+++ b/supabase-grafana-agent/agent.yaml
@@ -1,0 +1,29 @@
+server:
+  log_level: debug
+
+integrations:
+  agent:
+    enabled: false
+  node_exporter:
+    enabled: false
+
+metrics:
+  wal_directory: /tmp/wal
+  global:
+    scrape_interval: 5s
+  configs:
+    - name: supa_prom_scraper
+      scrape_configs:
+        - job_name: supa_prom_scraper
+          metrics_path: '/customer/v1/privileged/metrics'
+          basic_auth:
+            username: service_role
+            password: ${SUPABASE_KEY}
+          static_configs:
+            - targets: ['pxidrgkatumlvfqaxcll.supabase.co']
+
+      remote_write:
+        - url: https://prometheus-us-central1.grafana.net/api/prom/push
+          basic_auth:
+            username: 724327
+            password: ${GRAFANA_CLOUD_API_KEY}

--- a/supabase-grafana-agent/fly.toml
+++ b/supabase-grafana-agent/fly.toml
@@ -1,0 +1,12 @@
+app = "grafana-agent-prod"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]

--- a/supabase-grafana-agent/run.sh
+++ b/supabase-grafana-agent/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+exec /bin/agent                                             \
+  --config.file=/etc/agent/agent.yaml                       \
+  --metrics.wal-directory=/etc/agent/data                   \
+  --config.expand-env


### PR DESCRIPTION
Relatively self-explanatory, we have a fly.io app now that forwards the Prometheus metrics from Supabase to Grafana Cloud so we can look at them on a dashboard like this:

![image](https://user-images.githubusercontent.com/428637/211698450-6eaa193f-2246-49d7-95db-88cdd0718d45.png)

## FAQ

Q: What is Prometheus?
A: [Prometheus](https://prometheus.io/) is an very standard OSS tool that scrapes metrics from different sources on a box and then provides them in a standardized format for external tools to consume. Our Supabase instance [exposes](https://supabase.com/docs/guides/platform/metrics) a Prometheus-compatible metrics endpoint.

Q: What data does Prometheus export?
A: It exports a huge shitload of data about the OS on our Supabase instance and about Postgres stats.

Q: What is Grafana?
A: [Grafana](https://grafana.com/) is a very standard OSS tool that ingests time series data and creates a nice webpage with graphs from it. It's designed to read Prometheus metrics.

Q: What is Grafana Cloud?
A: Grafana Cloud is a cloud hosted version of Grafana so that we don't have to run a server with Grafana on it.

Q: What is fly.io?
A: [fly.io](https://fly.io/) is a kind of service that lets you basically run a Dockerfile in the cloud, kind of like Heroku or something.

Q: What is our fly.io app doing?
A: Our fly.io app is making HTTP requests to the Supabase instance Prometheus endpoint, authenticated with the Supabase key, and sending the metrics to our Grafana Cloud account, authenticated with our Grafana Cloud API key.

Q: Why did you do this instead of hosting Grafana on a GCP instance?
A: I was really lazy and it's not important for this to be a very good solution. Supabase already had an example fly.io config for a Grafana agent. It would be trivial to move it to GCP later.

Q: Does this cost money?
A: Our usage currently fits in the free tier of Grafana Cloud and fly.io.

Q: How can I access these things?
A: Contact me for an invite to our fly.io organization or our Grafana Cloud organization.
