### PR TITLE
Reverse order=shares for NO positions contract-metrics.ts

### DIFF
--- a/common/src/supabase/contract-metrics.ts
+++ b/common/src/supabase/contract-metrics.ts
@@ -183,7 +183,7 @@ export async function getContractMetricsForContractId(
       .select('*')
       .eq('contract_id', contractId)
       .eq(`data->hasNoShares`, true)
-      .order(`data->totalShares->NO` as any, { ascending: false })
+      .order(`data->totalShares->NO` as any, { ascending: true })
 
     q = q
       .eq(`data->hasYesShares`, true)


### PR DESCRIPTION
In `getContractMetricsForContractId()`, switch order=shares NO holders to be sorted ascending, so that top NO holders can be fetched without parsing all positions, as it is already possible to do with YES holders.

This is a more intuitive, continuous ordering, starting with strong YES, then weak YES, then weak NO, then strong NO at the end.