### PR TITLE
Make `updateUserMetrics` pull down less data for profit calcs

### DIFF
--- a/common/src/calculate-metrics.ts
+++ b/common/src/calculate-metrics.ts
@@ -16,7 +16,6 @@ import { removeUndefinedProps } from './util/object'
 import { buy, getProb, shortSell } from './calculate-cpmm-multi'
 import { average, logit } from './util/math'
 import { ContractMetric } from 'common/contract-metric'
-import { PortfolioMetrics } from 'common/portfolio-metrics'
 
 const computeInvestmentValue = (
   bets: Bet[],
@@ -225,42 +224,6 @@ export const calculateNewPortfolioMetrics = (
     userId: user.id,
   }
   return newPortfolio
-}
-
-const calculateProfitForPeriod = (
-  startingPortfolio: PortfolioMetrics | undefined,
-  currentProfit: number
-) => {
-  if (startingPortfolio === undefined) {
-    return currentProfit
-  }
-
-  const startingProfit = calculatePortfolioProfit(startingPortfolio)
-
-  return currentProfit - startingProfit
-}
-
-export const calculatePortfolioProfit = (portfolio: PortfolioMetrics) => {
-  return portfolio.investmentValue + portfolio.balance - portfolio.totalDeposits
-}
-
-export const calculateNewProfit = (
-  portfolioHistory: Record<
-    'current' | 'day' | 'week' | 'month',
-    PortfolioMetrics | undefined
-  >,
-  newPortfolio: PortfolioMetrics
-) => {
-  const allTimeProfit = calculatePortfolioProfit(newPortfolio)
-
-  const newProfit = {
-    daily: calculateProfitForPeriod(portfolioHistory.day, allTimeProfit),
-    weekly: calculateProfitForPeriod(portfolioHistory.week, allTimeProfit),
-    monthly: calculateProfitForPeriod(portfolioHistory.month, allTimeProfit),
-    allTime: allTimeProfit,
-  }
-
-  return newProfit
 }
 
 export const calculateMetricsByContract = (


### PR DESCRIPTION
Pretty self-explanatory, we can just make this query more efficient by doing the profit calc in SQL.

I thought I could speed this up by putting together the different historical profit queries, but I didn't see much benefit.