### PR TITLE
Create as many new test users via email as we want

### DIFF
--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -31,6 +31,10 @@ const ensureDeviceToken = () => {
   }
   return deviceToken
 }
+const getAdminToken = () => {
+  const deviceToken = safeLocalStorage?.getItem('TEST_CREATE_USER_KEY')
+  return deviceToken ?? ''
+}
 
 const stripUserData = (user: object) => {
   // there's some risk that this cookie could be too big for some clients,
@@ -55,6 +59,7 @@ export const setUserCookie = (data: object | undefined) => {
 }
 
 export const AuthContext = createContext<AuthUser>(undefined)
+
 export function AuthProvider(props: {
   children: ReactNode
   serverUser?: AuthUser
@@ -89,7 +94,11 @@ export function AuthProvider(props: {
           let current = await getUserAndPrivateUser(fbUser.uid)
           if (!current.user || !current.privateUser) {
             const deviceToken = ensureDeviceToken()
-            current = (await createUser({ deviceToken })) as UserAndPrivateUser
+            const adminToken = getAdminToken()
+            current = (await createUser({
+              deviceToken,
+              adminToken,
+            })) as UserAndPrivateUser
             setCachedReferralInfoForUser(current.user)
           }
           setAuthUser(current)

--- a/web/pages/admin/test-user.tsx
+++ b/web/pages/admin/test-user.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+import { Button } from 'web/components/buttons/button'
+import { Col } from 'web/components/layout/col'
+import { Row } from 'web/components/layout/row'
+import { Input } from 'web/components/widgets/input'
+import { Title } from 'web/components/widgets/title'
+import { useRedirectIfSignedIn } from 'web/hooks/use-redirect-if-signed-in'
+import { getAuth, createUserWithEmailAndPassword } from 'firebase/auth'
+
+export default function TestUser() {
+  useRedirectIfSignedIn()
+  const [password, setPassword] = useState('')
+  const [baseEmail, setBaseEmail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  useEffect(() => {
+    setBaseEmail(
+      'manifoldTestNewUser+' +
+        Math.random().toString(36).substring(2, 15) +
+        '@gmail.com'
+    )
+  }, [])
+  const create = () => {
+    setSubmitting(true)
+    const auth = getAuth()
+    createUserWithEmailAndPassword(auth, baseEmail, password)
+      .then((userCredential) => {
+        setSubmitting(false)
+        console.log('SUCCESS creating firebase user', userCredential)
+      })
+      .catch((error) => {
+        setSubmitting(false)
+        const errorCode = error.code
+        const errorMessage = error.message
+        console.log('ERROR creating firebase user', errorCode, errorMessage)
+      })
+  }
+
+  return (
+    <Col className={'items-center justify-items-center gap-1'}>
+      <Title>Test New User Creation</Title>
+      <Row className={'text-sm text-gray-600'}>
+        Prerequisite: Set TEST_CREATE_USER_KEY to the{' '}
+        <a
+          className={'mx-1 text-indigo-700'}
+          href={
+            'https://console.cloud.google.com/security/secret-manager/secret/TEST_CREATE_USER_KEY/versions?project=dev-mantic-markets'
+          }
+        >
+          proper value
+        </a>{' '}
+        in local storage
+      </Row>
+      Email
+      <Row className={'text-gray-600'}>{baseEmail}</Row>
+      Password
+      <Row>
+        <Input
+          type={'password'}
+          value={password}
+          onChange={(e) => setPassword(e.target.value || '')}
+        />
+      </Row>
+      <Button loading={submitting} className={'mt-2'} onClick={create}>
+        Submit
+      </Button>
+    </Col>
+  )
+}


### PR DESCRIPTION
This creates a new endpoint at admin/test-user where admins can create as many test users as they'd like. All you have to do is set the proper value in local storage, then sign out, revisit this page (it will automatically generate a new email address variant for you), type a password and hit submit. You'll be redirected to the home page after `createuser` finishes.

If you'd like to log in to the gmail account the information is in the bitwarden under `manifoldtestnewuser@gmail.com`

<img width="605" alt="Screenshot 2023-02-22 at 9 11 28 AM" src="https://user-images.githubusercontent.com/23196210/220704197-a4ede708-f7ea-4e3f-bd0b-a6ede0264033.png">
