### PR TITLE
API: Add market/[id]/update route

### DIFF
--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -1,7 +1,5 @@
 import * as admin from 'firebase-admin'
-import { JSONContent } from '@tiptap/core'
 import { FieldValue, Transaction } from 'firebase-admin/firestore'
-import { marked } from 'marked'
 import { runPostBountyTxn } from 'shared/txn/run-bounty-txn'
 import {
   DEV_HOUSE_LIQUIDITY_PROVIDER_ID,
@@ -13,6 +11,7 @@ import {
   Contract,
   CPMMBinaryContract,
   CPMMMultiContract,
+  getDescriptionJson,
   NO_CLOSE_TIME_TYPES,
   OutcomeType,
 } from 'common/contract'
@@ -27,7 +26,7 @@ import {
 import { randomString } from 'common/util/random'
 import { slugify } from 'common/util/slugify'
 import { getCloseDate } from 'shared/helpers/openai-utils'
-import { GCPLog, getUser, htmlToRichText, isProd } from 'shared/utils'
+import { GCPLog, getUser, isProd } from 'shared/utils'
 import { APIError, AuthedUser, typedEndpoint } from './helpers'
 import { STONK_INITIAL_PROB } from 'common/stonk'
 import {
@@ -287,30 +286,6 @@ const runCreateMarketTxn = async (
     })
 
   return contract
-}
-
-function getDescriptionJson(
-  description?: string | JSONContent,
-  descriptionHtml?: string,
-  descriptionMarkdown?: string,
-  descriptionJson?: string
-): JSONContent {
-  if (description) {
-    if (typeof description === 'string') {
-      return htmlToRichText(`<p>${description}</p>`)
-    } else {
-      return description
-    }
-  } else if (descriptionHtml) {
-    return htmlToRichText(descriptionHtml)
-  } else if (descriptionMarkdown) {
-    return htmlToRichText(marked.parse(descriptionMarkdown))
-  } else if (descriptionJson) {
-    return JSON.parse(descriptionJson)
-  } else {
-    // Use a single empty space as the description
-    return htmlToRichText('<p> </p>')
-  }
 }
 
 async function getCloseTimestamp(

--- a/backend/api/src/update-market.ts
+++ b/backend/api/src/update-market.ts
@@ -1,76 +1,114 @@
-import { APIError, authEndpoint, validate } from 'api/helpers'
+import { APIError, typedEndpoint, validate } from 'api/helpers'
 import { getContractSupabase } from 'shared/utils'
 import * as admin from 'firebase-admin'
-import { z } from 'zod'
 import { trackPublicEvent } from 'shared/analytics'
 import { throwErrorIfNotMod } from 'shared/helpers/auth'
 import { removeUndefinedProps } from 'common/util/object'
 import { recordContractEdit } from 'shared/record-contract-edit'
+import { getDescriptionJson } from 'common/contract'
+import { JSONContent } from '@tiptap/core'
+import { updateMarketProps } from 'common/api/market-types'
 
-const bodySchema = z
-  .object({
-    contractId: z.string(),
-    visibility: z.enum(['unlisted', 'public']).optional(),
-    closeTime: z.number().optional(),
-    addAnswersMode: z.enum(['ONLY_CREATOR', 'ANYONE']).optional(),
-    sort: z.string().optional(),
-  })
-  .strict()
-
-export const updatemarket = authEndpoint(async (req, auth, log) => {
-  const { contractId, visibility, addAnswersMode, closeTime, sort } = validate(
-    bodySchema,
-    req.body
-  )
-  if (!visibility && !closeTime && !addAnswersMode && !sort)
-    throw new APIError(
-      400,
-      'Must provide some change to the contract'
-    )
-  const contract = await getContractSupabase(contractId)
-  if (!contract) throw new APIError(404, `Contract ${contractId} not found`)
-  if (contract.creatorId !== auth.uid) await throwErrorIfNotMod(auth.uid)
-
-  await trackPublicEvent(
-    auth.uid,
-    'update market',
-    removeUndefinedProps({
+export const updatemarket = typedEndpoint(
+  'update-market',
+  async (props, auth, { log }) => {
+    const {
       contractId,
       visibility,
-      closeTime,
       addAnswersMode,
-    })
-  )
-  if (closeTime) {
-    await firestore.doc(`contracts/${contractId}`).update({
+      sort,
       closeTime,
-    })
-    log('updated close time')
-    await recordContractEdit(contract, auth.uid, ['closeTime'])
-  }
-  if (visibility) {
-    await firestore.doc(`contracts/${contractId}`).update(
+      question,
+      description,
+      descriptionHtml,
+      descriptionJson,
+      descriptionMarkdown,
+    } = validate(updateMarketProps, props)
+    if (
+      !visibility &&
+      !closeTime &&
+      !addAnswersMode &&
+      !sort &&
+      !question &&
+      !description &&
+      !descriptionHtml &&
+      !descriptionMarkdown &&
+      !descriptionJson
+    )
+      throw new APIError(400, 'Must provide some change to the contract')
+    const contract = await getContractSupabase(contractId)
+    if (!contract) throw new APIError(404, `Contract ${contractId} not found`)
+    if (contract.creatorId !== auth.uid) await throwErrorIfNotMod(auth.uid)
+
+    await trackPublicEvent(
+      auth.uid,
+      'update market',
       removeUndefinedProps({
-        unlistedById: visibility === 'unlisted' ? auth.uid : undefined,
+        contractId,
         visibility,
+        closeTime,
+        addAnswersMode,
+        question,
+        description,
+        descriptionHtml,
+        descriptionJson,
+        descriptionMarkdown,
       })
     )
-    log('updated visibility')
-    await recordContractEdit(contract, auth.uid, ['visibility'])
-  }
-  if (addAnswersMode) {
-    await firestore.doc(`contracts/${contractId}`).update({
-      addAnswersMode,
-    })
-    log('updated add answers mode')
-  }
-  if (sort) {
-    await firestore.doc(`contracts/${contractId}`).update({
-      sort,
-    })
-    log('updated sort')
-  }
+    if (closeTime) {
+      await firestore.doc(`contracts/${contractId}`).update({
+        closeTime,
+      })
+      log('updated close time')
+      await recordContractEdit(contract, auth.uid, ['closeTime'])
+    }
+    if (visibility) {
+      await firestore.doc(`contracts/${contractId}`).update(
+        removeUndefinedProps({
+          unlistedById: visibility === 'unlisted' ? auth.uid : undefined,
+          visibility,
+        })
+      )
+      log('updated visibility')
+      await recordContractEdit(contract, auth.uid, ['visibility'])
+    }
+    if (addAnswersMode) {
+      await firestore.doc(`contracts/${contractId}`).update({
+        addAnswersMode,
+      })
+      log('updated add answers mode')
+    }
+    if (sort) {
+      await firestore.doc(`contracts/${contractId}`).update({
+        sort,
+      })
+      log('updated sort')
+    }
+    if (question) {
+      await firestore.doc(`contracts/${contractId}`).update({
+        question,
+      })
+      log('updated question')
+    }
 
-  return { success: true }
-})
+    let resolvedDescription: JSONContent | undefined = undefined
+    if (
+      description ||
+      descriptionHtml ||
+      descriptionMarkdown ||
+      descriptionJson
+    ) {
+      resolvedDescription = getDescriptionJson(
+        description,
+        descriptionHtml,
+        descriptionMarkdown,
+        descriptionJson
+      )
+      await firestore.doc(`contracts/${contractId}`).update({
+        description: resolvedDescription,
+      })
+      log('updated description')
+    }
+  }
+)
 const firestore = admin.firestore()

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -288,6 +288,30 @@ export const createMarketProps = z
     ])
   )
 
+// update market
+
+export const updateMarketProps = z
+  .object({
+    contractId: z.string(),
+    visibility: z.enum(VISIBILITIES).default('public').optional(),
+    closeTime: z
+      .union([z.date(), z.number()])
+      .refine(
+        (date) =>
+          (typeof date === 'number' ? date : date.getTime()) > Date.now(),
+        'Close time must be in the future.'
+      )
+      .optional(),
+    question: z.string().min(1).max(MAX_QUESTION_LENGTH).optional(),
+    description: contentSchema.or(z.string()).optional(),
+    descriptionHtml: z.string().optional(),
+    descriptionMarkdown: z.string().optional(),
+    descriptionJson: z.string().optional(),
+    addAnswersMode: z.enum(['ONLY_CREATOR', 'ANYONE']).optional(),
+    sort: z.string().optional(),
+  })
+  .strict()
+
 // resolve market
 
 export const resolveBinarySchema = z

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -5,6 +5,7 @@ import {
   resolveMarketProps,
   type LiteMarket,
   FullMarket,
+  updateMarketProps,
 } from './market-types'
 import type { ContractComment } from 'common/comment'
 import type { User } from 'common/user'
@@ -185,6 +186,12 @@ export const API = (_apiTypeCheck = {
     authed: true,
     returns: {} as LiteMarket,
     props: createMarketProps,
+  },
+  'update-market': {
+    method: 'POST',
+    visibility: 'public',
+    authed: true,
+    props: updateMarketProps,
   },
   close: {
     method: 'POST',

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -2,17 +2,19 @@ import { Answer, DpmAnswer } from './answer'
 import { Bet } from './bet'
 import { MultiSerializedPoints, SerializedPoint } from './chart'
 import { Fees } from './fees'
-import { JSONContent } from '@tiptap/core'
+import { JSONContent, generateJSON } from '@tiptap/core'
 import { GroupLink } from 'common/group'
 import { ContractMetric, ContractMetricsByOutcome } from './contract-metric'
 import { ContractComment } from './comment'
 import { ENV_CONFIG } from './envs/constants'
 import { formatMoney, formatPercent } from './util/format'
+import { extensions } from './util/parse'
 import { getLiquidity } from './calculate-cpmm-multi'
 import { sum } from 'lodash'
 import { getDisplayProbability } from 'common/calculate'
 import { PollOption } from './poll-option'
 import { ChartAnnotation } from 'common/supabase/chart-annotations'
+import { marked } from 'marked'
 
 /************************************************
 
@@ -431,3 +433,27 @@ export type MaybeAuthedContractParams =
   | {
       state: 'not found'
     }
+
+export function getDescriptionJson(
+  description?: string | JSONContent,
+  descriptionHtml?: string,
+  descriptionMarkdown?: string,
+  descriptionJson?: string
+): JSONContent {
+  if (description) {
+    if (typeof description === 'string') {
+      return generateJSON(`<p>${description}</p>`, extensions)
+    } else {
+      return description
+    }
+  } else if (descriptionHtml) {
+    return generateJSON(descriptionHtml, extensions)
+  } else if (descriptionMarkdown) {
+    return generateJSON(marked.parse(descriptionMarkdown), extensions)
+  } else if (descriptionJson) {
+    return JSON.parse(descriptionJson)
+  } else {
+    // Use a single empty space as the description
+    return generateJSON('<p> </p>', extensions)
+  }
+}

--- a/web/pages/api/v0/market/[id]/update.ts
+++ b/web/pages/api/v0/market/[id]/update.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { nextHandler } from 'web/lib/api/handler'
+
+export const config = { api: { bodyParser: true } }
+
+const handler = nextHandler('update-market')
+
+export default async function route(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query
+
+  if (req.body) req.body.contractId = id
+  await handler(req, res)
+}


### PR DESCRIPTION
Hi - I've attempted to add the ability to update a market question or description via the API. It's a feature I could use and it was a nice reason to explore the Manifold source code. Is this contribution something that could be accepted/merged if I also update the API docs and figure out how to test it?

---

- Move `getDescriptionJson()` from `backend/api/src/create-market.ts` to `common/src/contract.ts` so it can be used for creating or updating
- Modify `backend/api/src/update-market.ts` to accept `question` and `description` (optional) and validate/save them
- Add `web/pages/api/v0/market/[id]/update.ts` to pass requests to the updatemarket() function.

Resolves #2043.