### PR TITLE
No need for node-fetch anymore

### DIFF
--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -49,7 +49,6 @@
     "lodash": "4.17.21",
     "mailgun-js": "0.22.0",
     "marked": "4.1.1",
-    "node-fetch": "2",
     "openai": "3.0.1",
     "pg-promise": "11.0.2",
     "stripe": "8.194.0",
@@ -58,7 +57,6 @@
   "devDependencies": {
     "@types/mailgun-js": "0.22.12",
     "@types/marked": "4.0.7",
-    "@types/node-fetch": "2.6.2",
     "puppeteer": "18.0.5",
     "tsc-alias": "1.8.2",
     "tsconfig-paths": "4.1.2"

--- a/backend/functions/src/api/claim-destiny-sub.ts
+++ b/backend/functions/src/api/claim-destiny-sub.ts
@@ -1,6 +1,5 @@
 import * as admin from 'firebase-admin'
 import { z } from 'zod'
-import fetch from 'node-fetch'
 import { FieldValue } from 'firebase-admin/firestore'
 
 import { APIError, newEndpoint, validate } from './helpers'

--- a/backend/replicator/package.json
+++ b/backend/replicator/package.json
@@ -30,7 +30,6 @@
     "@tiptap/suggestion": "2.0.0-beta.204",
     "express": "4.18.1",
     "firebase-admin": "11.2.0",
-    "node-fetch": "2",
     "pg-promise": "11.0.2",
     "lodash": "4.17.21",
     "typescript": "4.9.3"

--- a/backend/scripts/place-many-bets.ts
+++ b/backend/scripts/place-many-bets.ts
@@ -1,5 +1,4 @@
 import { initAdmin } from 'shared/init-admin'
-import fetch from 'node-fetch'
 
 async function placeManyBets(apiKey: string, count: number) {
   const url = 'https://placebet-w3txbmd3ba-uc.a.run.app'

--- a/backend/shared/package.json
+++ b/backend/shared/package.json
@@ -15,13 +15,11 @@
     "@tiptap/html": "2.0.0-beta.204",
     "firebase-admin": "11.2.0",
     "lodash": "4.17.21",
-    "node-fetch": "2",
     "pg-promise": "11.0.2",
     "dayjs": "1.11.4",
     "openai": "3.0.1"
   },
   "devDependencies": {
-    "@types/node-fetch": "2.6.2",
     "tsc-alias": "1.8.2"
   }
 }

--- a/backend/shared/src/dream-utils.ts
+++ b/backend/shared/src/dream-utils.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 import { DOMAIN } from 'common/envs/constants'
 
 export const dreamWithDefaultParams = async (input: string) => {

--- a/backend/shared/src/helpers/generate-and-update-avatar-urls.ts
+++ b/backend/shared/src/helpers/generate-and-update-avatar-urls.ts
@@ -1,7 +1,6 @@
 import * as admin from 'firebase-admin'
 
 import { getStorage, Storage } from 'firebase-admin/storage'
-import fetch from 'node-fetch'
 import { User } from 'common/user'
 import { DOMAIN } from 'common/envs/constants'
 

--- a/backend/shared/src/utils.ts
+++ b/backend/shared/src/utils.ts
@@ -1,5 +1,4 @@
 import * as admin from 'firebase-admin'
-import fetch from 'node-fetch'
 import {
   CollectionReference,
   CollectionGroup,

--- a/web/lib/api/proxy.ts
+++ b/web/lib/api/proxy.ts
@@ -2,7 +2,6 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { promisify } from 'util'
 import { pipeline } from 'stream'
 import { getFunctionUrl } from 'common/api'
-import fetch, { Headers, Response } from 'node-fetch'
 
 function getProxiedRequestHeaders(req: NextApiRequest, whitelist: string[]) {
   const result = new Headers()
@@ -41,11 +40,11 @@ export const fetchBackend = (req: NextApiRequest, name: string) => {
     'Origin',
   ])
   const hasBody = req.method != 'HEAD' && req.method != 'GET'
-  const body = req.body ? JSON.stringify(req.body) : req
+  const body = req.body ? JSON.stringify(req.body) : null
   const opts = {
     headers,
     method: req.method,
-    body: hasBody ? body : undefined,
+    body: hasBody ? body : null,
   }
   return fetch(url, opts)
 }
@@ -63,6 +62,9 @@ export const forwardResponse = async (
   ])
   res.writeHead(backendRes.status, headers)
   if (backendRes.body != null) {
-    return await promisify(pipeline)(backendRes.body, res)
+    return await promisify(pipeline)(
+      backendRes.body as unknown as NodeJS.ReadableStream,
+      res
+    )
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -60,7 +60,6 @@
     "lodash": "4.17.21",
     "nanoid": "^3.3.4",
     "next": "13.1.0",
-    "node-fetch": "2.6.7",
     "prosemirror-state": "1.4.2",
     "rc-slider": "10.0.1",
     "react": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,14 +2375,6 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
-"@types/node-fetch@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
-  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node@*", "@types/node@18.11.16", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=8.1.0":
   version "18.11.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.16.tgz#966cae211e970199559cfbd295888fca189e49af"
@@ -4719,15 +4711,6 @@ form-data@^2.3.3, form-data@^2.5.0:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -6584,7 +6567,7 @@ next@13.1.0:
     "@next/swc-win32-ia32-msvc" "13.1.0"
     "@next/swc-win32-x64-msvc" "13.1.0"
 
-node-fetch@2, node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
Node 18 [includes `fetch`](https://nodejs.org/de/blog/announcements/v18-release-announce/#fetch-experimental) in the standard library, so now that we are on Node 18 we don't need to use `node-fetch` on Vercel or Cloud Functions anymore.