### PR TITLE
Make absolute import of `common` work in `common`

### DIFF
--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -57,9 +57,7 @@
   "devDependencies": {
     "@types/mailgun-js": "0.22.12",
     "@types/marked": "4.0.7",
-    "puppeteer": "18.0.5",
-    "tsc-alias": "1.8.2",
-    "tsconfig-paths": "4.1.2"
+    "puppeteer": "18.0.5"
   },
   "private": true
 }

--- a/backend/functions/package.json
+++ b/backend/functions/package.json
@@ -5,7 +5,7 @@
     "firestore": "dev-mantic-markets.appspot.com"
   },
   "scripts": {
-    "build": "yarn compile && yarn --cwd=../shared alias && yarn alias && yarn dist",
+    "build": "yarn compile && yarn --cwd=../../common alias && yarn --cwd=../shared alias && yarn alias && yarn dist",
     "dist": "yarn dist:prepare && yarn dist:copy",
     "dist:prepare": "rm -rf dist && mkdir -p dist/common/lib dist/backend/shared/lib dist/backend/functions/lib",
     "dist:copy": "cp -R ../../common/lib/* dist/common/lib && cp -R ../shared/lib/* dist/backend/shared/lib && cp -R ./lib/* dist/backend/functions/lib && cp ../../yarn.lock dist && cp package.json dist && cp .env.prod dist && cp .env.dev dist",

--- a/backend/replicator/package.json
+++ b/backend/replicator/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "nodemon src/index.ts",
-    "build": "yarn compile && yarn --cwd=../shared alias && yarn alias && yarn dist",
+    "build": "yarn compile && yarn --cwd=../../common alias && yarn --cwd=../shared alias && yarn alias && yarn dist",
     "dist": "yarn dist:prepare && yarn dist:copy",
     "dist:prepare": "rm -rf dist && mkdir -p dist/common/lib dist/backend/shared/lib dist/backend/replicator/lib",
     "dist:copy": "cp -R ../../common/lib/* dist/common/lib && cp -R ../shared/lib/* dist/backend/shared/lib && cp -R ./lib/* dist/backend/replicator/lib && cp ../../yarn.lock dist && cp package.json dist",

--- a/backend/replicator/package.json
+++ b/backend/replicator/package.json
@@ -33,8 +33,5 @@
     "pg-promise": "11.0.2",
     "lodash": "4.17.21",
     "typescript": "4.9.3"
-  },
-  "devDependencies": {
-    "tsc-alias": "1.8.2"
   }
 }

--- a/backend/shared/package.json
+++ b/backend/shared/package.json
@@ -18,8 +18,5 @@
     "pg-promise": "11.0.2",
     "dayjs": "1.11.4",
     "openai": "3.0.1"
-  },
-  "devDependencies": {
-    "tsc-alias": "1.8.2"
   }
 }

--- a/backend/shared/package.json
+++ b/backend/shared/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "yarn compile && yarn alias",
+    "build": "yarn compile && yarn --cwd=../../common alias && yarn alias",
     "compile": "tsc -b",
     "alias": "tsc-alias",
     "verify": "yarn --cwd=../.. verify",

--- a/common/package.json
+++ b/common/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "yarn compile",
+    "build": "yarn compile && yarn alias",
     "compile": "tsc -b",
+    "alias": "tsc-alias",
     "verify": "yarn --cwd=.. verify",
     "verify:dir": "npx eslint . --max-warnings 0",
     "test": "jest"

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "target": "es2017",
     "paths": {
-      "common/*": ["./src/*"]
+      "common/*": ["./src/*", "../lib/*"]
     }
   },
   "include": ["src/**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "nodemon": "2.0.19",
     "prettier": "2.7.1",
     "ts-node": "10.9.1",
+    "tsc-alias": "1.8.2",
+    "tsconfig-paths": "4.1.2",
     "typescript": "4.9.3"
   }
 }


### PR DESCRIPTION
I guess someone wrote some code doing this even though it doesn't build correctly, so probably I should just make it build correctly.