### PR TITLE
Get daily profits in modal, highlight when unseen today

### DIFF
--- a/common/events.ts
+++ b/common/events.ts
@@ -1,3 +1,8 @@
+export type UserEvent = {
+  name: string
+  timestamp: number
+}
+
 export type ContractCardView = {
   slug: string
   contractId: string

--- a/common/tracking.ts
+++ b/common/tracking.ts
@@ -1,5 +1,3 @@
-export type UserEvent = ClickEvent
-
 export type ClickEvent = {
   type: 'click'
   contractId: string

--- a/web/components/contract/contract-mention.tsx
+++ b/web/components/contract/contract-mention.tsx
@@ -8,8 +8,12 @@ import { BinaryContractOutcomeLabel } from '../outcome-label'
 import { getTextColor } from '../bet/quick-bet'
 import { useIsClient } from 'web/hooks/use-is-client'
 
-export function ContractMention(props: { contract: Contract }) {
-  const { contract } = props
+export function ContractMention(props: {
+  contract: Contract
+  probChange?: string
+  className?: string
+}) {
+  const { contract, probChange, className } = props
   const { outcomeType, resolution } = contract
   const probTextColor = getTextColor(contract)
   const isClient = useIsClient()
@@ -17,7 +21,10 @@ export function ContractMention(props: { contract: Contract }) {
   return (
     <Link
       href={contractPath(contract)}
-      className="group inline whitespace-nowrap rounded-sm hover:bg-indigo-50 focus:bg-indigo-50"
+      className={clsx(
+        'group inline whitespace-nowrap rounded-sm hover:bg-indigo-50 focus:bg-indigo-50',
+        className
+      )}
       title={isClient ? tooltipLabel(contract) : undefined}
     >
       <span className="break-anywhere mr-0.5 whitespace-normal font-medium text-gray-900">
@@ -39,6 +46,9 @@ export function ContractMention(props: { contract: Contract }) {
             getBinaryProbPercent(contract)
           )}
         </span>
+      )}
+      {!resolution && probChange && (
+        <span className="ml-0.5 text-xs text-gray-500">{probChange}</span>
       )}
       &zwnj;{/* cursor positioning hack */}
     </Link>

--- a/web/components/daily-stats.tsx
+++ b/web/components/daily-stats.tsx
@@ -182,9 +182,9 @@ function DailyProfitModal(props: {
         <Col className={'mb-4'}>
           <Title className={'mb-1'}>Daily profit</Title>
           <span className="text-sm text-gray-500">
-            This is the daily expected value change of all your positions. It
-            includes positions you held in markets that resolved within the past
-            24 hours.
+            This is the 24-hour expected value change of your positions. It
+            includes positions you held in markets that recently resolved.
+            Updates every 15 minutes.
           </span>
         </Col>
         {!data ? (

--- a/web/components/daily-stats.tsx
+++ b/web/components/daily-stats.tsx
@@ -1,24 +1,33 @@
-import React, { useEffect, useState } from 'react'
+import React, { memo, useEffect, useState } from 'react'
 import Router from 'next/router'
 import clsx from 'clsx'
-import { sum } from 'lodash'
+import { keyBy, partition, sortBy } from 'lodash'
 
 import { Col } from 'web/components/layout/col'
 import { User } from 'common/user'
-import {
-  usePrivateUser,
-  useUserContractMetricsByProfit,
-} from 'web/hooks/use-user'
+import { usePrivateUser } from 'web/hooks/use-user'
 import { Row } from 'web/components/layout/row'
-import { formatMoney } from 'common/util/format'
+import { formatMoney, formatPercent } from 'common/util/format'
 import {
   BettingStreakModal,
   hasCompletedStreakToday,
 } from 'web/components/profile/betting-streak-modal'
 import { LoansModal } from 'web/components/profile/loans-modal'
-import Link from 'next/link'
+import { Tooltip } from 'web/components/widgets/tooltip'
+import { Modal } from 'web/components/layout/modal'
+import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import { CPMMBinaryContract } from 'common/contract'
+import { ContractMetrics } from 'common/calculate-metrics'
+import { Grid } from 'gridjs-react'
+import { _ } from 'gridjs-react'
+import { Title } from 'web/components/widgets/title'
+import { ContractMention } from 'web/components/contract/contract-mention'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/outline'
+import { withTracking } from 'web/lib/service/analytics'
+import { getUserEvents } from 'web/lib/supabase/user-events'
+import { DAY_MS } from 'common/lib/util/time'
+import { getUserContractMetricsByProfit } from 'web/lib/supabase/contract-metrics'
 
-const dailyStatsHeaderClass = 'text-gray-500 text-xs font-thin'
 const dailyStatsClass = 'items-center text-lg'
 const rainbowClass = 'text-rainbow'
 export function DailyStats(props: {
@@ -43,7 +52,7 @@ export function DailyStats(props: {
   const [showStreakModal, setShowStreakModal] = useState(false)
 
   return (
-    <Row className={'flex-shrink-0 gap-4'}>
+    <Row className={'flex-shrink-0 items-center gap-4'}>
       <DailyProfit user={user} />
 
       {!streaksHidden && (
@@ -51,15 +60,16 @@ export function DailyStats(props: {
           className="cursor-pointer"
           onClick={() => setShowStreakModal(true)}
         >
-          <div className={dailyStatsHeaderClass}>Streak</div>
-          <Row
-            className={clsx(
-              dailyStatsClass,
-              user && !hasCompletedStreakToday(user) && 'grayscale'
-            )}
-          >
-            <span>{user?.currentBettingStreak ?? 0}🔥</span>
-          </Row>
+          <Tooltip text={'Prediction streak'}>
+            <Row
+              className={clsx(
+                dailyStatsClass,
+                user && !hasCompletedStreakToday(user) && 'grayscale'
+              )}
+            >
+              <span>🔥{user?.currentBettingStreak ?? 0}</span>
+            </Row>
+          </Tooltip>
         </Col>
       )}
       {showLoans && (
@@ -67,17 +77,18 @@ export function DailyStats(props: {
           className="flex cursor-pointer"
           onClick={() => setShowLoansModal(true)}
         >
-          <div className={dailyStatsHeaderClass}>Next loan</div>
-          <Row
-            className={clsx(
-              dailyStatsClass,
-              user && !hasCompletedStreakToday(user) && 'grayscale'
-            )}
-          >
-            <span className="text-teal-500">
-              🏦 {formatMoney(user?.nextLoanCached ?? 0)}
-            </span>
-          </Row>
+          <Tooltip text={'Next loan'}>
+            <Row
+              className={clsx(
+                dailyStatsClass,
+                user && !hasCompletedStreakToday(user) && 'grayscale'
+              )}
+            >
+              <span className="text-teal-500">
+                🏦 {formatMoney(user?.nextLoanCached ?? 0)}
+              </span>
+            </Row>
+          </Tooltip>
         </Col>
       )}
       {showLoansModal && (
@@ -94,29 +105,201 @@ export function DailyStats(props: {
   )
 }
 
-export function DailyProfit(props: { user: User | null | undefined }) {
+export const DailyProfit = memo(function DailyProfit(props: {
+  user: User | null | undefined
+}) {
   const { user } = props
-
-  const contractMetricsByProfit = useUserContractMetricsByProfit(user?.id)
-  const profit = sum(
-    contractMetricsByProfit?.metrics.map((m) =>
-      m.from ? m.from.day.profit : 0
-    ) ?? []
-  )
-  const profitable = profit > 0
-  return (
-    <Link className="mr-2 flex flex-col" href="/daily-movers">
-      <div
-        className={clsx(dailyStatsHeaderClass, profitable && rainbowClass)}
-        style={
-          profitable ? { textShadow: '-0.1px -0.1px rgba(0,0,0,0.2)' } : {}
+  const [open, setOpen] = useState(false)
+  const [seen, setSeen] = useState(true)
+  const dailyProfitEventName = 'click daily profit button'
+  useEffect(() => {
+    // get start of today in ms since epoch
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const todayMs = today.getTime()
+    const todayMsEnd = todayMs + DAY_MS
+    if (user?.id) {
+      getUserEvents(user.id, dailyProfitEventName, todayMs, todayMsEnd).then(
+        (events) => {
+          if (events.length === 0) {
+            setSeen(false)
+          }
         }
+      )
+    }
+  }, [user])
+
+  const profit = user?.profitCached.daily ?? 0
+  const profitable = profit > 0
+  // emoji options: ⌛ 💰 🕛
+  return (
+    <>
+      <button
+        className={clsx(
+          'rounded-md px-2 py-1 text-center transition-colors disabled:cursor-not-allowed',
+          !seen
+            ? 'from-indigo-500 to-blue-500 text-white hover:from-indigo-700 hover:to-blue-700 enabled:bg-gradient-to-r'
+            : profitable
+            ? rainbowClass
+            : ''
+        )}
+        onClick={withTracking(() => {
+          setOpen(true)
+          setSeen(true)
+        }, dailyProfitEventName)}
       >
-        Daily profit
+        <Tooltip text={'Daily profit'}>
+          <Row className={clsx(dailyStatsClass)}>
+            <span>💰{formatMoney(profit)}</span>
+          </Row>
+        </Tooltip>
+      </button>
+      {user && (
+        <DailyProfitModal userId={user.id} setOpen={setOpen} open={open} />
+      )}
+    </>
+  )
+})
+
+function DailyProfitModal(props: {
+  open: boolean
+  setOpen: (open: boolean) => void
+  userId: string
+}) {
+  const { open, setOpen, userId } = props
+  const [data, setData] = useState<
+    { metrics: ContractMetrics[]; contracts: CPMMBinaryContract[] } | undefined
+  >()
+
+  useEffect(() => {
+    if (!open || data) return
+    getUserContractMetricsByProfit(userId).then(setData)
+  }, [data, userId, open])
+
+  return (
+    <Modal open={open} setOpen={setOpen} size={'lg'}>
+      <div className="rounded-lg bg-white p-4">
+        <Col className={'mb-4'}>
+          <Title className={'mb-1'}>Daily profit</Title>
+          <span className="text-sm text-gray-500">
+            This is the daily expected value change of all your positions. It
+            includes positions you held in markets that resolved within the past
+            24 hours.
+          </span>
+        </Col>
+        {!data ? (
+          <LoadingIndicator />
+        ) : (
+          <ProfitChangeTable
+            contracts={data.contracts}
+            metrics={data.metrics}
+            maxRows={4}
+          />
+        )}
       </div>
-      <Row className={clsx(dailyStatsClass, profitable && 'text-teal-500')}>
-        <span>{formatMoney(profit)}</span>{' '}
+    </Modal>
+  )
+}
+
+function ProfitChangeTable(props: {
+  contracts: CPMMBinaryContract[]
+  metrics: ContractMetrics[]
+  maxRows?: number
+}) {
+  const { contracts, metrics, maxRows } = props
+
+  const metricsByContractId = keyBy(metrics, (m) => m.contractId)
+
+  const [positive, negative] = partition(
+    contracts,
+    (c) => (metricsByContractId[c.id].from?.day.profit ?? 0) > 0
+  )
+  // create an array with three columns: contract question, profit, daily change
+  const rows = [
+    ...sortBy(
+      positive,
+      (c) => -(metricsByContractId[c.id].from?.day.profit ?? 0)
+    )
+      .map((c) => [
+        c,
+        // c.probChanges.day,
+        metricsByContractId[c.id].from?.day.profit ?? 0,
+      ])
+      .slice(0, maxRows),
+    ...sortBy(negative, (c) => metricsByContractId[c.id].from?.day.profit ?? 0)
+      .map((c) => [
+        c,
+        // c.probChanges.day,
+        metricsByContractId[c.id].from?.day.profit ?? 0,
+      ])
+      .slice(0, maxRows),
+  ]
+
+  if (positive.length === 0 && negative.length === 0)
+    return <div className="px-4 text-gray-500">None</div>
+
+  const marketRow = (c: CPMMBinaryContract) =>
+    _(
+      <div className={' mb-2'}>
+        <ContractMention
+          contract={c}
+          probChange={
+            (c.probChanges.day > 0 ? '+' : '') +
+            formatPercent(c.probChanges.day).replace('%', '')
+          }
+          className={' line-clamp-2 !whitespace-normal'}
+        />
+      </div>
+    )
+
+  const columnHeader = (text: string) =>
+    _(
+      <Row className={'mx-2 cursor-pointer items-center gap-2 text-gray-600'}>
+        {text}
+        <Col className={'items-center'}>
+          <ChevronUpIcon className="h-2 w-2" />
+          <ChevronDownIcon className=" h-2 w-2" />
+        </Col>
       </Row>
-    </Link>
+    )
+  const profitRow = (profit: number) =>
+    _(
+      <div
+        className={clsx(
+          'mx-2 min-w-[2rem] text-center ',
+          profit > 0 ? 'text-teal-500' : 'text-scarlet-600'
+        )}
+      >
+        {formatMoney(profit)}
+      </div>
+    )
+
+  return (
+    <Col className="mb-4 w-full gap-4 rounded-lg md:flex-row">
+      <Col className="flex-1 gap-4">
+        <Grid
+          data={rows}
+          columns={[
+            {
+              name: columnHeader('Market'),
+              formatter: (c: CPMMBinaryContract) => marketRow(c),
+              id: 'market',
+              sort: {
+                compare: (a: CPMMBinaryContract, b: CPMMBinaryContract) => {
+                  const diff = b.probChanges.day - a.probChanges.day
+                  return diff < 0 ? -1 : diff > 0 ? 1 : 0
+                },
+              },
+            },
+            {
+              name: columnHeader('Profit'),
+              formatter: (value: number) => profitRow(value),
+              id: 'profit',
+            },
+          ]}
+          sort={true}
+        />
+      </Col>
+    </Col>
   )
 }

--- a/web/components/daily-stats.tsx
+++ b/web/components/daily-stats.tsx
@@ -25,7 +25,7 @@ import { ContractMention } from 'web/components/contract/contract-mention'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/outline'
 import { withTracking } from 'web/lib/service/analytics'
 import { getUserEvents } from 'web/lib/supabase/user-events'
-import { DAY_MS } from 'common/lib/util/time'
+import { DAY_MS } from 'common/util/time'
 import { getUserContractMetricsByProfit } from 'web/lib/supabase/contract-metrics'
 
 const dailyStatsClass = 'items-center text-lg'

--- a/web/components/daily-stats.tsx
+++ b/web/components/daily-stats.tsx
@@ -29,7 +29,6 @@ import { DAY_MS } from 'common/util/time'
 import { getUserContractMetricsByProfit } from 'web/lib/supabase/contract-metrics'
 
 const dailyStatsClass = 'items-center text-lg'
-const rainbowClass = 'text-rainbow'
 export function DailyStats(props: {
   user: User | null | undefined
   showLoans?: boolean
@@ -113,24 +112,17 @@ export const DailyProfit = memo(function DailyProfit(props: {
   const [seen, setSeen] = useState(true)
   const dailyProfitEventName = 'click daily profit button'
   useEffect(() => {
-    // get start of today in ms since epoch
+    if (!user) return
     const today = new Date()
     today.setHours(0, 0, 0, 0)
     const todayMs = today.getTime()
     const todayMsEnd = todayMs + DAY_MS
-    if (user?.id) {
-      getUserEvents(user.id, dailyProfitEventName, todayMs, todayMsEnd).then(
-        (events) => {
-          if (events.length === 0) {
-            setSeen(false)
-          }
-        }
-      )
-    }
+    getUserEvents(user.id, dailyProfitEventName, todayMs, todayMsEnd).then(
+      (events) => setSeen(events.length > 0)
+    )
   }, [user])
 
   const profit = user?.profitCached.daily ?? 0
-  const profitable = profit > 0
   // emoji options: ⌛ 💰 🕛
   return (
     <>
@@ -139,8 +131,6 @@ export const DailyProfit = memo(function DailyProfit(props: {
           'rounded-md px-2 py-1 text-center transition-colors disabled:cursor-not-allowed',
           !seen
             ? 'from-indigo-500 to-blue-500 text-white hover:from-indigo-700 hover:to-blue-700 enabled:bg-gradient-to-r'
-            : profitable
-            ? rainbowClass
             : ''
         )}
         onClick={withTracking(() => {
@@ -220,18 +210,10 @@ function ProfitChangeTable(props: {
       positive,
       (c) => -(metricsByContractId[c.id].from?.day.profit ?? 0)
     )
-      .map((c) => [
-        c,
-        // c.probChanges.day,
-        metricsByContractId[c.id].from?.day.profit ?? 0,
-      ])
+      .map((c) => [c, metricsByContractId[c.id].from?.day.profit ?? 0])
       .slice(0, maxRows),
     ...sortBy(negative, (c) => metricsByContractId[c.id].from?.day.profit ?? 0)
-      .map((c) => [
-        c,
-        // c.probChanges.day,
-        metricsByContractId[c.id].from?.day.profit ?? 0,
-      ])
+      .map((c) => [c, metricsByContractId[c.id].from?.day.profit ?? 0])
       .slice(0, maxRows),
   ]
 

--- a/web/components/daily-stats.tsx
+++ b/web/components/daily-stats.tsx
@@ -240,7 +240,7 @@ function ProfitChangeTable(props: {
 
   const marketRow = (c: CPMMBinaryContract) =>
     _(
-      <div className={' mb-2'}>
+      <div className={'mb-3 ml-2 text-lg'}>
         <ContractMention
           contract={c}
           probChange={

--- a/web/components/daily-stats.tsx
+++ b/web/components/daily-stats.tsx
@@ -204,7 +204,6 @@ function ProfitChangeTable(props: {
     contracts,
     (c) => (metricsByContractId[c.id].from?.day.profit ?? 0) > 0
   )
-  // create an array with three columns: contract question, profit, daily change
   const rows = [
     ...sortBy(
       positive,

--- a/web/components/daily-stats.tsx
+++ b/web/components/daily-stats.tsx
@@ -247,7 +247,7 @@ function ProfitChangeTable(props: {
             (c.probChanges.day > 0 ? '+' : '') +
             formatPercent(c.probChanges.day).replace('%', '')
           }
-          className={' line-clamp-2 !whitespace-normal'}
+          className={' line-clamp-3 !whitespace-normal'}
         />
       </div>
     )

--- a/web/lib/supabase/user-events.ts
+++ b/web/lib/supabase/user-events.ts
@@ -1,4 +1,4 @@
-import { run } from 'common/lib/supabase/utils'
+import { run } from 'common/supabase/utils'
 import { db } from 'web/lib/supabase/db'
 import { UserEvent } from 'common/events'
 

--- a/web/lib/supabase/user-events.ts
+++ b/web/lib/supabase/user-events.ts
@@ -1,0 +1,25 @@
+import { run } from 'common/lib/supabase/utils'
+import { db } from 'web/lib/supabase/db'
+import { UserEvent } from 'common/events'
+
+export async function getUserEvents(
+  userId: string,
+  eventName: string,
+  afterTime?: number,
+  beforeTime?: number
+) {
+  let q = db
+    .from('user_events')
+    .select('data')
+    .eq('user_id', userId)
+    .eq('data->>name', eventName)
+
+  if (beforeTime) {
+    q = q.lt('data->>timestamp', beforeTime)
+  }
+  if (afterTime) {
+    q = q.gt('data->>timestamp', afterTime)
+  }
+  const { data } = await run(q)
+  return data as UserEvent[]
+}


### PR DESCRIPTION
- Highlights your daily profit once a day until you click it
  - sidenote: this doesn't add a new prop onto the `user` object, but instead checks your relevant events today via supabase to see if you've done it yet!
- Brings up a modal that you can order by % contract prob change or profit, defaulting to ordered by profit.
- Previously, the daily profit button got 100 contract metrics and 100 contract metrics whenever it was rendered, now it just uses the user's cached daily profit.
- The modal only gets the contracts & metrics from supabase if it's opened

![Screenshot 2023-01-13 at 9 17 40 AM](https://user-images.githubusercontent.com/23196210/212367807-0b947856-ef08-4c05-bbd1-13ed74d916d6.png)
![Screenshot 2023-01-13 at 9 36 47 AM](https://user-images.githubusercontent.com/23196210/212371950-8851515b-362d-43d8-8ee6-5f79146b0fca.png)
