### PR TITLE
Use much more efficient version of `clean-old-feed-rows`

### DIFF
--- a/backend/scheduler/src/jobs/clean-old-feed-rows.ts
+++ b/backend/scheduler/src/jobs/clean-old-feed-rows.ts
@@ -1,22 +1,23 @@
-import { chunk } from 'lodash'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { JobContext } from 'shared/utils'
 
 export async function cleanOldFeedRows({ log }: JobContext) {
   log('Running clean old feed rows...')
   const pg = createSupabaseDirectClient()
-  const userIds = await pg.map(
-    'select distinct id from users',
-    [],
-    (r) => r.id as string
-  )
-  const chunks = chunk(userIds, 500)
-  for (const batch of chunks) {
-    await pg.none(
-      `delete from user_feed
-         where user_id in ($1:list) and created_time < now() - interval '2 weeks'`,
-      [batch]
+  const BATCH_SIZE = 1000000
+  while (true) {
+    const result = await pg.one(
+      `with deleted as (
+      delete from user_feed where id in
+        (select id from user_feed where created_time < now() - interval '2 weeks' limit $1)
+      returning 1
+     )
+     select count(*) as n from deleted`,
+      [BATCH_SIZE]
     )
-    log(`Deleted rows from ${batch.length} users`)
+    log(`Deleted ${result.n} old feed rows.`)
+    if (result.n < BATCH_SIZE) {
+      return
+    }
   }
 }

--- a/backend/supabase/user_feed.sql
+++ b/backend/supabase/user_feed.sql
@@ -39,6 +39,9 @@ create policy "user can update" on user_feed
     for update
     using (true);
 
+
+create index if not exists user_feed_created_time_idx on user_feed (created_time);
+
 create index if not exists user_feed_created_time on user_feed (user_id, created_time desc);
 
 create index if not exists user_feed_contract_items on user_feed (data_type, contract_id, greatest(created_time, seen_time) desc) where contract_id is not null;


### PR DESCRIPTION
Unlike the old version, this is actually efficient enough that the old feed rows should successfully get cleaned.