### PR TITLE
Change most public APIs to cache for 5 seconds instead of 15

### DIFF
--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -24,7 +24,10 @@ import { type LinkPreview } from 'common/link-preview'
 import { Headline } from 'common/news'
 import { Row } from 'common/supabase/utils'
 
-export const marketCacheStrategy = 's-maxage=15, stale-while-revalidate=45'
+// mqp: very unscientific, just balancing our willingness to accept load
+// with user willingness to put up with stale data
+export const DEFAULT_CACHE_STRATEGY =
+  'public, max-age=5, stale-while-revalidate=10'
 
 type APIGenericSchema = {
   // GET is for retrieval, POST is to mutate something, PUT is idempotent mutation (can be repeated safely)
@@ -70,7 +73,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'max-age=15, public',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as ContractComment[],
     props: z
       .object({
@@ -132,7 +135,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'max-age=15, public',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as Bet[],
     props: z
       .object({
@@ -154,7 +157,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'max-age=15, public',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as Bet[],
     props: z
       .object({
@@ -167,7 +170,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'no-cache',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: {} as Group,
     props: z.object({ slug: z.string() }),
   },
@@ -175,7 +178,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'no-cache',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: {} as Group,
     props: z.object({ id: z.string() }).strict(),
   },
@@ -184,7 +187,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: marketCacheStrategy,
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as LiteMarket[],
     props: z
       .object({
@@ -197,7 +200,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'max-age=60',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as Group[],
     props: z
       .object({
@@ -211,7 +214,7 @@ export const API = (_apiTypeCheck = {
     visibility: 'public',
     authed: false,
     returns: {} as LiteMarket | FullMarket,
-    cache: marketCacheStrategy,
+    cache: DEFAULT_CACHE_STRATEGY,
     props: z.object({ id: z.string(), lite: z.boolean().optional() }),
   },
   // deprecated. use /market/:id?lite=true instead
@@ -220,7 +223,7 @@ export const API = (_apiTypeCheck = {
     visibility: 'public',
     authed: false,
     returns: {} as LiteMarket,
-    cache: marketCacheStrategy,
+    cache: DEFAULT_CACHE_STRATEGY,
     props: z.object({ id: z.string() }),
   },
   'slug/:slug': {
@@ -228,7 +231,7 @@ export const API = (_apiTypeCheck = {
     visibility: 'public',
     authed: false,
     returns: {} as LiteMarket | FullMarket,
-    cache: marketCacheStrategy,
+    cache: DEFAULT_CACHE_STRATEGY,
     props: z.object({ slug: z.string(), lite: z.boolean().optional() }),
   },
   market: {
@@ -321,7 +324,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'max-age=60',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as League[],
     props: z
       .object({
@@ -335,7 +338,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: marketCacheStrategy,
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as LiteMarket[],
     props: z
       .object({
@@ -359,7 +362,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: marketCacheStrategy,
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as LiteMarket[],
     props: searchProps,
   },
@@ -367,7 +370,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'undocumented',
     authed: false,
-    cache: marketCacheStrategy,
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as Contract[],
     props: searchProps,
   },
@@ -410,7 +413,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 's-maxage=120, stale-while-revalidate=150',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: {} as any,
     props: z
       .object({
@@ -426,6 +429,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: true,
+    cache: DEFAULT_CACHE_STRATEGY,
     props: z.object({}),
     returns: {} as User,
   },
@@ -433,7 +437,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'no-cache',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: {} as LiteUser,
     props: z.object({ username: z.string() }),
   },
@@ -441,7 +445,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 'no-cache',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: {} as LiteUser,
     props: z.object({ id: z.string() }).strict(),
   },
@@ -449,7 +453,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: 's-maxage=45, stale-while-revalidate=45',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as LiteUser[],
     props: z
       .object({
@@ -462,7 +466,7 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'undocumented',
     authed: false,
-    cache: 's-maxage=45, stale-while-revalidate=45',
+    cache: DEFAULT_CACHE_STRATEGY,
     returns: [] as LiteUser[],
     props: z
       .object({


### PR DESCRIPTION
This will be a big improvement for some of our API users, and we don't really have a problem with load or bandwidth cost right now anymore on the API, so why not dial down the caching.