### PR TITLE
Switch backend code to connect to Supavisor pooler

### DIFF
--- a/backend/api/src/get-supabase-token.ts
+++ b/backend/api/src/get-supabase-token.ts
@@ -2,7 +2,6 @@ import { sign } from 'jsonwebtoken'
 import { authEndpoint, APIError } from './helpers/endpoint'
 import { DEV_CONFIG } from 'common/envs/dev'
 import { PROD_CONFIG } from 'common/envs/prod'
-import { getInstanceHostname } from 'common/supabase/utils'
 import { isProd } from 'shared/utils'
 
 export const getsupabasetoken = authEndpoint(async (_req, auth) => {
@@ -21,7 +20,7 @@ export const getsupabasetoken = authEndpoint(async (_req, auth) => {
     jwt: sign(payload, jwtSecret, {
       algorithm: 'HS256', // same as what supabase uses for its auth tokens
       expiresIn: '1d',
-      audience: `db.${getInstanceHostname(instanceId)}`,
+      audience: instanceId,
       issuer: isProd()
         ? PROD_CONFIG.firebaseConfig.projectId
         : DEV_CONFIG.firebaseConfig.projectId,

--- a/backend/shared/src/supabase/init.ts
+++ b/backend/shared/src/supabase/init.ts
@@ -1,5 +1,5 @@
 import * as pgPromise from 'pg-promise'
-import { createClient, getInstanceHostname } from 'common/supabase/utils'
+import { createClient } from 'common/supabase/utils'
 export { SupabaseClient } from 'common/supabase/utils'
 import { DEV_CONFIG } from 'common/envs/dev'
 import { PROD_CONFIG } from 'common/envs/prod'
@@ -59,9 +59,9 @@ export function createSupabaseDirectClient(
     )
   }
   pgpDirect = pgp({
-    host: `db.${getInstanceHostname(instanceId)}`,
-    port: 5432,
-    user: 'postgres',
+    host: 'aws-0-us-east-1.pooler.supabase.com',
+    port: 6543,
+    user: `postgres.${instanceId}`,
     password: password,
     query_timeout: HOUR_MS, // mqp: debugging scheduled job behavior
     max: 20,

--- a/backend/shared/src/supabase/init.ts
+++ b/backend/shared/src/supabase/init.ts
@@ -63,6 +63,7 @@ export function createSupabaseDirectClient(
     port: 6543,
     user: `postgres.${instanceId}`,
     password: password,
+    database: 'postgres',
     query_timeout: HOUR_MS, // mqp: debugging scheduled job behavior
     max: 20,
   })

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -52,16 +52,12 @@ export const subcollectionTables: SubcollectionTableMapping = {
   },
 }
 
-export function getInstanceHostname(instanceId: string) {
-  return `${instanceId}.supabase.co`
-}
-
 export function createClient(
   instanceId: string,
   key: string,
   opts?: SupabaseClientOptionsGeneric<'public'>
 ) {
-  const url = `https://${getInstanceHostname(instanceId)}`
+  const url = `https://${instanceId}.supabase.co`
   return createClientGeneric(url, key, opts) as SupabaseClient
 }
 


### PR DESCRIPTION
Per Supabase we need to switch to this in the next week because the old pgbouncer URL (`db.instance.supabase.co`) is getting shut off.

See https://supabase.com/blog/supavisor-postgres-connection-pooler for some marketing material.

Should be no big deal.