### PR TITLE
Fix incorrect denominator on d1 stat

### DIFF
--- a/backend/functions/src/scheduled/update-stats.ts
+++ b/backend/functions/src/scheduled/update-stats.ts
@@ -288,7 +288,7 @@ export const updateStatsCore = async () => {
     const retainedCount = sumBy(yesterday, (userId) =>
       today.includes(userId) ? 1 : 0
     )
-    return retainedCount / today.length
+    return retainedCount / yesterday.length
   })
 
   const d1WeeklyAvg = d1.map((_, i) => {


### PR DESCRIPTION
I noticed the d1 stat on https://manifold.markets/stats makes no sense in the context of recent traffic. It dips on the 8th when the NYT article was released, and then spikes back up the day after. Clearly we expect it to be normal-ish on the 8th and dip on the 9th.

The problem seems to simply be using the wrong denominator. We want retained DAUs (number active yesterday who were also active today) as a fraction of yesterday's DAUs, not today's.

I haven't tested this typescript code, I wouldn't know how, but I have been doing the equivalent in Python and the D1 stat makes a lot more sense with the right denominator (final day here is Oct 9th):

![image](https://github.com/manifoldmarkets/manifold/assets/1044087/71d34a43-55df-47ad-8b1a-d2806e7faf3c)
