### PR TITLE
Probability  -> Value

### DIFF
--- a/web/components/bet/limit-order-panel.tsx
+++ b/web/components/bet/limit-order-panel.tsx
@@ -220,7 +220,7 @@ export default function LimitOrderPanel(props: {
           />
         </Row>
         <Row className="w-full items-center gap-3">
-          Probability
+          {isPseudoNumeric ? 'Value' : 'Probability'}
           <ProbabilityOrNumericInput
             contract={contract}
             prob={limitProbInt}


### PR DESCRIPTION
The limit order screen reads "Value" instead of "Probability" on numeric markets