### PR TITLE
Search tweaks

### DIFF
--- a/backend/api/src/supabase-search-contract.ts
+++ b/backend/api/src/supabase-search-contract.ts
@@ -2,9 +2,6 @@ import { Contract } from 'common/contract'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { z } from 'zod'
 import { Json, MaybeAuthedEndpoint, validate } from './helpers'
-import { IDatabase } from 'pg-promise'
-import { IClient } from 'pg-promise/typescript/pg-subset'
-import { uniqBy } from 'lodash'
 
 const FIRESTORE_DOC_REF_ID_REGEX = /^[a-zA-Z0-9_-]{1,}$/
 

--- a/backend/api/src/supabase-search-contract.ts
+++ b/backend/api/src/supabase-search-contract.ts
@@ -2,6 +2,9 @@ import { Contract } from 'common/contract'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { z } from 'zod'
 import { Json, MaybeAuthedEndpoint, validate } from './helpers'
+import { IDatabase } from 'pg-promise'
+import { IClient } from 'pg-promise/typescript/pg-subset'
+import { uniqBy } from 'lodash'
 
 const FIRESTORE_DOC_REF_ID_REGEX = /^[a-zA-Z0-9_-]{1,}$/
 
@@ -64,6 +67,7 @@ export const supabasesearchcontracts = MaybeAuthedEndpoint(
       [term],
       (r) => r.data as Contract
     )
+
     return (contracts ?? []) as unknown as Json
   }
 )
@@ -102,8 +106,11 @@ function getSearchContractSQL(contractInput: {
     groupId,
     hasGroupAccess
   )
+  let sortAlgorithm: string | undefined = undefined
 
+  // Searching markets within a group
   if (groupId) {
+    // Blank search within group
     if (emptyTerm) {
       query = `
         SELECT contractz.data
@@ -117,7 +124,7 @@ function getSearchContractSQL(contractInput: {
         ${whereSQL}
         AND contractz.group_id = '${groupId}'`
     }
-    // if fuzzy search within group
+    // Fuzzy search within group
     else if (fuzzy) {
       query = `
         SELECT contractz.data
@@ -130,31 +137,43 @@ function getSearchContractSQL(contractInput: {
             on group_contracts.contract_id = contracts.id
         ) AS contractz
       ${whereSQL}
-      AND contractz.similarity_score > 0.3
+      AND contractz.similarity_score > 0.1
       AND contractz.group_id = '${groupId}'`
     } else {
-      // if full text search within group
+      // Normal full text search within group
       query = `
         SELECT contractz.data
         FROM (
             select contracts.*, group_contracts.group_id 
             from contracts 
             join group_contracts on group_contracts.contract_id = contracts.id
-        ) as contractz, websearch_to_tsquery('english', $1) as query
+        ) as contractz,
+             build_tsquery_with_prefix('english_nostop_with_prefix', $1) AS tsq(exact_query, prefix_query),
+             websearch_to_tsquery('english',  $1) as query
             ${whereSQL}
-        AND (contractz.question_fts @@ query
-            OR contractz.question ILIKE '%' || $1 || '%'
-            OR contractz.description_fts @@ query
+        AND (
+            contractz.question_nostop_fts @@ exact_query OR
+            contractz.question_nostop_fts @@ prefix_query OR
+            contractz.description_fts @@ query
             )
         AND contractz.group_id = '${groupId}'`
+      sortAlgorithm =
+        'ts_rank_cd(question_nostop_fts, exact_query, 2) * 1.0 +' +
+        'ts_rank_cd(question_nostop_fts, prefix_query, 2) * 0.5 +' +
+        'ts_rank_cd(description_fts, query) * 0.1'
     }
-  } else {
+  }
+  // Searching markets by creator
+  else if (creatorId) {
+    // Blank search for markets by creator
     if (emptyTerm) {
       query = `
       SELECT data
       FROM contracts 
       ${whereSQL}`
-    } else if (fuzzy) {
+    }
+    // Fuzzy search for markets by creator
+    else if (fuzzy) {
       query = `
       SELECT contractz.data
       FROM (
@@ -163,21 +182,97 @@ function getSearchContractSQL(contractInput: {
         FROM contracts
       ) AS contractz
       ${whereSQL}
-      AND contractz.similarity_score > 0.3`
-    } else {
+      AND contractz.similarity_score > 0.1`
+    }
+    // Normal full text search for markets by creator
+    else {
       query = `
       SELECT data
-      FROM contracts, websearch_to_tsquery('english',  $1) as query
+      FROM contracts,
+           build_tsquery_with_prefix('english_nostop_with_prefix', $1) AS tsq(exact_query, prefix_query),
+           websearch_to_tsquery('english',  $1) as query 
          ${whereSQL}
-      AND (question_fts @@ query
-        OR question ILIKE '%' || $1 || '%'
-        OR description_fts @@ query)`
+      AND (
+        question_nostop_fts @@ exact_query OR
+        question_nostop_fts @@ prefix_query OR
+        description_fts @@ query
+        )`
+      sortAlgorithm =
+        'ts_rank_cd(question_nostop_fts, exact_query, 2) * 1.0 +' +
+        'ts_rank_cd(question_nostop_fts, prefix_query, 2) * 0.5 +' +
+        'ts_rank_cd(description_fts, query) * 0.1'
+    }
+  }
+  // Blank search for markets not by group nor creator
+  else {
+    if (emptyTerm) {
+      query = `
+      SELECT data
+      FROM contracts 
+      ${whereSQL}`
+    }
+    // Fuzzy search for markets
+    // TODO: handle signed out user case
+    else if (fuzzy) {
+      query = `
+          SELECT contractz.*
+          FROM (
+          SELECT *,
+                 similarity(question, $1) AS similarity_score
+          FROM contracts 
+                   ${whereSQL}
+            and question_nostop_fts @@ websearch_to_tsquery('english_nostop_with_prefix', $1)
+            and similarity(question, $1) > 0.2
+          ) AS contractz
+             
+          union all
+
+          select your_recent_contracts.*
+          from (
+             SELECT *,
+                    similarity(question, $1)*10 AS similarity_score
+             FROM convert_data_array_to_contract_table(
+               ARRAY(
+                 SELECT data
+                 FROM get_your_recent_contracts('${uid}'::text, 100::int, 0::int)
+               )
+             )
+             where similarity(question, $1) > 0.1
+           ) as your_recent_contracts`
+    }
+    // Normal full text search for markets
+    else {
+      query = `
+      select * from (
+      SELECT contractz.*
+         FROM (SELECT *
+               FROM contracts,
+                    websearch_to_tsquery('english', $1) as query
+                    ${whereSQL}
+                    AND (
+                      question_fts @@ query OR
+                      description_fts @@ query
+                      )
+               ) AS contractz
+      union all
+
+      select your_recent_contracts.*
+      from (
+      SELECT *
+       FROM convert_data_array_to_contract_table(
+         ARRAY(
+           SELECT data
+           FROM get_your_recent_contracts('${uid}'::text, 100::int, 0::int)
+         )
+       ), websearch_to_tsquery('english', $1) as query
+       where similarity(question, $1) > 0.1) as your_recent_contracts
+     ) as combined_contracts`
     }
   }
   return (
     query +
     ' ' +
-    getSearchContractSortSQL(sort, fuzzy, emptyTerm) +
+    getSearchContractSortSQL(sort, fuzzy, emptyTerm, sortAlgorithm) +
     ' ' +
     `LIMIT ${limit} OFFSET ${offset}`
   )
@@ -224,15 +319,18 @@ function getSearchContractWhereSQL(
 function getSearchContractSortSQL(
   sort: string,
   fuzzy: boolean | undefined,
-  empty: boolean
+  empty: boolean,
+  sortingAlgorithm: string | undefined
 ) {
   type SortFields = Record<string, string>
   const sortFields: SortFields = {
-    relevance: empty
+    relevance: sortingAlgorithm
+      ? sortingAlgorithm
+      : empty
       ? 'popularity_score'
       : fuzzy
       ? 'similarity_score'
-      : 'ts_rank_cd(question_fts, query)',
+      : 'ts_rank_cd(question_fts, query) * 1.0 + ts_rank_cd(description_fts, query) * 0.5',
     score: 'popularity_score',
     'daily-score': "(data->>'dailyScore')::numeric",
     '24-hour-vol': "(data->>'volume24Hours')::numeric",


### PR DESCRIPTION
- improves fuzzy search in omni search by giving more prefix matches including stop words like 'will', 'i', 'he', 'which', etc. This does make going back and forth from fuzzy to full text a bit jarring though, as fuzzy seems more accurate rather than general. Will have to see what users say.
- group and creator normal searches are now more like the above prefix matching searches as they typically have less content so the general 'full text search' isn't as necessary/useful.
- the first commit in this PR actually merged a user's recent markets (bets,likes) into the omni search results but then I realized that there's no easy way to rank results retrieved via different types of searches (e.g. full text vs prefix matches). So I erased that work so that I could add it to a separate section of the omni search results