### PR TITLE
Cap streak forgiveness points to 3

### DIFF
--- a/backend/functions/src/scheduled/increment-streak-forgiveness.ts
+++ b/backend/functions/src/scheduled/increment-streak-forgiveness.ts
@@ -23,7 +23,7 @@ const incrementStreakForgivenessInternal = async () => {
         .collection('users')
         .doc(user.id)
         .update({
-          streakForgiveness: (user.streakForgiveness ?? 0) + 1,
+          streakForgiveness: Math.min((user.streakForgiveness ?? 0) + 1, 3),
         })
     )
   )


### PR DESCRIPTION
This PR is a suggestion which I've raised [here](https://discord.com/channels/915138780216823849/915138780653051910/1109035145303949352) to discuss with other Manifold users and team members.

Currently `user.streakForgiveness` increments every month, and quite a few people accumulated 6 of them already. This will soon enable 1+ week long breaks that won't break the user's prediction streak, which doesn't feel right.

This Pull Request caps the `streakForgiveness` value to 3, during the execution of the `incrementStreakForgivenessInternal` function which runs at the beginning of every month.