### PR TITLE
Replace bulky Firestore portfolio ID with small ID

### DIFF
--- a/backend/functions/src/scheduled/update-user-metrics.ts
+++ b/backend/functions/src/scheduled/update-user-metrics.ts
@@ -172,7 +172,6 @@ export async function updateUserMetricsCore() {
     if (didPortfolioChange) {
       portfolioUpdates.push({
         user_id: user.id,
-        portfolio_id: userDoc.collection('portfolioHistory').doc().id,
         ts: new Date(newPortfolio.timestamp).toISOString(),
         investment_value: newPortfolio.investmentValue,
         balance: newPortfolio.balance,

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -58,14 +58,13 @@ alter table private_users cluster on private_users_pkey;
 
 create table if not exists
   user_portfolio_history (
+    id bigint generated always as identity primary key,
     user_id text not null,
-    portfolio_id text not null,
     ts timestamp not null,
     investment_value numeric not null,
     balance numeric not null,
     total_deposits numeric not null,
     loan_total numeric,
-    primary key (user_id, portfolio_id)
   );
 
 alter table user_portfolio_history enable row level security;

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -1988,27 +1988,27 @@ export interface Database {
       user_portfolio_history: {
         Row: {
           balance: number | null
+          id: number
           investment_value: number | null
           loan_total: number | null
-          portfolio_id: string
           total_deposits: number | null
           ts: string | null
           user_id: string
         }
         Insert: {
           balance?: number | null
+          id?: never
           investment_value?: number | null
           loan_total?: number | null
-          portfolio_id: string
           total_deposits?: number | null
           ts?: string | null
           user_id: string
         }
         Update: {
           balance?: number | null
+          id?: never
           investment_value?: number | null
           loan_total?: number | null
-          portfolio_id?: string
           total_deposits?: number | null
           ts?: string | null
           user_id?: string


### PR DESCRIPTION
The portfolio history table is 100M rows, so replacing this big ass text ID with a normal ID (and likewise again in the primary key index) saves us gigabytes of DB space.