### PR TITLE
Remove code to replicate answers from `updateContractMetrics`

### DIFF
--- a/backend/shared/src/supabase/answers.ts
+++ b/backend/shared/src/supabase/answers.ts
@@ -1,7 +1,6 @@
 import { SupabaseDirectClient } from 'shared/supabase/init'
 import { convertAnswer } from 'common/supabase/contracts'
 import { groupBy } from 'lodash'
-import { Answer } from 'common/answer'
 
 export const getAnswersForContractsDirect = async (
   pg: SupabaseDirectClient,
@@ -18,21 +17,5 @@ export const getAnswersForContractsDirect = async (
       (r) => convertAnswer(r)
     ),
     'contractId'
-  )
-}
-
-export const replicateAnswers = async (
-  pg: SupabaseDirectClient,
-  answers: Answer[]
-) => {
-  return await Promise.all(
-    answers.map(async (a) =>
-      pg.none(
-        `insert into answers (id, contract_id, data, fs_updated_time)
-      values ($1, $2, $3, $4)
-    on conflict (id) do nothing`,
-        [a.id, a.contractId, a, new Date().toISOString()]
-      )
-    )
   )
 }


### PR DESCRIPTION
This is slow and it's not doing anything -- it only ever replicated one answer in a month (which doesn't mean it was addressing a real problem, because the pattern of "query answers, then after you get them, go look at firestore to see if there are any you didn't get" will find false positives that were just added to Firestore in the last few seconds.)

FYI @IanPhilips -- my understanding is that you did this to try to debug some answer replication stuff, but clearly the result was that this was not the bug.