### PR TITLE
If the user is trying to sell shares they don't own return an error 400 You don't have any shares to sell

### DIFF
--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -84,6 +84,9 @@ export const sellshares = authEndpoint(async (req, auth) => {
     const maxShares = sharesByOutcome[chosenOutcome]
     const sharesToSell = shares ?? maxShares
 
+    if (!maxShares)
+      throw new APIError(400, `You don't have any ${chosenOutcome} shares to sell.`)
+
     if (!floatingLesserEqual(sharesToSell, maxShares))
       throw new APIError(400, `You can only sell up to ${maxShares} shares.`)
 


### PR DESCRIPTION
Currently if a user tries to sell shares they down own on a CPPM-1 market using an API, they will get the following result:
```
POST https://manifold.markets/api/v0/market/[marketId]/sell body='{"outcome": "NO", "shares": 1}'
--> 400 {"message": "You can only sell up to undefined shares."}
```

This Pull Request changes this error message to:
```
POST https://manifold.markets/api/v0/market/[marketId]/sell body='{"outcome": "NO", "shares": 1}'
--> 400 {"message": "You don't have any [outcome] shares to sell."}
```