### PR TITLE
Revalidate props on stats page after DB update

### DIFF
--- a/backend/functions/src/scheduled/update-stats.ts
+++ b/backend/functions/src/scheduled/update-stats.ts
@@ -16,7 +16,7 @@ import {
   mapValues,
   intersection,
 } from 'lodash'
-import { log, logMemory } from 'shared/utils'
+import { log, logMemory, revalidateStaticProps } from 'shared/utils'
 import { Stats } from 'common/stats'
 import { DAY_MS } from 'common/util/time'
 import { average, median } from 'common/util/math'
@@ -460,6 +460,7 @@ export const updateStatsCore = async () => {
 
   // Write to postgres
   await bulkUpsert(pg, 'stats', 'title', rows)
+  await revalidateStaticProps(`/stats`)
   log('Done. Wrote', rows.length, ' rows to stats table')
 
   await saveCalibrationData(pg)


### PR DESCRIPTION
This should allow for more timely updates to the stats page after they are written to Postgres.