### PR TITLE
nit/style: add utility to easily use singular forms of words when there's only one; use on market page

### DIFF
--- a/common/src/util/format.ts
+++ b/common/src/util/format.ts
@@ -112,6 +112,10 @@ export function shortFormatNumber(num: number): string {
   return `${numStr}${suffix[i] ?? ''}`
 }
 
+export function maybePluralize(word: string, num: number, plural: string = 's'): string {
+  return num === 1 ? word + plural : word
+}
+
 export function toCamelCase(words: string) {
   const camelCase = words
     .split(' ')

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -10,7 +10,7 @@ import { Bet } from 'common/bet'
 import { ContractComment } from 'common/comment'
 import { CPMMBinaryContract, Contract } from 'common/contract'
 import { buildArray } from 'common/util/array'
-import { shortFormatNumber } from 'common/util/format'
+import { shortFormatNumber, maybePluralize } from 'common/util/format'
 import { MINUTE_MS } from 'common/util/time'
 import { UserPositionsTable } from 'web/components/contract/user-positions-table'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
@@ -75,7 +75,7 @@ export function ContractTabs(props: {
 
   const commentsTitle =
     (totalComments > 0 ? `${shortFormatNumber(totalComments)} ` : '') +
-    'Comments'
+    maybePluralize('Comment', totalComments)
 
   const user = useUser()
 
@@ -88,7 +88,7 @@ export function ContractTabs(props: {
   const userBets = rows ?? []
 
   const tradesTitle =
-    (totalBets > 0 ? `${shortFormatNumber(totalBets)} ` : '') + 'Trades'
+    (totalBets > 0 ? `${shortFormatNumber(totalBets)} ` : '') + maybePluralize('Trade', totalBets)
 
   const visibleUserBets = userBets.filter(
     (bet) => bet.amount !== 0 && !bet.isRedemption
@@ -102,7 +102,7 @@ export function ContractTabs(props: {
 
   const positionsTitle =
     (totalPositions > 0 ? `${shortFormatNumber(totalPositions)} ` : '') +
-    'Positions'
+    maybePluralize('Position', totalPositions)
 
   return (
     <ControlledTabs


### PR DESCRIPTION
see example that will be fixed:
<img width="351" alt="Screenshot 2023-11-29 at 12 21 24 PM" src="https://github.com/manifoldmarkets/manifold/assets/6895446/b358910c-edc9-4ce3-8cf1-f0bf223bcd3f">

* considered using https://www.npmjs.com/package/pluralize but seemed like overkill
* was unable to run lint (`npm run lint`), there was some eslint error (see below) ... so not sure if linting is working right now

```bash
➜  manifold git:(bgila/pluralize) ✗ npm run lint

> mantic@ lint /Users/barakgila/personal/manifold
> eslint common --fix ; eslint web --fix ; eslint backend/functions --fix


Oops! Something went wrong! :(

ESLint: 8.48.0

/Users/barakgila/personal/manifold/node_modules/@typescript-eslint/scope-manager/dist/referencer/ClassVisitor.js:123
        withMethodDecorators ||=
                             ^^^

SyntaxError: Unexpected token '||='
    at wrapSafe (internal/modules/cjs/loader.js:1001:16)
    at Module._compile (internal/modules/cjs/loader.js:1049:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:101:18)
    at Object.<anonymous> (/Users/barakgila/personal/manifold/node_modules/@typescript-eslint/scope-manager/dist/referencer/Referencer.js:20:24)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)

```