### PR TITLE
Improve efficiency of `updateContractMetrics`

### DIFF
--- a/backend/supabase/functions.sql
+++ b/backend/supabase/functions.sql
@@ -536,16 +536,6 @@ end;
 end $$;
 
 create
-or replace function get_cpmm_resolved_prob (data jsonb) returns numeric language sql immutable parallel safe as $$
-select case
-    when data->>'resolution' = 'YES' then 1
-    when data->>'resolution' = 'NO' then 0
-    when data->>'resolution' = 'MKT'
-    and data ? 'resolutionProbability' then (data->'resolutionProbability')::numeric
-    else null
-  end $$;
-
-create
 or replace function ts_to_millis (ts timestamptz) returns bigint language sql immutable parallel safe as $$
 select (
     extract(

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -471,9 +471,6 @@ create index if not exists contract_bets_data_gin on contract_bets using GIN (da
 /* serves bets API pagination */
 create index if not exists contract_bets_bet_id on contract_bets (bet_id);
 
-/* serving stats page, recent bets API */
-create index if not exists contract_bets_created_time_global on contract_bets (created_time desc);
-
 /* serving activity feed bets list */
 create index if not exists contract_bets_activity_feed on contract_bets (is_ante, is_redemption, created_time desc);
 

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -477,11 +477,13 @@ create index if not exists contract_bets_created_time_global on contract_bets (c
 /* serving activity feed bets list */
 create index if not exists contract_bets_activity_feed on contract_bets (is_ante, is_redemption, created_time desc);
 
+/* serving update contract metrics */
+create index if not exists contract_bets_historical_probs
+  on contract_bets (created_time)
+  include (contract_id, prob_before, prob_after);
+
 /* serving e.g. the contract page recent bets and the "bets by contract" API */
 create index if not exists contract_bets_created_time on contract_bets (contract_id, created_time desc);
-
-/* serving update contract metrics*/
-create index if not exists contract_bets_created_time_asc on contract_bets (contract_id, created_time);
 
 /* serving "my trades on a contract" kind of queries */
 create index if not exists contract_bets_contract_user_id on contract_bets (contract_id, user_id, created_time desc);


### PR DESCRIPTION
- Previously, this would get all the current probabilities for all contracts redundantly in each "historical snapshot" query for each time period, which was redundant.
- Now there is a covering index that has the probabilities in it, so the historical snapshot queries can do an index-only scan.

CC @IanPhilips since you were interested in this.