### PR TITLE
Fix the path to the list of secret keys in the functions' documentation

### DIFF
--- a/backend/functions/README.md
+++ b/backend/functions/README.md
@@ -80,4 +80,4 @@ Add or remove keys using [Google Secret Manager](https://console.cloud.google.co
 [Dev secrets manager](https://console.cloud.google.com/security/secret-manager?project=dev-mantic-markets)
 [Prod secrets manager](https://console.cloud.google.com/security/secret-manager?project=mantic-markets)
 
-Secondly, please update the list of secret keys at `backend/shared/src/secrets.ts`. Only these keys are provided to functions, scripts, and the api.
+Secondly, please update the list of secret keys at `common/src/secrets.ts`. Only these keys are provided to functions, scripts, and the api.


### PR DESCRIPTION
Hi folks,
The path to secret keys in functions' documentation is incorrect (the file is absent).
I'm trying to fix that.