### PR TITLE
Fix timezone handling on user_portfolio_history.ts column

### DIFF
--- a/common/src/supabase/portfolio-metrics.ts
+++ b/common/src/supabase/portfolio-metrics.ts
@@ -1,4 +1,4 @@
-import { run, SupabaseClient } from './utils'
+import { run, millisToTs, tsToMillis, SupabaseClient } from './utils'
 import { sortBy } from 'lodash'
 
 export async function getPortfolioHistory(
@@ -11,15 +11,18 @@ export async function getPortfolioHistory(
     .from('user_portfolio_history')
     .select('ts, investment_value, total_deposits, balance')
     .eq('user_id', userId)
-    .gt('ts', new Date(start).toISOString())
+    .gt('ts', millisToTs(start))
   if (end) {
     query = query.lt('ts', new Date(end).toISOString())
   }
   const { data } = await run(query)
-  return sortBy(data, 'ts').map((d) => ({
-    timestamp: Date.parse(d.ts!),
-    investmentValue: d.investment_value!,
-    totalDeposits: d.total_deposits!,
-    balance: d.balance!,
-  }))
+  return sortBy(data, 'ts').map((d) => {
+    console.log(d.ts)
+    return {
+      timestamp: tsToMillis(d.ts!),
+      investmentValue: d.investment_value!,
+      totalDeposits: d.total_deposits!,
+      balance: d.balance!,
+    }
+  })
 }

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -119,3 +119,14 @@ export function selectFrom<
   const builder = db.from(table).select<string, TResult>(query)
   return builder
 }
+
+export function millisToTs(millis: number) {
+  return new Date(millis).toISOString()
+}
+
+export function tsToMillis(ts: string) {
+  // mqp: hack for temporary unwise choice of postgres timestamp without time zone type
+  // -- we have to make it look like an ISO9601 date or the JS date constructor will
+  // assume that it's in local time. will fix this up soon
+  return Date.parse(ts + '+0000')
+}


### PR DESCRIPTION
Irritatingly, when we get this back from Postgres using the supabase-js library, it comes out not as an ISO8601 string, but as an ISO8601-but-no-timezone string, and then Javascript assumes it's in local time when we do `Date.parse`. So we have to make it look like an ISO8601 string to make `Date.parse` know that it's UTC.

I will be looking into how to address this more reasonably.