### PR TITLE
Return a full Bet from /api/v0/market/marketId/sell, and not just status success

### DIFF
--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -208,12 +208,12 @@ export const placebet = authEndpoint(async (req, auth) => {
       log(`Updated contract ${contract.slug} properties - auth ${auth.uid}.`)
     }
 
-    return { contract, betId: betDoc.id, makers, newBet, ordersToCancel, user }
+    return { newBet, betId: betDoc.id, contract, makers, ordersToCancel, user }
   })
 
   log(`Main transaction finished - auth ${auth.uid}.`)
 
-  const { contract, newBet, makers, ordersToCancel, user } = result
+  const { newBet, betId, contract, makers, ordersToCancel, user } = result
   const { mechanism } = contract
 
   if (
@@ -241,7 +241,7 @@ export const placebet = authEndpoint(async (req, auth) => {
     )
   }
 
-  return { ...newBet, betId: result.betId }
+  return { ...newBet, betId: betId }
 })
 
 const firestore = admin.firestore()

--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -143,10 +143,10 @@ export const sellshares = authEndpoint(async (req, auth) => {
       })
     }
 
-    return { newBet, makers, maxShares, soldShares, contract }
+    return { newBet, betId: newBetDoc.id, makers, maxShares, soldShares, contract }
   })
 
-  const { makers, maxShares, soldShares, contract } = result
+  const { newBet, betId, makers, maxShares, soldShares, contract } = result
 
   if (floatingEqual(maxShares, soldShares)) {
     await removeUserFromContractFollowers(contractId, auth.uid)
@@ -155,7 +155,7 @@ export const sellshares = authEndpoint(async (req, auth) => {
   await Promise.all(userIds.map((userId) => redeemShares(userId, contract)))
   log('Share redemption transaction finished.')
 
-  return { status: 'success' }
+  return { status: 'success', ...newBet, betId: betId }
 })
 
 const firestore = admin.firestore()

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -661,6 +661,8 @@ Parameters:
       depending on current unfilled limit bets and the AMM's liquidity. Any remaining
       portion of the bet not filled would remain to be matched against in the future.
   - An unfilled limit order bet can be cancelled using the cancel API.
+- `expiresAt`: Optional. A Unix timestamp (in milliseconds) at which the limit bet
+  should be automatically canceled.
 
 Example request:
 
@@ -671,6 +673,8 @@ $ curl https://manifold.markets/api/v0/bet -X POST -H 'Content-Type: application
                  "outcome":"YES", \
                  "contractId":"{...}"}'
 ```
+
+Response type: A `Bet`.
 
 ### `POST /v0/bet/cancel/[id]`
 
@@ -821,6 +825,9 @@ $ curl https://manifold.markets/api/v0/market/{marketId}/sell -X POST \
     -H 'Authorization: Key {...}' \
     --data-raw '{"outcome": "YES", "shares": 10}'
 ```
+
+Response type: A `Bet`, with an additional `"status": "success"` field, for backwards
+compatibility.  In previous versions it simply returned `{"status": "success"}`.
 
 ### `POST /v0/comment`
 

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -826,8 +826,7 @@ $ curl https://manifold.markets/api/v0/market/{marketId}/sell -X POST \
     --data-raw '{"outcome": "YES", "shares": 10}'
 ```
 
-Response type: A `Bet`, with an additional `"status": "success"` field, for backwards
-compatibility.  In previous versions it simply returned `{"status": "success"}`.
+Response type: A `Bet`, with an additional `"status": "success"` field.
 
 ### `POST /v0/comment`
 
@@ -941,6 +940,8 @@ Requires no authorization.
   </details>
 
 ## Changelog
+- 2023-05-15: Change the response of the `/market/{marketId}/sell` POST endpoint from
+  `{"status": "success"}` to a full `Bet`, with an additional `"status": "success"` field.
 - 2023-04-03: Add `/market/[marketId]/group` POST endpoint.
 - 2023-03-21: Add `/market/[marketId]/positions` and `/search-markets` endpoints
 - 2022-11-22: Update /market GET to remove `bets` and `comments`


### PR DESCRIPTION
Currently an API call `POST /v0/market/[marketId]/sell` returns a `{"status": "success"}`, while a call `POST /v0/bet` returns a full `Bet` object.

This Pull Request changes the return type of the `sell` handler to a also be a full `Bet` object, with an additional `"status": "success"` field for backwards compatibility.

It also updates the API documentation `/docs/docs/api.md` to reflect this change.