### PR TITLE
Change portfolio history to be native Supabase table

### DIFF
--- a/backend/functions/src/scheduled/backup-db.ts
+++ b/backend/functions/src/scheduled/backup-db.ts
@@ -51,7 +51,6 @@ export const backupDbCore = async (
     'latency',
     'views',
     'notifications',
-    'portfolioHistory',
     'folds',
   ]
   return await client.exportDocuments({ name, outputUriPrefix, collectionIds })

--- a/backend/functions/src/scheduled/update-loans.ts
+++ b/backend/functions/src/scheduled/update-loans.ts
@@ -1,9 +1,8 @@
 import * as functions from 'firebase-functions'
 import { onRequest } from 'firebase-functions/v2/https'
 import * as admin from 'firebase-admin'
-import { groupBy, keyBy, sortBy } from 'lodash'
+import { groupBy, sortBy } from 'lodash'
 import {
-  getValues,
   invokeFunction,
   loadPaginated,
   log,
@@ -15,10 +14,11 @@ import { Contract } from 'common/contract'
 import { User } from 'common/user'
 import { getUserLoanUpdates, isUserEligibleForLoan } from 'common/loans'
 import { createLoanIncomeNotification } from 'shared/create-notification'
-import { filterDefined } from 'common/util/array'
 import { mapAsync } from 'common/util/promise'
 import { CollectionReference, Query } from 'firebase-admin/firestore'
 import { PortfolioMetrics } from 'common/portfolio-metrics'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { secrets } from 'functions/secrets'
 
 const firestore = admin.firestore()
 
@@ -35,7 +35,7 @@ export const scheduleUpdateLoans = functions.pubsub
   })
 
 export const updateloans = onRequest(
-  { timeoutSeconds: 2000, memory: '8GiB', minInstances: 0 },
+  { timeoutSeconds: 2000, memory: '8GiB', minInstances: 0, secrets },
   async (_req, res) => {
     await updateLoansCore()
     res.status(200).json({ success: true })
@@ -43,6 +43,8 @@ export const updateloans = onRequest(
 )
 
 export async function updateLoansCore() {
+  const pg = createSupabaseDirectClient()
+
   log('Updating loans...')
 
   const [users, contracts] = await Promise.all([
@@ -53,7 +55,6 @@ export async function updateLoansCore() {
         .where('isResolved', '==', false) as Query<Contract>
     ),
   ])
-
   log(`Loaded ${users.length} users, ${contracts.length} contracts.`)
 
   const contractBets = await mapAsync(contracts, (contract) =>
@@ -65,23 +66,26 @@ export async function updateLoansCore() {
     )
   )
   const bets = sortBy(contractBets.flat(), (b) => b.createdTime)
-
   log(`Loaded ${bets.length} bets.`)
-  const userPortfolios = filterDefined(
-    await Promise.all(
-      users.map(async (user) => {
-        const portfolio = await getValues<PortfolioMetrics>(
-          firestore
-            .collection(`users/${user.id}/portfolioHistory`)
-            .orderBy('timestamp', 'desc')
-            .limit(1)
-        )
-        return portfolio[0]
-      })
+
+  const userPortfolios = Object.fromEntries(
+    await pg.map(
+      `select distinct on (user_id) user_id, ts, investment_value, balance, total_deposits
+       from user_portfolio_history order by user_id, ts desc`,
+      [],
+      (r) => [
+        r.user_id as string,
+        {
+          userId: r.user_id as string,
+          timestamp: Date.parse(r.ts as string),
+          investmentValue: parseFloat(r.investment_value as string),
+          balance: parseFloat(r.balance as string),
+          totalDeposits: parseFloat(r.total_deposits as string),
+        } as PortfolioMetrics,
+      ]
     )
   )
-  log(`Loaded ${userPortfolios.length} portfolios`)
-  const portfolioByUser = keyBy(userPortfolios, (portfolio) => portfolio.userId)
+  log(`Loaded ${users.length} portfolios.`)
 
   const contractsById = Object.fromEntries(
     contracts.map((contract) => [contract.id, contract])
@@ -89,7 +93,7 @@ export async function updateLoansCore() {
   const betsByUser = groupBy(bets, (bet) => bet.userId)
 
   const eligibleUsers = users.filter((u) =>
-    isUserEligibleForLoan(portfolioByUser[u.id])
+    isUserEligibleForLoan(userPortfolios[u.id])
   )
   const userUpdates = eligibleUsers.map((user) => {
     const userContractBets = groupBy(

--- a/backend/functions/src/scheduled/update-user-metrics.ts
+++ b/backend/functions/src/scheduled/update-user-metrics.ts
@@ -214,7 +214,7 @@ const getPortfolioHistorySnapshots = async (
 ) => {
   return Object.fromEntries(
     await pg.map(
-      `select distinct on (user_id) *
+      `select distinct on (user_id) user_id, ts, investment_value, balance, total_deposits
       from user_portfolio_history
       where ts < $2 and user_id in ($1:list)
       order by user_id, ts desc`,

--- a/backend/functions/src/scheduled/update-user-metrics.ts
+++ b/backend/functions/src/scheduled/update-user-metrics.ts
@@ -21,6 +21,7 @@ import {
   SupabaseDirectClient,
   createSupabaseDirectClient,
 } from 'shared/supabase/init'
+import { bulkInsert } from 'shared/supabase/utils'
 import { secrets } from 'functions/secrets'
 
 const firestore = admin.firestore()
@@ -46,7 +47,7 @@ export async function updateUserMetricsCore() {
 
   log('Loading users...')
   const users = await pg.map(
-    `select data from users order by data->'metricsLastUpdated' asc nulls first limit 500`,
+    `select data from users order by data->'metricsLastUpdated' asc nulls first limit 5000`,
     [],
     (r) => r.data as User
   )
@@ -94,6 +95,7 @@ export async function updateUserMetricsCore() {
 
   log('Computing metric updates...')
   const userUpdates = []
+  const portfolioUpdates = []
   for (const user of users) {
     const userContracts = contractsByCreator[user.id] ?? []
     const newMetricRelevantBets = metricRelevantBets[user.id] ?? []
@@ -138,7 +140,14 @@ export async function updateUserMetricsCore() {
 
     const userDoc = firestore.collection('users').doc(user.id)
     if (didPortfolioChange) {
-      writer.set(userDoc.collection('portfolioHistory').doc(), newPortfolio)
+      portfolioUpdates.push({
+        user_id: user.id,
+        portfolio_id: userDoc.collection('portfolioHistory').doc().id,
+        ts: new Date(newPortfolio.timestamp).toISOString(),
+        investment_value: newPortfolio.investmentValue,
+        balance: newPortfolio.balance,
+        total_deposits: newPortfolio.totalDeposits,
+      })
     }
 
     const contractMetricsCollection = userDoc.collection('contract-metrics')
@@ -162,7 +171,12 @@ export async function updateUserMetricsCore() {
     }
   }
 
-  log('Committing writes...')
+  log('Inserting Supabase portfolio history entries...')
+  if (portfolioUpdates.length > 0) {
+    await bulkInsert(pg, 'user_portfolio_history', portfolioUpdates)
+  }
+
+  log('Committing Firestore writes...')
   await writer.close()
 
   await revalidateStaticProps('/leaderboards')
@@ -218,7 +232,7 @@ const getPortfolioHistorySnapshots = async (
       from user_portfolio_history
       where ts < $2 and user_id in ($1:list)
       order by user_id, ts desc`,
-      [userIds, when],
+      [userIds, new Date(when).toISOString()],
       (r) => [
         r.user_id as string,
         {

--- a/backend/functions/src/scheduled/update-user-metrics.ts
+++ b/backend/functions/src/scheduled/update-user-metrics.ts
@@ -214,12 +214,21 @@ const getPortfolioHistorySnapshots = async (
 ) => {
   return Object.fromEntries(
     await pg.map(
-      `select distinct on (user_id) user_id, data
+      `select distinct on (user_id) *
       from user_portfolio_history
-      where (data->'timestamp')::bigint < $2 and user_id in ($1:list)
-      order by user_id, (data->'timestamp')::bigint desc`,
+      where ts < $2 and user_id in ($1:list)
+      order by user_id, ts desc`,
       [userIds, when],
-      (r) => [r.user_id as string, r.data as PortfolioMetrics]
+      (r) => [
+        r.user_id as string,
+        {
+          userId: r.user_id as string,
+          timestamp: Date.parse(r.ts as string),
+          investmentValue: parseFloat(r.investment_value as string),
+          balance: parseFloat(r.balance as string),
+          totalDeposits: parseFloat(r.total_deposits as string),
+        } as PortfolioMetrics,
+      ]
     )
   )
 }

--- a/backend/replicator/package.json
+++ b/backend/replicator/package.json
@@ -14,7 +14,7 @@
     "watch": "tsc -w",
     "alias": "tsc-alias",
     "regen-types": "supabase gen types typescript --project-id pxidrgkatumlvfqaxcll --schema public > ../../common/src/supabase/schema.ts",
-    "regen-types-dev": "supabase gen types typescript --project-id mfodonznyfxllcezufgr --schema public > ../../common/src/supabase.schema.ts"
+    "regen-types-dev": "supabase gen types typescript --project-id mfodonznyfxllcezufgr --schema public > ../../common/src/supabase/schema.ts"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/backend/scripts/calculate-mana-supply.ts
+++ b/backend/scripts/calculate-mana-supply.ts
@@ -36,6 +36,7 @@ async function calculateManaSupply() {
 }
 
 const loadPortfolioHistory = async (userId: string, now: number) => {
+  /* mqp: needs to be ported to supabase now
   const query = firestore
     .collection('users')
     .doc(userId)
@@ -52,7 +53,9 @@ const loadPortfolioHistory = async (userId: string, now: number) => {
     getValues<PortfolioMetrics>(
       query.where('timestamp', '<', now - 30 * DAY_MS)
     ),
-  ])
+    ])
+  */
+  const portfolioMetrics = [[], [], [], []]
   const [current, day, week, month] = portfolioMetrics.map(
     (p) => p[0] as PortfolioMetrics | undefined
   )

--- a/backend/scripts/clean-local-firestore-db.ts
+++ b/backend/scripts/clean-local-firestore-db.ts
@@ -49,12 +49,7 @@ async function deleteTopLevelCollections() {
 //  but in the end I used an old, smaller firestore export and using this wasn't necessary.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function deleteUsersSubcollections() {
-  const deleteSubCollections = [
-    'contract-metrics',
-    'notifications',
-    'portfolioHistory',
-    'events',
-  ]
+  const deleteSubCollections = ['contract-metrics', 'notifications', 'events']
   const userSnap = await firestore.collection('users').get()
   const users = userSnap.docs.map((d) => d.data() as User)
   const usersToDelete = users.filter(

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -515,7 +515,6 @@ begin
     when 'manalinks' then cast((null, 'id') as table_spec)
     when 'posts' then cast((null, 'id') as table_spec)
     when 'test' then cast((null, 'id') as table_spec)
-    when 'user_portfolio_history' then cast(('user_id', 'portfolio_id') as table_spec)
     when 'user_contract_metrics' then cast(('user_id', 'contract_id') as table_spec)
     else null
   end;

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -61,11 +61,8 @@ create table if not exists user_portfolio_history (
 alter table user_portfolio_history enable row level security;
 drop policy if exists "public read" on user_portfolio_history;
 create policy "public read" on user_portfolio_history for select using (true);
-create index if not exists user_portfolio_history_gin on user_portfolio_history using GIN (data);
-create index if not exists user_portfolio_history_timestamp on user_portfolio_history (user_id, (to_jsonb(data->'timestamp')) desc);
-create index if not exists user_portfolio_history_user_timestamp on user_portfolio_history (user_id, ((data->'timestamp')::bigint) desc);
 create index if not exists user_portfolio_history_user_ts on user_portfolio_history (user_id, ts desc);
-alter table user_portfolio_history cluster on user_portfolio_history_user_timestamp;
+alter table user_portfolio_history cluster on user_portfolio_history_user_ts;
 
 create or replace function user_portfolio_history_populate_cols()
   returns trigger

--- a/common/src/supabase/portfolio-metrics.ts
+++ b/common/src/supabase/portfolio-metrics.ts
@@ -7,19 +7,19 @@ export async function getPortfolioHistory(
   db: SupabaseClient,
   end?: number
 ) {
-  let query = selectFrom(
-    db,
-    'user_portfolio_history',
-    'timestamp',
-    'investmentValue',
-    'totalDeposits',
-    'balance'
-  )
+  let query = db
+    .from('user_portfolio_history')
+    .select('ts, investment_value, total_deposits, balance')
     .eq('user_id', userId)
-    .gt('data->>timestamp', start)
+    .gt('ts', new Date(start).toISOString())
   if (end) {
-    query = query.lt('data->>timestamp', end)
+    query = query.lt('ts', new Date(end).toISOString())
   }
   const { data } = await run(query)
-  return sortBy(data, 'timestamp')
+  return sortBy(data, 'ts').map((d) => ({
+    timestamp: Date.parse(d.ts!),
+    investmentValue: d.investment_value!,
+    totalDeposits: d.total_deposits!,
+    balance: d.balance!,
+  }))
 }

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -457,21 +457,33 @@ export interface Database {
       }
       user_portfolio_history: {
         Row: {
-          data: Json
-          fs_updated_time: string
+          balance: number | null
+          data: Json | null
+          fs_updated_time: string | null
+          investment_value: number | null
           portfolio_id: string
+          total_deposits: number | null
+          ts: string | null
           user_id: string
         }
         Insert: {
-          data: Json
-          fs_updated_time: string
+          balance?: number | null
+          data?: Json | null
+          fs_updated_time?: string | null
+          investment_value?: number | null
           portfolio_id: string
+          total_deposits?: number | null
+          ts?: string | null
           user_id: string
         }
         Update: {
-          data?: Json
-          fs_updated_time?: string
+          balance?: number | null
+          data?: Json | null
+          fs_updated_time?: string | null
+          investment_value?: number | null
           portfolio_id?: string
+          total_deposits?: number | null
+          ts?: string | null
           user_id?: string
         }
       }

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -13,7 +13,6 @@ import { Bet } from '../bet'
 import { ContractMetrics } from '../calculate-metrics'
 import { Group, GroupMemberDoc, GroupContractDoc } from '../group'
 import { UserEvent } from '../events'
-import { PortfolioMetrics } from 'common/portfolio-metrics'
 
 export type Schema = Database['public']
 export type Tables = Schema['Tables']
@@ -36,7 +35,6 @@ export type SubcollectionTableMapping = {
 }
 export const subcollectionTables: SubcollectionTableMapping = {
   users: {
-    portfolioHistory: 'user_portfolio_history',
     'contract-metrics': 'user_contract_metrics',
     follows: 'user_follows',
     reactions: 'user_reactions',
@@ -96,7 +94,6 @@ type TableJsonTypes = {
   users: User
   user_events: UserEvent
   user_contract_metrics: ContractMetrics
-  user_portfolio_history: PortfolioMetrics
   contracts: Contract
   contract_bets: Bet
   groups: Group


### PR DESCRIPTION
The goal is to make the `user_portfolio_history` table have normal columns rather than a JSON blob and to migrate it completely away from Firestore. You can view this as a test run for future tables.

The plan is like this:

1. Alter the table to make the JSON data blob nullable and add new nullable real columns. Create any indexes we want with the native columns.
2. Create a `before update or insert` trigger on the table that, if it sees a JSON blob, populates the real columns with the contents of the blob. If it doesn't see a JSON blob, it does nothing.
3. **Now: all new rows will have their native columns populated.**
4. Run `update foo_table set id = id where some_real_column is null`, running the trigger a lot.
5. **Now: all rows will always have their native columns populated.**
6. Rewrite existing code to read from Supabase using the native columns.
7. Deploy this.
8. Rewrite existing code to write to Supabase using the native columns, writing a `null` JSON blob.
9. Deploy this.
10. **Now: we are fully migrated.**
11. Clean up -- remove the trigger, delete the `data` and `fs_updated_time` columns, turn off replication to the table, delete data from Firestore, add any constraints on the new native columns that we want. Repack table.