### PR TITLE
[WEB] Show Outcome on Multi Trader Bonus Notifications

### DIFF
--- a/web/components/notifications/income-summary-notifications.tsx
+++ b/web/components/notifications/income-summary-notifications.tsx
@@ -498,14 +498,17 @@ function IncomeNotificationLabel(props: {
 
 const BettorStatusLabel = (props: { uniqueBettorData: UniqueBettorData }) => {
   const { bet, outcomeType, answerText } = props.uniqueBettorData
-  const { amount } = bet
+  const { amount, outcome } = bet
   const showProb =
     (outcomeType === 'PSEUDO_NUMERIC' &&
       props.uniqueBettorData.max !== undefined) ||
     outcomeType !== 'PSEUDO_NUMERIC'
+  const showOutcome = outcomeType === 'MULTIPLE_CHOICE'
   return (
     <Row className={'line-clamp-1 gap-1'}>
-      <span className="text-ink-600">{formatMoney(amount)}</span> on{' '}
+      <span className="text-ink-600">{formatMoney(amount)}</span>{' '}
+      {showOutcome && `${outcome} `}
+      on{' '}
       <BetOutcomeLabel
         bet={bet}
         contractOutcomeType={outcomeType}


### PR DESCRIPTION
<img width="955" alt="Screenshot 2024-01-09 at 2 57 39 PM" src="https://github.com/manifoldmarkets/manifold/assets/4633636/ccf897d2-63fd-484a-81f1-2f039ffc6408">

This PR adds the outcome to trader bonus notifications on multiple choice markets. 

Happy to change the format or colors if you would prefer, just let me know. 