### PR TITLE
Populate `manalink_claims` table from claims in manalink data

### DIFF
--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -855,6 +855,11 @@ as $$ begin
     new.creator_id := (new.data)->>'fromId';
     new.max_uses := ((new.data)->>'maxUses')::numeric;
     new.message := (new.data)->>'message';
+    if (new.data)->'claims' is not null then
+        delete from manalink_claims where manalink_id = new.id;
+        with claims as (select new.id, jsonb_array_elements((new.data)->'claims') as cdata)
+        insert into manalink_claims (manalink_id, txn_id) select id, cdata->>'txnId' from claims;
+    end if;
   end if;
   return new;
 end $$;
@@ -862,6 +867,15 @@ end $$;
 drop trigger manalinks_populate on manalinks;
 create trigger manalinks_populate before insert or update on manalinks
 for each row execute function manalinks_populate_cols();
+
+create table if not exists
+  manalink_claims (
+    manalink_id text not null,
+    txn_id text not null,
+    primary key (manalink_id, txn_id)
+  );
+
+alter table manalink_claims cluster on manalink_claims_pkey;
 
 create table if not exists
   posts (

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -1101,6 +1101,21 @@ export interface Database {
         }
         Relationships: []
       }
+      manalink_claims: {
+        Row: {
+          manalink_id: string
+          txn_id: string
+        }
+        Insert: {
+          manalink_id: string
+          txn_id: string
+        }
+        Update: {
+          manalink_id?: string
+          txn_id?: string
+        }
+        Relationships: []
+      }
       manalinks: {
         Row: {
           amount: number | null


### PR DESCRIPTION
This isn't a subcollection in Firestore, it's a JSON array in the manalink object. So we need to populate it in Supabase in the trigger that extracts the JSON from the manalink objects.

We can get the info we need about the claims, like the user that claimed the manalink, by joining the txns.