### PR TITLE
Write code for basic Supabase realtime functionality

### DIFF
--- a/common/src/leagues.ts
+++ b/common/src/leagues.ts
@@ -1,4 +1,4 @@
-import { PlainTablesAndViews } from './supabase/utils'
+import { Row } from './supabase/utils'
 
 export type season = typeof SEASONS[number]
 
@@ -38,7 +38,7 @@ export const getDemotionAndPromotionCount = (division: number) => {
   return { demotion: 5, promotion: 5, doublePromotion: 0 }
 }
 
-export type league_row = PlainTablesAndViews['leagues']
+export type league_row = Row<'leagues'>
 export type league_user_info = league_row & { rank: number }
 
 export const COHORT_SIZE = 25

--- a/common/src/supabase/realtime.ts
+++ b/common/src/supabase/realtime.ts
@@ -1,0 +1,84 @@
+import { TableName, Row, Column } from 'common/supabase/utils'
+import {
+  RealtimePostgresChangesPayload,
+  REALTIME_SUBSCRIBE_STATES
+} from '@supabase/realtime-js'
+
+// we could support the other filters that realtime supports rather than just 'eq'
+export type Filter<T extends TableName> = { k: Column<T>; v: string | number }
+export type Change<T extends TableName> = RealtimePostgresChangesPayload<Row<T>>
+export type SubscriptionStatus = `${REALTIME_SUBSCRIBE_STATES}`
+
+// to work with realtime, the table needs a primary key we can use to identify
+// matching rows, and it needs an update timestamp we can use to order changes
+export type TableSpec<T extends TableName> = {
+  pk: Column<T>[],
+  ts: (row: Row<T>) => number,
+}
+
+export const REALTIME_TABLES: Partial<{ [T in TableName]: TableSpec<T> }> = {
+  contract_bets: {
+    pk: ['contract_id', 'bet_id'],
+    ts: (r) => parseInt(r.fs_updated_time)
+  }
+}
+
+export function buildFilterString<T extends TableName>(filter: Filter<T>) {
+  return `${filter.k}=${filter.v}`
+}
+
+export function applyChange<T extends TableName>(
+  table: T,
+  rows: Row<T>[],
+  change: Change<T>
+) {
+  const spec = REALTIME_TABLES[table]
+  if (spec == null) {
+    throw new Error("No key and timestamp columns specified for subscription.")
+  }
+  const identical = (a: Row<T>, b: Row<T>) => {
+    return !spec.pk.some((col) => a[col] !== b[col])
+  }
+
+  // apply the change to the existing row set, taking into account timestamps.
+  // this presumes that when we get new changes, we get them in order, but some
+  // prefix of the changes we get may be already reflected in our existing rows.
+  switch (change.eventType)  {
+    case "INSERT": {
+      const existing = rows.find(r => identical(change.new, r))
+      if (existing != null) {
+        console.warn("Out-of-order subscription insert: ", change)
+        return rows
+      }
+      return [...rows, change.new]
+    }
+    case "UPDATE": {
+      const idx = rows.findIndex(r => identical(change.new, r))
+      if (idx == -1) {
+        console.warn("Out-of-order subscription update: ", change)
+        return [...rows, change.new]
+      }
+      if (spec.ts(rows[idx]) < spec.ts(change.new)) {
+        // replace the existing row with the updated row
+        return [...rows.slice(0, idx), change.new, ...rows.slice(idx)]
+      } else {
+        // the updated row is not more recent, so ignore the update
+        return rows
+      }
+    }
+    case "DELETE": {
+      // note: the old record only carries the replica identity columns of the table,
+      // by default the primary key (but configurable in postgres)
+      const idx = rows.findIndex(r => identical(change.old as Row<T>, r))
+      if (idx == -1) {
+        console.warn("Out-of-order subscription delete: ", change)
+        return rows
+      }
+      return [...rows.slice(0, idx), ...rows.slice(idx)]
+    }
+    default: {
+      console.warn('Unknown change type, ignoring: ', change)
+      return rows
+    }
+  }
+}

--- a/common/src/supabase/realtime.ts
+++ b/common/src/supabase/realtime.ts
@@ -1,12 +1,26 @@
 import { TableName, Row, Column } from 'common/supabase/utils'
 import {
-  RealtimePostgresChangesPayload,
+  RealtimePostgresInsertPayload,
+  RealtimePostgresUpdatePayload,
+  RealtimePostgresDeletePayload,
+  REALTIME_POSTGRES_CHANGES_LISTEN_EVENT,
   REALTIME_SUBSCRIBE_STATES
 } from '@supabase/realtime-js'
 
+export type Insert<T extends TableName> = RealtimePostgresInsertPayload<Row<T>>
+export type Update<T extends TableName> = RealtimePostgresUpdatePayload<Row<T>>
+export type Delete<T extends TableName> = RealtimePostgresDeletePayload<Row<T>>
+export type Event = `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT}`
+export type EventChangeTypes<T extends TableName> = {
+  '*': Insert<T> | Update<T> | Delete<T>,
+  'INSERT': Insert<T>,
+  'UPDATE': Update<T>,
+  'DELETE': Delete<T>
+}
+export type Change<T extends TableName, E extends Event = '*'> = EventChangeTypes<T>[E]
+
 // we could support the other filters that realtime supports rather than just 'eq'
 export type Filter<T extends TableName> = { k: Column<T>; v: string | number }
-export type Change<T extends TableName> = RealtimePostgresChangesPayload<Row<T>>
 export type SubscriptionStatus = `${REALTIME_SUBSCRIBE_STATES}`
 
 // to work with realtime, the table needs a primary key we can use to identify

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -15,16 +15,16 @@ import { Group, GroupMemberDoc, GroupContractDoc } from '../group'
 
 export type Schema = Database['public']
 export type Tables = Schema['Tables']
-export type PlainTables = {
-  [table in keyof Tables]: Tables[table]['Row']
-}
 export type Views = Schema['Views']
-export type PlainViews = {
-  [view in keyof Views]: Views[view]['Row']
-}
-export type PlainTablesAndViews = PlainTables & PlainViews
 export type TableName = keyof Tables
 export type ViewName = keyof Views
+export type Selectable = TableName | ViewName
+export type Row<T extends Selectable> = (
+  T extends TableName ? Tables[T]['Row'] :
+  T extends ViewName ? Views[T]['Row'] :
+  never);
+export type Column<T extends Selectable> = keyof Row<T> & string
+
 export type SupabaseClient = SupabaseClientGeneric<Database, 'public', Schema>
 
 export type CollectionTableMapping = { [coll: string]: TableName }
@@ -101,7 +101,7 @@ export async function run<T>(
   }
 }
 
-type TableJsonTypes = {
+type JsonTypes = {
   users: User
   user_contract_metrics: ContractMetrics
   contracts: Contract
@@ -112,8 +112,8 @@ type TableJsonTypes = {
   group_contracts: GroupContractDoc
 }
 
-export type DataFor<T extends TableName | ViewName> =
-  T extends keyof TableJsonTypes ? TableJsonTypes[T] : any
+export type DataFor<T extends Selectable> =
+  T extends keyof JsonTypes ? JsonTypes[T] : any
 
 export function selectJson<T extends TableName | ViewName>(
   db: SupabaseClient,

--- a/web/hooks/use-bets-supabase.ts
+++ b/web/hooks/use-bets-supabase.ts
@@ -5,7 +5,7 @@ import { useEffectCheckEquality } from './use-effect-check-equality'
 import { EMPTY_USER } from 'web/components/contract/contract-tabs'
 import { getBets, getTotalBetCount } from 'common/supabase/bets'
 import { Filter } from 'common/supabase/realtime'
-import { useLiveStream } from 'web/lib/supabase/realtime/use-live-stream'
+import { useRealtimeRows } from 'web/lib/supabase/realtime/use-realtime'
 
 function getFilteredQuery(filteredParam: string, filterId?: string) {
   if (filteredParam === 'contractId' && filterId) {
@@ -24,8 +24,8 @@ export function useRealtimeBets(options?: BetFilter, printUser?: boolean) {
     }
   }
   const [oldBets, setOldBets] = useState<Bet[]>([])
-  const stream = useLiveStream('contract_bets', filteredQuery)
-  const newBets = stream
+  const rows = useRealtimeRows('contract_bets', filteredQuery)
+  const newBets = rows
     .map(r => r.data as Bet)
     .filter(b => !betShouldBeFiltered(b, options))
 

--- a/web/hooks/use-comments-supabase.ts
+++ b/web/hooks/use-comments-supabase.ts
@@ -7,7 +7,7 @@ import { uniqBy } from 'lodash'
 import { usePersistentInMemoryState } from 'web/hooks/use-persistent-in-memory-state'
 import { getAllComments } from 'common/supabase/comments'
 import { isBlocked, usePrivateUser } from 'web/hooks/use-user'
-import { useLiveStream } from 'web/lib/supabase/realtime/use-live-stream'
+import { useRealtimeRows } from 'web/lib/supabase/realtime/use-realtime'
 
 export function useComments(contractId: string, limit: number) {
   const [comments, setComments] = useState<Json[]>([])
@@ -77,8 +77,8 @@ export function useNumUserComments(userId: string) {
 
 export function useRealtimeComments(limit: number): Comment[] {
   const [oldComments, setOldComments] = useState<Comment[]>([])
-  const stream = useLiveStream('contract_comments')
-  const newComments = stream.map(r => r.data as Comment)
+  const rows = useRealtimeRows('contract_comments')
+  const newComments = rows.map(r => r.data as Comment)
 
   useEffect(() => {
     getComments(limit)

--- a/web/hooks/use-contract-supabase.ts
+++ b/web/hooks/use-contract-supabase.ts
@@ -10,7 +10,7 @@ import { useEffectCheckEquality } from './use-effect-check-equality'
 import { ContractParameters } from 'web/pages/[username]/[contractSlug]'
 import { getContractParams } from 'web/lib/firebase/api'
 import { useIsAuthorized } from './use-user'
-import { useLiveStream } from 'web/lib/supabase/realtime/use-live-stream'
+import { useRealtimeRows } from 'web/lib/supabase/realtime/use-realtime'
 
 export const usePublicContracts = (contractIds: string[] | undefined) => {
   const [contracts, setContracts] = useState<Contract[] | undefined>()
@@ -67,8 +67,7 @@ export const useContractFromSlug = (contractSlug: string | undefined) => {
 
 export function useRealtimeContracts(limit: number) {
   const [oldContracts, setOldContracts] = useState<Contract[]>([])
-  const stream = useLiveStream('contracts')
-  const newContracts = stream.map(r => r.data as Contract)
+  const newContracts = useRealtimeRows('contracts').map(r => r.data as Contract)
 
   useEffect(() => {
     getPublicContracts({ limit, order: 'desc' })

--- a/web/hooks/use-group-supabase.ts
+++ b/web/hooks/use-group-supabase.ts
@@ -15,6 +15,7 @@ import { getUser } from 'web/lib/supabase/user'
 import { useAdmin } from './use-admin'
 import { useIsAuthorized, useUser } from './use-user'
 import { useSupabasePolling } from 'web/hooks/use-supabase'
+import { useRealtimeChannel } from 'web/lib/supabase/realtime/use-realtime'
 import { getUserIsGroupMember } from 'web/lib/firebase/api'
 import {
   GroupAndRoleType,
@@ -34,27 +35,14 @@ export function useRealtimeRole(groupId: string | undefined) {
       setTranslatedMemberRole(groupId, isManifoldAdmin, setUserRole, user)
     }
   }, [user, isManifoldAdmin, groupId])
-  useEffect(() => {
-    const channel = db.channel('user-group-role-realtime')
-    channel.on(
-      'postgres_changes',
-      {
-        event: '*',
-        schema: 'public',
-        table: 'group_members',
-        filter: `group_id=eq.${groupId}`,
-      },
-      (payload) => {
-        if ((payload.new as any).member_id === user?.id) {
-          setTranslatedMemberRole(groupId, isManifoldAdmin, setUserRole, user)
-        }
-      }
-    )
-    channel.subscribe(async (status) => {})
-    return () => {
-      db.removeChannel(channel)
+
+  const channelFilter = { k: 'group_id', v: groupId ?? '_' } as const
+  useRealtimeChannel('*', 'group_members', channelFilter, (change) => {
+    if ((change.new as any).member_id === user?.id) {
+      setTranslatedMemberRole(groupId, isManifoldAdmin, setUserRole, user)
     }
-  }, [db, user])
+  })
+
   return userRole
 }
 
@@ -124,25 +112,11 @@ export function useRealtimeGroupMembers(
     }
   }, [hitBottom])
 
-  useEffect(() => {
-    const channel = db.channel('group-members-realtime')
-    channel.on(
-      'postgres_changes',
-      {
-        event: '*',
-        schema: 'public',
-        table: 'group_members',
-        filter: `group_id=eq.${groupId}`,
-      },
-      (payload) => {
-        fetchGroupMembers()
-      }
-    )
-    channel.subscribe(async (status) => {})
-    return () => {
-      db.removeChannel(channel)
-    }
-  }, [db])
+  const channelFilter = { k: 'group_id', v: groupId } as const
+  useRealtimeChannel('*', 'group_members', channelFilter, (_change) => {
+    fetchGroupMembers()
+  })
+
   return { admins, moderators, members, loadMore }
 }
 

--- a/web/hooks/use-post-supabase.ts
+++ b/web/hooks/use-post-supabase.ts
@@ -1,52 +1,13 @@
 import { Post } from 'common/post'
 import { useEffect, useState } from 'react'
-import { db } from 'web/lib/supabase/db'
 import { getPost } from 'web/lib/supabase/post'
+import { useSubscription } from 'web/lib/supabase/realtime/use-subscription'
 
 export function useRealtimePost(postId?: string) {
-  const [post, setPost] = useState<Post | null>(null)
-  function fetchPost() {
-    if (postId) {
-      getPost(postId)
-        .then((result) => {
-          setPost(result)
-        })
-        .catch((e) => console.log(e))
-    }
-  }
-
-  useEffect(() => {
-    fetchPost()
-  }, [postId])
-
-  useEffect(() => {
-    if (postId) {
-      const channel = db.channel('post-realtime')
-      channel.on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'posts',
-          filter: `id=eq.${postId}`,
-        },
-        (payload) => {
-          console.log(payload)
-          if (payload.eventType === 'UPDATE') {
-            setPost(payload.new.data)
-          }
-          if (payload.eventType === 'DELETE') {
-            setPost(null)
-          }
-        }
-      )
-      channel.subscribe(async (status) => {})
-      return () => {
-        db.removeChannel(channel)
-      }
-    }
-  }, [db, postId])
-  return post
+  // mqp: the posts components are weird and it's hard to refactor them
+  // in a way that only calls this hook when there's a real post to subscribe to
+  const posts = useSubscription('posts', { k: 'id', v: postId ?? '_' })
+  return posts != null && posts.length > 0 ? posts[0].data as Post : undefined
 }
 
 export function usePost(postId?: string) {

--- a/web/lib/supabase/db.ts
+++ b/web/lib/supabase/db.ts
@@ -11,11 +11,11 @@ export function updateSupabaseAuth(token?: string) {
   if (currentToken != token) {
     currentToken = token
     if (token == null) {
-      delete (db as any).rest.headers['Authorization']
-      ;(db as any).realtime.setAuth(null)
+      db['rest'].headers['Authorization']
+      db['realtime'].setAuth(null)
     } else {
-      ;(db as any).rest.headers['Authorization'] = `Bearer ${token}`
-      ;(db as any).realtime.setAuth(token)
+      db['rest'].headers['Authorization'] = `Bearer ${token}`
+      db['realtime'].setAuth(token)
     }
   }
 }

--- a/web/lib/supabase/realtime/use-live-stream.ts
+++ b/web/lib/supabase/realtime/use-live-stream.ts
@@ -1,0 +1,45 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { RealtimeChannel } from '@supabase/realtime-js'
+import { TableName, Row } from 'common/supabase/utils'
+import { Filter, buildFilterString } from 'common/supabase/realtime'
+import { useIsPageVisible } from 'web/hooks/use-page-visible'
+import { db } from 'web/lib/supabase/db'
+
+export function useLiveStream<T extends TableName>(
+  table: T,
+  filter?: Filter<T>
+) {
+  const filterString = filter ? buildFilterString(filter) : undefined
+  const channelId = `${table}-${useId()}`
+  const channel = useRef<RealtimeChannel | undefined>()
+  const [changes, setChanges] = useState<Row<T>[]>([])
+  const isVisible = useIsPageVisible()
+
+  useEffect(() => {
+    if (isVisible) {
+      const opts = {
+        event: 'INSERT',
+        schema: 'public',
+        table,
+        filter: filterString
+      } as const
+      const chan = channel.current = db.channel(channelId)
+      chan.on<Row<T>>('postgres_changes', opts, (change) => {
+        // if we got this change over a channel we have recycled, ignore it
+        if (channel.current === chan) {
+          setChanges((cs) => [...cs, change.new])
+        }
+      }).subscribe((_status, err) => {
+        if (err) {
+          console.error(err)
+        }
+      })
+      return () => {
+        db.removeChannel(chan)
+        channel.current = undefined
+      }
+    }
+  }, [table, filterString, isVisible])
+
+  return changes
+}

--- a/web/lib/supabase/realtime/use-realtime.ts
+++ b/web/lib/supabase/realtime/use-realtime.ts
@@ -1,33 +1,53 @@
 import { useEffect, useId, useRef, useState } from 'react'
 import { RealtimeChannel } from '@supabase/realtime-js'
 import { TableName, Row } from 'common/supabase/utils'
-import { Filter, buildFilterString } from 'common/supabase/realtime'
+import { Change, Event, Filter, buildFilterString } from 'common/supabase/realtime'
 import { useIsPageVisible } from 'web/hooks/use-page-visible'
 import { db } from 'web/lib/supabase/db'
 
-export function useLiveStream<T extends TableName>(
+export function useRealtimeRows<T extends TableName>(
   table: T,
   filter?: Filter<T>
+) {
+  return useRealtimeChanges('INSERT', table, filter).map(i => i.new)
+}
+
+export function useRealtimeChanges<T extends TableName, E extends Event>(
+  event: E,
+  table: T,
+  filter?: Filter<T>
+) {
+  const [changes, setChanges] = useState<Change<T, E>[]>([])
+  useRealtimeChannel(event, table, filter, (change) => {
+    setChanges((cs) => [...cs, change as any])
+  })
+  return changes
+}
+
+export function useRealtimeChannel<T extends TableName, E extends Event>(
+  event: E,
+  table: T,
+  filter: Filter<T> | null | undefined,
+  callback: (change: Change<T, E>) => void
 ) {
   const filterString = filter ? buildFilterString(filter) : undefined
   const channelId = `${table}-${useId()}`
   const channel = useRef<RealtimeChannel | undefined>()
-  const [changes, setChanges] = useState<Row<T>[]>([])
   const isVisible = useIsPageVisible()
 
   useEffect(() => {
     if (isVisible) {
       const opts = {
-        event: 'INSERT',
+        event,
         schema: 'public',
         table,
         filter: filterString
       } as const
       const chan = channel.current = db.channel(channelId)
-      chan.on<Row<T>>('postgres_changes', opts, (change) => {
+      chan.on<Row<T>>('postgres_changes', opts as any, (change) => {
         // if we got this change over a channel we have recycled, ignore it
         if (channel.current === chan) {
-          setChanges((cs) => [...cs, change.new])
+          callback(change as any)
         }
       }).subscribe((_status, err) => {
         if (err) {
@@ -40,6 +60,4 @@ export function useLiveStream<T extends TableName>(
       }
     }
   }, [table, filterString, isVisible])
-
-  return changes
 }

--- a/web/lib/supabase/realtime/use-subscription.ts
+++ b/web/lib/supabase/realtime/use-subscription.ts
@@ -1,0 +1,162 @@
+import { useEffect, useId, useMemo, useReducer, useRef } from 'react'
+import { RealtimeChannel } from '@supabase/realtime-js'
+import { TableName, Row, run } from 'common/supabase/utils'
+import {
+  Change,
+  Filter,
+  SubscriptionStatus,
+  applyChange,
+  buildFilterString
+} from 'common/supabase/realtime'
+import { useEvent } from 'web/hooks/use-event'
+import { useIsPageVisible } from 'web/hooks/use-page-visible'
+import { db } from 'web/lib/supabase/db'
+
+async function fetchSnapshot<T extends TableName>(
+  table: T,
+  filter?: Filter<T>
+) {
+  let q = db.from(table).select('*')
+  if (filter != null) {
+    q = q.eq(filter.k, filter.v)
+  }
+  return (await run(q)).data as Row<T>[]
+}
+
+// subscription lifecycle:
+// 1. subscribing -- when we are awaiting our channel to connect
+// 2. fetching -- when we are connected and awaiting an initial snapshot
+// 3. live -- normal operation, we are up to date with postgres
+// 4. errored -- when the subscription is dead due to an error
+
+interface State<T extends TableName> {
+  status: 'subscribing' | 'fetching' | 'live' | 'errored',
+  rows?: Row<T>[],
+  pending: Change<T>[]
+}
+
+type ActionBase<K, V = void> = V extends void ? { type: K } : { type: K } & V
+
+type Action<T extends TableName> =
+  | ActionBase<'SUBSCRIBED'>
+  | ActionBase<'FETCHED', { snapshot: Row<T>[] }>
+  | ActionBase<'RECEIVED_CHANGE', { change: Change<T> }>
+  | ActionBase<'RECEIVED_ERROR', { err?: Error }>
+  | ActionBase<'BACKGROUNDED'>
+  | ActionBase<'RESTARTED'>
+
+const getReducer =
+  <T extends TableName>(table: T) =>
+  (state: State<T>, action: Action<T>): State<T> => {
+    switch (action.type) {
+      case 'RESTARTED': {
+        return { ...state, status: 'subscribing', pending: [] }
+      }
+      case 'SUBSCRIBED': {
+        return { ...state, status: 'fetching', pending: [] }
+      }
+      case 'FETCHED': {
+        let rows = action.snapshot
+        for (const change of state.pending) {
+          rows = applyChange(table, rows, change)
+        }
+        return { status: 'live', rows: rows, pending: [] }
+      }
+      case 'RECEIVED_CHANGE': {
+        if (state.rows != null) {
+          return { ...state, rows: applyChange(table, state.rows, action.change) }
+        } else {
+          return { ...state, pending: [...state.pending, action.change] }
+        }
+      }
+      case 'RECEIVED_ERROR': {
+        return { ...state, status: 'errored' }
+      }
+      default:
+        throw new Error('Invalid action.')
+    }
+  }
+
+export function useSubscription<T extends TableName>(
+  table: T,
+  filter?: Filter<T>,
+  preload?: Row<T>[]
+) {
+  const initialState = { status: 'subscribing', rows: preload, pending: [] } as State<T>
+  const filterString = filter ? buildFilterString(filter) : undefined
+  const channelId = `${table}-${useId()}`
+  const channel = useRef<RealtimeChannel | undefined>()
+  const reducer = useMemo(() => getReducer(table), [table])
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const isVisible = useIsPageVisible()
+
+  const onChange = useEvent((change: Change<T>) => {
+    dispatch({ type: 'RECEIVED_CHANGE', change })
+  })
+
+  const onStatus = useEvent((status: SubscriptionStatus, err?: Error) => {
+    console.log(status, err)
+    switch (status) {
+      case 'SUBSCRIBED': {
+        dispatch({ type: 'SUBSCRIBED' })
+        fetchSnapshot(table, filter).then((snapshot) => {
+          dispatch({ type: 'FETCHED', snapshot })
+        })
+        break
+      }
+      case 'TIMED_OUT': {
+        dispatch({ type: 'RECEIVED_ERROR', err })
+        break
+      }
+      case 'CHANNEL_ERROR': {
+        dispatch({ type: 'RECEIVED_ERROR', err })
+        break
+      }
+      case 'CLOSED': {
+        // nothing to do here
+      }
+    }
+  })
+
+  // WIP - test and figure out most appropriate stuff to do on
+  // socket close, socket error, channel error, channel timeout
+
+  const onSocketClose = useEvent((ev: CloseEvent) => {
+    console.log("onClose: ", ev)
+  })
+
+  const onSocketError = useEvent((ev: ErrorEvent) => {
+    console.log("onError: ", ev)
+  })
+
+  useEffect(() => {
+    if (isVisible) {
+      const opts = { event: '*', schema: 'public', table, filter: filterString } as const
+      const chan = channel.current = db.channel(channelId)
+      chan.on<Row<T>>('postgres_changes', opts, (change) => {
+        // if we got this change over a channel we have recycled, ignore it
+        if (channel.current === chan) {
+          onChange?.(change)
+        }
+      }).subscribe((status, err) => {
+        onStatus?.(status, err)
+      })
+      return () => {
+        db.removeChannel(chan)
+        channel.current = undefined
+      }
+    }
+  }, [table, filterString, isVisible, onChange, onStatus])
+
+  useEffect(() => {
+    const cbs = db['realtime'].stateChangeCallbacks
+    const closeIdx = cbs.close.push(onSocketClose) - 1
+    const errorIdx = cbs.error.push(onSocketError) - 1
+    return () => {
+      cbs.close.splice(closeIdx, 1)
+      cbs.error.splice(errorIdx, 1)
+    }
+  }, [])
+
+  return state.rows
+}

--- a/web/lib/supabase/realtime/use-subscription.ts
+++ b/web/lib/supabase/realtime/use-subscription.ts
@@ -79,10 +79,9 @@ const getReducer =
 
 export function useSubscription<T extends TableName>(
   table: T,
-  filter?: Filter<T>,
-  preload?: Row<T>[]
+  filter?: Filter<T>
 ) {
-  const initialState = { status: 'subscribing', rows: preload, pending: [] } as State<T>
+  const initialState = { status: 'subscribing', pending: [] } as State<T>
   const filterString = filter ? buildFilterString(filter) : undefined
   const channelId = `${table}-${useId()}`
   const channel = useRef<RealtimeChannel | undefined>()

--- a/web/lib/supabase/realtime/use-subscription.ts
+++ b/web/lib/supabase/realtime/use-subscription.ts
@@ -94,7 +94,6 @@ export function useSubscription<T extends TableName>(
   })
 
   const onStatus = useEvent((status: SubscriptionStatus, err?: Error) => {
-    console.log(status, err)
     switch (status) {
       case 'SUBSCRIBED': {
         dispatch({ type: 'SUBSCRIBED' })
@@ -117,17 +116,6 @@ export function useSubscription<T extends TableName>(
     }
   })
 
-  // WIP - test and figure out most appropriate stuff to do on
-  // socket close, socket error, channel error, channel timeout
-
-  const onSocketClose = useEvent((ev: CloseEvent) => {
-    console.log("onClose: ", ev)
-  })
-
-  const onSocketError = useEvent((ev: ErrorEvent) => {
-    console.log("onError: ", ev)
-  })
-
   useEffect(() => {
     if (isVisible) {
       const opts = { event: '*', schema: 'public', table, filter: filterString } as const
@@ -146,16 +134,6 @@ export function useSubscription<T extends TableName>(
       }
     }
   }, [table, filterString, isVisible, onChange, onStatus])
-
-  useEffect(() => {
-    const cbs = db['realtime'].stateChangeCallbacks
-    const closeIdx = cbs.close.push(onSocketClose) - 1
-    const errorIdx = cbs.error.push(onSocketError) - 1
-    return () => {
-      cbs.close.splice(closeIdx, 1)
-      cbs.error.splice(errorIdx, 1)
-    }
-  }, [])
 
   return state.rows
 }


### PR DESCRIPTION
This introduces two hooks:

1. `useLiveStream` opens and manages a channel and returns a live-updated stream of inserts on the chosen table. Useful for live feed kind of stuff and maybe the contract page bets.
2. `useSubscription` opens and manages a channel and returns a live-updated snapshot of the chosen table subset by merging a fetched snapshot with changes that come in, like subscribing to a Firestore query. Useful for most of the random stuff we want to use subscriptions for.

Some relevant facts:

1. When you call `db.removeChannel`, the websocket will be disconnected iff it has no more channels. So if all active channels are configured (as in this PR) to remove themselves when the tab is hidden, that will suffice to disconnect the websocket and not count against our connection cap.
2. Unlike in #1700, we don't try to multiplex subscriptions over the same channel, because I don't believe there's any need for it -- it's not saving any important resource, shouldn't impact our billing, and I think the Supabase library wants us to use the multiple-channels paradigm.

This is still WIP -- I need to test more disconnection and error scenarios to get things just right -- but it should be roughly right.