### PR TITLE
Replicate `privateUsers` -> `private_users` table

### DIFF
--- a/backend/scripts/supabase-import.ts
+++ b/backend/scripts/supabase-import.ts
@@ -167,6 +167,8 @@ async function importDatabase(
     await clearFailedWrites()
   }
 
+  if (shouldImport('private_users'))
+    await importCollection(pg, firestore.collection('private-users'), 'private_users', 500)
   if (shouldImport('users'))
     await importCollection(pg, firestore.collection('users'), 'users', 500)
   if (shouldImport('user_portfolio_history'))

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -41,6 +41,21 @@ $$;
 /******************************************/
 /* 1. tables containing firestore content */
 /******************************************/
+
+create table if not exists private_users (
+  id text not null primary key,
+  data jsonb not null,
+  fs_updated_time timestamp not null,
+);
+
+alter table private_users enable row level security;
+
+drop policy if exists "private read" on private_users;
+create policy "private read" on private_users for select
+  using (firebase_uid() = id);
+
+alter table private_users cluster on private_users_pkey;
+
 create table if not exists
   user_portfolio_history (
     user_id text not null,

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -1346,6 +1346,7 @@ begin
   return case
     table_id
            when 'users' then cast((null, 'id') as table_spec)
+           when 'private_users' then cast((null, 'id') as table_spec)
            when 'user_reactions' then cast(('user_id', 'reaction_id') as table_spec)
            when 'contracts' then cast((null, 'id') as table_spec)
            when 'contract_answers' then cast(('contract_id', 'answer_id') as table_spec)

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -1405,6 +1405,24 @@ export interface Database {
         }
         Relationships: []
       }
+      private_users: {
+        Row: {
+          data: Json
+          fs_updated_time: string
+          id: string
+        }
+        Insert: {
+          data: Json
+          fs_updated_time: string
+          id: string
+        }
+        Update: {
+          data?: Json
+          fs_updated_time?: string
+          id?: string
+        }
+        Relationships: []
+      }
       q_and_a: {
         Row: {
           bounty: number

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -31,6 +31,7 @@ export type SupabaseClient = SupabaseClientGeneric<Database, 'public', Schema>
 export type CollectionTableMapping = { [coll: string]: TableName }
 export const collectionTables: CollectionTableMapping = {
   users: 'users',
+  "private-users": 'private_users',
   contracts: 'contracts',
   txns: 'txns',
   manalinks: 'manalinks',


### PR DESCRIPTION
Self-explanatory. Uses RLS for reads. I plan to get reads migrated over and then probably instead of using RLS for writes, I will make API endpoints for writing to `private_users` from the client.