### PR TITLE
Fix loading of related markets on contract page to not load twice

### DIFF
--- a/web/components/contract/related-contracts-widget.tsx
+++ b/web/components/contract/related-contracts-widget.tsx
@@ -5,7 +5,6 @@ import { memo } from 'react'
 import clsx from 'clsx'
 
 import { useEvent } from 'web/hooks/use-event'
-import { useRelatedMarkets } from 'web/hooks/use-related-contracts'
 import { contractPath } from 'web/lib/firebase/contracts'
 import { Col } from '../layout/col'
 import { Row } from '../layout/row'
@@ -14,34 +13,7 @@ import { Avatar } from '../widgets/avatar'
 import { UserLink } from '../widgets/user-link'
 import { useIsClient } from 'web/hooks/use-is-client'
 
-export const RelatedContractsWidget = memo(
-  function RecommendedContractsWidget(props: {
-    contract: Contract
-    initialContracts: Contract[]
-    onContractClick?: (contract: Contract) => void
-    className?: string
-  }) {
-    const { contract, initialContracts, onContractClick, className } = props
-    const { contracts: relatedMarkets, loadMore } = useRelatedMarkets(
-      contract,
-      initialContracts
-    )
-
-    if (relatedMarkets.length === 0) {
-      return null
-    }
-    return (
-      <RelatedContractsList
-        className={className}
-        contracts={relatedMarkets}
-        onContractClick={onContractClick}
-        loadMore={loadMore}
-      />
-    )
-  }
-)
-
-function RelatedContractsList(props: {
+export const RelatedContractsList = memo(function RelatedContractsList(props: {
   contracts: Contract[]
   loadMore?: () => Promise<void>
   onContractClick?: (contract: Contract) => void
@@ -53,6 +25,10 @@ function RelatedContractsList(props: {
       loadMore()
     }
   })
+
+  if (contracts.length === 0) {
+    return null
+  }
 
   return (
     <Col className={clsx(className, 'flex-1')}>
@@ -84,7 +60,7 @@ function RelatedContractsList(props: {
       )}
     </Col>
   )
-}
+})
 
 const RelatedContractCard = memo(function RelatedContractCard(props: {
   contract: Contract

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -61,9 +61,12 @@ import Head from 'next/head'
 import { Linkify } from 'web/components/widgets/linkify'
 import { ContractDetails } from 'web/components/contract/contract-details'
 import { useSaveCampaign } from 'web/hooks/use-save-campaign'
-import { RelatedContractsWidget } from 'web/components/contract/related-contracts-widget'
+import { RelatedContractsList } from 'web/components/contract/related-contracts-widget'
 import { Row } from 'web/components/layout/row'
-import { getInitialRelatedMarkets } from 'web/hooks/use-related-contracts'
+import {
+  getInitialRelatedMarkets,
+  useRelatedMarkets,
+} from 'web/hooks/use-related-contracts'
 import { track } from 'web/lib/service/analytics'
 
 const CONTRACT_BET_FILTER: BetFilter = {
@@ -295,6 +298,11 @@ export function ContractPageContent(
   })
   const onCancelAnswerResponse = useEvent(() => setAnswerResponse(undefined))
 
+  const { contracts: relatedMarkets, loadMore } = useRelatedMarkets(
+    contract,
+    relatedContracts
+  )
+
   return (
     <Page maxWidth="max-w-[1400px]">
       <ContractSEO contract={contract} points={pointsString} />
@@ -421,22 +429,22 @@ export function ContractPageContent(
             />
           </div>
         </Col>
-        <RelatedContractsWidget
+        <RelatedContractsList
           className="hidden min-h-full max-w-[375px] xl:flex"
-          contract={contract}
-          initialContracts={relatedContracts}
+          contracts={relatedMarkets}
           onContractClick={(c) =>
             track('click related market', { contractId: c.id })
           }
+          loadMore={loadMore}
         />
       </Row>
-      <RelatedContractsWidget
+      <RelatedContractsList
         className="max-w-[600px] xl:hidden"
-        contract={contract}
-        initialContracts={relatedContracts}
+        contracts={relatedMarkets}
         onContractClick={(c) =>
           track('click related market', { contractId: c.id })
         }
+        loadMore={loadMore}
       />
       <Spacer className="xl:hidden" h={10} />
       <ScrollToTopButton className="fixed bottom-16 right-2 z-20 lg:bottom-2 xl:hidden" />


### PR DESCRIPTION
This was busted before, it would load all the related contract stuff in both individual widgets (which is not a cheap amount of stuff to load.)