### PR TITLE
Fix bugs with double formatting in some searches

### DIFF
--- a/backend/api/src/supabase-search-contract.ts
+++ b/backend/api/src/supabase-search-contract.ts
@@ -108,7 +108,7 @@ const search = async (
           searchType,
         })
         return pg
-          .map(searchSQL, [], (r) => ({
+          .map(searchSQL, null, (r) => ({
             data: convertContract(r),
             searchType,
           }))

--- a/backend/api/src/supabase-search-groups.ts
+++ b/backend/api/src/supabase-search-groups.ts
@@ -38,8 +38,7 @@ export const supabasesearchgroups = MaybeAuthedEndpoint(async (req, auth) => {
     addingToContract,
   })
 
-  const groups = await pg.map(searchGroupSQL, [], convertGroup)
-
+  const groups = await pg.map(searchGroupSQL, null, convertGroup)
   return (groups ?? []) as unknown as Json
 })
 

--- a/backend/api/src/supabase-search-users.ts
+++ b/backend/api/src/supabase-search-users.ts
@@ -26,8 +26,8 @@ export const searchUsers = typedEndpoint(
     const searchFollowersSQL = getSearchUserSQL({ term, offset, limit, userId })
     const searchAllSQL = getSearchUserSQL({ term, offset, limit })
     const [followers, all] = await Promise.all([
-      pg.map(searchFollowersSQL, [term], convertUser),
-      pg.map(searchAllSQL, [term], convertUser),
+      pg.map(searchFollowersSQL, null, convertUser),
+      pg.map(searchAllSQL, null, convertUser),
     ])
 
     return uniqBy([...followers, ...all], 'id')
@@ -63,7 +63,8 @@ function getSearchUserSQL(props: {
 
           orderBy(
             `ts_rank(name_username_vector, websearch_to_tsquery($1)) desc,
-             data->>'lastBetTime' desc nulls last`
+             data->>'lastBetTime' desc nulls last`,
+            [term]
           ),
         ]
       : orderBy(`data->'creatorTraders'->'allTime' desc nulls last`),

--- a/backend/shared/src/supabase/sql-builder.ts
+++ b/backend/shared/src/supabase/sql-builder.ts
@@ -62,8 +62,9 @@ export function where(clause: string, formatValues?: any) {
   return buildSql({ where })
 }
 
-export function orderBy(clause: string) {
-  return buildSql({ orderBy: clause })
+export function orderBy(clause: string, formatValues?: any) {
+  const orderBy = pgp.as.format(clause, formatValues)
+  return buildSql({ orderBy })
 }
 
 export function limit(limit: number, offset?: number) {


### PR DESCRIPTION
If you call pg-promise's formatter multiple times on SQL strings (either directly or implicitly by passing parameters to e.g. `db.map`), you may end up with bugs where the first format introduces formatting language syntax to the second format. For example, in the cases I fixed here, we were doing something like:

```typescript
const where = pg.as.format('where foo = $1', [query]);
const sql = 'select * from bars ' + where + ' order by $1';
const result = await db.many(sql, [sort]);
```
This will throw a template syntax exception given the query string `i have a $5 bill`.

Note that `db.many(sql, [])` is different from `db.many(sql)` or `db.many(sql, null)`. The first invokes the template formatting engine; the second does not.

The best way to handle this is to never write code that runs the template formatting on the same SQL snippets multiple times.