### PR TITLE
Tidy up landing page markup

### DIFF
--- a/web/components/landing-page-panel.tsx
+++ b/web/components/landing-page-panel.tsx
@@ -60,11 +60,7 @@ export function LandingPagePanel() {
 
   return (
     <>
-      <div
-        className={clsx(
-          'mt-8 flex h-96 w-full flex-col overflow-hidden drop-shadow-sm sm:mt-4 sm:h-60 sm:flex-row'
-        )}
-      >
+      <div className="mt-8 flex h-96 w-full flex-col overflow-hidden drop-shadow-sm sm:mt-4 sm:h-60 sm:flex-row">
         <div className="relative h-4/5 w-full rounded-t-xl bg-indigo-700 sm:h-full sm:w-3/5 sm:rounded-l-xl sm:rounded-r-none">
           {isMobile && <LandingPageManifoldMarketsLogo isMobile={isMobile} />}
           {pageNumber === 0 && <LandingPage0 isMobile={isMobile} />}
@@ -72,12 +68,12 @@ export function LandingPagePanel() {
           {pageNumber === 2 && <LandingPage2 isMobile={isMobile} />}
           {!isMobile && (
             <div className="absolute -right-0.5 bottom-0 z-20 h-full">
-              <SquiggleVerticalIcon className={clsx('text-indigo-200')} />
+              <SquiggleVerticalIcon className="text-indigo-200" />
             </div>
           )}
           {isMobile && (
             <div className="absolute right-0 -bottom-0.5 z-20 w-full items-center">
-              <SquiggleHorizontalIcon className={clsx('text-indigo-200')} />
+              <SquiggleHorizontalIcon className="text-indigo-200" />
             </div>
           )}
           <div
@@ -112,11 +108,7 @@ export function LandingPagePanel() {
             </div>
           </div>
         </div>
-        <div
-          className={clsx(
-            'relative z-30 h-1/5 w-full rounded-b-xl bg-indigo-200 sm:h-full sm:w-2/5 sm:rounded-r-xl sm:rounded-l-none'
-          )}
-        >
+        <div className="relative z-30 h-1/5 w-full rounded-b-xl bg-indigo-200 sm:h-full sm:w-2/5 sm:rounded-r-xl sm:rounded-l-none">
           {!isMobile && <LandingPageManifoldMarketsLogo isMobile={isMobile} />}
           <div className="group absolute bottom-16 right-8 z-30 md:right-12">
             <Button
@@ -308,16 +300,8 @@ export function LandingPage1(props: { isMobile: boolean }) {
             shouldPercentChange ? 'w-48' : 'w-[120px]'
           )}
         />
-        <EquilateralLeftTriangle
-          className={clsx(
-            'absolute left-[8px] top-[7px] z-10 h-6 w-6 text-indigo-400'
-          )}
-        />
-        <EquilateralLeftTriangle
-          className={clsx(
-            'absolute left-[11px] top-[11px] z-0 h-6 w-6 text-gray-900 opacity-20'
-          )}
-        />
+        <EquilateralLeftTriangle className="absolute left-[8px] top-[7px] z-10 h-6 w-6 text-indigo-400" />
+        <EquilateralLeftTriangle className="absolute left-[11px] top-[11px] z-0 h-6 w-6 text-gray-900 opacity-20" />
         <div className="absolute top-[6px] left-[100px] z-30 text-xl font-semibold">
           {shouldPercentChange && (
             <CountUp start={50} end={75} duration={1.3} suffix="%" />
@@ -330,11 +314,7 @@ export function LandingPage1(props: { isMobile: boolean }) {
             shouldButtonHighlight ? 'text-indigo-600' : 'text-indigo-400'
           )}
         />
-        <EquilateralRightTriangle
-          className={clsx(
-            'absolute right-[6px] top-[11px] z-0 h-6 w-6 text-gray-900 opacity-20'
-          )}
-        />
+        <EquilateralRightTriangle className="absolute right-[6px] top-[11px] z-0 h-6 w-6 text-gray-900 opacity-20" />
         <div
           className={clsx(
             'animate-float-and-fade-1 absolute right-[10px] top-[2px] z-40 font-thin text-indigo-600',

--- a/web/lib/icons/squiggle_horizontal.tsx
+++ b/web/lib/icons/squiggle_horizontal.tsx
@@ -2,8 +2,6 @@ export default function SquiggleHorizontalIcon(props: { className?: string }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="inherit"
-      height="inherit"
       fill="currentColor"
       className={props.className}
       viewBox="0 0 16 4"

--- a/web/lib/icons/squiggle_horizontal_flipped.tsx
+++ b/web/lib/icons/squiggle_horizontal_flipped.tsx
@@ -4,8 +4,6 @@ export default function SquiggleHorizontalFlippedIcon(props: {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="inherit"
-      height="inherit"
       fill="currentColor"
       className={props.className}
       viewBox="0 0 16 4"

--- a/web/lib/icons/squiggle_vertical.tsx
+++ b/web/lib/icons/squiggle_vertical.tsx
@@ -2,8 +2,6 @@ export default function SquiggleVerticalIcon(props: { className?: string }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="inherit"
-      height="inherit"
       fill="currentColor"
       className={props.className}
       viewBox="0 0 4 16"

--- a/web/lib/icons/squiggle_vertical_flipped.tsx
+++ b/web/lib/icons/squiggle_vertical_flipped.tsx
@@ -4,8 +4,6 @@ export default function SquiggleVerticalFlippedIcon(props: {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="inherit"
-      height="inherit"
       fill="currentColor"
       className={props.className}
       viewBox="0 0 4 16"

--- a/web/lib/icons/start_quote copy.tsx
+++ b/web/lib/icons/start_quote copy.tsx
@@ -2,8 +2,6 @@ export default function EndQuoteIcon(props: { className?: string }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="inherit"
-      height="inherit"
       fill="currentColor"
       className={props.className}
       viewBox="0 0 18 18"

--- a/web/lib/icons/start_quote.tsx
+++ b/web/lib/icons/start_quote.tsx
@@ -2,8 +2,6 @@ export default function StartQuoteIcon(props: { className?: string }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="inherit"
-      height="inherit"
       fill="currentColor"
       className={props.className}
       viewBox="0 0 18 18"


### PR DESCRIPTION
This was producing a bunch of console warnings since `width|height='inherit'` is not a thing.