### PR TITLE
Add `after` filter to `GET /managrams`

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -967,7 +967,8 @@ Parameters
 - `toId`: Optional. Returns managrams sent to this user.
 - `fromId`: Optional. Returns managrams sent from this user.
 - `limit`: Optional. How many managrams to return. The maximum and the default are 100.
-- `before`: Optional. The `createdTime` before which you want managrams 
+- `before`: Optional. The `createdTime` before which you want managrams
+- `after`: Optional. The `createdTime` after which you want managrams 
 
 Requires no authorization.
 

--- a/web/pages/api/v0/managrams.ts
+++ b/web/pages/api/v0/managrams.ts
@@ -16,6 +16,7 @@ const queryParams = z
       .or(z.string().regex(/\d+/).transform(Number))
       .refine((n) => n >= 0 && n <= 100, 'Limit must be between 0 and 100'),
     before: z.string().optional(),
+    after: z.string().optional(),
   })
   .strict()
 
@@ -44,6 +45,7 @@ export default async function handler(
       .order('data->createdTime', { ascending: false } as any)
       .limit(limit)
     if (before) query = query.lt('data->createdTime', before)
+    if (after) query = query.gt('data->createdTime', after)
     if (toId) query = query.eq('data->>toId', toId)
     if (fromId) query = query.eq('data->>fromId', fromId)
     const { data } = await run(query)

--- a/web/pages/api/v0/managrams.ts
+++ b/web/pages/api/v0/managrams.ts
@@ -37,7 +37,7 @@ export default async function handler(
     return res.status(500).json({ error: 'Unknown error during validation' })
   }
   try {
-    const { toId, fromId, before, limit } = params
+    const { toId, fromId, before, after, limit } = params
     let query = db
       .from('txns')
       .select('data')


### PR DESCRIPTION
Most of the time I will only be interested in new managrams, so would be nice to be able to query that directly.

(Sorry for commit spam. Don't see an option to squash the commits in the github interface.)