### PR TITLE
Add `pg_vector` and `pg_repack` extensions

### DIFF
--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -7,6 +7,12 @@
 /* allow our backend to have a long statement timeout */
 alter role service_role set statement_timeout = '120s';
 
+/* for clustering without locks */
+create extension if not exists pg_repack;
+
+/* for fancy machine learning stuff */
+create extension if not exists vector;
+
 /* GIN trigram indexes */
 create extension if not exists pg_trgm;
 
@@ -831,4 +837,3 @@ as $$
     and (data->>'createdTime')::bigint > created_time
     group by creator_id;
 $$;
-


### PR DESCRIPTION
`pg_vector` provides a `vector` data type that provides efficient storage over large multidimensional vectors and fast indexes for looking up vectors ordered by e.g. cosine similarity to a target vector. You can see [this Supabase blog post](https://supabase.com/blog/openai-embeddings-postgres-vector).

`pg_repack` provides a way to do the equivalent of `cluster` and `vacuum full` (i.e. keep tables in an efficient physical order) without locking, so we can do it regularly. This should greatly improve the performance of common operations on large tables like `contract_bets` and `user_seen_events`. See the documentation [here](https://github.com/reorg/pg_repack).