### PR TITLE
Add some convenience imports to `web` project

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -17,6 +17,10 @@
     "paths": {
       "common/*": ["../common/src/*"],
       "web/*": ["./*"],
+      "hooks/*": ["./hooks/*"],
+      "lib/*": ["./lib/*"],
+      "pages/*": ["./pages/*"],
+      "components/*": ["./components/*"]
     }
   },
   "watchOptions": {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,7 +16,7 @@
     "incremental": true,
     "paths": {
       "common/*": ["../common/src/*"],
-      "web/*": ["./src/*"]
+      "web/*": ["./*"],
     }
   },
   "watchOptions": {


### PR DESCRIPTION
Now you can do e.g. `import { useEvent } from 'hooks/use-event'` instead of `web/hooks/use-event`.