### PR TITLE
Include `slug` field in all API market responses

### DIFF
--- a/common/src/api-market-types.ts
+++ b/common/src/api-market-types.ts
@@ -24,6 +24,7 @@ export type LiteMarket = {
   // Market attributes. All times are in milliseconds since epoch
   closeTime?: number
   question: string
+  slug: string
   url: string
   outcomeType: string
   mechanism: string
@@ -111,6 +112,7 @@ export function toLiteMarket(contract: Contract): LiteMarket {
         ? Math.min(resolutionTime, closeTime)
         : closeTime,
     question,
+    slug,
     url: `https://${DOMAIN}/${creatorUsername}/${slug}`,
     pool: 'pool' in contract ? contract.pool : undefined,
     probability,


### PR DESCRIPTION
Partial fix for https://discord.com/channels/915138780216823849/1158506775784460408.