### PR TITLE
removing @s from link to Twitter

### DIFF
--- a/love/components/lover-profile-header.tsx
+++ b/love/components/lover-profile-header.tsx
@@ -103,7 +103,8 @@ export default function LoverProfileHeader(props: {
                 .replace('https://www.twitter.com/', '')
                 .replace('https://twitter.com/', '')
                 .replace('www.twitter.com/', '')
-                .replace('twitter.com/', '')}`}
+                .replace('twitter.com/', '')
+                .replace(/^@/, '')}`}
             >
               <Row className="items-center gap-1">
                 <img

--- a/web/components/user/user-handles.tsx
+++ b/web/components/user/user-handles.tsx
@@ -35,7 +35,8 @@ export function UserHandles(props: {
             .replace('https://www.twitter.com/', '')
             .replace('https://twitter.com/', '')
             .replace('www.twitter.com/', '')
-            .replace('twitter.com/', '')}`}
+            .replace('twitter.com/', '')
+            .replace(/^@/, '')}`}
         >
           <Row className="items-center gap-1">
             <img src="/twitter-logo.svg" className="h-4 w-4" alt="Twitter" />


### PR DESCRIPTION
On Android, linking to e.g. https://twitter.com/ManifoldMarkets when opening in app opens up the profile automatically, but linking to https://twitter.com/@ManifoldMarkets returns a failed search method.

Reproducible on https://manifold.love/TomboyTesting. 

System info:
Google Pixel 6
Android 15, October 5, 2023 security update (pixel 6 build/UP1A.231005.007)
Chrome browser 118.0.5993.111
Twitter app 10.13.1-release.0 and 10.14.0-release.0