### PR TITLE
Undo contract resolution

### DIFF
--- a/backend/functions/src/api/resolve-market.ts
+++ b/backend/functions/src/api/resolve-market.ts
@@ -64,9 +64,10 @@ export const payUsersTransactions = async (
           toId: userId,
           amount: payout,
           token: 'M$',
+          data: { deposit: deposit ?? 0 },
           description: 'Contract payout for resolution: ' + contractId,
         } as ContractResolutionPayoutTxn
-        runContractPayoutTxn(transaction, payoutTxn, deposit ?? 0)
+        runContractPayoutTxn(transaction, payoutTxn)
       })
     })
   }

--- a/backend/scripts/undo-resolution.ts
+++ b/backend/scripts/undo-resolution.ts
@@ -1,0 +1,53 @@
+import * as admin from 'firebase-admin'
+
+import { initAdmin } from 'shared/init-admin'
+initAdmin()
+import { ContractResolutionPayoutTxn } from 'common/txn'
+import { chunk } from 'lodash'
+import { undoContractPayoutTxn } from 'shared/run-txn'
+
+const firestore = admin.firestore()
+
+const undoResolution = async (contractId: string) => {
+  // get all the txns with category CONTRACT_RESOLUTION_PAYOUT
+  // and fromType CONTRACT and fromID contractId
+  const txns = await firestore
+    .collection('txns')
+    .where('category', '==', 'CONTRACT_RESOLUTION_PAYOUT')
+    .where('fromType', '==', 'CONTRACT')
+    .where('fromId', '==', contractId)
+    .get()
+    .then((snapshot) =>
+      snapshot.docs.map((doc) => doc.data() as ContractResolutionPayoutTxn)
+    )
+  console.log('reverting txns', txns.length)
+  const chunkedTxns = chunk(txns, 250)
+  for (const chunk of chunkedTxns) {
+    await firestore.runTransaction(async (transaction) => {
+      for (const txn of chunk) {
+        undoContractPayoutTxn(transaction, txn)
+      }
+    })
+  }
+  console.log('reverted txns')
+
+  await firestore.doc(`contracts/${contractId}`).update({
+    isResolved: false,
+    resolutionTime: admin.firestore.FieldValue.delete(),
+    resolution: admin.firestore.FieldValue.delete(),
+    resolutionProbability: admin.firestore.FieldValue.delete(),
+  })
+  console.log('updated contract')
+}
+
+if (require.main === module) {
+  const contractId = process.argv[2]
+  if (!contractId) {
+    console.log('Usage: ts-node undo-resolution.ts <contractId>')
+    process.exit()
+  }
+  console.log('reverting resolution for contract:', contractId)
+  undoResolution(contractId)
+    .then(() => process.exit())
+    .catch(console.log)
+}

--- a/common/src/txn.ts
+++ b/common/src/txn.ts
@@ -183,6 +183,10 @@ type ContractResolutionPayout = {
   toType: 'USER'
   category: 'CONTRACT_RESOLUTION_PAYOUT'
   token: 'M$'
+  data: {
+    reverted?: boolean
+    deposit?: number
+  }
 }
 
 type QfId = {


### PR DESCRIPTION
This doesn't undo all trades, just the final payouts and sets the contract back to its last, unresolved state.
