### PR TITLE
Clean up a couple things in `next.config.js`

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -5,7 +5,6 @@ const ABOUT_PAGE_URL = 'https://help.manifold.markets/'
 /** @type {import('next').NextConfig} */
 module.exports = {
   productionBrowserSourceMaps: true,
-  staticPageGenerationTimeout: 600, // e.g. stats page
   reactStrictMode: true,
   optimizeFonts: false,
   modularizeImports: {

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -6,7 +6,6 @@ const ABOUT_PAGE_URL = 'https://help.manifold.markets/'
 module.exports = {
   productionBrowserSourceMaps: true,
   reactStrictMode: true,
-  optimizeFonts: false,
   modularizeImports: {
     '@heroicons/react/solid/?(((\\w*)?/?)*)': {
       transform: '@heroicons/react/solid/{{ matches.[1] }}/{{member}}',

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -20,9 +20,9 @@ module.exports = {
       transform: 'lodash/{{member}}',
     },
   },
+  transpilePackages: ['common'],
   experimental: {
     scrollRestoration: true,
-    externalDir: true,
   },
   images: {
     dangerouslyAllowSVG: true,


### PR DESCRIPTION
I noticed some stuff here that could be tidied up while I was poking around trying out Turbopack.

The font thing comes from https://github.com/manifoldmarkets/manifold/pull/668. I read in one of the Next changelogs since then that the issue was fixed, so I think we're good to go back to the default behavior.