### PR TITLE
Fix issues with rendering zero-sized charts

### DIFF
--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -229,6 +229,10 @@ export const SVGChart = <X, TT>(props: {
     onMouseLeave?.()
   }
 
+  if (innerW <= 0 || innerH <= 0) { // i.e. chart is smaller than margin
+    return null;
+  }
+
   return (
     <div className="relative overflow-hidden">
       {ttParams && Tooltip && (

--- a/web/components/sized-container.tsx
+++ b/web/components/sized-container.tsx
@@ -30,7 +30,7 @@ export const SizedContainer = (props: {
   }, [threshold, fullHeight, mobileHeight])
   return (
     <div ref={containerRef} className={className}>
-      {width != null && height != null ? (
+      {width && height ? (
         children(width, height)
       ) : (
         <>


### PR DESCRIPTION
In some cases the `SizedContainer` would be of size zero during initial page render, and rendering zero-sized charts was A) a waste of time B) causing warnings to fly out. So let's not do that.