### PR TITLE
Fix duplicate bet IDs

### DIFF
--- a/functions/src/scripts/fix-busted-ids.ts
+++ b/functions/src/scripts/fix-busted-ids.ts
@@ -1,0 +1,26 @@
+// Fixing incorrect IDs in the document data, e.g. in the `bets` collection group.
+
+import * as admin from 'firebase-admin'
+import { initAdmin } from './script-init'
+import { log, processPartitioned } from '../utils'
+
+initAdmin()
+
+const firestore = admin.firestore()
+
+async function processGroup(group: admin.firestore.CollectionGroup) {
+  const writer = firestore.bulkWriter()
+  await processPartitioned(group, 100, async (docs) => {
+    const mismatchedIds = docs.filter((d) => d.id !== d.get('id'))
+    if (mismatchedIds.length > 0) {
+      log(`Found ${mismatchedIds.length} docs with mismatched IDs.`)
+      for (const doc of mismatchedIds) {
+        writer.update(doc.ref, { id: doc.id })
+      }
+    }
+  })
+  await writer.close()
+}
+if (require.main === module) {
+  processGroup(firestore.collectionGroup('bets'))
+}

--- a/functions/src/sell-bet.ts
+++ b/functions/src/sell-bet.ts
@@ -55,8 +55,11 @@ export const sellbet = newEndpoint({}, async (req, auth) => {
 
     transaction.update(userDoc, { balance: newBalance })
     transaction.update(betDoc, { isSold: true })
-    // Note: id should have been newBetDoc.id! But leaving it for now so it's consistent.
-    transaction.create(newBetDoc, { id: betDoc.id, userId: user.id, ...newBet })
+    transaction.create(newBetDoc, {
+      id: newBetDoc.id,
+      userId: user.id,
+      ...newBet,
+    })
     transaction.update(
       contractDoc,
       removeUndefinedProps({


### PR DESCRIPTION
It makes no sense and makes our API hard to use, since the API exposes the ID in the data blob, not the Firestore document ID.