### PR TITLE
Clean up reaction migration

### DIFF
--- a/backend/supabase/seed.sql
+++ b/backend/supabase/seed.sql
@@ -41,7 +41,6 @@ $$;
 /******************************************/
 /* 1. tables containing firestore content */
 /******************************************/
-
 begin;
 
 drop publication if exists supabase_realtime;
@@ -132,7 +131,6 @@ begin
     table_id
            when 'users' then cast((null, 'id') as table_spec)
            when 'private_users' then cast((null, 'id') as table_spec)
-           when 'user_reactions' then cast(('user_id', 'reaction_id') as table_spec)
            when 'contracts' then cast((null, 'id') as table_spec)
            when 'contract_answers' then cast(('contract_id', 'answer_id') as table_spec)
            when 'answers' then cast((null, 'id') as table_spec)

--- a/backend/supabase/user_reactions.sql
+++ b/backend/supabase/user_reactions.sql
@@ -21,22 +21,3 @@ select
   using (true);
 
 create index if not exists user_reactions_content_id_raw on user_reactions (content_id);
-
-create
-or replace function user_reactions_populate_cols () returns trigger language plpgsql as $$
-begin
-  if new.data is not null then
-    new.content_id := (new.data) ->> 'contentId';
-    new.content_type := (new.data) ->> 'contentType';
-    new.content_owner_id := (new.data) ->> 'contentOwnerId';
-    new.created_time :=
-      case when new.data ? 'createdTime' then millis_to_ts(((new.data) ->> 'createdTime')::bigint) else null end;
-  end if;
-  return new;
-end
-$$;
-
-create trigger user_reactions_populate before insert
-or
-update on user_reactions for each row
-execute function user_reactions_populate_cols ();

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -2290,8 +2290,6 @@ export interface Database {
           content_owner_id: string | null
           content_type: string | null
           created_time: string
-          data: Json | null
-          fs_updated_time: string | null
           reaction_id: string
           user_id: string
         }
@@ -2300,8 +2298,6 @@ export interface Database {
           content_owner_id?: string | null
           content_type?: string | null
           created_time?: string
-          data?: Json | null
-          fs_updated_time?: string | null
           reaction_id?: string
           user_id: string
         }
@@ -2310,8 +2306,6 @@ export interface Database {
           content_owner_id?: string | null
           content_type?: string | null
           created_time?: string
-          data?: Json | null
-          fs_updated_time?: string | null
           reaction_id?: string
           user_id?: string
         }

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -43,9 +43,6 @@ export type SubcollectionTableMapping = {
   [parent: string]: { [child: string]: TableName }
 }
 export const subcollectionTables: SubcollectionTableMapping = {
-  users: {
-    reactions: 'user_reactions',
-  },
   contracts: {
     answers: 'contract_answers',
     answersCpmm: 'answers',


### PR DESCRIPTION
Can do this in a few hours, doesn't matter when exactly

Tasks
- [x] `firebase deploy --only firestore:rules`
- [x] drop indexes
    ```sql
    drop index user_reactions_data_gin;
    drop index user_reactions_type;
    drop index user_reactions_content_id;
    ```
- [x] drop trigger and trigger function
- [x] `alter table user_reactions drop column data, drop column fs_updated_time;`
- [ ] `firebase deploy --only functions:logSubcollections` 