### PR TITLE
Disable quick bet on contract list popup

### DIFF
--- a/web/components/contract/contracts-list.tsx
+++ b/web/components/contract/contracts-list.tsx
@@ -59,6 +59,7 @@ function DesktopPopover(props: { contract: Contract }) {
       content={
         <ContractCard
           contract={contract}
+          hideQuickBet
           showImage
           showDescription
           className="w-[350px]"


### PR DESCRIPTION
I think the idea of having a quick bet tool in this list is perfectly reasonable, but unfortunately:

1. The quick bet widget is very expensive for performance because every one of them subscribes to a bunch of contract-specific stuff from Firestore. So its presence is hurting the browsing workflow.
2. When the widget is presented in a popup over to the right of the item that disappears if you mouse out of the list entry, it's going to be ridiculous to expect anyone to mouse over and use it.

So until point number 2 is resolved I don't think it makes sense to pay the price in point number 1.

My suggestion would be to add quick bet arrows inline with the list entry.