### PR TITLE
Remove group `mostRecentActivityTime`

### DIFF
--- a/backend/functions/src/api/create-group.ts
+++ b/backend/functions/src/api/create-group.ts
@@ -60,7 +60,6 @@ export const creategroup = newEndpoint({}, async (req, auth) => {
     name,
     about: about ?? '',
     createdTime: Date.now(),
-    mostRecentActivityTime: Date.now(),
     // TODO: allow users to add contract ids on group creation
     totalContracts: 0,
     totalMembers: memberIds.length,

--- a/backend/functions/src/triggers/on-update-group.ts
+++ b/backend/functions/src/triggers/on-update-group.ts
@@ -5,22 +5,6 @@ import { getContract } from 'shared/utils'
 import { uniq } from 'lodash'
 const firestore = admin.firestore()
 
-export const onUpdateGroup = functions.firestore
-  .document('groups/{groupId}')
-  .onUpdate(async (change) => {
-    const prevGroup = change.before.data() as Group
-    const group = change.after.data() as Group
-
-    // Ignore the activity update we just made
-    if (prevGroup.mostRecentActivityTime !== group.mostRecentActivityTime)
-      return
-
-    await firestore
-      .collection('groups')
-      .doc(group.id)
-      .update({ mostRecentActivityTime: Date.now() })
-  })
-
 export const onCreateGroupContract = functions.firestore
   .document('groups/{groupId}/groupContracts/{contractId}')
   .onCreate(async (change) => {
@@ -58,7 +42,6 @@ export const onCreateGroupMember = functions.firestore
         .collection('groups')
         .doc(groupId)
         .update({
-          mostRecentActivityTime: Date.now(),
           totalMembers: admin.firestore.FieldValue.increment(1),
         })
   })
@@ -72,7 +55,6 @@ export const onDeleteGroupMember = functions.firestore
         .collection('groups')
         .doc(groupId)
         .update({
-          mostRecentActivityTime: Date.now(),
           totalMembers: admin.firestore.FieldValue.increment(-1),
         })
   })

--- a/backend/scripts/convert-tag-to-group.ts
+++ b/backend/scripts/convert-tag-to-group.ts
@@ -37,7 +37,6 @@ const createGroup = async (
     name,
     about,
     createdTime: now,
-    mostRecentActivityTime: now,
     anyoneCanJoin: true,
     totalContracts: contracts.length,
     totalMembers: 1,

--- a/common/src/group.ts
+++ b/common/src/group.ts
@@ -7,7 +7,6 @@ export type Group = {
   about: string
   creatorId: string // User id
   createdTime: number
-  mostRecentActivityTime: number
   anyoneCanJoin?: boolean
   totalContracts: number
   totalMembers: number

--- a/twitch-bot/common/types/manifold-internal-types.ts
+++ b/twitch-bot/common/types/manifold-internal-types.ts
@@ -84,7 +84,6 @@ export type Group = {
   about: string;
   creatorId: string; // User id
   createdTime: number;
-  mostRecentActivityTime: number;
   anyoneCanJoin: boolean;
   totalContracts: number;
   totalMembers: number;


### PR DESCRIPTION
This is unnecessary and was running for every group when group leaderboards were recomputed.