### PR TITLE
Move remaining Vercel API endpoints to edge runtime

### DIFF
--- a/web/pages/api/v0/deployment-id.ts
+++ b/web/pages/api/v0/deployment-id.ts
@@ -1,6 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { applyCorsHeaders } from 'web/lib/api/cors'
 
+export const config = { runtime: 'edge' }
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse

--- a/web/pages/api/v0/revalidate.ts
+++ b/web/pages/api/v0/revalidate.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import { ValidationError } from './_types'
 import { validate } from './_validate'
 
+export const config = { runtime: 'edge' }
+
 const queryParams = z
   .object({
     // This secret is stored in both Firebase and Vercel's environment variables, as API_SECRET.


### PR DESCRIPTION
I think the revalidate one might actually be costing us some money for how long it spends sitting around waiting for contract pages to revalidate and so on? So I guess this way it will likely cost us less.