### PR TITLE
Ingawei/man 1143 sort by market type

### DIFF
--- a/backend/api/src/supabase-search-contract.ts
+++ b/backend/api/src/supabase-search-contract.ts
@@ -93,7 +93,6 @@ export const supabasesearchcontracts = MaybeAuthedEndpoint(
       topic,
     })
 
-    console.log(searchMarketSQL)
     const contracts = await pg.map(
       searchMarketSQL,
       [term],

--- a/backend/api/src/supabase-search-contract.ts
+++ b/backend/api/src/supabase-search-contract.ts
@@ -41,7 +41,7 @@ const bodySchema = z.object({
     z.literal('BINARY'),
     z.literal('MULTIPLE_CHOICE'),
     z.literal('FREE_RESPONSE'),
-    z.literal('NUMERIC'),
+    z.literal('PSEUDO_NUMERIC'),
     z.literal('BOUNTIED_QUESTION'),
   ]),
   topic: z.string().optional(),

--- a/backend/supabase/contracts/indexes.sql
+++ b/backend/supabase/contracts/indexes.sql
@@ -31,3 +31,11 @@ create index if not exists contracts_resolution_time on contracts (resolution_ti
 create index if not exists contracts_visibility_public on contracts (id)
 where
   visibility = 'public';
+
+create index contracts_outcome_type_binary on contracts (outcome_type)
+where
+  outcome_type = 'BINARY';
+
+create index contracts_outcome_type_not_binary on contracts (outcome_type)
+where
+  outcome_type <> 'BINARY';

--- a/web/components/comments/dropdown-menu.tsx
+++ b/web/components/comments/dropdown-menu.tsx
@@ -18,6 +18,7 @@ export default function DropdownMenu(props: {
   className?: string
   menuItemsClass?: string
   buttonDisabled?: boolean
+  selectedItemName?: string
 }) {
   const {
     Items,
@@ -27,6 +28,7 @@ export default function DropdownMenu(props: {
     buttonClass,
     className,
     buttonDisabled,
+    selectedItemName,
   } = props
   const icon = Icon ?? (
     <DotsHorizontalIcon className="h-5 w-5" aria-hidden="true" />
@@ -77,7 +79,11 @@ export default function DropdownMenu(props: {
                       item.onClick()
                     }}
                     className={clsx(
-                      active ? 'bg-ink-100 text-ink-900' : 'text-ink-700',
+                      selectedItemName && item.name == selectedItemName
+                        ? 'bg-primary-100'
+                        : active
+                        ? 'bg-ink-100 text-ink-900'
+                        : 'text-ink-700',
                       'block w-full px-4 py-2 text-sm'
                     )}
                   >

--- a/web/components/search/search-dropdown-helpers.tsx
+++ b/web/components/search/search-dropdown-helpers.tsx
@@ -1,0 +1,16 @@
+export default function generateFilterDropdownItems<T extends string>(
+  items: readonly { readonly label: string; readonly value: T }[],
+  setState: (selection: T) => void
+) {
+  return items.map((item) => {
+    return { name: item.label, onClick: () => setState(item.value) }
+  })
+}
+
+export function getLabelFromValue<T extends string>(
+  items: readonly { readonly label: string; readonly value: T }[],
+  value: T
+) {
+  const item = items.find((item) => item.value === value)
+  return item?.label
+}

--- a/web/components/supabase-search.tsx
+++ b/web/components/supabase-search.tsx
@@ -83,7 +83,7 @@ export const CONTRACT_TYPES = [
   { label: 'Binary', value: 'BINARY' },
   { label: 'Multiple Choice', value: 'MULTIPLE_CHOICE' },
   { label: 'Free Response', value: 'FREE_RESPONSE' },
-  { label: 'Numeric', value: 'NUMERIC' },
+  { label: 'Numeric', value: 'PSEUDO_NUMERIC' },
   { label: 'Bountied Question', value: 'BOUNTIED_QUESTION' },
 ] as const
 

--- a/web/components/supabase-search.tsx
+++ b/web/components/supabase-search.tsx
@@ -50,6 +50,13 @@ export const PROB_SORTS = ['prob-descending', 'prob-ascending']
 
 export type filter = 'open' | 'closed' | 'resolved' | 'all'
 
+export type ContractTypeType =
+  | 'Binary'
+  | 'Multiple Choice'
+  | 'Free Response'
+  | 'Numeric'
+  | 'Bountied Question'
+
 export type SupabaseSearchParameters = {
   query: string
   sort: Sort
@@ -391,6 +398,16 @@ function SupabaseContractSearchControls(props: {
       ? undefined
       : {
           key: 'f',
+          store: urlParamStore(router),
+        }
+  )
+
+  const [contractType, setContractType] = usePersistentState(
+    '',
+    !useQueryUrlParam
+      ? undefined
+      : {
+          key: 'search-contract-type',
           store: urlParamStore(router),
         }
   )

--- a/web/components/supabase-search.tsx
+++ b/web/components/supabase-search.tsx
@@ -79,7 +79,7 @@ export const FILTERS = [
 export type filter = typeof FILTERS[number]['value']
 
 export const CONTRACT_TYPES = [
-  { label: 'All markets', value: 'ALL' },
+  { label: 'All questions', value: 'ALL' },
   { label: 'Binary', value: 'BINARY' },
   { label: 'Multiple Choice', value: 'MULTIPLE_CHOICE' },
   { label: 'Free Response', value: 'FREE_RESPONSE' },

--- a/web/components/supabase-search.tsx
+++ b/web/components/supabase-search.tsx
@@ -533,7 +533,6 @@ function SupabaseContractSearchControls(props: {
           listViewDisabled={true}
         />
       </Col>
-      {/* <Spacer h={2} /> */}
       {showTopics && (
         <Carousel>
           {SELECTED_TOPICS.map((t) => (
@@ -598,7 +597,6 @@ export function SearchFilters(props: {
           Items={generateFilterDropdownItems(FILTERS, selectFilter)}
           Icon={
             <Row className="items-center gap-0.5">
-              {/* <AiTwotoneFilter className="mr-0.5 h-4 w-4 text-gray-500" /> */}
               <span className="truncate whitespace-nowrap text-sm font-medium text-gray-500">
                 {filterLabel}
               </span>
@@ -619,7 +617,6 @@ export function SearchFilters(props: {
           )}
           Icon={
             <Row className=" items-center gap-0.5 ">
-              {/* <FaSort className="mr-0.5 h-4 w-4 text-gray-500" /> */}
               <span className="whitespace-nowrap text-sm font-medium text-gray-500">
                 {sortLabel}
               </span>

--- a/web/lib/firebase/api.ts
+++ b/web/lib/firebase/api.ts
@@ -9,7 +9,7 @@ import { Group, PrivacyStatusType } from 'common/group'
 import { HideCommentReq } from 'web/pages/api/v0/hide-comment'
 import { Contract } from './contracts'
 export { APIError } from 'common/api'
-import { filter, Sort } from 'web/components/supabase-search'
+import { ContractTypeType, filter, Sort } from 'web/components/supabase-search'
 import { AD_RATE_LIMIT } from 'common/boost'
 import { groupRoleType } from 'web/components/groups/group-member-modal'
 import { Bet } from 'common/bet'
@@ -289,6 +289,7 @@ export function supabaseSearchContracts(params: {
   term: string
   filter: filter
   sort: Sort
+  contractType: ContractTypeType
   offset: number
   limit: number
   topic?: string

--- a/web/lib/supabase/contracts.ts
+++ b/web/lib/supabase/contracts.ts
@@ -8,7 +8,7 @@ import {
   Tables,
 } from 'common/supabase/utils'
 import { filterDefined } from 'common/util/array'
-import { Sort, filter } from 'web/components/supabase-search'
+import { ContractTypeType, Sort, filter } from 'web/components/supabase-search'
 import { stateType } from 'web/components/supabase-search'
 import { supabaseSearchContracts } from '../firebase/api'
 import { db } from './db'
@@ -204,6 +204,7 @@ export async function searchContract(props: {
   query: string
   filter: filter
   sort: Sort
+  contractType?: ContractTypeType
   offset?: number
   topic?: string
   limit: number
@@ -215,11 +216,13 @@ export async function searchContract(props: {
     topic,
     filter,
     sort,
+    contractType = 'ALL',
     offset = 0,
     limit,
     group_id,
     creator_id,
   } = props
+
   const state = props.state ?? {
     contracts: undefined,
     fuzzyContractOffset: 0,
@@ -236,6 +239,7 @@ export async function searchContract(props: {
       term: '',
       filter,
       sort,
+      contractType,
       offset,
       limit,
       topic,
@@ -252,6 +256,7 @@ export async function searchContract(props: {
       query,
       filter,
       sort,
+      contractType,
       limit,
       group_id,
       creator_id,
@@ -264,6 +269,7 @@ export async function searchContract(props: {
     term: query,
     filter,
     sort,
+    contractType,
     offset,
     limit,
     fuzzy: false,
@@ -280,6 +286,7 @@ export async function searchContract(props: {
         query,
         filter,
         sort,
+        contractType,
         limit: limit - contracts.length,
         group_id,
         creator_id,
@@ -298,17 +305,28 @@ export async function searchContractFuzzy(props: {
   query: string
   filter: filter
   sort: Sort
+  contractType: ContractTypeType
   topic?: string
   limit: number
   group_id?: string
   creator_id?: string
 }) {
-  const { state, topic, query, filter, sort, limit, group_id, creator_id } =
-    props
+  const {
+    state,
+    topic,
+    query,
+    filter,
+    sort,
+    contractType,
+    limit,
+    group_id,
+    creator_id,
+  } = props
   const contracts = await supabaseSearchContracts({
     term: query,
     filter,
     sort,
+    contractType,
     offset: state.fuzzyContractOffset,
     limit,
     fuzzy: true,


### PR DESCRIPTION
<img width="857" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/46611122/18584158-d9db-421e-8eda-9e481e2cb2bf">
Updated contract search to have market type sort, and also look of contract filter/sort


@jahooma pls review


also @mantikoros please take a look at predictionMarketSorts in `supabase-search.tsx` to see if there are some sorts there that would actually work for bountied questions/and or if theres something easy that can be done to make it work.

TODO: add sort by bounty option