### PR TITLE
Remove separate sharedholder stats querying on contract page

### DIFF
--- a/common/src/supabase/contract-metrics.ts
+++ b/common/src/supabase/contract-metrics.ts
@@ -200,32 +200,3 @@ export async function getContractMetricsForContractId(
   const { data } = await run(q)
   return data.map((d) => d.data) as ContractMetrics[]
 }
-
-export async function getShareholderCountsForContractId(
-  contractId: string,
-  db: SupabaseClient
-) {
-  const { count: noShareholders } = await run(
-    db
-      .from('user_contract_metrics')
-      .select('*', { head: true, count: 'exact' })
-      .eq('contract_id', contractId)
-      .eq(`data->hasNoShares`, true)
-  )
-
-  const { count: yesShareholders } = await run(
-    db
-      .from('user_contract_metrics')
-      .select('*', { head: true, count: 'exact' })
-      .eq('contract_id', contractId)
-      .eq(`data->hasYesShares`, true)
-  )
-
-  return {
-    yesShareholders,
-    noShareholders,
-  }
-}
-export type ShareholderStats = Awaited<
-  ReturnType<typeof getShareholderCountsForContractId>
->

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -9,7 +9,6 @@ import {
 import { Bet } from 'common/bet'
 import { ContractComment } from 'common/comment'
 import { CPMMBinaryContract, Contract } from 'common/contract'
-import { ShareholderStats } from 'common/supabase/contract-metrics'
 import { buildArray } from 'common/util/array'
 import { shortFormatNumber } from 'common/util/format'
 import { MINUTE_MS } from 'common/util/time'
@@ -59,7 +58,6 @@ export function ContractTabs(props: {
   setActiveIndex: (i: number) => void
   totalBets: number
   totalPositions: number
-  shareholderStats?: ShareholderStats
 }) {
   const {
     contract,
@@ -71,7 +69,6 @@ export function ContractTabs(props: {
     setActiveIndex,
     totalBets,
     userPositionsByOutcome,
-    shareholderStats,
   } = props
   const comments = useMemo(
     () =>
@@ -151,7 +148,6 @@ export function ContractTabs(props: {
                 positions={userPositionsByOutcome}
                 contract={contract as CPMMBinaryContract}
                 setTotalPositions={setTotalPositions}
-                shareholderStats={shareholderStats}
               />
             ),
           },

--- a/web/components/contract/user-positions-table.tsx
+++ b/web/components/contract/user-positions-table.tsx
@@ -2,11 +2,7 @@ import clsx from 'clsx'
 import { ContractMetrics } from 'common/calculate-metrics'
 import { CPMMContract } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
-import {
-  ShareholderStats,
-  getContractMetricsForContractId,
-  getShareholderCountsForContractId,
-} from 'common/supabase/contract-metrics'
+import { getContractMetricsForContractId } from 'common/supabase/contract-metrics'
 import { User } from 'common/user'
 import { formatMoney } from 'common/util/format'
 import { partition } from 'lodash'
@@ -43,7 +39,6 @@ export const BinaryUserPositionsTable = memo(
     contract: CPMMContract
     positions: ContractMetricsByOutcome
     setTotalPositions: (count: number) => void
-    shareholderStats?: ShareholderStats
   }) {
     const { contract, setTotalPositions } = props
     const contractId = contract.id
@@ -55,10 +50,6 @@ export const BinaryUserPositionsTable = memo(
     const [contractMetricsByProfit, setContractMetricsByProfit] = useState<
       ContractMetrics[] | undefined
     >()
-    const [shareholderStats, setShareholderStats] = useState<
-      ShareholderStats | undefined
-    >(props.shareholderStats)
-
     const [sortBy, setSortBy] = useState<'profit' | 'shares'>('shares')
 
     useEffect(() => {
@@ -78,22 +69,17 @@ export const BinaryUserPositionsTable = memo(
     }, [contractMetricsByProfit])
 
     const [livePositionsLimit, setLivePositionsLimit] = useState(100)
-    const positions =
-      useContractMetrics(contractId, livePositionsLimit, outcomes) ??
+    const positions = useContractMetrics(contractId, livePositionsLimit, outcomes) ??
       props.positions
 
     const yesPositionsSorted =
       sortBy === 'shares' ? positions.YES ?? [] : positiveProfitPositions
     const noPositionsSorted =
       sortBy === 'shares' ? positions.NO ?? [] : negativeProfitPositions
+
     useEffect(() => {
       // Let's use firebase here as supabase can be slightly out of date, leading to incorrect counts
       getTotalContractMetricsCount(contractId).then(setTotalPositions)
-
-      // This still uses supabase
-      getShareholderCountsForContractId(contractId, db).then(
-        setShareholderStats
-      )
     }, [positions, contractId])
 
     const visibleYesPositions = yesPositionsSorted.slice(
@@ -127,7 +113,7 @@ export const BinaryUserPositionsTable = memo(
             text={'Approximate count, refresh to update'}
             placement={'top'}
           >
-            {shareholderStats?.yesShareholders}{' '}
+            {yesPositionsSorted.length}{' '}
           </Tooltip>
           {isBinary ? (
             <>
@@ -151,7 +137,7 @@ export const BinaryUserPositionsTable = memo(
             text={'Approximate count, refresh to update'}
             placement={'top'}
           >
-            {shareholderStats?.noShareholders}{' '}
+            {noPositionsSorted.length}{' '}
           </Tooltip>
           {isBinary ? (
             <>

--- a/web/lib/contracts.ts
+++ b/web/lib/contracts.ts
@@ -13,10 +13,7 @@ import {
   getCPMMContractUserContractMetrics,
   getTopContractMetrics,
 } from 'web/lib/firebase/contract-metrics'
-import {
-  getShareholderCountsForContractId,
-  getTotalContractMetrics,
-} from 'common/supabase/contract-metrics'
+import { getTotalContractMetrics } from 'common/supabase/contract-metrics'
 import { db } from 'web/lib/supabase/db'
 import { getInitialProbability } from 'common/calculate'
 import { compressPoints, pointsToBase64 } from 'common/util/og'
@@ -61,11 +58,6 @@ export async function getContractParams(contract: Contract) {
     ? await getTopContractMetrics(contract.id, 10)
     : []
 
-  const shareholderStats =
-    contract.mechanism === 'cpmm-1'
-      ? await getShareholderCountsForContractId(contractId, db)
-      : undefined
-
   const totalPositions =
     contract.mechanism === 'cpmm-1'
       ? await getTotalContractMetrics(contractId, db)
@@ -104,7 +96,6 @@ export async function getContractParams(contract: Contract) {
     totalBets,
     topContractMetrics,
     creatorTwitter: creator?.twitterHandle,
-    relatedContracts,
-    shareholderStats,
+    relatedContracts
   })
 }

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -153,8 +153,7 @@ export function ContractPageContent(props: {
     comments,
     totalPositions,
     creatorTwitter,
-    relatedContracts,
-    shareholderStats,
+    relatedContracts
   } = contractParams
   const contract =
     useContract(contractParams.contract?.id) ?? contractParams.contract
@@ -464,7 +463,6 @@ export function ContractPageContent(props: {
                 blockedUserIds={blockedUserIds}
                 activeIndex={activeTabIndex}
                 setActiveIndex={setActiveTabIndex}
-                shareholderStats={shareholderStats}
               />
             </div>
           </Col>


### PR DESCRIPTION
This seems unnecessary because we are loading the whole list of positions right there, so we don't need to also get the count independently.