### PR TITLE
Add Auth Check Handler to Continue User Actions

### DIFF
--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -19,7 +19,7 @@ import {
   formatPercent,
 } from 'common/util/format'
 import { computeCpmmBet } from 'common/new-bet'
-import { User, firebaseLogin } from 'web/lib/firebase/users'
+import { User } from 'web/lib/firebase/users'
 import { LimitBet } from 'common/bet'
 import { APIError, placeBet } from 'web/lib/firebase/api'
 import { BuyAmountInput } from '../widgets/amount-input'
@@ -28,7 +28,7 @@ import { useFocus } from 'web/hooks/use-focus'
 import { useUnfilledBetsAndBalanceByUserId } from '../../hooks/use-bets'
 import { getFormattedMappedValue, getMappedValue } from 'common/pseudo-numeric'
 import { YourOrders } from './order-book'
-import { track, withTracking } from 'web/lib/service/analytics'
+import { track } from 'web/lib/service/analytics'
 import { YesNoSelector } from './yes-no-selector'
 import { isAndroid, isIOS } from 'web/lib/util/device'
 import { WarningConfirmationButton } from '../buttons/warning-confirmation-button'
@@ -41,6 +41,7 @@ import { getCpmmProbability } from 'common/calculate-cpmm'
 import { removeUndefinedProps } from 'common/util/object'
 import { calculateCpmmMultiArbitrageBet } from 'common/calculate-cpmm-arbitrage'
 import LimitOrderPanel from './limit-order-panel'
+import { useAuthCheckHandler } from 'web/hooks/use-auth-check-handler'
 
 export type BinaryOutcomes = 'YES' | 'NO' | undefined
 
@@ -101,6 +102,8 @@ export function BuyPanel(props: {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const [inputRef, focusAmountInput] = useFocus()
+
+  const { authCheckHandler } = useAuthCheckHandler()
 
   useEffect(() => {
     if (initialOutcome) {
@@ -411,7 +414,12 @@ export function BuyPanel(props: {
           <Button
             color={outcome === 'NO' ? 'red' : 'green'}
             size="xl"
-            onClick={withTracking(firebaseLogin, 'login from bet panel')}
+            onClick={async () => {
+              track('login from bet panel')
+              authCheckHandler(() => {
+                submitBet()
+              })
+            }}
           >
             Sign up to predict
           </Button>

--- a/web/components/bet/feed-bet-button.tsx
+++ b/web/components/bet/feed-bet-button.tsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx'
 import { CPMMBinaryContract } from 'common/contract'
 import { useState } from 'react'
-import { User, firebaseLogin } from 'web/lib/firebase/users'
+import { User } from 'web/lib/firebase/users'
 import { Button } from '../buttons/button'
 import { Col } from '../layout/col'
 import { MODAL_CLASS, Modal } from '../layout/modal'
 import { BuyPanel, BinaryOutcomes } from './bet-panel'
+import { useAuthCheckHandler } from 'web/hooks/use-auth-check-handler'
 
 export function BetButton(props: {
   contract: CPMMBinaryContract
@@ -41,6 +42,7 @@ function FeedBetButton(props: {
 }) {
   const { dialogueThatIsOpen, setDialogueThatIsOpen, contract, outcome, user } =
     props
+  const { authCheckHandler } = useAuthCheckHandler()
   return (
     <>
       <Button
@@ -49,11 +51,10 @@ function FeedBetButton(props: {
         onClick={(e) => {
           e.preventDefault()
           e.stopPropagation()
-          if (!user) {
-            firebaseLogin()
-            return
-          }
-          setDialogueThatIsOpen(outcome)
+
+          authCheckHandler(() => {
+            setDialogueThatIsOpen(outcome)
+          })
         }}
       >
         Bet

--- a/web/components/contract/contract-table-action.tsx
+++ b/web/components/contract/contract-table-action.tsx
@@ -1,7 +1,6 @@
 import { Contract } from 'common/contract'
 import { User } from 'common/user'
 import { useState } from 'react'
-import { firebaseLogin } from 'web/lib/firebase/users'
 import { BetDialog } from '../bet/bet-dialog'
 import { Button } from '../buttons/button'
 import { Col } from '../layout/col'
@@ -13,6 +12,7 @@ import { isClosed } from './contracts-table'
 import { AnswersResolvePanel } from '../answers/answer-resolve-panel'
 import { useUser } from 'web/hooks/use-user'
 import clsx from 'clsx'
+import { useAuthCheckHandler } from 'web/hooks/use-auth-check-handler'
 
 export function Action(props: { contract: Contract }) {
   const { contract } = props
@@ -28,6 +28,8 @@ export function BetButton(props: { contract: Contract; user?: User | null }) {
   const { contract } = props
   const user = useUser()
   const [open, setOpen] = useState(false)
+  const { authCheckHandler } = useAuthCheckHandler()
+
   if (
     !isClosed(contract) &&
     !contract.isResolved &&
@@ -42,11 +44,10 @@ export function BetButton(props: { contract: Contract; user?: User | null }) {
           onClick={(e) => {
             e.preventDefault()
             e.stopPropagation()
-            if (!user) {
-              firebaseLogin()
-              return
-            }
-            setOpen(true)
+
+            authCheckHandler(() => {
+              setOpen(true)
+            })
           }}
         >
           Bet

--- a/web/components/preview/preview-bet-panel.tsx
+++ b/web/components/preview/preview-bet-panel.tsx
@@ -17,7 +17,7 @@ import {
   formatPercent,
 } from 'common/util/format'
 import { APIError, placeBet } from 'web/lib/firebase/api'
-import { User, firebaseLogin } from 'web/lib/firebase/users'
+import { User } from 'web/lib/firebase/users'
 import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 import { BuyAmountInput } from '../widgets/amount-input'
@@ -31,12 +31,13 @@ import { SINGULAR_BET } from 'common/user'
 import { removeUndefinedProps } from 'common/util/object'
 import { InfoTooltip } from 'web/components/widgets/info-tooltip'
 import { useFocus } from 'web/hooks/use-focus'
-import { track, withTracking } from 'web/lib/service/analytics'
+import { track } from 'web/lib/service/analytics'
 import { isAndroid, isIOS } from 'web/lib/util/device'
 import { useUnfilledBetsAndBalanceByUserId } from '../../hooks/use-bets'
 import { Button } from '../buttons/button'
 import { WarningConfirmationButton } from '../buttons/warning-confirmation-button'
 import { PreviewYesNoSelector } from './preview-yes-no-selector'
+import { useAuthCheckHandler } from 'web/hooks/use-auth-check-handler'
 
 type BinaryOutcomes = 'YES' | 'NO' | undefined
 
@@ -95,6 +96,8 @@ export function PreviewBuyPanel(props: {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const [inputRef, focusAmountInput] = useFocus()
+
+  const { authCheckHandler } = useAuthCheckHandler()
 
   useEffect(() => {
     if (initialOutcome) {
@@ -392,7 +395,12 @@ export function PreviewBuyPanel(props: {
           <Button
             color={outcome === 'NO' ? 'red' : 'green'}
             size="xl"
-            onClick={withTracking(firebaseLogin, 'login from bet panel')}
+            onClick={() => {
+              track('login from bet panel')
+              authCheckHandler(() => {
+                submitBet()
+              })
+            }}
           >
             Sign up to predict
           </Button>

--- a/web/hooks/use-auth-check-handler.ts
+++ b/web/hooks/use-auth-check-handler.ts
@@ -1,0 +1,34 @@
+import { useUser } from './use-user'
+import { useCallback } from 'react'
+import { firebaseLogin } from 'web/lib/firebase/users'
+
+export function useAuthCheckHandler() {
+  const user = useUser()
+  const isAuthenticated = !!user
+
+  return {
+    authCheckHandler: useCallback(
+      async (action: (userId: string) => void) => {
+        if (!isAuthenticated) {
+          try {
+            const credential = await firebaseLogin()
+
+            if (credential) {
+              await action(credential.user.uid)
+            }
+
+            // If desktop and the auth provider returns an error
+            // If mobile, native auth provider doesn't return anything
+            return
+          } catch (_) {
+            // Firebase may throw if the user exits early on desktop
+            return
+          }
+        }
+
+        await action(user.id)
+      },
+      [isAuthenticated]
+    ),
+  }
+}


### PR DESCRIPTION
Right now when a logged out user goes to place a bet, they are forced to log in (or create an account) and then have to re-attempt placing the bet. This PR introduces an `authCheckHandler` to replace basic firebaseLogin calls and continue the user action automatically once they are successfully logged in.  