### PR TITLE
Fix dark theme

### DIFF
--- a/love/pages/_document.tsx
+++ b/love/pages/_document.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script'
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="en" className="no-js">
       <Head>
         <link rel="icon" href={ENV_CONFIG.faviconPath} />
         <Script src="/init-theme.js" strategy="beforeInteractive" />

--- a/love/public/init-theme.js
+++ b/love/public/init-theme.js
@@ -4,7 +4,12 @@
   const localTheme = localStorage.getItem('theme')
   const theme = localTheme ? JSON.parse(localTheme) : 'auto'
 
-  if (theme === 'dark' || (theme === 'auto' && autoDark)) {
+  document.documentElement.classList.remove('no-js')
+
+  if (
+    theme === 'dark' ||
+    ((theme === 'auto' || theme === 'loading') && autoDark)
+  ) {
     document.documentElement.classList.add('dark')
   }
 }

--- a/web/hooks/use-theme.ts
+++ b/web/hooks/use-theme.ts
@@ -34,6 +34,8 @@ const reRenderTheme = () => {
 
   const autoDark = window.matchMedia('(prefers-color-scheme: dark)').matches
 
+  document.documentElement.classList.remove('no-js')
+
   if (theme === 'dark' || (theme === 'auto' && autoDark)) {
     document.documentElement.classList.add('dark')
   } else {

--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script'
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="en" className="no-js">
       <Head>
         <link rel="icon" href={ENV_CONFIG.faviconPath} />
         <Script src="/init-theme.js" strategy="beforeInteractive" />

--- a/web/public/init-theme.js
+++ b/web/public/init-theme.js
@@ -4,7 +4,12 @@
   const localTheme = localStorage.getItem('theme')
   const theme = localTheme ? JSON.parse(localTheme) : 'auto'
 
-  if (theme === 'dark' || (theme === 'auto' && autoDark)) {
+  document.documentElement.classList.remove('no-js')
+
+  if (
+    theme === 'dark' ||
+    ((theme === 'auto' || theme === 'loading') && autoDark)
+  ) {
     document.documentElement.classList.add('dark')
   }
 }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -61,6 +61,65 @@
     --color-yes-900: 19 78 74;
     --color-yes-950: 4 47 46;
   }
+  @media (prefers-color-scheme: dark) {
+    .no-js {
+      color-scheme: dark;
+
+      --color-ink-1000: 255 255 255;
+      --color-ink-950: 248 248 252;
+      --color-ink-900: 236 237 248;
+      --color-ink-800: 221 222 238;
+      --color-ink-700: 194 195 219;
+      --color-ink-600: 158 159 189;
+      --color-ink-500: 118 118 147;
+      --color-ink-400: 86 86 118;
+      --color-ink-300: 61 61 92;
+      --color-ink-200: 39 39 73;
+      --color-ink-100: 22 21 55;
+      --color-ink-50: 10 8 43;
+      --color-ink-0: 0 0 0;
+
+      --color-canvas-0: 30 41 59;
+      --color-canvas-50: 15 23 41;
+      --color-canvas-100: 51 65 85;
+
+      --color-primary-950: 238 242 255;
+      --color-primary-900: 224 231 255;
+      --color-primary-800: 199 210 254;
+      --color-primary-700: 165 180 252;
+      --color-primary-600: 129 140 248;
+      --color-primary-500: 99 102 241;
+      --color-primary-400: 79 70 229;
+      --color-primary-300: 67 56 202;
+      --color-primary-200: 55 48 163;
+      --color-primary-100: 49 46 129;
+      --color-primary-50: 30 27 75;
+
+      --color-no-950: 255 243 241;
+      --color-no-900: 255 235 231;
+      --color-no-800: 255 208 194;
+      --color-no-700: 255 164 151;
+      --color-no-600: 255 124 102;
+      --color-no-500: 247 88 54;
+      --color-no-400: 239 48 19;
+      --color-no-300: 209 30 12;
+      --color-no-200: 166 27 10;
+      --color-no-100: 132 29 13;
+      --color-no-50: 73 15 6;
+
+      --color-yes-950: 240 253 250;
+      --color-yes-900: 204 251 241;
+      --color-yes-800: 153 246 228;
+      --color-yes-700: 94 234 212;
+      --color-yes-600: 45 212 191;
+      --color-yes-500: 20 184 166;
+      --color-yes-400: 13 148 136;
+      --color-yes-300: 15 118 110;
+      --color-yes-200: 17 94 89;
+      --color-yes-100: 19 78 74;
+      --color-yes-50: 4 47 46;
+    }
+  }
   .dark {
     color-scheme: dark;
 


### PR DESCRIPTION
There are currently two problems with dark theme. This PR fixes both of them.

## Problem 1

When a user is using dark theme on their device and opens the website for the first time, the website show light theme despite showing "Auto" in the side bar.

You can reproduce by deleting site data and reloading the site.

The device is set to dark theme in this recording:

https://github.com/manifoldmarkets/manifold/assets/8357970/f84e1467-a9da-4a2e-9609-86619146512d

You can see in this recording, only after clicking the theme toggle button 3 times and cycling back to "Auto" does the website show dark theme.

This is caused by the `useTheme` hook setting the initial value of `localStorage.getItem('theme')` to `"loading"` but `init-theme.js` not recognizing that value. This is fixed by checking for that value and treating it as `"auto"`, just like in the side bar:

https://github.com/manifoldmarkets/manifold/blob/e2e6048bc2d0c9f4f68c32cf1c7e3bf5474e28fe/web/components/nav/sidebar.tsx#L187

## Problem 2

When the theme is set to "Auto", the device is set to dark theme, and the network is slow, the site flashes light theme briefly. This has been annoying me when I use the site in bed at night.

You can reproduce by going to the Chrome DevTools's Network tab and switch "No throttling" to "Fast 3G".

In this recording you can see the site briefly flashing light theme before switching to dark theme.

https://github.com/manifoldmarkets/manifold/assets/8357970/e629186d-c3f2-4007-b313-0b6c606f395a

This is solved by adding a `no-js` class to the html element and removing it once the `init-theme.js` runs. A styling rule is added to `globals.css` to style the site in dark theme if the device is in dark theme and the `no-js` class is present. Once the `init-theme.js` runs, the `no-js` class is removed and the theme is set according to user setting.