### PR TITLE
Fix stringified popularity scores

### DIFF
--- a/backend/scripts/fix-popularity-scores.ts
+++ b/backend/scripts/fix-popularity-scores.ts
@@ -1,0 +1,24 @@
+import { runScript } from './run-script'
+
+import { log } from 'shared/utils'
+
+if (require.main === module) {
+  runScript(async ({ firestore }) => {
+    const writer = firestore.bulkWriter()
+    const contracts = await firestore.collection('contracts').get()
+    const now = Date.now()
+    let n = 0;
+    log(`Loaded ${contracts.size} contracts.`)
+    for (const doc of contracts.docs) {
+      if (typeof(doc.get('popularityScore')) === 'string') {
+        // no idea how these got busted, but fix them. `lastUpdatedTime` will
+        // cause them to get rescored next hour by scoreContracts
+        log(`Fixing broken score on contract ${doc.id}.`)
+        writer.update(doc.ref, { popularityScore: 0, lastUpdatedTime: now })
+        n++
+      }
+    }
+    log(`Fixed ${n} contracts.`)
+    await writer.close()
+  })
+}


### PR DESCRIPTION
It bothers me that I can't say how these got broken, but I will fix them and then look later to see if they are broken again. This currently affects 243 contracts on prod.