### PR TITLE
Don't mess stuff up when there are no new feed items

### DIFF
--- a/web/hooks/use-feed-timeline.ts
+++ b/web/hooks/use-feed-timeline.ts
@@ -171,6 +171,10 @@ export const useFeedTimeline = (
       newestCreatedTimestamp.current
     )
 
+    if (data.length == 0) {
+      return { timelineItems: [] }
+    }
+
     const newFeedRows = data.map((d) => {
       const createdTimeAdjusted =
         1 - dayjs().diff(dayjs(d.created_time), 'day') / 20


### PR DESCRIPTION
This is wasting time and causing error spam in our Postgres logs when it attempts to query for undefined news IDs.