### PR TITLE
Preserve newlines in Linkify component while linkifying text

### DIFF
--- a/web/components/widgets/linkify.tsx
+++ b/web/components/widgets/linkify.tsx
@@ -38,13 +38,7 @@ export function Linkify(props: { text: string; className?: string }) {
     <span className={clsx(className, 'break-anywhere')}>
       {text.split(regex).map((part, i) => (
         <Fragment key={i}>
-          {/* Ensure newlines are respected */}
-          {part.split('\n').map((line, j) => (
-            <Fragment key={j}>
-              {j > 0 && <br />}
-              {line}
-            </Fragment>
-          ))}
+          {part}
           {links[i]}
         </Fragment>
       ))}

--- a/web/components/widgets/linkify.tsx
+++ b/web/components/widgets/linkify.tsx
@@ -38,7 +38,13 @@ export function Linkify(props: { text: string; className?: string }) {
     <span className={clsx(className, 'break-anywhere')}>
       {text.split(regex).map((part, i) => (
         <Fragment key={i}>
-          {part}
+          {/* Ensure newlines are respected */}
+          {part.split('\n').map((line, j) => (
+            <Fragment key={j}>
+              {j > 0 && <br />}
+              {line}
+            </Fragment>
+          ))}
           {links[i]}
         </Fragment>
       ))}

--- a/web/components/widgets/linkify.tsx
+++ b/web/components/widgets/linkify.tsx
@@ -35,7 +35,7 @@ export function Linkify(props: { text: string; className?: string }) {
     )
   })
   return (
-    <span className={clsx(className, 'break-anywhere')}>
+    <span className={clsx(className, 'break-anywhere whitespace-pre-line')}>
       {text.split(regex).map((part, i) => (
         <Fragment key={i}>
           {part}


### PR DESCRIPTION
This PR modifies the Linkify component to preserve newlines in the text while also converting mentions and URLs into links.

<img width="767" alt="Screenshot 2023-10-31 at 9 18 03 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/e7dd15e7-b706-4544-9c5e-55a905ba0c03">
