### PR TITLE
`preventDefault` on Ctrl-K shortcut

### DIFF
--- a/web/components/search/search-context.tsx
+++ b/web/components/search/search-context.tsx
@@ -25,6 +25,7 @@ export const SearchProvider = (props: { children: ReactNode }) => {
     window.addEventListener('keydown', (e) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         setOpen(true)
+        e.preventDefault()
       }
     })
   }, [])


### PR DESCRIPTION
This was broken on Firefox and Edge because it was continuing to trigger the built-in browser Ctrl-K functionality.

(It might piss off people who use those browsers that we are overriding their stuff, but that's what we signed up for when we decided Ctrl-K should do special stuff on our website.)