### PR TITLE
Faster native sign in

### DIFF
--- a/common/src/native-message.ts
+++ b/common/src/native-message.ts
@@ -32,5 +32,7 @@ export type webToNativeMessageType =
   | 'share'
   | 'theme'
   | 'log'
+  | 'startedListening'
+
 export const IS_NATIVE_KEY = 'is-native'
 export const PLATFORM_KEY = 'native-platform'

--- a/common/src/native-message.ts
+++ b/common/src/native-message.ts
@@ -31,6 +31,6 @@ export type webToNativeMessageType =
   | 'onPageVisit'
   | 'share'
   | 'theme'
-
+  | 'log'
 export const IS_NATIVE_KEY = 'is-native'
 export const PLATFORM_KEY = 'native-platform'

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -497,7 +497,7 @@ const App = () => {
           />
         </View>
       </SafeAreaView>
-      {/*<ExportLogsButton />*/}
+      <ExportLogsButton />
     </>
   )
 }

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -74,7 +74,7 @@ const App = () => {
   useEffect(() => {
     getData<FirebaseUser>('user').then((user) => {
       if (!user) return
-      console.log('Got user from storage', user.email)
+      log('Got user from storage', user.email)
       setFbUser(user)
       webview.current?.postMessage(
         JSON.stringify({ type: 'nativeFbUser', data: user })
@@ -252,7 +252,7 @@ const App = () => {
 
   const getPushToken = async () => {
     const projectId = Constants.expoConfig?.extra?.eas.projectId
-    console.log('projectId', projectId)
+    log('projectId', projectId)
     const token = (
       await Notifications.getExpoPushTokenAsync({
         projectId,

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -118,9 +118,9 @@ android {
         applicationId 'com.markets.manifold'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 47
+        versionCode 48
         missingDimensionStrategy 'store', 'play'
-        versionName "2.0.39"
+        versionName "2.0.40"
     }
 
     splits {

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -118,9 +118,9 @@ android {
         applicationId 'com.markets.manifold'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 45
+        versionCode 46
         missingDimensionStrategy 'store', 'play'
-        versionName "2.0.37"
+        versionName "2.0.38"
     }
 
     splits {

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -118,9 +118,9 @@ android {
         applicationId 'com.markets.manifold'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 46
+        versionCode 47
         missingDimensionStrategy 'store', 'play'
-        versionName "2.0.38"
+        versionName "2.0.39"
     }
 
     splits {

--- a/native/android/app/src/main/AndroidManifest.xml
+++ b/native/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
     <meta-data android:name="expo.modules.notifications.default_notification_icon" android:resource="@drawable/notification_icon"/>
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
-    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
+    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="48.0.0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/0ce454fc-3885-4eab-88b6-787b1691973b"/>

--- a/native/android/app/src/main/AndroidManifest.xml
+++ b/native/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:usesCleartextTraffic="true">
     <meta-data android:name="expo.modules.notifications.default_notification_icon" android:resource="@drawable/notification_icon"/>
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
-    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="48.0.0"/>
+    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/0ce454fc-3885-4eab-88b6-787b1691973b"/>

--- a/native/app.json
+++ b/native/app.json
@@ -4,7 +4,7 @@
     "slug": "manifold-markets",
     "owner": "iansp",
     "sdkVersion": "48.0.0",
-    "version": "2.0.37",
+    "version": "2.0.38",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
     "userInterfaceStyle": "light",
@@ -56,7 +56,7 @@
         "backgroundColor": "#4337C9"
       },
       "package": "com.markets.manifold",
-      "versionCode": 45
+      "versionCode": 46
     },
     "ios": {
       "infoPlist": {
@@ -69,7 +69,7 @@
         "applinks:manifold.markets",
         "webcredentials:manifold.markets"
       ],
-      "buildNumber": "1.0.32",
+      "buildNumber": "1.0.33",
       "runtimeVersion": {
         "policy": "sdkVersion"
       }

--- a/native/app.json
+++ b/native/app.json
@@ -4,7 +4,7 @@
     "slug": "manifold-markets",
     "owner": "iansp",
     "sdkVersion": "48.0.0",
-    "version": "2.0.39",
+    "version": "2.0.40",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
     "userInterfaceStyle": "light",
@@ -56,7 +56,7 @@
         "backgroundColor": "#4337C9"
       },
       "package": "com.markets.manifold",
-      "versionCode": 47
+      "versionCode": 48
     },
     "ios": {
       "infoPlist": {
@@ -69,7 +69,7 @@
         "applinks:manifold.markets",
         "webcredentials:manifold.markets"
       ],
-      "buildNumber": "1.0.34",
+      "buildNumber": "1.0.35",
       "runtimeVersion": {
         "policy": "sdkVersion"
       }

--- a/native/app.json
+++ b/native/app.json
@@ -4,7 +4,7 @@
     "slug": "manifold-markets",
     "owner": "iansp",
     "sdkVersion": "48.0.0",
-    "version": "2.0.38",
+    "version": "2.0.39",
     "orientation": "portrait",
     "icon": "./assets/logo.png",
     "userInterfaceStyle": "light",
@@ -56,7 +56,7 @@
         "backgroundColor": "#4337C9"
       },
       "package": "com.markets.manifold",
-      "versionCode": 46
+      "versionCode": 47
     },
     "ios": {
       "infoPlist": {
@@ -69,7 +69,7 @@
         "applinks:manifold.markets",
         "webcredentials:manifold.markets"
       ],
-      "buildNumber": "1.0.33",
+      "buildNumber": "1.0.34",
       "runtimeVersion": {
         "policy": "sdkVersion"
       }

--- a/native/components/auth-page.tsx
+++ b/native/components/auth-page.tsx
@@ -90,7 +90,7 @@ export const AuthPage = (props: {
         JSON.stringify({ type: 'nativeFbUser', data: fbUser })
       )
     } catch (error: any) {
-      console.error(error)
+      log('login with apple error:', error)
     }
     setLoading(false)
   }

--- a/native/ios/Manifold/Info.plist
+++ b/native/ios/Manifold/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.39</string>
+    <string>2.0.40</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.0.34</string>
+    <string>1.0.35</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/native/ios/Manifold/Info.plist
+++ b/native/ios/Manifold/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.38</string>
+    <string>2.0.39</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.0.33</string>
+    <string>1.0.34</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/native/ios/Manifold/Info.plist
+++ b/native/ios/Manifold/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.37</string>
+    <string>2.0.38</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>1.0.32</string>
+    <string>1.0.33</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/native/ios/Podfile.lock
+++ b/native/ios/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
     - EXJSONUtils
   - EXNotifications (0.18.1):
     - ExpoModulesCore
-  - Expo (48.0.4):
+  - Expo (48.0.7):
     - ExpoModulesCore
   - expo-dev-client (2.1.4):
     - EXManifests
@@ -99,7 +99,7 @@ PODS:
     - ExpoModulesCore
   - ExpoKeepAwake (12.0.1):
     - ExpoModulesCore
-  - ExpoModulesCore (1.2.3):
+  - ExpoModulesCore (1.2.5):
     - React-Core
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
@@ -354,6 +354,8 @@ PODS:
   - React-jsinspector (0.71.3)
   - React-logger (0.71.3):
     - glog
+  - react-native-cookies (6.2.1):
+    - React-Core
   - react-native-webview (11.26.0):
     - React-Core
   - React-perflogger (0.71.3)
@@ -437,6 +439,8 @@ PODS:
     - React-jsi (= 0.71.3)
     - React-logger (= 0.71.3)
     - React-perflogger (= 0.71.3)
+  - RNCAsyncStorage (1.17.11):
+    - React-Core
   - RNCClipboard (1.11.1):
     - React-Core
   - RNIap (12.4.2):
@@ -493,6 +497,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - "react-native-cookies (from `../node_modules/@react-native-cookies/cookies`)"
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -507,6 +512,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - RNIap (from `../node_modules/react-native-iap`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
@@ -607,6 +613,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-cookies:
+    :path: "../node_modules/@react-native-cookies/cookies"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-perflogger:
@@ -635,6 +643,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
     :path: "../node_modules/@react-native-clipboard/clipboard"
   RNIap:
@@ -656,7 +666,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: 48b1e764ac35160e6f54d21ab60d7d9501f3e473
   EXManifests: 500666d48e8dd7ca5a482c9e729e4a7a6c34081b
   EXNotifications: dd628737af60fc8cc62dccebacd326b0fbbc0dcb
-  Expo: aae5eb5ed076ff163eb909a003b2be1b85f832dd
+  Expo: 707f9b0039eacc6a1dce90c08c9e37b9c417bba2
   expo-dev-client: 71c7a10806a324e4312c1cac34d4a439670d2c3b
   expo-dev-launcher: 53556b0670fe41380948d5010a3bf7dd5274c946
   expo-dev-menu: d4369e74d8d21a0ccdee35f7c732e7118b0fee16
@@ -665,7 +675,7 @@ SPEC CHECKSUMS:
   ExpoCrypto: 477dfe89c81527b376f2c344ca1d2a01244b243c
   ExpoDevice: e0bebf68f978b3d353377ce42e73c20c0a070215
   ExpoKeepAwake: 69f5f627670d62318410392d03e0b5db0f85759a
-  ExpoModulesCore: f11d8a16e8d3f26c183da2541d75edc6aa9cf8eb
+  ExpoModulesCore: 397fc99e9d6c9dcc010f36d5802097c17b90424c
   ExpoRandom: 7ee07d62e7003b74d0536e0495e3a653fe1b2a74
   ExpoWebBrowser: 033d34c478d9986da2f1679729041423837626e0
   EXSharing: 5a28af9de0884c255f401e1f1f0bea269e9c9bb9
@@ -691,6 +701,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 891dad49e50d35fba97eeb43a35ae7470a8e10b2
   React-jsinspector: 9f7c9137605e72ca0343db4cea88006cb94856dd
   React-logger: 957e5dc96d9dbffc6e0f15e0ee4d2b42829ff207
+  react-native-cookies: f54fcded06bb0cda05c11d86788020b43528a26c
   react-native-webview: 994b9f8fbb504d6314dc40d83f94f27c6831b3bf
   React-perflogger: af8a3d31546077f42d729b949925cc4549f14def
   React-RCTActionSheet: 57cc5adfefbaaf0aae2cf7e10bccd746f2903673
@@ -705,6 +716,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 5199a180d04873366a83855de55ac33ce60fe4d5
   React-runtimeexecutor: 7bf0dafc7b727d93c8cb94eb00a9d3753c446c3e
   ReactCommon: 5768a505f0bc7b798dc2becdd3ee6442224f796c
+  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
   RNIap: e17233fe11083a71e0420682b0b09d497861faa1
   RNSentry: 6503a8ec616947dbe98be828307c8f49e7686674

--- a/native/lib/auth.ts
+++ b/native/lib/auth.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+export type keys = 'user'
+export const storeData = async (key: keys, value: object) => {
+  try {
+    const jsonValue = JSON.stringify(value)
+    await AsyncStorage.setItem(key, jsonValue)
+  } catch (e) {
+    // saving error
+  }
+}
+export const clearData = async (key: keys) => {
+  try {
+    await AsyncStorage.setItem(key, '')
+  } catch (e) {
+    // saving error
+  }
+}
+export const getData = async <T>(key: keys) => {
+  try {
+    const jsonValue = await AsyncStorage.getItem(key)
+    return jsonValue != null ? (JSON.parse(jsonValue) as T) : null
+  } catch (e) {
+    // error reading value
+    console.log('error reading value', e)
+  }
+}

--- a/native/package.json
+++ b/native/package.json
@@ -26,7 +26,6 @@
     "@expo-google-fonts/readex-pro": "^0.2.2",
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-native-clipboard/clipboard": "^1.11.1",
-    "@react-native-cookies/cookies": "6.2.1",
     "@sentry/react-native": "4.9.0",
     "expo": "~48.0.6",
     "expo-apple-authentication": "~6.0.1",

--- a/native/package.json
+++ b/native/package.json
@@ -24,9 +24,11 @@
   "dependencies": {
     "@babel/runtime": "^7.19.4",
     "@expo-google-fonts/readex-pro": "^0.2.2",
+    "@react-native-async-storage/async-storage": "1.17.11",
     "@react-native-clipboard/clipboard": "^1.11.1",
+    "@react-native-cookies/cookies": "6.2.1",
     "@sentry/react-native": "4.9.0",
-    "expo": "~48.0.4",
+    "expo": "~48.0.6",
     "expo-apple-authentication": "~6.0.1",
     "expo-application": "~5.1.1",
     "expo-auth-session": "~4.0.3",

--- a/native/yarn.lock
+++ b/native/yarn.lock
@@ -2243,6 +2243,13 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@react-native-async-storage/async-storage@1.17.11":
+  version "1.17.11"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
+  integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-clipboard/clipboard@^1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.11.1.tgz#d3a9e685ce2383b1e92b89a334896c5575cc103d"
@@ -2431,6 +2438,13 @@
     graceful-fs "^4.1.3"
     prompts "^2.4.0"
     semver "^6.3.0"
+
+"@react-native-cookies/cookies@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-cookies/cookies/-/cookies-6.2.1.tgz#54d50b9496400bbdc19e43c155f70f8f918999e3"
+  integrity sha512-D17wCA0DXJkGJIxkL74Qs9sZ3sA+c+kCoGmXVknW7bVw/W+Vv1m/7mWTNi9DLBZSRddhzYw8SU0aJapIaM/g5w==
+  dependencies:
+    invariant "^2.2.4"
 
 "@react-native/assets@1.0.0":
   version "1.0.0"
@@ -4079,10 +4093,10 @@ expo-application@~5.1.0, expo-application@~5.1.1:
   resolved "https://registry.yarnpkg.com/expo-application/-/expo-application-5.1.1.tgz#5206bf0cf89cb0e32d1f5037a0481e5c86b951ab"
   integrity sha512-aDatTcTTCdTbHw8h4/Tq2ilc6InM5ntF9xWCJdOcnUEcglxxGphVI/lzJKBaBF6mJECA8mEOjpVg2EGxOctTwg==
 
-expo-asset@~8.9.0:
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-8.9.0.tgz#7b083b5f26971b5ac7958ac4f6596b66ca520287"
-  integrity sha512-zenkZrYcsJAcTVl478mCarVmaOE9r2GbTlVvKZaXL8UJIL4rnspk63xUSJLAGMArZIdHzsGFQMXlQG3pgEfzrg==
+expo-asset@~8.9.1:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-8.9.1.tgz#ecd43d7e8ee879e5023e7ce9fbbd6d011dcaf988"
+  integrity sha512-ugavxA7Scn96TBdeTYQA6xtHktnk0o/0xk7nFkxJKoH/t2cZDFSB05X0BI2/LDZY4iE6xTPOYw4C4mmourWfuA==
   dependencies:
     blueimp-md5 "^2.10.0"
     expo-constants "~14.2.0"
@@ -4217,10 +4231,10 @@ expo-modules-autolinking@1.1.2:
     find-up "^5.0.0"
     fs-extra "^9.1.0"
 
-expo-modules-core@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.2.3.tgz#03943710f09120d9b60200fac377bfabcc010890"
-  integrity sha512-bYWxL60NPzDTuvlBrNLlwu7K6H7GqlRKJJpF1c3lqHsMw9vusu3StHZhAXB2noMPD+Ww/pGa/A9tfTtieqvbcg==
+expo-modules-core@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.2.5.tgz#3f9166f4c32c68ab8ef3e120c70ce9890b711650"
+  integrity sha512-5pXNlLHNKLayOusAFMbqr27gjgymHuKuWl/Dtbw2MjoyJY1MZCGD2nIJxd1TTcfnyxNxLg6OQmgkyqoBUFqBuw==
   dependencies:
     compare-versions "^3.4.0"
     invariant "^2.2.4"
@@ -4300,10 +4314,10 @@ expo-web-browser@~12.1.0, expo-web-browser@~12.1.1:
     compare-urls "^2.0.0"
     url "^0.11.0"
 
-expo@~48.0.4:
-  version "48.0.4"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-48.0.4.tgz#de3be9695edb422a49c7734b2bde82f2caad668d"
-  integrity sha512-FGxaxqI8u0r3CvFQAEx/kpqZP4cA7q9ymMoIrrjtOsWvKsuk5Dt3gLEJpymGp6aicPuDXn3xBxo2dsRZF5NkUw==
+expo@~48.0.6:
+  version "48.0.7"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-48.0.7.tgz#7900bfda316d25127ed9c412daa31db66dc4a869"
+  integrity sha512-4sPW+HWm03z72FKIG9IddwEhF9+RlAUsTh8pnsoZjZbXALVikmV3QjD4zp/Dkt9YuiCAnJN1VBaT2AlhbYk2Rg==
   dependencies:
     "@babel/runtime" "^7.20.0"
     "@expo/cli" "0.6.2"
@@ -4313,13 +4327,13 @@ expo@~48.0.4:
     babel-preset-expo "~9.3.0"
     cross-spawn "^6.0.5"
     expo-application "~5.1.1"
-    expo-asset "~8.9.0"
+    expo-asset "~8.9.1"
     expo-constants "~14.2.1"
     expo-file-system "~15.2.2"
     expo-font "~11.1.1"
     expo-keep-awake "~12.0.1"
     expo-modules-autolinking "1.1.2"
-    expo-modules-core "1.2.3"
+    expo-modules-core "1.2.5"
     fbemitter "^3.0.0"
     getenv "^1.0.0"
     invariant "^2.2.4"
@@ -5318,6 +5332,11 @@ is-plain-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -5911,6 +5930,13 @@ memory-cache@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/memory-cache/-/memory-cache-0.2.0.tgz#7890b01d52c00c8ebc9d533e1f8eb17e3034871a"
   integrity sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA==
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"

--- a/native/yarn.lock
+++ b/native/yarn.lock
@@ -2439,13 +2439,6 @@
     prompts "^2.4.0"
     semver "^6.3.0"
 
-"@react-native-cookies/cookies@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@react-native-cookies/cookies/-/cookies-6.2.1.tgz#54d50b9496400bbdc19e43c155f70f8f918999e3"
-  integrity sha512-D17wCA0DXJkGJIxkL74Qs9sZ3sA+c+kCoGmXVknW7bVw/W+Vv1m/7mWTNi9DLBZSRddhzYw8SU0aJapIaM/g5w==
-  dependencies:
-    invariant "^2.2.4"
-
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"

--- a/web/components/native-message-listener.tsx
+++ b/web/components/native-message-listener.tsx
@@ -23,6 +23,10 @@ export const NativeMessageListener = () => {
   const privateUser = usePrivateUser()
 
   useEffect(() => {
+    postMessageToNative('startedListening', {})
+  }, [])
+
+  useEffect(() => {
     const { nativePlatform } = router.query
     if (nativePlatform !== undefined) {
       const platform = nativePlatform as string
@@ -36,6 +40,7 @@ export const NativeMessageListener = () => {
       setIsNative(true, data.platform)
       if (privateUser) setInstalledAppPlatform(privateUser, data.platform)
     } else if (type === 'nativeFbUser') {
+      console.log('received nativeFbUser')
       await setFirebaseUserViaJson(data, app, true)
     } else if (type === 'pushNotificationPermissionStatus') {
       const { status, userId } = data

--- a/web/hooks/use-native-messages.ts
+++ b/web/hooks/use-native-messages.ts
@@ -13,7 +13,7 @@ export const useNativeMessages = (
       return
     }
     const { type, data } = event
-    console.log('Received native event: ', event)
+    console.log('Received native event type: ', type)
     if (messageTypes.includes(type)) {
       onMessageReceived(type, data)
     }

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -6,14 +6,31 @@ import { useEffect } from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { AuthProvider, AuthUser } from 'web/components/auth-context'
 import { DarkModeProvider } from 'web/components/dark-mode-provider'
-import { NativeMessageListener } from 'web/components/native-message-listener'
+import {
+  NativeMessageListener,
+  postMessageToNative,
+} from 'web/components/native-message-listener'
 import Welcome from 'web/components/onboarding/welcome'
 import { SearchProvider } from 'web/components/search/search-context'
 import { useHasLoaded } from 'web/hooks/use-has-loaded'
 import '../styles/globals.css'
+import { getIsNative } from 'web/lib/native/is-native'
 
 function firstLine(msg: string) {
   return msg.replace(/\r?\n.*/s, '')
+}
+
+// It can be very hard to see client logs on native, so send them manually
+if (getIsNative()) {
+  const log = console.log.bind(console)
+  console.log = (...args) => {
+    postMessageToNative('log', { args })
+    log(...args)
+  }
+  console.error = (...args) => {
+    postMessageToNative('log', { args })
+    log(...args)
+  }
 }
 
 function printBuildInfo() {


### PR DESCRIPTION
- Sends web client logs to native for easier debugging
- Stores firebase users in native local storage and queries them on app load to pass them to the client. This seems to result in faster user re-sign-in time on the client. Perhaps an even better version would be to pass the user as a cookie to the server, but the react native webview cookie stuff is finicky and not easy to get working. Will try this PR first and if sign in is still laggy I'll add the user via cookie. 