### PR TITLE
Only stuff we actually need in `supabase_realtime` publication

### DIFF
--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -415,26 +415,11 @@ create index if not exists contract_embeddings_embedding on contract_embeddings
 begin;
   drop publication if exists supabase_realtime;
   create publication supabase_realtime;
-  alter publication supabase_realtime add table users;
-  alter publication supabase_realtime add table user_follows;
-  alter publication supabase_realtime add table user_reactions;
-  alter publication supabase_realtime add table user_events;
-  alter publication supabase_realtime add table user_seen_markets;
   alter publication supabase_realtime add table contracts;
-  alter publication supabase_realtime add table contract_answers;
   alter publication supabase_realtime add table contract_bets;
   alter publication supabase_realtime add table contract_comments;
-  alter publication supabase_realtime add table contract_follows;
-  alter publication supabase_realtime add table contract_liquidity;
-  alter publication supabase_realtime add table groups;
-  alter publication supabase_realtime add table group_contracts;
   alter publication supabase_realtime add table group_members;
-  alter publication supabase_realtime add table txns;
-  alter publication supabase_realtime add table manalinks;
   alter publication supabase_realtime add table posts;
-  alter publication supabase_realtime add table test;
-  alter publication supabase_realtime add table user_portfolio_history;
-  alter publication supabase_realtime add table user_contract_metrics;
 commit;
 
 /***************************************************************/


### PR DESCRIPTION
I think it's good to keep this slimmed down. I believe that everything in this publication is getting streamed to our Supabase Realtime server, which adds load to our Supabase, which we are basically paying for. So we shouldn't stream stuff we don't need (i.e. we should only stream stuff we are actually subscribing to on the client somewhere.)