### PR TITLE
Fix contract group search SQL

### DIFF
--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -684,7 +684,7 @@ select array_agg(data) from (
     from contracts
     where data->'groupSlugs' ?| elem
     and is_valid_contract(data)
-    order by (to_jsonb(data) ->> 'uniqueBettors7Days')::int desc, to_jsonb(data) ->> 'slug'
+    order by (data->'uniqueBettors7Days')::int desc, data->'slug'
     offset start limit lim
     ) as search_contracts
 $$;
@@ -717,8 +717,8 @@ select array_agg(data) from (
     from contracts
     where data->'groupSlugs' ?| elem
       and is_valid_contract(data)
-      and to_jsonb(data)->>'creatorId' = creator_id
-    order by (to_jsonb(data) ->> 'uniqueBettors7Days')::int desc, to_jsonb(data) ->> 'slug'
+      and data->'creatorId' = creator_id
+    order by (data->'uniqueBettors7Days')::int desc, data->'slug'
     offset start limit lim
 ) as search_contracts
 $$;

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -701,7 +701,7 @@ $$ language sql;
 create or replace function get_time()
     returns bigint
     language sql
-    immutable parallel safe
+    stable parallel safe
 as $$
 select (extract(epoch from now()) * 1000)::bigint;
 $$;

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -681,10 +681,8 @@ create or replace function search_contracts_by_group_slugs(group_slugs text[], l
 as $$
 select array_agg(data) from (
     select data
-    from contracts,
-      jsonb_array_elements(data -> 'groupSlugs')
-          as elem
-    where elem ?| group_slugs
+    from contracts
+    where data->'groupSlugs' ?| elem
     and is_valid_contract(data)
     order by (to_jsonb(data) ->> 'uniqueBettors7Days')::int desc, to_jsonb(data) ->> 'slug'
     offset start limit lim
@@ -716,10 +714,8 @@ create or replace function search_contracts_by_group_slugs_for_creator(creator_i
 as $$
 select array_agg(data) from (
     select data
-    from contracts,
-         jsonb_array_elements(data -> 'groupSlugs')
-             as elem
-    where elem ?| group_slugs
+    from contracts
+    where data->'groupSlugs' ?| elem
       and is_valid_contract(data)
       and to_jsonb(data)->>'creatorId' = creator_id
     order by (to_jsonb(data) ->> 'uniqueBettors7Days')::int desc, to_jsonb(data) ->> 'slug'

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -699,7 +699,7 @@ as $$
 select array_agg(data) from (
     select data
     from contracts
-    where data->'groupSlugs' ?| elem
+    where data->'groupSlugs' ?| group_slugs
     and is_valid_contract(data)
     order by (data->'uniqueBettors7Days')::int desc, data->'slug'
     offset start limit lim
@@ -714,9 +714,9 @@ as $$
 select array_agg(data) from (
     select data
     from contracts
-    where data->'groupSlugs' ?| elem
+    where data->'groupSlugs' ?| group_slugs
       and is_valid_contract(data)
-      and data->'creatorId' = creator_id
+      and data->>'creatorId' = creator_id
     order by (data->'uniqueBettors7Days')::int desc, data->'slug'
     offset start limit lim
 ) as search_contracts

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -126,6 +126,7 @@ alter table contracts enable row level security;
 drop policy if exists "public read" on contracts;
 create policy "public read" on contracts for select using (true);
 create index if not exists contracts_data_gin on contracts using GIN (data);
+create index if not exists contracts_group_slugs_gin on contracts using GIN ((data->'groupSlugs'));
 
 create table if not exists contract_answers (
     contract_id text not null,

--- a/supabase-replicator/supabase/seed.sql
+++ b/supabase-replicator/supabase/seed.sql
@@ -631,7 +631,7 @@ as $$
     select data
     from (
       select * from get_recommended_contract_ids(uid)
-      union 
+      union
       -- Default recommendations from this particular user if none for you.
       select * from get_recommended_contract_ids('Nm2QY6MmdnOu1HJUBcoG2OV2dQF2')
     ) as rec_contract_ids
@@ -705,7 +705,6 @@ create or replace function get_time()
 as $$
 select (extract(epoch from now()) * 1000)::bigint;
 $$;
-
 
 create or replace function search_contracts_by_group_slugs_for_creator(creator_id text,group_slugs text[], lim int, start int)
     returns jsonb[]


### PR DESCRIPTION
1. These functions weren't using any index -- the GIN index on the top-level JSON data doesn't "reach in" and index the contents of arrays and objects inside of it. You have to create an index on individual sub-objects that you want to query by. So they were really slow.

2. `immutable` on `get_time` was just wrong and would result in the wrong time being used in some cases. Please see the documentation [here](https://www.postgresql.org/docs/current/xfunc-volatility.html) to understand these annotations.

3. Cleaned up some unnecessary cruft. (The part of the cleanup where I rearranged the `jsonb_array_elements` stuff was necessary to even use the index.)