### PR TITLE
Grafana agent robustness

### DIFF
--- a/backend/supabase-grafana-agent/README.md
+++ b/backend/supabase-grafana-agent/README.md
@@ -4,4 +4,6 @@ Configuration for our fly.io Grafana agent host that is responsible for scraping
 the Supabase Prometheus endpoint and sending metrics to Grafana Cloud so we can
 look at them on https://manifoldmarkets.grafana.net/.
 
+To deploy the agent, use `flyctl deploy`.
+
 Mostly thanks to https://github.com/supabase/grafana-agent-fly-example.

--- a/backend/supabase-grafana-agent/agent.yaml
+++ b/backend/supabase-grafana-agent/agent.yaml
@@ -9,13 +9,13 @@ integrations:
 
 metrics:
   wal_directory: /tmp/wal
-  global:
-    scrape_interval: 5s
   configs:
     - name: supa_prom_scraper
       scrape_configs:
         - job_name: supa_prom_scraper
           metrics_path: '/customer/v1/privileged/metrics'
+          scrape_timeout: 30s
+          scrape_interval: 30s
           basic_auth:
             username: service_role
             password: ${SUPABASE_KEY}


### PR DESCRIPTION
I don't think this is actually causing our spotty dashboard data, but it's better to be more conservative with these settings. (Our cloud Grafana only supports 1 minute resolution anyway as far as I can tell, and Prometheus on the Supabase node seems to cache for some duration, so polling every 5 seconds is mega useless.)