### PR TITLE
Add name column to user

### DIFF
--- a/backend/scripts/add-reactivated-to-league.ts
+++ b/backend/scripts/add-reactivated-to-league.ts
@@ -1,7 +1,10 @@
 import { BOT_USERNAMES } from 'common/envs/constants'
 import { groupBy, mapValues } from 'lodash'
 import { runScript } from 'run-script'
-import { addToLeagueIfNotInOne, getUsersNotInLeague } from 'shared/generate-leagues'
+import {
+  addToLeagueIfNotInOne,
+  getUsersNotInLeague,
+} from 'shared/generate-leagues'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 
 if (require.main === module) {
@@ -34,7 +37,7 @@ const _reassignBots = (pg: SupabaseDirectClient) => {
         cohort = 'bots'
     where user_id in (
         select id from users
-        where data->>'username' in ($1:csv)
+        where username in ($1:csv)
         limit 40
     )`,
     [BOT_USERNAMES]

--- a/backend/shared/src/generate-leagues.ts
+++ b/backend/shared/src/generate-leagues.ts
@@ -38,7 +38,7 @@ export async function generateNextSeason(
     join users on users.id = user_id
     where coalesce(users.data->>'isBannedFromPosting', 'false') = 'false'
     and coalesce(users.data->>'userDeleted', 'false') = 'false'
-    and users.data->>'username' not in ($2:csv)
+    and users.username not in ($2:csv)
     `,
     [startDate, BOT_USERNAMES]
   )
@@ -167,7 +167,7 @@ export const insertBots = async (pg: SupabaseDirectClient, season: number) => {
   //   where season = $1
   //   and user_id in (
   //     select id from users
-  //     where data->>'username' in ($2:csv)
+  //     where data.username in ($2:csv)
   //   )
   //   `,
   //   [season, BOT_USERNAMES],
@@ -184,7 +184,7 @@ export const insertBots = async (pg: SupabaseDirectClient, season: number) => {
         where contract_bets.created_time > $1
       )
       select id from users
-      where data->>'username' in ($2:csv)
+      where data.username in ($2:csv)
       and id in (select user_id from active_user_ids)
     `,
     [startDate, BOT_USERNAMES],

--- a/backend/supabase/functions.sql
+++ b/backend/supabase/functions.sql
@@ -1078,8 +1078,8 @@ or replace function get_reply_chain_comments_matching_contracts (contract_ids te
   SELECT * FROM reply_chain_comments;
 $$ language sql;
 
-CREATE OR REPLACE FUNCTION count_recent_comments_by_contract()
-RETURNS TABLE (contract_id TEXT, comment_count INTEGER) AS $$
+create
+or replace function count_recent_comments_by_contract () returns table (contract_id text, comment_count integer) as $$
   SELECT
     contract_id,
     COUNT(*) AS comment_count
@@ -1091,7 +1091,7 @@ RETURNS TABLE (contract_id TEXT, comment_count INTEGER) AS $$
     contract_id
   ORDER BY
     comment_count DESC;
-$$ LANGUAGE SQL;
+$$ language sql;
 
 create
 or replace function get_contracts_with_unseen_liked_comments (
@@ -1154,11 +1154,11 @@ or replace function search_users (query text, count integer) returns setof users
 select *
 from users
 where users.name_username_vector @@ websearch_to_tsquery(query)
-   or (data->>'username') % query
-   or (data->>'name') % query
+   or username % query
+   or name % query
 order by greatest(
-    similarity(query, data->>'name'),
-    similarity(query, data->>'username')
+    similarity(query, name),
+    similarity(query, username)
   ) desc,
   data->>'lastBetTime' desc nulls last
 limit count $$ language sql stable;
@@ -1325,7 +1325,7 @@ or replace function get_engaged_users () returns table (user_id text, username t
        GROUP BY user_id, week
    )
 
-  SELECT u.id, u.data->>'username' AS username, u.data->>'name' AS name
+  SELECT u.id, u.username, u.name
   FROM users u
   WHERE u.id IN (
       SELECT user_id

--- a/backend/supabase/users/create.sql
+++ b/backend/supabase/users/create.sql
@@ -1,0 +1,12 @@
+create table if not exists
+  users (
+    id text not null primary key,
+    data jsonb not null,
+    fs_updated_time timestamp not null,
+    name text not null,
+    username text not null,
+    name_username_vector tsvector generated always as (to_tsvector(name || ' ' || username)) stored
+  );
+
+alter table users
+cluster on users_pkey;

--- a/backend/supabase/users/indexes.sql
+++ b/backend/supabase/users/indexes.sql
@@ -1,0 +1,13 @@
+create index if not exists users_name_idx on users (name);
+
+create index if not exists user_username_idx on users (username);
+
+create index users_name_username_vector_idx on users using gin (name_username_vector);
+
+create index if not exists users_follower_count_cached on users ((to_jsonb(data -> 'followerCountCached')) desc);
+
+create index if not exists user_referrals_idx on users ((data ->> 'referredByUserId'))
+where
+  data ->> 'referredByUserId' is not null;
+
+create index if not exists users_betting_streak_idx on users (((data -> 'currentBettingStreak')::int));

--- a/backend/supabase/users/rls.sql
+++ b/backend/supabase/users/rls.sql
@@ -1,0 +1,7 @@
+alter table users enable row level security;
+
+drop policy if exists "public read" on users;
+
+create policy "public read" on users for
+select
+  using (true);

--- a/backend/supabase/users/triggers.sql
+++ b/backend/supabase/users/triggers.sql
@@ -1,0 +1,13 @@
+create
+or replace function users_populate_cols () returns trigger language plpgsql as $$ begin
+    if new.data is not null then 
+      new.name := (new.data)->>'name';
+      new.username := (new.data)->>'username';
+    end if;
+    return new;
+end $$;
+
+create trigger users_popuate before insert
+or
+update on users for each row
+execute function users_populate_cols ();

--- a/backend/supabase/views.sql
+++ b/backend/supabase/views.sql
@@ -111,7 +111,7 @@ create view
       gp.slug as group_slug,
       gp.creator_id as creator_id,
       gp.total_members as total_members,
-      users.data ->> 'name' as name,
+      users.name as name,
       users.username as username,
       users.data ->> 'avatarUrl' as avatar_url,
       (
@@ -135,8 +135,8 @@ create or replace view
   user_groups as (
     select
       users.id as id,
-      users.data ->> 'name' as name,
-      users.data ->> 'username' as username,
+      users.name as name,
+      users.username as username,
       users.data ->> 'avatarUrl' as avatarurl,
       (users.data ->> 'followerCountCached')::integer as follower_count,
       coalesce(user_groups.groups, '{}') as groups

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -1471,22 +1471,25 @@ export interface Database {
           data: Json
           fs_updated_time: string
           id: string
+          name: string
           name_username_vector: unknown | null
-          username: string | null
+          username: string
         }
         Insert: {
           data: Json
           fs_updated_time: string
           id: string
+          name: string
           name_username_vector?: unknown | null
-          username?: string | null
+          username: string
         }
         Update: {
           data?: Json
           fs_updated_time?: string
           id?: string
+          name?: string
           name_username_vector?: unknown | null
-          username?: string | null
+          username?: string
         }
         Relationships: []
       }
@@ -2989,8 +2992,9 @@ export interface Database {
           data: Json
           fs_updated_time: string
           id: string
+          name: string
           name_username_vector: unknown | null
-          username: string | null
+          username: string
         }[]
       }
       set_limit: {


### PR DESCRIPTION
- also reorganizes user sql stuff from seed to supabase/users

### migration
```sql
alter table users
add column name text;

create
or replace function users_populate_cols () returns trigger language plpgsql as $$ begin
    if new.data is not null then 
      new.name := (new.data)->>'name';
      new.username := (new.data)->>'username';
    end if;
    return new;
end $$;

update users
set fs_updated_time = fs_updated_time;

alter table users
alter column name set not null,
alter column username set not null;
create index if not exists users_name_idx on users (name);

create index if not exists users_username_idx on users (username);

drop index users_name_gin;

drop index users_username_gin;

drop index user_profit_cached_all_time_idx;

drop index users_instance_id_email_idx;

drop index users_instance_id_idx;

-- drop index users_data_gin;
```

- then recreate views `group_role` and `user_groups`
- then recreate functions `search_users` and `engaged_users`