### PR TITLE
Improve efficiency of `get_recommended_contracts`

### DIFF
--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -166,6 +166,13 @@ create index if not exists contracts_unique_bettors on contracts (((data->'uniqu
 /* serves API recent markets endpoint */
 create index if not exists contracts_created_time on contracts ((to_jsonb(data)->>'createdTime') desc);
 create index if not exists contracts_close_time on contracts ((to_jsonb(data)->>'closeTime') desc);
+/* serves the criteria used to find valid contracts in get_recommended_contract_set */
+create index if not exists contracts_recommended_criteria on contracts (
+  ((data->>'createdTime')::bigint) desc,
+  (data->>'visibility'),
+  (data->>'outcomeType'),
+  ((data->>'isResolved')::boolean),
+  ((data->>'closeTime')::bigint));
 
 alter table contracts cluster on contracts_creator_id;
 


### PR DESCRIPTION
I like doing this because 1) this was responsible for a decent chunk of our total load 2) it's really nice to have the stuff on the home page load snappily.

What is going on here is bad statistics on JSON columns biting us again. Basically, as it was, the planner was deciding:

- OK, so they want the top N scoring contracts that satisfy this big complicated criteria (can't be closing soon, binary, etc.)
- That looks like a big complicated criteria. I bet most of the contracts will not satisfy it. If I start going down the list of scores looking up contracts by ID, I will probably end up looking up a shitload of contracts before I have N of them that satisfy the criteria.
- So it would be faster to just scan the whole contracts table, figure out which ones satisfy the criteria, and then go down the scores list with that in mind.

But the planner is wrong; it happens to be that most of our contracts satisfy the criteria. It's wrong because it's so bad at looking inside JSON columns to compile stats about the distribution of values. If the fields weren't in JSON columns, it would know better and we wouldn't have this problem. But they are.

To work around this issue, I made a covering index for the whole filter that has all the criteria. Then the planner sees that it can scan the index to find the contracts that fit the criteria, instead of scanning the contracts table (way bigger.) So it ends up being much faster. It's possible there would have been other things that nudged the planner to do things differently, but this one seems pretty simple and foolproof.

Let me know if this makes sense @jahooma.