### PR TITLE
Add 1d1w1m switcher to market page

### DIFF
--- a/web/components/buttons/follow-button.tsx
+++ b/web/components/buttons/follow-button.tsx
@@ -92,7 +92,10 @@ export function MiniUserFollowButton(props: {
   if (justFollowed) {
     return (
       <CheckCircleIcon
-        className={clsx('text-highlight-blue h-5 w-5 rounded-full bg-white')}
+        className={clsx(
+          'text-highlight-blue h-5 w-5 rounded-full bg-white',
+          className
+        )}
         aria-label="followed"
       />
     )

--- a/web/components/buttons/follow-button.tsx
+++ b/web/components/buttons/follow-button.tsx
@@ -61,8 +61,11 @@ export function UserFollowButton(props: { userId: string }) {
   )
 }
 
-export function MiniUserFollowButton(props: { userId: string }) {
-  const { userId } = props
+export function MiniUserFollowButton(props: {
+  userId: string
+  className?: string
+}) {
+  const { userId, className } = props
   const user = useUser()
   const privateUser = usePrivateUser()
   const following = useFollows(user?.id)
@@ -90,7 +93,7 @@ export function MiniUserFollowButton(props: { userId: string }) {
     return (
       <CheckCircleIcon
         className={clsx('text-highlight-blue h-5 w-5 rounded-full bg-white')}
-        aria-hidden="true"
+        aria-label="followed"
       />
     )
   }
@@ -103,15 +106,17 @@ export function MiniUserFollowButton(props: { userId: string }) {
   )
     return null
   return (
-    <>
-      <button onClick={withTracking(() => follow(user.id, userId), 'follow')}>
-        <PlusCircleIcon
-          className={clsx(
-            'text-highlight-blue hover:text-hover-blue h-5 w-5 rounded-full bg-white'
-          )}
-          aria-hidden="true"
-        />
-      </button>
-    </>
+    <button
+      onClick={withTracking(() => follow(user.id, userId), 'follow')}
+      className={className}
+      title="follow"
+    >
+      <PlusCircleIcon
+        className={clsx(
+          'text-highlight-blue hover:text-hover-blue h-5 w-5 rounded-full bg-white'
+        )}
+        aria-hidden
+      />
+    </button>
   )
 }

--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -14,7 +14,11 @@ import {
   formatDateInRange,
   formatPct,
 } from '../helpers'
-import { HistoryPoint, SingleValueHistoryChart } from '../generic-charts'
+import {
+  ControllableSingleValueHistoryChart,
+  HistoryPoint,
+  viewScale,
+} from '../generic-charts'
 import { Row } from 'web/components/layout/row'
 import { Avatar } from 'web/components/widgets/avatar'
 
@@ -45,11 +49,22 @@ export const BinaryContractChart = (props: {
   betPoints: HistoryPoint<Partial<Bet>>[]
   width: number
   height: number
+  viewScaleProps: viewScale
+  controlledStart?: number
   color?: string
   onMouseOver?: (p: HistoryPoint<Partial<Bet>> | undefined) => void
 }) => {
-  const { contract, width, height, onMouseOver, color } = props
-  const [start, end] = getDateRange(contract)
+  const {
+    contract,
+    width,
+    height,
+    viewScaleProps,
+    controlledStart,
+    onMouseOver,
+    color,
+  } = props
+  const [calcStart, end] = getDateRange(contract)
+  const start = controlledStart ?? calcStart
   const startP = getInitialProbability(contract)
   const endP = getProbability(contract)
   const betPoints = useMemo(
@@ -73,12 +88,13 @@ export const BinaryContractChart = (props: {
   const xScale = scaleTime(visibleRange, [0, width - MARGIN_X])
   const yScale = scaleLinear([0, 1], [height - MARGIN_Y, 0])
   return (
-    <SingleValueHistoryChart
+    <ControllableSingleValueHistoryChart
       w={width}
       h={height}
       margin={MARGIN}
       xScale={xScale}
       yScale={yScale}
+      viewScaleProps={viewScaleProps}
       yKind="percent"
       data={data}
       color={color ?? '#11b981'}

--- a/web/components/charts/contract/binary.tsx
+++ b/web/components/charts/contract/binary.tsx
@@ -63,8 +63,8 @@ export const BinaryContractChart = (props: {
     onMouseOver,
     color,
   } = props
-  const [calcStart, end] = getDateRange(contract)
-  const start = controlledStart ?? calcStart
+  const [start, end] = getDateRange(contract)
+  const rangeStart = controlledStart ?? start
   const startP = getInitialProbability(contract)
   const endP = getProbability(contract)
   const betPoints = useMemo(
@@ -84,7 +84,7 @@ export const BinaryContractChart = (props: {
     last(betPoints)?.x,
     Date.now()
   )
-  const visibleRange = [start, rightmostDate]
+  const visibleRange = [rangeStart, rightmostDate]
   const xScale = scaleTime(visibleRange, [0, width - MARGIN_X])
   const yScale = scaleLinear([0, 1], [height - MARGIN_Y, 0])
   return (

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -87,8 +87,8 @@ export const PseudoNumericContractChart = (props: {
     onMouseOver,
   } = props
   const { min, max, isLogScale } = contract
-  const [calcStart, end] = getDateRange(contract)
-  const start = controlledStart ?? calcStart
+  const [start, end] = getDateRange(contract)
+  const rangeStart = controlledStart ?? start
   const scaleP = useMemo(
     () => getScaleP(min, max, isLogScale),
     [min, max, isLogScale]
@@ -112,7 +112,7 @@ export const PseudoNumericContractChart = (props: {
     last(betPoints)?.x,
     Date.now()
   )
-  const visibleRange = [start, rightmostDate]
+  const visibleRange = [rangeStart, rightmostDate]
   const xScale = scaleTime(visibleRange, [0, width - MARGIN_X])
   // clamp log scale to make sure zeroes go to the bottom
   const yScale = isLogScale

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -15,7 +15,11 @@ import {
   getRightmostVisibleDate,
   formatDateInRange,
 } from '../helpers'
-import { HistoryPoint, SingleValueHistoryChart } from '../generic-charts'
+import {
+  HistoryPoint,
+  ControllableSingleValueHistoryChart,
+  viewScale,
+} from '../generic-charts'
 import { Row } from 'web/components/layout/row'
 import { Avatar } from 'web/components/widgets/avatar'
 
@@ -68,12 +72,23 @@ export const PseudoNumericContractChart = (props: {
   betPoints: HistoryPoint<Partial<Bet>>[]
   width: number
   height: number
+  viewScaleProps: viewScale
+  controlledStart?: number
   color?: string
   onMouseOver?: (p: HistoryPoint<Partial<Bet>> | undefined) => void
 }) => {
-  const { contract, width, height, color, onMouseOver } = props
+  const {
+    contract,
+    width,
+    height,
+    viewScaleProps,
+    controlledStart,
+    color,
+    onMouseOver,
+  } = props
   const { min, max, isLogScale } = contract
-  const [start, end] = getDateRange(contract)
+  const [calcStart, end] = getDateRange(contract)
+  const start = controlledStart ?? calcStart
   const scaleP = useMemo(
     () => getScaleP(min, max, isLogScale),
     [min, max, isLogScale]
@@ -104,12 +119,13 @@ export const PseudoNumericContractChart = (props: {
     ? scaleLog([Math.max(min, 1), max], [height - MARGIN_Y, 0]).clamp(true)
     : scaleLinear([min, max], [height - MARGIN_Y, 0])
   return (
-    <SingleValueHistoryChart
+    <ControllableSingleValueHistoryChart
       w={width}
       h={height}
       margin={MARGIN}
       xScale={xScale}
       yScale={yScale}
+      viewScaleProps={viewScaleProps}
       data={data}
       curve={curveStepAfter}
       onMouseOver={onMouseOver}

--- a/web/components/charts/generic-charts.tsx
+++ b/web/components/charts/generic-charts.tsx
@@ -450,58 +450,30 @@ export const ControllableSingleValueHistoryChart = <
   )
 }
 
-export const SingleValueHistoryChart = <P extends HistoryPoint>(props: {
-  data: P[]
-  w: number
-  h: number
-  color: string | ((p: P) => string)
-  margin: Margin
-  xScale: ScaleTime<number, number>
-  yScale: ScaleContinuousNumeric<number, number>
-  yKind?: ValueKind
-  curve?: CurveFactory
-  onMouseOver?: (p: P | undefined) => void
-  Tooltip?: TooltipComponent<Date, P>
-  pct?: boolean
-}) => {
-  const {
-    data,
-    w,
-    h,
-    color,
-    margin,
-    xScale,
-    yScale,
-    yKind,
-    curve,
-    onMouseOver,
-    Tooltip,
-    pct,
-  } = props
+export const SingleValueHistoryChart = <P extends HistoryPoint>(
+  props: Omit<
+    Parameters<typeof ControllableSingleValueHistoryChart<P>>[0],
+    'viewScaleProps'
+  >
+) => {
+  const viewScaleProps = useSingleValueHistoryChartViewScale()
+
+  return (
+    <ControllableSingleValueHistoryChart
+      {...props}
+      viewScaleProps={viewScaleProps}
+    />
+  )
+}
+
+export const useSingleValueHistoryChartViewScale = () => {
   const [viewXScale, setViewXScale] = useState<ScaleTime<number, number>>()
   const [viewYScale, setViewYScale] =
     useState<ScaleContinuousNumeric<number, number>>()
-  const viewScaleProps = {
+  return {
     viewXScale,
     setViewXScale,
     viewYScale,
     setViewYScale,
   }
-  return (
-    <ControllableSingleValueHistoryChart
-      w={w}
-      h={h}
-      margin={margin}
-      xScale={xScale}
-      yScale={yScale}
-      viewScaleProps={viewScaleProps}
-      yKind={yKind}
-      data={data}
-      curve={curve}
-      Tooltip={Tooltip}
-      onMouseOver={onMouseOver}
-      color={color}
-      pct={pct}
-    />
-  )
 }

--- a/web/components/charts/time-range-picker.tsx
+++ b/web/components/charts/time-range-picker.tsx
@@ -1,3 +1,5 @@
+import clsx from 'clsx'
+import { periodDurations } from 'web/hooks/use-portfolio-history'
 import { Period } from 'web/lib/firebase/users'
 import { ChoicesToggleGroup, ColorType } from '../choices-toggle-group'
 
@@ -11,19 +13,35 @@ const labels: { [label: string]: Period } = {
 export const TimeRangePicker = (props: {
   currentTimePeriod: Period
   setCurrentTimePeriod: (period: Period) => void
+  /** milliseconds */
+  maxRange?: number
   color?: ColorType
   disabled?: boolean
+  className?: string
 }) => {
-  const { currentTimePeriod, setCurrentTimePeriod, color, disabled } = props
+  const {
+    currentTimePeriod,
+    setCurrentTimePeriod,
+    maxRange,
+    color,
+    disabled,
+    className,
+  } = props
+
+  const disabledOptions = !maxRange
+    ? undefined
+    : Object.values(labels).filter(
+        (period) => period !== 'allTime' && periodDurations[period] > maxRange
+      )
 
   return (
     <ChoicesToggleGroup
       currentChoice={currentTimePeriod}
       choicesMap={labels}
       setChoice={setCurrentTimePeriod as any}
-      disabled={disabled}
+      disabledOptions={disabledOptions}
       color={color}
-      className="mt-1 !gap-1 self-start !shadow-none"
+      className={clsx('!shadow-none', className)}
       toggleClassName="py-1 !px-1"
     />
   )

--- a/web/components/charts/time-range-picker.tsx
+++ b/web/components/charts/time-range-picker.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { periodDurations } from 'web/hooks/use-portfolio-history'
+import { periodDurations } from 'web/lib/util/time'
 import { Period } from 'web/lib/firebase/users'
 import { ChoicesToggleGroup, ColorType } from '../choices-toggle-group'
 

--- a/web/components/charts/time-range-picker.tsx
+++ b/web/components/charts/time-range-picker.tsx
@@ -39,6 +39,7 @@ export const TimeRangePicker = (props: {
       currentChoice={currentTimePeriod}
       choicesMap={labels}
       setChoice={setCurrentTimePeriod as any}
+      disabled={disabled}
       disabledOptions={disabledOptions}
       color={color}
       className={clsx('!shadow-none', className)}

--- a/web/components/choices-toggle-group.tsx
+++ b/web/components/choices-toggle-group.tsx
@@ -18,6 +18,7 @@ export function ChoicesToggleGroup(props: {
   currentChoice: number | string
   choicesMap: { [key: string]: string | number }
   disabled?: boolean
+  disabledOptions?: Array<string | number> //values
   setChoice: (p: number | string) => void
   color?: ColorType
   className?: string
@@ -28,6 +29,7 @@ export function ChoicesToggleGroup(props: {
     currentChoice,
     setChoice,
     disabled,
+    disabledOptions,
     choicesMap,
     color = 'indigo-dark',
     className,
@@ -49,10 +51,11 @@ export function ChoicesToggleGroup(props: {
         <RadioGroup.Option
           key={choiceKey}
           value={choice}
+          disabled={disabledOptions?.includes(choice)}
           className={({ disabled }) =>
             clsx(
               disabled
-                ? 'cursor-not-allowed text-gray-400 aria-checked:bg-gray-300'
+                ? 'cursor-not-allowed text-gray-300 aria-checked:bg-gray-300 aria-checked:text-white'
                 : 'cursor-pointer ' + colorClasses[color],
               'flex items-center rounded-md p-2 outline-none ring-indigo-500 transition-all focus-visible:ring-2 sm:px-3',
               toggleClassName

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -23,6 +23,7 @@ import {
   BinaryContractOutcomeLabel,
   CancelLabel,
   FreeResponseOutcomeLabel,
+  NumericValueLabel,
 } from '../outcome-label'
 import {
   getOutcomeProbability,
@@ -237,44 +238,38 @@ export const ContractCard = memo(function ContractCard(props: {
   )
 })
 
+// TODO: move the "resolution or chance" components out of this file
+
 export function BinaryResolutionOrChance(props: {
   contract: BinaryContract
-  large?: boolean
   className?: string
 }) {
-  const { contract, large, className } = props
+  const { contract, className } = props
   const { resolution } = contract
   const textColor = getTextColor(contract)
 
   const prob = getBinaryProbPercent(contract)
 
   return (
-    <Col
-      className={clsx('items-end', large ? 'text-4xl' : 'text-3xl', className)}
-    >
+    <Row className={clsx('items-baseline gap-2 text-3xl', className)}>
       {resolution ? (
-        <Row className="flex items-start">
-          <div>
-            <div
-              className={clsx('text-gray-500', large ? 'text-xl' : 'text-base')}
-            >
-              Resolved
-            </div>
-            <BinaryContractOutcomeLabel
-              contract={contract}
-              resolution={resolution}
-            />
+        <>
+          <div className={clsx('text-base font-light')}>
+            Resolved
+            {resolution === 'MKT' && ' as '}
           </div>
-        </Row>
+          <BinaryContractOutcomeLabel
+            contract={contract}
+            resolution={resolution}
+          />
+        </>
       ) : (
         <>
           <div className={textColor}>{prob}</div>
-          <div className={clsx(textColor, large ? 'text-xl' : 'text-base')}>
-            chance
-          </div>
+          <div className={clsx(textColor, 'text-base font-light')}>chance</div>
         </>
       )}
-    </Col>
+    </Row>
   )
 }
 
@@ -381,7 +376,6 @@ export function PseudoNumericResolutionOrExpectation(props: {
 }) {
   const { contract, className } = props
   const { resolution, resolutionValue, resolutionProbability } = contract
-  const textColor = `text-gray-900`
 
   const value = resolution
     ? resolutionValue
@@ -390,31 +384,29 @@ export function PseudoNumericResolutionOrExpectation(props: {
     : getMappedValue(contract)(getProbability(contract))
 
   return (
-    <Col className={clsx(resolution ? 'text-3xl' : 'text-xl', className)}>
+    <Row className={clsx('items-baseline gap-2 text-3xl', className)}>
       {resolution ? (
         <>
-          <div className={clsx('text-base text-gray-500')}>Resolved</div>
-
+          <div className="text-base font-light">Resolved</div>
           {resolution === 'CANCEL' ? (
             <CancelLabel />
           ) : (
-            <Tooltip className={textColor} text={value.toFixed(2)}>
-              {formatLargeNumber(value)}
-            </Tooltip>
+            <>
+              <Tooltip text={value.toFixed(2)} placement="bottom">
+                <NumericValueLabel value={value} />
+              </Tooltip>
+            </>
           )}
         </>
       ) : (
         <>
-          <Tooltip
-            className={clsx('text-3xl', textColor)}
-            text={value.toFixed(2)}
-          >
+          <Tooltip text={value.toFixed(2)} placement="bottom">
             {formatLargeNumber(value)}
           </Tooltip>
-          <div className={clsx('text-base', textColor)}>expected</div>
+          <div className="text-base font-light">expected</div>
         </>
       )}
-    </Col>
+    </Row>
   )
 }
 

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -1,11 +1,14 @@
 import { ClockIcon, UserGroupIcon } from '@heroicons/react/outline'
-import { DotsCircleHorizontalIcon, PencilIcon } from '@heroicons/react/solid'
+import {
+  DotsCircleHorizontalIcon,
+  PencilIcon,
+  PlusIcon,
+} from '@heroicons/react/solid'
 import clsx from 'clsx'
 import { Editor } from '@tiptap/react'
 import dayjs from 'dayjs'
 import Link from 'next/link'
 import { Row } from '../layout/row'
-import { formatMoney } from 'common/util/format'
 import { Contract, updateContract } from 'web/lib/firebase/contracts'
 import { DateTimeTooltip } from '../widgets/datetime-tooltip'
 import { fromNow } from 'web/lib/util/time'
@@ -121,7 +124,7 @@ export function ContractDetails(props: { contract: Contract }) {
   const { contract } = props
 
   return (
-    <Row className="flex-wrap gap-2 sm:flex-nowrap">
+    <Row className="flex-wrap gap-4 sm:flex-nowrap">
       <MarketSubheader contract={contract} />
       <MarketGroups contract={contract} />
       <ExtraContractActionsRow contract={contract} />
@@ -132,32 +135,29 @@ export function ContractDetails(props: { contract: Contract }) {
 export function MarketSubheader(props: { contract: Contract }) {
   const { contract } = props
   const { creatorName, creatorUsername, creatorId, creatorAvatarUrl } = contract
-  const user = useUser()
-  const isCreator = user?.id === creatorId
   return (
-    <Row className="relative grow">
-      <Avatar
-        username={creatorUsername}
-        avatarUrl={creatorAvatarUrl}
-        size={9}
-        className="mr-1.5"
-      />
-
-      <div className="absolute bottom-0 ml-5 flex h-5 w-5 items-center justify-center sm:-bottom-1">
-        <MiniUserFollowButton userId={creatorId} />
+    <Row className="grow items-center gap-3">
+      <div className="relative">
+        <Avatar
+          username={creatorUsername}
+          avatarUrl={creatorAvatarUrl}
+          size={9}
+        />
+        <MiniUserFollowButton
+          userId={creatorId}
+          className="absolute bottom-0 right-0 h-4 w-4"
+        />
       </div>
 
-      <Col className="ml-2 flex-1 text-sm text-gray-600">
-        <Row className="gap-1">
-          <UserLink
-            className="my-auto whitespace-nowrap"
-            name={creatorName}
-            username={creatorUsername}
-          />
-        </Row>
-        <div className="text-2xs text-gray-400 sm:text-xs">
-          <CloseOrResolveTime contract={contract} isCreator={isCreator} />
-        </div>
+      <Col className="whitespace-nowrap text-sm">
+        <UserLink
+          className="text-gray-600"
+          name={creatorName}
+          username={creatorUsername}
+        />
+        <span className="text-xs font-light text-gray-400">
+          <CloseOrResolveTime contract={contract} />
+        </span>
       </Col>
     </Row>
   )
@@ -165,34 +165,31 @@ export function MarketSubheader(props: { contract: Contract }) {
 
 export function CloseOrResolveTime(props: {
   contract: Contract
-  isCreator: boolean
-  disabled?: boolean
+  editable?: boolean
 }) {
-  const { contract, isCreator, disabled } = props
+  const { contract, editable } = props
   const { resolvedDate } = contractMetrics(contract)
   const { resolutionTime, closeTime } = contract
   if (!!closeTime || !!resolvedDate) {
     return (
-      <Row className="select-none flex-nowrap items-center gap-1">
-        {resolvedDate && resolutionTime ? (
+      <Row className="select-none items-center">
+        {resolvedDate && resolutionTime && (
           <DateTimeTooltip
             className="whitespace-nowrap"
             text="Market resolved:"
             time={resolutionTime}
+            placement="bottom-start"
           >
             resolved {resolvedDate}
           </DateTimeTooltip>
-        ) : null}
+        )}
 
         {!resolvedDate && closeTime && (
-          <div className="flex gap-1 whitespace-nowrap">
-            <EditableCloseDate
-              closeTime={closeTime}
-              contract={contract}
-              isCreator={isCreator ?? false}
-              disabled={disabled}
-            />
-          </div>
+          <EditableCloseDate
+            closeTime={closeTime}
+            contract={contract}
+            editable={!!editable}
+          />
         )}
       </Row>
     )
@@ -214,11 +211,14 @@ function MarketGroups(props: { contract: Contract }) {
         ))}
 
         {user && (
-          <button
-            className="text-gray-400 hover:text-gray-300"
-            onClick={() => setOpen(true)}
-          >
-            <DotsCircleHorizontalIcon className="h-[20px]" />
+          <button onClick={() => setOpen(true)}>
+            {groupsToDisplay.length ? (
+              <DotsCircleHorizontalIcon className="h-[20px] text-gray-400 hover:text-gray-400/75" />
+            ) : (
+              <span className="flex items-center rounded-full bg-gray-400 py-0.5 px-2 text-xs font-light text-white hover:bg-gray-400/75">
+                <PlusIcon className="mr-1 h-3 w-3" /> Group
+              </span>
+            )}
           </button>
         )}
       </Row>
@@ -235,75 +235,14 @@ function MarketGroups(props: { contract: Contract }) {
   )
 }
 
-export function ExtraMobileContractDetails(props: {
-  contract: Contract
-  forceShowVolume?: boolean
-}) {
-  const { contract, forceShowVolume } = props
-  const { volume, resolutionTime, closeTime, creatorId, uniqueBettorCount } =
-    contract
-  const user = useUser()
-  const uniqueBettors = uniqueBettorCount ?? 0
-  const { resolvedDate } = contractMetrics(contract)
-  const volumeTranslation =
-    volume > 800 || uniqueBettors >= 20
-      ? 'High'
-      : volume > 300 || uniqueBettors >= 10
-      ? 'Medium'
-      : 'Low'
-
-  return (
-    <Row
-      className={clsx(
-        'items-center justify-around md:hidden',
-        user ? 'w-full' : ''
-      )}
-    >
-      {resolvedDate && resolutionTime ? (
-        <Col className={'items-center text-sm'}>
-          <Row className={'text-gray-500'}>
-            <DateTimeTooltip text="Market resolved:" time={resolutionTime}>
-              {resolvedDate}
-            </DateTimeTooltip>
-          </Row>
-          <Row className={'text-gray-400'}>Ended</Row>
-        </Col>
-      ) : (
-        !resolvedDate &&
-        closeTime && (
-          <Col className={'items-center text-sm text-gray-500'}>
-            <EditableCloseDate
-              closeTime={closeTime}
-              contract={contract}
-              isCreator={creatorId === user?.id}
-            />
-          </Col>
-        )
-      )}
-      {(user || forceShowVolume) && (
-        <Col className={'items-center text-sm text-gray-500'}>
-          <Tooltip
-            text={`${formatMoney(
-              volume
-            )} bet - ${uniqueBettors} unique traders`}
-          >
-            {volumeTranslation}
-          </Tooltip>
-          <Row className={'text-gray-400'}>Activity</Row>
-        </Col>
-      )}
-    </Row>
-  )
-}
-
-export function GroupDisplay(props: { groupToDisplay: GroupLink }) {
+function GroupDisplay(props: { groupToDisplay: GroupLink }) {
   const { groupToDisplay } = props
 
   return (
     <Link prefetch={false} href={groupPath(groupToDisplay.slug)} legacyBehavior>
       <a
         className={clsx(
-          'max-w-[200px] truncate whitespace-nowrap rounded-full bg-gray-400 py-0.5 px-2 text-xs text-white sm:max-w-[250px]'
+          'max-w-[200px] truncate whitespace-nowrap rounded-full bg-gray-400 py-0.5 px-2 text-xs font-light text-white sm:max-w-[250px]'
         )}
       >
         {groupToDisplay.name}
@@ -315,10 +254,9 @@ export function GroupDisplay(props: { groupToDisplay: GroupLink }) {
 function EditableCloseDate(props: {
   closeTime: number
   contract: Contract
-  isCreator: boolean
-  disabled?: boolean
+  editable: boolean
 }) {
-  const { closeTime, contract, isCreator, disabled } = props
+  const { closeTime, contract, editable } = props
 
   const isClient = useIsClient()
   const dayJsCloseTime = dayjs(closeTime)
@@ -415,12 +353,10 @@ function EditableCloseDate(props: {
       </Modal>
 
       <Row
-        className={clsx(
-          'items-center gap-1 text-gray-500',
-          !disabled && isCreator ? 'cursor-pointer' : ''
-        )}
-        onClick={() => !disabled && isCreator && setIsEditingCloseTime(true)}
+        className={clsx('items-center gap-1', editable ? 'cursor-pointer' : '')}
+        onClick={() => editable && setIsEditingCloseTime(true)}
       >
+        {editable && <PencilIcon className="h-4 w-4" />}
         <DateTimeTooltip
           text={closeTime <= Date.now() ? 'Trading ended:' : 'Trading ends:'}
           time={closeTime}
@@ -441,7 +377,6 @@ function EditableCloseDate(props: {
             dayJsCloseTime.format('MMM D, YYYY')
           )}
         </DateTimeTooltip>
-        {isCreator && !disabled && <PencilIcon className="h-4 w-4" />}
       </Row>
     </>
   )

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -145,7 +145,7 @@ export function MarketSubheader(props: { contract: Contract }) {
         />
         <MiniUserFollowButton
           userId={creatorId}
-          className="absolute bottom-0 right-0 h-4 w-4"
+          className="absolute -bottom-1 -right-1"
         />
       </div>
 

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from 'react'
+import { memo, useState } from 'react'
 
 import { tradingAllowed } from 'web/lib/firebase/contracts'
 import { Col } from '../layout/col'
@@ -40,7 +40,7 @@ import { PlayMoneyDisclaimer } from '../play-money-disclaimer'
 import { TimeRangePicker } from '../charts/time-range-picker'
 import { Period } from 'web/lib/firebase/users'
 import { useEvent } from 'web/hooks/use-event'
-import { getCutoff } from 'web/hooks/use-portfolio-history'
+import { getCutoff } from 'web/lib/util/time'
 
 export const ContractOverview = memo(
   (props: {

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -40,7 +40,7 @@ import { PlayMoneyDisclaimer } from '../play-money-disclaimer'
 import { TimeRangePicker } from '../charts/time-range-picker'
 import { Period } from 'web/lib/firebase/users'
 import { useEvent } from 'web/hooks/use-event'
-import { getCutoff, periodDurations } from 'web/lib/util/time'
+import { periodDurations } from 'web/lib/util/time'
 import { getDateRange } from '../charts/helpers'
 
 export const ContractOverview = memo(

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -29,11 +29,12 @@ import {
   PseudoNumericContract,
   BinaryContract,
 } from 'common/contract'
-import { ContractDetails } from './contract-details'
+import { CloseOrResolveTime, ContractDetails } from './contract-details'
 import { SizedContainer } from 'web/components/sized-container'
 import { CertOverview } from './cert-overview'
 import { BetSignUpPrompt } from '../sign-up-prompt'
 import { PlayMoneyDisclaimer } from '../play-money-disclaimer'
+import { TimeRangePicker } from '../charts/time-range-picker'
 
 export const ContractOverview = memo(
   (props: {
@@ -111,6 +112,7 @@ const BinaryOverview = (props: {
 }) => {
   const { contract, betPoints } = props
   const user = useUser()
+  const isCreator = user?.id === contract.creatorId
 
   return (
     <Col className="gap-1 md:gap-2">
@@ -137,6 +139,18 @@ const BinaryOverview = (props: {
           />
         )}
       </SizedContainer>
+
+      <Row className="justify-between px-2">
+        <TimeRangePicker
+          currentTimePeriod="allTime"
+          setCurrentTimePeriod={() => {}}
+          color="green"
+        />
+        <div className="mr-8 mt-1 text-right text-xs text-gray-500">
+          <CloseOrResolveTime contract={contract} editable={isCreator} />
+          <div className="mt-0.5">{contract.uniqueBettorCount} traders</div>
+        </div>
+      </Row>
 
       {user && tradingAllowed(contract) && (
         <SignedInBinaryMobileBetting contract={contract} user={user} />

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -123,21 +123,21 @@ export function CancelLabel() {
 }
 
 export function ProbLabel() {
-  return <span className="text-blue-600">PROB</span>
+  return <span className="text-sky-600">PROB</span>
 }
 
 export function MultiLabel() {
-  return <span className="text-blue-600">MANY</span>
+  return <span className="text-sky-600">MANY</span>
 }
 
 export function ProbPercentLabel(props: { prob: number }) {
   const { prob } = props
-  return <span className="text-blue-600">{formatPercent(prob)}</span>
+  return <span className="text-sky-600">{formatPercent(prob)}</span>
 }
 
 export function NumericValueLabel(props: { value: number }) {
   const { value } = props
-  return <span className="text-blue-600">{formatLargeNumber(value)}</span>
+  return <span className="text-sky-600">{formatLargeNumber(value)}</span>
 }
 
 export function AnswerNumberLabel(props: { number: string }) {

--- a/web/components/portfolio/portfolio-value-section.tsx
+++ b/web/components/portfolio/portfolio-value-section.tsx
@@ -10,13 +10,13 @@ import { SizedContainer } from 'web/components/sized-container'
 import { Period } from 'web/lib/firebase/users'
 import { useEvent } from 'web/hooks/use-event'
 import PlaceholderGraph from 'web/lib/icons/placeholder-graph'
-import { ScaleContinuousNumeric, ScaleTime } from 'd3-scale'
 import { AddFundsModal } from '../add-funds-modal'
 import { Button } from '../buttons/button'
 import { ENV_CONFIG } from 'common/envs/constants'
 import { useUser } from 'web/hooks/use-user'
 import { TimeRangePicker } from '../charts/time-range-picker'
 import { ColorType } from '../choices-toggle-group'
+import { useSingleValueHistoryChartViewScale } from '../charts/generic-charts'
 
 export const PortfolioValueSection = memo(
   function PortfolioValueSection(props: { userId: string }) {
@@ -47,24 +47,15 @@ export const PortfolioValueSection = memo(
     const onClickNumber = useEvent((mode: GraphMode) => {
       setGraphMode(mode)
       setGraphDisplayNumber(null)
-      setGraphViewYScale(undefined)
+      graphView.setViewYScale(undefined)
     })
-    const [graphViewXScale, setGraphViewXScale] =
-      useState<ScaleTime<number, number>>()
-    const [graphViewYScale, setGraphViewYScale] =
-      useState<ScaleContinuousNumeric<number, number>>()
-    const viewScaleProps = {
-      viewXScale: graphViewXScale,
-      setViewXScale: setGraphViewXScale,
-      viewYScale: graphViewYScale,
-      setViewYScale: setGraphViewYScale,
-    }
+    const graphView = useSingleValueHistoryChartViewScale()
 
     //zooms out of graph if zoomed in upon time selection change
     const setTimePeriod = useEvent((timePeriod: Period) => {
       setCurrentTimePeriod(timePeriod)
-      setGraphViewXScale(undefined)
-      setGraphViewYScale(undefined)
+      graphView.setViewXScale(undefined)
+      graphView.setViewYScale(undefined)
     })
     // placeholder when loading
     if (graphPoints === undefined || !lastPortfolioMetrics) {
@@ -152,7 +143,7 @@ export const PortfolioValueSection = memo(
             points={graphPoints}
             width={width}
             height={height}
-            viewScaleProps={viewScaleProps}
+            viewScaleProps={graphView}
             onMouseOver={handleGraphDisplayChange}
           />
         )}
@@ -228,6 +219,7 @@ export function PortfolioValueSkeleton(props: {
         setCurrentTimePeriod={setCurrentTimePeriod}
         color={switcherColor}
         disabled={disabled}
+        className="mt-1 self-start"
       />
     </>
   )

--- a/web/hooks/use-portfolio-history.ts
+++ b/web/hooks/use-portfolio-history.ts
@@ -11,9 +11,12 @@ import {
   usePersistentState,
 } from 'web/hooks/use-persistent-state'
 
-const getCutoff = (period: Period) => {
+export const getCutoff = (period: Period) => {
+  if (period === 'allTime') {
+    return new Date(0).valueOf()
+  }
   const nowRounded = Math.round(Date.now() / HOUR_MS) * HOUR_MS
-  return periodToCutoff(nowRounded, period).valueOf()
+  return nowRounded - periodDurations[period]
 }
 
 export const usePrefetchPortfolioHistory = (userId: string, period: Period) => {
@@ -51,16 +54,10 @@ export const usePortfolioHistory = (userId: string, period: Period) => {
   return portfolioHistories[cutoff]
 }
 
-const periodToCutoff = (now: number, period: Period) => {
-  switch (period) {
-    case 'daily':
-      return now - 1 * DAY_MS
-    case 'weekly':
-      return now - 7 * DAY_MS
-    case 'monthly':
-      return now - 30 * DAY_MS
-    case 'allTime':
-    default:
-      return new Date(0)
-  }
+export const periodDurations: {
+  [period in Exclude<Period, 'allTime'>]: number
+} = {
+  daily: 1 * DAY_MS,
+  weekly: 7 * DAY_MS,
+  monthly: 30 * DAY_MS,
 }

--- a/web/hooks/use-portfolio-history.ts
+++ b/web/hooks/use-portfolio-history.ts
@@ -10,14 +10,7 @@ import {
   inMemoryStore,
   usePersistentState,
 } from 'web/hooks/use-persistent-state'
-
-export const getCutoff = (period: Period) => {
-  if (period === 'allTime') {
-    return new Date(0).valueOf()
-  }
-  const nowRounded = Math.round(Date.now() / HOUR_MS) * HOUR_MS
-  return nowRounded - periodDurations[period]
-}
+import { getCutoff } from 'web/lib/util/time'
 
 export const usePrefetchPortfolioHistory = (userId: string, period: Period) => {
   const queryClient = useQueryClient()
@@ -52,12 +45,4 @@ export const usePortfolioHistory = (userId: string, period: Period) => {
     })
   }, [userId, cutoff, setPortfolioHistories, portfolioHistories])
   return portfolioHistories[cutoff]
-}
-
-export const periodDurations: {
-  [period in Exclude<Period, 'allTime'>]: number
-} = {
-  daily: 1 * DAY_MS,
-  weekly: 7 * DAY_MS,
-  monthly: 30 * DAY_MS,
 }

--- a/web/lib/util/time.ts
+++ b/web/lib/util/time.ts
@@ -1,5 +1,7 @@
+import { DAY_MS, HOUR_MS } from 'common/util/time'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import { Period } from '../firebase/users'
 dayjs.extend(relativeTime)
 
 export function fromNow(time: number) {
@@ -15,4 +17,20 @@ export const formatTime = FORMATTER.format
 
 export function formatTimeShort(time: number) {
   return dayjs(time).format('MMM D, h:mma')
+}
+
+export const periodDurations: {
+  [period in Exclude<Period, 'allTime'>]: number
+} = {
+  daily: 1 * DAY_MS,
+  weekly: 7 * DAY_MS,
+  monthly: 30 * DAY_MS,
+}
+
+export const getCutoff = (period: Period) => {
+  if (period === 'allTime') {
+    return new Date(0).valueOf()
+  }
+  const nowRounded = Math.round(Date.now() / HOUR_MS) * HOUR_MS
+  return nowRounded - periodDurations[period]
 }

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -28,7 +28,10 @@ import { useRouter } from 'next/router'
 import { Avatar } from 'web/components/widgets/avatar'
 import { OrderByDirection } from 'firebase/firestore'
 import { useUser } from 'web/hooks/use-user'
-import { HistoryPoint } from 'web/components/charts/generic-charts'
+import {
+  HistoryPoint,
+  useSingleValueHistoryChartViewScale,
+} from 'web/components/charts/generic-charts'
 import { listBets } from 'web/lib/firebase/bets'
 
 type HistoryData = { bets?: Bet[]; points?: HistoryPoint<Partial<Bet>>[] }
@@ -135,11 +138,14 @@ const ContractChart = (props: {
   color?: string
 }) => {
   const { contract, data, ...rest } = props
+  const viewScale = useSingleValueHistoryChartViewScale()
+
   switch (contract.outcomeType) {
     case 'BINARY':
       return (
         <BinaryContractChart
           {...rest}
+          viewScaleProps={viewScale}
           contract={contract}
           betPoints={data?.points ?? []}
         />
@@ -148,6 +154,7 @@ const ContractChart = (props: {
       return (
         <PseudoNumericContractChart
           {...rest}
+          viewScaleProps={viewScale}
           contract={contract}
           betPoints={data?.points ?? []}
         />
@@ -200,10 +207,18 @@ function ContractSmolView(props: {
             {question}
           </a>
         </div>
-        {isBinary && <BinaryResolutionOrChance contract={contract} />}
+        {isBinary && (
+          <BinaryResolutionOrChance
+            contract={contract}
+            className="!flex-col !gap-0"
+          />
+        )}
 
         {isPseudoNumeric && (
-          <PseudoNumericResolutionOrExpectation contract={contract} />
+          <PseudoNumericResolutionOrExpectation
+            contract={contract}
+            className="!flex-col !gap-0"
+          />
         )}
 
         {outcomeType === 'FREE_RESPONSE' && (

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -237,7 +237,7 @@ const Details = (props: { contract: Contract }) => {
 
   return (
     <div className="relative right-0 mt-2 flex flex-wrap items-center gap-4 text-xs text-gray-400">
-      <span className="flex gap-1">
+      <span className="flex gap-1 text-gray-600">
         <Avatar
           size="xxs"
           avatarUrl={creatorAvatarUrl}
@@ -246,7 +246,7 @@ const Details = (props: { contract: Contract }) => {
         />
         {creatorName}
       </span>
-      <CloseOrResolveTime contract={props.contract} isCreator disabled />
+      <CloseOrResolveTime contract={props.contract} />
       <span>{uniqueBettorCount} traders</span>
     </div>
   )


### PR DESCRIPTION
Resolves MAN-371

- just binary and pseudonumeric for now
- ended up not adding 1H as most markets don't have hourly updates
- I'm not happy with the look of having the entire thing be disabled with just "ALL" selectable when you create it

also includes some a few style changes / refactors to the market header to make it look nicer
- thinner close date, market tags
- add group cta more prominent when there are no groups
these don't really belong in this PR but at this point I can't be bothered to untangle it out
