### PR TITLE
Bump function runtime from Node 16 to Node 18

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "predeploy": "cd backend/functions && yarn build",
-    "runtime": "nodejs16",
+    "runtime": "nodejs18",
     "source": "backend/functions/dist",
     "ignore": [
       "node_modules",


### PR DESCRIPTION
It's comfy to upgrade this because it means that the runtime environment is closer to what we are running on our box. Also, Node 18 has some good convenience stuff like built-in `fetch`.

I'm going to bump the Vercel Node to 18 too.