### PR TITLE
Removing bot tag from firstuserhere

### DIFF
--- a/common/src/envs/constants.ts
+++ b/common/src/envs/constants.ts
@@ -95,7 +95,6 @@ export const BOT_USERNAMES = [
   'MetaculusBot',
   'KevinBurke',
   'Botflux',
-  'firstuserhere',
 ]
 
 export const CORE_USERNAMES = [


### PR DESCRIPTION
Removing bot tag from firstuserhere as I am no longer using automated trading from the API 