### PR TITLE
[WEB] Track users last seen time

### DIFF
--- a/common/src/api/user-types.ts
+++ b/common/src/api/user-types.ts
@@ -25,6 +25,7 @@ export type LiteUser = {
   balance: number
   totalDeposits: number
   lastBetTime?: number
+  lastSeenTime?: number
   currentBettingStreak?: number
   profitCached: {
     daily: number
@@ -52,6 +53,7 @@ export function toLiteUser(user: User): LiteUser {
     userDeleted,
     currentBettingStreak,
     lastBetTime,
+    lastSeenTime,
   } = user
 
   const isBot = BOT_USERNAMES.includes(username)
@@ -79,5 +81,6 @@ export function toLiteUser(user: User): LiteUser {
     userDeleted,
     currentBettingStreak,
     lastBetTime,
+    lastSeenTime,
   })
 }

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -47,6 +47,7 @@ export type User = {
   referredByGroupId?: string
   shouldShowWelcome?: boolean
   lastBetTime?: number
+  lastSeenTime?: number
 
   currentBettingStreak?: number
   streakForgiveness: number

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -129,6 +129,7 @@ type LiteUser = {
   balance: number
   totalDeposits: number
   lastBetTime?: number
+  lastSeenTime?: number
   currentBettingStreak?: number
   profitCached: {
     daily: number
@@ -919,7 +920,7 @@ Example response:
   // Limit bet, partially filled.
   {
     "isFilled": false,
-    "amount": 15.596681605353808,//The amount that has already been filled.
+    "amount": 15.596681605353808, //The amount that has already been filled.
     "userId": "IPTOzEqrpkWmEzh6hwvAyY9PqFb2",
     "contractId": "Tz5dA01GkK5QKiQfZeDL",
     "probBefore": 0.5730753474948571,
@@ -930,7 +931,7 @@ Example response:
     "limitProb": 0.5,
     "id": "yXB8lVbs86TKkhWA1FVi",
     "loanAmount": 0,
-    "orderAmount": 100,//The original amount placed on the limit order when it was created. The amount remaining can be calulated as orderAmount - amount.
+    "orderAmount": 100, //The original amount placed on the limit order when it was created. The amount remaining can be calulated as orderAmount - amount.
     "probAfter": 0.5730753474948571,
     "createdTime": 1659482775970,
     "fills": [

--- a/web/components/layout/page.tsx
+++ b/web/components/layout/page.tsx
@@ -13,6 +13,7 @@ import { safeLocalStorage } from 'web/lib/util/local'
 import { Banner } from '../nav/banner'
 import { ENV_CONFIG } from 'common/envs/constants'
 import { useUser } from 'web/hooks/use-user'
+import { useLastSeen } from 'web/hooks/use-last-seen'
 
 export function Page(props: {
   trackPageView: string | false
@@ -48,6 +49,7 @@ export function Page(props: {
     }
   }, [showBanner])
   const user = useUser()
+  useLastSeen()
 
   return (
     <>

--- a/web/hooks/use-last-seen.ts
+++ b/web/hooks/use-last-seen.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useIsAuthorized, useUser } from 'web/hooks/use-user'
+import { updateUser } from 'web/lib/firebase/users'
+
+export const useLastSeen = () => {
+  const user = useUser()
+  const isAuthed = useIsAuthorized()
+
+  useEffect(() => {
+    if (user?.id && isAuthed) {
+      updateUser(user.id, { lastSeenTime: Date.now() })
+    }
+  }, [user?.id, isAuthed])
+}


### PR DESCRIPTION
The mods have been requesting better visibility into inactive users (see [Good User Suggestions](https://manifoldmarkets.notion.site/Good-user-suggestions-86f377ac982a411bb84067d0971bf31a?p=de637cf182714a1ab69b4f7ba86e26ad&pm=s)). This tracks users last seen time so that it can be exposed in user hover cards, profiles, etc...

I am getting a firebase error `Missing or insufficient permissions` so putting up a draft PR to attempt to debug in deployed dev env. 