### PR TITLE
Clean up data and schema of user_events table

### DIFF
--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -198,13 +198,13 @@ cluster on user_reactions_type;
 
 create table if not exists
   user_events (
-    user_id text not null,
-    event_id text not null,
+    id bigint generated always as identity primary key,
+    ts timestamptz not null default now(),
+    name text not null,
+    event_id text null,
+    user_id text null,
     contract_id text null,
-    name text null,
-    ts timestamptz null,
-    data jsonb not null,
-    primary key (user_id, event_id)
+    data jsonb not null
   );
 
 alter table user_events enable row level security;
@@ -223,8 +223,6 @@ with
     user_id = 'NO_USER'
     or user_id = firebase_uid ()
   );
-
-create index if not exists user_events_data_gin on user_events using GIN (data);
 
 create index if not exists user_events_name on user_events (user_id, name);
 

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -642,26 +642,29 @@ export interface Database {
         Row: {
           contract_id: string | null
           data: Json
-          event_id: string
-          name: string | null
+          event_id: string | null
+          id: number
+          name: string
           ts: string | null
-          user_id: string
+          user_id: string | null
         }
         Insert: {
           contract_id?: string | null
           data: Json
-          event_id: string
-          name?: string | null
+          event_id?: string | null
+          id?: never
+          name: string
           ts?: string | null
-          user_id: string
+          user_id?: string | null
         }
         Update: {
           contract_id?: string | null
           data?: Json
-          event_id?: string
-          name?: string | null
+          event_id?: string | null
+          id?: never
+          name?: string
           ts?: string | null
-          user_id?: string
+          user_id?: string | null
         }
       }
       user_follows: {

--- a/web/lib/firebase/utils.ts
+++ b/web/lib/firebase/utils.ts
@@ -1,6 +1,5 @@
 import {
   collection,
-  doc,
   getDoc,
   getDocs,
   onSnapshot,
@@ -14,11 +13,6 @@ import { db } from './init'
 
 export const coll = <T>(path: string, ...rest: string[]) => {
   return collection(db, path, ...rest) as CollectionReference<T>
-}
-
-export const getId = () => {
-  // mqp: if there's a better way than this idk what it is
-  return doc(collection(db, 'temp')).id
 }
 
 export const getValue = async <T>(doc: DocumentReference) => {

--- a/web/lib/supabase/ads.ts
+++ b/web/lib/supabase/ads.ts
@@ -1,4 +1,5 @@
 import { run, selectJson, selectFrom } from 'common/supabase/utils'
+import { filterDefined } from 'common/util/array'
 import { db } from './db'
 
 export async function getAllAds() {
@@ -48,7 +49,7 @@ export async function getUsersWhoSkipped(adId: string) {
     .eq('data->>adId', adId)
 
   const { data } = await run(query)
-  return data.map((r) => r['user_id']) ?? []
+  return filterDefined(data.map((r) => r['user_id']))
 }
 
 export const getBoosts = async (userId: string) => {

--- a/web/lib/supabase/user-events.ts
+++ b/web/lib/supabase/user-events.ts
@@ -1,7 +1,6 @@
-import { run, millisToTs } from 'common/supabase/utils'
+import { run } from 'common/supabase/utils'
 import { Json } from 'common/supabase/schema'
 import { db } from './db'
-import { getId } from 'web/lib/firebase/utils'
 
 export async function saveUserEvent(
   userId: string | undefined,
@@ -11,10 +10,8 @@ export async function saveUserEvent(
 ) {
   return await run(
     db.from('user_events').insert({
-      user_id: userId ?? 'NO_USER',
+      user_id: userId,
       contract_id: contractId,
-      event_id: getId(),
-      ts: millisToTs(Date.now()),
       name: eventName,
       data: eventProperties ?? {},
     })


### PR DESCRIPTION
WIP. Stuff I am doing:

- [x] 1. Manually fixing obsolete data in the table (e.g. migrating old events with `type: click` to have `name` of 'click')
- [x] 2. Adding appropriate constraints, default `ts` to server timestamp (we have clients with bad clocks actively putting in bad data, you can see if you query the table)
- [x] 3. Changing 'NO_USER' user_id events to have `null` user_id instead
- [x] 4. Changing primary key to be an autoincrementing `id` column instead of `(user_id, event_id)`

(I will do a bit more in a later PR.)