### PR TITLE
Ensuring that users are unique in lover.sql

### DIFF
--- a/backend/supabase/love/lover.sql
+++ b/backend/supabase/love/lover.sql
@@ -3,7 +3,7 @@
 create table if not exists
     lovers (
       id bigint generated always as identity primary key,
-      user_id text not null,
+      user_id text not null unique,
       created_time timestamptz not null default now(),
       last_online_time timestamptz not null default now(),
 


### PR DESCRIPTION
Should fix the problem where user can create several profiles:

![изображение](https://github.com/manifoldmarkets/manifold/assets/82749242/55b7590d-de47-41b0-9bcc-5369aa807eb2)

---

I think that bug was caused by race condition between DB select and check whether user exists https://github.com/manifoldmarkets/manifold/blob/97d04032dd9764b145f5c454e66e5ed3b0ee8c4b/backend/api/src/love/create-lover.ts#L46 and insert https://github.com/manifoldmarkets/manifold/blob/97d04032dd9764b145f5c454e66e5ed3b0ee8c4b/backend/api/src/love/create-lover.ts#L57