### PR TITLE
Further improve `get-related-markets` query

### DIFF
--- a/backend/supabase/contracts/indexes.sql
+++ b/backend/supabase/contracts/indexes.sql
@@ -41,3 +41,5 @@ where
 create index contracts_outcome_type_not_binary on contracts (outcome_type)
 where
   outcome_type <> 'BINARY';
+
+create index contracts_group_slugs_importance on contracts using gin (group_slugs, importance_score);

--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -11,6 +11,9 @@ alter role service_role
 set
   statement_timeout = '1h';
 
+/* multi-column GIN indexes */
+create extension if not exists btree_gin;
+
 /* for clustering without locks */
 create extension if not exists pg_repack;
 


### PR DESCRIPTION
This is still a substantial source of load, so it's worth making it as good as we can reasonably do at the moment.

This implementation is nicer because it ends up with a plan that is basically "for each group slug, do a single index scan on contracts to pick up the top N for that slug." That isn't clearly possible to do with a single index when the "group IDs to contracts" mapping and "importance score ordering" were in two tables. So the denormalized `group_slugs` field is helping us out.

The `btree_gin` extension is necessary to use a GIN index on columns like `importance_score` with scalar values.

It would make sense to further improve this code to do more of the work in SQL -- then we wouldn't have to spit out as many contracts from the middle step (in the expectation that they will be deduplicated in application code.)