### PR TITLE
Add job to clean up old replicator tombstones

### DIFF
--- a/backend/scheduler/src/jobs/clean-old-tombstones.ts
+++ b/backend/scheduler/src/jobs/clean-old-tombstones.ts
@@ -1,0 +1,12 @@
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { JobContext } from 'shared/utils'
+
+export async function cleanOldTombstones({ log }: JobContext) {
+  const pg = createSupabaseDirectClient()
+  const count = await pg.result(
+    "delete from tombstones where fs_deleted_at < now() - interval '1 week'",
+    [],
+    (r) => r.rowCount
+  )
+  log(`Deleted ${count} old tombstones.`)
+}

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -6,6 +6,7 @@ import { updateContractViews } from 'shared/update-contract-views'
 import { updateUserMetricsCore } from 'shared/update-user-metrics-core'
 import { updateGroupMetricsCore } from 'shared/update-group-metrics-core'
 import { cleanOldFeedRows } from './clean-old-feed-rows'
+import { cleanOldTombstones } from './clean-old-tombstones'
 import { cleanOldNotifications } from './clean-old-notifications'
 import { truncateIncomingWrites } from './truncate-incoming-writes'
 
@@ -39,8 +40,13 @@ export function createJobs() {
     ),
     createJob(
       'truncate-incoming-writes',
-      '0 0 4 * * *', // 4 AM daily
+      '0 0 0 * * *', // midnight daily
       truncateIncomingWrites
+    ),
+    createJob(
+      'clean-old-tombstones',
+      '0 0 0 * * *', // midnight daily
+      cleanOldTombstones
     ),
     createJob(
       'clean-old-feed-rows',


### PR DESCRIPTION
In case you forgot, these are markers that indicate a Firestore document was deleted, which is relatively rare in our DB. Once all the writes prior to a delete have been replicated, the delete tombstone isn't needed anymore.

It's nice to keep this table clean because every replicated write has to check this table in order to protect itself from race conditions between replicated updates and deletes, so let's clean up the old ones.