### PR TITLE
Ingawei/feed tweaks

### DIFF
--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -57,6 +57,7 @@ export function BuyPanel(props: {
   hidden: boolean
   onBuySuccess?: () => void
   mobileView?: boolean
+  singularView?: 'YES' | 'NO'
   initialOutcome?: binaryOutcomes
   location?: string
   className?: string
@@ -67,6 +68,7 @@ export function BuyPanel(props: {
     hidden,
     onBuySuccess,
     mobileView,
+    singularView,
     initialOutcome,
     location = 'bet panel',
     className,
@@ -204,7 +206,12 @@ export function BuyPanel(props: {
 
   return (
     <Col className={clsx(className, hidden ? 'hidden' : '')}>
-      <Row className="mb-2 w-full items-center gap-3">
+      <Row
+        className={clsx(
+          'mb-2 w-full items-center gap-3',
+          singularView ? 'hidden' : ''
+        )}
+      >
         <YesNoSelector
           className="flex-1"
           btnClassName="flex-1"
@@ -232,30 +239,18 @@ export function BuyPanel(props: {
 
       <Col
         className={clsx(
-          outcome === 'NO'
-            ? 'bg-red-500/10'
-            : outcome === 'YES'
-            ? 'bg-teal-500/10'
-            : 'hidden',
-          'rounded-lg px-4 py-2'
+          !singularView
+            ? outcome === 'NO'
+              ? 'bg-red-500/10'
+              : outcome === 'YES'
+              ? 'bg-teal-500/10'
+              : 'hidden'
+            : '',
+          'rounded-lg',
+          singularView ? '' : ' px-4 py-2'
         )}
       >
-        <div className="text-ink-800 mt-2 mb-1 text-sm">Amount</div>
-
-        <BuyAmountInput
-          inputClassName="w-full max-w-none"
-          amount={betAmount}
-          onChange={onBetChange}
-          error={displayError ? error : undefined}
-          setError={setError}
-          disabled={isSubmitting}
-          inputRef={inputRef}
-          sliderOptions={{ show: true, wrap: false }}
-          binaryOutcome={outcome}
-          showBalance
-        />
-
-        <Row className="mt-8 w-full">
+        <Row className=" w-full">
           <Col className="w-1/2 text-sm">
             <Col className="text-ink-800 flex-nowrap whitespace-nowrap text-sm">
               <div>
@@ -327,8 +322,22 @@ export function BuyPanel(props: {
             )}
           </Col>
         </Row>
+        <Spacer h={2} />
+        <div className="text-ink-800 mt-2 mb-1 text-sm">Amount</div>
 
-        <Spacer h={8} />
+        <BuyAmountInput
+          inputClassName="w-full max-w-none"
+          amount={betAmount}
+          onChange={onBetChange}
+          error={displayError ? error : undefined}
+          setError={setError}
+          disabled={isSubmitting}
+          inputRef={inputRef}
+          sliderOptions={{ show: true, wrap: false }}
+          binaryOutcome={outcome}
+          showBalance
+        />
+        <Spacer h={6} />
         {user && (
           <WarningConfirmationButton
             marketType="binary"

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -250,16 +250,14 @@ export function BuyPanel(props: {
           singularView ? '' : ' px-4 py-2'
         )}
       >
-        <Row className=" w-full">
-          <Col className="w-1/2 text-sm">
-            <Col className="text-ink-800 flex-nowrap whitespace-nowrap text-sm">
-              <div>
-                {isPseudoNumeric || isStonk ? (
-                  'Shares'
-                ) : (
-                  <>Payout if {outcome ?? 'YES'}</>
-                )}
-              </div>
+        <Row className="border-ink-200 w-full rounded border px-4 py-2">
+          <Col className="w-1/2">
+            <Col className="text-ink-400 flex-nowrap whitespace-nowrap text-xs">
+              {isPseudoNumeric || isStonk ? (
+                'Shares'
+              ) : (
+                <>Payout if {outcome ?? 'YES'}</>
+              )}
             </Col>
             <div>
               <span className="whitespace-nowrap text-lg font-semibold">
@@ -276,7 +274,7 @@ export function BuyPanel(props: {
           </Col>
           <Col className="w-1/2 text-sm">
             <Row>
-              <span className="text-ink-800 whitespace-nowrap text-sm">
+              <span className="text-ink-400 whitespace-nowrap text-xs">
                 {isPseudoNumeric
                   ? 'Estimated value'
                   : isStonk
@@ -286,7 +284,8 @@ export function BuyPanel(props: {
               {!isPseudoNumeric && !isStonk && (
                 <InfoTooltip
                   text={`The probability of YES after your ${SINGULAR_BET}`}
-                  className="ml-1"
+                  className="text-ink-400 ml-1"
+                  size="sm"
                 />
               )}
             </Row>

--- a/web/components/bet/bet-row.tsx
+++ b/web/components/bet/bet-row.tsx
@@ -48,7 +48,7 @@ function FeedBetButton(props: {
     <>
       <button
         className={clsx(
-          'border-ink-300 hover:text-canvas-0 border px-2 py-1 transition-colors',
+          'border-ink-300 hover:text-canvas-0 whitespace-nowrap border px-2 py-1 transition-colors',
           outcome == 'YES'
             ? 'rounded-l border-r-0 text-teal-500 hover:bg-teal-500'
             : 'text-scarlet-500 hover:bg-scarlet-500 rounded-r'
@@ -62,7 +62,7 @@ function FeedBetButton(props: {
           setDialogueThatIsOpen(outcome)
         }}
       >
-        {outcome}
+        Bet <span>{outcome}</span>
       </button>
 
       <Modal

--- a/web/components/bet/bet-row.tsx
+++ b/web/components/bet/bet-row.tsx
@@ -1,60 +1,96 @@
-import { useState } from 'react'
+import clsx from 'clsx'
 import { CPMMBinaryContract } from 'common/contract'
-import { Button } from '../buttons/button'
-import { BetDialog } from './bet-dialog'
-import { binaryOutcomes } from './bet-panel'
-import { firebaseLogin } from 'web/lib/firebase/users'
+import { useState } from 'react'
+import { User, firebaseLogin } from 'web/lib/firebase/users'
+import { Col } from '../layout/col'
+import { MODAL_CLASS, Modal } from '../layout/modal'
+import { Row } from '../layout/row'
+import { Subtitle } from '../widgets/subtitle'
+import { BuyPanel, binaryOutcomes } from './bet-panel'
 
 export function BetRow(props: {
   contract: CPMMBinaryContract
-  noUser?: boolean
+  user: User | null | undefined
 }) {
-  const { contract, noUser } = props
-  const [outcome, setOutcome] = useState<binaryOutcomes>()
-  const [betDialogOpen, setBetDialogOpen] = useState(false)
+  const { contract, user } = props
+  const [dialogueThatIsOpen, setDialogueThatIsOpen] =
+    useState<binaryOutcomes>(undefined)
+  return (
+    <Row>
+      <FeedBetButton
+        dialogueThatIsOpen={dialogueThatIsOpen}
+        setDialogueThatIsOpen={setDialogueThatIsOpen}
+        contract={contract}
+        outcome="YES"
+        user={user}
+      />
+      <FeedBetButton
+        dialogueThatIsOpen={dialogueThatIsOpen}
+        setDialogueThatIsOpen={setDialogueThatIsOpen}
+        contract={contract}
+        outcome="NO"
+        user={user}
+      />
+    </Row>
+  )
+}
 
+function FeedBetButton(props: {
+  dialogueThatIsOpen: binaryOutcomes
+  setDialogueThatIsOpen: (outcome: binaryOutcomes) => void
+  contract: CPMMBinaryContract
+  outcome: 'YES' | 'NO'
+  user?: User | null | undefined
+}) {
+  const { dialogueThatIsOpen, setDialogueThatIsOpen, contract, outcome, user } =
+    props
   return (
     <>
-      <Button
-        size="2xs"
-        color="gray-outline"
-        className="!ring-1"
+      <button
+        className={clsx(
+          'border-ink-300 hover:text-canvas-0 border px-2 py-1 transition-colors',
+          outcome == 'YES'
+            ? 'rounded-l border-r-0 text-teal-500 hover:bg-teal-500'
+            : 'text-scarlet-500 hover:bg-scarlet-500 rounded-r'
+        )}
         onClick={(e) => {
           e.stopPropagation()
-          if (noUser) {
+          if (!user) {
             firebaseLogin()
             return
           }
-          setOutcome('YES')
-          setBetDialogOpen(true)
+          setDialogueThatIsOpen(outcome)
         }}
       >
-        Bet YES
-      </Button>
-      <Button
-        size="2xs"
-        color="gray-outline"
-        className="!ring-1"
-        onClick={(e) => {
-          e.stopPropagation()
-          if (noUser) {
-            firebaseLogin()
-            return
-          }
-          setOutcome('NO')
-          setBetDialogOpen(true)
-        }}
-      >
-        Bet NO
-      </Button>
+        {outcome}
+      </button>
 
-      <BetDialog
-        contract={contract}
-        initialOutcome={outcome}
-        open={betDialogOpen}
-        setOpen={setBetDialogOpen}
-        trackingLocation="contract card"
-      />
+      <Modal
+        open={dialogueThatIsOpen == outcome}
+        setOpen={(open) => {
+          setDialogueThatIsOpen(open ? outcome : undefined)
+        }}
+        className={clsx(
+          MODAL_CLASS,
+          'pointer-events-auto max-h-[32rem] overflow-auto'
+        )}
+      >
+        <Col>
+          <div className="!mt-0 !mb-4 !text-xl">{contract.question}</div>
+          <BuyPanel
+            contract={contract}
+            user={user}
+            mobileView={true}
+            hidden={false}
+            initialOutcome={outcome}
+            onBuySuccess={() =>
+              setTimeout(() => setDialogueThatIsOpen(undefined), 500)
+            }
+            location={'feed card'}
+            singularView={outcome}
+          />
+        </Col>
+      </Modal>
     </>
   )
 }

--- a/web/components/bet/quick-bet.tsx
+++ b/web/components/bet/quick-bet.tsx
@@ -507,7 +507,7 @@ export function ContractCardAnswers(props: {
     return <div>No answers yet...</div>
   }
   return (
-    <Col className="gap-2">
+    <Col className="w-full gap-2">
       {answers.map((answer) => (
         <ContractCardAnswer
           key={answer.id}

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -253,6 +253,7 @@ function GroupDisplay(props: {
       legacyBehavior
       onClick={(e) => {
         e.preventDefault()
+        e.stopPropagation()
       }}
     >
       <a

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -180,25 +180,47 @@ export function CloseOrResolveTime(props: {
   } else return <></>
 }
 
-function PublicMarketGroups(props: { contract: Contract }) {
+export function PublicMarketGroups(props: {
+  contract: Contract
+  className?: string
+  justGroups?: boolean
+}) {
   const [open, setOpen] = useState(false)
   const user = useUser()
-  const { contract } = props
+  const { contract, className, justGroups } = props
   const groupsToDisplay = getGroupLinksToDisplay(contract)
 
   return (
     <>
-      <Row className="w-full flex-wrap items-end gap-1">
+      <Row
+        className={clsx(
+          'w-full flex-wrap items-end gap-1',
+          (!groupsToDisplay || groupsToDisplay.length == 0) && justGroups
+            ? 'hidden'
+            : '',
+          className
+        )}
+      >
         {groupsToDisplay.map((group) => (
           <GroupDisplay key={group.groupId} groupToDisplay={group} />
         ))}
 
         {user && (
-          <button onClick={() => setOpen(true)}>
+          <button
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              setOpen(true)
+            }}
+          >
             {groupsToDisplay.length ? (
               <DotsCircleHorizontalIcon className="text-ink-400 hover:text-ink-400/75 h-6" />
             ) : (
-              <span className="bg-ink-400 hover:bg-ink-400/75 text-ink-0 flex items-center rounded-full py-0.5 px-2 text-sm">
+              <span
+                className={clsx(
+                  'bg-ink-400 hover:bg-ink-400/75 text-ink-0 flex items-center rounded-full py-0.5 px-2 text-sm'
+                )}
+              >
                 <PlusIcon className="mr-1 h-4 w-4" /> Group
               </span>
             )}
@@ -225,7 +247,14 @@ function GroupDisplay(props: {
   const { groupToDisplay, isPrivate } = props
 
   return (
-    <Link prefetch={false} href={groupPath(groupToDisplay.slug)} legacyBehavior>
+    <Link
+      prefetch={false}
+      href={groupPath(groupToDisplay.slug)}
+      legacyBehavior
+      onClick={(e) => {
+        e.preventDefault()
+      }}
+    >
       <a
         className={clsx(
           'w-fit max-w-[200px] truncate whitespace-nowrap rounded-full py-0.5 px-2 text-sm sm:max-w-[250px]',

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -1,6 +1,5 @@
 import { ClockIcon, UserGroupIcon } from '@heroicons/react/outline'
 import {
-  DotsCircleHorizontalIcon,
   FireIcon,
   LockClosedIcon,
   PencilIcon,
@@ -32,6 +31,7 @@ import {
 import { Title } from '../widgets/title'
 import { useIsClient } from 'web/hooks/use-is-client'
 import { Input } from '../widgets/input'
+import { IoEllipsisHorizontal } from 'react-icons/io5'
 
 export type ShowTime = 'resolve-date' | 'close-date'
 
@@ -214,14 +214,15 @@ export function PublicMarketGroups(props: {
             }}
           >
             {groupsToDisplay.length ? (
-              <DotsCircleHorizontalIcon className="text-ink-400 hover:text-ink-400/75 h-6" />
+              <IoEllipsisHorizontal className="text-ink-1000 bg-ink-100 hover:bg-ink-200 h-6 w-6 rounded-full bg-opacity-90 px-1" />
             ) : (
               <span
                 className={clsx(
                   'bg-ink-400 hover:bg-ink-400/75 text-ink-0 flex items-center rounded-full py-0.5 px-2 text-sm'
                 )}
               >
-                <PlusIcon className="mr-1 h-4 w-4" /> Group
+                <PlusIcon className="text-ink-1000 bg-ink-100 hover:bg-ink-200 mr-1 h-4 w-4" />{' '}
+                Group
               </span>
             )}
           </button>
@@ -258,7 +259,7 @@ function GroupDisplay(props: {
     >
       <a
         className={clsx(
-          'w-fit max-w-[200px] truncate whitespace-nowrap rounded-full py-0.5 px-2 text-sm sm:max-w-[250px]',
+          'text-ink-1000 bg-ink-100 hover:bg-ink-200 w-fit max-w-[200px] truncate whitespace-nowrap rounded-full bg-opacity-90 py-0.5 px-2 text-sm sm:max-w-[250px]',
           isPrivate
             ? 'text-ink-1000 bg-indigo-200 dark:bg-indigo-700'
             : 'bg-ink-400 text-ink-0'

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -335,7 +335,7 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
   )
 })
 
-const BetsTabContent = memo(function BetsTabContent(props: {
+export const BetsTabContent = memo(function BetsTabContent(props: {
   contract: Contract
   bets: Bet[]
   setReplyToBet?: (bet: Bet) => void

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -339,8 +339,9 @@ export const BetsTabContent = memo(function BetsTabContent(props: {
   contract: Contract
   bets: Bet[]
   setReplyToBet?: (bet: Bet) => void
+  scrollToTop?: boolean
 }) {
-  const { contract, setReplyToBet } = props
+  const { contract, setReplyToBet, scrollToTop = true } = props
   const [olderBets, setOlderBets] = useState<Bet[]>([])
   const [page, setPage] = useState(0)
   const ITEMS_PER_PAGE = 50
@@ -426,7 +427,7 @@ export const BetsTabContent = memo(function BetsTabContent(props: {
         itemsPerPage={ITEMS_PER_PAGE}
         totalItems={totalItems}
         setPage={setPage}
-        UNSAFE_scrollToTop
+        UNSAFE_scrollToTop={scrollToTop}
       />
     </>
   )

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -30,6 +30,7 @@ import { UserLink } from '../widgets/user-link'
 import { ContractStatusLabel } from './contracts-table'
 import { LikeButton } from './like-button'
 import { useFirebasePublicAndRealtimePrivateContract } from 'web/hooks/use-contract-supabase'
+import { QuickOutcomeView } from '../bet/quick-bet'
 
 export function FeedContractCard(props: {
   contract: Contract
@@ -107,6 +108,22 @@ export function FeedContractCard(props: {
     >
       <Col className="bg-canvas-0 gap-2 p-4 py-2">
         {/* Title is link to contract for open in new tab and a11y */}
+        <Row className="justify-between">
+          <Row onClick={(e) => e.stopPropagation()} className="gap-2">
+            <Avatar username={creatorUsername} avatarUrl={creatorAvatarUrl} />
+            <Col>
+              <UserLink
+                name={creatorName}
+                username={creatorUsername}
+                createdTime={creatorCreatedTime}
+              />
+              <div className="text-ink-500 text-sm">
+                created {fromNow(contract.createdTime)}
+              </div>
+            </Col>
+          </Row>
+          {promotedData && <BoostPill />}
+        </Row>
         <Link
           href={path}
           className={clsx(
@@ -123,62 +140,14 @@ export function FeedContractCard(props: {
           {question}
         </Link>
 
-        <Row className="text-ink-600 items-center gap-3 overflow-hidden text-sm">
-          <Row className="gap-2" onClick={(e) => e.stopPropagation()}>
-            <Avatar
-              username={creatorUsername}
-              avatarUrl={creatorAvatarUrl}
-              size="xs"
-            />
-            <UserLink
-              name={creatorName}
-              username={creatorUsername}
-              className="text-ink-600 h-[24px] text-sm"
-              createdTime={creatorCreatedTime}
-            />
-          </Row>
-          <div className="flex-1" />
-          {promotedData ? (
-            <BoostPill />
-          ) : (
-            <ReasonChosen contract={contract} reason={reason} />
-          )}
-        </Row>
-
         <Row ref={ref} className="text-ink-500 items-center gap-3 text-sm">
-          <div className="text-base font-semibold">
-            <ContractStatusLabel contract={contract} chanceLabel />
-          </div>
+          <QuickOutcomeView contract={contract} />
 
           {isBinaryCpmm && (
             <div className="flex gap-2">
-              <BetRow contract={contract} noUser={!user} />
+              <BetRow contract={contract} user={user} />
             </div>
           )}
-
-          <Row
-            className="ml-auto items-center gap-1"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center gap-1.5 p-1">
-              <LikeButton
-                contentId={contract.id}
-                contentCreatorId={contract.creatorId}
-                user={user}
-                contentType={'contract'}
-                totalLikes={contract.likedByUserCount ?? 0}
-                contract={contract}
-                contentText={question}
-                showTotalLikesUnder
-                size="md"
-                color="gray"
-                className="!px-0"
-                trackingLocation={'contract card (feed)'}
-              />
-            </div>
-
-            <CommentsButton contract={contract} user={user} />
-          </Row>
         </Row>
 
         {isBinaryCpmm && metrics && metrics.hasShares && (
@@ -208,6 +177,26 @@ export function FeedContractCard(props: {
           </div>
         </>
       )}
+      <Row className="justify-between" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-1.5 p-1">
+          <LikeButton
+            contentId={contract.id}
+            contentCreatorId={contract.creatorId}
+            user={user}
+            contentType={'contract'}
+            totalLikes={contract.likedByUserCount ?? 0}
+            contract={contract}
+            contentText={question}
+            showTotalLikesUnder
+            size="md"
+            color="gray"
+            className="!px-0"
+            trackingLocation={'contract card (feed)'}
+          />
+        </div>
+
+        <CommentsButton contract={contract} user={user} />
+      </Row>
     </div>
   )
 }

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -31,6 +31,9 @@ import { ContractStatusLabel } from './contracts-table'
 import { LikeButton } from './like-button'
 import { useFirebasePublicAndRealtimePrivateContract } from 'web/hooks/use-contract-supabase'
 import { QuickOutcomeView } from '../bet/quick-bet'
+import { TradesButton } from './trades-button'
+import { getGroupLinksToDisplay } from 'common/group'
+import { PublicMarketGroups } from './contract-details'
 
 export function FeedContractCard(props: {
   contract: Contract
@@ -94,7 +97,7 @@ export function FeedContractCard(props: {
     <div
       className={clsx(
         'relative',
-        'group flex cursor-pointer flex-col overflow-hidden',
+        'bg-canvas-0 group flex cursor-pointer flex-col overflow-hidden',
         'outline-none transition-colors',
         className
       )}
@@ -122,7 +125,7 @@ export function FeedContractCard(props: {
               </div>
             </Col>
           </Row>
-          {promotedData && <BoostPill />}
+          {promotedData && <ClaimButton {...promotedData} />}
         </Row>
         <Link
           href={path}
@@ -153,20 +156,11 @@ export function FeedContractCard(props: {
         {isBinaryCpmm && metrics && metrics.hasShares && (
           <YourMetricsFooter metrics={metrics} />
         )}
-
-        {!showImage && promotedData && (
-          <div className="flex justify-center">
-            <ClaimButton {...promotedData} />
-          </div>
-        )}
       </Col>
 
       {showImage && (
         <div className="relative">
-          <div className="flex h-40 w-full items-center justify-center">
-            {promotedData && <ClaimButton {...promotedData} className="mt-2" />}
-          </div>
-          <div className="absolute inset-0 -z-10 transition-all group-hover:saturate-150">
+          <div className="absolute inset-0 bg-transparent transition-all group-hover:saturate-150">
             <Image
               fill
               alt=""
@@ -177,10 +171,22 @@ export function FeedContractCard(props: {
           </div>
         </div>
       )}
+      <PublicMarketGroups
+        contract={contract}
+        className={'px-4 pt-2 pb-4'}
+        justGroups={true}
+      />
+      {!showImage ||
+        (contract.groupLinks && (
+          <div className="w-full">
+            <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
+          </div>
+        ))}
       <Row
-        className="bg-canvas-0 justify-between gap-2 px-4 py-2"
+        className="justify-between gap-2 px-4 py-1"
         onClick={(e) => e.stopPropagation()}
       >
+        <TradesButton contract={contract} />
         <div className="flex items-center gap-1.5 p-1">
           <LikeButton
             contentId={contract.id}
@@ -197,7 +203,6 @@ export function FeedContractCard(props: {
             trackingLocation={'contract card (feed)'}
           />
         </div>
-
         <CommentsButton contract={contract} user={user} />
       </Row>
     </div>
@@ -374,10 +379,11 @@ function ClaimButton(props: {
   return (
     <button
       className={clsx(
-        'rounded-lg bg-yellow-300 bg-gradient-to-br from-yellow-400 via-yellow-200 to-yellow-300 py-2.5 px-6 font-semibold text-gray-900 transition-colors',
+        'h-min rounded-full bg-yellow-300 bg-gradient-to-br from-yellow-400 via-yellow-200 to-yellow-300 py-1 px-2 font-semibold text-gray-900 transition-colors',
         'hover:via-yellow-100 focus:via-yellow-100',
         'disabled:bg-canvas-50 disabled:text-ink-800 disabled:cursor-default disabled:bg-none',
-        className
+        className,
+        'text-sm'
       )}
       disabled={loading || claimed}
       onClick={async (e) => {
@@ -403,7 +409,7 @@ function ClaimButton(props: {
       ) : loading ? (
         <LoadingIndicator />
       ) : (
-        `Claim ${formatMoney(reward)}`
+        `Claim ${formatMoney(reward)} Boost`
       )}
     </button>
   )

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -42,8 +42,9 @@ export function FeedContractCard(props: {
   trackingPostfix?: string
   className?: string
   reason?: string
+  hasItems?: boolean
 }) {
-  const { className, promotedData, reason, trackingPostfix } = props
+  const { className, promotedData, reason, trackingPostfix, hasItems } = props
   const user = useUser()
 
   const contract =
@@ -173,38 +174,42 @@ export function FeedContractCard(props: {
       )}
       <PublicMarketGroups
         contract={contract}
-        className={'px-4 pt-2 pb-4'}
+        className={'px-4 py-2'}
         justGroups={true}
       />
-      {!showImage ||
-        (contract.groupLinks && (
-          <div className="w-full">
-            <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
+      <div className=" mt-2 w-full">
+        <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
+      </div>
+      <Col className="relative">
+        <Row
+          className="justify-between gap-2 px-4 py-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <TradesButton contract={contract} />
+          <div className="flex items-center gap-1.5 p-1">
+            <LikeButton
+              contentId={contract.id}
+              contentCreatorId={contract.creatorId}
+              user={user}
+              contentType={'contract'}
+              totalLikes={contract.likedByUserCount ?? 0}
+              contract={contract}
+              contentText={question}
+              showTotalLikesUnder
+              size="md"
+              color="gray"
+              className="!px-0"
+              trackingLocation={'contract card (feed)'}
+            />
           </div>
-        ))}
-      <Row
-        className="justify-between gap-2 px-4 py-1"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <TradesButton contract={contract} />
-        <div className="flex items-center gap-1.5 p-1">
-          <LikeButton
-            contentId={contract.id}
-            contentCreatorId={contract.creatorId}
-            user={user}
-            contentType={'contract'}
-            totalLikes={contract.likedByUserCount ?? 0}
-            contract={contract}
-            contentText={question}
-            showTotalLikesUnder
-            size="md"
-            color="gray"
-            className="!px-0"
-            trackingLocation={'contract card (feed)'}
-          />
+          <CommentsButton contract={contract} user={user} />
+        </Row>
+      </Col>
+      {hasItems && (
+        <div className=" w-full">
+          <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
         </div>
-        <CommentsButton contract={contract} user={user} />
-      </Row>
+      )}
     </div>
   )
 }

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -423,7 +423,7 @@ function ClaimButton(props: {
       {claimed ? (
         'Claimed!'
       ) : loading ? (
-        <LoadingIndicator />
+        <LoadingIndicator size={'sm'} />
       ) : (
         `Claim ${formatMoney(reward)} Boost`
       )}

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -160,8 +160,8 @@ export function FeedContractCard(props: {
       </Col>
 
       {showImage && (
-        <div className="relative">
-          <div className="absolute inset-0 bg-transparent transition-all group-hover:saturate-150">
+        <div className="relative mt-1 h-40 w-full">
+          <div className="absolute inset-0 mt-2 bg-transparent transition-all group-hover:saturate-150">
             <Image
               fill
               alt=""
@@ -170,16 +170,27 @@ export function FeedContractCard(props: {
               src={coverImageUrl}
             />
           </div>
+          <div className="absolute bottom-0">
+            <PublicMarketGroups
+              contract={contract}
+              className={'px-4 py-2'}
+              justGroups={true}
+            />
+          </div>
         </div>
       )}
-      <PublicMarketGroups
-        contract={contract}
-        className={'px-4 py-2'}
-        justGroups={true}
-      />
-      <div className=" mt-2 w-full">
-        <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
-      </div>
+      {!showImage && (
+        <PublicMarketGroups
+          contract={contract}
+          className={'px-4 py-2'}
+          justGroups={true}
+        />
+      )}
+      {!showImage && (
+        <div className="w-full">
+          <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
+        </div>
+      )}
       <Col className="relative">
         <Row
           className="justify-between gap-2 px-4 py-1"

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -197,6 +197,7 @@ export function FeedContractCard(props: {
           onClick={(e) => e.stopPropagation()}
         >
           <TradesButton contract={contract} />
+          <CommentsButton contract={contract} user={user} />
           <div className="flex items-center gap-1.5 p-1">
             <LikeButton
               contentId={contract.id}
@@ -213,7 +214,6 @@ export function FeedContractCard(props: {
               trackingLocation={'contract card (feed)'}
             />
           </div>
-          <CommentsButton contract={contract} user={user} />
         </Row>
       </Col>
       {hasItems && (

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -106,7 +106,7 @@ export function FeedContractCard(props: {
         e.currentTarget.focus() // focus the div like a button, for style
       }}
     >
-      <Col className="bg-canvas-0 gap-2 p-4 py-2">
+      <Col className=" bg-canvas-0 gap-2 p-4 py-2">
         {/* Title is link to contract for open in new tab and a11y */}
         <Row className="justify-between">
           <Row onClick={(e) => e.stopPropagation()} className="gap-2">
@@ -162,7 +162,7 @@ export function FeedContractCard(props: {
       </Col>
 
       {showImage && (
-        <>
+        <div className="relative">
           <div className="flex h-40 w-full items-center justify-center">
             {promotedData && <ClaimButton {...promotedData} className="mt-2" />}
           </div>
@@ -175,9 +175,12 @@ export function FeedContractCard(props: {
               src={coverImageUrl}
             />
           </div>
-        </>
+        </div>
       )}
-      <Row className="justify-between" onClick={(e) => e.stopPropagation()}>
+      <Row
+        className="bg-canvas-0 justify-between gap-2 px-4 py-2"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center gap-1.5 p-1">
           <LikeButton
             contentId={contract.id}

--- a/web/components/contract/like-button.tsx
+++ b/web/components/contract/like-button.tsx
@@ -180,6 +180,7 @@ export const LikeButton = memo(function LikeButton(props: {
           user={user}
           userLiked={liked}
           setOpen={setModalOpen}
+          titleName={contentText}
         />
       )}
       {showTotalLikesUnder && totalLikes > 0 && (
@@ -226,8 +227,9 @@ function UserLikedFullList(props: {
   user?: User | null
   userLiked?: boolean
   setOpen: (isOpen: boolean) => void
+  titleName?: string
 }) {
-  const { contentType, contentId, user, userLiked, setOpen } = props
+  const { contentType, contentId, user, userLiked, setOpen, titleName } = props
   const reacts = useLikesOnContent(contentType, contentId)
   const displayInfos = reacts
     ? getLikeDisplayList(reacts, user, userLiked)
@@ -236,8 +238,12 @@ function UserLikedFullList(props: {
   return (
     <MultiUserTransactionModal
       userInfos={displayInfos}
-      modalLabel={`💖 Liked this ${
-        contentType === 'contract' ? 'market' : contentType
+      modalLabel={`💖 Liked ${
+        titleName
+          ? titleName
+          : contentType === 'contract'
+          ? 'this market'
+          : `this ${contentType}`
       }`}
       open={true}
       setOpen={setOpen}

--- a/web/components/contract/like-button.tsx
+++ b/web/components/contract/like-button.tsx
@@ -238,13 +238,18 @@ function UserLikedFullList(props: {
   return (
     <MultiUserTransactionModal
       userInfos={displayInfos}
-      modalLabel={`💖 Liked ${
-        titleName
-          ? titleName
-          : contentType === 'contract'
-          ? 'this market'
-          : `this ${contentType}`
-      }`}
+      modalLabel={
+        <span>
+          💖 Liked{' '}
+          <span className="font-bold">
+            {titleName
+              ? titleName
+              : contentType === 'contract'
+              ? 'this market'
+              : `this ${contentType}`}
+          </span>
+        </span>
+      }
       open={true}
       setOpen={setOpen}
       short={true}

--- a/web/components/contract/like-button.tsx
+++ b/web/components/contract/like-button.tsx
@@ -152,8 +152,8 @@ export const LikeButton = memo(function LikeButton(props: {
                   'text-ink-0 absolute rounded-full text-center',
                   size === 'md' &&
                     '-bottom-1.5 -right-1.5 min-w-[15px] p-[1.5px] text-[10px] leading-3',
-                  // size === 'xl' &&
-                  //   'bottom-0 right-0 min-w-[24px] p-0.5 text-sm',
+                  size === 'xl' &&
+                    'bottom-0 right-0 min-w-[24px] p-0.5 text-sm',
                   color === 'white' && 'text-white'
                 )}
               >

--- a/web/components/contract/trades-button.tsx
+++ b/web/components/contract/trades-button.tsx
@@ -59,7 +59,6 @@ export function TradesButton(props: { contract: Contract }) {
 
 function BetsModalContent(props: { contract: Contract }) {
   const { contract } = props
-  console.log('BETS')
   const bets = useBets({ contractId: contract.id })
   if (bets === undefined) return <LoadingIndicator />
   else if (bets.length === 0) return <div>No bets yet</div>

--- a/web/components/contract/trades-button.tsx
+++ b/web/components/contract/trades-button.tsx
@@ -1,0 +1,62 @@
+import { Contract } from 'common/contract'
+import { useEffect, useState } from 'react'
+import { Tooltip } from '../widgets/tooltip'
+import { UserIcon } from '@heroicons/react/outline'
+import clsx from 'clsx'
+import { Row } from '../layout/row'
+import { MODAL_CLASS, Modal, SCROLLABLE_MODAL_CLASS } from '../layout/modal'
+import { FeedBet } from '../feed/feed-bets'
+import { useBets } from 'web/hooks/use-bets-supabase'
+import { BetsTabContent } from './contract-tabs'
+import { LoadingIndicator } from '../widgets/loading-indicator'
+
+export function TradesButton(props: { contract: Contract }) {
+  const { contract } = props
+  const [modalOpen, setModalOpen] = useState<boolean>(false)
+  const [uniqueTraders, setUniqueTraders] = useState(contract.uniqueBettorCount)
+
+  useEffect(() => {
+    setUniqueTraders(contract.uniqueBettorCount)
+  }, [contract.uniqueBettorCount])
+
+  return (
+    <>
+      <Tooltip
+        text={'Unique Traders'}
+        placement={'bottom'}
+        className={clsx('flex flex-row items-center')}
+      >
+        <button
+          disabled={uniqueTraders === 0}
+          className={clsx(
+            'text-ink-500 pr-2 transition-transform disabled:cursor-not-allowed'
+          )}
+          onClick={(e) => {
+            e.preventDefault()
+            setModalOpen(true)
+          }}
+        >
+          <Row className="relative justify-center gap-1.5 p-1 text-sm">
+            <UserIcon className={clsx('h-5 w-5')} />
+            <div>{uniqueTraders > 0 ? uniqueTraders : ''}</div>
+          </Row>
+        </button>
+      </Tooltip>
+      <Modal
+        open={modalOpen}
+        setOpen={setModalOpen}
+        className={clsx(MODAL_CLASS, SCROLLABLE_MODAL_CLASS)}
+      >
+        <BetsModalContent contract={contract} />
+      </Modal>
+    </>
+  )
+}
+
+function BetsModalContent(props: { contract: Contract }) {
+  const { contract } = props
+  const bets = useBets({ contractId: contract.id })
+  if (bets === undefined) return <LoadingIndicator />
+  else if (bets.length === 0) return <div>No bets yet</div>
+  return <BetsTabContent contract={contract} bets={bets} />
+}

--- a/web/components/contract/trades-button.tsx
+++ b/web/components/contract/trades-button.tsx
@@ -1,14 +1,13 @@
-import { Contract } from 'common/contract'
-import { useEffect, useState } from 'react'
-import { Tooltip } from '../widgets/tooltip'
 import { UserIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
-import { Row } from '../layout/row'
-import { MODAL_CLASS, Modal, SCROLLABLE_MODAL_CLASS } from '../layout/modal'
-import { FeedBet } from '../feed/feed-bets'
+import { Contract } from 'common/contract'
+import { useEffect, useState } from 'react'
 import { useBets } from 'web/hooks/use-bets-supabase'
-import { BetsTabContent } from './contract-tabs'
+import { MODAL_CLASS, Modal, SCROLLABLE_MODAL_CLASS } from '../layout/modal'
+import { Row } from '../layout/row'
 import { LoadingIndicator } from '../widgets/loading-indicator'
+import { Tooltip } from '../widgets/tooltip'
+import { BetsTabContent } from './contract-tabs'
 
 export function TradesButton(props: { contract: Contract }) {
   const { contract } = props
@@ -43,9 +42,14 @@ export function TradesButton(props: { contract: Contract }) {
           <Modal
             open={modalOpen}
             setOpen={setModalOpen}
-            className={clsx(MODAL_CLASS, SCROLLABLE_MODAL_CLASS)}
+            className={clsx(MODAL_CLASS)}
           >
-            <BetsModalContent contract={contract} />
+            <div className={'bg-canvas-0 sticky top-0 py-2'}>
+              Bets on <span className="font-bold">{contract.question}</span>
+            </div>
+            <div className={SCROLLABLE_MODAL_CLASS}>
+              <BetsModalContent contract={contract} />
+            </div>
           </Modal>
         </button>
       </Tooltip>
@@ -55,8 +59,9 @@ export function TradesButton(props: { contract: Contract }) {
 
 function BetsModalContent(props: { contract: Contract }) {
   const { contract } = props
+  console.log('BETS')
   const bets = useBets({ contractId: contract.id })
   if (bets === undefined) return <LoadingIndicator />
   else if (bets.length === 0) return <div>No bets yet</div>
-  return <BetsTabContent contract={contract} bets={bets} />
+  return <BetsTabContent contract={contract} bets={bets} scrollToTop={false} />
 }

--- a/web/components/contract/trades-button.tsx
+++ b/web/components/contract/trades-button.tsx
@@ -40,15 +40,15 @@ export function TradesButton(props: { contract: Contract }) {
             <UserIcon className={clsx('h-5 w-5')} />
             <div>{uniqueTraders > 0 ? uniqueTraders : ''}</div>
           </Row>
+          <Modal
+            open={modalOpen}
+            setOpen={setModalOpen}
+            className={clsx(MODAL_CLASS, SCROLLABLE_MODAL_CLASS)}
+          >
+            <BetsModalContent contract={contract} />
+          </Modal>
         </button>
       </Tooltip>
-      <Modal
-        open={modalOpen}
-        setOpen={setModalOpen}
-        className={clsx(MODAL_CLASS, SCROLLABLE_MODAL_CLASS)}
-      >
-        <BetsModalContent contract={contract} />
-      </Modal>
     </>
   )
 }

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -18,6 +18,7 @@ import { Row } from '../layout/row'
 import { ContractComment } from 'common/comment'
 import { BoostsType } from 'web/hooks/use-feed'
 import { AD_PERIOD, AD_REDEEM_REWARD } from 'common/boost'
+import { useState } from 'react'
 
 export const FeedItems = (props: {
   contracts: Contract[]

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -82,11 +82,16 @@ export const FeedItems = (props: {
               contract={contract}
               className={clsx(
                 'my-0 border-0',
-                hasItems ? 'rounded-t-xl rounded-b-none  ' : ''
+                hasItems ? 'rounded-t-xl rounded-b-none' : ''
               )}
               promotedData={promotedData}
               trackingPostfix="feed"
             />
+            {hasItems && (
+              <div className="bg-canvas-0 w-full">
+                <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
+              </div>
+            )}
             <Row className="bg-canvas-0">
               <FeedCommentItem
                 contract={contract}

--- a/web/components/feed/feed-items.tsx
+++ b/web/components/feed/feed-items.tsx
@@ -86,12 +86,8 @@ export const FeedItems = (props: {
               )}
               promotedData={promotedData}
               trackingPostfix="feed"
+              hasItems={hasItems}
             />
-            {hasItems && (
-              <div className="bg-canvas-0 w-full">
-                <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
-              </div>
-            )}
             <Row className="bg-canvas-0">
               <FeedCommentItem
                 contract={contract}

--- a/web/components/feed/feed-timeline-items.tsx
+++ b/web/components/feed/feed-timeline-items.tsx
@@ -109,6 +109,11 @@ export const FeedTimelineItems = (props: {
                     : undefined
                 }
               />
+              {hasItems && (
+                <div className="bg-canvas-0 w-full">
+                  <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
+                </div>
+              )}
               <Row className="bg-canvas-0">
                 <FeedCommentItem
                   contract={contract}

--- a/web/components/feed/feed-timeline-items.tsx
+++ b/web/components/feed/feed-timeline-items.tsx
@@ -109,11 +109,6 @@ export const FeedTimelineItems = (props: {
                     : undefined
                 }
               />
-              {hasItems && (
-                <div className="bg-canvas-0 w-full">
-                  <hr className="border-ink-200 mx-auto w-[calc(100%-1rem)]" />
-                </div>
-              )}
               <Row className="bg-canvas-0">
                 <FeedCommentItem
                   contract={contract}

--- a/web/components/feed/feed-timeline-items.tsx
+++ b/web/components/feed/feed-timeline-items.tsx
@@ -108,6 +108,7 @@ export const FeedTimelineItems = (props: {
                     ? item.reasonDescription
                     : undefined
                 }
+                hasItems={hasItems}
               />
               <Row className="bg-canvas-0">
                 <FeedCommentItem

--- a/web/components/groups/contract-groups-list.tsx
+++ b/web/components/groups/contract-groups-list.tsx
@@ -61,7 +61,7 @@ export function ContractGroupsList(props: {
                 <span
                   key={groupLink.groupId}
                   className={clsx(
-                    'bg-ink-600 text-ink-0 hover:bg-primary-600 group relative rounded-full p-1 px-4 text-sm transition-colors'
+                    'text-ink-1000 bg-ink-100 hover:bg-ink-200 group relative rounded-full p-1 px-4 text-sm transition-colors'
                   )}
                 >
                   <GroupLinkItem group={groupLink} />

--- a/web/components/multi-user-transaction-link.tsx
+++ b/web/components/multi-user-transaction-link.tsx
@@ -55,7 +55,7 @@ export function MultiUserTransactionModal(props: {
   return (
     <Modal open={open} setOpen={setOpen} size={'sm'}>
       <Col className="bg-canvas-0 text-ink-1000 relative items-start gap-4 rounded-md p-6">
-        <span className={'sticky top-0 text-xl'}>{modalLabel}</span>
+        <span className={'sticky top-0'}>{modalLabel}</span>
         {userInfos == null ? (
           <LoadingIndicator />
         ) : userInfos.length > 0 ? (

--- a/web/components/multi-user-transaction-link.tsx
+++ b/web/components/multi-user-transaction-link.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { formatMoney } from 'common/util/format'
 import { Col } from 'web/components/layout/col'
 import { Modal } from 'web/components/layout/modal'
@@ -46,7 +46,7 @@ export function MultiUserTransactionLink(props: {
 
 export function MultiUserTransactionModal(props: {
   userInfos: MultiUserLinkInfo[] | null
-  modalLabel: string
+  modalLabel: string | ReactNode
   open: boolean
   setOpen: (open: boolean) => void
   short?: boolean

--- a/web/components/swipe/swipe-comments.tsx
+++ b/web/components/swipe/swipe-comments.tsx
@@ -3,7 +3,7 @@ import { ChatIcon } from '@heroicons/react/outline'
 import { ChatIcon as ChatIconSolid } from '@heroicons/react/solid'
 import clsx from 'clsx'
 import { Contract } from 'common/contract'
-import { Modal, MODAL_CLASS } from '../layout/modal'
+import { Modal, MODAL_CLASS, SCROLLABLE_MODAL_CLASS } from '../layout/modal'
 import { Col } from '../layout/col'
 import { useComments } from 'web/hooks/use-comments'
 import { CommentsTabContent } from '../contract/contract-tabs'
@@ -99,15 +99,11 @@ function CommentsDialog(props: {
   const blockedUserIds = privateUser?.blockedUserIds ?? []
 
   return (
-    <Modal
-      open={open}
-      setOpen={setOpen}
-      className={clsx(
-        MODAL_CLASS,
-        'pointer-events-auto max-h-[32rem] overflow-auto'
-      )}
-    >
-      <Col>
+    <Modal open={open} setOpen={setOpen} className={clsx(MODAL_CLASS)}>
+      <div className="mb-2">
+        Comments on <span className="font-bold">{contract.question}</span>
+      </div>
+      <Col className={SCROLLABLE_MODAL_CLASS}>
         <CommentsTabContent
           contract={contract}
           comments={comments}

--- a/web/components/widgets/info-tooltip.tsx
+++ b/web/components/widgets/info-tooltip.tsx
@@ -6,8 +6,9 @@ export function InfoTooltip(props: {
   text: string
   className?: string
   children?: React.ReactNode
+  size?: 'sm' | 'md' | 'lg'
 }) {
-  const { text, className, children } = props
+  const { text, className, children, size } = props
   return (
     <Tooltip className="inline-block" text={text}>
       {children ? (
@@ -21,7 +22,14 @@ export function InfoTooltip(props: {
         </span>
       ) : (
         <InformationCircleIcon
-          className={clsx('text-ink-500 -mb-1 h-5 w-5', className)}
+          className={clsx(
+            'text-ink-500 -mb-1',
+            className,
+            size === 'sm' && 'h-4 w-4',
+            size === 'md' && 'h-5 w-5',
+            size === 'lg' && 'h-6 w-6',
+            !size && 'h-5 w-5'
+          )}
         />
       )}
     </Tooltip>

--- a/web/pages/feed-timeline.tsx
+++ b/web/pages/feed-timeline.tsx
@@ -27,7 +27,7 @@ export default function FeedTimeline() {
   return (
     <Page>
       <Col className="gap-2 py-2 pb-8 sm:px-2">
-        <Row className="mx-4 mb-2 items-center gap-4">
+        <Row className="mx-4 mb-2 items-center justify-between gap-4">
           <Title children="Home" className="!my-0 hidden sm:block" />
           <DailyStats user={user} />
         </Row>

--- a/web/pages/group/[...slugs]/index.tsx
+++ b/web/pages/group/[...slugs]/index.tsx
@@ -260,7 +260,7 @@ export function GroupPageContent(props: { groupParams?: GroupParams }) {
             key={group.id}
           />
         </div>
-        <Col className="bg-canvas-0 absolute bottom-0 w-full bg-opacity-80 px-4">
+        <Col className="bg-canvas-0 absolute bottom-0 w-full bg-opacity-90 px-4">
           <Row className="mt-4 mb-2 w-full justify-between gap-1">
             <div className="text-ink-900 text-2xl font-normal sm:text-3xl">
               {group.name}


### PR DESCRIPTION
A couple of visual feed tweaks:
<img width="659" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/46611122/32f66506-2819-4f33-8f99-b278f55d922d">
- avatar is larger, no more random reasons on top right side
- always shows when market was created under name
- brought back percentage bar thingy
- twitter like bottom bar with actions
- groups is overlaid on picture

<img width="644" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/46611122/1b9187c2-aa2a-4595-8a23-cb4aad821e35">

- made yes and no bet panels singular

<img width="660" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/46611122/c4db32fb-a83c-421f-bde3-22e78c2e6821">

- explicitly state market for bets, likes and comments

<img width="667" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/46611122/cd2e4caf-6268-4cbc-8f3d-8032cf602d32">

- made boost button smaller and on top right



