### PR TITLE
Fix suspicious `updateContractMetrics` historical probs query

### DIFF
--- a/backend/supabase/contract_bets.sql
+++ b/backend/supabase/contract_bets.sql
@@ -62,7 +62,7 @@ create index if not exists contract_bets_bet_id on contract_bets (bet_id);
 create index if not exists contract_bets_activity_feed on contract_bets (is_ante, is_redemption, created_time desc);
 
 /* serving update contract metrics */
-create index if not exists contract_bets_historical_probs on contract_bets (created_time) include (contract_id, prob_before, prob_after);
+create index if not exists contract_bets_historical_probs on contract_bets (created_time) include (contract_id, answer_id, prob_before, prob_after);
 
 /* serving e.g. the contract page recent bets and the "bets by contract" API */
 create index if not exists contract_bets_created_time on contract_bets (contract_id, created_time desc);


### PR DESCRIPTION
There was no reason for this to be two queries, and the answer part of the queries wasn't working well because the covering index hadn't been updated with the `answer_id` to help it out.

FYI @IanPhilips 