### PR TITLE
Clean up some stuff on the `user_seen_markets` table

### DIFF
--- a/backend/scripts/supabase-import.ts
+++ b/backend/scripts/supabase-import.ts
@@ -213,14 +213,6 @@ async function importDatabase(
       timeChunk,
       startTime
     )
-  if (shouldImport('user_seen_markets'))
-    await importCollectionGroup(
-      pg,
-      firestore.collectionGroup('seenMarkets'),
-      'user_seen_markets',
-      (_) => true,
-      2500
-    )
   if (shouldImport('user_notifications'))
     await importCollectionGroup(
       pg,
@@ -348,7 +340,7 @@ if (require.main === module) {
   if (chunk != null) log('Chunking by:', chunk, 'day(s)')
 
   runScript(async ({ pg }) => {
-    await importDatabase(pg, tables, timestamp, chunk)    
+    await importDatabase(pg, tables, timestamp, chunk)
   })
   .then(() => {
     log('Finished importing.')

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -222,14 +222,14 @@ cluster on user_events_name;
 
 create table if not exists
   user_seen_markets (
+    id bigint generated always as identity primary key,
     user_id text not null,
     contract_id text not null,
     data jsonb not null,
     fs_updated_time timestamp not null,
     created_time timestamptz not null default now(),
     -- so far we have: 'view market' or 'view market card'
-    type text not null default 'view market',
-    primary key (user_id, contract_id, created_time)
+    type text not null default 'view market'
   );
 
 alter table user_seen_markets enable row level security;

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -1128,7 +1128,6 @@ begin
            when 'user_follows' then cast(('user_id', 'follow_id') as table_spec)
            when 'user_notifications' then cast(('user_id', 'notification_id') as table_spec)
            when 'user_reactions' then cast(('user_id', 'reaction_id') as table_spec)
-           when 'user_seen_markets' then cast(('user_id', 'contract_id', 'created_time') as table_spec)
            when 'contracts' then cast((null, 'id') as table_spec)
            when 'contract_answers' then cast(('contract_id', 'answer_id') as table_spec)
            when 'contract_bets' then cast(('contract_id', 'bet_id') as table_spec)

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -245,8 +245,6 @@ create policy "user can insert" on user_seen_markets for insert with check (true
 create index if not exists user_seen_markets_created_time_desc_idx
   on user_seen_markets (user_id, contract_id, created_time desc);
 
-create index if not exists user_seen_markets_data_gin on user_seen_markets using GIN (data);
-
 alter table user_seen_markets
 cluster on user_seen_markets_pkey;
 

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -226,7 +226,6 @@ create table if not exists
     user_id text not null,
     contract_id text not null,
     data jsonb not null,
-    fs_updated_time timestamp not null,
     created_time timestamptz not null default now(),
     -- so far we have: 'view market' or 'view market card'
     type text not null default 'view market'

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -48,9 +48,6 @@ export const subcollectionTables: SubcollectionTableMapping = {
     reactions: 'user_reactions',
     notifications: 'user_notifications',
   },
-  'private-users': {
-    seenMarkets: 'user_seen_markets',
-  },
   contracts: {
     answers: 'contract_answers',
     bets: 'contract_bets',


### PR DESCRIPTION
This is urgent because old `user_seen_markets` writes which are conflicting with the broken primary key stuff are currently wedging replication.

- Added autogenerated ID primary column -- the existing primary key didn't make sense for it to be unique.
- Dropped the GIN index. This table is relatively large and GIN indexes are beefy. We have no use for it.
- Dropped `fs_updated_time`.
- Turned off replication on `user_seen_markets` since we are not writing to Firestore anymore.