### PR TITLE
Allow bot accounts to use managrams immediately

### DIFF
--- a/common/src/manalink.ts
+++ b/common/src/manalink.ts
@@ -1,5 +1,6 @@
 import { User } from './user'
 import { last } from 'lodash'
+import { BOT_USERNAMES } from 'common/envs/constants'
 import { getPortfolioHistory } from 'common/supabase/portfolio-metrics'
 import { DAY_MS } from 'common/util/time'
 import { SupabaseClient } from 'common/supabase/utils'
@@ -48,9 +49,7 @@ export async function canSendMana(user: User, db: SupabaseClient) {
   )
 
   return (
-    // Exception for new Manifest ticket purchasers
-    (user.balance > 20000 && Date.now() < new Date(1695625200000).valueOf()) ||
-    (user.createdTime < ageThreshold &&
+    ((user.createdTime < ageThreshold || BOT_USERNAMES.includes(user.username)) &&
       (user.balance > 1000 ||
         user.profitCached.allTime > 500 ||
         (portfolioHistory?.investmentValue ?? 0) > 1000 ||


### PR DESCRIPTION
Since getting the bot tag requires admin intervention I think the waiting period is not necessary here. If someone (me) wants to build something cool using managrams, they should not be blocked by this!

Also removed the Manifest ticket exception, which doesn't do anything anymore.