### PR TITLE
Just hand `req.body` `ReadableStream` directly to `fetch`

### DIFF
--- a/web/lib/api/proxy.ts
+++ b/web/lib/api/proxy.ts
@@ -48,14 +48,11 @@ export const fetchBackend = (req: NextRequest, path: string) => {
     'Origin',
   ])
   const hasBody = req.method != 'HEAD' && req.method != 'GET'
-  const body = req.body
-    ? JSON.stringify(req.body)
-    : (req as unknown as ReadableStream)
   const opts = {
     headers,
     method: req.method,
     duplex: 'half',
-    body: hasBody ? body : null,
+    body: hasBody ? req.body : null,
   }
   return fetch(url, opts)
 }


### PR DESCRIPTION
Previously when this code was running on the non-edge-runtime stuff I don't know what the type of `req.body` was, but presumably the old version made sense.

Now, `req.body` always seems to be a `ReadableStream`, so we can pass it [directly to `fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#body) instead of calling `JSON.stringify` or whatever to dick around with it.