### PR TITLE
Simplify recommendation algorithm

### DIFF
--- a/backend/functions/src/scheduled/update-recommended.ts
+++ b/backend/functions/src/scheduled/update-recommended.ts
@@ -1,6 +1,6 @@
 import * as functions from 'firebase-functions'
 import * as admin from 'firebase-admin'
-import { Query } from 'firebase-admin/firestore'
+import { Query, CollectionReference } from 'firebase-admin/firestore'
 import { uniq } from 'lodash'
 
 import { invokeFunction, loadPaginated } from 'shared/utils'
@@ -172,11 +172,9 @@ export const loadUserDataForRecommendations = async () => {
 }
 
 export const loadContracts = async () => {
-  const db = createSupabaseClient()
-
-  const { data } = await run(db.from('contracts').select('*'))
-  const contracts = data.map(({ data }) => data) as Contract[]
-
+  const contracts = await loadPaginated(
+    firestore.collection('contracts') as CollectionReference<Contract>
+  )
   console.log('Loaded', contracts.length, 'contracts')
   return contracts
 }

--- a/backend/scripts/recommend.ts
+++ b/backend/scripts/recommend.ts
@@ -6,12 +6,16 @@ import { getContract } from 'shared/utils'
 import { initAdmin } from 'shared/init-admin'
 initAdmin()
 
-import { loadUserDataForRecommendations } from 'functions/update-recommended'
+import {
+  loadContracts,
+  loadUserDataForRecommendations,
+} from 'functions/scheduled/update-recommended'
+import { Contract } from 'common/contract'
 
 const recommend = async () => {
   console.log('Recommend script')
 
-  let userData = await readJson<user_data[]>('user-data5.json')
+  let userData = await readJson<user_data[]>('user-data1.json')
 
   if (userData) {
     console.log('Loaded view data from file.')
@@ -21,8 +25,20 @@ const recommend = async () => {
     await writeJson('user-data5.json', userData)
   }
 
+  let contracts = await readJson<Contract[]>('contracts.json')
+  if (contracts) {
+    console.log('Loaded contracts from file.')
+  } else {
+    console.log('Loading contracts...')
+    contracts = await loadContracts()
+    await writeJson('contracts.json', contracts)
+  }
+
   console.log('Computing recommendations...')
-  const { getUserContractScores } = getMarketRecommendations(userData)
+  const { getUserContractScores } = getMarketRecommendations(
+    contracts,
+    userData
+  )
 
   await debug(getUserContractScores)
 }
@@ -33,11 +49,11 @@ async function debug(
   console.log('Destiny user scores')
   await printUserScores('PKj937RvUZYUbnG7IU8sVPN7XYr1', getUserContractScores)
 
-  console.log('Bembo scores')
-  await printUserScores('G3S3nhcGWhPU3WEtlUYbAH4tv7f1', getUserContractScores)
+  // console.log('Bembo scores')
+  // await printUserScores('G3S3nhcGWhPU3WEtlUYbAH4tv7f1', getUserContractScores)
 
-  console.log('Stephen scores')
-  await printUserScores('tlmGNz9kjXc2EteizMORes4qvWl2', getUserContractScores)
+  // console.log('Stephen scores')
+  // await printUserScores('tlmGNz9kjXc2EteizMORes4qvWl2', getUserContractScores)
 
   console.log('James scores')
   const jamesId = '5LZ4LgYuySdL1huCWe7bti02ghx2'

--- a/backend/scripts/recommend.ts
+++ b/backend/scripts/recommend.ts
@@ -22,16 +22,16 @@ const recommend = async () => {
   } else {
     console.log('Loading view data from Firestore...')
     userData = await loadUserDataForRecommendations()
-    await writeJson('user-data5.json', userData)
+    await writeJson('user-data1.json', userData)
   }
 
-  let contracts = await readJson<Contract[]>('contracts.json')
+  let contracts = await readJson<Contract[]>('contracts1.json')
   if (contracts) {
     console.log('Loaded contracts from file.')
   } else {
     console.log('Loading contracts...')
     contracts = await loadContracts()
-    await writeJson('contracts.json', contracts)
+    await writeJson('contracts1.json', contracts)
   }
 
   console.log('Computing recommendations...')

--- a/backend/scripts/recommend.ts
+++ b/backend/scripts/recommend.ts
@@ -49,11 +49,11 @@ async function debug(
   console.log('Destiny user scores')
   await printUserScores('PKj937RvUZYUbnG7IU8sVPN7XYr1', getUserContractScores)
 
-  // console.log('Bembo scores')
-  // await printUserScores('G3S3nhcGWhPU3WEtlUYbAH4tv7f1', getUserContractScores)
+  console.log('Bembo scores')
+  await printUserScores('G3S3nhcGWhPU3WEtlUYbAH4tv7f1', getUserContractScores)
 
-  // console.log('Stephen scores')
-  // await printUserScores('tlmGNz9kjXc2EteizMORes4qvWl2', getUserContractScores)
+  console.log('Stephen scores')
+  await printUserScores('tlmGNz9kjXc2EteizMORes4qvWl2', getUserContractScores)
 
   console.log('James scores')
   const jamesId = '5LZ4LgYuySdL1huCWe7bti02ghx2'

--- a/common/src/recommendation.ts
+++ b/common/src/recommendation.ts
@@ -78,9 +78,9 @@ export function getMarketRecommendations(
     for (const groupId of groupIds) {
       // If you follow a group, count that as interest in random subset of group markets.
       const contractIds = Object.keys(groupsToContracts[groupId] ?? {})
-      const contractIdSubset = chooseRandomSubset(contractIds, 25)
+      const contractIdSubset = chooseRandomSubset(contractIds, 5)
       for (const contractId of contractIdSubset) {
-        sparseMatrix[userIndex][contractId] = 0.5
+        sparseMatrix[userIndex][contractId] = 1
         contractIdSet.add(contractId)
       }
     }
@@ -103,7 +103,7 @@ export function getMarketRecommendations(
   // which is bad for the algorithm to distinguish between good and bad contracts:
   // it will just predict 1 for all contracts.
   for (const row of sparseMatrix) {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 20; i++) {
       const randContractId =
         contractIds[Math.floor(Math.random() * contractIds.length)]
       if (row[randContractId] === undefined) row[randContractId] = 0

--- a/common/src/recommendation.ts
+++ b/common/src/recommendation.ts
@@ -1,5 +1,7 @@
-import { uniq, zip } from 'lodash'
+import { uniq } from 'lodash'
+import { Contract } from './contract'
 import { dotProduct, factorizeMatrix } from './util/matrix'
+import { chooseRandomSubset } from './util/random'
 
 export type user_data = {
   userId: string
@@ -11,15 +13,34 @@ export type user_data = {
   groupIds: string[]
 }
 
+const DESTINY_GROUP_ID = 'W2ES30fRo6CCbPNwMTTj'
+
 export function getMarketRecommendations(
+  contracts: Contract[],
   userData: user_data[],
   iterations = 2000
 ) {
   const userIds = userData.map(({ userId }) => userId)
   const userIdToIndex = Object.fromEntries(userIds.map((id, i) => [id, i]))
 
-  const sparseMatrix = userIds.map(() => ({} as { [column: string]: number }))
-  const columnSet = new Set<string>()
+  const groupsToContracts: {
+    [groupId: string]: { [contractId: string]: true }
+  } = {}
+  for (const contract of contracts) {
+    const groupIds = contract.groupLinks?.map((g) => g.groupId) ?? []
+    for (const groupId of groupIds) {
+      if (!groupsToContracts[groupId]) {
+        groupsToContracts[groupId] = {}
+      }
+      groupsToContracts[groupId][contract.id] = true
+    }
+  }
+
+  // Sparse matrix of users x contracts.
+  const sparseMatrix = userIds.map(
+    () => ({} as { [contractId: string]: number })
+  )
+  const contractIdSet = new Set<string>()
 
   for (const {
     userId,
@@ -32,88 +53,79 @@ export function getMarketRecommendations(
   } of userData) {
     const userIndex = userIdToIndex[userId]
 
+    const viewedCardsOrSwipes = uniq([...viewedCardIds, ...swipedIds])
     const likedOrBetOnIds = uniq([...likedIds, ...betOnIds])
 
-    for (const contractId of viewedCardIds) {
+    for (const contractId of viewedCardsOrSwipes) {
+      // If you viewed it but didn't take any action, that's evidence you're not interested.
       sparseMatrix[userIndex][contractId] = 0
-      columnSet.add(contractId)
+      contractIdSet.add(contractId)
+    }
+    if (!groupIds.includes(DESTINY_GROUP_ID)) {
+      // Downweight markets in the Destiny group if you don't follow it.
+      const contractIds = Object.keys(groupsToContracts[DESTINY_GROUP_ID] ?? {})
+      const contractIdSubset = chooseRandomSubset(contractIds, 25)
+      for (const contractId of contractIdSubset) {
+        sparseMatrix[userIndex][contractId] = 0
+        contractIdSet.add(contractId)
+      }
     }
     for (const contractId of viewedPageIds) {
+      // If you clicked into a market, that demonstrates interest.
       sparseMatrix[userIndex][contractId] = 0.25
-      columnSet.add(contractId)
+      contractIdSet.add(contractId)
+    }
+    for (const groupId of groupIds) {
+      // If you follow a group, count that as interest in random subset of group markets.
+      const contractIds = Object.keys(groupsToContracts[groupId] ?? {})
+      const contractIdSubset = chooseRandomSubset(contractIds, 25)
+      for (const contractId of contractIdSubset) {
+        sparseMatrix[userIndex][contractId] = 0.5
+        contractIdSet.add(contractId)
+      }
     }
     for (const contractId of likedOrBetOnIds) {
       // Don't include contracts bet on before we recorded views.
       // If there are no views, then algorithm can just predict 1 always.
-      if (columnSet.has(contractId)) {
+      if (contractIdSet.has(contractId)) {
+        // Predicting these bets and likes is the goal!
         sparseMatrix[userIndex][contractId] = 1
       }
     }
-
-    // Add new columns for swiped contracts.
-    for (const contractId of swipedIds) {
-      sparseMatrix[userIndex]['swiped-' + contractId] = 0
-      columnSet.add('swiped-' + contractId)
-    }
-    for (const contractId of likedOrBetOnIds) {
-      sparseMatrix[userIndex]['swiped-' + contractId] = 1
-      columnSet.add('swiped-' + contractId)
-    }
-
-    // Add new columns for groups.
-    for (const groupId of groupIds) {
-      sparseMatrix[userIndex]['group-' + groupId] = 1
-      columnSet.add('group-' + groupId)
-    }
   }
 
-  const columns = Array.from(columnSet)
-  console.log('rows', sparseMatrix.length, 'columns', columns.length)
+  const contractIds = Array.from(contractIdSet)
+  console.log('rows', sparseMatrix.length, 'columns', contractIds.length)
 
-  // Fill in a few random 0's for each user and contract/group column.
+  // Fill in a few random 0's for each user and contract column.
   // When users click a link directly to a market or search for it,
   // and bet on it, then we start to get only 1's in the matrix,
   // which is bad for the algorithm to distinguish between good and bad contracts:
   // it will just predict 1 for all contracts.
-  const contractAndGroupColumns = Array.from(columnSet).filter(
-    (column) => !column.startsWith('swiped-')
-  )
   for (const row of sparseMatrix) {
     for (let i = 0; i < 10; i++) {
-      const randColumn =
-        contractAndGroupColumns[
-          Math.floor(Math.random() * contractAndGroupColumns.length)
-        ]
-      if (row[randColumn] === undefined) row[randColumn] = 0
+      const randContractId =
+        contractIds[Math.floor(Math.random() * contractIds.length)]
+      if (row[randContractId] === undefined) row[randContractId] = 0
     }
   }
-  for (const column of contractAndGroupColumns) {
+  for (const contractId of contractIds) {
     for (let i = 0; i < 10; i++) {
       const randUser = Math.floor(Math.random() * sparseMatrix.length)
-      if (sparseMatrix[randUser][column] === undefined)
-        sparseMatrix[randUser][column] = 0
+      if (sparseMatrix[randUser][contractId] === undefined)
+        sparseMatrix[randUser][contractId] = 0
     }
   }
 
   const [userFeatures, contractFeatures] = factorizeMatrix(
     sparseMatrix,
-    columns,
+    contractIds,
     5,
     iterations
   )
 
-  const swipeColumnIndices = columns
-    .map((column, i) => [column, i] as const)
-    .filter(([column]) => column.startsWith('swiped-'))
-    .map(([_, i]) => i)
-  const swipeContractFeatures = swipeColumnIndices.map(
-    (i) => contractFeatures[i]
-  )
-  const swipeContractIds = swipeColumnIndices.map((i) =>
-    columns[i].replace('swiped-', '')
-  )
-  const swipeContractToFeatures = Object.fromEntries(
-    zip(swipeContractIds, swipeContractFeatures) as [string, number[]][]
+  const contractIdToIndex = Object.fromEntries(
+    contractIds.map((column, i) => [column, i] as const)
   )
 
   // Compute scores per user one at a time to save memory.
@@ -121,10 +133,11 @@ export function getMarketRecommendations(
     const userIndex = userIdToIndex[userId]
     if (!userIndex) return {}
 
-    const contractScorePairs = swipeContractIds.map((contractId) => {
+    const contractScorePairs = contractIds.map((contractId) => {
+      const contractIndex = contractIdToIndex[contractId]
       const score = dotProduct(
         userFeatures[userIndex],
-        swipeContractToFeatures[contractId]
+        contractFeatures[contractIndex]
       )
       return [contractId, score] as const
     })
@@ -135,8 +148,8 @@ export function getMarketRecommendations(
   return {
     userIds,
     userFeatures,
-    contractIds: swipeContractIds,
-    contractFeatures: swipeContractFeatures,
+    contractIds,
+    contractFeatures,
     getUserContractScores,
   }
 }

--- a/common/src/recommendation.ts
+++ b/common/src/recommendation.ts
@@ -54,6 +54,9 @@ export function getMarketRecommendations(
     const userIndex = userIdToIndex[userId]
 
     const viewedCardsOrSwipes = uniq([...viewedCardIds, ...swipedIds])
+    const yourViewedContractsSet = new Set(
+      viewedCardsOrSwipes.concat(viewedPageIds)
+    )
     const likedOrBetOnIds = uniq([...likedIds, ...betOnIds])
 
     for (const contractId of viewedCardsOrSwipes) {
@@ -87,7 +90,7 @@ export function getMarketRecommendations(
     for (const contractId of likedOrBetOnIds) {
       // Don't include contracts bet on before we recorded views.
       // If there are no views, then algorithm can just predict 1 always.
-      if (contractIdSet.has(contractId)) {
+      if (yourViewedContractsSet.has(contractId)) {
         // Predicting these bets and likes is the goal!
         sparseMatrix[userIndex][contractId] = 1
       }


### PR DESCRIPTION
One column per contract instead of splitting off a second set of columns for each swiped contract (and more columns for groups).

Also, followed groups will shape your results better: we count some markets within the group as bet on by you to juice things. Should be especially helpful for new users.