### PR TITLE
Removed logging "Received native event"

### DIFF
--- a/web/hooks/use-native-messages.ts
+++ b/web/hooks/use-native-messages.ts
@@ -13,7 +13,6 @@ export const useNativeMessages = (
       return
     }
     const { type, data } = event
-    console.log('Received native event: ', event)
     if (messageTypes.includes(type)) {
       onMessageReceived(type, data)
     }


### PR DESCRIPTION
I noticed console logging on manifold.markets and thought that might not be intended.

![image](https://user-images.githubusercontent.com/61841994/215188154-0bba83a5-f756-4957-a509-f5f1e224f1d5.png)
