### PR TITLE
Charge no fees when bot bets result in added liquidity

### DIFF
--- a/backend/functions/src/triggers/on-create-bet.ts
+++ b/backend/functions/src/triggers/on-create-bet.ts
@@ -104,8 +104,9 @@ export const onCreateBet = functions
     if (bet.replyToCommentId)
       await handleBetReplyToComment(bet, contract, bettor, pg)
 
+    const betRemovesLiquidity = bet.isFilled ?? true
     const isApiOrBot = bet.isApi || BOT_USERNAMES.includes(bettor.username)
-    if (isApiOrBot) {
+    if (isApiOrBot && betRemovesLiquidity) {
       // assess flat fee for bots
       const userRef = firestore.doc(`users/${bettor.id}`)
       await userRef.update({


### PR DESCRIPTION
This was (briefly) discussed on the discord and I thought it was worth making a PR to discuss it further.
The idea of this change is to incentivise market-making and generally make it easier for bots to provide liquidity for markets.

Alternative approaches:
* Instead of no fee, introduce a reduced fee such as 1 mana
* Keep the .25 mana fee but _raise_ the fee for market-taking bets
