### PR TITLE
[API] Allow for Unrestricted Cors On Undocumented Apis

### DIFF
--- a/backend/api/src/app.ts
+++ b/backend/api/src/app.ts
@@ -220,8 +220,9 @@ const handlers: { [k in APIPath]: RequestHandler } = {
 
 Object.entries(handlers).forEach(([path, handler]) => {
   const api = API[path as APIPath]
-  const cors =
-    api.visibility === 'public' ? allowCorsUnrestricted : allowCorsManifold
+  const cors = ['public', 'undocumented'].includes(api.visibility)
+    ? allowCorsUnrestricted
+    : allowCorsManifold
   const cache = cacheController((api as any).cache)
 
   const apiRoute = [


### PR DESCRIPTION
I was trying to use the newly exposed `search-users` endpoint, however it looks like because its considered undocumented its getting blocked with cors. 