### PR TITLE
Make `localStorage` access safer

### DIFF
--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -64,7 +64,7 @@ export function AuthProvider(props: {
 
   useEffect(() => {
     if (serverUser === undefined) {
-      const cachedUser = localStorage.getItem(CACHED_USER_KEY)
+      const cachedUser = safeLocalStorage?.getItem(CACHED_USER_KEY)
       const parsed = cachedUser ? JSON.parse(cachedUser) : undefined
       setAuthUser(parsed)
     }
@@ -74,9 +74,9 @@ export function AuthProvider(props: {
     if (authUser) {
       // Persist to local storage, to reduce login blink next time.
       // Note: Cap on localStorage size is ~5mb
-      localStorage.setItem(CACHED_USER_KEY, JSON.stringify(authUser))
+      safeLocalStorage?.setItem(CACHED_USER_KEY, JSON.stringify(authUser))
     } else if (authUser === null) {
-      localStorage.removeItem(CACHED_USER_KEY)
+      safeLocalStorage?.removeItem(CACHED_USER_KEY)
     }
   }, [authUser])
 

--- a/web/components/comments/comment-input.tsx
+++ b/web/components/comments/comment-input.tsx
@@ -16,6 +16,7 @@ import { ContractCommentInput } from '../feed/feed-comments'
 import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 import { LoadingIndicator } from '../widgets/loading-indicator'
+import { safeLocalStorage } from 'web/lib/util/local'
 
 export function CommentInput(props: {
   replyTo?: { id: string; username: string }
@@ -70,7 +71,7 @@ export function CommentInput(props: {
     setIsSubmitting(false)
     editor.commands.clearContent(true)
     // force clear save, because it can fail if editor unrenders
-    localStorage.removeItem(`text ${key}`)
+    safeLocalStorage?.removeItem(`text ${key}`)
   }
 
   if (user?.isBannedFromPosting) return <></>

--- a/web/components/new-contract-panel.tsx
+++ b/web/components/new-contract-panel.tsx
@@ -40,6 +40,7 @@ import {
 } from 'web/lib/supabase/groups'
 import { GroupsInfoBlob } from './groups/contract-groups-list'
 import { QfExplainer } from './contract/qf-overview'
+import { safeLocalStorage } from 'web/lib/util/local'
 
 export type NewQuestionParams = {
   groupId?: string
@@ -209,7 +210,7 @@ export function NewContractPanel(props: {
       })
       editor?.commands.clearContent(true)
       // force clear save, because it can fail if editor unrenders
-      localStorage.removeItem(`text create market`)
+      safeLocalStorage?.removeItem(`text create market`)
       await router.push(contractPath(result as Contract))
     } catch (e) {
       console.error('error creating contract', e, (e as any).details)

--- a/web/hooks/use-user-bets.ts
+++ b/web/hooks/use-user-bets.ts
@@ -31,19 +31,3 @@ export const useUserContractBets = (
 
   return bets
 }
-
-export const useGetUserBetContractIds = (userId: string | undefined) => {
-  const [contractIds, setContractIds] = useState<string[] | undefined>()
-
-  useEffect(() => {
-    if (userId) {
-      const key = `user-bet-contractIds-${userId}`
-      const userBetContractJson = localStorage.getItem(key)
-      if (userBetContractJson) {
-        setContractIds(JSON.parse(userBetContractJson))
-      }
-    }
-  }, [userId])
-
-  return contractIds
-}

--- a/web/lib/util/local.ts
+++ b/web/lib/util/local.ts
@@ -1,7 +1,10 @@
 function getStorageProxy(store: Storage) {
   try {
+    store.setItem('test', '')
     store.getItem('test')
+    store.removeItem('test')
   } catch (e) {
+    console.warn(e)
     return undefined
   }
   return {
@@ -19,12 +22,13 @@ function getStorageProxy(store: Storage) {
   }
 }
 
-export const safeLocalStorage =
-  typeof localStorage !== 'undefined'
-    ? getStorageProxy(localStorage)
-    : undefined
+export let safeLocalStorage: ReturnType<typeof getStorageProxy> | undefined
+export let safeSessionStorage: ReturnType<typeof getStorageProxy> | undefined
 
-export const safeSessionStorage =
-  typeof sessionStorage !== 'undefined'
-    ? getStorageProxy(sessionStorage)
-    : undefined
+try {
+  safeLocalStorage = getStorageProxy(localStorage)
+} catch {}
+
+try {
+  safeSessionStorage = getStorageProxy(sessionStorage)
+} catch {}


### PR DESCRIPTION
Now this covers the case where accessing the property throws (I think this happens when a security policy restricts local storage use in Chromium) and it covers the case where `set` and `remove` don't work (I don't know of a case where this happens, but it makes sense that it could happen for "not allowing trackers to set stuff" reasons.)