### PR TITLE
Clean up some stuff with metrics functions

### DIFF
--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -21,15 +21,15 @@ export * from './triggers/on-delete-group'
 export * from './triggers/on-update-reaction'
 
 // scheduled functions
-export { scheduleUpdateContractMetrics } from './scheduled/update-contract-metrics'
-export { scheduleUpdateUserMetrics } from './scheduled/update-user-metrics'
-export { scheduleUpdateGroupMetrics } from './scheduled/update-group-metrics'
 export { scheduleUpdateLoans } from './scheduled/update-loans'
 export { scheduleUpdateRecommended } from './scheduled/update-recommended'
 export {
   sendWeeklyPortfolioUpdate,
   saveWeeklyContractMetrics,
 } from './scheduled/weekly-portfolio-updates'
+export * from './scheduled/update-contract-metrics'
+export * from './scheduled/update-user-metrics'
+export * from './scheduled/update-group-metrics'
 export * from './scheduled/update-stats'
 export * from './scheduled/backup-db'
 export * from './scheduled/mana-signup-bonus'
@@ -45,16 +45,12 @@ export * from './scheduled/increment-streak-forgiveness'
 
 // v2
 // HTTP endpoints
-import { updatecontractmetrics } from './scheduled/update-contract-metrics'
-import { updategroupmetrics } from './scheduled/update-group-metrics'
 import { updateloans } from './scheduled/update-loans'
 import { updaterecommended } from './scheduled/update-recommended'
 
 const toCloudFunction = ({ opts, handler }: EndpointDefinition) => {
   return onRequest(opts, handler as any)
 }
-const updateContractMetricsFunction = toCloudFunction(updatecontractmetrics)
-const updateGroupMetricsFunction = toCloudFunction(updategroupmetrics)
 const updateLoansFunction = toCloudFunction(updateloans)
 const updateRecommendedFunction = toCloudFunction(updaterecommended)
 
@@ -125,8 +121,6 @@ export {
   saveTwitchCredentials as savetwitchcredentials,
   createCommentFunction as createcomment,
   testScheduledFunction as testscheduledfunction,
-  updateContractMetricsFunction as updatecontractmetrics,
-  updateGroupMetricsFunction as updategroupmetrics,
   updateLoansFunction as updateloans,
   updateRecommendedFunction as updaterecommended,
   validateIAPFunction as validateiap,

--- a/backend/functions/src/scheduled/score-contracts.ts
+++ b/backend/functions/src/scheduled/score-contracts.ts
@@ -16,7 +16,7 @@ import { bulkUpdate } from 'shared/supabase/utils'
 
 export const scoreContracts = functions
   .runWith({
-    memory: '4GB',
+    memory: '1GB',
     timeoutSeconds: 540,
     secrets: ['SUPABASE_KEY', 'SUPABASE_PASSWORD'],
   })

--- a/backend/functions/src/scheduled/update-contract-metrics.ts
+++ b/backend/functions/src/scheduled/update-contract-metrics.ts
@@ -16,7 +16,7 @@ import { getAll } from 'shared/supabase/utils'
 
 export const updateContractMetrics = functions
   .runWith({
-    memory: '2GB',
+    memory: '1GB',
     timeoutSeconds: 540,
     secrets: ['SUPABASE_PASSWORD'],
   })

--- a/backend/functions/src/scheduled/update-group-metrics.ts
+++ b/backend/functions/src/scheduled/update-group-metrics.ts
@@ -7,11 +7,7 @@ import { getIds } from 'shared/supabase/utils'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 
 export const updateGroupMetrics = functions
-  .runWith({
-    memory: '2GB',
-    timeoutSeconds: 540,
-    secrets: ['SUPABASE_PASSWORD'],
-  })
+  .runWith({ timeoutSeconds: 540, secrets: ['SUPABASE_PASSWORD'] })
   .pubsub.schedule('every 15 minutes')
   .onRun(async () => {
     await updateGroupMetricsCore()

--- a/backend/functions/src/scheduled/update-group-metrics.ts
+++ b/backend/functions/src/scheduled/update-group-metrics.ts
@@ -3,35 +3,21 @@ import * as admin from 'firebase-admin'
 import { groupBy, mapValues, sortBy } from 'lodash'
 
 import { log } from 'shared/utils'
-import { newEndpointNoAuth } from '../api/helpers'
-import { invokeFunction } from 'shared/utils'
 import { getIds } from 'shared/supabase/utils'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 
-export const scheduleUpdateGroupMetrics = functions.pubsub
-  .schedule('every 15 minutes')
+export const updateGroupMetrics = functions
+  .runWith({
+    memory: '2GB',
+    timeoutSeconds: 540,
+    secrets: ['SUPABASE_PASSWORD'],
+  })
+  .pubsub.schedule('every 15 minutes')
   .onRun(async () => {
-    try {
-      console.log(await invokeFunction('updategroupmetrics'))
-    } catch (e) {
-      console.error(e)
-    }
+    await updateGroupMetricsCore()
   })
 
-export const updategroupmetrics = newEndpointNoAuth(
-  {
-    timeoutSeconds: 2000,
-    memory: '2GiB',
-    minInstances: 0,
-    secrets: ['SUPABASE_PASSWORD'],
-  },
-  async (_req) => {
-    await updateGroupMetrics()
-    return { success: true }
-  }
-)
-
-export async function updateGroupMetrics() {
+export async function updateGroupMetricsCore() {
   const firestore = admin.firestore()
   const pg = createSupabaseDirectClient()
   log('Loading group IDs...')

--- a/backend/functions/src/scheduled/update-recommended.ts
+++ b/backend/functions/src/scheduled/update-recommended.ts
@@ -29,7 +29,7 @@ export const updaterecommended = newEndpointNoAuth(
   {
     timeoutSeconds: 3600,
     cpu: 4,
-    memory: '8GiB',
+    memory: '2GiB',
     minInstances: 0,
     secrets: ['SUPABASE_PASSWORD'],
   },

--- a/backend/functions/src/scheduled/update-stats.ts
+++ b/backend/functions/src/scheduled/update-stats.ts
@@ -425,7 +425,7 @@ export const updateStatsCore = async () => {
 
 export const updateStats = functions
   .runWith({
-    memory: '8GB',
+    memory: '2GB',
     timeoutSeconds: 540,
     secrets: ['SUPABASE_PASSWORD'],
   })

--- a/backend/functions/src/scheduled/update-user-metrics.ts
+++ b/backend/functions/src/scheduled/update-user-metrics.ts
@@ -24,7 +24,7 @@ import {
 
 const firestore = admin.firestore()
 
-export const scheduleUpdateUserMetrics = functions
+export const updateUserMetrics = functions
   .runWith({
     memory: '4GB',
     timeoutSeconds: 540,
@@ -32,10 +32,10 @@ export const scheduleUpdateUserMetrics = functions
   })
   .pubsub.schedule('every 1 minutes')
   .onRun(async () => {
-    await updateUserMetrics()
+    await updateUserMetricsCore()
   })
 
-export async function updateUserMetrics() {
+export async function updateUserMetricsCore() {
   const now = Date.now()
   const yesterday = now - DAY_MS
   const weekAgo = now - DAY_MS * 7

--- a/backend/functions/src/scheduled/update-user-metrics.ts
+++ b/backend/functions/src/scheduled/update-user-metrics.ts
@@ -26,7 +26,7 @@ const firestore = admin.firestore()
 
 export const updateUserMetrics = functions
   .runWith({
-    memory: '4GB',
+    memory: '1GB',
     timeoutSeconds: 540,
     secrets: ['API_SECRET', 'SUPABASE_PASSWORD'],
   })

--- a/backend/scripts/update-metrics.ts
+++ b/backend/scripts/update-metrics.ts
@@ -2,17 +2,17 @@ import { initAdmin } from 'shared/init-admin'
 initAdmin()
 
 import { log } from 'shared/utils'
-import { updateUserMetrics } from 'functions/scheduled/update-user-metrics'
-import { updateContractMetrics } from 'functions/scheduled/update-contract-metrics'
-import { updateGroupMetrics } from 'functions/scheduled/update-group-metrics'
+import { updateUserMetricsCore } from 'functions/scheduled/update-user-metrics'
+import { updateContractMetricsCore } from 'functions/scheduled/update-contract-metrics'
+import { updateGroupMetricsCore } from 'functions/scheduled/update-group-metrics'
 
 async function updateMetrics() {
   log('Updating user metrics...')
-  await updateUserMetrics()
+  await updateUserMetricsCore()
   log('Updating contract metrics...')
-  await updateContractMetrics()
+  await updateContractMetricsCore()
   log('Updating group metrics...')
-  await updateGroupMetrics()
+  await updateGroupMetricsCore()
 }
 
 if (require.main === module) {


### PR DESCRIPTION
- Now that they don't take ten minutes, there's no need for them to be v2 functions, so we don't need the weird wrapper function stuff.
- These functions don't need nearly as much memory now, probably because of the Supabase stuff (Firestore document fetches return extremely inflated blobs of crap.)