### PR TITLE
love: Add filter for interested in

### DIFF
--- a/love/components/filters.tsx
+++ b/love/components/filters.tsx
@@ -26,6 +26,7 @@ const initialFilters = {
   wants_kids_strength: -1,
   is_smoker: undefined,
   pref_relation_styles: undefined,
+  pref_gender: undefined,
 }
 export const Filters = (props: {
   allLovers: Lover[] | undefined
@@ -102,6 +103,12 @@ export const Filters = (props: {
       ) {
         return false
       } else if (filters.gender && lover.gender !== filters.gender) {
+        return false
+      } else if (
+        filters.pref_gender !== undefined &&
+        filters.pref_gender.length > 0 &&
+        !filters.pref_gender.every((g) => lover.pref_gender.includes(g))
+      ) {
         return false
       }
 
@@ -227,6 +234,24 @@ export const Filters = (props: {
                   }
                   onChange={(c) => {
                     updateFilter({ pref_relation_styles: c })
+                  }}
+                />
+              </Col>
+              <Col className={clsx(rowClassName)}>
+                <label className={clsx(labelClassName)}>Interested in</label>
+                <MultiCheckbox
+                  selected={filters.pref_gender ?? []}
+                  choices={
+                    {
+                      Male: 'male',
+                      Female: 'female',
+                      'Non-binary': 'non-binary',
+                      'Trans-female': 'trans-female',
+                      'Trans-male': 'trans-male',
+                    } as any
+                  }
+                  onChange={(c) => {
+                    updateFilter({ pref_gender: c })
                   }}
                 />
               </Col>


### PR DESCRIPTION
# Description

As a gay man I wanted to be able to filter the profiles to other gay men, so I added the ability to filter on users's preferred genders. 

The filtering on the checkboxes will be the intersection of all selections. This will support people only wanting to look for bisexual people. 

# Testing

## Beautiful new filters for "Interested in" 
<img width="839" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/4751193/e16a78bc-f2aa-437c-8fc9-db92c1d5bb14">

## Filter testing

1. Load page, see all profiles
2. Check "Interested in -> Male". Now I only see profiles that are interested in men.
3. Also check "Interested in -> Female". Now I see the intersection of profiles interested in men and interested in women.
4. Uncheck all boxes. Now I see all the profiles again.
