### PR TITLE
Make daily/weekly/etc stock/crypto price markets non-predictive

### DIFF
--- a/backend/shared/src/supabase/contracts.ts
+++ b/backend/shared/src/supabase/contracts.ts
@@ -335,8 +335,12 @@ export const isContractNonPredictive = (contract: Contract) => {
     .trim()
     .toLowerCase()
     .includes('daily coinflip')
+  const questionIncludesCloseHigher = contract.question
+    .trim()
+    .toLowerCase()
+    .includes('close higher')
   const createdByManifoldLove = contract.creatorUsername === 'ManifoldLove'
-  return questionIncludesDailyCoinflip || createdByManifoldLove
+  return questionIncludesDailyCoinflip || questionIncludesCloseHigher || createdByManifoldLove
   // return (
   //   await pg.map(
   //     `


### PR DESCRIPTION
e.g "Will BTC close higher on blah date than blah date"

Very good [coverage of the relevant markets](https://manifold.markets/browse?q=%22close%20higher%22&s=score&f=all&ct=ALL) and few (if any) false positives matching on "close higher"

As suggested by Ian on discord

(I have not tested if this actually works, just copying the "daily-coinflip" code)

![image](https://github.com/manifoldmarkets/manifold/assets/1044087/b5144ea8-2fcb-44b1-9054-cd3de3a19dfb)
