### PR TITLE
Remove CORS requirement from all API endpoints

### DIFF
--- a/web/lib/api/cors.ts
+++ b/web/lib/api/cors.ts
@@ -4,11 +4,11 @@ import { NextApiRequest, NextApiResponse } from 'next'
 export function applyCorsHeaders(
   req: NextApiRequest,
   res: NextApiResponse,
-  params: Cors.CorsOptions
+  params?: Cors.CorsOptions
 ) {
   // This cors module is made as express.js middleware, so it's easier to promisify it for ourselves.
   return new Promise((resolve, reject) => {
-    Cors(params)(req, res, (result) => {
+    Cors(params ?? CORS_UNRESTRICTED)(req, res, (result) => {
       if (result instanceof Error) {
         return reject(result)
       }

--- a/web/pages/api/v0/bet/cancel/[betId].ts
+++ b/web/pages/api/v0/bet/cancel/[betId].ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
 
   const { betId } = req.query as { betId: string }
 

--- a/web/pages/api/v0/bet/index.ts
+++ b/web/pages/api/v0/bet/index.ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: false } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
   try {
     const backendRes = await fetchBackend(req, 'placebet')
     await forwardResponse(res, backendRes)

--- a/web/pages/api/v0/bets.ts
+++ b/web/pages/api/v0/bets.ts
@@ -1,6 +1,6 @@
 import { Bet, BetFilter } from 'common/bet'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { CORS_UNRESTRICTED, applyCorsHeaders } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { getUserByUsername } from 'web/lib/firebase/users'
 import { getBet, getPublicBets } from 'web/lib/supabase/bets'
 import { getContractFromSlug } from 'web/lib/supabase/contracts'

--- a/web/pages/api/v0/bets.ts
+++ b/web/pages/api/v0/bets.ts
@@ -89,7 +89,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Bet[] | ValidationError | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
 
   let params: z.infer<typeof queryParams>
   try {

--- a/web/pages/api/v0/comment.ts
+++ b/web/pages/api/v0/comment.ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
   try {
     const backendRes = await fetchBackend(req, 'createcomment')
     await forwardResponse(res, backendRes)

--- a/web/pages/api/v0/comments.ts
+++ b/web/pages/api/v0/comments.ts
@@ -43,7 +43,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Comment[] | ValidationError | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
 
   let params: z.infer<typeof queryParams>
   try {

--- a/web/pages/api/v0/comments.ts
+++ b/web/pages/api/v0/comments.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import type { Comment } from 'common/comment'
 import { getContractFromSlug } from 'web/lib/supabase/contracts'
 import { ApiError, ValidationError } from './_types'

--- a/web/pages/api/v0/dalle.ts
+++ b/web/pages/api/v0/dalle.ts
@@ -1,9 +1,6 @@
 import OpenAI from 'openai'
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { upload } from 'web/pages/api/v0/dream'
 
@@ -11,10 +8,7 @@ export const config = { api: { bodyParser: true } }
 
 // Highly experimental. Proxy for https://github.com/vpzomtrrfrt/stability-client
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
 
   // Check that prompt and apiKey are included in the body
   if (!req.body.prompt) {

--- a/web/pages/api/v0/deployment-id.ts
+++ b/web/pages/api/v0/deployment-id.ts
@@ -5,7 +5,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
 
   const deploymentId = process.env.VERCEL_URL
   return res.status(200).json({ deploymentId })

--- a/web/pages/api/v0/deployment-id.ts
+++ b/web/pages/api/v0/deployment-id.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 
 export default async function handler(
   req: NextApiRequest,

--- a/web/pages/api/v0/dream.ts
+++ b/web/pages/api/v0/dream.ts
@@ -3,20 +3,14 @@ import { nanoid } from 'nanoid'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { generateAsync } from 'stability-client'
 import { storage } from 'web/lib/firebase/init'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 
 export const config = { api: { bodyParser: true } }
 
 // Highly experimental. Proxy for https://github.com/vpzomtrrfrt/stability-client
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
 
   // Check that prompt and apiKey are included in the body
   if (!req.body.prompt) {

--- a/web/pages/api/v0/group/[slug].ts
+++ b/web/pages/api/v0/group/[slug].ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { getGroupBySlug } from 'web/lib/supabase/groups'
 
 export default async function handler(

--- a/web/pages/api/v0/group/[slug].ts
+++ b/web/pages/api/v0/group/[slug].ts
@@ -6,7 +6,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { slug } = req.query
   const group = await getGroupBySlug(slug as string)
   if (!group) {

--- a/web/pages/api/v0/group/by-id/[id]/index.ts
+++ b/web/pages/api/v0/group/by-id/[id]/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { getGroup } from 'web/lib/supabase/group'
 
 export default async function handler(

--- a/web/pages/api/v0/group/by-id/[id]/index.ts
+++ b/web/pages/api/v0/group/by-id/[id]/index.ts
@@ -6,7 +6,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { id } = req.query
   const group = await getGroup(id as string)
   if (!group) {

--- a/web/pages/api/v0/group/by-id/[id]/markets.ts
+++ b/web/pages/api/v0/group/by-id/[id]/markets.ts
@@ -8,7 +8,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { id } = req.query
   const contracts = (await getGroupMarkets(id as string))?.map((contract) =>
     toLiteMarket(contract)

--- a/web/pages/api/v0/group/by-id/[id]/markets.ts
+++ b/web/pages/api/v0/group/by-id/[id]/markets.ts
@@ -1,6 +1,6 @@
 import { toLiteMarket } from 'common/api-market-types'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { marketCacheStrategy } from 'web/pages/api/v0/market/[id]'
 import { getGroupMarkets } from 'web/lib/supabase/group'
 

--- a/web/pages/api/v0/groups.ts
+++ b/web/pages/api/v0/groups.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { z } from 'zod'
 import { validate } from 'web/pages/api/v0/_validate'
 import { getMemberGroups, getPublicGroups } from 'web/lib/supabase/groups'

--- a/web/pages/api/v0/groups.ts
+++ b/web/pages/api/v0/groups.ts
@@ -18,7 +18,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   let params: z.infer<typeof queryParams>
   try {
     params = validate(queryParams, req.query)

--- a/web/pages/api/v0/hide-comment.ts
+++ b/web/pages/api/v0/hide-comment.ts
@@ -1,9 +1,4 @@
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-  isAdminId,
-  isModId,
-} from 'common/envs/constants'
+import { isAdminId, isModId } from 'common/envs/constants'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import * as admin from 'firebase-admin'
@@ -29,10 +24,7 @@ export type HideCommentReq = {
 }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
   const { commentPath } = validate(schema, req.body)
 
   const userId = await getUserId(req, res)

--- a/web/pages/api/v0/managram.ts
+++ b/web/pages/api/v0/managram.ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
   try {
     const backendRes = await fetchBackend(req, 'send-mana')
     await forwardResponse(res, backendRes)

--- a/web/pages/api/v0/managrams.ts
+++ b/web/pages/api/v0/managrams.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { ApiError, ValidationError } from 'web/pages/api/v0/_types'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { z } from 'zod'
 import { validate } from 'web/pages/api/v0/_validate'
 import { db } from 'web/lib/supabase/db'

--- a/web/pages/api/v0/managrams.ts
+++ b/web/pages/api/v0/managrams.ts
@@ -24,7 +24,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ManaPayTxn[] | ValidationError | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
 
   let params: z.infer<typeof queryParams>
   try {

--- a/web/pages/api/v0/market/[id]/add-liquidity.ts
+++ b/web/pages/api/v0/market/[id]/add-liquidity.ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
 
   const { id } = req.query
   const contractId = id as string

--- a/web/pages/api/v0/market/[id]/close.ts
+++ b/web/pages/api/v0/market/[id]/close.ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
 
   const { id } = req.query
   const contractId = id as string

--- a/web/pages/api/v0/market/[id]/group.ts
+++ b/web/pages/api/v0/market/[id]/group.ts
@@ -1,8 +1,4 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 

--- a/web/pages/api/v0/market/[id]/group.ts
+++ b/web/pages/api/v0/market/[id]/group.ts
@@ -9,10 +9,7 @@ import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
   const { id } = req.query
   const contractId = id as string
   if (req.body) req.body.contractId = contractId

--- a/web/pages/api/v0/market/[id]/index.ts
+++ b/web/pages/api/v0/market/[id]/index.ts
@@ -9,7 +9,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<FullMarket | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { id } = req.query
   const contractId = id as string
   const contract = await getContract(contractId)

--- a/web/pages/api/v0/market/[id]/index.ts
+++ b/web/pages/api/v0/market/[id]/index.ts
@@ -1,6 +1,6 @@
 import { FullMarket, toFullMarket } from 'common/api-market-types'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { ApiError } from '../../_types'
 import { getContract } from 'web/lib/supabase/contracts'
 

--- a/web/pages/api/v0/market/[id]/lite.ts
+++ b/web/pages/api/v0/market/[id]/lite.ts
@@ -9,7 +9,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<LiteMarket | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { id } = req.query
   const contractId = id as string
 

--- a/web/pages/api/v0/market/[id]/lite.ts
+++ b/web/pages/api/v0/market/[id]/lite.ts
@@ -1,6 +1,6 @@
 import { LiteMarket, toLiteMarket } from 'common/api-market-types'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { ApiError } from '../../_types'
 import { marketCacheStrategy } from 'web/pages/api/v0/market/[id]/index'
 import { getContract } from 'web/lib/supabase/contracts'

--- a/web/pages/api/v0/market/[id]/positions.ts
+++ b/web/pages/api/v0/market/[id]/positions.ts
@@ -27,7 +27,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ContractMetric[] | ValidationError | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   let params: z.infer<typeof queryParams>
   try {
     params = validate(queryParams, req.query)

--- a/web/pages/api/v0/market/[id]/positions.ts
+++ b/web/pages/api/v0/market/[id]/positions.ts
@@ -5,7 +5,7 @@ import {
 } from 'common/supabase/contract-metrics'
 import { uniqBy } from 'lodash'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { db } from 'web/lib/supabase/db'
 import { validate } from 'web/pages/api/v0/_validate'
 import { z } from 'zod'

--- a/web/pages/api/v0/market/[id]/resolve.ts
+++ b/web/pages/api/v0/market/[id]/resolve.ts
@@ -1,8 +1,4 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 

--- a/web/pages/api/v0/market/[id]/resolve.ts
+++ b/web/pages/api/v0/market/[id]/resolve.ts
@@ -9,10 +9,7 @@ import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
 
   const { id } = req.query
   const contractId = id as string

--- a/web/pages/api/v0/market/[id]/sell.ts
+++ b/web/pages/api/v0/market/[id]/sell.ts
@@ -1,8 +1,4 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 

--- a/web/pages/api/v0/market/[id]/sell.ts
+++ b/web/pages/api/v0/market/[id]/sell.ts
@@ -9,10 +9,7 @@ import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
 
   const { id } = req.query
   const contractId = id as string

--- a/web/pages/api/v0/market/index.ts
+++ b/web/pages/api/v0/market/index.ts
@@ -1,18 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
+
 import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: false } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
   try {
     const backendRes = await fetchBackend(req, 'createmarket')
     await forwardResponse(res, backendRes)

--- a/web/pages/api/v0/markets.ts
+++ b/web/pages/api/v0/markets.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { CORS_UNRESTRICTED, applyCorsHeaders } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: false } }

--- a/web/pages/api/v0/markets.ts
+++ b/web/pages/api/v0/markets.ts
@@ -5,7 +5,7 @@ import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 export const config = { api: { bodyParser: false } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   try {
     const backendRes = await fetchBackend(req, 'v0/markets')
     await forwardResponse(res, backendRes)

--- a/web/pages/api/v0/reports.ts
+++ b/web/pages/api/v0/reports.ts
@@ -26,7 +26,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<LiteReport[] | ValidationError | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
 
   const { data: mostRecentReports } = await run(
     db

--- a/web/pages/api/v0/reports.ts
+++ b/web/pages/api/v0/reports.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { ApiError, ValidationError } from 'web/pages/api/v0/_types'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { contractUrl } from 'common/contract'
 import { filterDefined } from 'common/util/array'
 import { getComment, getCommentsOnPost } from 'web/lib/supabase/comments'

--- a/web/pages/api/v0/slug/[slug].ts
+++ b/web/pages/api/v0/slug/[slug].ts
@@ -1,6 +1,6 @@
 import { FullMarket, toFullMarket } from 'common/api-market-types'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { getContractFromSlug } from 'web/lib/supabase/contracts'
 import { ApiError } from '../_types'
 import { db } from 'web/lib/supabase/db'

--- a/web/pages/api/v0/slug/[slug].ts
+++ b/web/pages/api/v0/slug/[slug].ts
@@ -9,7 +9,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<FullMarket | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { slug } = req.query
 
   const contract = await getContractFromSlug(slug as string, db)

--- a/web/pages/api/v0/twitch/save.ts
+++ b/web/pages/api/v0/twitch/save.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { CORS_UNRESTRICTED, applyCorsHeaders } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: true } }

--- a/web/pages/api/v0/twitch/save.ts
+++ b/web/pages/api/v0/twitch/save.ts
@@ -1,18 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import {
-  CORS_ORIGIN_MANIFOLD,
-  CORS_ORIGIN_LOCALHOST,
-} from 'common/envs/constants'
-import { applyCorsHeaders } from 'web/lib/api/cors'
+import { CORS_UNRESTRICTED, applyCorsHeaders } from 'web/lib/api/cors'
 import { fetchBackend, forwardResponse } from 'web/lib/api/proxy'
 
 export const config = { api: { bodyParser: true } }
 
 export default async function route(req: NextApiRequest, res: NextApiResponse) {
-  await applyCorsHeaders(req, res, {
-    origin: [CORS_ORIGIN_MANIFOLD, CORS_ORIGIN_LOCALHOST],
-    methods: 'POST',
-  })
+  await applyCorsHeaders(req, res)
   try {
     const backendRes = await fetchBackend(req, 'savetwitchcredentials')
     await forwardResponse(res, backendRes)

--- a/web/pages/api/v0/user/[username]/bets/index.ts
+++ b/web/pages/api/v0/user/[username]/bets/index.ts
@@ -10,7 +10,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Bet[] | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { username } = req.query
 
   const user = await getUserByUsername(username as string)

--- a/web/pages/api/v0/user/[username]/bets/index.ts
+++ b/web/pages/api/v0/user/[username]/bets/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { Bet } from 'web/lib/firebase/bets'
 import { getUserByUsername } from 'web/lib/firebase/users'
 import { ApiError } from '../../../_types'

--- a/web/pages/api/v0/user/[username]/index.ts
+++ b/web/pages/api/v0/user/[username]/index.ts
@@ -7,7 +7,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<LiteUser | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { username } = req.query
   const user = await getUserByUsername(username as string)
   if (!user) {

--- a/web/pages/api/v0/user/[username]/index.ts
+++ b/web/pages/api/v0/user/[username]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { getUserByUsername } from 'web/lib/firebase/users'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { LiteUser, ApiError, toLiteUser } from '../../_types'
 
 export default async function handler(

--- a/web/pages/api/v0/user/by-id/[id].ts
+++ b/web/pages/api/v0/user/by-id/[id].ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { getUser } from 'web/lib/firebase/users'
 import { User } from 'common/user'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { ApiError } from '../../_types'
 
 export default async function handler(

--- a/web/pages/api/v0/user/by-id/[id].ts
+++ b/web/pages/api/v0/user/by-id/[id].ts
@@ -8,7 +8,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<User | ApiError>
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
   const { id } = req.query
   const user = await getUser(id as string)
   if (!user) {

--- a/web/pages/api/v0/users.ts
+++ b/web/pages/api/v0/users.ts
@@ -1,7 +1,7 @@
 // Next.js API route support: https://vercel.com/docs/concepts/functions/serverless-functions
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { listAllUsers } from 'web/lib/firebase/users'
-import { applyCorsHeaders, CORS_UNRESTRICTED } from 'web/lib/api/cors'
+import { applyCorsHeaders } from 'web/lib/api/cors'
 import { toLiteUser, ValidationError } from './_types'
 import { z } from 'zod'
 import { validate } from './_validate'

--- a/web/pages/api/v0/users.ts
+++ b/web/pages/api/v0/users.ts
@@ -21,7 +21,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  await applyCorsHeaders(req, res, CORS_UNRESTRICTED)
+  await applyCorsHeaders(req, res)
 
   let params: z.infer<typeof queryParams>
   try {


### PR DESCRIPTION
This allows other websites (like manifund.org) make client-side requests to Manifold's API endpoints without any additional work. Note that before this PR, about half of our 32 APIs restricted CORS access to Manifold's website and localhost; the other half had no restrictions. AFAICT there was no underlying reason for this, so I'm getting rid of all of it.

This also fixes the Manifund issue where it is unable to pull up your account and balance via the /v0/me API:

<img width="679" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/856034/275518ef-4267-4b95-ae7b-b3a6469ab941">
