### PR TITLE
expand description if have images/embed

### DIFF
--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -37,6 +37,7 @@ import FeedContractCardDescription from '../feed/feed-contract-card-description'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { descriptionIsEmpty } from './contract-description'
+import { type } from 'os'
 
 export function FeedContractCard(props: {
   contract: Contract
@@ -102,6 +103,13 @@ export function FeedContractCard(props: {
       slug: contract.slug,
       isPromoted: !!promotedData,
     })
+
+  const nonTextDescription =
+    typeof contract.description !== 'string' &&
+    contract.description.content &&
+    contract.description.content.some(
+      (item) => item.type === 'image' || item.type === 'embed'
+    )
 
   return (
     <ClickFrame
@@ -189,9 +197,13 @@ export function FeedContractCard(props: {
         </Col>
       )}
 
-      {item?.dataType == 'new_contract' && !descriptionIsEmpty(contract) && (
-        <FeedContractCardDescription contract={contract} />
-      )}
+      {!descriptionIsEmpty(contract) &&
+        (item?.dataType == 'new_contract' || nonTextDescription) && (
+          <FeedContractCardDescription
+            contract={contract}
+            nonTextDescription={nonTextDescription}
+          />
+        )}
 
       {isBinaryCpmm && metrics && metrics.hasShares && (
         <YourMetricsFooter metrics={metrics} />

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -37,7 +37,6 @@ import FeedContractCardDescription from '../feed/feed-contract-card-description'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { descriptionIsEmpty } from './contract-description'
-import { type } from 'os'
 
 export function FeedContractCard(props: {
   contract: Contract

--- a/web/components/feed/feed-contract-card-description.tsx
+++ b/web/components/feed/feed-contract-card-description.tsx
@@ -6,17 +6,21 @@ import { Row } from '../layout/row'
 import { Col } from '../layout/col'
 import { useEffectCheckEquality } from 'web/hooks/use-effect-check-equality'
 import { Spacer } from '../layout/spacer'
-export const MAX_HEIGHT = 250
+export const TEXT_MAX_HEIGHT = 250
+export const NON_TEXT_MAX_HEIGHT = 2000
 
 export default function FeedContractCardDescription(props: {
   contract: Contract
+  nonTextDescription?: boolean
 }) {
-  const { contract } = props
+  const { contract, nonTextDescription } = props
   const [isOverflowing, setIsOverflowing] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
 
+  const maxHeight = nonTextDescription ? NON_TEXT_MAX_HEIGHT : TEXT_MAX_HEIGHT
+
   useEffectCheckEquality(() => {
-    if (contentRef.current && contentRef.current.scrollHeight > MAX_HEIGHT) {
+    if (contentRef.current && contentRef.current.scrollHeight > maxHeight) {
       setIsOverflowing(true)
     }
   }, [contract.description])
@@ -25,7 +29,7 @@ export default function FeedContractCardDescription(props: {
       <div
         ref={contentRef}
         className={`overflow-hidden`}
-        style={{ maxHeight: `${MAX_HEIGHT}px` }}
+        style={{ maxHeight: `${maxHeight}px` }}
       >
         <Spacer h={2} className="hidden sm:inline-block" />
         <Content content={contract.description} />

--- a/web/components/feed/feed-contract-card-description.tsx
+++ b/web/components/feed/feed-contract-card-description.tsx
@@ -17,6 +17,7 @@ export default function FeedContractCardDescription(props: {
   const [isOverflowing, setIsOverflowing] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
 
+  // if content has images/embeds, have larger max height
   const maxHeight = nonTextDescription ? NON_TEXT_MAX_HEIGHT : TEXT_MAX_HEIGHT
 
   useEffectCheckEquality(() => {

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -303,8 +303,6 @@ export function ContractPageContent(props: {
     user === null ||
     (user && user.createdTime > Date.now() - 24 * 60 * 60 * 1000)
 
-  console.log(contract.description)
-
   return (
     <>
       {creatorTwitter && (

--- a/web/pages/[username]/[contractSlug].tsx
+++ b/web/pages/[username]/[contractSlug].tsx
@@ -303,6 +303,8 @@ export function ContractPageContent(props: {
     user === null ||
     (user && user.createdTime > Date.now() - 24 * 60 * 60 * 1000)
 
+  console.log(contract.description)
+
   return (
     <>
       {creatorTwitter && (


### PR DESCRIPTION
Just an idea I think we could try out, basically if a description has images/embed (visually stimulating content), we add the description to the feed card and make it really big so that it can read more like a post:

examples:
![image](https://github.com/manifoldmarkets/manifold/assets/46611122/01cee1b7-2374-4028-825d-dfe91bb75a19)
![image](https://github.com/manifoldmarkets/manifold/assets/46611122/234c6488-d324-4c5d-b855-bdf7c7c10a7a)
