### PR TITLE
Make `lastUpdatedTime` on contracts more useful, improve API

### DIFF
--- a/backend/shared/src/importance-score.ts
+++ b/backend/shared/src/importance-score.ts
@@ -31,8 +31,8 @@ export async function calculateImportanceScore(
 
   const activeContracts = await pg.map(
     `select data from contracts
-    where ((data->'lastBetTime')::numeric) > $1
-    or ((data->'lastCommentTime')::numeric) > $1 `,
+    where last_bet_time > millis_to_ts($1)
+    or last_comment_time > millis_to_ts($1)`,
     [now - IMPORTANCE_MINUTE_INTERVAL * MINUTE_MS],
     (row) => row.data as Contract
   )

--- a/backend/shared/src/importance-score.ts
+++ b/backend/shared/src/importance-score.ts
@@ -25,14 +25,15 @@ export async function calculateImportanceScore(
   readOnly = false
 ) {
   const now = Date.now()
-  const lastUpdatedTime = now - IMPORTANCE_MINUTE_INTERVAL * MINUTE_MS
   const hourAgo = now - HOUR_MS
   const dayAgo = now - DAY_MS
   const weekAgo = now - 7 * DAY_MS
 
   const activeContracts = await pg.map(
-    `select data from contracts where ((data->'lastUpdatedTime')::numeric) > $1`,
-    [lastUpdatedTime],
+    `select data from contracts
+    where ((data->'lastBetTime')::numeric) > $1
+    or ((data->'lastCommentTime')::numeric) > $1 `,
+    [now - IMPORTANCE_MINUTE_INTERVAL * MINUTE_MS],
     (row) => row.data as Contract
   )
   // We have to downgrade previously active contracts to allow the new ones to bubble up

--- a/backend/supabase/contracts/indexes.sql
+++ b/backend/supabase/contracts/indexes.sql
@@ -20,7 +20,11 @@ create index if not exists contracts_volume_24_hours on contracts (
 
 create index if not exists contracts_elasticity on contracts (((data ->> 'elasticity')::numeric) desc);
 
-create index if not exists contracts_last_updated_time on contracts (((data ->> 'lastUpdatedTime')::numeric) desc);
+create index if not exists contracts_last_updated_time on contracts (last_updated_time desc nulls last);
+
+create index if not exists contracts_last_bet_time on contracts (last_bet_time desc nulls last);
+
+create index if not exists contracts_last_comment_time on contracts (last_comment_time desc nulls last);
 
 create index if not exists contracts_unique_bettor_count on contracts (((data ->> 'uniqueBettorCount')::integer) desc);
 

--- a/backend/supabase/groups/groups.sql
+++ b/backend/supabase/groups/groups.sql
@@ -15,7 +15,7 @@ select data, importance_score
 from public_contracts
 where (public_contracts.group_slugs && p_group_slugs)
   and not (public_contracts.group_slugs && ignore_slugs)
-order by ((data->>'lastUpdatedTime')::bigint) desc
+order by last_updated_time desc
 limit max
 $$;
 

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -113,6 +113,7 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     uniqueBettorCount,
     lastUpdatedTime,
     lastBetTime,
+    lastCommentTime,
   } = contract
 
   const { p, totalLiquidity } = contract as any
@@ -159,6 +160,7 @@ export function toLiteMarket(contract: Contract): LiteMarket {
     uniqueBettorCount,
     lastUpdatedTime,
     lastBetTime,
+    lastCommentTime,
     ...numericValues,
   })
 }

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -338,6 +338,15 @@ export const API = (_apiTypeCheck = {
     props: z
       .object({
         limit: z.coerce.number().gte(0).lte(1000).default(500),
+        sort: z
+          .enum([
+            'created-time',
+            'updated-time',
+            'last-bet-time',
+            'last-comment-time',
+          ])
+          .optional(),
+        order: z.enum(['asc', 'desc']).optional(),
         before: z.string().optional(),
         userId: z.string().optional(),
         groupId: z.string().optional(),

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -89,7 +89,7 @@ export type Contract<T extends AnyContractType = AnyContractType> = {
   visibility: Visibility
 
   createdTime: number // Milliseconds since epoch
-  lastUpdatedTime: number // Updated on new bet or comment
+  lastUpdatedTime: number // Updated on any change to the market (metadata, bet, comment)
   lastBetTime?: number
   lastCommentTime?: number
   closeTime?: number // When no more trading is allowed

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -474,6 +474,9 @@ export interface Database {
           group_slugs: string[] | null
           id: string
           importance_score: number | null
+          last_bet_time: string | null
+          last_comment_time: string | null
+          last_updated_time: string | null
           mechanism: string | null
           outcome_type: string | null
           popularity_score: number | null
@@ -498,6 +501,9 @@ export interface Database {
           group_slugs?: string[] | null
           id: string
           importance_score?: number | null
+          last_bet_time?: string | null
+          last_comment_time?: string | null
+          last_updated_time?: string | null
           mechanism?: string | null
           outcome_type?: string | null
           popularity_score?: number | null
@@ -522,6 +528,9 @@ export interface Database {
           group_slugs?: string[] | null
           id?: string
           importance_score?: number | null
+          last_bet_time?: string | null
+          last_comment_time?: string | null
+          last_updated_time?: string | null
           mechanism?: string | null
           outcome_type?: string | null
           popularity_score?: number | null
@@ -2746,6 +2755,9 @@ export interface Database {
           group_slugs: string[] | null
           id: string | null
           importance_score: number | null
+          last_bet_time: string | null
+          last_comment_time: string | null
+          last_updated_time: string | null
           mechanism: string | null
           outcome_type: string | null
           popularity_score: number | null
@@ -2769,6 +2781,9 @@ export interface Database {
           group_slugs?: string[] | null
           id?: string | null
           importance_score?: number | null
+          last_bet_time?: string | null
+          last_comment_time?: string | null
+          last_updated_time?: string | null
           mechanism?: string | null
           outcome_type?: string | null
           popularity_score?: number | null
@@ -2792,6 +2807,9 @@ export interface Database {
           group_slugs?: string[] | null
           id?: string | null
           importance_score?: number | null
+          last_bet_time?: string | null
+          last_comment_time?: string | null
+          last_updated_time?: string | null
           mechanism?: string | null
           outcome_type?: string | null
           popularity_score?: number | null
@@ -3395,6 +3413,9 @@ export interface Database {
           group_slugs: string[] | null
           id: string
           importance_score: number | null
+          last_bet_time: string | null
+          last_comment_time: string | null
+          last_updated_time: string | null
           mechanism: string | null
           outcome_type: string | null
           popularity_score: number | null

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -202,6 +202,9 @@ List all markets, ordered by creation date descending.
 Parameters:
 
 - `limit`: Optional. How many markets to return. The maximum is 1000 and the default is 500.
+- `sort`: Optional. One of 'created-time', 'updated-time', 'last-bet-time', or 'last-comment-time'
+  to sort by that timestamp. Defaults to 'created-time'.
+- `order`: Optional. One of 'asc' or 'desc'. Defaults to 'desc'.
 - `before`: Optional. The ID of the market before which the list will start. For
   example, if you ask for the most recent 10 markets, and then perform a second
   query for 10 more markets with `before=[the id of the 10th market]`, you will


### PR DESCRIPTION
`lastUpdatedTime` used to mean `max(lastBetTime, lastCommentTime)`. Now it also covers other user-salient edits to contract properties.

In addition, the new `/markets` parameters will allow API users to easily get "fresh" markets from the API without having to constantly poll everything in the universe.