### PR TITLE
Get contract metrics position counts from Firestore for now

### DIFF
--- a/common/src/supabase/contract-metrics.ts
+++ b/common/src/supabase/contract-metrics.ts
@@ -201,31 +201,7 @@ export async function getContractMetricsForContractId(
   return data.map((d) => d.data) as ContractMetrics[]
 }
 
-export async function getShareholderCountsForContractId(
-  contractId: string,
-  db: SupabaseClient
-) {
-  const { count: noShareholders } = await run(
-    db
-      .from('user_contract_metrics')
-      .select('*', { head: true, count: 'exact' })
-      .eq('contract_id', contractId)
-      .eq(`data->hasNoShares`, true)
-  )
-
-  const { count: yesShareholders } = await run(
-    db
-      .from('user_contract_metrics')
-      .select('*', { head: true, count: 'exact' })
-      .eq('contract_id', contractId)
-      .eq(`data->hasYesShares`, true)
-  )
-
-  return {
-    yesShareholders,
-    noShareholders,
-  }
+export type ShareholderStats = {
+  yesShareholders: number,
+  noShareholders: number
 }
-export type ShareholderStats = Awaited<
-  ReturnType<typeof getShareholderCountsForContractId>
->

--- a/web/components/contract/user-positions-table.tsx
+++ b/web/components/contract/user-positions-table.tsx
@@ -5,7 +5,6 @@ import { ContractMetric } from 'common/contract-metric'
 import {
   ShareholderStats,
   getContractMetricsForContractId,
-  getShareholderCountsForContractId,
 } from 'common/supabase/contract-metrics'
 import { User } from 'common/user'
 import { formatMoney } from 'common/util/format'
@@ -34,6 +33,8 @@ import { useUser } from 'web/hooks/use-user'
 import {
   ContractMetricsByOutcome,
   getTotalContractMetricsCount,
+  getContractMetricsYesCount,
+  getContractMetricsNoCount,
 } from 'web/lib/firebase/contract-metrics'
 import { db } from 'web/lib/supabase/db'
 import { getStonkShares } from 'common/stonk'
@@ -90,9 +91,14 @@ export const BinaryUserPositionsTable = memo(
       // Let's use firebase here as supabase can be slightly out of date, leading to incorrect counts
       getTotalContractMetricsCount(contractId).then(setTotalPositions)
 
-      // This still uses supabase
-      getShareholderCountsForContractId(contractId, db).then(
-        setShareholderStats
+      Promise.all([
+        getContractMetricsYesCount(contractId),
+        getContractMetricsNoCount(contractId)
+      ]).then(([yesCount, noCount]) =>
+        setShareholderStats({
+          yesShareholders: yesCount,
+          noShareholders: noCount
+        })
       )
     }, [positions, contractId])
 

--- a/web/lib/contracts.ts
+++ b/web/lib/contracts.ts
@@ -12,9 +12,11 @@ import { getAllComments } from 'web/lib/supabase/comments'
 import {
   getCPMMContractUserContractMetrics,
   getTopContractMetrics,
+  getContractMetricsYesCount,
+  getContractMetricsNoCount,
 } from 'web/lib/firebase/contract-metrics'
 import {
-  getShareholderCountsForContractId,
+  ShareholderStats,
   getTotalContractMetrics,
 } from 'common/supabase/contract-metrics'
 import { db } from 'web/lib/supabase/db'
@@ -61,10 +63,18 @@ export async function getContractParams(contract: Contract) {
     ? await getTopContractMetrics(contract.id, 10)
     : []
 
-  const shareholderStats =
-    contract.mechanism === 'cpmm-1'
-      ? await getShareholderCountsForContractId(contractId, db)
-      : undefined
+
+  let shareholderStats: ShareholderStats | undefined = undefined
+  if (contract.mechanism === 'cpmm-1') {
+    const [yesCount, noCount] = await Promise.all([
+      getContractMetricsYesCount(contractId),
+      getContractMetricsNoCount(contractId)
+    ])
+    shareholderStats = {
+      yesShareholders: yesCount,
+      noShareholders: noCount
+    }
+  }
 
   const totalPositions =
     contract.mechanism === 'cpmm-1'

--- a/web/lib/firebase/contract-metrics.ts
+++ b/web/lib/firebase/contract-metrics.ts
@@ -110,3 +110,25 @@ export async function getTotalContractMetricsCount(contractId: string) {
   )
   return resp.data().count
 }
+
+export async function getContractMetricsYesCount(contractId: string) {
+  const resp = await getCountFromServer(
+    query(
+      collectionGroup(db, 'contract-metrics'),
+      where('contractId', '==', contractId),
+      where('hasYesShares', '==', true)
+    )
+  )
+  return resp.data().count
+}
+
+export async function getContractMetricsNoCount(contractId: string) {
+  const resp = await getCountFromServer(
+    query(
+      collectionGroup(db, 'contract-metrics'),
+      where('contractId', '==', contractId),
+      where('hasNoShares', '==', true)
+    )
+  )
+  return resp.data().count
+}


### PR DESCRIPTION
Supabase was struggling slightly to keep up with this on the whales vs. minnows market. This should get way better when the user contract metrics migration is done, but for now, just offload this to Firestore.