### PR TITLE
Update the API docs to refer to `api.manifold.markets`

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -129,7 +129,7 @@ Requires no authorization.
 
 - Example request
   ```
-  https://manifold.markets/api/v0/markets?limit=1
+  https://api.manifold.markets/v0/markets?limit=1
   ```
 - Example response
   ```json
@@ -217,7 +217,7 @@ Requires no authorization.
 - Example request
 
   ```
-  https://manifold.markets/api/v0/market/3zspH9sSzMlbFQLn9GKR
+  https://api.manifold.markets/v0/market/3zspH9sSzMlbFQLn9GKR
   ```
 
 - Example response
@@ -322,7 +322,7 @@ Requires no authorization.
 - Example request
 
   ```
-  https://manifold.markets/api/v0/market/kupKInoLsjMuiDiNfogm/positions?top=1&bottom=1
+  https://api.manifold.markets/v0/market/kupKInoLsjMuiDiNfogm/positions?top=1&bottom=1
   ```
 
 - Example response
@@ -464,7 +464,7 @@ Requires no authorization.
 
 - Example request
   ```
-  https://manifold.markets/api/v0/slug/will-carrick-flynn-win-the-general
+  https://api.manifold.markets/v0/slug/will-carrick-flynn-win-the-general
   ```
 - Response type: A `FullMarket` ; same as above.
 
@@ -490,7 +490,7 @@ Requires no authorization.
 - Example request
 
   ```
-  https://manifold.markets/api/v0/search-markets?term=biden&sort=liquidity&filter=resolved&contractType=BINARY&limit=2
+  https://api.manifold.markets/v0/search-markets?term=biden&sort=liquidity&filter=resolved&contractType=BINARY&limit=2
   ```
 
 - Example response
@@ -578,7 +578,7 @@ Requires no authorization.
 
 - Example request
   ```
-  https://manifold.markets/api/v0/users?limit=1
+  https://api.manifold.markets/v0/users?limit=1
   ```
 - Example response
   ```json
@@ -660,7 +660,7 @@ Parameters:
 Example request:
 
 ```
-$ curl https://manifold.markets/api/v0/bet -X POST -H 'Content-Type: application/json' \
+$ curl https://api.manifold.markets/v0/bet -X POST -H 'Content-Type: application/json' \
     -H 'Authorization: Key {...}' \
     --data-raw '{"amount":1, \
                  "outcome":"YES", \
@@ -722,7 +722,7 @@ For polls, you must also provide:
 Example request:
 
 ```
-$ curl https://manifold.markets/api/v0/market -X POST -H 'Content-Type: application/json' \
+$ curl https://api.manifold.markets/v0/market -X POST -H 'Content-Type: application/json' \
     -H 'Authorization: Key {...}'
     --data-raw '{"outcomeType":"BINARY", \
                  "question":"Is there life on Mars?", \
@@ -797,26 +797,26 @@ Example request:
 
 ```
 # Resolve a binary market
-$ curl https://manifold.markets/api/v0/market/{marketId}/resolve -X POST \
+$ curl https://api.manifold.markets/v0/market/{marketId}/resolve -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Key {...}' \
     --data-raw '{"outcome": "YES"}'
 
 # Resolve a binary market with a specified probability
-$ curl https://manifold.markets/api/v0/market/{marketId}/resolve -X POST \
+$ curl https://api.manifold.markets/v0/market/{marketId}/resolve -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Key {...}' \
     --data-raw '{"outcome": "MKT", \
                  "probabilityInt": 75}'
 
 # Resolve a free response market with a single answer chosen
-$ curl https://manifold.markets/api/v0/market/{marketId}/resolve -X POST \
+$ curl https://api.manifold.markets/v0/market/{marketId}/resolve -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Key {...}' \
     --data-raw '{"outcome": 2}'
 
 # Resolve a free response market with multiple answers chosen
-$ curl https://manifold.markets/api/v0/market/{marketId}/resolve -X POST \
+$ curl https://api.manifold.markets/v0/market/{marketId}/resolve -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Key {...}' \
     --data-raw '{"outcome": "MKT", \
@@ -840,7 +840,7 @@ Parameters:
 Example request:
 
 ```
-$ curl https://manifold.markets/api/v0/market/{marketId}/sell -X POST \
+$ curl https://api.manifold.markets/v0/market/{marketId}/sell -X POST \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Key {...}' \
     --data-raw '{"outcome": "YES", "shares": 10}'
@@ -894,7 +894,7 @@ Requires no authorization.
 
 - Example request
   ```
-  https://manifold.markets/api/v0/bets?username=Manifold&contractSlug=will-i-be-able-to-place-a-limit-ord
+  https://api.manifold.markets/v0/bets?username=Manifold&contractSlug=will-i-be-able-to-place-a-limit-ord
   ```
 - Response type: A `Bet[]`.
 
@@ -977,7 +977,7 @@ Requires no authorization.
 Example request
 
 ```
-https://manifold.markets/api/v0/managrams?toId=IPTOzEqrpkWmEzh6hwvAyY9PqFb2
+https://api.manifold.markets/v0/managrams?toId=IPTOzEqrpkWmEzh6hwvAyY9PqFb2
 ```
 
 Example response

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -9,6 +9,14 @@ Programatic access to [Manifold](https://manifold.markets).
 
 :::caution
 
+Our API was historically hosted on `https://manifold.markets/api`, but we recently moved to give the API its own domain at `api.manifold.markets`.
+
+Please migrate any code you have to the new domain. The old domain will disappear at some point in the future.
+
+:::
+
+:::caution
+
 Our API is still in alpha — things may change or break at any time!
 
 If you have questions, come chat with us on [Discord](https://discord.com/invite/eHQBNBqXuh). We’d love to hear about what you build!
@@ -1055,6 +1063,7 @@ Requires no authorization.
 
 ## Changelog
 
+- 2023-12-18: `manifold.markets/api` -> `api.manifold.markets`. Please migrate old code.
 - 2023-10-27: Update `/search-markets` to allow all the same search options as our search.
 - 2023-09-29: Add `/managrams` and `/managram` endpoints
 - 2023-05-15: Change the response of the `/market/{marketId}/sell` POST endpoint from


### PR DESCRIPTION
Now we are happy for people to actually move, since the new one is an API-compatible implementation of the old one.