### PR TITLE
Implement basic Supabase polling stuff

### DIFF
--- a/web/components/groups/add-member-modal.tsx
+++ b/web/components/groups/add-member-modal.tsx
@@ -30,7 +30,8 @@ export function AddMemberContent(props: {
   )
   const requestId = useRef(0)
   const [loading, setLoading] = useState(false)
-  const groupMemberIds = useRealtimeGroupMemberIds(group.id).members
+  const [groupMemberIds] = useRealtimeGroupMemberIds(group.id)
+
   useEffect(() => {
     const id = ++requestId.current
     setLoading(true)
@@ -61,7 +62,7 @@ export function AddMemberContent(props: {
             key={user.id}
             user={user}
             group={group}
-            isDisabled={groupMemberIds.some((memberId) => memberId == user.id)}
+            isDisabled={groupMemberIds?.data.some((r) => r.member_id == user.id)}
           />
         ))}
       </Col>

--- a/web/hooks/use-supabase.ts
+++ b/web/hooks/use-supabase.ts
@@ -1,0 +1,53 @@
+import { useMemo, useEffect, useRef, useState } from 'react'
+import { PostgrestBuilder } from '@supabase/postgrest-js'
+import { QueryMultiSuccessResponse, run } from 'common/supabase/utils'
+import { MINUTE_MS } from 'common/util/time'
+
+export type DependencyList = readonly unknown[];
+export type PollingOptions = {
+  ms: number,
+  deps: DependencyList | undefined
+}
+
+type PollingState =
+  { state: "waiting", version: number, timeout?: undefined } |
+  { state: "polling", version: number, timeout: NodeJS.Timeout }
+
+export function useSupabasePolling<T>(
+  q: PostgrestBuilder<T>,
+  opts?: PollingOptions,
+) {
+  const { ms, deps } = opts ?? { ms: MINUTE_MS, deps: [] }
+  const state = useRef<PollingState>({ state: "waiting", version: 0 });
+  const [results, setResults] = useState<QueryMultiSuccessResponse<T> | undefined>()
+
+  const updateResults = useMemo(() => () => {
+    const version = state.current.version;
+    run(q).then(r => {
+      // if the version changed, then the deps changed, so throw out these results
+      // and stop polling with this version of the query
+      if (state.current.version == version) {
+        setResults(r)
+        state.current = {
+          state: "polling",
+          version,
+          timeout: setTimeout(updateResults, ms),
+        }
+      }
+    })
+  }, [q, opts])
+
+  useEffect(() => {
+    setResults(undefined) // if we changed the deps, we have no results
+    updateResults();
+    return () => {
+      // either unmounting, or restarting the effect because the deps changed
+      if (state.current.timeout != null) {
+        clearTimeout(state.current.timeout)
+      }
+      state.current = { state: "waiting", version: state.current.version + 1 }
+    }
+  }, deps)
+
+  return [results, setResults] as const
+}


### PR DESCRIPTION
Pretty self-explanatory, this provides `useSupabasePolling(q)` which re-runs the query given repeatedly and returns the results, and optionally takes deps that restart the polling (e.g. if the query is based on a user ID and they just logged in.)

I updated a couple places where we were using realtime for groups and just re-fetching everything every time to use this instead, as a proof of concept.