### PR TITLE
Add some pagination infrastructure, paginate donations on charity page

### DIFF
--- a/web/components/widgets/pagination.tsx
+++ b/web/components/widgets/pagination.tsx
@@ -11,31 +11,38 @@ export const PAGE_ELLIPSES = '...'
 
 export function PaginationNextPrev(props: {
   className?: string
-  prev?: ReactNode
-  next?: ReactNode
+  showPrev: boolean
+  showNext: boolean
   onClickPrev: () => void
   onClickNext: () => void
   scrollToTop?: boolean
 }) {
-  const { className, prev, next, onClickPrev, onClickNext, scrollToTop } = props
+  const {
+    className,
+    showPrev,
+    showNext,
+    onClickPrev,
+    onClickNext,
+    scrollToTop,
+  } = props
   return (
     <Row className={clsx(className, 'flex-1 justify-between sm:justify-end')}>
-      {prev != null && (
+      {showPrev && (
         <a
           href={scrollToTop ? '#' : undefined}
           className="border-ink-300 text-ink-700 hover:bg-canvas-50 bg-canvas-0 relative inline-flex cursor-pointer select-none items-center rounded-md border px-4 py-2 text-sm font-medium"
           onClick={onClickPrev}
         >
-          {prev ?? 'Previous'}
+          Previous
         </a>
       )}
-      {next != null && (
+      {showNext && (
         <a
           href={scrollToTop ? '#' : undefined}
           className="border-ink-300 text-ink-700 hover:bg-canvas-50 bg-canvas-0 relative ml-3 inline-flex cursor-pointer select-none items-center rounded-md border px-4 py-2 text-sm font-medium"
           onClick={onClickNext}
         >
-          {next ?? 'Next'}
+          Next
         </a>
       )}
     </Row>

--- a/web/components/widgets/pagination.tsx
+++ b/web/components/widgets/pagination.tsx
@@ -17,7 +17,6 @@ export function PaginationNextPrev(props: {
   isLoadingNext: boolean
   onClickPrev: () => void
   onClickNext: () => void
-  scrollToTop?: boolean
 }) {
   const {
     className,
@@ -26,27 +25,25 @@ export function PaginationNextPrev(props: {
     isLoadingNext,
     onClickPrev,
     onClickNext,
-    scrollToTop,
   } = props
   return (
     <Row className={clsx(className, 'flex-1 justify-between sm:justify-end')}>
       {showPrev && (
-        <a
-          href={scrollToTop ? '#' : undefined}
+        <button
           className="border-ink-300 text-ink-700 hover:bg-canvas-50 bg-canvas-0 relative inline-flex cursor-pointer select-none items-center rounded-md border px-4 py-2 text-sm font-medium"
           onClick={onClickPrev}
         >
           Previous
-        </a>
+        </button>
       )}
       {showNext && (
-        <a
-          href={scrollToTop ? '#' : undefined}
+        <button
           className="border-ink-300 text-ink-700 hover:bg-canvas-50 bg-canvas-0 relative ml-3 inline-flex cursor-pointer select-none items-center rounded-md border px-4 py-2 text-sm font-medium"
           onClick={onClickNext}
+          disabled={isLoadingNext}
         >
           {isLoadingNext ? <LoadingIndicator size="sm" /> : 'Next'}
-        </a>
+        </button>
       )}
     </Row>
   )

--- a/web/components/widgets/pagination.tsx
+++ b/web/components/widgets/pagination.tsx
@@ -2,10 +2,11 @@ import clsx from 'clsx'
 import { Spacer } from '../layout/spacer'
 import { Row } from '../layout/row'
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/solid'
-import { ReactNode, useEffect } from 'react'
+import { useEffect } from 'react'
 import { range } from 'lodash'
 import { usePathname, useRouter } from 'next/navigation'
 import { useDefinedSearchParams } from 'web/hooks/use-defined-search-params'
+import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
 
 export const PAGE_ELLIPSES = '...'
 
@@ -13,6 +14,7 @@ export function PaginationNextPrev(props: {
   className?: string
   showPrev: boolean
   showNext: boolean
+  isLoadingNext: boolean
   onClickPrev: () => void
   onClickNext: () => void
   scrollToTop?: boolean
@@ -21,6 +23,7 @@ export function PaginationNextPrev(props: {
     className,
     showPrev,
     showNext,
+    isLoadingNext,
     onClickPrev,
     onClickNext,
     scrollToTop,
@@ -42,7 +45,7 @@ export function PaginationNextPrev(props: {
           className="border-ink-300 text-ink-700 hover:bg-canvas-50 bg-canvas-0 relative ml-3 inline-flex cursor-pointer select-none items-center rounded-md border px-4 py-2 text-sm font-medium"
           onClick={onClickNext}
         >
-          Next
+          {isLoadingNext ? <LoadingIndicator size="sm" /> : 'Next'}
         </a>
       )}
     </Row>

--- a/web/components/widgets/pagination.tsx
+++ b/web/components/widgets/pagination.tsx
@@ -7,44 +7,36 @@ import { range } from 'lodash'
 import { usePathname, useRouter } from 'next/navigation'
 import { useDefinedSearchParams } from 'web/hooks/use-defined-search-params'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
-
+import { buttonClass } from 'web/components/buttons/button'
 export const PAGE_ELLIPSES = '...'
 
 export function PaginationNextPrev(props: {
   className?: string
-  showPrev: boolean
-  showNext: boolean
-  isLoadingNext: boolean
-  onClickPrev: () => void
-  onClickNext: () => void
+  isStart: boolean
+  isEnd: boolean
+  isLoading: boolean
+  getPrev: () => void
+  getNext: () => void
 }) {
-  const {
-    className,
-    showPrev,
-    showNext,
-    isLoadingNext,
-    onClickPrev,
-    onClickNext,
-  } = props
+  const { className, isStart, isEnd, isLoading, getPrev, getNext } = props
   return (
-    <Row className={clsx(className, 'flex-1 justify-between sm:justify-end')}>
-      {showPrev && (
-        <button
-          className="border-ink-300 text-ink-700 hover:bg-canvas-50 bg-canvas-0 relative inline-flex cursor-pointer select-none items-center rounded-md border px-4 py-2 text-sm font-medium"
-          onClick={onClickPrev}
-        >
-          Previous
-        </button>
-      )}
-      {showNext && (
-        <button
-          className="border-ink-300 text-ink-700 hover:bg-canvas-50 bg-canvas-0 relative ml-3 inline-flex cursor-pointer select-none items-center rounded-md border px-4 py-2 text-sm font-medium"
-          onClick={onClickNext}
-          disabled={isLoadingNext}
-        >
-          {isLoadingNext ? <LoadingIndicator size="sm" /> : 'Next'}
-        </button>
-      )}
+    <Row
+      className={clsx(className, 'flex-1 justify-between gap-2 sm:justify-end')}
+    >
+      <button
+        className={buttonClass('lg', 'gray-outline')}
+        onClick={getPrev}
+        disabled={isStart}
+      >
+        Previous
+      </button>
+      <button
+        className={buttonClass('lg', 'gray-outline')}
+        onClick={getNext}
+        disabled={isLoading || isEnd}
+      >
+        {isLoading ? <LoadingIndicator size="sm" /> : 'Next'}
+      </button>
     </Row>
   )
 }

--- a/web/hooks/use-pagination.ts
+++ b/web/hooks/use-pagination.ts
@@ -53,6 +53,7 @@ function getReducer<T>() {
         return { ...state, isLoading: false, pageStart, pageEnd }
       }
       case 'NEXT': {
+        // if it's not complete and the next page needs more items, load more
         const shouldLoad =
           !state.isComplete &&
           state.allItems.length < state.pageEnd + state.pageSize
@@ -91,7 +92,6 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
   const [state, dispatch] = useReducer(getReducer<T>(), opts, getInitialState)
 
   useEffect(() => {
-    console.log('Dispatching init: ', opts, state)
     dispatch({
       type: 'INIT',
       opts: { q: opts.q, pageSize: opts.pageSize, preload: opts.preload },
@@ -100,7 +100,6 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
 
   useEffect(() => {
     if (state.isLoading) {
-      console.log('Dispatching load: ', state)
       const after = state.allItems[state.allItems.length - 1]
       opts.q(state.pageSize, after).then((newItems) => {
         const isComplete = newItems.length < state.pageSize
@@ -115,7 +114,7 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
     }
   }, [state.isLoading, opts.q, state.allItems, state.pageSize])
 
-  const pageItems = useMemo(
+  const items = useMemo(
     () => state.allItems.slice(state.pageStart, state.pageEnd),
     [state.allItems, state.pageStart, state.pageEnd]
   )
@@ -127,12 +126,11 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
     [dispatch]
   )
 
-  console.log(state)
   return {
     ...state,
     isStart: state.pageStart === 0,
     isEnd: state.isComplete && state.pageEnd >= state.allItems.length,
-    pageItems,
+    items,
     getPrev,
     getNext,
     prepend,

--- a/web/hooks/use-pagination.ts
+++ b/web/hooks/use-pagination.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react'
+
+type ItemFactory<T> = (limit: number, after?: T) => PromiseLike<T[]>
+
+interface State<T> {
+  allItems: T[]
+  pageStart: number
+  pageEnd: number
+  pageSize: number
+  isLoading: boolean
+  isComplete: boolean
+}
+
+type ActionBase<K, V = void> = V extends void ? { type: K } : { type: K } & V
+
+type Action<T> =
+  | ActionBase<'INIT', { opts: PaginationOptions<T> }>
+  | ActionBase<'PREPEND', { items: T[] }>
+  | ActionBase<'LOAD', { oldItems: T[]; newItems: T[] }>
+  | ActionBase<'PREV'>
+  | ActionBase<'NEXT'>
+
+function getReducer<T>() {
+  return (state: State<T>, action: Action<T>): State<T> => {
+    switch (action.type) {
+      case 'INIT': {
+        return getInitialState(action.opts)
+      }
+      case 'PREPEND': {
+        return { ...state, allItems: [...action.items, ...state.allItems] }
+      }
+      case 'LOAD': {
+        const allItems = action.oldItems.concat(action.newItems)
+        const isComplete = action.newItems.length < state.pageSize
+        return { ...state, allItems, isComplete, isLoading: false }
+      }
+      case 'PREV': {
+        const pageStart = state.pageStart - state.pageSize
+        const pageEnd = state.pageStart
+        return { ...state, pageStart, pageEnd, isLoading: false }
+      }
+      case 'NEXT': {
+        const pageStart = state.pageEnd
+        const pageEnd = state.pageEnd + state.pageSize
+        const isLoading = !state.isComplete && state.allItems.length < pageEnd
+        return { ...state, pageStart, pageEnd, isLoading }
+      }
+      default:
+        throw new Error('Invalid action.')
+    }
+  }
+}
+
+export type PaginationOptions<T> = {
+  q: ItemFactory<T>
+  pageSize: number
+  preload?: T[]
+}
+
+function getInitialState<T>(opts: PaginationOptions<T>): State<T> {
+  return {
+    allItems: opts.preload ?? [],
+    pageStart: 0,
+    pageEnd: opts.pageSize,
+    pageSize: opts.pageSize,
+    isLoading: (opts.preload?.length ?? 0) < opts.pageSize,
+    isComplete: false,
+  }
+}
+
+export function usePagination<T>(opts: PaginationOptions<T>) {
+  const [state, dispatch] = useReducer(getReducer<T>(), opts, getInitialState)
+
+  useEffect(() => {
+    dispatch({ type: 'INIT', opts: { q: opts.q, pageSize: opts.pageSize } })
+  }, [opts.q, opts.pageSize])
+
+  useEffect(() => {
+    if (state.isLoading) {
+      const after = state.allItems[state.allItems.length - 1]
+      opts.q(state.pageSize, after).then((newItems) => {
+        dispatch({ type: 'LOAD', oldItems: state.allItems, newItems })
+      })
+    }
+  }, [state.isLoading, opts.q, state.allItems, state.pageSize])
+
+  const pageItems = useMemo(
+    () => state.allItems.slice(state.pageStart, state.pageEnd),
+    [state.allItems, state.pageStart, state.pageEnd]
+  )
+
+  const getPrev = useCallback(() => dispatch({ type: 'PREV' }), [dispatch])
+  const getNext = useCallback(() => dispatch({ type: 'NEXT' }), [dispatch])
+  const prepend = useCallback(
+    (...items: T[]) => dispatch({ type: 'PREPEND', items }),
+    [dispatch]
+  )
+
+  return {
+    ...state,
+    isStart: state.pageStart === 0,
+    isEnd: state.isComplete && state.pageEnd >= state.allItems.length,
+    pageItems,
+    getPrev,
+    getNext,
+    prepend,
+  }
+}

--- a/web/lib/supabase/txns.ts
+++ b/web/lib/supabase/txns.ts
@@ -1,19 +1,37 @@
+import { uniq } from 'lodash'
 import { db } from './db'
 import { run, selectFrom } from 'common/supabase/utils'
+import { filterDefined } from 'common/util/array'
+import { getUsers } from './user'
 
 export async function getDonationsByCharity() {
   const { data } = await db.rpc('get_donations_by_charity')
   return Object.fromEntries((data ?? []).map((r) => [r.charity_id, r.total]))
 }
 
-export async function getAllDonations(charityId: string) {
-  const { data } = await run(
-    selectFrom(db, 'txns', 'fromId', 'createdTime', 'amount')
+export function getDonationsPageQuery(charityId: string) {
+  return async (limit: number, after?: { ts: number }) => {
+    let q = selectFrom(db, 'txns', 'fromId', 'createdTime', 'amount')
       .eq('data->>category', 'CHARITY')
       .eq('data->>toId', charityId)
       .order('data->createdTime', { ascending: false } as any)
-  )
-  return data
+      .limit(limit)
+    if (after?.ts) {
+      q = q.lt('data->createdTime', after.ts)
+    }
+    const txnData = (await run(q)).data
+    const userIds = uniq(txnData.map((t) => t.fromId))
+    const users = await getUsers(userIds)
+    const usersById = Object.fromEntries(
+      filterDefined(users).map((u) => [u.id, u])
+    )
+    const donations = txnData.map((t) => ({
+      user: usersById[t.fromId],
+      ts: t.createdTime,
+      amount: t.amount,
+    }))
+    return donations
+  }
 }
 
 export async function getMostRecentDonation() {

--- a/web/pages/charity/[charitySlug].tsx
+++ b/web/pages/charity/[charitySlug].tsx
@@ -71,7 +71,7 @@ function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
     charity.id,
   ])
 
-  const { pageItems, isStart, isEnd, getPrev, getNext, prepend } =
+  const { pageItems, isStart, isEnd, isLoading, getPrev, getNext, prepend } =
     usePagination({
       pageSize: PAGE_SIZE,
       q: paginationCallback,
@@ -116,6 +116,7 @@ function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
           <PaginationNextPrev
             showPrev={!isStart}
             showNext={!isEnd}
+            isLoadingNext={isLoading}
             onClickPrev={getPrev}
             onClickNext={getNext}
           />

--- a/web/pages/charity/[charitySlug].tsx
+++ b/web/pages/charity/[charitySlug].tsx
@@ -71,12 +71,11 @@ function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
     charity.id,
   ])
 
-  const { pageItems, isStart, isEnd, isLoading, getPrev, getNext, prepend } =
-    usePagination({
-      pageSize: PAGE_SIZE,
-      q: paginationCallback,
-      preload: donations,
-    })
+  const pagination = usePagination({
+    pageSize: PAGE_SIZE,
+    q: paginationCallback,
+    preload: donations,
+  })
   return (
     <Page
       trackPageView={'charity slug page'}
@@ -94,13 +93,13 @@ function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
                 <Image src={photo} alt="" layout="fill" objectFit="contain" />
               </div>
             )}
-            <Details charity={charity} donations={pageItems} />
+            <Details charity={charity} donations={pagination.items} />
           </Row>
           <DonationBox
             user={user}
             charity={charity}
             onDonated={(user, ts, amount) => {
-              prepend({ user, ts, amount })
+              pagination.prepend({ user, ts, amount })
               setShowConfetti(true)
             }}
           />
@@ -109,17 +108,10 @@ function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
             stateKey={`isCollapsed-charity-${charity.id}`}
           />
           <Spacer h={8} />
-          {pageItems &&
-            pageItems.map((d, i) => (
-              <Donation key={i} user={d.user} ts={d.ts} amount={d.amount} />
-            ))}
-          <PaginationNextPrev
-            showPrev={!isStart}
-            showNext={!isEnd}
-            isLoadingNext={isLoading}
-            onClickPrev={getPrev}
-            onClickNext={getNext}
-          />
+          {(pagination.items ?? []).map((d, i) => (
+            <Donation key={i} user={d.user} ts={d.ts} amount={d.amount} />
+          ))}
+          <PaginationNextPrev {...pagination} />
         </Col>
       </Col>
     </Page>

--- a/web/pages/charity/[charitySlug].tsx
+++ b/web/pages/charity/[charitySlug].tsx
@@ -1,5 +1,5 @@
-import { sumBy, uniq, uniqBy } from 'lodash'
-import { useState } from 'react'
+import { sumBy, uniqBy } from 'lodash'
+import { useCallback, useState } from 'react'
 import Image from 'next/legacy/image'
 
 import { Col } from 'web/components/layout/col'
@@ -10,12 +10,12 @@ import { BuyAmountInput } from 'web/components/widgets/amount-input'
 import { Spacer } from 'web/components/layout/spacer'
 import { User } from 'common/user'
 import { useUser } from 'web/hooks/use-user'
+import { usePagination } from 'web/hooks/use-pagination'
 import { Linkify } from 'web/components/widgets/linkify'
 import { transact } from 'web/lib/firebase/api'
 import { charities, Charity } from 'common/charity'
 import Custom404 from '../404'
-import { getAllDonations } from 'web/lib/supabase/txns'
-import { getUsers } from 'web/lib/supabase/user'
+import { getDonationsPageQuery } from 'web/lib/supabase/txns'
 import { Donation } from 'web/components/charity/feed-items'
 import { manaToUSD } from 'common/util/format'
 import { track } from 'web/lib/service/analytics'
@@ -23,9 +23,11 @@ import { SEO } from 'web/components/SEO'
 import { Button } from 'web/components/buttons/button'
 import { FullscreenConfetti } from 'web/components/widgets/fullscreen-confetti'
 import { CollapsibleContent } from 'web/components/widgets/collapsible-content'
-import { filterDefined } from 'common/util/array'
+import { PaginationNextPrev } from 'web/components/widgets/pagination'
 
 type DonationItem = { user: User; ts: number; amount: number }
+
+const PAGE_SIZE = 50
 
 export async function getStaticPaths() {
   return { paths: [], fallback: 'blocking' }
@@ -40,15 +42,7 @@ export async function getStaticProps(ctx: { params: { charitySlug: string } }) {
       revalidate: 60,
     }
   }
-  const txns = await getAllDonations(charity.id)
-  const userIds = uniq(txns.map((t) => t.fromId))
-  const users = filterDefined(await getUsers(userIds))
-  const usersById = Object.fromEntries(users.map((u) => [u.id, u]))
-  const donations = txns.map((t) => ({
-    user: usersById[t.fromId],
-    ts: t.createdTime,
-    amount: t.amount,
-  }))
+  const donations = await getDonationsPageQuery(charity.id)(PAGE_SIZE)
   return {
     props: { charity, donations },
     revalidate: 60,
@@ -67,13 +61,22 @@ export default function CharityPageWrapper(props: {
 }
 
 function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
-  const { charity } = props
+  const { charity, donations } = props
   const { name, photo, description } = charity
   const user = useUser()
 
-  const [donations, setDonations] = useState<DonationItem[]>(props.donations)
   const [showConfetti, setShowConfetti] = useState(false)
 
+  const paginationCallback = useCallback(getDonationsPageQuery(charity.id), [
+    charity.id,
+  ])
+
+  const { pageItems, isStart, isEnd, getPrev, getNext, prepend } =
+    usePagination({
+      pageSize: PAGE_SIZE,
+      q: paginationCallback,
+      preload: donations,
+    })
   return (
     <Page
       trackPageView={'charity slug page'}
@@ -91,16 +94,13 @@ function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
                 <Image src={photo} alt="" layout="fill" objectFit="contain" />
               </div>
             )}
-            <Details charity={charity} donations={donations} />
+            <Details charity={charity} donations={pageItems} />
           </Row>
           <DonationBox
             user={user}
             charity={charity}
             onDonated={(user, ts, amount) => {
-              setDonations((existing) => [
-                { user, ts, amount },
-                ...(existing ?? []),
-              ])
+              prepend({ user, ts, amount })
               setShowConfetti(true)
             }}
           />
@@ -109,10 +109,16 @@ function CharityPage(props: { charity: Charity; donations: DonationItem[] }) {
             stateKey={`isCollapsed-charity-${charity.id}`}
           />
           <Spacer h={8} />
-          {donations &&
-            donations.map((d, i) => (
+          {pageItems &&
+            pageItems.map((d, i) => (
               <Donation key={i} user={d.user} ts={d.ts} amount={d.amount} />
             ))}
+          <PaginationNextPrev
+            showPrev={!isStart}
+            showNext={!isEnd}
+            onClickPrev={getPrev}
+            onClickNext={getNext}
+          />
         </Col>
       </Col>
     </Page>


### PR DESCRIPTION
Proximate issue: the charity page was trying to load a ton of user IDs from PostgREST using an `in` clause, which produced a too-long URL, so it couldn't load them, and long charity pages (e.g. GiveWell) were 500ing.

Generally speaking we need to make more things that are both paginated (i.e. they don't load every single one up front) with data from Supabase, but also can update on the client with new stuff that was just added, instead of sitting around waiting seconds to hear back from the database that the new thing appeared (e.g. when you make a bet on a contract page, it should tack it onto the front of the paginated list of all bets, and when you make a comment, it should tack it onto the top of the list of all comments.) This is starting to move in the direction of making that easy to do.

@sipec this seems like the kind of thing you might have an opinion about.