### PR TITLE
Introduce `pg-promise` library, use for imports

### DIFF
--- a/common/envs/dev.ts
+++ b/common/envs/dev.ts
@@ -16,7 +16,7 @@ export const DEV_CONFIG: EnvConfig = {
   cloudRunId: 'w3txbmd3ba',
   cloudRunRegion: 'uc',
   amplitudeApiKey: 'fd8cbfd964b9a205b8678a39faae71b3',
-  supabaseUrl: 'https://mfodonznyfxllcezufgr.supabase.co',
+  supabaseInstanceId: 'mfodonznyfxllcezufgr',
   supabaseAnonKey:
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mb2RvbnpueWZ4bGxjZXp1ZmdyIiwicm9sZSI6ImFub24iLCJpYXQiOjE2Njc5ODgxNjcsImV4cCI6MTk4MzU2NDE2N30.RK8CA3G2_yccgiIFoxzweEuJ2XU5SoB7x7wBzMKitvo',
   twitchBotEndpoint: 'https://dev-twitch-bot.manifold.markets',

--- a/common/envs/prod.ts
+++ b/common/envs/prod.ts
@@ -2,7 +2,7 @@ export type EnvConfig = {
   domain: string
   firebaseConfig: FirebaseConfig
   amplitudeApiKey?: string
-  supabaseUrl?: string
+  supabaseInstanceId?: string
   supabaseAnonKey?: string
   twitchBotEndpoint?: string
   sprigEnvironmentId?: string
@@ -64,7 +64,7 @@ type FirebaseConfig = {
 export const PROD_CONFIG: EnvConfig = {
   domain: 'manifold.markets',
   amplitudeApiKey: '2d6509fd4185ebb8be29709842752a15',
-  supabaseUrl: 'https://pxidrgkatumlvfqaxcll.supabase.co',
+  supabaseInstanceId: 'pxidrgkatumlvfqaxcll',
   supabaseAnonKey:
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB4aWRyZ2thdHVtbHZmcWF4Y2xsIiwicm9sZSI6ImFub24iLCJpYXQiOjE2Njg5OTUzOTgsImV4cCI6MTk4NDU3MTM5OH0.d_yYtASLzAoIIGdXUBIgRAGLBnNow7JG2SoaNMQ8ySg',
   sprigEnvironmentId: 'sQcrq9TDqkib',

--- a/common/supabase/utils.ts
+++ b/common/supabase/utils.ts
@@ -19,6 +19,10 @@ export type Tables = Schema['Tables']
 export type TableName = keyof Tables
 export type SupabaseClient = SupabaseClientGeneric<Database, 'public', Schema>
 
+export function getInstanceUrl(instanceId: string) {
+  return `https://${instanceId}.supabase.co`
+}
+
 export function createClient(
   url: string,
   key: string,

--- a/common/supabase/utils.ts
+++ b/common/supabase/utils.ts
@@ -19,15 +19,16 @@ export type Tables = Schema['Tables']
 export type TableName = keyof Tables
 export type SupabaseClient = SupabaseClientGeneric<Database, 'public', Schema>
 
-export function getInstanceUrl(instanceId: string) {
-  return `https://${instanceId}.supabase.co`
+export function getInstanceHostname(instanceId: string) {
+  return `${instanceId}.supabase.co`
 }
 
 export function createClient(
-  url: string,
+  instanceId: string,
   key: string,
   opts?: SupabaseClientOptionsGeneric<'public'>
 ) {
+  const url = `https://${getInstanceHostname(instanceId)}`
   return createClientGeneric(url, key, opts) as SupabaseClient
 }
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -48,6 +48,7 @@
     "marked": "4.1.1",
     "node-fetch": "2",
     "openai": "3.0.1",
+    "pg": "8.8.0",
     "stripe": "8.194.0",
     "zod": "3.17.2"
   },
@@ -55,6 +56,7 @@
     "@types/mailgun-js": "0.22.12",
     "@types/marked": "4.0.7",
     "@types/node-fetch": "2.6.2",
+    "@types/pg": "8.6.6",
     "puppeteer": "18.0.5"
   },
   "private": true

--- a/functions/package.json
+++ b/functions/package.json
@@ -48,7 +48,7 @@
     "marked": "4.1.1",
     "node-fetch": "2",
     "openai": "3.0.1",
-    "pg": "8.8.0",
+    "pg-promise": "11.0.2",
     "stripe": "8.194.0",
     "zod": "3.17.2"
   },
@@ -56,7 +56,6 @@
     "@types/mailgun-js": "0.22.12",
     "@types/marked": "4.0.7",
     "@types/node-fetch": "2.6.2",
-    "@types/pg": "8.6.6",
     "puppeteer": "18.0.5"
   },
   "private": true

--- a/functions/src/scripts/supabase-import.ts
+++ b/functions/src/scripts/supabase-import.ts
@@ -135,9 +135,7 @@ async function importAppendOnlyCollectionGroup(
     log(`Use ${endTime} as the starting point for the next run.`)
     startTime = endTime
     log(
-      `Total documents processed: ${
-        totalProcessed + snap.size
-      }. Total % time processed: ${(
+      `Total documents processed: ${totalProcessed}. Total % time processed: ${(
         ((endTime - originalStartTime) / (t1.getTime() - originalStartTime)) *
         100
       ).toFixed(2)}%.`

--- a/functions/src/supabase/init.ts
+++ b/functions/src/supabase/init.ts
@@ -1,20 +1,20 @@
-import { createClient } from '../../../common/supabase/utils'
+import { createClient, getInstanceUrl } from '../../../common/supabase/utils'
 import { DEV_CONFIG } from '../../../common/envs/dev'
 import { PROD_CONFIG } from '../../../common/envs/prod'
 import { isProd } from '../utils'
 
 export function createSupabaseClient() {
-  const url =
-    process.env.SUPABASE_URL ??
-    (isProd() ? PROD_CONFIG.supabaseUrl : DEV_CONFIG.supabaseUrl)
-  if (!url) {
+  const instanceId =
+    process.env.SUPABASE_INSTANCE_ID ??
+    (isProd() ? PROD_CONFIG.supabaseInstanceId : DEV_CONFIG.supabaseInstanceId)
+  if (!instanceId) {
     throw new Error(
-      "Can't connect to Supabase; no process.env.SUPABASE_URL and no supabaseUrl in config."
+      "Can't connect to Supabase; no process.env.SUPABASE_INSTANCE_ID and no instance ID in config."
     )
   }
   const key = process.env.SUPABASE_KEY
   if (!key) {
     throw new Error("Can't connect to Supabase; no process.env.SUPABASE_KEY.")
   }
-  return createClient(url, key)
+  return createClient(getInstanceUrl(instanceId), key)
 }

--- a/functions/src/supabase/init.ts
+++ b/functions/src/supabase/init.ts
@@ -1,7 +1,15 @@
-import { createClient, getInstanceUrl } from '../../../common/supabase/utils'
+import * as pgPromise from 'pg-promise'
+import {
+  createClient,
+  getInstanceHostname,
+} from '../../../common/supabase/utils'
 import { DEV_CONFIG } from '../../../common/envs/dev'
 import { PROD_CONFIG } from '../../../common/envs/prod'
 import { isProd } from '../utils'
+
+export const pgp = pgPromise()
+
+export type SupabaseDirectClient = ReturnType<typeof createSupabaseDirectClient>
 
 export function createSupabaseClient() {
   const instanceId =
@@ -16,5 +24,28 @@ export function createSupabaseClient() {
   if (!key) {
     throw new Error("Can't connect to Supabase; no process.env.SUPABASE_KEY.")
   }
-  return createClient(getInstanceUrl(instanceId), key)
+  return createClient(instanceId, key)
+}
+
+export function createSupabaseDirectClient() {
+  const instanceId =
+    process.env.SUPABASE_INSTANCE_ID ??
+    (isProd() ? PROD_CONFIG.supabaseInstanceId : DEV_CONFIG.supabaseInstanceId)
+  if (!instanceId) {
+    throw new Error(
+      "Can't connect to Supabase; no process.env.SUPABASE_INSTANCE_ID and no instance ID in config."
+    )
+  }
+  const password = process.env.SUPABASE_PASSWORD
+  if (!password) {
+    throw new Error(
+      "Can't connect to Supabase; no process.env.SUPABASE_PASSWORD."
+    )
+  }
+  return pgp({
+    host: `db.${getInstanceHostname(instanceId)}`,
+    port: 5432,
+    user: 'postgres',
+    password: password,
+  })
 }

--- a/functions/src/supabase/utils.ts
+++ b/functions/src/supabase/utils.ts
@@ -1,0 +1,14 @@
+import { pgp, SupabaseDirectClient } from './init'
+import { Tables, TableName } from '../../../common/supabase/utils'
+
+export async function bulkInsert<
+  T extends TableName,
+  ColumnValues extends Tables[T]['Insert']
+>(db: SupabaseDirectClient, table: T, values: ColumnValues[]) {
+  if (values.length) {
+    const columnNames = Object.keys(values[0])
+    const cs = new pgp.helpers.ColumnSet(columnNames, { table })
+    const query = pgp.helpers.insert(values, cs)
+    await db.none(query)
+  }
+}

--- a/supabase-replicator/src/index.ts
+++ b/supabase-replicator/src/index.ts
@@ -7,7 +7,7 @@ import {
   replayFailedWrites,
 } from './replicate-writes'
 import { log } from './utils'
-import { createClient, getInstanceUrl } from '../../common/supabase/utils'
+import { createClient } from '../../common/supabase/utils'
 import { TLEntry } from '../../common/transaction-log'
 import { CONFIGS } from '../../common/envs/constants'
 
@@ -32,8 +32,7 @@ if (!SUPABASE_KEY) {
 const pubsub = new PubSub()
 const writeSub = pubsub.subscription('supabaseReplicationPullSubscription')
 const firestore = admin.initializeApp().firestore()
-const supabaseUrl = getInstanceUrl(SUPABASE_INSTANCE_ID)
-const supabase = createClient(supabaseUrl, SUPABASE_KEY)
+const supabase = createClient(SUPABASE_INSTANCE_ID, SUPABASE_KEY)
 
 const app = express()
 app.use(express.json())

--- a/supabase-replicator/src/index.ts
+++ b/supabase-replicator/src/index.ts
@@ -7,7 +7,7 @@ import {
   replayFailedWrites,
 } from './replicate-writes'
 import { log } from './utils'
-import { createClient } from '../../common/supabase/utils'
+import { createClient, getInstanceUrl } from '../../common/supabase/utils'
 import { TLEntry } from '../../common/transaction-log'
 import { CONFIGS } from '../../common/envs/constants'
 
@@ -19,9 +19,9 @@ if (CONFIG == null) {
   throw new Error(`process.env.ENVIRONMENT = ${ENV} - should be DEV or PROD.`)
 }
 
-const SUPABASE_URL = CONFIG.supabaseUrl
-if (!SUPABASE_URL) {
-  throw new Error(`Can't connect to Supabase; no supabaseUrl set for ${ENV}.`)
+const SUPABASE_INSTANCE_ID = CONFIG.supabaseInstanceId
+if (!SUPABASE_INSTANCE_ID) {
+  throw new Error(`Can't connect to Supabase; no instance ID set for ${ENV}.`)
 }
 
 const SUPABASE_KEY = process.env.SUPABASE_KEY
@@ -32,7 +32,8 @@ if (!SUPABASE_KEY) {
 const pubsub = new PubSub()
 const writeSub = pubsub.subscription('supabaseReplicationPullSubscription')
 const firestore = admin.initializeApp().firestore()
-const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
+const supabaseUrl = getInstanceUrl(SUPABASE_INSTANCE_ID)
+const supabase = createClient(supabaseUrl, SUPABASE_KEY)
 
 const app = express()
 app.use(express.json())

--- a/web/lib/supabase/db.ts
+++ b/web/lib/supabase/db.ts
@@ -1,4 +1,4 @@
-import { createClient, getInstanceUrl } from 'common/supabase/utils'
+import { createClient } from 'common/supabase/utils'
 import { ENV_CONFIG } from 'common/envs/constants'
 
 if (!ENV_CONFIG.supabaseInstanceId || !ENV_CONFIG.supabaseAnonKey) {
@@ -6,6 +6,6 @@ if (!ENV_CONFIG.supabaseInstanceId || !ENV_CONFIG.supabaseAnonKey) {
 }
 
 export const db = createClient(
-  getInstanceUrl(ENV_CONFIG.supabaseInstanceId),
+  ENV_CONFIG.supabaseInstanceId,
   ENV_CONFIG.supabaseAnonKey
 )

--- a/web/lib/supabase/db.ts
+++ b/web/lib/supabase/db.ts
@@ -1,11 +1,11 @@
-import { createClient } from 'common/supabase/utils'
+import { createClient, getInstanceUrl } from 'common/supabase/utils'
 import { ENV_CONFIG } from 'common/envs/constants'
 
-if (!ENV_CONFIG.supabaseUrl || !ENV_CONFIG.supabaseAnonKey) {
+if (!ENV_CONFIG.supabaseInstanceId || !ENV_CONFIG.supabaseAnonKey) {
   throw new Error("No Supabase config present; Supabase stuff won't work.")
 }
 
 export const db = createClient(
-  ENV_CONFIG.supabaseUrl,
+  getInstanceUrl(ENV_CONFIG.supabaseInstanceId),
   ENV_CONFIG.supabaseAnonKey
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2393,6 +2393,15 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/pg@8.6.6":
+  version "8.6.6"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.6.tgz#21cdf873a3e345a6e78f394677e3b3b1b543cb80"
+  integrity sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/phoenix@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.5.4.tgz#c08a1da6d7b4e365f6a1fe1ff9aada55f5356d24"
@@ -3176,6 +3185,11 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
 buffer@^5.2.1, buffer@^5.5.0:
   version "5.7.1"
@@ -6860,6 +6874,11 @@ pac-resolver@^3.0.0:
     netmask "^1.0.6"
     thunkify "^2.1.2"
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -6938,6 +6957,57 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
+
+pg-connection-string@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
+  integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.5.2.tgz#ed1bed1fb8d79f1c6fd5fb1c99e990fbf9ddf178"
+  integrity sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==
+
+pg-protocol@*, pg-protocol@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
+  integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
+
+pg-types@^2.1.0, pg-types@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.8.0.tgz#a77f41f9d9ede7009abfca54667c775a240da686"
+  integrity sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.5.0"
+    pg-pool "^3.5.2"
+    pg-protocol "^1.5.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+
+pgpass@1.x:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -7027,6 +7097,28 @@ postcss@8.4.14, postcss@^8.4.14:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 preact@^10.10.6:
   version "10.11.3"
@@ -7956,6 +8048,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
   integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
+split2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.1.0.tgz#101907a24370f85bb782f08adaabe4e281ecf809"
+  integrity sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -8815,7 +8912,7 @@ xregexp@2.0.0:
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-2.0.0.tgz#52a63e56ca0b84a7f3a5f3d61872f126ad7a5943"
   integrity sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=
 
-xtend@^4.0.2:
+xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2393,15 +2393,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
-"@types/pg@8.6.6":
-  version "8.6.6"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.6.6.tgz#21cdf873a3e345a6e78f394677e3b3b1b543cb80"
-  integrity sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==
-  dependencies:
-    "@types/node" "*"
-    pg-protocol "*"
-    pg-types "^2.2.0"
-
 "@types/phoenix@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.5.4.tgz#c08a1da6d7b4e365f6a1fe1ff9aada55f5356d24"
@@ -2877,6 +2868,11 @@ asn1@~0.2.3:
   integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
+
+assert-options@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/assert-options/-/assert-options-0.8.0.tgz#cf71882534d23d3027945bc7462e20d3d3682380"
+  integrity sha512-qSELrEaEz4sGwTs4Qh+swQkjiHAysC4rot21+jzXU86dJzNG+FDqBzyS3ohSoTRf4ZLA3FSwxQdiuNl5NXUtvA==
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -6968,17 +6964,32 @@ pg-int8@1.0.1:
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
 
+pg-minify@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/pg-minify/-/pg-minify-1.6.2.tgz#055acfe862cfca3ca0a529020846b0f308d68e70"
+  integrity sha512-1KdmFGGTP6jplJoI8MfvRlfvMiyBivMRP7/ffh4a11RUFJ7kC2J0ZHlipoKiH/1hz+DVgceon9U2qbaHpPeyPg==
+
 pg-pool@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.5.2.tgz#ed1bed1fb8d79f1c6fd5fb1c99e990fbf9ddf178"
   integrity sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==
 
-pg-protocol@*, pg-protocol@^1.5.0:
+pg-promise@11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/pg-promise/-/pg-promise-11.0.2.tgz#50f2acf7f821fa2329b2db6e4fbead07306ec35e"
+  integrity sha512-XSTfU+aRUPjx7FUzGwBfLK/LpJLLMbB1TE6taBpVZBj4kqjuxVdvrSoH6EYF8PPO9OOGIaSK/E8b733b82x7cw==
+  dependencies:
+    assert-options "0.8.0"
+    pg "8.8.0"
+    pg-minify "1.6.2"
+    spex "3.2.0"
+
+pg-protocol@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.5.0.tgz#b5dd452257314565e2d54ab3c132adc46565a6a0"
   integrity sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==
 
-pg-types@^2.1.0, pg-types@^2.2.0:
+pg-types@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
   integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
@@ -8047,6 +8058,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
   integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
+
+spex@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/spex/-/spex-3.2.0.tgz#fa4a21922407e112624977b445a6d634578a1127"
+  integrity sha512-9srjJM7NaymrpwMHvSmpDeIK5GoRMX/Tq0E8aOlDPS54dDnDUIp30DrP9SphMPEETDLzEM9+4qo+KipmbtPecg==
 
 split2@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
This library lets us connect to Postgres directly, so that we can write arbitrary SQL on the backend and run it more efficiently than we can do stuff when only using the HTTP API.