### PR TITLE
Make local storage wrapper not inefficient

### DIFF
--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -23,14 +23,11 @@ import { safeLocalStorage } from 'web/lib/util/local'
 export type AuthUser = undefined | null | UserAndPrivateUser
 const CACHED_USER_KEY = 'CACHED_USER_KEY_V2'
 
-// Proxy localStorage in case it's not available (eg in incognito iframe)
-const localStorage = safeLocalStorage()
-
 const ensureDeviceToken = () => {
-  let deviceToken = localStorage.getItem('device-token')
+  let deviceToken = safeLocalStorage?.getItem('device-token')
   if (!deviceToken) {
     deviceToken = randomString()
-    localStorage.setItem('device-token', deviceToken)
+    safeLocalStorage?.setItem('device-token', deviceToken)
   }
   return deviceToken
 }

--- a/web/components/contract-search.tsx
+++ b/web/components/contract-search.tsx
@@ -279,7 +279,7 @@ function ContractSearchControls(props: {
   )
 
   const sortKey = `${persistPrefix}-search-sort`
-  const savedSort = safeLocalStorage()?.getItem(sortKey)
+  const savedSort = safeLocalStorage?.getItem(sortKey)
 
   const [sort, setSort] = usePersistentState(
     savedSort ?? defaultSort,
@@ -302,7 +302,7 @@ function ContractSearchControls(props: {
 
   useEffect(() => {
     if (persistPrefix && sort) {
-      safeLocalStorage()?.setItem(sortKey, sort as string)
+      safeLocalStorage?.setItem(sortKey, sort as string)
     }
   }, [persistPrefix, query, sort, sortKey])
 

--- a/web/components/daily-profit.tsx
+++ b/web/components/daily-profit.tsx
@@ -43,7 +43,7 @@ export const DailyProfit = memo(function DailyProfit(props: {
     undefined,
     {
       key: `daily-profit-${user?.id}`,
-      store: storageStore(safeLocalStorage()),
+      store: storageStore(safeLocalStorage),
     },
     {
       every: HOUR_MS,

--- a/web/components/notification-settings.tsx
+++ b/web/components/notification-settings.tsx
@@ -285,7 +285,7 @@ export function NotificationSettings(props: {
     // due to a private user settings change. Just going to persist expanded state here
     const [expanded, setExpanded] = usePersistentState(expand ?? false, {
       key: 'NotificationsSettingsSection-' + subscriptionTypes.join('-'),
-      store: storageStore(safeLocalStorage()),
+      store: storageStore(safeLocalStorage),
     })
 
     // Not working as the default value for expanded, so using a useEffect

--- a/web/components/widgets/collapsible-content.tsx
+++ b/web/components/widgets/collapsible-content.tsx
@@ -85,7 +85,7 @@ function ActuallyCollapsibleContent(props: {
 }) {
   const { content, stateKey } = props
   const [isCollapsed, setIsCollapsed] = usePersistentState<boolean>(false, {
-    store: storageStore(safeLocalStorage()),
+    store: storageStore(safeLocalStorage),
     key: stateKey,
   })
   return (

--- a/web/components/widgets/editor.tsx
+++ b/web/components/widgets/editor.tsx
@@ -88,7 +88,7 @@ export function useTextEditor(props: {
     undefined,
     {
       key: `text ${key}`,
-      store: storageStore(safeLocalStorage()),
+      store: storageStore(safeLocalStorage),
     }
   )
 

--- a/web/hooks/use-follows.ts
+++ b/web/hooks/use-follows.ts
@@ -9,13 +9,12 @@ export const useFollows = (userId: string | null | undefined) => {
   useEffect(() => {
     if (userId) {
       const key = `follows:${userId}`
-      const localStorage = safeLocalStorage()
-      const follows = localStorage.getItem(key)
+      const follows = safeLocalStorage?.getItem(key)
       if (follows) setFollowIds(JSON.parse(follows))
 
       return listenForFollows(userId, (follows) => {
         setFollowIds(follows)
-        localStorage.setItem(key, JSON.stringify(follows))
+        safeLocalStorage?.setItem(key, JSON.stringify(follows))
       })
     }
   }, [userId])

--- a/web/hooks/use-group.ts
+++ b/web/hooks/use-group.ts
@@ -110,7 +110,7 @@ export function useMemberGroupsSubscription(user: User | null | undefined) {
     undefined,
     {
       key: 'member-groups',
-      store: storageStore(safeLocalStorage()),
+      store: storageStore(safeLocalStorage),
     }
   )
 
@@ -133,7 +133,7 @@ export function useMemberGroupsIdsAndSlugs(userId: string | null | undefined) {
     { id: string; slug: string }[] | undefined
   >(undefined, {
     key: 'member-groups-ids-and-slugs',
-    store: storageStore(safeLocalStorage()),
+    store: storageStore(safeLocalStorage),
   })
 
   useEffect(() => {

--- a/web/hooks/use-is-mobile.ts
+++ b/web/hooks/use-is-mobile.ts
@@ -7,7 +7,7 @@ export function useIsMobile(threshold = 640) {
   const [isMobile, setIsMobile] = usePersistentState(false, {
     key: 'is-mobile',
     // Save in localstorage because isMobile status doesn't change much.
-    store: storageStore(safeLocalStorage()),
+    store: storageStore(safeLocalStorage),
   })
   useEffect(() => {
     const onResize = () => setIsMobile(window.innerWidth < threshold)

--- a/web/hooks/use-notifications.ts
+++ b/web/hooks/use-notifications.ts
@@ -25,7 +25,7 @@ function useNotifications(privateUser: PrivateUser) {
     Notification[] | undefined
   >(undefined, {
     key: NOTIFICATIONS_KEY,
-    store: storageStore(safeLocalStorage()),
+    store: storageStore(safeLocalStorage),
   })
   useEffect(() => {
     listenForNotifications(privateUser.id, setNotifications)
@@ -47,7 +47,7 @@ function useUnseenNotifications(privateUser: PrivateUser) {
     undefined,
     {
       key: NOTIFICATIONS_KEY,
-      store: storageStore(safeLocalStorage()),
+      store: storageStore(safeLocalStorage),
     }
   )
   useEffect(() => {

--- a/web/hooks/use-persistent-state.ts
+++ b/web/hooks/use-persistent-state.ts
@@ -10,6 +10,8 @@ export type RevalidationOptions<T> = {
   callback: () => Promise<T>
 }
 
+export type Backend = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
 export interface PersistentStore<T> {
   get: (k: string) => T | undefined
   set: (k: string, v: T | undefined) => void
@@ -28,7 +30,7 @@ const withURLParam = (location: Location, k: string, v?: string) => {
   return newUrl
 }
 
-export const storageStore = <T>(storage?: Storage): PersistentStore<T> => ({
+export const storageStore = <T>(storage?: Backend): PersistentStore<T> => ({
   get: (k: string) => {
     if (!storage) {
       return undefined

--- a/web/hooks/use-save-binary-shares.ts
+++ b/web/hooks/use-save-binary-shares.ts
@@ -23,10 +23,8 @@ export const useSaveBinaryShares = (
     : [savedShares.yesShares, savedShares.noShares]
 
   useEffectCheckEquality(() => {
-    const local = safeLocalStorage()
-
     // Read shares from local storage.
-    const savedShares = local?.getItem(`${contract.id}-shares`)
+    const savedShares = safeLocalStorage?.getItem(`${contract.id}-shares`)
     if (savedShares) {
       setSavedShares(JSON.parse(savedShares))
     }
@@ -34,7 +32,7 @@ export const useSaveBinaryShares = (
     if (userBets?.length) {
       // Save shares to local storage.
       const sharesData = JSON.stringify({ yesShares, noShares })
-      local?.setItem(`${contract.id}-shares`, sharesData)
+      safeLocalStorage?.setItem(`${contract.id}-shares`, sharesData)
     }
   }, [contract.id, userBets, noShares, yesShares])
 

--- a/web/hooks/use-saved-contract-metrics.ts
+++ b/web/hooks/use-saved-contract-metrics.ts
@@ -12,7 +12,7 @@ export const useSavedContractMetrics = (contract: Contract) => {
     ContractMetrics | undefined
   >(undefined, {
     key: `contract-metrics-${contract.id}`,
-    store: storageStore(safeLocalStorage()),
+    store: storageStore(safeLocalStorage),
   })
 
   const metrics =

--- a/web/hooks/use-user.ts
+++ b/web/hooks/use-user.ts
@@ -90,9 +90,9 @@ export const useUserContractMetricsByProfit = (userId = '_', count = 50) => {
 
     const key = `user-contract-metrics-${userId}`
     if (isReady) {
-      safeLocalStorage()?.setItem(key, JSON.stringify(result))
+      safeLocalStorage?.setItem(key, JSON.stringify(result))
     } else if (!result) {
-      const saved = safeLocalStorage()?.getItem(key)
+      const saved = safeLocalStorage?.getItem(key)
       if (saved) {
         savedResult.current = JSON.parse(saved)
       }

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -127,7 +127,7 @@ export function writeReferralInfo(
     groupId?: string
   }
 ) {
-  const local = safeLocalStorage()
+  const local = safeLocalStorage
   const cachedReferralUser = local?.getItem(CACHED_REFERRAL_USERNAME_KEY)
   const { contractId, explicitReferrer, groupId } = otherOptions || {}
 
@@ -158,7 +158,7 @@ export async function setCachedReferralInfoForUser(user: User | null) {
   const userCreatedTime = dayjs(user.createdTime)
   if (now.diff(userCreatedTime, 'minute') > 5) return
 
-  const local = safeLocalStorage()
+  const local = safeLocalStorage
   const cachedReferralUsername = local?.getItem(CACHED_REFERRAL_USERNAME_KEY)
   const cachedReferralContractId = local?.getItem(
     CACHED_REFERRAL_CONTRACT_ID_KEY

--- a/web/lib/native/is-native.ts
+++ b/web/lib/native/is-native.ts
@@ -17,21 +17,21 @@ export const getNativePlatform = () => {
 
 const getNativeInfo = () => {
   if (typeof window === 'undefined') return { isNative: false, platform: '' }
-  const local = safeLocalStorage()
-  const ss = safeSessionStorage()
-  const isNative = local.getItem(IS_NATIVE_KEY) || ss.getItem(IS_NATIVE_KEY)
-  const platform = local.getItem(PLATFORM_KEY) || ss.getItem(PLATFORM_KEY)
+  const local = safeLocalStorage
+  const ss = safeSessionStorage
+  const isNative = local?.getItem(IS_NATIVE_KEY) || ss?.getItem(IS_NATIVE_KEY)
+  const platform = local?.getItem(PLATFORM_KEY) || ss?.getItem(PLATFORM_KEY)
   return { isNative: isNative === 'true', platform }
 }
 
 export const setIsNative = (isNative: boolean, platform: string) => {
-  const local = safeLocalStorage()
-  const ss = safeSessionStorage()
-  local.setItem(IS_NATIVE_KEY, isNative ? 'true' : 'false')
-  ss.setItem(IS_NATIVE_KEY, isNative ? 'true' : 'false')
+  const local = safeLocalStorage
+  const ss = safeSessionStorage
+  local?.setItem(IS_NATIVE_KEY, isNative ? 'true' : 'false')
+  ss?.setItem(IS_NATIVE_KEY, isNative ? 'true' : 'false')
   if (platform) {
-    local.setItem(PLATFORM_KEY, platform)
-    ss.setItem(PLATFORM_KEY, platform)
+    local?.setItem(PLATFORM_KEY, platform)
+    ss?.setItem(PLATFORM_KEY, platform)
   }
 }
 

--- a/web/lib/util/local.ts
+++ b/web/lib/util/local.ts
@@ -1,53 +1,30 @@
-export const safeLocalStorage = () => {
-  const localStorage = ls()
-
-  return {
-    getItem: (key: string) => localStorage?.getItem(key),
-    setItem: (key: string, value: string) => {
-      try {
-        localStorage?.setItem(key, value)
-      } catch (e) {
-        localStorage?.clear()
-        // try again
-        localStorage?.setItem(key, value)
-      }
-    },
-    removeItem: (key: string) => localStorage?.removeItem(key),
-  } as Storage
-}
-
-export const safeSessionStorage = () => {
-  const sessionStorage = ss()
-
-  return {
-    getItem: (key: string) => sessionStorage?.getItem(key),
-    setItem: (key: string, value: string) => {
-      try {
-        sessionStorage?.setItem(key, value)
-      } catch (e) {
-        sessionStorage?.clear()
-        // try again
-        sessionStorage?.setItem(key, value)
-      }
-    },
-    removeItem: (key: string) => sessionStorage?.removeItem(key),
-  } as Storage
-}
-
-const ls = () => {
+function getStorageProxy(store: Storage) {
   try {
-    localStorage.getItem('test')
-    return localStorage
+    store.getItem('test')
   } catch (e) {
     return undefined
   }
-}
-
-const ss = () => {
-  try {
-    sessionStorage.getItem('test')
-    return sessionStorage
-  } catch (e) {
-    return undefined
+  return {
+    getItem: (key: string) => store.getItem(key) ?? null,
+    setItem: (key: string, value: string) => {
+      try {
+        store.setItem(key, value)
+      } catch (e) {
+        store.clear()
+        // try again
+        store.setItem(key, value)
+      }
+    },
+    removeItem: (key: string) => store.removeItem(key) as void,
   }
 }
+
+export const safeLocalStorage =
+  typeof localStorage !== 'undefined'
+    ? getStorageProxy(localStorage)
+    : undefined
+
+export const safeSessionStorage =
+  typeof sessionStorage !== 'undefined'
+    ? getStorageProxy(sessionStorage)
+    : undefined


### PR DESCRIPTION
Previously, every time you called `safeLocalStorage` we would do our "test" to see if an exception flew out, so it was frequently doing that hundreds or thousands of times in a page load. There's no point in doing that because for a given interpreter session either `localStorage` is gonna be there or it isn't.