### PR TITLE
Fix mana-printing bug

### DIFF
--- a/backend/api/src/send-mana.ts
+++ b/backend/api/src/send-mana.ts
@@ -32,10 +32,13 @@ export const sendmana = authEndpoint(async (req, auth) => {
       throw new APIError(403, `You must have at least 1000 mana.`)
     }
 
-    if (fromUser.balance < amount) {
+    if (toIds.length <= 0) {
+      throw new APIError(400, 'Destination users not found.')
+    }
+    if (fromUser.balance < amount * toIds.length) {
       throw new APIError(
         403,
-        `Insufficient balance: ${fromUser.name} needed ${amount} but only had ${fromUser.balance} `
+        `Insufficient balance: ${fromUser.name} needed ${amount * toIds.length} but only had ${fromUser.balance} `
       )
     }
 


### PR DESCRIPTION
Fix for https://manifold.markets/derikk?tab=managrams, where managrams with multiple destinations can leave the user with negative mana balance:
![изображение](https://github.com/manifoldmarkets/manifold/assets/82749242/5dcb9d7d-bbd5-4a85-b419-d923bdaeca58)
