### PR TITLE
common/src/envs: add different bot user for Kevin

### DIFF
--- a/common/src/envs/constants.ts
+++ b/common/src/envs/constants.ts
@@ -93,7 +93,7 @@ export const BOT_USERNAMES = [
   'Turbot',
   'MiraBot',
   'MetaculusBot',
-  'KevinBurke',
+  'burkebot',
   'Botflux',
   '7'
 ]
@@ -149,6 +149,7 @@ export const CHECK_USERNAMES = [
   'KatjaGrace',
   'AndrewG',
   'MarcusAbramovitch',
+  'KevinBurke',
 ]
 
 export const HOUSE_BOT_USERNAME = 'acc'


### PR DESCRIPTION
I'm going to do automated trades from the "burkebot" account now, and use my existing account just for web/UI trades.

I had a "check" account before I got labeled a bot and would be great to have that back.