### PR TITLE
Don't proxy `Content-Length` header to backend

### DIFF
--- a/web/lib/api/proxy.ts
+++ b/web/lib/api/proxy.ts
@@ -35,7 +35,6 @@ export const fetchBackend = (req: NextApiRequest, name: string) => {
   const url = getFunctionUrl(name)
   const headers = getProxiedRequestHeaders(req, [
     'Authorization',
-    'Content-Length',
     'Content-Type',
     'Origin',
   ])


### PR DESCRIPTION
Since #1511 it seems like this is causing some trouble with our proxied API routes where `fetch` thinks that our body length doesn't match the `Content-Length` header. It's not clear to me why that is the case, but it seems like just not proxying that header (and thereby sending a correct one for sure via the `fetch` internals) is easy and safe, so I am just going to do that and fix the thing.