### PR TITLE
API POST endpoints should not accept extra parameters

### DIFF
--- a/backend/api/src/add-contract-to-group.ts
+++ b/backend/api/src/add-contract-to-group.ts
@@ -12,7 +12,7 @@ import { getUser } from 'shared/utils'
 const bodySchema = z.object({
   groupId: z.string(),
   contractId: z.string(),
-})
+}).strict()
 
 export const addcontracttogroup = authEndpoint(async (req, auth) => {
   const { groupId, contractId } = validate(bodySchema, req.body)

--- a/backend/api/src/add-group-member.ts
+++ b/backend/api/src/add-group-member.ts
@@ -13,7 +13,7 @@ const bodySchema = z.object({
   groupId: z.string(),
   userId: z.string(),
   role: z.string().optional(),
-})
+}).strict()
 
 export const addgroupmember = authEndpoint(async (req, auth) => {
   const { groupId, userId, role } = validate(bodySchema, req.body)

--- a/backend/api/src/add-subsidy.ts
+++ b/backend/api/src/add-subsidy.ts
@@ -9,7 +9,7 @@ import { APIError, authEndpoint, validate } from './helpers'
 const bodySchema = z.object({
   contractId: z.string(),
   amount: z.number().gt(0),
-})
+}).strict()
 
 export const addsubsidy = authEndpoint(async (req, auth) => {
   const { amount, contractId } = validate(bodySchema, req.body)

--- a/backend/api/src/auction-bid.ts
+++ b/backend/api/src/auction-bid.ts
@@ -8,7 +8,7 @@ import { max } from 'lodash'
 
 const bodySchema = z.object({
   amount: z.number().gte(1),
-})
+}).strict()
 
 const CUTOFF_TIME = 1680418800000 // Apr 2nd, 12 am PT
 

--- a/backend/api/src/award-q-and-a-answer.ts
+++ b/backend/api/src/award-q-and-a-answer.ts
@@ -15,7 +15,7 @@ import { isProd } from 'shared/utils'
 const bodySchema = z.object({
   answerId: z.string(),
   amount: z.number(),
-})
+}).strict()
 
 export const awardQAndAAnswer = authEndpoint(async (req, auth) => {
   const { answerId, amount } = validate(bodySchema, req.body)

--- a/backend/api/src/cancel-bet.ts
+++ b/backend/api/src/cancel-bet.ts
@@ -5,7 +5,7 @@ import { LimitBet } from 'common/bet'
 
 const bodySchema = z.object({
   betId: z.string(),
-})
+}).strict()
 
 export const cancelbet = authEndpoint(async (req, auth) => {
   const { betId } = validate(bodySchema, req.body)

--- a/backend/api/src/change-user-info.ts
+++ b/backend/api/src/change-user-info.ts
@@ -23,7 +23,7 @@ const bodySchema = z.object({
   username: z.string().optional(),
   name: z.string().optional(),
   avatarUrl: z.string().optional(),
-})
+}).strict()
 
 export const changeuserinfo = authEndpoint(async (req, auth) => {
   const { username, name, avatarUrl } = validate(bodySchema, req.body)

--- a/backend/api/src/claim-manalink.ts
+++ b/backend/api/src/claim-manalink.ts
@@ -9,7 +9,7 @@ import { createSupabaseClient } from 'shared/supabase/init'
 
 const bodySchema = z.object({
   slug: z.string(),
-})
+}).strict()
 
 export const claimmanalink = authEndpoint(async (req, auth) => {
   const { slug } = validate(bodySchema, req.body)

--- a/backend/api/src/close-market.ts
+++ b/backend/api/src/close-market.ts
@@ -10,7 +10,7 @@ import { APIError, authEndpoint, validate } from './helpers'
 const bodySchema = z.object({
   contractId: z.string(),
   closeTime: z.number().int().nonnegative().optional(),
-})
+}).strict()
 
 export const closemarket = authEndpoint(async (req, auth) => {
   const { contractId, closeTime } = validate(bodySchema, req.body)

--- a/backend/api/src/complete-quest.ts
+++ b/backend/api/src/complete-quest.ts
@@ -5,7 +5,7 @@ import { completeCalculatedQuest } from 'shared/complete-quest-internal'
 
 const bodySchema = z.object({
   questType: z.enum(['SHARES'] as const),
-})
+}).strict()
 
 export const completequest = authEndpoint(async (req, auth) => {
   const { questType } = validate(bodySchema, req.body)

--- a/backend/api/src/create-answer.ts
+++ b/backend/api/src/create-answer.ts
@@ -13,7 +13,7 @@ const bodySchema = z.object({
   contractId: z.string().max(MAX_ANSWER_LENGTH),
   amount: z.number().gt(0),
   text: z.string(),
-})
+}).strict()
 
 export const createanswer = authEndpoint(async (req, auth) => {
   const { contractId, amount, text } = validate(bodySchema, req.body)

--- a/backend/api/src/create-chat-message.ts
+++ b/backend/api/src/create-chat-message.ts
@@ -34,7 +34,7 @@ export const contentSchema: z.ZodType<JSONContent> = z.lazy(() =>
 const postSchema = z.object({
   content: contentSchema.optional(),
   channelId: z.string(),
-})
+}).strict()
 
 export const MAX_COMMENT_JSON_LENGTH = 20000
 

--- a/backend/api/src/create-debate.ts
+++ b/backend/api/src/create-debate.ts
@@ -10,7 +10,7 @@ import { getUser, revalidateStaticProps } from 'shared/utils'
 const bodySchema = z.object({
   topic1: z.string().min(1).max(MAX_QUESTION_LENGTH),
   topic2: z.string().min(1).max(MAX_QUESTION_LENGTH),
-})
+}).strict()
 
 const debateBotUserId = 'PzOAq29wOnWw401h613wyQPvbZF2'
 const debateGroupId = '0i8ozKhPq5qJ89DG9tCW'

--- a/backend/api/src/create-group-invite.ts
+++ b/backend/api/src/create-group-invite.ts
@@ -14,7 +14,7 @@ const schema = z.object({
     .refine((value) => value === undefined || durationOptions.includes(value), {
       message: 'Duration must be one of: 1 hour, 1 week, 1 month, 1 year',
     }),
-})
+}).strict()
 
 export const creategroupinvite = authEndpoint(async (req, auth) => {
   const { groupId, maxUses, duration } = validate(schema, req.body)

--- a/backend/api/src/create-group.ts
+++ b/backend/api/src/create-group.ts
@@ -20,7 +20,7 @@ const bodySchema = z.object({
   memberIds: z.array(z.string().min(1).max(MAX_ID_LENGTH)),
   about: z.string().min(1).max(MAX_ABOUT_LENGTH).optional(),
   privacyStatus: z.string().min(1).optional(),
-})
+}).strict()
 
 export const creategroup = authEndpoint(async (req, auth) => {
   const firestore = admin.firestore()

--- a/backend/api/src/create-market-ad.ts
+++ b/backend/api/src/create-market-ad.ts
@@ -11,7 +11,7 @@ const schema = z.object({
   marketId: z.string(),
   totalCost: z.number(),
   costPerView: z.number(),
-})
+}).strict()
 
 export const boostmarket = authEndpoint(async (req, auth) => {
   const { marketId, totalCost, costPerView } = validate(schema, req.body)

--- a/backend/api/src/create-q-and-a-answer.ts
+++ b/backend/api/src/create-q-and-a-answer.ts
@@ -7,7 +7,7 @@ import { randomString } from 'common/util/random'
 const bodySchema = z.object({
   questionId: z.string(),
   text: z.string(),
-})
+}).strict()
 
 export const createQAndAAnswer = authEndpoint(async (req, auth) => {
   const { questionId, text } = validate(bodySchema, req.body)

--- a/backend/api/src/create-q-and-a.ts
+++ b/backend/api/src/create-q-and-a.ts
@@ -21,7 +21,7 @@ const bodySchema = z.object({
   question: z.string(),
   description: z.string(),
   bounty: z.number(),
-})
+}).strict()
 
 export const createQAndA = authEndpoint(async (req, auth) => {
   const { question, description, bounty } = validate(bodySchema, req.body)

--- a/backend/api/src/create-user.ts
+++ b/backend/api/src/create-user.ts
@@ -27,7 +27,7 @@ const bodySchema = z.object({
   deviceToken: z.string().optional(),
   adminToken: z.string().optional(),
   visitedContractIds: z.array(z.string()).optional(),
-})
+}).strict()
 
 export const createuser = authEndpoint(async (req, auth) => {
   const {

--- a/backend/api/src/delete-market.ts
+++ b/backend/api/src/delete-market.ts
@@ -9,7 +9,7 @@ import { APIError, authEndpoint, validate } from './helpers'
 
 const bodySchema = z.object({
   contractId: z.string(),
-})
+}).strict()
 
 export const deleteMarket = authEndpoint(async (req, auth) => {
   const { contractId } = validate(bodySchema, req.body)

--- a/backend/api/src/dividend-cert.ts
+++ b/backend/api/src/dividend-cert.ts
@@ -12,7 +12,7 @@ import { payUsers } from 'shared/utils'
 const bodySchema = z.object({
   certId: z.string(),
   amount: z.number(),
-})
+}).strict()
 
 export const dividendcert = authEndpoint(async (req, auth) => {
   return await firestore.runTransaction(async (transaction) => {

--- a/backend/api/src/edit-comment.ts
+++ b/backend/api/src/edit-comment.ts
@@ -12,7 +12,8 @@ const editSchema = z.object({
   content: contentSchema.optional(),
   html: z.string().optional(),
   markdown: z.string().optional(),
-})
+}).strict()
+
 export const editcomment = authEndpoint(async (req, auth) => {
   const firestore = admin.firestore()
   const { commentId, contractId, content, html, markdown } = validate(

--- a/backend/api/src/get-contract-params.ts
+++ b/backend/api/src/get-contract-params.ts
@@ -32,7 +32,7 @@ import { APIError, MaybeAuthedEndpoint, validate } from './helpers'
 const bodySchema = z.object({
   contractSlug: z.string(),
   fromStaticProps: z.boolean(),
-})
+}).strict()
 
 export const getcontractparams = MaybeAuthedEndpoint(async (req, auth) => {
   const { contractSlug, fromStaticProps } = validate(bodySchema, req.body)

--- a/backend/api/src/get-user-is-group-member.ts
+++ b/backend/api/src/get-user-is-group-member.ts
@@ -1,9 +1,10 @@
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { z } from 'zod'
 import { authEndpoint, validate } from './helpers'
+
 const bodySchema = z.object({
   groupSlug: z.string(),
-})
+}).strict()
 
 export const getuserisgroupmember = authEndpoint(async (req, auth) => {
   const { groupSlug } = validate(bodySchema, req.body)

--- a/backend/api/src/join-group-through-invite.ts
+++ b/backend/api/src/join-group-through-invite.ts
@@ -6,7 +6,7 @@ import { joinGroupHelper } from './join-group'
 
 const schema = z.object({
   inviteId: z.string(),
-})
+}).strict()
 
 export const joingroupthroughinvite = authEndpoint(async (req, auth) => {
   const { inviteId } = validate(schema, req.body)

--- a/backend/api/src/join-group.ts
+++ b/backend/api/src/join-group.ts
@@ -6,7 +6,7 @@ import { APIError, AuthedUser, authEndpoint, validate } from './helpers'
 
 const bodySchema = z.object({
   groupId: z.string(),
-})
+}).strict()
 
 export const joingroup = authEndpoint(async (req, auth) => {
   const { groupId } = validate(bodySchema, req.body)

--- a/backend/api/src/league-activity.ts
+++ b/backend/api/src/league-activity.ts
@@ -14,7 +14,7 @@ import { Bet } from 'common/bet'
 const bodySchema = z.object({
   season: z.number(),
   cohort: z.string(),
-})
+}).strict()
 
 export const leagueActivity = authEndpoint(async (req) => {
   const { season, cohort } = validate(bodySchema, req.body)

--- a/backend/api/src/mark-all-notifications.ts
+++ b/backend/api/src/mark-all-notifications.ts
@@ -5,7 +5,7 @@ import { authEndpoint, validate } from './helpers'
 
 const bodySchema = z.object({
   seen: z.boolean(),
-})
+}).strict()
 
 export const markallnotifications = authEndpoint(async (req, auth) => {
   const { seen } = validate(bodySchema, req.body)

--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -30,23 +30,23 @@ import { createLimitBetCanceledNotification } from 'shared/create-notification'
 const bodySchema = z.object({
   contractId: z.string(),
   amount: z.number().gte(1),
-})
+}).strict()
 
 const binarySchema = z.object({
   outcome: z.enum(['YES', 'NO']),
   limitProb: z.number().gte(0).lte(1).optional(),
   expiresAt: z.number().optional(),
-})
+}).strict()
 
 const freeResponseSchema = z.object({
   outcome: z.string(),
   shortSell: z.boolean().optional(),
-})
+}).strict()
 
 const numericSchema = z.object({
   outcome: z.string(),
   value: z.number(),
-})
+}).strict()
 
 export const placebet = authEndpoint(async (req, auth) => {
   log(`Inside endpoint handler for ${auth.uid}.`)

--- a/backend/api/src/redeem-ad-reward.ts
+++ b/backend/api/src/redeem-ad-reward.ts
@@ -11,7 +11,7 @@ import { APIError, authEndpoint, validate } from './helpers'
 
 const schema = z.object({
   adId: z.string(),
-})
+}).strict()
 
 export const redeemad = authEndpoint(async (req, auth) => {
   const firestore = admin.firestore()

--- a/backend/api/src/redeem-market-ad-reward.ts
+++ b/backend/api/src/redeem-market-ad-reward.ts
@@ -9,7 +9,7 @@ import { MarketAdRedeemFeeTxn, MarketAdRedeemTxn } from 'common/txn'
 
 const schema = z.object({
   adId: z.string(),
-})
+}).strict()
 
 export const redeemboost = authEndpoint(async (req, auth) => {
   const { adId } = validate(schema, req.body)

--- a/backend/api/src/register-discord-id.ts
+++ b/backend/api/src/register-discord-id.ts
@@ -7,7 +7,7 @@ import { randomUUID } from 'crypto'
 
 const bodySchema = z.object({
   discordId: z.string(),
-})
+}).strict()
 
 export const registerdiscordid = authEndpoint(async (req, auth) => {
   const { discordId } = validate(bodySchema, req.body)

--- a/backend/api/src/remove-contract-from-group.ts
+++ b/backend/api/src/remove-contract-from-group.ts
@@ -11,7 +11,7 @@ import { getUser } from 'shared/utils'
 const bodySchema = z.object({
   groupId: z.string(),
   contractId: z.string(),
-})
+}).strict()
 
 export const removecontractfromgroup = authEndpoint(async (req, auth) => {
   const { groupId, contractId } = validate(bodySchema, req.body)

--- a/backend/api/src/save-topic.ts
+++ b/backend/api/src/save-topic.ts
@@ -6,7 +6,7 @@ import { authEndpoint, validate } from './helpers'
 
 const bodySchema = z.object({
   topic: z.string(),
-})
+}).strict()
 
 export const saveTopic = authEndpoint(async (req) => {
   const { topic } = validate(bodySchema, req.body)

--- a/backend/api/src/save-twitch-credentials.ts
+++ b/backend/api/src/save-twitch-credentials.ts
@@ -7,8 +7,8 @@ const bodySchema = z.object({
   twitchInfo: z.object({
     twitchName: z.string(),
     controlToken: z.string(),
-  }),
-})
+  }).strict(),
+}).strict()
 
 export const savetwitchcredentials = authEndpoint(async (req, auth) => {
   const { twitchInfo } = validate(bodySchema, req.body)

--- a/backend/api/src/sell-bet.ts
+++ b/backend/api/src/sell-bet.ts
@@ -11,7 +11,7 @@ import { addObjects, removeUndefinedProps } from 'common/util/object'
 const bodySchema = z.object({
   contractId: z.string(),
   betId: z.string(),
-})
+}).strict()
 
 export const sellbet = authEndpoint(async (req, auth) => {
   const { contractId, betId } = validate(bodySchema, req.body)

--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -20,7 +20,7 @@ const bodySchema = z.object({
   contractId: z.string(),
   shares: z.number().positive().optional(), // leave it out to sell all shares
   outcome: z.enum(['YES', 'NO']).optional(), // leave it out to sell whichever you have
-})
+}).strict()
 
 export const sellshares = authEndpoint(async (req, auth) => {
   const { contractId, shares, outcome } = validate(bodySchema, req.body)

--- a/backend/api/src/supabase-search-contract.ts
+++ b/backend/api/src/supabase-search-contract.ts
@@ -31,7 +31,7 @@ const bodySchema = z.object({
   fuzzy: z.boolean().optional(),
   groupId: z.string().regex(FIRESTORE_DOC_REF_ID_REGEX).optional(),
   creatorId: z.string().regex(FIRESTORE_DOC_REF_ID_REGEX).optional(),
-})
+}).strict()
 
 export const supabasesearchcontracts = MaybeAuthedEndpoint(
   async (req, auth) => {

--- a/backend/api/src/supabase-search-groups.ts
+++ b/backend/api/src/supabase-search-groups.ts
@@ -13,7 +13,7 @@ const bodySchema = z.object({
   limit: z.number().gt(0),
   fuzzy: z.boolean().optional(),
   yourGroups: z.boolean().optional(),
-})
+}).strict()
 
 export const supabasesearchgroups = MaybeAuthedEndpoint(async (req, auth) => {
   const { term, offset, limit, fuzzy, yourGroups } = validate(

--- a/backend/api/src/swap-cert.ts
+++ b/backend/api/src/swap-cert.ts
@@ -13,7 +13,7 @@ const bodySchema = z.object({
   amount: z.number(),
   // Assumes 'M$' for now.
   // token: z.enum(['SHARE', 'M$']),
-})
+}).strict()
 
 export const swapcert = authEndpoint(async (req, auth) => {
   return await firestore.runTransaction(async (transaction) => {

--- a/backend/api/src/update-group-member-role.ts
+++ b/backend/api/src/update-group-member-role.ts
@@ -12,7 +12,7 @@ const bodySchema = z.object({
   groupId: z.string(),
   memberId: z.string(),
   role: z.string(),
-})
+}).strict()
 
 export const updatememberrole = authEndpoint(async (req, auth) => {
   const { groupId, memberId, role } = validate(bodySchema, req.body)

--- a/backend/api/src/update-group-privacy.ts
+++ b/backend/api/src/update-group-privacy.ts
@@ -9,7 +9,7 @@ import { APIError, authEndpoint, validate } from './helpers'
 const bodySchema = z.object({
   groupId: z.string(),
   privacy: z.string(),
-})
+}).strict()
 
 export const updategroupprivacy = authEndpoint(async (req, auth) => {
   const { groupId, privacy } = validate(bodySchema, req.body)

--- a/backend/api/src/update-user-embedding.ts
+++ b/backend/api/src/update-user-embedding.ts
@@ -6,7 +6,7 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 
 const bodySchema = z.object({
   userId: z.string(),
-})
+}).strict()
 
 export const updateUserEmbedding = authEndpoint(async (req, auth) => {
   const pg = createSupabaseDirectClient()

--- a/backend/api/src/validate-iap.ts
+++ b/backend/api/src/validate-iap.ts
@@ -14,7 +14,7 @@ import { runTxn } from 'shared/run-txn'
 
 const bodySchema = z.object({
   receipt: z.string(),
-})
+}).strict()
 
 const PRODUCTS_TO_AMOUNTS: { [key: string]: number } = {
   mana_1000: 1000,

--- a/web/pages/api/v0/hide-comment.ts
+++ b/web/pages/api/v0/hide-comment.ts
@@ -19,7 +19,8 @@ const firestore = admin.firestore()
 
 const schema = z.object({
   commentPath: z.string(),
-})
+}).strict()
+
 export type HideCommentReq = {
   // eg 'contracts/iisfjklsd/comments/1jdkisjoof'
   commentPath: string

--- a/web/pages/api/v0/market/[id]/positions.ts
+++ b/web/pages/api/v0/market/[id]/positions.ts
@@ -19,7 +19,8 @@ const queryParams = z.object({
   top: z.number().optional().or(z.string().regex(/\d+/).transform(Number)),
   bottom: z.number().optional().or(z.string().regex(/\d+/).transform(Number)),
   order: z.string().optional(),
-})
+}).strict()
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ContractMetric[] | ValidationError | ApiError>

--- a/web/pages/api/v0/qf/add-pool.ts
+++ b/web/pages/api/v0/qf/add-pool.ts
@@ -21,7 +21,8 @@ const firestore = admin.firestore()
 const schema = z.object({
   qfId: z.string(),
   amount: z.number(),
-})
+}).strict()
+
 export type QfAddPoolReq = {
   qfId: string
   amount: number

--- a/web/pages/api/v0/qf/answer.ts
+++ b/web/pages/api/v0/qf/answer.ts
@@ -22,7 +22,8 @@ const schema = z.object({
   qfId: z.string(),
   text: z.string(),
   receiverId: z.string().optional(),
-})
+}).strict()
+
 export type QfAnswerReq = {
   qfId: string
   text: string

--- a/web/pages/api/v0/qf/pay.ts
+++ b/web/pages/api/v0/qf/pay.ts
@@ -22,7 +22,8 @@ const schema = z.object({
   qfId: z.string(),
   answerId: z.string(),
   amount: z.number(),
-})
+}).strict()
+
 export type QfPayReq = {
   qfId: string
   answerId: string

--- a/web/pages/api/v0/qf/resolve.ts
+++ b/web/pages/api/v0/qf/resolve.ts
@@ -22,7 +22,8 @@ const firestore = admin.firestore()
 
 const schema = z.object({
   qfId: z.string(),
-})
+}).strict()
+
 export type QfResolveReq = {
   qfId: string
 }


### PR DESCRIPTION
Currently any POST request to any of the auth endpoint can have extra parameters unspecified in the schema. This is prone to bugs where the caller expected that their parameter will have an effect on the result of the call, but it didn't.

Example: sending a POST request to the `/sell` endpoint and providing `amount` parameter by mistake (instead of `shares`), which results in all the available shares being sold, instead of the specified amount. The desired behavior in this scenario is to send a status code 400 with a body `{"message": 'Unknown parameter "amount"'}`.

This pull requests adds a `.strict()` call to all `zod` body schemas of all auth endpoints, that will reject any POST request that has extra parameters.

Note, that I'm not sure if is this change breaks any existing server logic, although it might help to reveal some bugs where the caller incorrectly assumed parameters in the endpoint schema.

I'm also unsure how the `.strict()` feature interacts with `z.union`, `z.intersection`, or `z.infer<typeof schema1> & (z.infer<typeof schema2> | {})`, therefore I didn't add any `.strict()` calls to the following files:
```
backend/api/src/create-chat-message.ts
backend/api/src/create-comment.ts
backend/api/src/create-market.ts
backend/api/src/create-post.ts
backend/api/src/resolve-market.ts
```
I request help from more experienced developers to assist or consult me on those cases.
