### PR TITLE
Search list tweaks

### DIFF
--- a/common/contract-details.ts
+++ b/common/contract-details.ts
@@ -90,7 +90,8 @@ export const getOpenGraphProps = (
 
   const numericValue =
     outcomeType === 'PSEUDO_NUMERIC'
-      ? getFormattedMappedValue(contract)(
+      ? getFormattedMappedValue(
+          contract,
           contract.resolutionProbability
             ? contract.resolutionProbability
             : getProbability(contract)

--- a/common/pseudo-numeric.ts
+++ b/common/pseudo-numeric.ts
@@ -5,11 +5,11 @@ export function formatNumericProbability(
   p: number,
   contract: PseudoNumericContract
 ) {
-  const value = getMappedValue(contract)(p)
+  const value = getMappedValue(contract, p)
   return formatLargeNumber(value)
 }
 
-export const getMappedValue = (contract: Contract) => (p: number) => {
+export const getMappedValue = (contract: Contract, p: number) => {
   if (contract.outcomeType !== 'PSEUDO_NUMERIC') return p
 
   const { min, max, isLogScale } = contract
@@ -22,10 +22,10 @@ export const getMappedValue = (contract: Contract) => (p: number) => {
   return p * (max - min) + min
 }
 
-export const getFormattedMappedValue = (contract: Contract) => (p: number) => {
+export const getFormattedMappedValue = (contract: Contract, p: number) => {
   if (contract.outcomeType !== 'PSEUDO_NUMERIC') return formatPercent(p)
 
-  const value = getMappedValue(contract)(p)
+  const value = getMappedValue(contract, p)
   return formatLargeNumber(value)
 }
 

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -289,10 +289,9 @@ export function BuyPanel(props: {
   const currentReturn = betAmount ? (currentPayout - betAmount) / betAmount : 0
   const currentReturnPercent = formatPercent(currentReturn)
 
-  const format = getFormattedMappedValue(contract)
-
-  const getValue = getMappedValue(contract)
-  const rawDifference = Math.abs(getValue(resultProb) - getValue(initialProb))
+  const rawDifference = Math.abs(
+    getMappedValue(contract, resultProb) - getMappedValue(contract, initialProb)
+  )
   const displayedDifference = isPseudoNumeric
     ? formatLargeNumber(rawDifference)
     : formatPercent(rawDifference)
@@ -396,10 +395,12 @@ export function BuyPanel(props: {
               )}
             </Row>
             {probStayedSame ? (
-              <div className="text-lg">{format(initialProb)}</div>
+              <div className="text-lg">
+                {getFormattedMappedValue(contract, initialProb)}
+              </div>
             ) : (
               <div className="text-lg">
-                {format(resultProb)}
+                {getFormattedMappedValue(contract, resultProb)}
                 <span className={clsx('text-sm text-gray-500')}>
                   {isPseudoNumeric ? (
                     <></>
@@ -407,7 +408,10 @@ export function BuyPanel(props: {
                     <>
                       {' '}
                       {outcome != 'NO' && '+'}
-                      {format(resultProb - initialProb)}
+                      {getFormattedMappedValue(
+                        contract,
+                        resultProb - initialProb
+                      )}
                     </>
                   )}
                 </span>

--- a/web/components/bet/limit-bets.tsx
+++ b/web/components/bet/limit-bets.tsx
@@ -185,7 +185,7 @@ function LimitBet(props: {
       )}
       <td>
         {isPseudoNumeric
-          ? getFormattedMappedValue(contract)(limitProb)
+          ? getFormattedMappedValue(contract, limitProb)
           : formatPercent(limitProb)}
       </td>
       <td>{formatMoney(orderAmount - amount)}</td>

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -449,7 +449,7 @@ function cardText(contract: Contract, previewProb?: number) {
       return (
         <>
           <span className="my-auto text-sm font-normal">resolved as</span>
-          {getFormattedMappedValue(contract)(resolutionProbability)}
+          {getFormattedMappedValue(contract, resolutionProbability)}
         </>
       )
     }
@@ -465,7 +465,7 @@ function cardText(contract: Contract, previewProb?: number) {
   }
 
   if (previewProb) {
-    return getFormattedMappedValue(contract)(previewProb)
+    return getFormattedMappedValue(contract, previewProb)
   }
 
   switch (outcomeType) {

--- a/web/components/bet/sell-panel.tsx
+++ b/web/components/bet/sell-panel.tsx
@@ -119,8 +119,9 @@ export function SellPanel(props: {
   const profit = saleValue - costBasis
   const resultProb = getCpmmProbability(cpmmState.pool, cpmmState.p)
 
-  const getValue = getMappedValue(contract)
-  const rawDifference = Math.abs(getValue(resultProb) - getValue(initialProb))
+  const rawDifference = Math.abs(
+    getMappedValue(contract, resultProb) - getMappedValue(contract, initialProb)
+  )
   const displayedDifference =
     contract.outcomeType === 'PSEUDO_NUMERIC'
       ? formatLargeNumber(rawDifference)
@@ -147,7 +148,6 @@ export function SellPanel(props: {
 
   const { outcomeType } = contract
   const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
-  const format = getFormattedMappedValue(contract)
 
   return (
     <>
@@ -180,9 +180,9 @@ export function SellPanel(props: {
             {isPseudoNumeric ? 'Estimated value' : 'Probability'}
           </div>
           <div>
-            {format(initialProb)}
+            {getFormattedMappedValue(contract, initialProb)}
             <span className="mx-2">→</span>
-            {format(resultProb)}
+            {getFormattedMappedValue(contract, initialProb)}
           </div>
         </Row>
         {loanPaid !== 0 && (
@@ -234,7 +234,7 @@ const getSaleProbChange = (
     balanceByUserId
   )
   const resultProb = getCpmmProbability(cpmmState.pool, cpmmState.p)
-
-  const getValue = getMappedValue(contract)
-  return Math.abs(getValue(resultProb) - getValue(initialProb))
+  return Math.abs(
+    getMappedValue(contract, resultProb) - getMappedValue(contract, initialProb)
+  )
 }

--- a/web/components/buttons/duplicate-contract-button.tsx
+++ b/web/components/buttons/duplicate-contract-button.tsx
@@ -47,7 +47,7 @@ function duplicateContractHref(contract: Contract) {
       // Conditional, because `?isLogScale=false` evaluates to `true`
       params.isLogScale = true
     }
-    params.initValue = getMappedValue(contract)(contract.initialProbability)
+    params.initValue = getMappedValue(contract, contract.initialProbability)
   }
 
   // TODO: Support multiple choice markets?

--- a/web/components/contract/contract-card.tsx
+++ b/web/components/contract/contract-card.tsx
@@ -421,8 +421,8 @@ export function PseudoNumericResolutionOrExpectation(props: {
   const value = resolution
     ? resolutionValue
       ? resolutionValue
-      : getMappedValue(contract)(resolutionProbability ?? 0)
-    : getMappedValue(contract)(getProbability(contract))
+      : getMappedValue(contract, resolutionProbability ?? 0)
+    : getMappedValue(contract, getProbability(contract))
 
   return (
     <Row className={clsx('items-baseline gap-2 text-3xl', className)}>

--- a/web/components/contract/contracts-list-entry.tsx
+++ b/web/components/contract/contracts-list-entry.tsx
@@ -57,7 +57,7 @@ export function ContractsListEntry(props: {
       )}
     >
       <Avatar
-        username={contract.creatorName}
+        username={contract.creatorUsername}
         avatarUrl={contract.creatorAvatarUrl}
         size="xs"
       />

--- a/web/components/contract/contracts-list-entry.tsx
+++ b/web/components/contract/contracts-list-entry.tsx
@@ -1,19 +1,51 @@
 import clsx from 'clsx'
 import { Contract } from 'common/contract'
 import Link from 'next/link'
+import { getProbability } from 'common/calculate'
+import { getValueFromBucket } from 'common/calculate-dpm'
 import { contractPath, getBinaryProbPercent } from 'web/lib/firebase/contracts'
+import { getFormattedMappedValue } from 'common/pseudo-numeric'
 import { BinaryContractOutcomeLabel } from '../outcome-label'
 import { getTextColor } from '../bet/quick-bet'
 import { Avatar } from '../widgets/avatar'
 
+function ContractStatusLabel(props: { contract: Contract }) {
+  const { contract } = props
+  switch (contract.outcomeType) {
+    case 'BINARY': {
+      return contract.resolution ? (
+        <BinaryContractOutcomeLabel
+          contract={contract}
+          resolution={contract.resolution}
+        />
+      ) : (
+        <span>{getBinaryProbPercent(contract, true)}</span>
+      )
+    }
+    case 'PSEUDO_NUMERIC': {
+      const val = contract.resolutionProbability ?? getProbability(contract)
+      return <span>{getFormattedMappedValue(contract, val)}</span>
+    }
+    case 'NUMERIC': {
+      const val = contract.resolutionValue ?? getValueFromBucket('', contract)
+      return <span>{getFormattedMappedValue(contract, val)}</span>
+    }
+    case 'FREE_RESPONSE':
+    case 'MULTIPLE_CHOICE': {
+      return <span>FR</span>
+    }
+    case 'CERT': {
+      return <span>CERT</span>
+    }
+  }
+}
+
 // TODO: Replace with a proper table/datagrid implementation?
 export function ContractsListEntry(props: {
   contract: Contract
-  probChange?: string
   className?: string
 }) {
-  const { contract, probChange, className } = props
-  const { outcomeType, resolution } = contract
+  const { contract, className } = props
   const probTextColor = getTextColor(contract)
 
   return (
@@ -31,26 +63,14 @@ export function ContractsListEntry(props: {
         size="xs"
       />
       <div className="min-w-[34px]">
-        {outcomeType === 'BINARY' && (
-          <span
-            className={clsx(
-              probTextColor,
-              'rounded-full font-semibold ring-inset ring-indigo-100 group-hover:ring-indigo-200'
-            )}
-          >
-            {resolution ? (
-              <BinaryContractOutcomeLabel
-                contract={contract}
-                resolution={resolution}
-              />
-            ) : (
-              getBinaryProbPercent(contract, true)
-            )}
-          </span>
-        )}
-        {!resolution && probChange && (
-          <span className="ml-0.5 text-xs text-gray-500">{probChange}</span>
-        )}
+        <span
+          className={clsx(
+            probTextColor,
+            'rounded-full font-semibold ring-inset ring-indigo-100 group-hover:ring-indigo-200'
+          )}
+        >
+          <ContractStatusLabel contract={contract} />
+        </span>
       </div>
       <div className="break-anywhere mr-0.5 whitespace-normal font-medium text-gray-900">
         {contract.question}

--- a/web/components/contract/contracts-list-entry.tsx
+++ b/web/components/contract/contracts-list-entry.tsx
@@ -52,7 +52,7 @@ export function ContractsListEntry(props: {
     <Link
       href={contractPath(contract)}
       className={clsx(
-        'group flex flex-row gap-2 whitespace-nowrap rounded-sm hover:bg-indigo-50 focus:bg-indigo-50 md:gap-4',
+        'group flex flex-row gap-2 whitespace-nowrap rounded-sm p-2 hover:bg-indigo-50 focus:bg-indigo-50 md:gap-4',
         className
       )}
     >

--- a/web/components/contract/contracts-list-entry.tsx
+++ b/web/components/contract/contracts-list-entry.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx'
 import { Contract } from 'common/contract'
 import Link from 'next/link'
 import { getProbability } from 'common/calculate'
@@ -11,6 +10,8 @@ import { Avatar } from '../widgets/avatar'
 
 function ContractStatusLabel(props: { contract: Contract }) {
   const { contract } = props
+  const probTextColor = getTextColor(contract)
+
   switch (contract.outcomeType) {
     case 'BINARY': {
       return contract.resolution ? (
@@ -19,7 +20,9 @@ function ContractStatusLabel(props: { contract: Contract }) {
           resolution={contract.resolution}
         />
       ) : (
-        <span>{getBinaryProbPercent(contract, true)}</span>
+        <span className={probTextColor}>
+          {getBinaryProbPercent(contract, true)}
+        </span>
       )
     }
     case 'PSEUDO_NUMERIC': {
@@ -41,35 +44,20 @@ function ContractStatusLabel(props: { contract: Contract }) {
 }
 
 // TODO: Replace with a proper table/datagrid implementation?
-export function ContractsListEntry(props: {
-  contract: Contract
-  className?: string
-}) {
-  const { contract, className } = props
-  const probTextColor = getTextColor(contract)
-
+export function ContractsListEntry(props: { contract: Contract }) {
+  const { contract } = props
   return (
     <Link
       href={contractPath(contract)}
-      className={clsx(
-        'group flex flex-row gap-2 whitespace-nowrap rounded-sm p-2 hover:bg-indigo-50 focus:bg-indigo-50 md:gap-4',
-        className
-      )}
+      className="group flex flex-row gap-2 whitespace-nowrap rounded-sm p-2 hover:bg-indigo-50 focus:bg-indigo-50 md:gap-4"
     >
       <Avatar
         username={contract.creatorUsername}
         avatarUrl={contract.creatorAvatarUrl}
         size="xs"
       />
-      <div className="min-w-[34px]">
-        <span
-          className={clsx(
-            probTextColor,
-            'rounded-full font-semibold ring-inset ring-indigo-100 group-hover:ring-indigo-200'
-          )}
-        >
-          <ContractStatusLabel contract={contract} />
-        </span>
+      <div className="min-w-[34px] rounded-full font-semibold">
+        <ContractStatusLabel contract={contract} />
       </div>
       <div className="break-anywhere mr-0.5 whitespace-normal font-medium text-gray-900">
         {contract.question}

--- a/web/components/contract/contracts-list-entry.tsx
+++ b/web/components/contract/contracts-list-entry.tsx
@@ -57,7 +57,6 @@ export function ContractsListEntry(props: {
       )}
     >
       <Avatar
-        className="mt-0.5"
         username={contract.creatorName}
         avatarUrl={contract.creatorAvatarUrl}
         size="xs"

--- a/web/components/contract/contracts-list.tsx
+++ b/web/components/contract/contracts-list.tsx
@@ -27,7 +27,7 @@ export function ContractsList(props: {
   }
 
   return (
-    <Col className="gap-3">
+    <Col>
       {contracts.map((contract) => (
         <DesktopPopover contract={contract} key={contract.id}></DesktopPopover>
       ))}

--- a/web/components/contract/contracts-list.tsx
+++ b/web/components/contract/contracts-list.tsx
@@ -27,7 +27,7 @@ export function ContractsList(props: {
   }
 
   return (
-    <Col className="gap-2">
+    <Col className="gap-3">
       {contracts.map((contract) => (
         <DesktopPopover contract={contract} key={contract.id}></DesktopPopover>
       ))}

--- a/web/components/feed/feed-bets.tsx
+++ b/web/components/feed/feed-bets.tsx
@@ -75,13 +75,13 @@ export function BetStatusText(props: {
 
   const fromProb =
     hadPoolMatch || isFreeResponse
-      ? getFormattedMappedValue(contract)(bet.probBefore)
-      : getFormattedMappedValue(contract)(bet.limitProb ?? bet.probBefore)
+      ? getFormattedMappedValue(contract, bet.probBefore)
+      : getFormattedMappedValue(contract, bet.limitProb ?? bet.probBefore)
 
   const toProb =
     hadPoolMatch || isFreeResponse
-      ? getFormattedMappedValue(contract)(bet.probAfter)
-      : getFormattedMappedValue(contract)(bet.limitProb ?? bet.probAfter)
+      ? getFormattedMappedValue(contract, bet.probAfter)
+      : getFormattedMappedValue(contract, bet.limitProb ?? bet.probAfter)
 
   return (
     <div className={clsx('text-sm text-gray-500', className)}>


### PR DESCRIPTION
Just fixing up some small bugs:

- The list now shows something useful instead of empty space on non-binary contracts.
- The hover highlight now doesn't have gaps between the items.
- There's a couple pixels of left-right padding, which makes the highlight look better.
- The user avatar link is un-broken.
- The vertical alignment is fixed up.