### PR TITLE
Fix bugs in `constructPrefixTsQuery`

### DIFF
--- a/backend/shared/src/helpers/search.ts
+++ b/backend/shared/src/helpers/search.ts
@@ -1,7 +1,10 @@
 export const constructPrefixTsQuery = (term: string) => {
-  const trimmed = term.trim()
-  if (trimmed === '') return ''
-  const sanitizedTrimmed = trimmed.replace(/'/g, "''").replace(/[!&|():*]/g, '')
-  const tokens = sanitizedTrimmed.split(' ')
+  const sanitized = term
+    .replace(/'/g, "''")
+    .replace(/[!&|():*]/g, '')
+    .trim()
+  console.log(`Term: "${sanitized}"`)
+  if (sanitized === '') return ''
+  const tokens = sanitized.split(' ')
   return tokens.join(' & ') + ':*'
 }


### PR DESCRIPTION
Just fixing some errors I noticed in the logs:

1) The code would produce an unsyntactical query if `term` was entirely special characters, since the bailout for empty strings was before the special character removal.
2) The code would produce an unsyntactical query if there were special characters at the start or end of the string guarding spaces (like `foo !`) because the trimming was before the special character removal.

Now I can't see any reason it should obviously produce an unsyntactical query.