### PR TITLE
Show number of followers when adding a topic

### DIFF
--- a/web/components/topics/topic-selector.tsx
+++ b/web/components/topics/topic-selector.tsx
@@ -135,7 +135,7 @@ export function TopicSelector(props: {
                       )
                     }
                   >
-                    <div className={'truncate'}>{group.name}</div>
+                    <div className={'truncate'}>{group.name} ({group.totalMembers} followers)</div>
                     {group.privacyStatus != 'public' && (
                       <Row className={'text-ink-500'}>
                         {PRIVACY_STATUS_ITEMS[group.privacyStatus].icon}


### PR DESCRIPTION
mattyb said in discord:

> when there’s 4 “Apple”s, limiting to 5 feels way too low
> if tags were clearly organized, and lacking dupes, this would be fine (imo)
> but i can’t tell which Apple I’m using, and thus need them all.
> 
> If there was “Apple (30 Markets)” and “Apple (350 markets)” this would also be better

We don't have market stats, but we do have follower stats.