### PR TITLE
Change /me to return LiteUser

### DIFF
--- a/backend/api/src/get-current-user.ts
+++ b/backend/api/src/get-current-user.ts
@@ -1,4 +1,5 @@
 import { User } from 'common/user'
+import { toLiteUser } from 'common/api/user-types'
 import * as admin from 'firebase-admin'
 import { APIError, type APIHandler } from './helpers/endpoint'
 
@@ -7,7 +8,7 @@ export const getCurrentUser: APIHandler<'me'> = async (_, auth) => {
   const [userSnap] = await firestore.getAll(userDoc)
   if (!userSnap.exists) throw new APIError(401, 'Your account was not found')
 
-  return userSnap.data() as User
+  return toLiteUser(userSnap.data() as User)
 }
 
 const firestore = admin.firestore()


### PR DESCRIPTION
The `/me` endpoint in the API returns a `User` instead of a `LiteUser` which is inconsistent with `/user`. I do `toLiteUser` on the `User` from `getCurrentUser` which should fix this. 