### PR TITLE
Move `updateGroupMetrics` to scheduler

### DIFF
--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -19,7 +19,6 @@ export {
   sendWeeklyPortfolioUpdate,
   saveWeeklyContractMetrics,
 } from './scheduled/weekly-portfolio-updates'
-export * from './scheduled/update-group-metrics'
 export * from './scheduled/update-stats'
 export * from './scheduled/backup-db'
 export * from './scheduled/market-close-notifications'

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -4,6 +4,7 @@ import { updateContractMetricsCore } from 'shared/update-contract-metrics-core'
 import { sendOnboardingNotificationsInternal } from 'shared/onboarding-helpers'
 import { updateContractViews } from 'shared/update-contract-views'
 import { updateUserMetricsCore } from 'shared/update-user-metrics-core'
+import { updateGroupMetricsCore } from 'shared/update-group-metrics-core'
 import { truncateIncomingWrites } from './truncate-incoming-writes'
 
 export function createJobs() {
@@ -28,6 +29,11 @@ export function createJobs() {
       'update-user-metrics',
       '0 */10 * * * *', // every 10 minutes
       updateUserMetricsCore
+    ),
+    createJob(
+      'update-group-metrics',
+      '0 */15 * * * *', // every 15 minutes
+      updateGroupMetricsCore
     ),
     createJob(
       'truncate-incoming-writes',

--- a/backend/scripts/update-metrics.ts
+++ b/backend/scripts/update-metrics.ts
@@ -2,7 +2,7 @@ import { runScript } from './run-script'
 
 import { log } from 'shared/utils'
 import { updateUserMetricsCore } from 'shared/update-user-metrics-core'
-import { updateGroupMetricsCore } from 'functions/scheduled/update-group-metrics'
+import { updateGroupMetricsCore } from 'shared/update-group-metrics-core'
 import { updateContractMetricsCore } from 'shared/update-contract-metrics-core'
 
 if (require.main === module) {
@@ -12,6 +12,6 @@ if (require.main === module) {
     log('Updating contract metrics...')
     await updateContractMetricsCore({ log })
     log('Updating group metrics...')
-    await updateGroupMetricsCore()
+    await updateGroupMetricsCore({ log })
   })
 }

--- a/backend/shared/src/update-group-metrics-core.ts
+++ b/backend/shared/src/update-group-metrics-core.ts
@@ -1,20 +1,11 @@
-import * as functions from 'firebase-functions'
 import { groupBy, mapValues, sortBy } from 'lodash'
 
-import { log } from 'shared/utils'
 import { getIds } from 'shared/supabase/utils'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
-import { secrets } from 'common/secrets'
 import { updateData } from 'shared/supabase/utils'
+import { JobContext } from 'shared/utils'
 
-export const updateGroupMetrics = functions
-  .runWith({ timeoutSeconds: 540, secrets })
-  .pubsub.schedule('every 15 minutes')
-  .onRun(async () => {
-    await updateGroupMetricsCore()
-  })
-
-export async function updateGroupMetricsCore() {
+export async function updateGroupMetricsCore({ log }: JobContext) {
   const pg = createSupabaseDirectClient()
   log('Loading group IDs...')
   const groupIds = await getIds(pg, 'groups')
@@ -78,6 +69,4 @@ export async function updateGroupMetricsCore() {
       },
     })
   }
-
-  log('Done.')
 }


### PR DESCRIPTION
It's really cozy to pause this stuff if I am doing heavy DB maintenance so I want to move it to the scheduler, which has a "pause" button.