### PR TITLE
Fixing conditional probablity render in the case of resolved dating markets

### DIFF
--- a/love/lib/util/relationship-market.ts
+++ b/love/lib/util/relationship-market.ts
@@ -7,6 +7,6 @@ export const getCumulativeRelationshipProb = (
   const { answers } = contract
   return answers
     .slice(0, index + 1)
-    .map((a) => a.prob)
+    .map((a) => a.resolution === "YES"? 1:a.prob)
     .reduce((a, b) => a * b, 1)
 }


### PR DESCRIPTION
https://discord.com/channels/915138780216823849/1166835928518631454/1172784262047617025

as noted here, there are issues with showing conditional probability for dates when one of the previous markets has already resolved

replicable on second date market between Annie L and https://manifold.love/emmy here

Fix looks at markets that have resolved yes using a ternary statement and sets their probability to 1 instead of whatever the answer was before resolution