### PR TITLE
Implement fancy Typescript stuff for Supabase queries

### DIFF
--- a/common/group.ts
+++ b/common/group.ts
@@ -41,7 +41,9 @@ export type GroupLink = {
   createdTime: number
   userId?: string
 }
+
 export type GroupContractDoc = { contractId: string; createdTime: number }
+export type GroupMemberDoc = { userId: string; createdTime: number }
 
 const excludedGroups = [
   'features',

--- a/common/supabase/utils.ts
+++ b/common/supabase/utils.ts
@@ -5,11 +5,19 @@ import {
   SupabaseClientOptions as SupabaseClientOptionsGeneric,
   createClient as createClientGeneric,
 } from '@supabase/supabase-js'
+
 import { Database } from './schema'
+import { User, PortfolioMetrics } from '../user'
+import { Contract } from '../contract'
+import { Bet } from '../bet'
+import { ContractMetrics } from '../calculate-metrics'
+import { Group, GroupMemberDoc, GroupContractDoc } from '../group'
+import { UserEvent } from '../events'
 
-export type QueryResponse<T> = PostgrestResponse<T> | PostgrestSingleResponse<T>
-
-export type SupabaseClient = SupabaseClientGeneric<Database, 'public'>
+export type Schema = Database['public']
+export type Tables = Schema['Tables']
+export type TableName = keyof Tables
+export type SupabaseClient = SupabaseClientGeneric<Database, 'public', Schema>
 
 export function createClient(
   url: string,
@@ -19,13 +27,54 @@ export function createClient(
   return createClientGeneric(url, key, opts) as SupabaseClient
 }
 
-export async function run<T, R extends QueryResponse<T>>(q: PromiseLike<R>) {
-  const response = await q
-  if (response.error != null) {
-    throw response.error
+export type QueryResponse<T> = PostgrestResponse<T> | PostgrestSingleResponse<T>
+export type QueryMultiSuccessResponse<T> = { data: T[]; count: number }
+export type QuerySingleSuccessResponse<T> = { data: T; count: number }
+
+export async function run<T>(
+  q: PromiseLike<PostgrestResponse<T>>
+): Promise<QueryMultiSuccessResponse<T>>
+export async function run<T>(
+  q: PromiseLike<PostgrestSingleResponse<T>>
+): Promise<QuerySingleSuccessResponse<T>>
+export async function run<T>(
+  q: PromiseLike<PostgrestSingleResponse<T> | PostgrestResponse<T>>
+) {
+  const { data, count, error } = await q
+  if (error != null) {
+    throw error
   } else {
-    // mqp: turn on typing once it works for JSON accesses, see
-    // https://github.com/supabase/postgrest-js/pull/380
-    return { data: response.data as any, count: response.count }
+    return { data, count }
   }
+}
+
+type TableJsonTypes = {
+  users: User
+  user_events: UserEvent
+  user_contract_metrics: ContractMetrics
+  user_portfolio_history: PortfolioMetrics
+  contracts: Contract
+  contract_bets: Bet
+  groups: Group
+  group_members: GroupMemberDoc
+  group_contracts: GroupContractDoc
+}
+
+type DataFor<T extends TableName> = T extends keyof TableJsonTypes
+  ? TableJsonTypes[T]
+  : any
+
+export function selectJson<T extends TableName>(db: SupabaseClient, table: T) {
+  return db.from(table).select<string, { data: DataFor<T> }>('data')
+}
+
+export function selectFrom<
+  T extends TableName,
+  TData extends DataFor<T>,
+  TFields extends (string & keyof TData)[],
+  TResult = Pick<TData, TFields[number]>
+>(db: SupabaseClient, table: T, ...fields: TFields) {
+  const query = fields.map((f) => `data->${f}`).join(', ')
+  const builder = db.from(table).select<string, TResult>(query)
+  return builder
 }

--- a/web/components/buttons/referrals-button.tsx
+++ b/web/components/buttons/referrals-button.tsx
@@ -13,7 +13,7 @@ import { TextButton } from './text-button'
 import { UserLink } from 'web/components/widgets/user-link'
 import { Button } from './button'
 import { getReferralCount, getReferrals } from 'web/lib/supabase/referrals'
-import { SearchUserInfo } from 'web/lib/supabase/users'
+import { UserSearchResult } from 'web/lib/supabase/users'
 
 export const ReferralsButton = memo(function ReferralsButton(props: {
   user: User
@@ -21,7 +21,7 @@ export const ReferralsButton = memo(function ReferralsButton(props: {
 }) {
   const { user, className } = props
   const [isOpen, setIsOpen] = useState(false)
-  const [referrals, setReferrals] = useState<SearchUserInfo[] | undefined>(
+  const [referrals, setReferrals] = useState<UserSearchResult[] | undefined>(
     undefined
   )
   const [referralCount, setReferralCount] = useState(0)
@@ -51,12 +51,12 @@ export const ReferralsButton = memo(function ReferralsButton(props: {
 
 function ReferralsDialog(props: {
   user: User
-  referredUsers: SearchUserInfo[]
+  referredUsers: UserSearchResult[]
   isOpen: boolean
   setIsOpen: (isOpen: boolean) => void
 }) {
   const { user, referredUsers, isOpen, setIsOpen } = props
-  const [referredBy, setReferredBy] = useState<SearchUserInfo[]>([])
+  const [referredBy, setReferredBy] = useState<UserSearchResult[]>([])
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errorText, setErrorText] = useState('')
 

--- a/web/components/filter-select-users.tsx
+++ b/web/components/filter-select-users.tsx
@@ -6,11 +6,11 @@ import { Avatar } from 'web/components/widgets/avatar'
 import { Row } from 'web/components/layout/row'
 import { UserLink } from 'web/components/widgets/user-link'
 import { Input } from './widgets/input'
-import { searchUsers, SearchUserInfo } from 'web/lib/supabase/users'
+import { searchUsers, UserSearchResult } from 'web/lib/supabase/users'
 
 export function FilterSelectUsers(props: {
-  setSelectedUsers: (users: SearchUserInfo[]) => void
-  selectedUsers: SearchUserInfo[]
+  setSelectedUsers: (users: UserSearchResult[]) => void
+  selectedUsers: UserSearchResult[]
   ignoreUserIds: string[]
   showSelectedUsersTitle?: boolean
   selectedUsersClassName?: string
@@ -25,7 +25,7 @@ export function FilterSelectUsers(props: {
     maxUsers,
   } = props
   const [query, setQuery] = useState('')
-  const [filteredUsers, setFilteredUsers] = useState<SearchUserInfo[]>([])
+  const [filteredUsers, setFilteredUsers] = useState<UserSearchResult[]>([])
 
   const requestId = useRef(0)
   useEffect(() => {
@@ -35,7 +35,7 @@ export function FilterSelectUsers(props: {
         // if there's a more recent request, forget about this one
         if (id === requestId.current) {
           setFilteredUsers(
-            results.filter((user: SearchUserInfo) => {
+            results.filter((user) => {
               return (
                 !selectedUsers.some(({ name }) => name === user.name) &&
                 !ignoreUserIds.includes(user.id)
@@ -135,7 +135,7 @@ export function FilterSelectUsers(props: {
               selectedUsersClassName
             )}
           >
-            {selectedUsers.map((user: SearchUserInfo) => (
+            {selectedUsers.map((user) => (
               <div
                 key={user.id}
                 className="col-span-2 flex flex-row items-center justify-between"

--- a/web/components/groups/edit-group-button.tsx
+++ b/web/components/groups/edit-group-button.tsx
@@ -11,7 +11,7 @@ import { FilterSelectUsers } from 'web/components/filter-select-users'
 import { useMemberIds } from 'web/hooks/use-group'
 import { Input } from '../widgets/input'
 import { Button } from '../buttons/button'
-import { SearchUserInfo } from 'web/lib/supabase/users'
+import { UserSearchResult } from 'web/lib/supabase/users'
 
 export function EditGroupButton(props: { group: Group; className?: string }) {
   const { group, className } = props
@@ -20,7 +20,7 @@ export function EditGroupButton(props: { group: Group; className?: string }) {
   const [name, setName] = useState(group.name)
   const [open, setOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [addMemberUsers, setAddMemberUsers] = useState<SearchUserInfo[]>([])
+  const [addMemberUsers, setAddMemberUsers] = useState<UserSearchResult[]>([])
   const memberIds = useMemberIds(group.id) ?? []
   function updateOpen(newOpen: boolean) {
     setAddMemberUsers([])

--- a/web/components/portfolio/portfolio-value-graph.tsx
+++ b/web/components/portfolio/portfolio-value-graph.tsx
@@ -31,38 +31,26 @@ export const PortfolioTooltip = (props: TooltipProps<Date, HistoryPoint>) => {
   )
 }
 
-const getY = (mode: GraphMode, p: PortfolioMetrics) =>
-  p.balance + p.investmentValue - (mode === 'profit' ? p.totalDeposits : 0)
-
-export function getPoints(mode: GraphMode, history: PortfolioMetrics[]) {
-  return history.map((p) => ({
-    x: p.timestamp,
-    y: getY(mode, p),
-    obj: p,
-  }))
-}
-
 export const PortfolioGraph = (props: {
   mode: 'profit' | 'value'
-  history: PortfolioMetrics[]
+  points: HistoryPoint<Partial<PortfolioMetrics>>[]
   width: number
   height: number
   viewScaleProps: viewScale
-  onMouseOver?: (p: HistoryPoint<PortfolioMetrics> | undefined) => void
+  onMouseOver?: (p: HistoryPoint<Partial<PortfolioMetrics>> | undefined) => void
 }) => {
-  const { mode, history, onMouseOver, width, height, viewScaleProps } = props
-  const { data, minDate, maxDate, minValue, maxValue } = useMemo(() => {
-    const data = getPoints(mode, history)
+  const { mode, points, onMouseOver, width, height, viewScaleProps } = props
+  const { minDate, maxDate, minValue, maxValue } = useMemo(() => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const minDate = min(data.map((d) => d.x))!
+    const minDate = min(points.map((d) => d.x))!
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const maxDate = max(data.map((d) => d.x))!
+    const maxDate = max(points.map((d) => d.x))!
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const minValue = min(data.map((d) => d.y))!
+    const minValue = min(points.map((d) => d.y))!
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const maxValue = max(data.map((d) => d.y))!
-    return { data, minDate, maxDate, minValue, maxValue }
-  }, [mode, history])
+    const maxValue = max(points.map((d) => d.y))!
+    return { minDate, maxDate, minValue, maxValue }
+  }, [points])
 
   return (
     <ControllableSingleValueHistoryChart
@@ -73,7 +61,7 @@ export const PortfolioGraph = (props: {
       yScale={scaleLinear([minValue, maxValue], [height - MARGIN_Y, 0])}
       viewScaleProps={viewScaleProps}
       yKind="Ṁ"
-      data={data}
+      data={points}
       curve={curveStepAfter}
       Tooltip={PortfolioTooltip}
       onMouseOver={onMouseOver}

--- a/web/components/search/search.tsx
+++ b/web/components/search/search.tsx
@@ -2,14 +2,13 @@ import { Combobox } from '@headlessui/react'
 import { UsersIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
 import { Contract } from 'common/contract'
-import { User } from 'common/user'
 import { useRouter } from 'next/router'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 import { useTrendingContracts } from 'web/hooks/use-contracts'
 import { getBinaryProbPercent } from 'web/lib/firebase/contracts'
 import { searchContracts } from 'web/lib/service/algolia'
 import { SearchGroupInfo, searchGroups } from 'web/lib/supabase/groups'
-import { searchUsers } from 'web/lib/supabase/users'
+import { searchUsers, UserSearchResult } from 'web/lib/supabase/users'
 import { BinaryContractOutcomeLabel } from '../outcome-label'
 import { Avatar } from '../widgets/avatar'
 import { defaultPages, PageData, searchPages } from './query-pages'
@@ -92,7 +91,7 @@ const Results = (props: { query: string }) => {
   const [{ pageHits, userHits, groupHits, marketHits }, setSearchResults] =
     useState({
       pageHits: [] as PageData[],
-      userHits: [] as User[],
+      userHits: [] as UserSearchResult[],
       groupHits: [] as SearchGroupInfo[],
       marketHits: [] as Contract[],
     })
@@ -181,7 +180,7 @@ const MarketResults = (props: { markets: Contract[] }) => {
   )
 }
 
-const UserResults = (props: { users: User[] }) => {
+const UserResults = (props: { users: UserSearchResult[] }) => {
   if (!props.users.length) return null
   return (
     <>

--- a/web/hooks/use-group.ts
+++ b/web/hooks/use-group.ts
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react'
-import { Group } from 'common/group'
+import { Group, GroupMemberDoc } from 'common/group'
 import { User } from 'common/user'
 import {
   getGroup,
   getMemberGroups,
-  GroupMemberDoc,
   groupMembers,
   listenForGroup,
   listenForGroupContractDocs,

--- a/web/hooks/use-portfolio-history.ts
+++ b/web/hooks/use-portfolio-history.ts
@@ -1,9 +1,11 @@
 import { useQueryClient } from 'react-query'
 import { DAY_MS, HOUR_MS, MINUTE_MS, sleep } from 'common/util/time'
 import { Period } from 'web/lib/firebase/users'
-import { getPortfolioHistory } from 'web/lib/supabase/portfolio-history'
+import {
+  getPortfolioHistory,
+  PortfolioSnapshot,
+} from 'web/lib/supabase/portfolio-history'
 import { useEffect, useState } from 'react'
-import { PortfolioMetrics } from 'common/user'
 
 const getCutoff = (period: Period) => {
   const nowRounded = Math.round(Date.now() / HOUR_MS) * HOUR_MS
@@ -23,7 +25,7 @@ export const usePrefetchPortfolioHistory = (userId: string, period: Period) => {
 export const usePortfolioHistory = (userId: string, period: Period) => {
   const cutoff = getCutoff(period)
   const [portfolioHistory, setPortfolioHistory] = useState<
-    PortfolioMetrics[] | undefined
+    PortfolioSnapshot[] | undefined
   >()
   useEffect(() => {
     setPortfolioHistory(undefined)

--- a/web/hooks/use-referrals.ts
+++ b/web/hooks/use-referrals.ts
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
-import { SearchUserInfo } from 'web/lib/supabase/users'
 import { getReferrals } from 'web/lib/supabase/referrals'
+
+type UserSearchResult = Awaited<ReturnType<typeof getReferrals>>[number]
 
 export const useReferrals = (userId: string) => {
   const [referredUsers, setReferredUsers] = useState<
-    SearchUserInfo[] | undefined
+    UserSearchResult[] | undefined
   >()
 
   useEffect(() => {

--- a/web/lib/firebase/groups.ts
+++ b/web/lib/firebase/groups.ts
@@ -13,7 +13,12 @@ import {
   where,
 } from 'firebase/firestore'
 import { partition, uniq, uniqBy } from 'lodash'
-import { Group, GroupLink } from 'common/group'
+import {
+  Group,
+  GroupMemberDoc,
+  GroupContractDoc,
+  GroupLink,
+} from 'common/group'
 import {
   coll,
   getValue,
@@ -34,9 +39,6 @@ export const groupContracts = (groupId: string) =>
 const openGroupsQuery = query(groups, where('anyoneCanJoin', '==', true))
 export const memberGroupsQuery = (userId: string) =>
   query(collectionGroup(db, 'groupMembers'), where('userId', '==', userId))
-
-export type GroupContractDoc = { contractId: string; createdTime: number }
-export type GroupMemberDoc = { userId: string; createdTime: number }
 
 export function updateGroup(group: Group, updates: Partial<Group>) {
   return updateDoc(doc(groups, group.id), updates)

--- a/web/lib/supabase/bets.ts
+++ b/web/lib/supabase/bets.ts
@@ -1,7 +1,5 @@
 import { db } from './db'
-import { run } from 'common/supabase/utils'
-import { Bet } from 'common/bet'
-import { JsonData } from 'common/supabase/json-data'
+import { run, selectJson } from 'common/supabase/utils'
 import { BetFilter } from 'web/lib/firebase/bets'
 
 export async function getOlderBets(
@@ -9,29 +7,26 @@ export async function getOlderBets(
   beforeTime: number,
   limit: number
 ) {
-  const query = db
-    .from('contract_bets')
-    .select('data')
+  const query = selectJson(db, 'contract_bets')
     .eq('contract_id', contractId)
     .lt('data->>createdTime', beforeTime)
     .order('data->>createdTime', { ascending: false } as any)
     .limit(limit)
   const { data } = await run(query)
 
-  return data.map((d: JsonData<Bet>) => d.data)
+  return data.map((r) => r.data)
 }
 
 export const getBets = async (options?: BetFilter) => {
   const query = getBetsQuery(options)
-  const { data } = (await run(query)) as { data: JsonData<Bet>[] }
-  return data.map((d) => d.data)
+  const { data } = await run(query)
+  return data.map((r) => r.data)
 }
 
 export const getBetsQuery = (options?: BetFilter) => {
-  let q = db
-    .from('contract_bets')
-    .select('data')
-    .order('data->>createdTime', { ascending: options?.order === 'asc' } as any)
+  let q = selectJson(db, 'contract_bets').order('data->>createdTime', {
+    ascending: options?.order === 'asc',
+  } as any)
 
   if (options?.contractId) {
     q = q.eq('contract_id', options.contractId)

--- a/web/lib/supabase/contracts.ts
+++ b/web/lib/supabase/contracts.ts
@@ -1,7 +1,6 @@
-import { run } from 'common/supabase/utils'
+import { run, selectJson } from 'common/supabase/utils'
 import { db } from 'web/lib/supabase/db'
 import { Contract } from 'common/contract'
-import { JsonData } from 'common/supabase/json-data'
 import { chunk } from 'lodash'
 
 export const getContracts = async (contractIds: string[]) => {
@@ -10,10 +9,8 @@ export const getContracts = async (contractIds: string[]) => {
   }
   const chunks = chunk(contractIds, 300)
   const promises = chunks.map((chunk) =>
-    run(db.from('contracts').select('data').in('id', chunk))
+    run(selectJson(db, 'contracts').in('id', chunk))
   )
   const results = await Promise.all(promises)
-  return results.flatMap((result) =>
-    result.data.map((d: JsonData<Contract>) => d.data)
-  )
+  return results.flatMap((result) => result.data.map((r) => r.data))
 }

--- a/web/lib/supabase/groups.ts
+++ b/web/lib/supabase/groups.ts
@@ -1,5 +1,5 @@
 import { db } from './db'
-import { run } from 'common/supabase/utils'
+import { run, selectFrom } from 'common/supabase/utils'
 import { Group } from 'common/group'
 export type SearchGroupInfo = Pick<
   Group,
@@ -13,18 +13,23 @@ export type SearchGroupInfo = Pick<
 >
 
 export async function searchGroups(prompt: string, limit: number) {
-  const query = db
-    .from('groups')
-    .select(
-      'id, data->name, data->about, data->slug, data->totalMembers, data->totalContracts, data->anyoneCanJoin'
-    )
+  const query = selectFrom(
+    db,
+    'groups',
+    'id',
+    'name',
+    'about',
+    'slug',
+    'totalMembers',
+    'totalContracts',
+    'anyoneCanJoin'
+  )
     .order('data->totalMembers', { ascending: false } as any)
     .limit(limit)
   if (prompt)
     query.or(`data->>name.ilike.%${prompt}%,data->>about.ilike.%${prompt}%`)
 
-  const { data } = await run(query)
-  return data as SearchGroupInfo[]
+  return (await run(query)).data
 }
 
 export async function getMemberGroups(userId: string) {
@@ -32,24 +37,30 @@ export async function getMemberGroups(userId: string) {
     db.from('group_members').select('group_id').eq('member_id', userId)
   )
 
-  const { data: groups } = await run(
-    db
-      .from('groups')
-      .select(
-        'id, data->name, data->about, data->slug, data->totalMembers, data->totalContracts, data->anyoneCanJoin'
-      )
-      .in(
-        'id',
-        groupIds.map((d: { group_id: string }) => d.group_id)
-      )
+  const query = selectFrom(
+    db,
+    'groups',
+    'id',
+    'name',
+    'about',
+    'slug',
+    'totalMembers',
+    'totalContracts',
+    'anyoneCanJoin'
+  ).in(
+    'id',
+    groupIds.map((d: { group_id: string }) => d.group_id)
   )
 
-  return groups as SearchGroupInfo[]
+  return (await run(query)).data
 }
 
 export async function getMemberGroupsCount(userId: string) {
-  const { data } = await run(
-    db.from('group_members').select('count').eq('member_id', userId)
+  const { count } = await run(
+    db
+      .from('group_members')
+      .select('*', { head: true, count: 'exact' })
+      .eq('member_id', userId)
   )
-  return data[0].count as number
+  return count
 }

--- a/web/lib/supabase/portfolio-history.ts
+++ b/web/lib/supabase/portfolio-history.ts
@@ -1,17 +1,23 @@
-import { run } from 'common/supabase/utils'
+import { run, selectFrom } from 'common/supabase/utils'
 import { db } from 'web/lib/supabase/db'
-import { PortfolioMetrics } from 'common/user'
 import { sortBy } from 'lodash'
+
+export type PortfolioSnapshot = Awaited<
+  ReturnType<typeof getPortfolioHistory>
+>[number]
 
 export async function getPortfolioHistory(userId: string, cutoff: number) {
   const { data } = await run(
-    db
-      .from('user_portfolio_history')
-      .select(
-        'data->timestamp, data->investmentValue, data->totalDeposits, data->balance'
-      )
+    selectFrom(
+      db,
+      'user_portfolio_history',
+      'timestamp',
+      'investmentValue',
+      'totalDeposits',
+      'balance'
+    )
       .eq('user_id', userId)
       .gt('data->>timestamp', cutoff)
   )
-  return sortBy(data as PortfolioMetrics[], 'timestamp')
+  return sortBy(data, 'timestamp')
 }

--- a/web/lib/supabase/reactions.ts
+++ b/web/lib/supabase/reactions.ts
@@ -1,4 +1,4 @@
-import { run } from 'common/supabase/utils'
+import { run, selectFrom } from 'common/supabase/utils'
 import { db } from 'web/lib/supabase/db'
 import { Reaction } from 'common/reaction'
 
@@ -7,14 +7,18 @@ export type SearchLikedContent = Pick<
   'id' | 'title' | 'slug' | 'contentId' | 'contentType' | 'text'
 >
 export async function getLikedContracts(userId: string) {
+  // The best way to do this would be to join the matching table via contentId and contentType
+  // but not sure if people even use this button, so we'll wait until someone complains
   const { data } = await run(
-    db
-      .from('user_reactions')
-      // The best way to do this would be to join the matching table via contentId and contentType
-      // but not sure if people even use this button, so we'll wait until someone complains
-      .select(
-        'reaction_id, data->title, data->slug, data->contentId, data->contentType, data->text'
-      )
+    selectFrom(
+      db,
+      'user_reactions',
+      'title',
+      'slug',
+      'contentId',
+      'contentType',
+      'text'
+    )
       .eq('user_id', userId)
       .eq('data->>type', 'like')
       .contains('data', { contentType: 'contract' })
@@ -24,13 +28,13 @@ export async function getLikedContracts(userId: string) {
 }
 
 export async function getLikedContractsCount(userId: string) {
-  const { data } = await run(
+  const { count } = await run(
     db
       .from('user_reactions')
-      .select('count')
+      .select('*', { head: true, count: 'exact' })
       .eq('user_id', userId)
       .eq('data->>type', 'like')
       .contains('data', { contentType: 'contract' })
   )
-  return data[0].count as number
+  return count
 }

--- a/web/lib/supabase/referrals.ts
+++ b/web/lib/supabase/referrals.ts
@@ -1,23 +1,25 @@
-import { run } from 'common/supabase/utils'
+import { run, selectFrom } from 'common/supabase/utils'
 import { db } from 'web/lib/supabase/db'
-import { SearchUserInfo } from 'web/lib/supabase/users'
 
 export async function getReferrals(userId: string) {
-  const { data } = await run(
-    db
-      .from('users')
-      .select('id, data->name, data->username, data->avatarUrl')
-      .contains('data', { referredByUserId: userId })
-  )
-  return data as SearchUserInfo[]
+  const query = selectFrom(
+    db,
+    'users',
+    'id',
+    'name',
+    'username',
+    'avatarUrl'
+  ).contains('data', { referredByUserId: userId })
+
+  return (await run(query)).data
 }
 
 export async function getReferralCount(userId: string) {
-  const { data } = await run(
+  const { count } = await run(
     db
       .from('users')
-      .select('count')
+      .select('*', { head: true, count: 'exact' })
       .contains('data', { referredByUserId: userId })
   )
-  return data[0].count as number
+  return count
 }

--- a/web/lib/supabase/user-events.ts
+++ b/web/lib/supabase/user-events.ts
@@ -1,6 +1,5 @@
-import { run } from 'common/supabase/utils'
+import { run, selectJson } from 'common/supabase/utils'
 import { db } from 'web/lib/supabase/db'
-import { UserEvent } from 'common/events'
 
 export async function getUserEvents(
   userId: string,
@@ -8,9 +7,7 @@ export async function getUserEvents(
   afterTime?: number,
   beforeTime?: number
 ) {
-  let q = db
-    .from('user_events')
-    .select('data')
+  let q = selectJson(db, 'user_events')
     .eq('user_id', userId)
     .eq('data->>name', eventName)
 
@@ -20,6 +17,5 @@ export async function getUserEvents(
   if (afterTime) {
     q = q.gt('data->>timestamp', afterTime)
   }
-  const { data } = await run(q)
-  return data as UserEvent[]
+  return (await run(q)).data.map((r) => r.data)
 }

--- a/web/lib/supabase/users.ts
+++ b/web/lib/supabase/users.ts
@@ -1,19 +1,13 @@
 import { db } from './db'
-import { run } from 'common/supabase/utils'
-import { User } from 'common/user'
+import { run, selectFrom } from 'common/supabase/utils'
 import { uniqBy } from 'lodash'
 
-export type SearchUserInfo = Pick<
-  User,
-  'id' | 'name' | 'username' | 'avatarUrl'
->
+export type UserSearchResult = Awaited<ReturnType<typeof searchUsers>>[number]
 
 export async function searchUsers(prompt: string, limit: number) {
   if (prompt === '') {
     const { data } = await run(
-      db
-        .from('users')
-        .select('id, data->name, data->username, data->avatarUrl')
+      selectFrom(db, 'users', 'id', 'name', 'username', 'avatarUrl')
         .order('data->followerCountCached', { ascending: false } as any)
         .limit(limit)
     )
@@ -21,9 +15,7 @@ export async function searchUsers(prompt: string, limit: number) {
   }
 
   const { data: exactData } = await run(
-    db
-      .from('users')
-      .select('id, data->name, data->username, data->avatarUrl')
+    selectFrom(db, 'users', 'id', 'name', 'username', 'avatarUrl')
       .or(`data->>username.ilike.${prompt},data->>name.ilike.${prompt}`)
       .limit(limit)
   )
@@ -33,9 +25,7 @@ export async function searchUsers(prompt: string, limit: number) {
   }
 
   const { data: similarData } = await run(
-    db
-      .from('users')
-      .select('id, data->name, data->username, data->avatarUrl')
+    selectFrom(db, 'users', 'id', 'name', 'username', 'avatarUrl')
       .or(`data->>username.ilike.%${prompt}%,data->>name.ilike.%${prompt}%`)
       .order('data->lastBetTime', {
         ascending: false,


### PR DESCRIPTION
Introducing two new helpers:

- `selectFrom(db, tableName, ...fields)`, which selects the fields in `fields` from the `data` JSON blob in `tableName`, and produces a query returning `Pick<TData, TKeys>` where `TData` is the type of the blob (e.g. `User`, `Contract`) and `TKeys` is the union of the fields.

- `selectJson(db, tableName)`, which just selects the whole `data` blob and produces a query returning `{ data: TData }` where `TData` is the type of the blob.

These should cut down a lot on the type wrangling associated with querying the JSON blob.

The main limitation is that these helpers don't provide an interface to also select other stuff, like computed fields, or joined tables, or whatever. (They could, they just don't.) So they will only help with queries that are just selecting a bunch of fields out of the JSON blob associated with some rows. That's most of our queries though.