### PR TITLE
Acx discord

### DIFF
--- a/backend/discord-bot/src/commands/about.ts
+++ b/backend/discord-bot/src/commands/about.ts
@@ -1,0 +1,31 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js'
+import { shouldIgnoreMessageFromGuild } from 'discord-bot/helpers'
+import { Command } from 'discord-bot/command'
+import { config } from 'discord-bot/constants/config'
+
+const data = new SlashCommandBuilder()
+  .setName('about')
+  .setDescription('Learn more about the Manifold bot and how to use it.')
+
+async function execute(interaction: ChatInputCommandInteraction) {
+  if (shouldIgnoreMessageFromGuild(interaction.guildId)) return
+  await interaction.reply({
+    content: `${interaction.client.user.toString()} is the official Discord bot of [Manifold Markets](<${
+      config.domain
+    }>).
+ 
+Manifold is a play-money prediction market platform where users can create and settle their own questions. Their token exchange system allows the platform to operate in jurisdictions where anti-gambling laws prohibit real money prediction markets. While users can't cash out to themselves, tokens (aka mana) can be bought and donated to charities at a rate of $1:M100. The Manifold team is heavily involved with the EA community, and also has a platform for *Impact Certificates* called [Manifund](<${'https://manifund.org/'}>). 
+    
+This bot lets you...
+ **/create** - Create a prediction market
+ **/search** - Search for pre-made markets
+ **/market** - Link to a market and allow discord users to bet via reactions
+ **/about** - Learn more about the Manifold bot and how to use it
+`,
+  })
+}
+
+export const aboutCommand = {
+  data,
+  execute,
+} as Command

--- a/backend/discord-bot/src/commands/index.ts
+++ b/backend/discord-bot/src/commands/index.ts
@@ -2,5 +2,11 @@ import { Command } from 'discord-bot/command'
 import { marketCommand } from 'discord-bot/commands/react-to-bet-on-market'
 import { searchCommand } from 'discord-bot/commands/search'
 import { createCommand } from 'discord-bot/commands/create'
+import { aboutCommand } from 'discord-bot/commands/about'
 
-export const commands: Command[] = [marketCommand, searchCommand, createCommand]
+export const commands: Command[] = [
+  marketCommand,
+  searchCommand,
+  createCommand,
+  aboutCommand,
+]

--- a/backend/discord-bot/src/helpers.ts
+++ b/backend/discord-bot/src/helpers.ts
@@ -229,7 +229,9 @@ const getOrCreateThread = async (
   const name = marketName.slice(0, 40) + '-' + randomString(5)
   if (discordMessageIdsToThreads[messageId])
     return discordMessageIdsToThreads[messageId]
-  if (threadId) {
+  else if (channel.isThread()) {
+    return channel
+  } else if (threadId) {
     await channel.threads.fetch({}, { cache: true })
     const thread = channel.threads.cache.find((t) => t.id === threadId)
     if (thread) return thread

--- a/backend/discord-bot/src/leaderboard.ts
+++ b/backend/discord-bot/src/leaderboard.ts
@@ -66,6 +66,9 @@ export const sendPositionsEmbed = async (
     `the thread`,
     `https://discord.com/channels/${channel.guildId}/${thread.id}/${leaderboardMessage.id}`
   )
+  if (interaction.channel.isThread()) {
+    return await interaction.deleteReply()
+  }
   return await interaction.editReply({
     content: `I sent the leaderboard to the ${linkedMessageContent} for you!`,
     options: { ephemeral: true },


### PR DESCRIPTION
Zenbu, (ACX mod) requested a few features:
- adds /about command
- allows users to confine all bot-related activity to the thread the market was linked/created/searched for in
<img width="974" alt="Screenshot 2023-05-16 at 3 10 36 PM" src="https://github.com/manifoldmarkets/manifold/assets/23196210/9b522f98-5844-4620-bbf9-1810a2559326">
