### PR TITLE
Add Back Button to Profile on Mobile

### DIFF
--- a/web/components/bet/user-bets-table.tsx
+++ b/web/components/bet/user-bets-table.tsx
@@ -477,9 +477,10 @@ function BetsTable(props: {
     <Col className="mb-4 flex-1 gap-4">
       <Col className={'w-full'}>
         <Row
-          className={
-            'grid-cols-15 bg-canvas-50 sticky top-0 z-10 grid w-full py-2 pr-1'
-          }
+          className={clsx(
+            'grid-cols-15 bg-canvas-50 sticky z-10 grid w-full py-2 pr-1',
+            isMobile ? 'top-16' : 'top-0' // Sets it below sticy user profile header on mobile
+          )}
         >
           {dataColumns.map((c) => (
             <span

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -236,7 +236,9 @@ function UserProfile(props: {
               />
             </div>
 
-            <MoreOptionsUserButton user={user} />
+            <div>
+              <MoreOptionsUserButton user={user} />
+            </div>
           </Row>
         )}
 

--- a/web/pages/[username]/index.tsx
+++ b/web/pages/[username]/index.tsx
@@ -69,6 +69,8 @@ import { getUserRating } from 'web/lib/supabase/reviews'
 import Custom404 from 'web/pages/404'
 import { UserPayments } from 'web/pages/payments'
 import { UserHandles } from 'web/components/user/user-handles'
+import { BackButton } from 'web/components/contract/back-button'
+import { useHeaderIsStuck } from 'web/hooks/use-header-is-stuck'
 
 export const getStaticProps = async (props: {
   params: {
@@ -159,6 +161,7 @@ function UserProfile(props: {
   const isCurrentUser = user.id === currentUser?.id
   const [showConfetti, setShowConfetti] = useState(false)
   const [followsYou, setFollowsYou] = useState(false)
+  const { ref: titleRef, headerStuck } = useHeaderIsStuck()
 
   useEffect(() => {
     const claimedMana = router.query['claimed-mana'] === 'yes'
@@ -211,13 +214,34 @@ function UserProfile(props: {
       {showConfetti && <FullscreenConfetti />}
 
       <Col className="mx-4 mt-1">
-        <Row
-          className={clsx(
-            'flex-wrap gap-2 py-1',
-            isMobile ? '' : 'justify-between'
-          )}
-        >
-          <Row className={clsx('gap-2')}>
+        {isMobile && (
+          <Row
+            className={
+              'bg-canvas-50 sticky top-0 z-10 w-full items-center justify-between gap-1 py-2 pr-1 sm:gap-2'
+            }
+          >
+            <BackButton />
+
+            <div
+              className={clsx(
+                'opacity-0 transition-opacity',
+                headerStuck && 'opacity-100'
+              )}
+            >
+              <StackedUserNames
+                usernameClassName={'sm:text-base'}
+                className={'font-bold sm:mr-0 sm:text-xl'}
+                user={user}
+                followsYou={followsYou}
+              />
+            </div>
+
+            <MoreOptionsUserButton user={user} />
+          </Row>
+        )}
+
+        <Row className={clsx('flex-wrap justify-between gap-2 py-1')}>
+          <Row className={clsx('gap-2')} ref={titleRef}>
             <Col className={'relative max-h-14'}>
               <ImageWithBlurredShadow
                 image={
@@ -253,17 +277,10 @@ function UserProfile(props: {
               <QuestsOrStreak user={user} />
             </Row>
           ) : isMobile ? (
-            <>
-              <div className={'my-auto'}>
-                <SendMessageButton toUser={user} currentUser={currentUser} />
-              </div>
-              <div className={'my-auto'}>
-                <FollowButton userId={user.id} />
-              </div>
-              <div className={'my-auto'}>
-                <MoreOptionsUserButton user={user} />
-              </div>
-            </>
+            <Row className={'items-center gap-1 sm:gap-2'}>
+              <SendMessageButton toUser={user} currentUser={currentUser} />
+              <FollowButton userId={user.id} />
+            </Row>
           ) : (
             <Row className="items-center gap-1 sm:gap-2">
               <SendMessageButton toUser={user} currentUser={currentUser} />


### PR DESCRIPTION
**Problem:** The UX on mobile when clicking into a profile is confusing because there is no way to get back out of the profile. Most modern phones will have auto-hid the browser bar thus making it very tricky to go back to the page you were just on. 

To solve for this I have added a sticky header to the top of user profile on mobile with a back button and relocated the More Options menu here as well. As you scroll down the page it shows the username in the header as well. 

**Before:**

<img width="480" alt="Screenshot 2023-10-31 at 3 39 31 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/b03a91a6-75b2-48dd-966b-3ddd63641250">


**After:**

<img width="448" alt="Screenshot 2023-10-31 at 4 14 07 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/24a26316-9aaf-458c-9b86-d89da1289ad9">

(Page on first load)

<img width="457" alt="Screenshot 2023-10-31 at 4 14 15 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/8f2519f3-3864-4274-a6d9-76d57ba95152">

(Scrolled shows username and the bumped down sticky table headers)


