### PR TITLE
Replicator can do repacking of DB tables on demand

### DIFF
--- a/backend/replicator/Dockerfile
+++ b/backend/replicator/Dockerfile
@@ -1,7 +1,16 @@
 # prereq: first do `yarn build` to compile typescript & etc.
 
-FROM node:19-slim
+FROM node:19-alpine
 WORKDIR /usr/src/app
+
+# install pg_repack
+RUN apk add \
+    wget make unzip gcc musl-dev libssl1.1 zlib-dev lz4-dev readline-dev zstd-dev postgresql15-dev
+RUN wget -q -O pg_repack.zip "https://api.pgxn.org/dist/pg_repack/1.4.8/pg_repack-1.4.8.zip"
+RUN unzip pg_repack.zip && rm pg_repack.zip
+WORKDIR pg_repack-1.4.8
+RUN make && make install
+WORKDIR ..
 
 # first get dependencies in for efficient docker layering
 COPY dist/package.json dist/yarn.lock ./

--- a/backend/replicator/Dockerfile
+++ b/backend/replicator/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:19-alpine
 WORKDIR /usr/src/app
 
-# install pg_repack
+# install pg_repack. note that the version must match the version of repack installed in the DB
 RUN apk add \
     wget make unzip gcc musl-dev libssl1.1 zlib-dev lz4-dev readline-dev zstd-dev postgresql15-dev
 RUN wget -q -O pg_repack.zip "https://api.pgxn.org/dist/pg_repack/1.4.8/pg_repack-1.4.8.zip"

--- a/backend/replicator/src/index.ts
+++ b/backend/replicator/src/index.ts
@@ -5,9 +5,9 @@ import {
   replicateWrites,
   createFailedWrites,
   replayFailedWrites,
+  WriteMessage,
 } from './replicate-writes'
 import { log } from './utils'
-import { TLEntry } from 'common/transaction-log'
 import { CONFIGS } from 'common/envs/constants'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 
@@ -49,7 +49,7 @@ function parseMessage<T>(msg: Message): ParsedMessage<T> {
   return { msg, data: JSON.parse(msg.data.toString()) }
 }
 
-async function tryReplicateBatch(batchId: number, ...entries: TLEntry[]) {
+async function tryReplicateBatch(batchId: number, ...entries: WriteMessage[]) {
   try {
     const t0 = process.hrtime.bigint()
     log('DEBUG', `Beginning replication of batch=${batchId}.`)
@@ -76,7 +76,7 @@ function processSubscriptionBatched(
   batchTimeoutMs: number
 ) {
   let i = 0
-  const batch: ParsedMessage<TLEntry>[] = []
+  const batch: ParsedMessage<WriteMessage>[] = []
 
   const processBatch = async (kind: string) => {
     if (batch.length > 0) {
@@ -93,7 +93,7 @@ function processSubscriptionBatched(
 
   subscription.on('message', async (message) => {
     try {
-      const parsed = parseMessage<TLEntry>(message)
+      const parsed = parseMessage<WriteMessage>(message)
       const entry = parsed.data
       log(
         'DEBUG',

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -4,8 +4,9 @@
 /* 0. database-wide configuration */
 /***************************************************************/
 
-/* allow our backend to have a long statement timeout */
-alter role service_role set statement_timeout = '120s';
+/* allow our backend and CLI users to have a long statement timeout */
+alter role postgres set statement_timeout = '1h';
+alter role service_role set statement_timeout = '1h';
 
 /* for clustering without locks */
 create extension if not exists pg_repack;

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -44,6 +44,7 @@ create index if not exists users_data_gin on users using GIN (data);
 create index if not exists users_name_gin on users using GIN ((data->>'name') gin_trgm_ops);
 create index if not exists users_username_gin on users using GIN ((data->>'username') gin_trgm_ops);
 create index if not exists users_follower_count_cached on users ((to_jsonb(data->'followerCountCached')) desc);
+alter table users cluster on users_pkey;
 
 create table if not exists user_portfolio_history (
     user_id text not null,
@@ -58,6 +59,7 @@ create policy "public read" on user_portfolio_history for select using (true);
 create index if not exists user_portfolio_history_gin on user_portfolio_history using GIN (data);
 create index if not exists user_portfolio_history_timestamp on user_portfolio_history (user_id, (to_jsonb(data->'timestamp')) desc);
 create index if not exists user_portfolio_history_user_timestamp on user_portfolio_history (user_id, ((data->'timestamp')::bigint) desc);
+alter table user_portfolio_history cluster on user_portfolio_history_user_timestamp;
 
 create table if not exists user_contract_metrics (
     user_id text not null,
@@ -78,6 +80,7 @@ create index if not exists user_contract_metrics_contract_id on user_contract_me
 create index if not exists user_contract_metrics_weekly_profit on user_contract_metrics ((data->'from'->'week'->'profit'))
  where (data->'from'->'week'->'profit') is not null;
 create index if not exists user_contract_metrics_user_id on user_contract_metrics (user_id);
+alter table user_contract_metrics cluster on user_contract_metrics_pkey;
 
 create table if not exists user_follows (
     user_id text not null,
@@ -90,6 +93,7 @@ alter table user_follows enable row level security;
 drop policy if exists "public read" on user_follows;
 create policy "public read" on user_follows for select using (true);
 create index if not exists user_follows_data_gin on user_follows using GIN (data);
+alter table user_follows cluster on user_follows_pkey;
 
 create table if not exists user_reactions (
     user_id text not null,
@@ -108,6 +112,7 @@ create index if not exists user_reactions_type
 -- useful for getting all reactions for a given contentId recently
 create index if not exists user_reactions_content_id
   on user_reactions ((to_jsonb(data)->>'contentId'), (to_jsonb(data)->>'createdTime') desc);
+alter table user_reactions cluster on user_reactions_type;
 
 create table if not exists user_events (
     user_id text not null,
@@ -120,9 +125,11 @@ alter table user_events enable row level security;
 drop policy if exists "public read" on user_events;
 create policy "public read" on user_events for select using (true);
 create index if not exists user_events_data_gin on user_events using GIN (data);
+create index if not exists user_events_name on user_events (user_id, (data->>'name'));
 create index if not exists user_events_viewed_markets
     on user_events (user_id, (data->>'name'), (data->>'contractId'), ((data->'timestamp')::bigint) desc)
     where data->>'name' = 'view market' or data->>'name' = 'view market card';
+alter table user_events cluster on user_events_name;
 
 create table if not exists user_seen_markets (
     user_id text not null,
@@ -135,6 +142,7 @@ alter table user_seen_markets enable row level security;
 drop policy if exists "public read" on user_seen_markets;
 create policy "public read" on user_seen_markets for select using (true);
 create index if not exists user_seen_markets_data_gin on user_seen_markets using GIN (data);
+alter table user_seen_markets cluster on user_seen_markets_pkey;
 
 create table if not exists contracts (
     id text not null primary key,
@@ -148,6 +156,7 @@ create index if not exists contracts_data_gin on contracts using GIN (data);
 create index if not exists contracts_group_slugs_gin on contracts using GIN ((data->'groupSlugs'));
 create index if not exists contracts_creator_id on contracts ((data->>'creatorId'));
 create index if not exists contracts_unique_bettors on contracts (((data->'uniqueBettors7Days')::int) desc);
+alter table contracts cluster on contracts_creator_id;
 
 create table if not exists contract_answers (
     contract_id text not null,
@@ -160,6 +169,7 @@ alter table contract_answers enable row level security;
 drop policy if exists "public read" on contract_answers;
 create policy "public read" on contract_answers for select using (true);
 create index if not exists contract_answers_data_gin on contract_answers using GIN (data);
+alter table contract_answers cluster on contract_answers_pkey;
 
 create table if not exists contract_bets (
     contract_id text not null,
@@ -192,6 +202,7 @@ create index if not exists contract_bets_user_outstanding_limit_orders on contra
    (data->>'userId'),
    ((data->'isFilled')::boolean),
    ((data->'isCancelled')::boolean));
+alter table contract_bets cluster on contract_bets_created_time;
 
 create table if not exists contract_comments (
     contract_id text not null,
@@ -204,6 +215,7 @@ alter table contract_comments enable row level security;
 drop policy if exists "public read" on contract_comments;
 create policy "public read" on contract_comments for select using (true);
 create index if not exists contract_comments_data_gin on contract_comments using GIN (data);
+alter table contract_comments cluster on contract_comments_pkey;
 
 create table if not exists contract_follows (
     contract_id text not null,
@@ -216,6 +228,7 @@ alter table contract_follows enable row level security;
 drop policy if exists "public read" on contract_follows;
 create policy "public read" on contract_follows for select using (true);
 create index if not exists contract_follows_data_gin on contract_follows using GIN (data);
+alter table contract_follows cluster on contract_follows_pkey;
 
 create table if not exists contract_liquidity (
     contract_id text not null,
@@ -228,6 +241,7 @@ alter table contract_liquidity enable row level security;
 drop policy if exists "public read" on contract_liquidity;
 create policy "public read" on contract_liquidity for select using (true);
 create index if not exists contract_liquidity_data_gin on contract_liquidity using GIN (data);
+alter table contract_liquidity cluster on contract_liquidity_pkey;
 
 create table if not exists groups (
     id text not null primary key,
@@ -238,6 +252,7 @@ alter table groups enable row level security;
 drop policy if exists "public read" on groups;
 create policy "public read" on groups for select using (true);
 create index if not exists groups_data_gin on groups using GIN (data);
+alter table groups cluster on groups_pkey;
 
 create table if not exists group_contracts (
     group_id text not null,
@@ -250,6 +265,7 @@ alter table group_contracts enable row level security;
 drop policy if exists "public read" on group_contracts;
 create policy "public read" on group_contracts for select using (true);
 create index if not exists group_contracts_data_gin on group_contracts using GIN (data);
+alter table group_contracts cluster on group_contracts_pkey;
 
 create table if not exists group_members (
     group_id text not null,
@@ -262,6 +278,7 @@ alter table group_members enable row level security;
 drop policy if exists "public read" on group_members;
 create policy "public read" on group_members for select using (true);
 create index if not exists group_members_data_gin on group_members using GIN (data);
+alter table group_members cluster on group_members_pkey;
 
 create table if not exists txns (
     id text not null primary key,
@@ -272,6 +289,7 @@ alter table txns enable row level security;
 drop policy if exists "public read" on txns;
 create policy "public read" on txns for select using (true);
 create index if not exists txns_data_gin on txns using GIN (data);
+alter table txns cluster on txns_pkey;
 
 create table if not exists manalinks (
     id text not null primary key,
@@ -282,6 +300,7 @@ alter table manalinks enable row level security;
 drop policy if exists "public read" on manalinks;
 create policy "public read" on manalinks for select using (true);
 create index if not exists manalinks_data_gin on manalinks using GIN (data);
+alter table manalinks cluster on manalinks_pkey;
 
 create table if not exists posts (
     id text not null primary key,
@@ -292,6 +311,7 @@ alter table posts enable row level security;
 drop policy if exists "public read" on posts;
 create policy "public read" on posts for select using (true);
 create index if not exists posts_data_gin on posts using GIN (data);
+alter table posts cluster on posts_pkey;
 
 create table if not exists test (
     id text not null primary key,
@@ -302,6 +322,7 @@ alter table test enable row level security;
 drop policy if exists "public read" on test;
 create policy "public read" on test for select using (true);
 create index if not exists test_data_gin on test using GIN (data);
+alter table test cluster on test_pkey;
 
 create table if not exists user_recommendation_features (
     user_id text not null primary key,
@@ -392,6 +413,7 @@ create table if not exists tombstones (
 );
 alter table tombstones enable row level security;
 create index if not exists tombstones_table_id_doc_id_fs_deleted_at on tombstones (table_id, doc_id, fs_deleted_at desc);
+alter table tombstones cluster on tombstones_table_id_doc_id_fs_deleted_at;
 
 drop function if exists get_document_table_spec;
 drop type if exists table_spec;


### PR DESCRIPTION
Now the replicator can use [`pg_repack`](https://reorg.github.io/pg_repack/) to repack (cluster and vacuum full) all the DB tables without locking on demand. I will probably wire this up to run nightly. This should be a great boon towards speeding up queries by predictable criteria on our larger tables.