### PR TITLE
Query "similar users" in following dialog via Supabase

### DIFF
--- a/backend/supabase/functions.sql
+++ b/backend/supabase/functions.sql
@@ -1245,3 +1245,17 @@ or replace function get_engaged_users () returns table (user_id text, username t
       HAVING COUNT(*) >= 3 AND MIN(activity_count) >= 2
   )
 $$ language sql stable;
+
+create or replace function top_creators_for_user(uid text, excluded_ids text[], limit_n int)
+  returns table (user_id text, n float)
+  language sql
+  stable parallel safe
+as $$
+  select c.creator_id as user_id, count(*) as n
+  from contract_bets as cb
+  join contracts as c on c.id = cb.contract_id
+  where cb.user_id = uid and not c.creator_id = any(excluded_ids)
+  group by c.creator_id
+  order by count(*) desc
+  limit limit_n
+$$;

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -2488,6 +2488,17 @@ export interface Database {
         }
         Returns: Json
       }
+      top_creators_for_user: {
+        Args: {
+          uid: string
+          excluded_ids: string[]
+          limit_n: number
+        }
+        Returns: {
+          user_id: string
+          n: number
+        }[]
+      }
       ts_to_millis:
         | {
             Args: {

--- a/web/hooks/use-users.ts
+++ b/web/hooks/use-users.ts
@@ -1,24 +1,23 @@
 import { useState, useEffect } from 'react'
 import { User } from 'common/user'
-import { debounce, groupBy, sortBy } from 'lodash'
-import { getUserBetContracts } from 'web/lib/firebase/contracts'
-import { searchUsers, UserSearchResult } from 'web/lib/supabase/users'
+import { debounce } from 'lodash'
+import {
+  getTopUserCreators,
+  searchUsers,
+  UserSearchResult
+} from 'web/lib/supabase/users'
 
-export const useDiscoverUsers = (userId: string | null | undefined) => {
+export const useDiscoverUsers = (
+  userId: string | null | undefined,
+  excludedUserIds: string[],
+  limit: number
+) => {
   const [discoverUserIds, setDiscoverUserIds] = useState<string[] | undefined>()
 
   useEffect(() => {
     if (userId)
-      getUserBetContracts(userId).then((contracts) => {
-        const creatorCounts = Object.entries(
-          groupBy(contracts, 'creatorId')
-        ).map(([id, contracts]) => [id, contracts.length] as const)
-
-        const topCreatorIds = sortBy(creatorCounts, ([_, i]) => i)
-          .map(([id]) => id)
-          .reverse()
-
-        setDiscoverUserIds(topCreatorIds)
+      getTopUserCreators(userId, excludedUserIds, limit).then((rows) => {
+        setDiscoverUserIds(rows.map(r => r.user_id))
       })
   }, [userId])
 

--- a/web/lib/firebase/contracts.ts
+++ b/web/lib/firebase/contracts.ts
@@ -101,19 +101,6 @@ export async function listAllContracts(
   return snapshot.docs.map((doc) => doc.data())
 }
 
-export function getUserBetContracts(userId: string) {
-  return getValues<Contract>(getUserBetContractsQuery(userId))
-}
-
-export const MAX_USER_BET_CONTRACTS_LOADED = 1000
-export function getUserBetContractsQuery(userId: string) {
-  return query(
-    contracts,
-    where('uniqueBettorIds', 'array-contains', userId),
-    limit(MAX_USER_BET_CONTRACTS_LOADED)
-  ) as Query<Contract>
-}
-
 export function listenForContract(
   contractId: string,
   setContract: (contract: Contract | null) => void

--- a/web/lib/supabase/users.ts
+++ b/web/lib/supabase/users.ts
@@ -125,3 +125,18 @@ export async function getTopCreators(period: Period) {
   )
   return data
 }
+
+export async function getTopUserCreators(
+  userId: string,
+  excludedUserIds: string[],
+  limit: number
+) {
+  const { data } = await run(
+    db.rpc('top_creators_for_user', {
+      uid: userId,
+      excluded_ids: excludedUserIds,
+      limit_n: limit
+    }))
+  // work around rpc typing bug
+  return data as unknown as { user_id: string, n: number }[]
+}

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -447,19 +447,11 @@ function FollowsDialog(props: {
 
   const currentUser = useUser()
   const myFollowedIds = useFollows(currentUser?.id)
-
-  // mqp: this is a ton of work, don't fetch it unless someone looks.
-  // if you want it to be faster, then you gotta precompute stuff for it somewhere
-  const discoverUserIds = useDiscoverUsers(isOpen ? user.id : undefined)
-  const nonSuggestions = [
-    user?.id ?? '',
-    currentUser?.id ?? '',
-    ...(myFollowedIds ?? []),
-  ]
-  const suggestedUserIds =
-    discoverUserIds == null
-      ? undefined
-      : difference(discoverUserIds, nonSuggestions).slice(0, 50)
+  const suggestedUserIds = useDiscoverUsers(
+    isOpen ? user.id : undefined, // don't bother fetching this unless someone looks
+    myFollowedIds ?? [],
+    50
+  )
 
   usePrefetchUsers([
     ...(followerIds ?? []),


### PR DESCRIPTION
Now this is much more efficient, which is nice, but really this is important because this was using the contract `uniqueBettorIds`, which we are preparing to throw out. CC @IanPhilips 