### PR TITLE
Be more parsimonious with runtime secret loading

### DIFF
--- a/web/lib/supabase/admin-db.ts
+++ b/web/lib/supabase/admin-db.ts
@@ -1,14 +1,21 @@
 import { createClient } from 'common/supabase/utils'
 import { ENV, ENV_CONFIG } from 'common/envs/constants'
-import {
-  getSecret,
-  getServiceAccountCredentials,
-  loadSecretsToEnv,
-} from 'common/secrets'
+import { getSecrets, getServiceAccountCredentials } from 'common/secrets'
+
+// the vercel names for these secrets
+let key =
+  ENV == 'PROD'
+    ? process.env.PROD_ADMIN_SUPABASE_KEY
+    : process.env.DEV_ADMIN_SUPABASE_KEY
 
 export async function initSupabaseAdmin() {
-  await loadSecretsToEnv(getServiceAccountCredentials(ENV))
-
-  const key = getSecret('SUPABASE_KEY')
+  if (key == null) {
+    console.warn(
+      'Loading Supabase key from GCP. (Should happen only locally, never in production!)'
+    )
+    const creds = getServiceAccountCredentials(ENV)
+    const result = await getSecrets(creds, 'SUPABASE_KEY')
+    key = result['SUPABASE_KEY']
+  }
   return createClient(ENV_CONFIG.supabaseInstanceId, key)
 }


### PR DESCRIPTION
Loading secrets in various Vercel server-side handlers is costing us about twenty bucks a day on GCP.

Let's not make a habit of doing this, because it will just get more and more expensive as our traffic grows and as we use our secrets in more code. It's easy to just put the secrets in Vercel.

I think the cost is probably driven completely by this and the stuff we do in local dev is a matter of pennies, so we can keep doing easy mode "load everything when you run anything" style locally.