### PR TITLE
Don't subscribe to contracts in some places

### DIFF
--- a/web/components/contract/contracts-table.tsx
+++ b/web/components/contract/contracts-table.tsx
@@ -7,7 +7,6 @@ import { ENV_CONFIG } from 'common/envs/constants'
 import { getFormattedMappedValue } from 'common/pseudo-numeric'
 import { formatPercentShort } from 'common/util/format'
 import { IoUnlink } from 'react-icons/io5'
-import { useContract } from 'web/hooks/use-contracts'
 import { useUser } from 'web/hooks/use-user'
 import { getTextColor } from '../bet/quick-bet'
 import { ContractMinibar } from '../charts/minibar'
@@ -167,7 +166,7 @@ export function ContractsTable(props: {
   ]
 
   function ContractRow(props: { contract: Contract }) {
-    const contract = useContract(props.contract.id) ?? props.contract
+    const contract = props.contract
     const contractListEntryHighlightClass =
       'bg-gradient-to-b from-primary-100 via-ink-0 to-ink-0 outline outline-2 outline-primary-400'
 

--- a/web/components/contract/prob-change-table.tsx
+++ b/web/components/contract/prob-change-table.tsx
@@ -6,7 +6,6 @@ import { ContractStatusLabel } from './contracts-table'
 import clsx from 'clsx'
 import Link from 'next/link'
 import { forwardRef } from 'react'
-import { useContract } from 'web/hooks/use-contracts'
 import { Avatar } from '../widgets/avatar'
 import { Row } from '../layout/row'
 import { formatPercentShort } from 'common/util/format'
@@ -44,9 +43,7 @@ const ContractWithProbChange = forwardRef(
     },
     ref: React.Ref<HTMLAnchorElement>
   ) => {
-    const { onContractClick, className } = props
-    const contract = (useContract(props.contract.id) ??
-      props.contract) as CPMMContract
+    const { contract, onContractClick, className } = props
     const {
       creatorUsername,
       creatorAvatarUrl,

--- a/web/components/contract/related-contracts-widget.tsx
+++ b/web/components/contract/related-contracts-widget.tsx
@@ -9,7 +9,6 @@ import { LoadMoreUntilNotVisible } from '../widgets/visibility-observer'
 import { Avatar } from '../widgets/avatar'
 import { UserLink } from '../widgets/user-link'
 import { ContractStatusLabel } from './contracts-table'
-import { useContract } from 'web/hooks/use-contracts'
 
 export const RelatedContractsList = memo(function RelatedContractsList(props: {
   contracts: Contract[]
@@ -51,9 +50,7 @@ const RelatedContractCard = memo(function RelatedContractCard(props: {
   contract: Contract
   onContractClick?: (contract: Contract) => void
 }) {
-  const { onContractClick } = props
-
-  const contract = useContract(props.contract.id) ?? props.contract
+  const { contract, onContractClick } = props
   const { creatorUsername, creatorAvatarUrl, question, creatorCreatedTime } =
     contract
 

--- a/web/pages/todays-updates.tsx
+++ b/web/pages/todays-updates.tsx
@@ -14,7 +14,6 @@ import { Row } from 'web/components/layout/row'
 import { Avatar } from 'web/components/widgets/avatar'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
 import { Title } from 'web/components/widgets/title'
-import { useContract } from 'web/hooks/use-contracts'
 import { useUser } from 'web/hooks/use-user'
 import { useYourDailyChangedContracts } from 'web/hooks/use-your-daily-changed-contracts'
 import { db } from 'web/lib/supabase/db'
@@ -101,9 +100,7 @@ const ContractChangeRow = forwardRef(
     },
     ref: React.Ref<HTMLAnchorElement>
   ) => {
-    const { metrics, onContractClick, className } = props
-    const contract = (useContract(props.contract.id) ??
-      props.contract) as CPMMContract
+    const { contract, metrics, onContractClick, className } = props
     const {
       creatorUsername,
       creatorAvatarUrl,


### PR DESCRIPTION
General philosophy: If the contract is not the focus of the page, and if users can't bet on it without clicking through, it's not really worth subscribing to changes on it. That's the case for related markets on the contract page, list mode search result contracts, and "today's changes" on the homepage.