### PR TITLE
Market search and filter/sort at the same time

### DIFF
--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -28,13 +28,14 @@ import { Select } from './widgets/select'
 import { useSafeLayoutEffect } from 'web/hooks/use-safe-layout-effect'
 
 export const SORTS = [
+  { label: 'Relevance', value: 'relevance' },
   { label: 'New', value: 'newest' },
   { label: 'Trending', value: 'score' },
   { label: 'Daily change', value: 'daily-score' },
   { label: '24h volume', value: '24-hour-vol' },
   { label: 'Total traders', value: 'most-popular' },
   { label: 'Liquidity', value: 'liquidity' },
-  { label: 'Last updated', value: 'last-updated' },
+  { label: 'Last activity', value: 'last-updated' },
   { label: 'Closing soon', value: 'close-date' },
   { label: 'Resolve date', value: 'resolve-date' },
   { label: 'Highest %', value: 'prob-descending' },
@@ -139,9 +140,10 @@ export function ContractSearch(props: {
     const id = ++requestId.current
     const requestedPage = freshQuery ? 0 : state.pages.length
     if (freshQuery || requestedPage < state.numPages) {
-      const index = query
-        ? searchIndex
-        : searchClient.initIndex(getIndexName(sort))
+      const index =
+        sort === 'relevance'
+          ? searchIndex
+          : searchClient.initIndex(getIndexName(sort))
       const numericFilters = query
         ? []
         : [
@@ -240,8 +242,8 @@ function ContractSearchControls(props: {
 }) {
   const {
     className,
-    defaultSort,
-    defaultFilter,
+    defaultSort = 'relevance',
+    defaultFilter = 'all',
     additionalFilter,
     persistPrefix,
     hideOrderSelector,
@@ -266,7 +268,7 @@ function ContractSearchControls(props: {
   const savedSort = safeLocalStorage()?.getItem(sortKey)
 
   const [sort, setSort] = usePersistentState(
-    savedSort ?? defaultSort ?? 'score',
+    savedSort ?? defaultSort,
     !useQueryUrlParam
       ? undefined
       : {
@@ -275,7 +277,7 @@ function ContractSearchControls(props: {
         }
   )
   const [filter, setFilter] = usePersistentState(
-    defaultFilter ?? 'open',
+    defaultFilter,
     !useQueryUrlParam
       ? undefined
       : {
@@ -343,36 +345,32 @@ function ContractSearchControls(props: {
   }, [query, sort, openClosedFilter, JSON.stringify(facetFilters)])
 
   return (
-    <Col
+    <div
       className={clsx(
-        'sticky top-0 z-20 mb-1 gap-3 bg-gray-50 pb-2',
+        'sticky top-0 z-20 mb-1 flex flex-col items-stretch gap-3 bg-gray-50 pb-2 pt-px sm:flex-row sm:gap-2',
         className
       )}
     >
-      <div className="mt-px flex flex-col items-stretch gap-3 sm:flex-row sm:gap-2">
-        <Input
-          type="text"
-          inputMode="search"
-          value={query}
-          onChange={(e) => updateQuery(e.target.value)}
-          onBlur={trackCallback('search', { query: query })}
-          placeholder="Search"
-          className="w-full"
-          autoFocus={autoFocus}
-        />
-        {!query && (
-          <SearchFilters
-            filter={filter}
-            selectFilter={selectFilter}
-            hideOrderSelector={hideOrderSelector}
-            selectSort={selectSort}
-            sort={sort}
-            className={'flex flex-row gap-2'}
-            includeProbSorts={includeProbSorts}
-          />
-        )}
-      </div>
-    </Col>
+      <Input
+        type="text"
+        inputMode="search"
+        value={query}
+        onChange={(e) => updateQuery(e.target.value)}
+        onBlur={trackCallback('search', { query: query })}
+        placeholder="Search"
+        className="w-full"
+        autoFocus={autoFocus}
+      />
+      <SearchFilters
+        filter={filter}
+        selectFilter={selectFilter}
+        hideOrderSelector={hideOrderSelector}
+        selectSort={selectSort}
+        sort={sort}
+        className={'flex flex-row gap-2'}
+        includeProbSorts={includeProbSorts}
+      />
+    </div>
   )
 }
 

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -76,11 +76,8 @@ export function ContractSearch(props: {
   }
   headerClassName?: string
   persistPrefix?: string
-  useQueryUrlParam?: boolean
   isWholePage?: boolean
   includeProbSorts?: boolean
-  noControls?: boolean
-  maxResults?: number
   renderContracts?: (
     contracts: Contract[] | undefined,
     loadMore: () => void
@@ -98,11 +95,8 @@ export function ContractSearch(props: {
     highlightCards,
     headerClassName,
     persistPrefix,
-    useQueryUrlParam,
     includeProbSorts,
     isWholePage,
-    noControls,
-    maxResults,
     renderContracts,
     autoFocus,
     profile,
@@ -195,8 +189,7 @@ export function ContractSearch(props: {
   const contracts = state.pages
     .flat()
     .filter((c) => !additionalFilter?.excludeContractIds?.includes(c.id))
-  const renderedContracts =
-    state.pages.length === 0 ? undefined : contracts.slice(0, maxResults)
+  const renderedContracts = state.pages.length === 0 ? undefined : contracts
 
   if (IS_PRIVATE_MANIFOLD || process.env.NEXT_PUBLIC_FIREBASE_EMULATE) {
     return <ContractSearchFirestore additionalFilter={additionalFilter} />
@@ -211,10 +204,9 @@ export function ContractSearch(props: {
         additionalFilter={additionalFilter}
         persistPrefix={persistPrefix}
         hideOrderSelector={hideOrderSelector}
-        useQueryUrlParam={useQueryUrlParam}
+        useQueryUrlParam={isWholePage}
         includeProbSorts={includeProbSorts}
         onSearchParametersChanged={onSearchParametersChanged}
-        noControls={noControls}
         autoFocus={autoFocus}
       />
       {renderContracts ? (
@@ -224,7 +216,6 @@ export function ContractSearch(props: {
       ) : (
         <ContractsGrid
           contracts={renderedContracts}
-          loadMore={noControls ? undefined : performQuery}
           showTime={state.showTime ?? undefined}
           onContractClick={onContractClick}
           highlightCards={highlightCards}
@@ -245,7 +236,6 @@ function ContractSearchControls(props: {
   includeProbSorts?: boolean
   onSearchParametersChanged: (params: SearchParameters) => void
   useQueryUrlParam?: boolean
-  noControls?: boolean
   autoFocus?: boolean
 }) {
   const {
@@ -257,7 +247,6 @@ function ContractSearchControls(props: {
     hideOrderSelector,
     onSearchParametersChanged,
     useQueryUrlParam,
-    noControls,
     autoFocus,
     includeProbSorts,
   } = props
@@ -352,10 +341,6 @@ function ContractSearchControls(props: {
       facetFilters: facetFilters,
     })
   }, [query, sort, openClosedFilter, JSON.stringify(facetFilters)])
-
-  if (noControls) {
-    return <></>
-  }
 
   return (
     <Col

--- a/web/components/profile/user-contracts-list.tsx
+++ b/web/components/profile/user-contracts-list.tsx
@@ -71,7 +71,6 @@ export function UserContractsList(props: { creator: User }) {
       </Row>
       <ContractSearch
         defaultSort="newest"
-        defaultFilter="all"
         additionalFilter={{
           creatorId: creator.id,
         }}

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -64,14 +64,6 @@ export async function getStaticPropz(props: { params: { slugs: string[] } }) {
   const memberIds = group && (await listMemberIds(group))
   const creatorPromise = group ? getUser(group.creatorId) : null
 
-  const contracts =
-    (group && (await listContractsByGroupSlug(group.slug))) ?? []
-  const now = Date.now()
-  const suggestedFilter =
-    contracts.filter((c) => (c.closeTime ?? 0) > now).length < 5
-      ? 'all'
-      : 'open'
-
   const messages = group && (await listAllCommentsOnGroup(group.id))
 
   const cachedTopTraderIds =
@@ -96,7 +88,6 @@ export async function getStaticPropz(props: { params: { slugs: string[] } }) {
       topTraders,
       topCreators,
       messages,
-      suggestedFilter,
       aboutPost,
       posts,
     },
@@ -127,18 +118,10 @@ export default function GroupPage(props: {
     topTraders: [],
     topCreators: [],
     messages: [],
-    suggestedFilter: 'open',
     aboutPost: null,
     posts: [],
   }
-  const {
-    creator,
-    topTraders,
-    topCreators,
-    suggestedFilter,
-    posts,
-    memberIds,
-  } = props
+  const { creator, topTraders, topCreators, posts, memberIds } = props
 
   const router = useRouter()
 
@@ -282,8 +265,6 @@ export default function GroupPage(props: {
               title: 'Markets',
               content: (
                 <ContractSearch
-                  defaultSort={'score'}
-                  defaultFilter={suggestedFilter}
                   additionalFilter={{
                     groupSlug: group.slug,
                     facetFilters: getUsersBlockFacetFilters(privateUser, true),

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -15,7 +15,7 @@ import {
 } from 'web/hooks/use-group'
 import { fromPropz, usePropz } from 'web/hooks/use-propz'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
-import { Contract, listContractsByGroupSlug } from 'web/lib/firebase/contracts'
+import { Contract } from 'web/lib/firebase/contracts'
 import {
   addContractToGroup,
   getGroupBySlug,

--- a/web/pages/search.tsx
+++ b/web/pages/search.tsx
@@ -33,7 +33,6 @@ export default function Search() {
         <Title text="Market search" className="!mt-0" />
         <ContractSearch
           persistPrefix="search"
-          useQueryUrlParam={true}
           autoFocus={autoFocus}
           additionalFilter={{
             facetFilters: getUsersBlockFacetFilters(privateUser),


### PR DESCRIPTION
Adds a sort "relevance" which is the same as not having a sort (pure algolia search, trending if empty)
Aside from that, if user sets a sort then algolia will search with that sort.

The previous UI where the filters disappear when typing was very magic, but I think instead we should have omni be very magic while market search be powerful