### PR TITLE
Implement locking system for `addcontractstofeed`

### DIFF
--- a/backend/functions/src/scheduled/add-trending-feed-contracts.ts
+++ b/backend/functions/src/scheduled/add-trending-feed-contracts.ts
@@ -8,6 +8,7 @@ import {
   createSupabaseClient,
   createSupabaseDirectClient,
 } from 'shared/supabase/init'
+import { runSingleton } from 'shared/firestore-lock'
 
 export const addcontractstofeed = onSchedule(
   {
@@ -18,14 +19,17 @@ export const addcontractstofeed = onSchedule(
     cpu: 2
   },
   async () => {
-    const db = createSupabaseClient()
-    const pg = createSupabaseDirectClient()
-    const startTime = Date.now()
-    // TODO: we should just turn this into a docker container
-    // Keep running with the users cached (we refresh for new users) until we've just 10 minutes left,
-    // on the next run we'll do a full refresh (picking a new random sample of old users)
-    while (Date.now() < startTime + (MINUTE_INTERVAL * 60 - 10) * 1000) {
-      await addInterestingContractsToFeed(db, pg)
-    }
+    runSingleton('add-contracts-to-feed', async () => {
+      const db = createSupabaseClient()
+      const pg = createSupabaseDirectClient()
+      const startTime = Date.now()
+      // TODO: we should just turn this into a docker container
+      // Keep running with the users cached (we refresh for new users) until we've just 10 minutes left,
+      // on the next run we'll do a full refresh (picking a new random sample of old users)
+      while (Date.now() < startTime + (MINUTE_INTERVAL * 60 - 10) * 1000) {
+        await addInterestingContractsToFeed(db, pg)
+      }
+
+    })
   }
 )

--- a/backend/shared/src/firestore-lock.ts
+++ b/backend/shared/src/firestore-lock.ts
@@ -1,0 +1,42 @@
+import * as admin from 'firebase-admin'
+import { FieldValue } from 'firebase-admin/firestore'
+import { log } from 'shared/utils'
+export async function acquire(id: string) {
+  const fs = admin.firestore()
+  const ref = fs.collection('locks').doc(id)
+  try {
+    await ref.create({ id, ts: FieldValue.serverTimestamp() })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function release(id: string) {
+  const fs = admin.firestore()
+  const ref = fs.collection('locks').doc(id)
+  try {
+    await ref.delete()
+    return true
+  } catch { // it didn't exist
+    console.warn(`Attempted to release lock ${id} which wasn't taken.`)
+    return false
+  }
+}
+
+// attempts to take the lock, and runs fn if successful; else do nothing
+export async function runSingleton<T>(id: string, fn: () => Promise<T>) {
+  const lock = await acquire(id)
+  if (lock) {
+    log(`Acquired lock ${id}. Running.`)
+    try {
+      return await fn()
+    } finally {
+      await release(id)
+      log(`Released lock ${id}.`)
+    }
+  } else {
+    log(`Failed to acquire lock ${id}. Not running.`)
+    return null
+  }
+}


### PR DESCRIPTION
It seems that even though this is just a normal v2 scheduled function, it gets invoked multiple times as a matter of course. I think this may be by design in GCP (i.e. it's not guaranteed only once) so we should just deal with it.