### PR TITLE
Clean up stuff and performance issues related to comment list

### DIFF
--- a/web/components/buttons/report-button.tsx
+++ b/web/components/buttons/report-button.tsx
@@ -55,7 +55,7 @@ export const reportContent = async (
     contentId,
     description,
   } = report
-  const reportDoc = await doc(collection(db, 'reports'))
+  const reportDoc = doc(collection(db, 'reports'))
   await setDoc(
     reportDoc,
     removeUndefinedProps({

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { memo, useEffect, useMemo, useState } from 'react'
-import { groupBy, last, sortBy, sum } from 'lodash'
+import { groupBy, last, sortBy } from 'lodash'
 
 import { Pagination } from 'web/components/widgets/pagination'
 import { FeedBet } from '../feed/feed-bets'
@@ -15,7 +15,6 @@ import { Col } from '../layout/col'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
 import { useComments } from 'web/hooks/use-comments'
 import { useLiquidity } from 'web/hooks/use-liquidity'
-import { useTipTxns } from 'web/hooks/use-tip-txns'
 import {
   DEV_HOUSE_LIQUIDITY_PROVIDER_ID,
   HOUSE_LIQUIDITY_PROVIDER_ID,
@@ -309,7 +308,6 @@ const CommentsTabContent = memo(function CommentsTabContent(props: {
 }) {
   const { contract, answerResponse, onCancelAnswerResponse, blockedUserIds } =
     props
-  const tips = useTipTxns({ contractId: contract.id })
   const comments = (useComments(contract.id) ?? props.comments).filter(
     (c) => !blockedUserIds.includes(c.userId)
   )
@@ -362,15 +360,11 @@ const CommentsTabContent = memo(function CommentsTabContent(props: {
         sort={sort}
         onSortClick={() => {
           setSort(sort === 'Newest' ? 'Best' : 'Newest')
-          const totalTips = sum(
-            Object.values(tips).map((t) => sum(Object.values(t)))
-          )
           track('change-comments-sort', {
             contractSlug: contract.slug,
             contractName: contract.question,
             totalComments: comments.length,
             totalUniqueTraders: contract.uniqueBettorCount,
-            totalTips,
           })
         }}
       />
@@ -381,7 +375,6 @@ const CommentsTabContent = memo(function CommentsTabContent(props: {
           onCancelAnswerResponse={onCancelAnswerResponse}
           topLevelComments={topLevelComments}
           commentsByParent={commentsByParent}
-          tips={tips}
         />
       )}
       {contract.outcomeType !== 'FREE_RESPONSE' &&
@@ -394,7 +387,6 @@ const CommentsTabContent = memo(function CommentsTabContent(props: {
               commentsByParent[parent.id] ?? [],
               (c) => c.createdTime
             )}
-            tips={tips}
           />
         ))}
     </>

--- a/web/components/contract/like-button.tsx
+++ b/web/components/contract/like-button.tsx
@@ -120,14 +120,7 @@ export const LikeButton = memo(function LikeButton(props: {
   const hasSafePolygon =
     (likedUserInfo != undefined && likedUserInfo.length > 0) || userLiked
   return (
-    <Row
-      className={clsx(
-        'relative items-center',
-        size === 'md' && 'mx-2',
-        size === 'xl' && 'mx-4',
-        className
-      )}
-    >
+    <>
       <Tooltip
         text={
           <UserLikedList
@@ -140,7 +133,12 @@ export const LikeButton = memo(function LikeButton(props: {
         placement={'bottom'}
         noTap
         hasSafePolygon={hasSafePolygon}
-        className={'flex items-center'}
+        className={clsx(
+          'flex flex-row items-center',
+          size === 'md' && 'mx-2',
+          size === 'xl' && 'mx-4',
+          className
+        )}
       >
         <button
           disabled={disabled}
@@ -199,7 +197,7 @@ export const LikeButton = memo(function LikeButton(props: {
           {totalLikes > 0 ? totalLikes : ''}
         </div>
       )}
-    </Row>
+    </>
   )
 })
 

--- a/web/components/contract/like-button.tsx
+++ b/web/components/contract/like-button.tsx
@@ -3,8 +3,7 @@ import clsx from 'clsx'
 import { Contract } from 'common/contract'
 import { ReactionContentTypes, ReactionTypes } from 'common/reaction'
 import { User } from 'common/user'
-import { debounce, partition } from 'lodash'
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 import { useIsLiked, useLikesOnContent } from 'web/hooks/use-likes'
 import useLongTouch from 'web/hooks/use-long-touch'
 import { react, unReact } from 'web/lib/firebase/reactions'
@@ -17,6 +16,7 @@ import {
 import { Avatar } from '../widgets/avatar'
 import { Tooltip } from '../widgets/tooltip'
 import { UserLink } from '../widgets/user-link'
+import { LoadingIndicator } from '../widgets/loading-indicator'
 
 const LIKES_SHOWN = 3
 
@@ -51,6 +51,7 @@ export const LikeButton = memo(function LikeButton(props: {
     isSwipe,
   } = props
   const userLiked = useIsLiked(user?.id, contentType, contentId)
+  const [allLikes, setAllLikes] = useState<MultiUserLinkInfo[]>([])
   const disabled = !user || contentCreatorId === user?.id
   const [liked, setLiked] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
@@ -78,21 +79,15 @@ export const LikeButton = memo(function LikeButton(props: {
     )
   }
 
-  const debouncedOnLike = useMemo(() => debounce(onLike, 1000), [user])
-
   // Handle changes from our useLike hook
   useEffect(() => {
     setLiked(userLiked)
   }, [userLiked])
 
-  useEffect(() => {
-    return () => debouncedOnLike.cancel()
-  }, [debouncedOnLike])
-
   function handleLiked(liked: boolean) {
     setLiked(liked)
     setTotalLikes((prev) => (liked ? prev + 1 : prev - 1))
-    debouncedOnLike(liked)
+    onLike(liked)
   }
 
   const likeLongPress = useLongTouch(
@@ -106,33 +101,29 @@ export const LikeButton = memo(function LikeButton(props: {
     }
   )
 
-  const likedUsers = useLikesOnContent(contentType, contentId)
-  const likedUserInfo = likedUsers
-    ? likedUsers.map((reaction) => {
-        return {
-          name: reaction.userDisplayName,
-          username: reaction.userUsername,
-          avatarUrl: reaction.userAvatarUrl,
-        } as MultiUserLinkInfo
-      })
-    : undefined
+  const otherLikes = liked ? totalLikes - 1 : totalLikes
+  const showList = otherLikes > 0
 
-  const hasSafePolygon =
-    (likedUserInfo != undefined && likedUserInfo.length > 0) || userLiked
   return (
     <>
       <Tooltip
         text={
-          <UserLikedList
-            likedUserInfo={likedUserInfo}
-            setModalOpen={() => setModalOpen(true)}
-            user={user}
-            userLiked={userLiked}
-          />
+          showList ? (
+            <UserLikedList
+              contentType={contentType}
+              contentId={contentId}
+              onRequestModal={(infos) => {
+                setAllLikes(infos)
+                setModalOpen(true)
+              }}
+              user={user}
+              userLiked={liked}
+            />
+          ) : null
         }
         placement={'bottom'}
         noTap
-        hasSafePolygon={hasSafePolygon}
+        hasSafePolygon={showList}
         className={clsx(
           'flex flex-row items-center',
           size === 'md' && 'mx-2',
@@ -176,17 +167,15 @@ export const LikeButton = memo(function LikeButton(props: {
           </div>
         </button>
       </Tooltip>
-      {likedUserInfo && (
-        <MultiUserTransactionModal
-          userInfos={likedUserInfo}
-          modalLabel={`💖 Liked this ${
-            contentType === 'contract' ? 'market' : contentType
-          }`}
-          open={modalOpen}
-          setOpen={setModalOpen}
-          short={true}
-        />
-      )}
+      <MultiUserTransactionModal
+        userInfos={allLikes}
+        modalLabel={`💖 Liked this ${
+          contentType === 'contract' ? 'market' : contentType
+        }`}
+        open={modalOpen}
+        setOpen={setModalOpen}
+        short={true}
+      />
       {showTotalLikesUnder && (
         <div
           className={clsx(
@@ -202,43 +191,57 @@ export const LikeButton = memo(function LikeButton(props: {
 })
 
 function UserLikedList(props: {
-  likedUserInfo: MultiUserLinkInfo[] | undefined
-  setModalOpen: () => void
+  contentType: ReactionContentTypes
+  contentId: string
+  onRequestModal: (infos: MultiUserLinkInfo[]) => void
   user?: User | null
   userLiked?: boolean
 }) {
-  const { likedUserInfo, user, setModalOpen, userLiked } = props
-  const length = likedUserInfo?.length
-  if (!likedUserInfo || !length || length <= 0) {
-    return <div className="cursor-default">Like</div>
-  }
-  let userInfo = likedUserInfo
-  if (userLiked && user) {
-    const [youLiked, otherUsersLiked] = partition(
-      likedUserInfo,
-      (u) => u.username === user?.username
-    )
-    userInfo = youLiked.concat(otherUsersLiked)
+  const { contentType, contentId, onRequestModal, user, userLiked } = props
+  const likedUsers = useLikesOnContent(contentType, contentId) ?? []
+  const likedUserInfos = likedUsers.map((reaction) => {
+    return {
+      name: reaction.userDisplayName,
+      username: reaction.userUsername,
+      avatarUrl: reaction.userAvatarUrl,
+    } as MultiUserLinkInfo
+  })
+
+  let displayInfos = likedUserInfos
+  if (user) {
+    displayInfos = likedUserInfos.filter((u) => u.username !== user.username)
+    if (userLiked) {
+      displayInfos = [user, ...displayInfos]
+    }
   }
 
   // only show "& n more" for n > 1
   const shown =
-    userInfo.length <= LIKES_SHOWN + 1 ? userInfo : userInfo.slice(0, 3)
+    displayInfos.length <= LIKES_SHOWN + 1
+      ? displayInfos
+      : displayInfos.slice(0, LIKES_SHOWN)
 
   return (
     <Col className="min-w-24 items-start">
       <div className="mb-1 font-bold">Like</div>
-      {shown.map((u) => {
-        return (
-          <UserLikedItem key={u.avatarUrl + u.username + u.name} userInfo={u} />
-        )
-      })}
-      {userInfo.length > shown.length && (
+      {displayInfos.length == 0 ? (
+        <LoadingIndicator className="mx-auto my-2" size="sm" />
+      ) : (
+        shown.map((u) => {
+          return (
+            <UserLikedItem
+              key={u.avatarUrl + u.username + u.name}
+              userInfo={u}
+            />
+          )
+        })
+      )}
+      {displayInfos.length > shown.length && (
         <div
           className="w-full cursor-pointer text-left text-indigo-300 hover:text-indigo-200"
-          onClick={setModalOpen}
+          onClick={() => onRequestModal(displayInfos)}
         >
-          & {userInfo.length - shown.length} more
+          & {displayInfos.length - shown.length} more
         </div>
       )}
     </Col>

--- a/web/components/feed/feed-answer-comment-group.tsx
+++ b/web/components/feed/feed-answer-comment-group.tsx
@@ -16,7 +16,6 @@ import { ContractComment } from 'common/comment'
 import { Dictionary, sortBy } from 'lodash'
 import { getAnswerColor } from '../answers/answers-panel'
 import Curve from 'web/public/custom-components/curve'
-import { CommentTipMap } from 'web/hooks/use-tip-txns'
 import { useChartAnswers } from '../charts/contract/choice'
 
 export function CommentsAnswer(props: {
@@ -76,7 +75,6 @@ export function FreeResponseComments(props: {
   onCancelAnswerResponse?: () => void
   topLevelComments: ContractComment[]
   commentsByParent: Dictionary<[ContractComment, ...ContractComment[]]>
-  tips: CommentTipMap
 }) {
   const {
     contract,
@@ -84,7 +82,6 @@ export function FreeResponseComments(props: {
     onCancelAnswerResponse,
     topLevelComments,
     commentsByParent,
-    tips,
   } = props
   const answersArray = useChartAnswers(contract).map((answer) => answer.text)
   return (
@@ -108,7 +105,6 @@ export function FreeResponseComments(props: {
                 commentsByParent[parent.id] ?? [],
                 (c) => c.createdTime
               )}
-              tips={tips}
             />
           )
         }
@@ -143,7 +139,6 @@ export function FreeResponseComments(props: {
                   commentsByParent[parent.id] ?? [],
                   (c) => c.createdTime
                 )}
-                tips={tips}
               />
             </div>
           </>

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useEffect, useRef, useState } from 'react'
 import { Editor } from '@tiptap/react'
 import { useRouter } from 'next/router'
-import { sum } from 'lodash'
 import clsx from 'clsx'
 
 import { ContractComment } from 'common/comment'
@@ -19,7 +18,6 @@ import { firebaseLogin } from 'web/lib/firebase/users'
 import { createCommentOnContract } from 'web/lib/firebase/comments'
 import { Col } from 'web/components/layout/col'
 import { track } from 'web/lib/service/analytics'
-import { CommentTipMap } from 'web/hooks/use-tip-txns'
 import { useEvent } from 'web/hooks/use-event'
 import { Content } from '../widgets/editor'
 import { UserLink } from 'web/components/widgets/user-link'
@@ -41,14 +39,12 @@ export type ReplyTo = { id: string; username: string }
 export function FeedCommentThread(props: {
   contract: Contract
   threadComments: ContractComment[]
-  tips: CommentTipMap
   parentComment: ContractComment
 }) {
-  const { contract, threadComments, tips, parentComment } = props
+  const { contract, threadComments, parentComment } = props
   const [replyTo, setReplyTo] = useState<ReplyTo>()
   const [seeReplies, setSeeReplies] = useState(true)
   const [highlightedId, setHighlightedId] = useState<string>()
-  const user = useUser()
 
   const router = useRouter()
   useEffect(() => {
@@ -75,8 +71,6 @@ export function FeedCommentThread(props: {
         contract={contract}
         comment={parentComment}
         highlighted={highlightedId === parentComment.id}
-        myTip={user ? tips[parentComment.id]?.[user.id] : undefined}
-        totalTip={sum(Object.values(tips[parentComment.id] ?? {}))}
         showLike={true}
         seeReplies={seeReplies}
         numComments={threadComments.length}
@@ -90,8 +84,6 @@ export function FeedCommentThread(props: {
             contract={contract}
             comment={comment}
             highlighted={highlightedId === comment.id}
-            myTip={user ? tips[comment.id]?.[user.id] : undefined}
-            totalTip={sum(Object.values(tips[comment.id] ?? {}))}
             showLike={true}
             onReplyClick={onReplyClick}
           />
@@ -115,8 +107,6 @@ export const ParentFeedComment = memo(function ParentFeedComment(props: {
   comment: ContractComment
   highlighted?: boolean
   showLike?: boolean
-  myTip?: number
-  totalTip?: number
   seeReplies: boolean
   numComments: number
   onReplyClick?: (comment: ContractComment) => void
@@ -126,8 +116,6 @@ export const ParentFeedComment = memo(function ParentFeedComment(props: {
     contract,
     comment,
     highlighted,
-    myTip,
-    totalTip,
     showLike,
     onReplyClick,
     onSeeReplyClick,
@@ -169,8 +157,6 @@ export const ParentFeedComment = memo(function ParentFeedComment(props: {
             onReplyClick={onReplyClick}
             comment={comment}
             showLike={showLike}
-            myTip={myTip}
-            totalTip={totalTip}
             contract={contract}
           />
         </Row>
@@ -183,8 +169,6 @@ export function CommentActions(props: {
   onReplyClick?: (comment: ContractComment) => void
   comment: ContractComment
   showLike?: boolean
-  myTip?: number
-  totalTip?: number
   contract: Contract
 }) {
   const { onReplyClick, comment, showLike, contract } = props
@@ -258,19 +242,9 @@ export const FeedComment = memo(function FeedComment(props: {
   comment: ContractComment
   highlighted?: boolean
   showLike?: boolean
-  myTip?: number
-  totalTip?: number
   onReplyClick?: (comment: ContractComment) => void
 }) {
-  const {
-    contract,
-    comment,
-    highlighted,
-    myTip,
-    totalTip,
-    showLike,
-    onReplyClick,
-  } = props
+  const { contract, comment, highlighted, showLike, onReplyClick } = props
   const { text, content, userUsername, userAvatarUrl } = comment
   const commentRef = useRef<HTMLDivElement>(null)
 
@@ -297,8 +271,6 @@ export const FeedComment = memo(function FeedComment(props: {
           onReplyClick={onReplyClick}
           comment={comment}
           showLike={showLike}
-          myTip={myTip}
-          totalTip={totalTip}
           contract={contract}
         />
       </Col>

--- a/web/components/feed/feed-comments.tsx
+++ b/web/components/feed/feed-comments.tsx
@@ -69,7 +69,7 @@ export function FeedCommentThread(props: {
   })
 
   return (
-    <Col className="relative w-full items-stretch gap-3 pb-2">
+    <Col className="w-full items-stretch gap-3 pb-2">
       <ParentFeedComment
         key={parentComment.id}
         contract={contract}
@@ -151,13 +151,11 @@ export const ParentFeedComment = memo(function ParentFeedComment(props: {
       id={comment.id}
       className={clsx(
         commentKind,
-        'relative ml-3 gap-2',
+        'gap-2',
         highlighted ? 'bg-indigo-50' : 'hover:bg-gray-50'
       )}
     >
-      <Col className="-ml-3.5">
-        <Avatar size="sm" username={userUsername} avatarUrl={userAvatarUrl} />
-      </Col>
+      <Avatar size="sm" username={userUsername} avatarUrl={userAvatarUrl} />
       <Col className="w-full">
         <FeedCommentHeader comment={comment} contract={contract} />
         <Content size="sm" content={content || text} />
@@ -287,13 +285,11 @@ export const FeedComment = memo(function FeedComment(props: {
       ref={commentRef}
       id={comment.id}
       className={clsx(
-        'relative ml-12 gap-2 ',
+        'ml-9 gap-2 ',
         highlighted ? 'bg-indigo-50' : 'hover:bg-gray-50'
       )}
     >
-      <Col className="-ml-3">
-        <Avatar size="xs" username={userUsername} avatarUrl={userAvatarUrl} />
-      </Col>
+      <Avatar size="xs" username={userUsername} avatarUrl={userAvatarUrl} />
       <Col className="w-full">
         <FeedCommentHeader comment={comment} contract={contract} />
         <Content className="mt-2 grow" size="sm" content={content || text} />
@@ -402,31 +398,29 @@ export function FeedCommentHeader(props: {
   }
   const shouldDisplayOutcome = betOutcome && !comment.answerOutcome
   return (
-    <Row>
-      <div className="mt-0.5 text-sm text-gray-600">
-        <UserLink username={userUsername} name={userName} />{' '}
-        <span className="text-gray-400">
-          <CommentStatus contract={contract} comment={comment} />
-          {bought} {money}
-          {shouldDisplayOutcome && (
-            <>
-              {' '}
-              of{' '}
-              <OutcomeLabel
-                outcome={betOutcome ? betOutcome : ''}
-                contract={contract}
-                truncate="short"
-              />
-            </>
-          )}
-        </span>
-        <CopyLinkDateTimeComponent
-          prefix={contract.creatorUsername}
-          slug={contract.slug}
-          createdTime={createdTime}
-          elementId={comment.id}
-        />
-      </div>
-    </Row>
+    <span className="mt-0.5 text-sm text-gray-600">
+      <UserLink username={userUsername} name={userName} />
+      <span className="ml-1 text-gray-400">
+        <CommentStatus contract={contract} comment={comment} />
+        {bought} {money}
+        {shouldDisplayOutcome && (
+          <>
+            {' '}
+            of{' '}
+            <OutcomeLabel
+              outcome={betOutcome ? betOutcome : ''}
+              contract={contract}
+              truncate="short"
+            />
+          </>
+        )}
+      </span>
+      <CopyLinkDateTimeComponent
+        prefix={contract.creatorUsername}
+        slug={contract.slug}
+        createdTime={createdTime}
+        elementId={comment.id}
+      />
+    </span>
   )
 }

--- a/web/components/widgets/editor.tsx
+++ b/web/components/widgets/editor.tsx
@@ -208,16 +208,15 @@ function RichContent(props: {
   )
 
   return (
-    <div className={className}>
-      <div
-        className={clsx(
-          'ProseMirror',
-          proseClass(size),
-          String.raw`empty:prose-p:after:content-["\00a0"]` // make empty paragraphs have height
-        )}
-      >
-        {jsxContent}
-      </div>
+    <div
+      className={clsx(
+        'ProseMirror',
+        className,
+        proseClass(size),
+        String.raw`empty:prose-p:after:content-["\00a0"]` // make empty paragraphs have height
+      )}
+    >
+      {jsxContent}
     </div>
   )
 }

--- a/web/components/widgets/loading-indicator.tsx
+++ b/web/components/widgets/loading-indicator.tsx
@@ -1,19 +1,30 @@
 import clsx from 'clsx'
-export type spinnerSizes = 'md' | 'lg'
+export type SpinnerSize = 'sm' | 'md' | 'lg'
+
+function getSizeClass(size: SpinnerSize) {
+  switch (size) {
+    case 'sm':
+      return 'h-4 w-4'
+    case 'md':
+      return 'h-6 w-6'
+    case 'lg':
+    default:
+      return 'h-8 w-8'
+  }
+}
 
 export function LoadingIndicator(props: {
   className?: string
   spinnerClassName?: string
-  size?: spinnerSizes
+  size?: SpinnerSize
 }) {
   const { className, spinnerClassName, size = 'lg' } = props
-
   return (
     <div className={clsx('flex items-center justify-center', className)}>
       <div
         className={clsx(
           'spinner-border inline-block animate-spin rounded-full border-4 border-solid border-indigo-500 border-r-transparent',
-          size === 'lg' ? 'h-8 w-8' : 'h-6 w-6',
+          getSizeClass(size),
           spinnerClassName
         )}
         role="status"

--- a/web/components/widgets/user-link.tsx
+++ b/web/components/widgets/user-link.tsx
@@ -58,16 +58,14 @@ export function UserLink(props: {
     <SiteLink
       href={`/${username}`}
       className={clsx(
-        'max-w-[120px] truncate min-[480px]:max-w-[200px]',
+        'inline-flex max-w-[120px] flex-row items-center gap-1 truncate min-[480px]:max-w-[200px]',
         className,
         noLink && 'pointer-events-none'
       )}
       followsLinkClass
     >
-      <div className="inline-flex flex-row items-center gap-1">
-        {shortName}
-        <UserBadge username={username} fresh={fresh} />
-      </div>
+      {shortName}
+      <UserBadge username={username} fresh={fresh} />
     </SiteLink>
   )
 }


### PR DESCRIPTION
Comment rendering is a large culprit making the "search and look at contracts and go back to the search" user flow feel slow.

The big fix here is that previously we were loading all the lists of likes for all the comments in tiny Firestore subscriptions when we rendered each like button, but now we only load them when you hover the button to see the tooltip.