### PR TITLE
Use upstream @supabase/realtime-js 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "tsc-alias": "1.8.2",
     "tsconfig-paths": "4.1.2",
     "typescript": "5.3.2"
-  },
-  "resolutions": {
-    "@supabase/realtime-js": "git+https://github.com/mqp/realtime-js.git"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,9 +2536,10 @@
   dependencies:
     "@supabase/node-fetch" "^2.6.14"
 
-"@supabase/realtime-js@^2.8.4", "@supabase/realtime-js@git+https://github.com/mqp/realtime-js.git":
-  version "0.0.0-automated"
-  resolved "git+https://github.com/mqp/realtime-js.git#c9e9608f075fe5f78133e8af67ae282882e03b20"
+"@supabase/realtime-js@^2.8.4":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-2.9.0.tgz#7c1ff41d674e06ab003cff1d43105c4ae93d8a56"
+  integrity sha512-e/SI+/eqFJorAKAgVAwKQ9hSDQSBp86Yh7XbQmfJJ90LEfpM52HlTfJt/03lcepRu6BmH5h1uYn1b4zta7ghdw==
   dependencies:
     "@supabase/node-fetch" "^2.6.14"
     "@types/phoenix" "^1.5.4"


### PR DESCRIPTION
Now upstream uses the [fixed up websocket stuff](https://github.com/supabase/realtime-js/pull/263), so we don't need to use my fork in order to get Turbopack to work anymore.

@sipec because I think you had some kind of difficulty that I didn't understand with the fork dependency. Now it will be gone.