### PR TITLE
Add `Order by` to Profiles View

### DIFF
--- a/love/components/filters.tsx
+++ b/love/components/filters.tsx
@@ -140,14 +140,14 @@ export const Filters = (props: {
     console.log(filteredLovers)
   }
   const cities: { [key: string]: string } = {
+    All: '',
     'San Francisco': 'San Francisco',
     'New York City': 'New York City',
     London: 'London',
-    All: '',
   }
   const [showFilters, setShowFilters] = useState(false)
 
-  const rowClassName = 'gap-2'
+  const rowClassName = 'gap-2 items-start'
   return (
     <Row className="bg-canvas-0 w-full gap-2 py-2">
       <Col className={'w-full'}>
@@ -189,12 +189,16 @@ export const Filters = (props: {
         </Row>
         {showFilters && (
           <>
-            <Row className={'flex-wrap gap-4'}>
+            <Row
+              className={
+                'border-ink-300 dark:border-ink-300 grid grid-cols-1 gap-4 rounded-md border p-4 md:grid-cols-2'
+              }
+            >
               <Col className={clsx(rowClassName)}>
                 <label className={clsx(labelClassName)}>Gender</label>
                 <select
                   className={
-                    'bg-canvas-0 text-ink-1000 border-ink-300 focus:border-primary-500 focus:ring-primary-500 rounded-md '
+                    'bg-canvas-0 text-ink-1000 border-ink-300 focus:border-primary-500 focus:ring-primary-500 w-full rounded-md sm:w-3/4'
                   }
                   onChange={(e) =>
                     updateFilter({
@@ -232,12 +236,12 @@ export const Filters = (props: {
                 />
               </Col>
 
-              <Row className="gap-4">
-                <Col className={clsx(rowClassName)}>
+              <Row className="gap-4 sm:pr-8">
+                <Col className={clsx(rowClassName, 'grow')}>
                   <label className={clsx(labelClassName)}>Min age</label>
                   <Input
                     type="number"
-                    className={'w-20'}
+                    className={'w-full'}
                     value={filters.pref_age_min}
                     onChange={(e) =>
                       updateFilter({ pref_age_min: Number(e.target.value) })
@@ -245,12 +249,12 @@ export const Filters = (props: {
                   />
                 </Col>
 
-                <Col className={clsx(rowClassName)}>
+                <Col className={clsx(rowClassName, 'grow')}>
                   <label className={clsx(labelClassName)}>Max age</label>
                   <Input
                     type="number"
                     value={filters.pref_age_max}
-                    className={'w-20'}
+                    className={'w-full'}
                     onChange={(e) =>
                       updateFilter({ pref_age_max: Number(e.target.value) })
                     }
@@ -271,13 +275,14 @@ export const Filters = (props: {
                 <ChoicesToggleGroup
                   currentChoice={filters.wants_kids_strength ?? 0}
                   choicesMap={{
+                    Any: -1,
                     Yes: 2,
                     No: 0,
-                    Any: -1,
                   }}
                   setChoice={(c) =>
                     updateFilter({ wants_kids_strength: Number(c) })
                   }
+                  toggleClassName="min-w-[80px] justify-center"
                 />
               </Col>
               <Col className={clsx(rowClassName)}>
@@ -299,8 +304,7 @@ export const Filters = (props: {
                   }}
                 />
               </Col>
-            </Row>
-            <Row className={'mt-2'}>
+
               <Col>
                 <label className={clsx(labelClassName)}>Other</label>
                 <Row className={'mt-2 gap-2'}>


### PR DESCRIPTION
This PR adds a select next to the filter button to allow users to switch ordering between `Recently Active` and `Newly Registered`. I also included a change to the display of filters to make them 2-column on desktop for easier scanning. 

New Order By select:

<img width="923" alt="Screenshot 2023-10-31 at 6 09 17 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/e7495943-f510-4849-9292-55ca03efd8b2">

Two-column filters on desktop:

<img width="875" alt="Screenshot 2023-10-31 at 6 09 33 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/133f93b5-34e3-4556-8fd7-dfe5de3e35f1">

One-column filters on mobile:

<img width="482" alt="Screenshot 2023-10-31 at 6 09 46 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/255e870b-d370-490f-9a6c-cea8fd10cd44">

