### PR TITLE
Really fix proxy code to work with built-in fetch

### DIFF
--- a/web/lib/api/proxy.ts
+++ b/web/lib/api/proxy.ts
@@ -39,10 +39,13 @@ export const fetchBackend = (req: NextApiRequest, name: string) => {
     'Origin',
   ])
   const hasBody = req.method != 'HEAD' && req.method != 'GET'
-  const body = req.body ? JSON.stringify(req.body) : null
+  const body = req.body
+    ? JSON.stringify(req.body)
+    : (req as unknown as ReadableStream)
   const opts = {
     headers,
     method: req.method,
+    duplex: 'half',
     body: hasBody ? body : null,
   }
   return fetch(url, opts)


### PR DESCRIPTION
This fixes a bug I made in #1511 because I didn't understand that in some cases next.js will hand us a `NextApiRequest` that is an `ReadableStream` with the request contents in and of itself, rather than having a `body` property.

The `duplex: 'half'` thing is a small change required by the built-in fetch vs. our previous fetch implementation in cases that the `body` of the fetch request is a `ReadableStream`. See https://github.com/nodejs/node/issues/46221 and linked issues.