### PR TITLE
Replication robustness

### DIFF
--- a/supabase-replicator/deploy.sh
+++ b/supabase-replicator/deploy.sh
@@ -29,7 +29,7 @@ yarn build && \
          --region us-east4 \
          --set-env-vars ENVIRONMENT=${ENVIRONMENT} \
          --set-env-vars GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT} \
-         --set-secrets SUPABASE_KEY=SUPABASE_KEY:latest \
+         --set-secrets SUPABASE_PASSWORD=SUPABASE_PASSWORD:latest \
          --execution-environment gen2 \
          --cpu ${GCLOUD_CPU} \
          --memory 2Gi \

--- a/supabase-replicator/package.json
+++ b/supabase-replicator/package.json
@@ -19,6 +19,7 @@
     "node-fetch": "2.6.7",
     "@google-cloud/pubsub": "3.2.1",
     "@supabase/supabase-js": "2.2.0",
+    "pg-promise": "11.0.2",
     "typescript": "4.9.3"
   },
   "devDependencies": {

--- a/supabase-replicator/src/index.ts
+++ b/supabase-replicator/src/index.ts
@@ -48,51 +48,68 @@ app.post('/replay-failed', async (_req, res) => {
   }
 })
 
-async function tryReplicateBatch(...messages: Message[]) {
-  const entries = messages.map((m) => JSON.parse(m.data.toString()) as TLEntry)
+type ParsedMessage<T> = { msg: Message; data: T }
+
+function parseMessage<T>(msg: Message): ParsedMessage<T> {
+  return { msg, data: JSON.parse(msg.data.toString()) }
+}
+
+async function tryReplicateBatch(batchId: number, ...entries: TLEntry[]) {
   try {
     const t0 = process.hrtime.bigint()
-    log('DEBUG', `Beginning replication of batch=${messages[0].id}.`)
+    log('DEBUG', `Beginning replication of batch=${batchId}.`)
     await replicateWrites(supabase, ...entries)
     const t1 = process.hrtime.bigint()
     const ms = (t1 - t0) / 1000000n
     log(
       'INFO',
-      `Replicated batch=${messages[0].id} count=${entries.length}, time=${ms}ms.`
+      `Replicated batch=${batchId} count=${entries.length}, time=${ms}ms.`
     )
   } catch (e) {
     log(
       'ERROR',
-      `Failed to replicate batch=${messages[0].id} count=${entries.length}. Logging failed writes.`,
+      `Failed to replicate batch=${batchId} count=${entries.length}. Logging failed writes.`,
       e
     )
     await createFailedWrites(firestore, ...entries)
-  }
-  for (const msg of messages) {
-    msg.ack()
   }
 }
 
 function processSubscriptionBatched(
   subscription: Subscription,
-  process: (msgs: Message[]) => Promise<void>,
   batchSize: number,
   batchTimeoutMs: number
 ) {
-  const batch: Message[] = []
+  let i = 0
+  const batch: ParsedMessage<TLEntry>[] = []
 
-  subscription.on('message', async (message) => {
-    log('DEBUG', `Received message ${message.id}.`)
-    batch.push(message)
-    if (batch.length >= batchSize) {
+  const processBatch = async (kind: string) => {
+    if (batch.length > 0) {
+      const batchId = i++
       const toWrite = [...batch]
       batch.length = 0
-      try {
-        log('DEBUG', `Starting clear batch ${toWrite[0].id}.`)
-        await process(toWrite)
-      } catch (e) {
-        log('ERROR', 'Big error processing messages:', e)
+      log('DEBUG', `Starting ${kind} batch=${batchId}.`)
+      await tryReplicateBatch(batchId, ...toWrite.map((x) => x.data))
+      for (const x of toWrite) {
+        x.msg.ack()
       }
+    }
+  }
+
+  subscription.on('message', async (message) => {
+    try {
+      const parsed = parseMessage<TLEntry>(message)
+      const entry = parsed.data
+      log(
+        'DEBUG',
+        `Received message id=${message.id} batch=${i} eventId=${entry.eventId} kind=${entry.writeKind} tableId=${entry.tableId} parentId=${entry.parentId} docId=${entry.docId}.`
+      )
+      batch.push(parsed)
+      if (batch.length >= batchSize) {
+        await processBatch('clear')
+      }
+    } catch (e) {
+      log('ERROR', 'Big error processing message:', e)
     }
   })
 
@@ -106,24 +123,13 @@ function processSubscriptionBatched(
 
   return setInterval(async () => {
     if (batch.length > 0) {
-      const toWrite = [...batch]
-      batch.length = 0
-      try {
-        log('DEBUG', `Starting interval batch ${toWrite[0].id}.`)
-        await process(toWrite)
-      } catch (e) {
-        log('ERROR', 'Big error processing messages:', e)
-      }
+      await processBatch('interval')
     }
   }, batchTimeoutMs)
 }
 
-processSubscriptionBatched(
-  writeSub,
-  (msgs) => tryReplicateBatch(...msgs),
-  1000,
-  100
-).unref() // unref() means it won't keep the process running if GCP stops the webserver
+// unref() means it won't keep the process running if GCP stops the webserver
+processSubscriptionBatched(writeSub, 1000, 100).unref()
 
 app.listen(PORT, () =>
   log('INFO', `Running in ${ENV} environment listening on port ${PORT}.`)

--- a/supabase-replicator/src/replicate-writes.ts
+++ b/supabase-replicator/src/replicate-writes.ts
@@ -1,7 +1,6 @@
 import { Firestore } from 'firebase-admin/firestore'
 import { TLEntry } from '../../common/transaction-log'
-import { run, SupabaseClient } from '../../common/supabase/utils'
-import { log } from './utils'
+import { SupabaseDirectClient, bulkInsert, log } from './utils'
 
 export async function createFailedWrites(
   firestore: Firestore,
@@ -20,7 +19,7 @@ export async function createFailedWrites(
 
 export async function replayFailedWrites(
   firestore: Firestore,
-  supabase: SupabaseClient,
+  supabase: SupabaseDirectClient,
   limit = 1000
 ) {
   const failedWrites = await firestore
@@ -46,20 +45,20 @@ export async function replayFailedWrites(
 }
 
 export async function replicateWrites(
-  supabase: SupabaseClient,
+  pg: SupabaseDirectClient,
   ...entries: TLEntry[]
 ) {
-  return await run(
-    supabase.from('incoming_writes').insert(
-      entries.map((e) => ({
-        event_id: e.eventId,
-        table_id: e.tableId,
-        write_kind: e.writeKind,
-        parent_id: e.parentId,
-        doc_id: e.docId,
-        data: e.data,
-        ts: new Date(e.ts).toISOString(),
-      }))
-    )
+  return await bulkInsert(
+    pg,
+    'incoming_writes',
+    entries.map((e) => ({
+      event_id: e.eventId,
+      table_id: e.tableId,
+      write_kind: e.writeKind,
+      parent_id: e.parentId,
+      doc_id: e.docId,
+      data: e.data,
+      ts: new Date(e.ts).toISOString(),
+    }))
   )
 }

--- a/supabase-replicator/src/utils.ts
+++ b/supabase-replicator/src/utils.ts
@@ -1,3 +1,14 @@
+import * as pgPromise from 'pg-promise'
+import {
+  Tables,
+  TableName,
+  getInstanceHostname,
+} from '../../common/supabase/utils'
+
+export const pgp = pgPromise()
+
+export type SupabaseDirectClient = ReturnType<typeof createSupabaseDirectClient>
+
 function getMessage(obj: unknown) {
   if (typeof obj === 'string') {
     return obj
@@ -15,5 +26,31 @@ export function log(severity: string, message: string, details?: unknown) {
     console.log(
       JSON.stringify({ severity, message: `${message} ${getMessage(details)}` })
     )
+  }
+}
+
+// would be nice to reuse these between this project and functions project
+
+export function createSupabaseDirectClient(
+  instanceId: string,
+  password: string
+) {
+  return pgp({
+    host: `db.${getInstanceHostname(instanceId)}`,
+    port: 5432,
+    user: 'postgres',
+    password: password,
+  })
+}
+
+export async function bulkInsert<
+  T extends TableName,
+  ColumnValues extends Tables[T]['Insert']
+>(db: SupabaseDirectClient, table: T, values: ColumnValues[]) {
+  if (values.length) {
+    const columnNames = Object.keys(values[0])
+    const cs = new pgp.helpers.ColumnSet(columnNames, { table })
+    const query = pgp.helpers.insert(values, cs)
+    await db.none(query)
   }
 }


### PR DESCRIPTION
Aiming to work towards solving any problems causing spotty replication, and make the replication more stable under load.

1. Add logging to the Firestore triggers and replicator so that we can track individual event and document write IDs. This way if we ever see that a write didn't get all the way to Supabase, we can go back and see where it got lost.
2. Talk directly to Postgres in the replicator. This should be more efficient and removes the Cloudflare HTTP proxying as a potential point of failure.