### PR TITLE
Set `autoRefreshToken` false when creating backend `SupabaseClient`

### DIFF
--- a/backend/shared/src/supabase/init.ts
+++ b/backend/shared/src/supabase/init.ts
@@ -27,7 +27,12 @@ export function createSupabaseClient() {
   if (!key) {
     throw new Error("Can't connect to Supabase; no process.env.SUPABASE_KEY.")
   }
-  return createClient(instanceId, key)
+
+  // mqp - note that if you want to pass autoRefreshToken: true, you MUST call
+  // `client.auth.stopAutoRefresh` on the client when you are done or it will
+  // leak the refresh interval!
+
+  return createClient(instanceId, key, { auth: { autoRefreshToken: false } })
 }
 
 // Use one connection to avoid WARNING: Creating a duplicate database object for the same connection.


### PR DESCRIPTION
Should mitigate memory leakage in the backend, see [this issue](https://github.com/supabase/supabase-js/issues/926) and the relevant code in `SupabaseAuthClient` [here](https://github.com/supabase/gotrue-js/blob/master/src/GoTrueClient.ts#L2105).