### PR TITLE
Compute group leaderboards in SQL

### DIFF
--- a/backend/functions/src/scheduled/update-group-metrics.ts
+++ b/backend/functions/src/scheduled/update-group-metrics.ts
@@ -1,12 +1,12 @@
 import * as functions from 'firebase-functions'
 import * as admin from 'firebase-admin'
-import { groupBy, sumBy, mapValues, uniq } from 'lodash'
+import { groupBy, mapValues, sortBy } from 'lodash'
 
 import { log } from 'shared/utils'
-import { Contract } from 'common/contract'
-import { mapAsync } from 'common/util/promise'
 import { newEndpointNoAuth } from '../api/helpers'
 import { invokeFunction } from 'shared/utils'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+
 const firestore = admin.firestore()
 
 export const scheduleUpdateGroupMetrics = functions.pubsub
@@ -28,119 +28,70 @@ export const updategroupmetrics = newEndpointNoAuth(
 )
 
 export async function updateGroupMetrics() {
+  const pg = createSupabaseDirectClient()
   log('Loading groups...')
   const groups = await firestore.collection('groups').select().get()
   log(`Loaded ${groups.size} groups.`)
 
-  log('Loading group-contract associations...')
-  const groupContractDocs = await firestore
-    .collectionGroup('groupContracts')
-    .get()
-  const contractIdsByGroupId = mapValues(
-    groupBy(
-      groupContractDocs.docs,
-      (d) => d.ref.path.split('/')[1] // groups/foo/groupContracts/bar
-    ),
-    (ds) => ds.map((d) => d.get('contractId') as string)
+  log(`Loading contract creator scores...`)
+  const groupCreatorScores = await pg.manyOrNone(
+    `with creator_scores as (
+      select gc.group_id, c.data->>'creatorId' as user_id, count(*) as score
+      from group_contracts as gc
+      join contracts as c on gc.contract_id = c.id
+      join user_contract_metrics as ucm on ucm.contract_id = gc.contract_id
+      group by gc.group_id, c.data->>'creatorId'
+    ), ranked_scores as (
+      select *, rank() over (partition by group_id order by score desc, user_id) as nth
+      from creator_scores
+    )
+    select * from ranked_scores where nth <= 50`
   )
-  log(`Loaded ${groupContractDocs.size} associations.`)
+  const creatorScoresByGroup = mapValues(
+    groupBy(groupCreatorScores, (r) => r.group_id as string),
+    (rows) =>
+      rows.map((r) => ({
+        userId: r.user_id as string,
+        score: parseFloat(r.score as string),
+      }))
+  )
 
-  log('Loading contracts...')
-  const contractIds = uniq(
-    groupContractDocs.docs.map((d) => d.get('contractId') as string)
+  log(`Loading contract profit scores...`)
+  const groupProfitScores = await pg.manyOrNone(
+    `with profit_scores as (
+      select gc.group_id, ucm.user_id, sum((ucm.data->'profit')::numeric) as score
+      from group_contracts as gc
+      join user_contract_metrics as ucm on ucm.contract_id = gc.contract_id
+      group by gc.group_id, ucm.user_id
+    ), ranked_scores as (
+      select *, rank() over (partition by group_id order by score desc, user_id) as nth
+      from profit_scores
+    )
+    select * from ranked_scores where nth <= 50`
   )
-  const contractsById = Object.fromEntries(
-    (await loadContracts(contractIds)).map((c) => [c.id, c])
+  const profitScoresByGroup = mapValues(
+    groupBy(groupProfitScores, (r) => r.group_id as string),
+    (rows) =>
+      rows.map((r) => ({
+        userId: r.user_id as string,
+        score: parseFloat(r.score as string),
+      }))
   )
-  log(`Loaded ${contractIds.length} contracts.`)
 
-  log('Computing metric updates...')
+  log('Updating leaderboards...')
   const writer = firestore.bulkWriter()
-  await mapAsync(groups.docs, async (doc) => {
-    const contractIds = contractIdsByGroupId[doc.id] ?? []
-    const contracts = contractIds.map((c) => contractsById[c])
-    const creatorScores = scoreCreators(contracts)
-    const traderScores = await scoreTraders(contractIds)
-    const topTraderScores = topUserScores(traderScores)
-    const topCreatorScores = topUserScores(creatorScores)
+  for (const doc of groups.docs) {
+    const topTraderScores = profitScoresByGroup[doc.id] ?? []
+    const topCreatorScores = creatorScoresByGroup[doc.id] ?? []
     writer.update(doc.ref, {
       cachedLeaderboard: {
-        topTraders: topTraderScores,
-        topCreators: topCreatorScores,
+        topTraders: sortBy(topTraderScores, (x) => -x.score),
+        topCreators: sortBy(topCreatorScores, (x) => -x.score),
       },
     })
-  })
+  }
 
   log('Committing writes...')
   await writer.close()
   log('Done.')
-}
-
-function scoreCreators(contracts: Contract[]) {
-  if (contracts.length === 0) {
-    return {}
-  }
-  const creatorScore = mapValues(
-    groupBy(contracts, ({ creatorId }) => creatorId),
-    (contracts) =>
-      sumBy(
-        contracts.map((contract) => {
-          return contract?.uniqueBettorCount ?? 0
-        })
-      )
-  )
-
-  return creatorScore
-}
-
-async function scoreTraders(contractIds: string[]) {
-  if (contractIds.length === 0) {
-    return {}
-  }
-  const userScoresByContract = await mapAsync(contractIds, (c) =>
-    scoreUsersByContract(c)
-  )
-  const userScores: { [userId: string]: number } = {}
-  for (const scores of userScoresByContract) {
-    addUserScores(scores, userScores)
-  }
-  return userScores
-}
-
-async function scoreUsersByContract(contractId: string) {
-  const userContractMetrics = await firestore
-    .collectionGroup('contract-metrics')
-    .where('contractId', '==', contractId)
-    .select('profit')
-    .get()
-  return Object.fromEntries(
-    userContractMetrics.docs.map((d) => {
-      const userId = d.ref.path.split('/')[1] // users/foo/contract-metrics/bar
-      const profit = d.get('profit') as number
-      return [userId, profit]
-    })
-  )
-}
-
-function addUserScores(
-  src: { [userId: string]: number },
-  dest: { [userId: string]: number }
-) {
-  for (const [userId, score] of Object.entries(src)) {
-    if (dest[userId] === undefined) dest[userId] = 0
-    dest[userId] += score
-  }
-}
-
-const topUserScores = (scores: { [userId: string]: number }) => {
-  const top50 = Object.entries(scores)
-    .sort(([, scoreA], [, scoreB]) => scoreB - scoreA)
-    .slice(0, 50)
-  return top50.map(([userId, score]) => ({ userId, score }))
-}
-
-async function loadContracts(contractIds: string[]) {
-  const refs = contractIds.map((c) => firestore.collection('contracts').doc(c))
-  const contractDocs = await firestore.getAll(...refs)
-  return contractDocs.map((d) => d.data() as Contract)
 }


### PR DESCRIPTION
Self-explanatory. This was loading 500k contract metrics documents (plus other stuff) so it's a nice chunk of reads to cut. Obviously it's also faster and simpler.