### PR TITLE
Show fractional shares for advanced traders

### DIFF
--- a/common/src/util/format.ts
+++ b/common/src/util/format.ts
@@ -38,7 +38,8 @@ export function getMoneyNumber(amount: number) {
 }
 
 export function formatMoneyWithDecimals(amount: number) {
-  return ENV_CONFIG.moneyMoniker + amount.toFixed(2)
+  const newAmount = getMoneyNumber(amount)
+  return ENV_CONFIG.moneyMoniker + newAmount.toFixed(2)
 }
 
 export function formatMoneyToDecimal(amount: number) {

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -41,6 +41,7 @@ import { getCpmmProbability } from 'common/calculate-cpmm'
 import { removeUndefinedProps } from 'common/util/object'
 import { calculateCpmmMultiArbitrageBet } from 'common/calculate-cpmm-arbitrage'
 import LimitOrderPanel from './limit-order-panel'
+import { useIsAdvancedTrader } from 'web/hooks/use-is-advanced-trader'
 
 export type BinaryOutcomes = 'YES' | 'NO' | undefined
 
@@ -255,6 +256,8 @@ export function BuyPanel(props: {
 
   const selected = seeLimit ? 'LIMIT' : outcome
 
+  const isAdvancedTrader = useIsAdvancedTrader()
+
   return (
     <Col>
       <Row
@@ -336,6 +339,8 @@ export function BuyPanel(props: {
                     ? getStonkDisplayShares(contract, currentPayout, 2)
                     : isPseudoNumeric
                     ? Math.floor(currentPayout)
+                    : isAdvancedTrader
+                    ? formatMoneyWithDecimals(currentPayout)
                     : formatMoney(currentPayout)}
                 </span>
                 <span className="text-ink-500 pr-3 text-sm">


### PR DESCRIPTION
This shows fractional shares to 2 decimal places if advanced trader mode is on.

Inspired by Eliza's discord suggestion "Displaying fractional mana/shares can teach people that small bets at 5% or 95% are still meaningful"