### PR TITLE
handle multiple choice markets in daily profit chart

### DIFF
--- a/web/components/daily-profit.tsx
+++ b/web/components/daily-profit.tsx
@@ -234,10 +234,13 @@ const MarketCell = (props: {
   from: 'day' | 'week' | 'month'
 }) => {
   const c = props.contract
-  const probChange = c.probChanges[props.from]
-  const change =
-    (probChange > 0 ? '+' : '') +
-    getFormattedMappedValue(c, probChange).replace('%', '')
+  let change: undefined | string
+  if (c.probChanges?.[props.from]) {
+    const probChange = c.probChanges[props.from]
+    change =
+      (probChange > 0 ? '+' : '') +
+      getFormattedMappedValue(c, probChange).replace('%', '')
+  }
 
   return (
     <td>


### PR DESCRIPTION
bug report: my lil bro reported an error from tapping "$ invested" on `/home` and I repro'd

probable cause: multiple choice markets don't have a `probChanges` value defined

fix: check whether probChanges is defined, and if it isn't, leave `propChange` as undefined, which `ContractMention` can handle, rather than crashing.

bug:
<img width="1054" alt="bug on localhost" src="https://github.com/manifoldmarkets/manifold/assets/6895446/a40ec26c-f948-4a24-9738-e28bc34307d0">

confirmed fix locally:
<img width="1115" alt="fixed" src="https://github.com/manifoldmarkets/manifold/assets/6895446/395114e5-5963-44c8-ba8e-2ddf81df73d7">
