### PR TITLE
Store failed writes in replicator in a way that is robust to nesting

### DIFF
--- a/backend/scripts/find-deep-docs.ts
+++ b/backend/scripts/find-deep-docs.ts
@@ -1,0 +1,48 @@
+import { runScript } from './run-script'
+
+import { log, processPartitioned } from 'shared/utils'
+
+type DeepContractResult = {
+  data: any
+  depth: number
+}
+
+function maxDepth(obj: unknown) {
+  if (obj == null || typeof obj !== 'object') {
+    return 0
+  }
+  let result = 0
+  for (const [_key, val] of Object.entries(obj)) {
+    const depth = maxDepth(val) + 1
+    if (depth > result) {
+      result = depth
+    }
+  }
+  return result
+}
+
+if (require.main === module) {
+  runScript(async ({ firestore }) => {
+    log('Searching for deep contract objects...')
+    const results = [] as DeepContractResult[]
+    const source = firestore.collectionGroup('contracts')
+    await processPartitioned(source, 100, async (docs) => {
+      for (const doc of docs) {
+        const data = doc.data()
+        try {
+          const depth = maxDepth(data)
+          if (depth >= 20) {
+            results.push({ data, depth })
+          }
+        } catch (e) {
+          console.error(e)
+          console.log(data)
+        }
+      }
+    })
+    for (const result of results) {
+      console.log(result.data?.id, result.depth)
+    }
+    console.log(results.length)
+  })
+}


### PR DESCRIPTION
This was busted in a crazy way. If you use the Firestore server SDK to write a document with more than 20 levels of nesting, you get an error like this:

```
Error: Value for argument "data" is not a valid Firestore document. Input object is deeper than 20 levels or contains a cycle.
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:258:15)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:271:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:265:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:271:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:265:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:271:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:265:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:271:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:265:13)
    at validateUserInput (/usr/src/app/node_modules/@google-cloud/firestore/build/src/serializer.js:271:13)
```

This is totally just something that happens to us. We have 69 contracts in our DB that have deeper objects than this. It's because TipTap content can get extremely nested. For example, nesting 3 bulleted lists in a contract description basically does it.

When this happened, if the replicator tried to replicate a change to such a contract, and it failed, then the error handling where it tried to record the failed write to Firestore in order to replay later, also failed, because it couldn't record the failing document.

By stringifying the JSON we avoid this limitation.

FYI @sipec 