### PR TITLE
Use native columns in `user_seen_markets`

### DIFF
--- a/backend/api/src/get-ad-analytics.ts
+++ b/backend/api/src/get-ad-analytics.ts
@@ -1,7 +1,6 @@
 import { APIHandler } from 'api/helpers/endpoint'
 import { createSupabaseClient } from 'shared/supabase/init'
 import { run } from 'common/supabase/utils'
-import { ContractCardView } from 'common/events'
 import { uniqBy } from 'lodash'
 
 export const getadanalytics: APIHandler<'get-ad-analytics'> = async (
@@ -21,7 +20,7 @@ export const getadanalytics: APIHandler<'get-ad-analytics'> = async (
     run(
       db
         .from('user_seen_markets')
-        .select('user_id, data')
+        .select('user_id, is_promoted')
         .eq('type', 'view market card')
         .eq('contract_id', contractId)
     ),
@@ -37,9 +36,7 @@ export const getadanalytics: APIHandler<'get-ad-analytics'> = async (
       .eq('data->>category' as any, 'MARKET_BOOST_REDEEM')
       .eq('data->>fromId' as any, lastAdData?.id)
   )
-  const promotedViewData = viewData?.filter(
-    (v) => (v.data as ContractCardView).isPromoted
-  )
+  const promotedViewData = viewData?.filter((v) => v.is_promoted)
   const totalFunds = adData?.reduce((acc, v) => acc + v.funds, 0) ?? 0
   return {
     uniquePromotedViewers: uniqBy(promotedViewData, 'user_id').length,

--- a/backend/supabase/user_seen_markets.sql
+++ b/backend/supabase/user_seen_markets.sql
@@ -4,11 +4,23 @@ create table if not exists
                           id bigint generated always as identity primary key,
                           user_id text not null,
                           contract_id text not null,
-                          data jsonb not null,
+                          data jsonb null,
                           created_time timestamptz not null default now(),
-    -- so far we have: 'view market' or 'view market card'
-                          type text not null default 'view market'
-);
+                          -- so far we have: 'view market' or 'view market card'
+                          type text not null default 'view market',
+                          is_promoted boolean null
+    );
+
+create or replace function user_seen_market_populate_cols () returns trigger language plpgsql as $$ begin
+    if new.data is not null then
+        new.is_promoted := ((new.data)->'isPromoted')::boolean;
+    end if;
+    return new;
+end $$;
+
+create trigger user_seen_market_populate before insert or update on user_seen_markets for each row
+execute function user_seen_market_populate_cols ();
+
 
 alter table user_seen_markets enable row level security;
 

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -2332,6 +2332,7 @@ export interface Database {
           created_time: string
           data: Json
           id: number
+          is_promoted: boolean | null
           type: string
           user_id: string
         }
@@ -2340,6 +2341,7 @@ export interface Database {
           created_time?: string
           data: Json
           id?: never
+          is_promoted?: boolean | null
           type?: string
           user_id: string
         }
@@ -2348,6 +2350,7 @@ export interface Database {
           created_time?: string
           data?: Json
           id?: never
+          is_promoted?: boolean | null
           type?: string
           user_id?: string
         }


### PR DESCRIPTION
This is like, a big table, so it's worth fixing up to be efficient.

After this we can migrate writes and ditch the `data` column. And after that we can migrate the table to be one-row-per-user-market as is our plan.