### PR TITLE
Make `getDonationsByCharity` not die on `null` response from `rpc`

### DIFF
--- a/web/lib/supabase/txns.ts
+++ b/web/lib/supabase/txns.ts
@@ -3,7 +3,7 @@ import { run, selectFrom } from 'common/supabase/utils'
 
 export async function getDonationsByCharity() {
   const { data } = await db.rpc('get_donations_by_charity')
-  return Object.fromEntries(data!.map((r: any) => [r.charity_id, r.total]))
+  return Object.fromEntries((data ?? []).map((r: any) => [r.charity_id, r.total]))
 }
 
 export async function getAllDonations(charityId: string) {


### PR DESCRIPTION
For some reason this happened during a Vercel build and it killed the build? Very unclear why.