### PR TITLE
Add .sql to prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,16 @@
   "useTabs": false,
   "semi": false,
   "trailingComma": "es5",
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-sql"],
+  "overrides": [
+    {
+      "files": "*.sql",
+      "options": {
+        "language": "postgresql",
+        "keywordCase": "lower",
+        "logicalOperatorNewline": "before"
+      }
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,6 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[sql]": {
-    "editor.defaultFormatter": "mtxr.sqltools"
-  },
   "sqltools.connections": [
     {
       "previewLimit": 50,

--- a/backend/supabase/bets/rls.sql
+++ b/backend/supabase/bets/rls.sql
@@ -1,9 +1,14 @@
 drop policy if exists "Enable read access for non private bets" on public.contract_bets;
-CREATE POLICY "Enable read access for non private bets" ON public.contract_bets FOR
-SELECT USING ((visibility <> 'private'::text));
+
+create policy "Enable read access for non private bets" on public.contract_bets for
+select
+  using ((visibility <> 'private'::text));
+
 drop policy if exists "Enable read access for private bets with permissions" on public.contract_bets;
-CREATE POLICY "Enable read access for private bets with permissions" ON public.contract_bets FOR
-SELECT USING (
-        (visibility = 'private'::text)
-        AND can_access_private_contract(contract_id, firebase_uid())
-    );
+
+create policy "Enable read access for private bets with permissions" on public.contract_bets for
+select
+  using (
+    (visibility = 'private'::text)
+    and can_access_private_contract (contract_id, firebase_uid ())
+  );

--- a/backend/supabase/bets/view.sql
+++ b/backend/supabase/bets/view.sql
@@ -1,7 +1,11 @@
-create or replace view public.contract_bets_rbac as
-select *
-from contract_bets
-where (visibility <> 'private')
-    OR (
-        can_access_private_contract(contract_id, firebase_uid())
-    )
+create or replace view
+  public.contract_bets_rbac as
+select
+  *
+from
+  contract_bets
+where
+  (visibility <> 'private')
+  or (
+    can_access_private_contract (contract_id, firebase_uid ())
+  )

--- a/backend/supabase/contracts/create-question-fts-col.sql
+++ b/backend/supabase/contracts/create-question-fts-col.sql
@@ -1,4 +1,6 @@
 alter table public.contracts
 add column question_fts tsvector generated always as (to_tsvector('english', question)) stored;
+
 create index if not exists question_fts on contracts using gin (question_fts);
+
 -- generate the index

--- a/backend/supabase/contracts/functions.sql
+++ b/backend/supabase/contracts/functions.sql
@@ -1,4 +1,5 @@
-create or replace function can_access_private_contract(this_contract_id text, this_member_id text) returns boolean immutable parallel safe language sql as $$
+create
+or replace function can_access_private_contract (this_contract_id text, this_member_id text) returns boolean immutable parallel safe language sql as $$
 select EXISTS (
         SELECT 1
         FROM (

--- a/backend/supabase/contracts/indexes.sql
+++ b/backend/supabase/contracts/indexes.sql
@@ -1,17 +1,33 @@
 create index if not exists contracts_data_gin on contracts using GIN (data);
-create index if not exists contracts_group_slugs_gin on contracts using GIN ((data->'groupSlugs'));
+
+create index if not exists contracts_group_slugs_gin on contracts using GIN ((data -> 'groupSlugs'));
+
 create index if not exists contracts_slug on contracts (slug);
+
 create index if not exists contracts_creator_id on contracts (creator_id, created_time);
+
 create index if not exists contracts_created_time on contracts (created_time desc);
+
 create index if not exists contracts_close_time on contracts (close_time desc);
+
 create index if not exists contracts_popularity_score on contracts (popularity_score desc);
-create index if not exists contracts_daily_score on contracts (((data->>'dailyScore')::numeric) desc nulls last);
-create index if not exists contracts_volume_24_hours on contracts (
-    ((data->>'volume24Hours')::numeric) desc nulls last
+
+create index if not exists contracts_daily_score on contracts (
+  ((data ->> 'dailyScore')::numeric) desc nulls last
 );
-create index if not exists contracts_elasticity on contracts (((data->>'elasticity')::numeric) desc);
-create index if not exists contracts_last_updated_time on contracts (((data->>'lastUpdatedTime')::numeric) desc);
-create index if not exists contracts_unique_bettor_count on contracts (((data->>'uniqueBettorCount')::integer) desc);
+
+create index if not exists contracts_volume_24_hours on contracts (
+  ((data ->> 'volume24Hours')::numeric) desc nulls last
+);
+
+create index if not exists contracts_elasticity on contracts (((data ->> 'elasticity')::numeric) desc);
+
+create index if not exists contracts_last_updated_time on contracts (((data ->> 'lastUpdatedTime')::numeric) desc);
+
+create index if not exists contracts_unique_bettor_count on contracts (((data ->> 'uniqueBettorCount')::integer) desc);
+
 create index if not exists contracts_resolution_time on contracts (resolution_time desc nulls last);
-create index if not exists contracts_visibility_public ON contracts (id)
-where visibility = 'public';
+
+create index if not exists contracts_visibility_public on contracts (id)
+where
+  visibility = 'public';

--- a/backend/supabase/contracts/rls.sql
+++ b/backend/supabase/contracts/rls.sql
@@ -1,15 +1,23 @@
 -- ALTER TABLE public.contracts ENABLE ROW LEVEL SECURITY;
 drop policy if exists "Enable read access all public/unlisted markets" on public.contracts;
-CREATE POLICY "Enable read access all public/unlisted markets" ON public.contracts FOR
-SELECT USING ((visibility <> 'private'::text));
-drop policy if exists "Enable read access for admins" ON public.contracts;
-CREATE POLICY "Enable read access for admins" ON public.contracts FOR
-SELECT TO service_role USING (true);
-drop policy if exists "Enable read access for private group markets if user is member" ON public.contracts;
-CREATE POLICY "Enable read access for private group markets if user is member" ON public.contracts FOR
-SELECT USING (
-        (
-            visibility = 'private'::text
-            and can_access_private_contract(id, firebase_uid())
-        )
-    );
+
+create policy "Enable read access all public/unlisted markets" on public.contracts for
+select
+  using ((visibility <> 'private'::text));
+
+drop policy if exists "Enable read access for admins" on public.contracts;
+
+create policy "Enable read access for admins" on public.contracts for
+select
+  to service_role using (true);
+
+drop policy if exists "Enable read access for private group markets if user is member" on public.contracts;
+
+create policy "Enable read access for private group markets if user is member" on public.contracts for
+select
+  using (
+    (
+      visibility = 'private'::text
+      and can_access_private_contract (id, firebase_uid ())
+    )
+  );

--- a/backend/supabase/functions.sql
+++ b/backend/supabase/functions.sql
@@ -1,38 +1,47 @@
 -- Get the dot product of two vectors stored as rows in two tables.
-create or replace function dot(
-    urf user_recommendation_features,
-    crf contract_recommendation_features
-  ) returns real immutable parallel safe language sql as $$
+create
+or replace function dot (
+  urf user_recommendation_features,
+  crf contract_recommendation_features
+) returns real immutable parallel safe language sql as $$
 select round(
     (
       urf.f0 * crf.f0 + urf.f1 * crf.f1 + urf.f2 * crf.f2 + urf.f3 * crf.f3 + urf.f4 * crf.f4
     ) * 10000
   ) / 10000;
 $$;
-create or replace function calculate_distance(
-    row1 contract_recommendation_features,
-    row2 contract_recommendation_features
-  ) returns float language sql immutable parallel safe as $$
+
+create
+or replace function calculate_distance (
+  row1 contract_recommendation_features,
+  row2 contract_recommendation_features
+) returns float language sql immutable parallel safe as $$
 select sqrt(
     (row1.f0 - row2.f0) ^ 2 + (row1.f1 - row2.f1) ^ 2 + (row1.f2 - row2.f2) ^ 2 + (row1.f3 - row2.f3) ^ 2 + (row1.f4 - row2.f4) ^ 2
   ) $$;
-create or replace function recently_liked_contract_counts(since bigint) returns table (contract_id text, n int) immutable parallel safe language sql as $$
+
+create
+or replace function recently_liked_contract_counts (since bigint) returns table (contract_id text, n int) immutable parallel safe language sql as $$
 select data->>'contentId' as contract_id,
   count(*) as n
 from user_reactions
 where data->>'contentType' = 'contract'
   and data->>'createdTime' > since::text
 group by contract_id $$;
+
 -- Use cached tables of user and contract features to computed the top scoring
 -- markets for a user.
-create or replace function get_recommended_contract_scores(uid text) returns table (contract_id text, score real) immutable parallel safe language sql as $$
+create
+or replace function get_recommended_contract_scores (uid text) returns table (contract_id text, score real) immutable parallel safe language sql as $$
 select crf.contract_id,
   dot(urf, crf) as score
 from user_recommendation_features as urf
   cross join contract_recommendation_features as crf
 where user_id = uid
 order by score desc $$;
-create or replace function get_recommended_contract_scores_unseen(uid text) returns table (contract_id text, score real) immutable parallel safe language sql as $$
+
+create
+or replace function get_recommended_contract_scores_unseen (uid text) returns table (contract_id text, score real) immutable parallel safe language sql as $$
 select crf.contract_id,
   coalesce(dot(urf, crf) * crf.freshness_score, 0.0) as score
 from user_recommendation_features as urf
@@ -60,11 +69,9 @@ where user_id = uid -- That has not been viewed.
       and (user_events.data->'timestamp')::bigint > ts_to_millis(now() - interval '1 day')
   )
 order by score desc $$;
-create or replace function get_recommended_contracts_by_score_excluding(
-    uid text,
-    count int,
-    excluded_contract_ids text []
-  ) returns table (data jsonb, score real) immutable parallel safe language sql as $$
+
+create
+or replace function get_recommended_contracts_by_score_excluding (uid text, count int, excluded_contract_ids text[]) returns table (data jsonb, score real) immutable parallel safe language sql as $$
 select data,
   score
 from get_recommended_contract_scores_unseen(uid)
@@ -77,7 +84,9 @@ where is_valid_contract(contracts)
     where w = contract_id
   )
 limit count $$;
-create or replace function get_recommended_contract_set(uid text, n int, excluded_contract_ids text []) returns table (data jsonb, score real) immutable parallel safe language sql as $$ with recommendation_scores as materialized (
+
+create
+or replace function get_recommended_contract_set (uid text, n int, excluded_contract_ids text[]) returns table (data jsonb, score real) immutable parallel safe language sql as $$ with recommendation_scores as materialized (
     select contract_id,
       score
     from get_recommended_contract_scores_unseen(uid)
@@ -124,7 +133,9 @@ select data,
   score
 from trending_contracts
 order by score desc $$;
-create or replace function get_recommended_contracts(uid text, n int, excluded_contract_ids text []) returns setof jsonb language plpgsql as $$ begin create temp table your_recs on commit drop as (
+
+create
+or replace function get_recommended_contracts (uid text, n int, excluded_contract_ids text[]) returns setof jsonb language plpgsql as $$ begin create temp table your_recs on commit drop as (
     select *
     from get_recommended_contract_set(uid, n, excluded_contract_ids)
   );
@@ -149,12 +160,14 @@ return query (
 );
 end if;
 end $$;
-create or replace function get_recommended_contracts_embeddings(uid text, n int, excluded_contract_ids text []) returns table (
-    data jsonb,
-    distance numeric,
-    relative_dist numeric,
-    popularity_score numeric
-  ) immutable parallel safe language sql as $$ with user_embedding as (
+
+create
+or replace function get_recommended_contracts_embeddings (uid text, n int, excluded_contract_ids text[]) returns table (
+  data jsonb,
+  distance numeric,
+  relative_dist numeric,
+  popularity_score numeric
+) immutable parallel safe language sql as $$ with user_embedding as (
     select interest_embedding
     from user_embeddings
     where user_id = uid
@@ -170,17 +183,19 @@ from get_recommended_contracts_embeddings_from(
     excluded_contract_ids,
     0.25
   ) $$;
-create or replace function get_recommended_contracts_embeddings_topic(
-    uid text,
-    p_topic text,
-    n int,
-    excluded_contract_ids text []
-  ) returns table (
-    data jsonb,
-    distance numeric,
-    relative_dist numeric,
-    popularity_score numeric
-  ) immutable parallel safe language sql as $$ with topic_embedding as (
+
+create
+or replace function get_recommended_contracts_embeddings_topic (
+  uid text,
+  p_topic text,
+  n int,
+  excluded_contract_ids text[]
+) returns table (
+  data jsonb,
+  distance numeric,
+  relative_dist numeric,
+  popularity_score numeric
+) immutable parallel safe language sql as $$ with topic_embedding as (
     select embedding
     from topic_embeddings
     where topic_embeddings.topic = p_topic
@@ -206,18 +221,20 @@ from get_recommended_contracts_embeddings_from(
     excluded_contract_ids,
     0.10
   ) $$;
-create or replace function get_recommended_contracts_embeddings_from(
-    uid text,
-    p_embedding vector,
-    n int,
-    excluded_contract_ids text [],
-    max_dist numeric
-  ) returns table (
-    data jsonb,
-    distance numeric,
-    relative_dist numeric,
-    popularity_score numeric
-  ) immutable parallel safe language sql as $$ with available_contracts_unscored as (
+
+create
+or replace function get_recommended_contracts_embeddings_from (
+  uid text,
+  p_embedding vector,
+  n int,
+  excluded_contract_ids text[],
+  max_dist numeric
+) returns table (
+  data jsonb,
+  distance numeric,
+  relative_dist numeric,
+  popularity_score numeric
+) immutable parallel safe language sql as $$ with available_contracts_unscored as (
     select contract_id,
       p_embedding <=> ce.embedding as distance,
       (
@@ -396,7 +413,9 @@ select data,
   combined_results.popularity_score
 from combined_results
   join contracts on contracts.id = combined_results.contract_id $$;
-create or replace function get_cpmm_pool_prob(pool jsonb, p numeric) returns numeric language plpgsql immutable parallel safe as $$
+
+create
+or replace function get_cpmm_pool_prob (pool jsonb, p numeric) returns numeric language plpgsql immutable parallel safe as $$
 declare p_no numeric := (pool->>'NO')::numeric;
 p_yes numeric := (pool->>'YES')::numeric;
 no_weight numeric := p * p_no;
@@ -406,7 +425,9 @@ begin return case
   else (no_weight / yes_weight)
 end;
 end $$;
-create or replace function get_cpmm_resolved_prob(data jsonb) returns numeric language sql immutable parallel safe as $$
+
+create
+or replace function get_cpmm_resolved_prob (data jsonb) returns numeric language sql immutable parallel safe as $$
 select case
     when data->>'resolution' = 'YES' then 1
     when data->>'resolution' = 'NO' then 0
@@ -414,24 +435,36 @@ select case
     and data ? 'resolutionProbability' then (data->'resolutionProbability')::numeric
     else null
   end $$;
-create or replace function ts_to_millis(ts timestamptz) returns bigint language sql immutable parallel safe as $$
+
+create
+or replace function ts_to_millis (ts timestamptz) returns bigint language sql immutable parallel safe as $$
 select (
     extract(
       epoch
       from ts
     ) * 1000
   )::bigint $$;
-create or replace function millis_to_ts(millis bigint) returns timestamptz language sql immutable parallel safe as $$
+
+create
+or replace function millis_to_ts (millis bigint) returns timestamptz language sql immutable parallel safe as $$
 select to_timestamp(millis / 1000.0) $$;
-create or replace function millis_interval(start_millis bigint, end_millis bigint) returns interval language sql immutable parallel safe as $$
+
+create
+or replace function millis_interval (start_millis bigint, end_millis bigint) returns interval language sql immutable parallel safe as $$
 select millis_to_ts(end_millis) - millis_to_ts(start_millis) $$;
-create or replace function get_time() returns bigint language sql stable parallel safe as $$
+
+create
+or replace function get_time () returns bigint language sql stable parallel safe as $$
 select ts_to_millis(now()) $$;
-create or replace function is_valid_contract(ct contracts) returns boolean stable parallel safe as $$
+
+create
+or replace function is_valid_contract (ct contracts) returns boolean stable parallel safe as $$
 select ct.resolution_time is null
   and ct.visibility = 'public'
   and ct.close_time > now() + interval '10 minutes' $$ language sql;
-create or replace function get_related_contract_ids(source_id text) returns table(contract_id text, distance float) immutable parallel safe language sql as $$ with target_contract as (
+
+create
+or replace function get_related_contract_ids (source_id text) returns table (contract_id text, distance float) immutable parallel safe language sql as $$ with target_contract as (
     select *
     from contract_recommendation_features
     where contract_id = source_id
@@ -442,7 +475,9 @@ from contract_recommendation_features as crf,
   target_contract
 where crf.contract_id != target_contract.contract_id
 order by distance $$;
-create or replace function get_related_contracts(cid text, lim int, start int) returns JSONB [] immutable parallel safe language sql as $$
+
+create
+or replace function get_related_contracts (cid text, lim int, start int) returns JSONB[] immutable parallel safe language sql as $$
 select array_agg(data)
 from (
     select data
@@ -451,7 +486,9 @@ from (
     where is_valid_contract(contracts)
     limit lim offset start
   ) as rel_contracts $$;
-create or replace function search_contracts_by_group_slugs(group_slugs text [], lim int, start int) returns jsonb [] immutable parallel safe language sql as $$
+
+create
+or replace function search_contracts_by_group_slugs (group_slugs text[], lim int, start int) returns jsonb[] immutable parallel safe language sql as $$
 select array_agg(data)
 from (
     select data
@@ -462,12 +499,14 @@ from (
       data->'slug' offset start
     limit lim
   ) as search_contracts $$;
-create or replace function search_contracts_by_group_slugs_for_creator(
-    creator_id text,
-    group_slugs text [],
-    lim int,
-    start int
-  ) returns jsonb [] immutable parallel safe language sql as $$
+
+create
+or replace function search_contracts_by_group_slugs_for_creator (
+  creator_id text,
+  group_slugs text[],
+  lim int,
+  start int
+) returns jsonb[] immutable parallel safe language sql as $$
 select array_agg(data)
 from (
     select data
@@ -479,7 +518,9 @@ from (
       data->'slug' offset start
     limit lim
   ) as search_contracts $$;
-create or replace function get_contract_metrics_with_contracts(uid text, count int, start int) returns table(contract_id text, metrics jsonb, contract jsonb) immutable parallel safe language sql as $$
+
+create
+or replace function get_contract_metrics_with_contracts (uid text, count int, start int) returns table (contract_id text, metrics jsonb, contract jsonb) immutable parallel safe language sql as $$
 select ucm.contract_id,
   ucm.data as metrics,
   c.data as contract
@@ -489,7 +530,9 @@ where ucm.user_id = uid
   and ucm.data->'lastBetTime' is not null
 order by ((ucm.data)->'lastBetTime')::bigint desc offset start
 limit count $$;
-create or replace function get_open_limit_bets_with_contracts(uid text, count int) returns table(contract_id text, bets jsonb [], contract jsonb) immutable parallel safe language sql as $$;
+
+create
+or replace function get_open_limit_bets_with_contracts (uid text, count int) returns table (contract_id text, bets jsonb[], contract jsonb) immutable parallel safe language sql as $$;
 select contract_id,
   bets.data as bets,
   contracts.data as contracts
@@ -507,7 +550,9 @@ from (
   ) as bets
   join contracts on contracts.id = bets.contract_id
 limit count $$;
-create or replace function get_user_bets_from_resolved_contracts(uid text, count int, start int) returns table(contract_id text, bets jsonb [], contract jsonb) immutable parallel safe language sql as $$;
+
+create
+or replace function get_user_bets_from_resolved_contracts (uid text, count int, start int) returns table (contract_id text, bets jsonb[], contract jsonb) immutable parallel safe language sql as $$;
 select contract_id,
   bets.data as bets,
   contracts.data as contracts
@@ -526,7 +571,9 @@ from (
 where contracts.resolution_time is not null
   and contracts.outcome_type = 'BINARY'
 limit count offset start $$;
-create or replace function get_contracts_by_creator_ids(creator_ids text [], created_time bigint) returns table(creator_id text, contracts jsonb) immutable parallel safe language sql as $$
+
+create
+or replace function get_contracts_by_creator_ids (creator_ids text[], created_time bigint) returns table (creator_id text, contracts jsonb) immutable parallel safe language sql as $$
 select creator_id,
   jsonb_agg(data) as contracts
 from contracts
@@ -534,24 +581,32 @@ where creator_id = any(creator_ids)
   and contracts.created_time > millis_to_ts($2)
 group by creator_id;
 $$;
-create table if not exists discord_users (
-  discord_user_id text not null,
-  api_key text not null,
-  user_id text not null,
-  primary key(discord_user_id)
-);
+
+create table if not exists
+  discord_users (
+    discord_user_id text not null,
+    api_key text not null,
+    user_id text not null,
+    primary key (discord_user_id)
+  );
+
 alter table discord_users enable row level security;
-create table if not exists discord_messages_markets (
-  message_id text not null,
-  market_id text not null,
-  market_slug text not null,
-  channel_id text not null,
-  last_updated_thread_time bigint,
-  thread_id text,
-  primary key(message_id)
-);
+
+create table if not exists
+  discord_messages_markets (
+    message_id text not null,
+    market_id text not null,
+    market_slug text not null,
+    channel_id text not null,
+    last_updated_thread_time bigint,
+    thread_id text,
+    primary key (message_id)
+  );
+
 alter table discord_messages_markets enable row level security;
-create or replace function get_your_contract_ids(uid text) returns table (contract_id text) immutable parallel safe language sql as $$ with your_liked_contracts as (
+
+create
+or replace function get_your_contract_ids (uid text) returns table (contract_id text) immutable parallel safe language sql as $$ with your_liked_contracts as (
     select (data->>'contentId') as contract_id
     from user_reactions
     where user_id = uid
@@ -566,7 +621,9 @@ from your_liked_contracts
 union
 select contract_id
 from your_followed_contracts $$;
-create or replace function get_your_daily_changed_contracts(uid text, n int, start int) returns table (data jsonb, daily_score real) immutable parallel safe language sql as $$
+
+create
+or replace function get_your_daily_changed_contracts (uid text, n int, start int) returns table (data jsonb, daily_score real) immutable parallel safe language sql as $$
 select data,
   coalesce((data->>'dailyScore')::real, 0.0) as daily_score
 from get_your_contract_ids(uid)
@@ -574,7 +631,9 @@ from get_your_contract_ids(uid)
 where contracts.outcome_type = 'BINARY'
 order by daily_score desc
 limit n offset start $$;
-create or replace function get_your_trending_contracts(uid text, n int, start int) returns table (data jsonb, score real) immutable parallel safe language sql as $$
+
+create
+or replace function get_your_trending_contracts (uid text, n int, start int) returns table (data jsonb, score real) immutable parallel safe language sql as $$
 select data,
   popularity_score as score
 from get_your_contract_ids(uid)
@@ -583,8 +642,10 @@ where is_valid_contract(contracts)
   and contracts.outcome_type = 'BINARY'
 order by score desc
 limit n offset start $$;
+
 -- Your most recent contracts by bets or likes.
-create or replace function get_your_recent_contracts(uid text, n int, start int) returns table (data jsonb, max_ts bigint) immutable parallel safe language sql as $$ with your_bet_on_contracts as (
+create
+or replace function get_your_recent_contracts (uid text, n int, start int) returns table (data jsonb, max_ts bigint) immutable parallel safe language sql as $$ with your_bet_on_contracts as (
     select contract_id,
       (data->>'lastBetTime')::bigint as ts
     from user_contract_metrics
@@ -619,7 +680,9 @@ from recent_unique_contract_ids
 where data is not null
 order by max_ts desc
 limit n offset start $$;
-create or replace function get_contract_metrics_grouped_by_user_ids(uids text [], period text) returns table(user_id text, contract_metrics jsonb []) immutable parallel safe language sql as $$
+
+create
+or replace function get_contract_metrics_grouped_by_user_ids (uids text[], period text) returns table (user_id text, contract_metrics jsonb[]) immutable parallel safe language sql as $$
 select ucm.user_id,
   array_agg(ucm.data) as contract_metrics
 from user_contract_metrics as ucm
@@ -629,11 +692,13 @@ where ucm.user_id in (
   and (ucm.data->'from'->period->'profit') is not null
   and abs((ucm.data->'from'->period->'profit')::bigint) > 1
 group by ucm.user_id $$;
-create or replace function search_contract_embeddings (
-    query_embedding vector(1536),
-    similarity_threshold float,
-    match_count int
-  ) returns table (contract_id text, similarity float) language plpgsql as $$ begin return query
+
+create
+or replace function search_contract_embeddings (
+  query_embedding vector (1536),
+  similarity_threshold float,
+  match_count int
+) returns table (contract_id text, similarity float) language plpgsql as $$ begin return query
 select contract_embeddings.contract_id as contract_id,
   1 - (
     contract_embeddings.embedding <=> query_embedding
@@ -646,15 +711,13 @@ order by contract_embeddings.embedding <=> query_embedding
 limit match_count;
 end;
 $$;
-create or replace function closest_contract_embeddings (
-    input_contract_id text,
-    similarity_threshold float,
-    match_count int
-  ) returns table (
-    contract_id text,
-    similarity float,
-    data jsonb
-  ) language sql as $$ WITH embedding AS (
+
+create
+or replace function closest_contract_embeddings (
+  input_contract_id text,
+  similarity_threshold float,
+  match_count int
+) returns table (contract_id text, similarity float, data jsonb) language sql as $$ WITH embedding AS (
     SELECT embedding
     FROM contract_embeddings
     WHERE contract_id = input_contract_id
@@ -676,7 +739,9 @@ where contract_id != input_contract_id
 order by similarity * similarity * log(popularity_score + 100) desc
 limit match_count;
 $$;
-create or replace function save_user_topics(p_user_id text, p_topics text []) returns void language sql as $$ with chosen_embedding as (
+
+create
+or replace function save_user_topics (p_user_id text, p_topics text[]) returns void language sql as $$ with chosen_embedding as (
     select avg(embedding) as average
     from topic_embeddings
     where topic = any(p_topics)
@@ -706,13 +771,17 @@ update
 set topics = excluded.topics,
   topic_embedding = excluded.topic_embedding;
 $$;
-create or replace function firebase_uid() returns text language sql stable parallel safe as $$
+
+create
+or replace function firebase_uid () returns text language sql stable parallel safe as $$
 select nullif(
     current_setting('request.jwt.claims', true)::json->>'sub',
     ''
   )::text;
 $$;
-create or replace function firebase_uid() returns text language sql stable parallel safe as $$
+
+create
+or replace function firebase_uid () returns text language sql stable parallel safe as $$
 select nullif(
     current_setting('request.jwt.claims', true)::json->>'sub',
     ''

--- a/backend/supabase/groups/functions.sql
+++ b/backend/supabase/groups/functions.sql
@@ -1,4 +1,5 @@
-create or replace function is_group_member(this_group_id text, this_user_id text) returns boolean immutable parallel safe language sql as $$
+create
+or replace function is_group_member (this_group_id text, this_user_id text) returns boolean immutable parallel safe language sql as $$
 select EXISTS (
         SELECT 1
         FROM group_members

--- a/backend/supabase/groups/rls.sql
+++ b/backend/supabase/groups/rls.sql
@@ -1,28 +1,39 @@
-DROP policy IF EXISTS "Enable read access for admin" ON public.groups;
-CREATE POLICY "Enable read access for admin" ON public.groups FOR
-SELECT TO service_role USING (TRUE);
-DROP policy IF EXISTS "Enable read access for all if group is public/curated" ON public.groups;
-CREATE POLICY "Enable read access for all if group is public/curated" ON public.groups FOR
-SELECT USING (
-        (
-            (data @> '{"privacyStatus": "public"}'::jsonb)
-            OR (data @> '{"privacyStatus": "curated"}'::jsonb)
-        )
-    );
-DROP policy IF EXISTS "Enable read access for members of private groups" ON public.groups;
-CREATE POLICY "Enable read access for members of private groups" ON public.groups FOR
-SELECT USING (
-        (
-            (data @> '{"privacyStatus": "private"}'::jsonb)
-            AND (
-                EXISTS (
-                    SELECT 1
-                    FROM public.group_members
-                    WHERE (
-                            (group_members.group_id = groups.id)
-                            AND (group_members.member_id = public.firebase_uid())
-                        )
-                )
+drop policy if exists "Enable read access for admin" on public.groups;
+
+create policy "Enable read access for admin" on public.groups for
+select
+  to service_role using (true);
+
+drop policy if exists "Enable read access for all if group is public/curated" on public.groups;
+
+create policy "Enable read access for all if group is public/curated" on public.groups for
+select
+  using (
+    (
+      (data @> '{"privacyStatus": "public"}'::jsonb)
+      or (data @> '{"privacyStatus": "curated"}'::jsonb)
+    )
+  );
+
+drop policy if exists "Enable read access for members of private groups" on public.groups;
+
+create policy "Enable read access for members of private groups" on public.groups for
+select
+  using (
+    (
+      (data @> '{"privacyStatus": "private"}'::jsonb)
+      and (
+        exists (
+          select
+            1
+          from
+            public.group_members
+          where
+            (
+              (group_members.group_id = groups.id)
+              and (group_members.member_id = public.firebase_uid ())
             )
         )
-    );
+      )
+    )
+  );

--- a/backend/supabase/posts/rls.sql
+++ b/backend/supabase/posts/rls.sql
@@ -1,9 +1,14 @@
 drop policy if exists "Enable read access for non private posts" on public.posts;
-CREATE POLICY "Enable read access for non private posts" ON public.posts FOR
-SELECT USING (NOT (data @> '{"visibility": "private"}'::jsonb));
+
+create policy "Enable read access for non private posts" on public.posts for
+select
+  using (not (data @> '{"visibility": "private"}'::jsonb));
+
 drop policy if exists "Enable read access for private posts with permissions" on public.posts;
-CREATE POLICY "Enable read access for private posts with permissions" ON public.posts FOR
-SELECT USING (
-        (data @> '{"visibility": "private"}'::jsonb)
-        AND is_group_member(data->>'groupId', firebase_uid())
-    );
+
+create policy "Enable read access for private posts with permissions" on public.posts for
+select
+  using (
+    (data @> '{"visibility": "private"}'::jsonb)
+    and is_group_member (data ->> 'groupId', firebase_uid ())
+  );

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -1,205 +1,324 @@
 -- noinspection SqlNoDataSourceInspectionForFile
-/***************************************************************/
+/ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * /
 /* 0. database-wide configuration */
-/***************************************************************/
+/ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * /
 /* allow our backend and CLI users to have a long statement timeout */
 alter role postgres
-set statement_timeout = '1h';
+set
+  statement_timeout = '1h';
+
 alter role service_role
-set statement_timeout = '1h';
+set
+  statement_timeout = '1h';
+
 /* for clustering without locks */
 create extension if not exists pg_repack;
+
 /* for fancy machine learning stuff */
 create extension if not exists vector;
+
 /* GIN trigram indexes */
 create extension if not exists pg_trgm;
+
 /* enable `explain` via the HTTP API for convenience */
 alter role authenticator
-set pgrst.db_plan_enabled to true;
+set
+  pgrst.db_plan_enabled to true;
+
 notify pgrst,
 'reload config';
+
 /* create a version of to_jsonb marked immutable so that we can index over it.
- see https://github.com/PostgREST/postgrest/issues/2594 */
-create or replace function to_jsonb(jsonb) returns jsonb immutable parallel safe strict language sql as $$
+see https://github.com/PostgREST/postgrest/issues/2594 */
+create
+or replace function to_jsonb(jsonb) returns jsonb immutable parallel safe strict language sql as $$
 select $1 $$;
+
 /******************************************/
 /* 1. tables containing firestore content */
 /******************************************/
-create table if not exists users (
-  id text not null primary key,
-  data jsonb not null,
-  fs_updated_time timestamp not null
-);
-alter table users enable row level security;
-drop policy if exists "public read" on users;
-create policy "public read" on users for
-select using (true);
-create index if not exists users_data_gin on users using GIN (data);
-/* indexes supporting @-mention autocomplete */
-create index if not exists users_name_gin on users using GIN ((data->>'name') gin_trgm_ops);
-create index if not exists users_username_gin on users using GIN ((data->>'username') gin_trgm_ops);
-create index if not exists users_follower_count_cached on users ((to_jsonb(data->'followerCountCached')) desc);
-create index if not exists user_referrals_idx on users ((data->>'referredByUserId')) where data->>'referredByUserId' is not null;
-create index if not exists user_profit_cached_all_time_idx on users (((data->'profitCached'->>'allTime')::numeric));
+create table if not exists
+  users (
+    id text not null primary key,
+    data jsonb not null,
+    fs_updated_time timestamp not null
+  );
 
-alter table users cluster on users_pkey;
-create table if not exists user_portfolio_history (
-  user_id text not null,
-  portfolio_id text not null,
-  ts timestamp not null,
-  investment_value numeric not null,
-  balance numeric not null,
-  total_deposits numeric not null,
-  primary key(user_id, portfolio_id)
-);
+alter table users enable row level security;
+
+drop policy if exists "public read" on users;
+
+create policy "public read" on users for
+select
+  using (true);
+
+create index if not exists users_data_gin on users using GIN (data);
+
+/* indexes supporting @-mention autocomplete */
+create index if not exists users_name_gin on users using GIN ((data ->> 'name') gin_trgm_ops);
+
+create index if not exists users_username_gin on users using GIN ((data ->> 'username') gin_trgm_ops);
+
+create index if not exists users_follower_count_cached on users ((to_jsonb(data -> 'followerCountCached')) desc);
+
+create index if not exists user_referrals_idx on users ((data ->> 'referredByUserId'))
+where
+  data ->> 'referredByUserId' is not null;
+
+create index if not exists user_profit_cached_all_time_idx on users (((data -> 'profitCached' ->> 'allTime')::numeric));
+
+alter table users
+cluster on users_pkey;
+
+create table if not exists
+  user_portfolio_history (
+    user_id text not null,
+    portfolio_id text not null,
+    ts timestamp not null,
+    investment_value numeric not null,
+    balance numeric not null,
+    total_deposits numeric not null,
+    primary key (user_id, portfolio_id)
+  );
+
 alter table user_portfolio_history enable row level security;
+
 drop policy if exists "public read" on user_portfolio_history;
+
 create policy "public read" on user_portfolio_history for
-select using (true);
+select
+  using (true);
+
 create index if not exists user_portfolio_history_user_ts on user_portfolio_history (user_id, ts desc);
-alter table user_portfolio_history cluster on user_portfolio_history_user_ts;
-create table if not exists user_contract_metrics (
-  user_id text not null,
-  contract_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(user_id, contract_id)
-);
+
+alter table user_portfolio_history
+cluster on user_portfolio_history_user_ts;
+
+create table if not exists
+  user_contract_metrics (
+    user_id text not null,
+    contract_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (user_id, contract_id)
+  );
+
 alter table user_contract_metrics enable row level security;
+
 drop policy if exists "public read" on user_contract_metrics;
+
 create policy "public read" on user_contract_metrics for
-select using (true);
+select
+  using (true);
+
 create index if not exists user_contract_metrics_gin on user_contract_metrics using GIN (data);
-create index if not exists user_contract_metrics_recent_bets on user_contract_metrics (
-  user_id,
-  ((data->'lastBetTime')::bigint) desc
-);
+
+create index if not exists user_contract_metrics_recent_bets on user_contract_metrics (user_id, ((data -> 'lastBetTime')::bigint) desc);
+
 create index if not exists user_contract_metrics_contract_id on user_contract_metrics (contract_id);
-create index if not exists user_contract_metrics_weekly_profit on user_contract_metrics ((data->'from'->'week'->'profit'))
-where (data->'from'->'week'->'profit') is not null;
+
+create index if not exists user_contract_metrics_weekly_profit on user_contract_metrics ((data -> 'from' -> 'week' -> 'profit'))
+where
+  (data -> 'from' -> 'week' -> 'profit') is not null;
+
 create index if not exists user_contract_metrics_user_id on user_contract_metrics (user_id);
+
 create index if not exists user_contract_metrics_has_no_shares on user_contract_metrics (contract_id)
-where ((data)->>'hasNoShares') = 'true';
+where
+  ((data) ->> 'hasNoShares') = 'true';
+
 create index if not exists user_contract_metrics_has_yes_shares on user_contract_metrics (contract_id)
-where ((data)->>'hasYesShares') = 'true';
+where
+  ((data) ->> 'hasYesShares') = 'true';
+
 create index if not exists user_contract_metrics_profit on user_contract_metrics (contract_id)
-where ((data)->>'profit') is not null
-  and ((data)->>'profit')::float > 0;
-alter table user_contract_metrics cluster on user_contract_metrics_pkey;
-create table if not exists user_follows (
-  user_id text not null,
-  follow_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(user_id, follow_id)
-);
+where
+  ((data) ->> 'profit') is not null
+  and ((data) ->> 'profit')::float > 0;
+
+alter table user_contract_metrics
+cluster on user_contract_metrics_pkey;
+
+create table if not exists
+  user_follows (
+    user_id text not null,
+    follow_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (user_id, follow_id)
+  );
+
 alter table user_follows enable row level security;
+
 drop policy if exists "public read" on user_follows;
+
 create policy "public read" on user_follows for
-select using (true);
+select
+  using (true);
+
 create index if not exists user_follows_data_gin on user_follows using GIN (data);
-alter table user_follows cluster on user_follows_pkey;
-create table if not exists user_reactions (
-  user_id text not null,
-  reaction_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(user_id, reaction_id)
-);
+
+alter table user_follows
+cluster on user_follows_pkey;
+
+create table if not exists
+  user_reactions (
+    user_id text not null,
+    reaction_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (user_id, reaction_id)
+  );
+
 alter table user_reactions enable row level security;
+
 drop policy if exists "public read" on user_reactions;
+
 create policy "public read" on user_reactions for
-select using (true);
+select
+  using (true);
+
 create index if not exists user_reactions_data_gin on user_reactions using GIN (data);
+
 -- useful for getting just 'likes', we may want to index contentType as well
-create index if not exists user_reactions_type on user_reactions (user_id, (to_jsonb(data)->>'type') desc);
+create index if not exists user_reactions_type on user_reactions (user_id, (to_jsonb(data) ->> 'type') desc);
+
 -- useful for getting all reactions for a given contentId recently
 create index if not exists user_reactions_content_id on user_reactions (
-  (to_jsonb(data)->>'contentId'),
-  (to_jsonb(data)->>'createdTime') desc
+  (to_jsonb(data) ->> 'contentId'),
+  (to_jsonb(data) ->> 'createdTime') desc
 );
-alter table user_reactions cluster on user_reactions_type;
-create table if not exists user_events (
-  user_id text not null,
-  event_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(user_id, event_id)
-);
+
+alter table user_reactions
+cluster on user_reactions_type;
+
+create table if not exists
+  user_events (
+    user_id text not null,
+    event_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (user_id, event_id)
+  );
+
 alter table user_events enable row level security;
+
 drop policy if exists "public read" on user_events;
+
 create policy "public read" on user_events for
-select using (true);
+select
+  using (true);
+
 create index if not exists user_events_data_gin on user_events using GIN (data);
-create index if not exists user_events_name on user_events (user_id, (data->>'name'));
+
+create index if not exists user_events_name on user_events (user_id, (data ->> 'name'));
+
 create index if not exists user_events_viewed_markets on user_events (
   user_id,
-  (data->>'name'),
-  (data->>'contractId'),
-  ((data->'timestamp')::bigint) desc
+  (data ->> 'name'),
+  (data ->> 'contractId'),
+  ((data -> 'timestamp')::bigint) desc
 )
-where data->>'name' = 'view market'
-  or data->>'name' = 'view market card';
-alter table user_events cluster on user_events_name;
-create table if not exists user_seen_markets (
-  user_id text not null,
-  contract_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(user_id, contract_id)
-);
+where
+  data ->> 'name' = 'view market'
+  or data ->> 'name' = 'view market card';
+
+alter table user_events
+cluster on user_events_name;
+
+create table if not exists
+  user_seen_markets (
+    user_id text not null,
+    contract_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (user_id, contract_id)
+  );
+
 alter table user_seen_markets enable row level security;
+
 drop policy if exists "public read" on user_seen_markets;
+
 create policy "public read" on user_seen_markets for
-select using (true);
+select
+  using (true);
+
 create index if not exists user_seen_markets_data_gin on user_seen_markets using GIN (data);
-alter table user_seen_markets cluster on user_seen_markets_pkey;
 
-create table if not exists user_notifications (
-  user_id text not null,
-  notification_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(user_id, notification_id)
-);
+alter table user_seen_markets
+cluster on user_seen_markets_pkey;
+
+create table if not exists
+  user_notifications (
+    user_id text not null,
+    notification_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (user_id, notification_id)
+  );
+
 alter table user_notifications enable row level security;
-drop policy if exists "public read" on user_notifications;
-create policy "public read" on user_notifications for select using (true);
-create index if not exists user_notifications_data_gin on user_notifications using GIN (data);
-alter table user_notifications cluster on user_notifications_pkey;
 
-create table if not exists contracts (
-  id text not null primary key,
-  slug text,
-  question text,
-  creator_id text,
-  visibility text,
-  mechanism text,
-  outcome_type text,
-  created_time timestamptz,
-  close_time timestamptz,
-  resolution_time timestamptz,
-  resolution_probability numeric,
-  resolution text,
-  popularity_score numeric,
-  data jsonb not null,
-  question_fts tsvector GENERATED ALWAYS AS (to_tsvector('english'::regconfig, question)) STORED,
-  fs_updated_time timestamp not null
-);
+drop policy if exists "public read" on user_notifications;
+
+create policy "public read" on user_notifications for
+select
+  using (true);
+
+create index if not exists user_notifications_data_gin on user_notifications using GIN (data);
+
+alter table user_notifications
+cluster on user_notifications_pkey;
+
+create table if not exists
+  contracts (
+    id text not null primary key,
+    slug text,
+    question text,
+    creator_id text,
+    visibility text,
+    mechanism text,
+    outcome_type text,
+    created_time timestamptz,
+    close_time timestamptz,
+    resolution_time timestamptz,
+    resolution_probability numeric,
+    resolution text,
+    popularity_score numeric,
+    data jsonb not null,
+    question_fts tsvector generated always as (to_tsvector('english'::regconfig, question)) stored,
+    fs_updated_time timestamp not null
+  );
+
 alter table contracts enable row level security;
+
 drop policy if exists "public read" on contracts;
+
 create policy "public read" on contracts for
-select using (true);
+select
+  using (true);
+
 create index if not exists contracts_data_gin on contracts using GIN (data);
-create index if not exists contracts_group_slugs_gin on contracts using GIN ((data->'groupSlugs'));
+
+create index if not exists contracts_group_slugs_gin on contracts using GIN ((data -> 'groupSlugs'));
+
 create index if not exists contracts_slug on contracts (slug);
+
 create index if not exists contracts_creator_id on contracts (creator_id, created_time);
+
 create index if not exists contracts_created_time on contracts (created_time desc);
+
 create index if not exists contracts_close_time on contracts (close_time desc);
+
 create index if not exists contracts_popularity_score on contracts (popularity_score desc);
-create index if not exists contracts_visibility on contracts(visibility);
-alter table contracts cluster on contracts_creator_id;
-create or replace function contract_populate_cols() returns trigger language plpgsql as $$ begin if new.data is not null then new.slug := (new.data)->>'slug';
+
+create index if not exists contracts_visibility on contracts (visibility);
+
+alter table contracts
+cluster on contracts_creator_id;
+
+create
+or replace function contract_populate_cols () returns trigger language plpgsql as $$ begin if new.data is not null then new.slug := (new.data)->>'slug';
 new.question := (new.data)->>'question';
 new.creator_id := (new.data)->>'creatorId';
 new.visibility := (new.data)->>'visibility';
@@ -223,50 +342,64 @@ new.popularity_score := coalesce(((new.data)->>'popularityScore')::numeric, 0);
 end if;
 return new;
 end $$;
-create trigger contract_populate before
-insert
-  or
-update on contracts for each row execute function contract_populate_cols();
-create table if not exists contract_answers (
-  contract_id text not null,
-  answer_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(contract_id, answer_id)
-);
+
+create trigger contract_populate before insert
+or
+update on contracts for each row
+execute function contract_populate_cols ();
+
+create table if not exists
+  contract_answers (
+    contract_id text not null,
+    answer_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (contract_id, answer_id)
+  );
+
 alter table contract_answers enable row level security;
+
 drop policy if exists "public read" on contract_answers;
+
 create policy "public read" on contract_answers for
-select using (true);
+select
+  using (true);
+
 create index if not exists contract_answers_data_gin on contract_answers using GIN (data);
-alter table contract_answers cluster on contract_answers_pkey;
 
-create table if not exists contract_bets (
-  contract_id text not null,
-  bet_id text not null,
-  user_id text,
-  created_time timestamptz,
-  amount numeric,
-  shares numeric,
-  outcome text,
-  prob_before numeric,
-  prob_after numeric,
-  is_ante boolean,
-  is_redemption boolean,
-  is_challenge boolean,
-  visibility text,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(contract_id, bet_id)
-);
+alter table contract_answers
+cluster on contract_answers_pkey;
+
+create table if not exists
+  contract_bets (
+    contract_id text not null,
+    bet_id text not null,
+    user_id text,
+    created_time timestamptz,
+    amount numeric,
+    shares numeric,
+    outcome text,
+    prob_before numeric,
+    prob_after numeric,
+    is_ante boolean,
+    is_redemption boolean,
+    is_challenge boolean,
+    visibility text,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (contract_id, bet_id)
+  );
+
 alter table contract_bets enable row level security;
-drop policy if exists "public read" on contract_bets;
-create policy "public read" on contract_bets for select using (true);
 
-create or replace function contract_bet_populate_cols()
-  returns trigger
-  language plpgsql
-as $$
+drop policy if exists "public read" on contract_bets;
+
+create policy "public read" on contract_bets for
+select
+  using (true);
+
+create
+or replace function contract_bet_populate_cols () returns trigger language plpgsql as $$
   begin
     if new.data is not null then
       new.user_id := (new.data)->>'userId';
@@ -284,335 +417,525 @@ as $$
     return new;
   end $$;
 
-create trigger contract_bet_populate before insert or update on contract_bets
-    for each row execute function contract_bet_populate_cols();
+create trigger contract_bet_populate before insert
+or
+update on contract_bets for each row
+execute function contract_bet_populate_cols ();
 
 create index if not exists contract_bets_data_gin on contract_bets using GIN (data);
+
 /* serves bets API pagination */
 create index if not exists contract_bets_bet_id on contract_bets (bet_id);
+
 /* serving stats page, recent bets API */
-create index if not exists contract_bets_created_time_global on contract_bets ((to_jsonb(data)->>'createdTime') desc);
+create index if not exists contract_bets_created_time_global on contract_bets ((to_jsonb(data) ->> 'createdTime') desc);
+
 /* serving activity feed bets list */
 create index if not exists contract_bets_activity_feed on contract_bets (
-  (to_jsonb(data)->'isAnte'),
-  (to_jsonb(data)->'isRedemption'),
-  (to_jsonb(data)->>'createdTime') desc
+  (to_jsonb(data) -> 'isAnte'),
+  (to_jsonb(data) -> 'isRedemption'),
+  (to_jsonb(data) ->> 'createdTime') desc
 );
+
 /* serving e.g. the contract page recent bets and the "bets by contract" API */
 create index if not exists contract_bets_created_time on contract_bets (
   contract_id,
-  (to_jsonb(data)->>'createdTime') desc
+  (to_jsonb(data) ->> 'createdTime') desc
 );
+
 /* serving "my trades on a contract" kind of queries */
 create index if not exists contract_bets_contract_user_id on contract_bets (
   contract_id,
-  (to_jsonb(data)->>'userId'),
-  (to_jsonb(data)->>'createdTime') desc
+  (to_jsonb(data) ->> 'userId'),
+  (to_jsonb(data) ->> 'createdTime') desc
 );
+
 /* serving the user bets API */
 create index if not exists contract_bets_user_id on contract_bets (
-  (to_jsonb(data)->>'userId'),
-  (to_jsonb(data)->>'createdTime') desc
+  (to_jsonb(data) ->> 'userId'),
+  (to_jsonb(data) ->> 'createdTime') desc
 );
+
 create index if not exists contract_bets_user_outstanding_limit_orders on contract_bets (
-  (data->>'userId'),
-  ((data->'isFilled')::boolean),
-  ((data->'isCancelled')::boolean)
+  (data ->> 'userId'),
+  ((data -> 'isFilled')::boolean),
+  ((data -> 'isCancelled')::boolean)
 );
+
 create index if not exists contract_bets_unexpired_limit_orders on contract_bets (
-  (data->>'expiresAt' is not null),
-  ((data->>'isFilled')),
-  ((data->>'isCancelled')),
-  ((data->>'isAnte')),
-  ((data->>'isRedemption')),
-  ((data->>'expiresAt'))
+  (data ->> 'expiresAt' is not null),
+  ((data ->> 'isFilled')),
+  ((data ->> 'isCancelled')),
+  ((data ->> 'isAnte')),
+  ((data ->> 'isRedemption')),
+  ((data ->> 'expiresAt'))
 );
-alter table contract_bets cluster on contract_bets_created_time;
 
-create table if not exists contract_comments (
-  contract_id text not null,
-  comment_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(contract_id, comment_id)
-);
+alter table contract_bets
+cluster on contract_bets_created_time;
+
+create table if not exists
+  contract_comments (
+    contract_id text not null,
+    comment_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (contract_id, comment_id)
+  );
+
 alter table contract_comments enable row level security;
+
 drop policy if exists "public read" on contract_comments;
+
 create policy "public read" on contract_comments for
-select using (true);
+select
+  using (true);
+
 create index if not exists contract_comments_data_gin on contract_comments using GIN (data);
-alter table contract_comments cluster on contract_comments_pkey;
-create table if not exists contract_follows (
-  contract_id text not null,
-  follow_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(contract_id, follow_id)
-);
+
+alter table contract_comments
+cluster on contract_comments_pkey;
+
+create table if not exists
+  contract_follows (
+    contract_id text not null,
+    follow_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (contract_id, follow_id)
+  );
+
 alter table contract_follows enable row level security;
+
 drop policy if exists "public read" on contract_follows;
+
 create policy "public read" on contract_follows for
-select using (true);
+select
+  using (true);
+
 create index if not exists contract_follows_data_gin on contract_follows using GIN (data);
-alter table contract_follows cluster on contract_follows_pkey;
-create table if not exists contract_liquidity (
-  contract_id text not null,
-  liquidity_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(contract_id, liquidity_id)
-);
+
+alter table contract_follows
+cluster on contract_follows_pkey;
+
+create table if not exists
+  contract_liquidity (
+    contract_id text not null,
+    liquidity_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (contract_id, liquidity_id)
+  );
+
 alter table contract_liquidity enable row level security;
+
 drop policy if exists "public read" on contract_liquidity;
+
 create policy "public read" on contract_liquidity for
-select using (true);
+select
+  using (true);
+
 create index if not exists contract_liquidity_data_gin on contract_liquidity using GIN (data);
-alter table contract_liquidity cluster on contract_liquidity_pkey;
-create table if not exists groups (
-  id text not null primary key,
-  data jsonb not null,
-  fs_updated_time timestamp not null
-);
+
+alter table contract_liquidity
+cluster on contract_liquidity_pkey;
+
+create table if not exists
+  groups (
+    id text not null primary key,
+    data jsonb not null,
+    fs_updated_time timestamp not null
+  );
+
 alter table groups enable row level security;
+
 drop policy if exists "public read" on groups;
+
 create policy "public read" on groups for
-select using (true);
+select
+  using (true);
+
 create index if not exists groups_data_gin on groups using GIN (data);
-alter table groups cluster on groups_pkey;
-create table if not exists group_contracts (
-  group_id text not null,
-  contract_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(group_id, contract_id)
-);
+
+alter table groups
+cluster on groups_pkey;
+
+create table if not exists
+  group_contracts (
+    group_id text not null,
+    contract_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (group_id, contract_id)
+  );
+
 alter table group_contracts enable row level security;
+
 drop policy if exists "public read" on group_contracts;
+
 create policy "public read" on group_contracts for
-select using (true);
+select
+  using (true);
+
 create index if not exists group_contracts_data_gin on group_contracts using GIN (data);
-alter table group_contracts cluster on group_contracts_pkey;
-create table if not exists group_members (
-  group_id text not null,
-  member_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(group_id, member_id)
-);
+
+alter table group_contracts
+cluster on group_contracts_pkey;
+
+create table if not exists
+  group_members (
+    group_id text not null,
+    member_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (group_id, member_id)
+  );
+
 alter table group_members enable row level security;
+
 drop policy if exists "public read" on group_members;
+
 create policy "public read" on group_members for
-select using (true);
+select
+  using (true);
+
 create index if not exists group_members_data_gin on group_members using GIN (data);
-alter table group_members cluster on group_members_pkey;
-create table if not exists user_quest_metrics (
-  user_id text not null,
-  score_id text not null,
-  score_value numeric not null,
-  idempotency_key text,
-  primary key(user_id, score_id)
-);
+
+alter table group_members
+cluster on group_members_pkey;
+
+create table if not exists
+  user_quest_metrics (
+    user_id text not null,
+    score_id text not null,
+    score_value numeric not null,
+    idempotency_key text,
+    primary key (user_id, score_id)
+  );
+
 alter table user_quest_metrics enable row level security;
+
 drop policy if exists "public read" on user_quest_metrics;
+
 create policy "public read" on user_quest_metrics for
-select using (true);
-alter table user_quest_metrics cluster on user_quest_metrics_pkey;
-create table if not exists txns (
-  id text not null primary key,
-  data jsonb not null,
-  fs_updated_time timestamp not null
-);
+select
+  using (true);
+
+alter table user_quest_metrics
+cluster on user_quest_metrics_pkey;
+
+create table if not exists
+  txns (
+    id text not null primary key,
+    data jsonb not null,
+    fs_updated_time timestamp not null
+  );
+
 alter table txns enable row level security;
+
 drop policy if exists "public read" on txns;
+
 create policy "public read" on txns for
-select using (true);
+select
+  using (true);
+
 create index if not exists txns_data_gin on txns using GIN (data);
-alter table txns cluster on txns_pkey;
-create table if not exists manalinks (
-  id text not null primary key,
-  data jsonb not null,
-  fs_updated_time timestamp not null
-);
+
+alter table txns
+cluster on txns_pkey;
+
+create table if not exists
+  manalinks (
+    id text not null primary key,
+    data jsonb not null,
+    fs_updated_time timestamp not null
+  );
+
 alter table manalinks enable row level security;
+
 drop policy if exists "public read" on manalinks;
+
 create policy "public read" on manalinks for
-select using (true);
+select
+  using (true);
+
 create index if not exists manalinks_data_gin on manalinks using GIN (data);
-alter table manalinks cluster on manalinks_pkey;
-create table if not exists posts (
-  id text not null primary key,
-  data jsonb not null,
-  fs_updated_time timestamp not null
-);
+
+alter table manalinks
+cluster on manalinks_pkey;
+
+create table if not exists
+  posts (
+    id text not null primary key,
+    data jsonb not null,
+    fs_updated_time timestamp not null
+  );
+
 alter table posts enable row level security;
+
 drop policy if exists "public read" on posts;
+
 create policy "public read" on posts for
-select using (true);
+select
+  using (true);
+
 create index if not exists posts_data_gin on posts using GIN (data);
-alter table posts cluster on posts_pkey;
 
-create table if not exists post_comments (
-  post_id text not null,
-  comment_id text not null,
-  data jsonb not null,
-  fs_updated_time timestamp not null,
-  primary key(post_id, comment_id)
-);
+alter table posts
+cluster on posts_pkey;
+
+create table if not exists
+  post_comments (
+    post_id text not null,
+    comment_id text not null,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    primary key (post_id, comment_id)
+  );
+
 alter table post_comments enable row level security;
-drop policy if exists "public read" on post_comments;
-create policy "public read" on post_comments for select using (true);
-create index if not exists post_comments_data_gin on post_comments using GIN (data);
-alter table post_comments cluster on post_comments_pkey;
 
-create table if not exists test (
-  id text not null primary key,
-  data jsonb not null,
-  fs_updated_time timestamp not null
-);
+drop policy if exists "public read" on post_comments;
+
+create policy "public read" on post_comments for
+select
+  using (true);
+
+create index if not exists post_comments_data_gin on post_comments using GIN (data);
+
+alter table post_comments
+cluster on post_comments_pkey;
+
+create table if not exists
+  test (
+    id text not null primary key,
+    data jsonb not null,
+    fs_updated_time timestamp not null
+  );
+
 alter table test enable row level security;
+
 drop policy if exists "public read" on test;
+
 create policy "public read" on test for
-select using (true);
+select
+  using (true);
+
 create index if not exists test_data_gin on test using GIN (data);
-alter table test cluster on test_pkey;
-create table if not exists user_recommendation_features (
-  user_id text not null primary key,
-  f0 real not null,
-  f1 real not null,
-  f2 real not null,
-  f3 real not null,
-  f4 real not null
-);
+
+alter table test
+cluster on test_pkey;
+
+create table if not exists
+  user_recommendation_features (
+    user_id text not null primary key,
+    f0 real not null,
+    f1 real not null,
+    f2 real not null,
+    f3 real not null,
+    f4 real not null
+  );
+
 alter table user_recommendation_features enable row level security;
+
 drop policy if exists "public read" on user_recommendation_features;
+
 create policy "public read" on user_recommendation_features for
-select using (true);
+select
+  using (true);
+
 drop policy if exists "admin write access" on user_recommendation_features;
-create policy "admin write access" on user_recommendation_features as PERMISSIVE FOR ALL to service_role;
-create table if not exists contract_recommendation_features (
-  contract_id text not null primary key,
-  f0 real not null,
-  f1 real not null,
-  f2 real not null,
-  f3 real not null,
-  f4 real not null,
-  freshness_score real not null default 1
-);
+
+create policy "admin write access" on user_recommendation_features as PERMISSIVE for all to service_role;
+
+create table if not exists
+  contract_recommendation_features (
+    contract_id text not null primary key,
+    f0 real not null,
+    f1 real not null,
+    f2 real not null,
+    f3 real not null,
+    f4 real not null,
+    freshness_score real not null default 1
+  );
+
 alter table contract_recommendation_features enable row level security;
+
 drop policy if exists "public read" on contract_recommendation_features;
+
 create policy "public read" on contract_recommendation_features for
-select using (true);
+select
+  using (true);
+
 drop policy if exists "admin write access" on contract_recommendation_features;
-create policy "admin write access" on contract_recommendation_features as PERMISSIVE FOR ALL to service_role;
+
+create policy "admin write access" on contract_recommendation_features as PERMISSIVE for all to service_role;
+
 create index if not exists contract_recommendation_features_freshness_score on contract_recommendation_features (freshness_score desc);
-create table if not exists user_embeddings (
+
+create table if not exists
+  user_embeddings (
     user_id text not null primary key,
     created_at timestamp not null default now(),
-    interest_embedding vector(1536) not null,
-    pre_signup_interest_embedding vector(1536)
-);
+    interest_embedding vector (1536) not null,
+    pre_signup_interest_embedding vector (1536)
+  );
+
 alter table user_embeddings enable row level security;
+
 drop policy if exists "public read" on user_embeddings;
+
 create policy "public read" on user_embeddings for
-select using (true);
+select
+  using (true);
+
 drop policy if exists "admin write access" on user_embeddings;
-create policy "admin write access" on user_embeddings as PERMISSIVE FOR ALL to service_role;
-create index if not exists user_embeddings_interest_embedding on user_embeddings using ivfflat (interest_embedding vector_cosine_ops) with (lists = 100);
-create table if not exists contract_embeddings (
-  contract_id text not null primary key,
-  created_at timestamp not null default now(),
-  embedding vector(1536) not null
-);
+
+create policy "admin write access" on user_embeddings as PERMISSIVE for all to service_role;
+
+create index if not exists user_embeddings_interest_embedding on user_embeddings using ivfflat (interest_embedding vector_cosine_ops)
+with
+  (lists = 100);
+
+create table if not exists
+  contract_embeddings (
+    contract_id text not null primary key,
+    created_at timestamp not null default now(),
+    embedding vector (1536) not null
+  );
+
 alter table contract_embeddings enable row level security;
+
 drop policy if exists "public read" on contract_embeddings;
+
 create policy "public read" on contract_embeddings for
-select using (true);
+select
+  using (true);
+
 drop policy if exists "admin write access" on contract_embeddings;
-create policy "admin write access" on contract_embeddings as PERMISSIVE FOR ALL to service_role;
-SET ivfflat.probes = 7;
-create index if not exists contract_embeddings_embedding on contract_embeddings
-  using ivfflat (embedding vector_cosine_ops)
-  with (lists = 100);
 
+create policy "admin write access" on contract_embeddings as PERMISSIVE for all to service_role;
 
-create table if not exists topic_embeddings (
+set
+  ivfflat.probes = 7;
+
+create index if not exists contract_embeddings_embedding on contract_embeddings using ivfflat (embedding vector_cosine_ops)
+with
+  (lists = 100);
+
+create table if not exists
+  topic_embeddings (
     topic text not null primary key,
     created_at timestamp not null default now(),
-    embedding vector(1536) not null
-);
+    embedding vector (1536) not null
+  );
+
 alter table topic_embeddings enable row level security;
+
 drop policy if exists "public read" on topic_embeddings;
-create policy "public read" on topic_embeddings for select using (true);
+
+create policy "public read" on topic_embeddings for
+select
+  using (true);
+
 drop policy if exists "admin write access" on topic_embeddings;
-create policy "admin write access" on topic_embeddings
-  as PERMISSIVE FOR ALL
-  to service_role;
 
+create policy "admin write access" on topic_embeddings as PERMISSIVE for all to service_role;
 
-create table if not exists user_topics (
+create table if not exists
+  user_topics (
     user_id text not null primary key,
     created_at timestamp not null default now(),
-    topic_embedding vector(1536) not null,
+    topic_embedding vector (1536) not null,
     topics text[] not null
-);
-alter table user_topics enable row level security;
-drop policy if exists "public read" on user_topics;
-create policy "public read" on user_topics for select using (true);
-drop policy if exists "public write access" on user_topics;
-create policy "public write access" on user_topics
-  for all using(true);
+  );
 
+alter table user_topics enable row level security;
+
+drop policy if exists "public read" on user_topics;
+
+create policy "public read" on user_topics for
+select
+  using (true);
+
+drop policy if exists "public write access" on user_topics;
+
+create policy "public write access" on user_topics for all using (true);
 
 begin;
+
 drop publication if exists supabase_realtime;
+
 create publication supabase_realtime;
+
 alter publication supabase_realtime
 add table contracts;
+
 alter publication supabase_realtime
 add table contract_bets;
+
 alter publication supabase_realtime
 add table contract_comments;
+
 alter publication supabase_realtime
 add table group_members;
+
 alter publication supabase_realtime
 add table posts;
+
 commit;
-/***************************************************************/
+
+/ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * /
 /* 2. internal machinery for making firestore replication work */
-/***************************************************************/
+/ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * /
 /* records all incoming writes to any logged firestore document */
-create table if not exists incoming_writes (
-  id bigint generated always as identity primary key,
-  event_id text null,
-  /* can be null for writes generated by manual import */
-  table_id text not null,
-  write_kind text not null,
-  parent_id text null,
-  /* null for top-level collections */
-  doc_id text not null,
-  data jsonb null,
-  /* can be null on deletes */
-  ts timestamp not null
-);
+create table if not exists
+  incoming_writes (
+    id bigint generated always as identity primary key,
+    event_id text null,
+    /* can be null for writes generated by manual import */
+    table_id text not null,
+    write_kind text not null,
+    parent_id text null,
+    /* null for top-level collections */
+    doc_id text not null,
+    data jsonb null,
+    /* can be null on deletes */
+    ts timestamp not null
+  );
+
 alter table incoming_writes enable row level security;
+
 create index if not exists incoming_writes_ts on incoming_writes (ts desc);
+
 create index if not exists incoming_writes_table_id_ts on incoming_writes (table_id, ts desc);
+
 /* records all deletions of firestore documents, with the deletion timestamp */
-create table if not exists tombstones (
-  id bigint generated always as identity primary key,
-  table_id text not null,
-  parent_id text null,
-  doc_id text not null,
-  fs_deleted_at timestamp not null,
-  unique(table_id, parent_id, doc_id)
-);
+create table if not exists
+  tombstones (
+    id bigint generated always as identity primary key,
+    table_id text not null,
+    parent_id text null,
+    doc_id text not null,
+    fs_deleted_at timestamp not null,
+    unique (table_id, parent_id, doc_id)
+  );
+
 alter table tombstones enable row level security;
+
 create index if not exists tombstones_table_id_doc_id_fs_deleted_at on tombstones (table_id, doc_id, fs_deleted_at desc);
-alter table tombstones cluster on tombstones_table_id_doc_id_fs_deleted_at;
+
+alter table tombstones
+cluster on tombstones_table_id_doc_id_fs_deleted_at;
+
 drop function if exists get_document_table_spec;
+
 drop type if exists table_spec;
+
 create type table_spec as (parent_id_col_name text, id_col_name text);
-create or replace function get_document_table_spec(table_id text) returns table_spec language plpgsql as $$ begin return case
+
+create
+or replace function get_document_table_spec (table_id text) returns table_spec language plpgsql as $$ begin return case
     table_id
     when 'users' then cast((null, 'id') as table_spec)
     when 'user_follows' then cast(('user_id', 'follow_id') as table_spec)
@@ -638,13 +961,15 @@ create or replace function get_document_table_spec(table_id text) returns table_
     else null
   end;
 end $$;
+
 /* takes a single new firestore write and replicates it into the database.
- the contract of this function is:
- - if you have a set of timestamped firestore writes, and you call this function
- *at least once* on *every write*, in *any order*, then the database will be
- the same and correct at the end.
- */
-create or replace function replicate_writes_process_one(r incoming_writes) returns boolean language plpgsql as $$
+the contract of this function is:
+- if you have a set of timestamped firestore writes, and you call this function
+*at least once* on *every write*, in *any order*, then the database will be
+the same and correct at the end.
+*/
+create
+or replace function replicate_writes_process_one (r incoming_writes) returns boolean language plpgsql as $$
 declare dest_spec table_spec;
 begin dest_spec = get_document_table_spec(r.table_id);
 if dest_spec is null then raise warning 'Invalid table ID: %',
@@ -773,12 +1098,14 @@ return false;
 end if;
 return true;
 end $$;
+
 /* when processing batches of writes, we order by document ID to avoid deadlocks
- when incoming write batches hit the same documents with new writes in different
- sequences. */
+when incoming write batches hit the same documents with new writes in different
+sequences. */
 /* todo: we could process batches more efficiently by doing batch modifications for
- each destination table in the batch, but likely not important right now */
-create or replace function replicate_writes_process_since(since timestamp) returns table(id bigint, succeeded boolean) language plpgsql as $$ begin return query
+each destination table in the batch, but likely not important right now */
+create
+or replace function replicate_writes_process_since (since timestamp) returns table (id bigint, succeeded boolean) language plpgsql as $$ begin return query
 select r.id,
   replicate_writes_process_one(r) as succeeded
 from incoming_writes as r
@@ -786,14 +1113,18 @@ where r.ts >= since
 order by r.parent_id,
   r.doc_id;
 end $$;
-create or replace function replicate_writes_process_new() returns trigger language plpgsql as $$ begin perform r.id,
+
+create
+or replace function replicate_writes_process_new () returns trigger language plpgsql as $$ begin perform r.id,
   replicate_writes_process_one(r) as succeeded
 from new_table as r
 order by r.parent_id,
   r.doc_id;
 return null;
 end $$;
+
 drop trigger if exists replicate_writes on incoming_writes;
+
 create trigger replicate_writes
-after
-insert on incoming_writes referencing new table as new_table for each statement execute function replicate_writes_process_new();
+after insert on incoming_writes referencing new table as new_table for each statement
+execute function replicate_writes_process_new ();

--- a/backend/supabase/views.sql
+++ b/backend/supabase/views.sql
@@ -1,166 +1,251 @@
-create or replace view public_open_contracts as (
-    select *
-    from contracts
-    where resolution_time is null
+create or replace view
+  public_open_contracts as (
+    select
+      *
+    from
+      contracts
+    where
+      resolution_time is null
       and visibility = 'public'
       and close_time > now() + interval '10 minutes'
   );
-create or replace view public_contracts as (
-    select *
-    from contracts
-    where visibility = 'public'
+
+create or replace view
+  public_contracts as (
+    select
+      *
+    from
+      contracts
+    where
+      visibility = 'public'
   );
-create or replace view listed_open_contracts as (
-    select *
-    from contracts
-    where resolution_time is null --    row level security prevents the 'private' contracts from being returned
+
+create or replace view
+  listed_open_contracts as (
+    select
+      *
+    from
+      contracts
+    where
+      resolution_time is null --    row level security prevents the 'private' contracts from being returned
       and visibility != 'unlisted'
       and close_time > now() + interval '10 minutes'
   );
-create or replace view trending_contracts as (
-    select *
-    from listed_open_contracts
-    where listed_open_contracts.popularity_score > 0
-    order by popularity_score desc
+
+create or replace view
+  trending_contracts as (
+    select
+      *
+    from
+      listed_open_contracts
+    where
+      listed_open_contracts.popularity_score > 0
+    order by
+      popularity_score desc
   );
-create or replace view contract_distance as (
-    select ce1.contract_id as id1,
+
+create or replace view
+  contract_distance as (
+    select
+      ce1.contract_id as id1,
       ce2.contract_id as id2,
-      ce1.embedding <=> ce2.embedding as distance
-    from contract_embeddings ce1
+      ce1.embedding <= > ce2.embedding as distance
+    from
+      contract_embeddings ce1
       cross join contract_embeddings ce2
-    order by distance
+    order by
+      distance
   );
-create or replace view related_contracts as (
-    select id1 as from_contract_id,
+
+create or replace view
+  related_contracts as (
+    select
+      id1 as from_contract_id,
       id2 as contract_id,
       distance,
       data
-    from contract_distance
+    from
+      contract_distance
       join listed_open_contracts on id = id2
-    where id1 != id2
+    where
+      id1 != id2
   );
-create or replace view user_contract_distance as (
-    select user_id,
+
+create or replace view
+  user_contract_distance as (
+    select
+      user_id,
       contract_id,
-      user_embeddings.interest_embedding <=> contract_embeddings.embedding as distance
-    from user_embeddings
+      user_embeddings.interest_embedding <= > contract_embeddings.embedding as distance
+    from
+      user_embeddings
       cross join contract_embeddings
   );
-create or replace view user_trending_contract as (
-    select user_contract_distance.user_id,
+
+create or replace view
+  user_trending_contract as (
+    select
+      user_contract_distance.user_id,
       user_contract_distance.contract_id,
       distance,
       public_open_contracts.popularity_score,
       public_open_contracts.created_time,
       public_open_contracts.close_time
-    from user_contract_distance
+    from
+      user_contract_distance
       join public_open_contracts on public_open_contracts.id = user_contract_distance.contract_id
-    where public_open_contracts.popularity_score > 0
-    order by popularity_score desc
+    where
+      public_open_contracts.popularity_score > 0
+    order by
+      popularity_score desc
   );
-create or replace view group_role as (
-    select member_id,
+
+create or replace view
+  group_role as (
+    select
+      member_id,
       gp.id as group_id,
       gp.data as group_data,
-      gp.data->>'name' as group_name,
-      gp.data->>'slug' as group_slug,
-      gp.data->>'creatorId' as creator_id,
-      users.data->>'name' as name,
-      users.data->>'username' as username,
-      users.data->>'avatarUrl' as avatar_url,
+      gp.data ->> 'name' as group_name,
+      gp.data ->> 'slug' as group_slug,
+      gp.data ->> 'creatorId' as creator_id,
+      users.data ->> 'name' as name,
+      users.data ->> 'username' as username,
+      users.data ->> 'avatarUrl' as avatar_url,
       (
-        select CASE
-            WHEN (gp.data->>'creatorId')::text = member_id THEN 'admin'
-            ELSE (gm.data->>'role')
-          END
+        select
+          case
+            when (gp.data ->> 'creatorId')::text = member_id then 'admin'
+            else (gm.data ->> 'role')
+          end
       ) as role,
-      (gm.data->>'createdTime')::bigint as createdTime
-    from (
+      (gm.data ->> 'createdTime')::bigint as createdTime
+    from
+      (
         group_members gm
         join groups gp on gp.id = gm.group_id
       )
       join users on users.id = gm.member_id
   );
-create or replace view user_groups as (
-    select users.id as id,
-      users.data->>'name' as name,
-      users.data->>'username' as username,
-      users.data->>'avatarUrl' as avatarurl,
-      (users.data->>'followerCountCached')::integer as follower_count,
+
+create or replace view
+  user_groups as (
+    select
+      users.id as id,
+      users.data ->> 'name' as name,
+      users.data ->> 'username' as username,
+      users.data ->> 'avatarUrl' as avatarurl,
+      (users.data ->> 'followerCountCached')::integer as follower_count,
       user_groups.groups as groups
-    from (
+    from
+      (
         users
         left join (
-          select member_id,
+          select
+            member_id,
             array_agg(group_id) as groups
-          from group_members
-          group by member_id
+          from
+            group_members
+          group by
+            member_id
         ) user_groups on users.id = user_groups.member_id
       )
   );
-CREATE OR REPLACE VIEW contracts_rbac AS
-SELECT *
-FROM contracts
-WHERE contracts.visibility = 'public'
+
+create or replace view
+  contracts_rbac as
+select
+  *
+from
+  contracts
+where
+  contracts.visibility = 'public'
   or contracts.visibility = 'unlisted'
   or (
     contracts.visibility = 'private'
     and (
-      can_access_private_contract(contracts.id, firebase_uid())
+      can_access_private_contract (contracts.id, firebase_uid ())
     )
   );
-CREATE OR REPLACE VIEW groups_rbac AS
-SELECT *
-FROM groups
-WHERE groups.data->>'privacyStatus' <> 'private'
+
+create or replace view
+  groups_rbac as
+select
+  *
+from
+  groups
+where
+  groups.data ->> 'privacyStatus' <> 'private'
   or (
     (
-      EXISTS (
-        SELECT 1
-        FROM group_members
-        WHERE (
+      exists (
+        select
+          1
+        from
+          group_members
+        where
+          (
             (group_members.group_id = groups.id)
-            AND (group_members.member_id = firebase_uid())
+            and (group_members.member_id = firebase_uid ())
           )
       )
     )
   );
-CREATE VIEW user_referrals AS
-SELECT id,
+
+create view
+  user_referrals as
+select
+  id,
   data,
   total_referrals,
-  RANK() OVER (
-    ORDER BY total_referrals DESC
-  ) AS rank
-FROM (
-    SELECT referrer.id AS id,
-      referrer.data AS data,
-      COUNT(*) AS total_referrals
-    FROM users AS referred
-      JOIN users AS referrer ON referrer.data->>'id' = referred.data->>'referredByUserId'
-    WHERE referred.data->>'referredByUserId' IS NOT NULL
-    GROUP BY referrer.id
+  rank() over (
+    order by
+      total_referrals desc
+  ) as rank
+from
+  (
+    select
+      referrer.id as id,
+      referrer.data as data,
+      count(*) as total_referrals
+    from
+      users as referred
+      join users as referrer on referrer.data ->> 'id' = referred.data ->> 'referredByUserId'
+    where
+      referred.data ->> 'referredByUserId' is not null
+    group by
+      referrer.id
   ) subquery
-ORDER BY total_referrals DESC;
-CREATE VIEW user_referrals_profit AS
-SELECT id,
+order by
+  total_referrals desc;
+
+create view
+  user_referrals_profit as
+select
+  id,
   data,
   total_referrals,
   total_referred_profit,
-  RANK() OVER (
-    ORDER BY total_referrals DESC
-  ) AS rank
-FROM (
-    SELECT referrer.id AS id,
-      referrer.data AS data,
-      COUNT(*) AS total_referrals,
-      SUM(
-        (referred.data->'profitCached'->>'allTime')::numeric
-      ) AS total_referred_profit
-    FROM users AS referred
-      JOIN users AS referrer ON referrer.data->>'id' = referred.data->>'referredByUserId'
-    WHERE referred.data->>'referredByUserId' IS NOT NULL
-    GROUP BY referrer.id
+  rank() over (
+    order by
+      total_referrals desc
+  ) as rank
+from
+  (
+    select
+      referrer.id as id,
+      referrer.data as data,
+      count(*) as total_referrals,
+      sum(
+        (referred.data -> 'profitCached' ->> 'allTime')::numeric
+      ) as total_referred_profit
+    from
+      users as referred
+      join users as referrer on referrer.data ->> 'id' = referred.data ->> 'referredByUserId'
+    where
+      referred.data ->> 'referredByUserId' is not null
+    group by
+      referrer.id
   ) subquery
-ORDER BY total_referrals DESC;
+order by
+  total_referrals desc;

--- a/web/package.json
+++ b/web/package.json
@@ -100,6 +100,7 @@
     "eslint-config-prettier": "8.5.0",
     "next-sitemap": "^2.5.14",
     "postcss": "8.3.5",
+    "prettier-plugin-sql": "false0.14.0",
     "prettier-plugin-tailwindcss": "^0.2.1",
     "prop-types": "^15.8.1",
     "tailwindcss": "3.2.4",

--- a/web/package.json
+++ b/web/package.json
@@ -100,7 +100,7 @@
     "eslint-config-prettier": "8.5.0",
     "next-sitemap": "^2.5.14",
     "postcss": "8.3.5",
-    "prettier-plugin-sql": "false0.14.0",
+    "prettier-plugin-sql": "0.14.0",
     "prettier-plugin-tailwindcss": "^0.2.1",
     "prop-types": "^15.8.1",
     "tailwindcss": "3.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8865,7 +8865,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier-plugin-sql@false0.14.0:
+prettier-plugin-sql@0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/prettier-plugin-sql/-/prettier-plugin-sql-0.14.0.tgz#dc7dc0b643431eded7f4e8ecad785dcaf8db0180"
   integrity sha512-dRgINgNd3ZhBDuO/+EFalJjSlAqNXvXv9XDtSCeMufXaP6O64HHLBo1Szo+l+cfvXFxwvkTSGrS+sjpEpSchNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3515,7 +3515,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-big-integer@^1.6.16:
+big-integer@^1.6.16, big-integer@^1.6.48:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
@@ -4037,7 +4037,7 @@ commander@10.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
   integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
 
-commander@2, commander@^2.15.1:
+commander@2, commander@^2.15.1, commander@^2.19.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -4761,6 +4761,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
 
 discord-api-types@^0.37.20, discord-api-types@^0.37.23:
   version "0.37.35"
@@ -7928,6 +7933,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moo@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 mouse-change@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/mouse-change/-/mouse-change-1.4.0.tgz#c2b77e5bfa34a43ce1445c8157a4e4dc9895c14f"
@@ -8012,6 +8022,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 needle@^2.5.2:
   version "2.9.1"
@@ -8115,6 +8135,13 @@ node-releases@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
   integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
+
+node-sql-parser@^4.6.6:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/node-sql-parser/-/node-sql-parser-4.6.6.tgz#910fcd4ba0132d9a5a8c312637313acc2b43b24a"
+  integrity sha512-zpash5xnRY6+0C9HFru32iRJV1LTkwtrVpO90i385tYVF6efyXK/B3Nsq/15Fuv2utxrqHNjKtL55OHb8sl+eQ==
+  dependencies:
+    big-integer "^1.6.48"
 
 nodemon@2.0.19:
   version "2.0.19"
@@ -8838,6 +8865,15 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-plugin-sql@false0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-sql/-/prettier-plugin-sql-0.14.0.tgz#dc7dc0b643431eded7f4e8ecad785dcaf8db0180"
+  integrity sha512-dRgINgNd3ZhBDuO/+EFalJjSlAqNXvXv9XDtSCeMufXaP6O64HHLBo1Szo+l+cfvXFxwvkTSGrS+sjpEpSchNA==
+  dependencies:
+    node-sql-parser "^4.6.6"
+    sql-formatter "^12.2.0"
+    tslib "^2.5.0"
+
 prettier-plugin-tailwindcss@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.1.tgz#989b35afd86c550cb671da69891aba4f4a051159"
@@ -9204,6 +9240,19 @@ raf@^3.4.0, raf@^3.4.1:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -9682,6 +9731,11 @@ resolve@^2.0.0-next.3:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
 retry-request@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-5.0.2.tgz#143d85f90c755af407fcc46b7166a4ba520e44da"
@@ -10010,6 +10064,14 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+sql-formatter@^12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-12.2.0.tgz#57a86a6ba37e586d85a518d1816d671eca5b7474"
+  integrity sha512-wNsPUdOD6nnN9RUgHlNprQtm+iLW5LTOy/T0/2DDr2UeWSP8mvlQHrx6TY+IG1nfu5Kipq9GaOtS9SVq8s0Vig==
+  dependencies:
+    argparse "^2.0.1"
+    nearley "^2.20.1"
 
 sshpk@^1.7.0:
   version "1.17.0"
@@ -10653,7 +10715,7 @@ tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.4.1:
+tslib@^2.0.0, tslib@^2.4.1, tslib@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==


### PR DESCRIPTION
I couldn't find a nice postgres formatter that didn't do nonsense like always putting `select` on its own line
There's https://github.com/nene/prettier-plugin-sql-cst ... but it doesn't work for postgres syntax 😔

So I just went the path of least resistance and added the most used prettier sql plugin. (Which kinda doesn't make sense to put in `web/` but oh well).

I actually liked the most recent formatter that @ingawei was using more, but I don't feel like making everyone get the sqltools vscode extension