### PR TITLE
[WEB] Skip Market Type on Duplicate Market

### DIFF
--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { ChevronRightIcon } from '@heroicons/react/solid'
 import { User } from 'common/user'
 import { CreateableOutcomeType, add_answers_mode } from 'common/contract'
@@ -46,6 +46,15 @@ export function NewContractPanel(props: {
   const [state, setState] = useState<CreateContractStateType>(
     params?.outcomeType ? 'filling contract params' : 'choosing contract'
   )
+
+  useEffect(() => {
+    if (outcomeType !== params?.outcomeType) {
+      setOutcomeType(params?.outcomeType)
+    }
+    if (params?.outcomeType) {
+      setState('filling contract params')
+    }
+  }, [params?.outcomeType])
 
   return (
     <Col


### PR DESCRIPTION
URL params are coming in after the page has rendered and thus required selecting the market type on duplicate market, even though its already in the params. This useEffect keeps local state in sync with the params coming in, allowing users to skip selecting market type if its provided. 