### PR TITLE
Spread out the points we grab for feed chart

### DIFF
--- a/common/src/chart.ts
+++ b/common/src/chart.ts
@@ -39,7 +39,8 @@ export const maxMinBin = <P extends HistoryPoint>(
   const max = points[points.length - 1].x
   const binWidth = Math.ceil((max - min) / bins)
 
-  //  for each bin, get the max, min, and median in that bin
+  // for each bin, get the max, min, and median in that bin
+  // TODO: time-weighted average instead of median?
   const result = []
   let lastInBin = points[0]
   for (let i = 0; i < bins; i++) {

--- a/common/src/contract-params.ts
+++ b/common/src/contract-params.ts
@@ -153,7 +153,6 @@ export const getSingleBetPoints = (
   betPoints: { x: number; y: number }[],
   contract: Contract
 ) => {
-  betPoints.sort((a, b) => a.x - b.x)
   const points = buildArray<{ x: number; y: number }>(
     contract.mechanism === 'cpmm-1' && {
       x: contract.createdTime,

--- a/common/src/supabase/bets.ts
+++ b/common/src/supabase/bets.ts
@@ -5,8 +5,9 @@ import { Bet, BetFilter } from 'common/bet'
 import { User } from 'common/user'
 import { getContractBetMetrics } from 'common/calculate'
 import { Contract } from 'common/contract'
-import { chunk, groupBy, maxBy, minBy } from 'lodash'
+import { chunk, groupBy, maxBy, minBy, sortBy } from 'lodash'
 import { removeUndefinedProps } from 'common/util/object'
+import { buildArray } from 'common/util/array'
 
 export const CONTRACT_BET_FILTER: BetFilter = {
   filterRedemptions: true,
@@ -83,7 +84,7 @@ export const getBets = async (db: SupabaseClient, options?: BetFilter) => {
   return data.map((r) => r.data)
 }
 
-// gets 50,000 unsorted random bets
+// gets random bets - 50,000 by default
 export const getBetPoints = async <S extends SupabaseClient>(
   db: S,
   contractId: string,
@@ -92,7 +93,7 @@ export const getBetPoints = async <S extends SupabaseClient>(
   let q = db
     .from('contract_bets')
     .select('created_time, prob_before, prob_after, data->answerId')
-    .order('bet_id')
+    .order('bet_id') // get "random" points so it doesn't bunch up at the end
   q = applyBetsFilter(q, {
     contractId,
     limit: 50000,
@@ -100,13 +101,25 @@ export const getBetPoints = async <S extends SupabaseClient>(
   })
   const { data } = await run(q)
 
-  return data
-    .filter((r: any) => r.prob_after != r.prob_before)
-    .map((r: any) => ({
+  const sorted = sortBy(data, 'created_time')
+
+  if (sorted.length === 0) return []
+
+  // we need to include previous prob for binary in case the prob shifted from something
+  const includePrevProb = !!options?.afterTime && !sorted[0].answerId
+
+  return buildArray(
+    includePrevProb && {
+      x: tsToMillis(sorted[0].created_time) - 1,
+      y: sorted[0].prob_before as number,
+      answerId: sorted[0].answerId as string,
+    },
+    sorted.map((r: any) => ({
       x: tsToMillis(r.created_time),
       y: r.prob_after as number,
       answerId: r.answerId as string,
     }))
+  )
 }
 
 export const applyBetsFilter = <

--- a/politics/components/contract/contract-card.tsx
+++ b/politics/components/contract/contract-card.tsx
@@ -178,7 +178,6 @@ export function FeedContractCard(props: {
             contract={contract}
             className="my-4"
             startDate={startTime ? startTime : contract.createdTime}
-            addLeadingBetPoint={true}
           />
         )}
         {promotedData && (

--- a/web/components/charts/contract/zoom-utils.ts
+++ b/web/components/charts/contract/zoom-utils.ts
@@ -17,7 +17,6 @@ export async function getPointsBetween(
     afterTime: min,
   })
 
-  points.sort((a, b) => a.x - b.x)
   const compressed = maxMinBin(points, 500)
 
   return compressed

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -280,7 +280,6 @@ export function FeedContractCard(props: {
             contract={contract}
             className="my-4"
             startDate={startTime ? startTime : contract.createdTime}
-            addLeadingBetPoint={true}
           />
         )}
         {promotedData && canAdPay && (

--- a/web/components/contract/related-contracts-widget.tsx
+++ b/web/components/contract/related-contracts-widget.tsx
@@ -477,12 +477,7 @@ const RelatedContractCard = memo(function (props: {
         </Row>
       </Row>
       {contract.outcomeType === 'BINARY' && probChange !== 0 && (
-        <FeedBinaryChart
-          contract={contract}
-          className="my-4"
-          startDate={Date.now() - DAY_MS}
-          addLeadingBetPoint={true}
-        />
+        <FeedBinaryChart contract={contract} className="my-4" />
       )}
     </Link>
   )

--- a/web/components/feed/feed-chart.tsx
+++ b/web/components/feed/feed-chart.tsx
@@ -1,25 +1,23 @@
 import { BinaryContract } from 'common/contract'
 import { useEffect, useState } from 'react'
 import { BinaryChart } from '../contract/contract-overview'
-import { DAY_MS, HOUR_MS } from 'common/util/time'
+import { DAY_MS } from 'common/util/time'
 import PlaceholderGraph from 'web/lib/icons/placeholder-graph.svg'
 import { usePersistentInMemoryState } from 'web/hooks/use-persistent-in-memory-state'
-import { applyBetsFilter } from 'common/supabase/bets'
+import { getBetPoints } from 'common/supabase/bets'
 import { db } from 'web/lib/supabase/db'
-import { Row, run, tsToMillis } from 'common/supabase/utils'
-import { first, last, maxBy, minBy, sortBy } from 'lodash'
-import dayjs from 'dayjs'
+import { maxBy, minBy } from 'lodash'
 
+// defaults to the previous day, unless you set a startDate
 export function FeedBinaryChart(props: {
   contract: BinaryContract
-  startDate: number | undefined
+  startDate?: number
   className?: string
-  addLeadingBetPoint?: boolean
 }) {
-  const { contract, addLeadingBetPoint, className, startDate } = props
+  const { contract, className, startDate } = props
 
-  const [bets, setBets] = usePersistentInMemoryState<
-    Partial<Row<'contract_bets'>>[] | null | undefined
+  const [points, setPoints] = usePersistentInMemoryState<
+    { x: number; y: number }[] | null | undefined
   >(undefined, `${contract.id}-feed-chart`)
 
   // cache the current time so we don't re-render the chart every time
@@ -27,65 +25,19 @@ export function FeedBinaryChart(props: {
   const startingDate = startDate ? startDate : now - DAY_MS
 
   useEffect(() => {
-    let q = db
-      .from('contract_bets')
-      .select('created_time, prob_before, prob_after, data->answerId')
-      .order('bet_id') // get "random" points so it doesn't bunch up at the end
-    q = applyBetsFilter(q, {
-      contractId: contract.id,
+    getBetPoints(db, contract.id, {
       limit: 1000,
       filterRedemptions: true,
       afterTime: startingDate,
-    })
-    run(q).then(({ data }) => {
-      if (data && data.length > 0) {
-        setBets(sortBy(data, 'created_time'))
-      }
-    })
+    }).then(setPoints)
   }, [startDate, contract.id])
 
-  const max = Math.max(
-    maxBy(bets, 'prob_after')?.prob_after ?? 1,
-    maxBy(bets, 'prob_before')?.prob_before ?? 1
-  )
-  const min = Math.min(
-    minBy(bets, 'prob_after')?.prob_after ?? 0,
-    minBy(bets, 'prob_before')?.prob_before ?? 0
-  )
-  const percentBounds = {
-    max,
-    min,
-  }
+  const max = maxBy(points, 'y')?.y ?? 1
+  const min = minBy(points, 'y')?.y ?? 0
 
-  // We want both before and after probs, as the prob may have been sitting for a while, and if
-  // we limit bets by the startDate, we may not capture the bet that brought it to that stasis.
-  const points = bets
-    ?.filter((r: any) => r.prob_after != r.prob_before)
-    ?.map((r: any) => [
-      {
-        x: tsToMillis(r.created_time) - 1,
-        y: r.prob_before as number,
-        answerId: r.answerId as string,
-      },
-      {
-        x: tsToMillis(r.created_time),
-        y: r.prob_after as number,
-        answerId: r.answerId as string,
-      },
-    ])
-    .flat()
-  const leadingBetTime = dayjs(last(points)?.x).diff(
-    dayjs(first(points)?.x),
-    'day'
-  )
+  const percentBounds = { max, min }
+
   if (points && points.length > 0 && !!points[0]) {
-    if (addLeadingBetPoint) {
-      points.unshift({
-        x: startingDate - leadingBetTime * HOUR_MS,
-        y: points[0].y,
-        answerId: points[0].answerId,
-      })
-    }
     return (
       <BinaryChart
         betPoints={points}

--- a/web/components/feed/feed-chart.tsx
+++ b/web/components/feed/feed-chart.tsx
@@ -7,7 +7,7 @@ import { usePersistentInMemoryState } from 'web/hooks/use-persistent-in-memory-s
 import { applyBetsFilter } from 'common/supabase/bets'
 import { db } from 'web/lib/supabase/db'
 import { Row, run, tsToMillis } from 'common/supabase/utils'
-import { first, last, maxBy, minBy } from 'lodash'
+import { first, last, maxBy, minBy, sortBy } from 'lodash'
 import dayjs from 'dayjs'
 
 export function FeedBinaryChart(props: {
@@ -30,7 +30,7 @@ export function FeedBinaryChart(props: {
     let q = db
       .from('contract_bets')
       .select('created_time, prob_before, prob_after, data->answerId')
-      .order('created_time')
+      .order('bet_id') // get "random" points so it doesn't bunch up at the end
     q = applyBetsFilter(q, {
       contractId: contract.id,
       limit: 1000,
@@ -39,7 +39,7 @@ export function FeedBinaryChart(props: {
     })
     run(q).then(({ data }) => {
       if (data && data.length > 0) {
-        setBets(data)
+        setBets(sortBy(data, 'created_time'))
       }
     })
   }, [startDate, contract.id])

--- a/web/components/us-elections/contracts/which-party-card.tsx
+++ b/web/components/us-elections/contracts/which-party-card.tsx
@@ -221,7 +221,6 @@ export function WhichPartyCard(props: {
             contract={contract}
             className="my-4"
             startDate={startTime ? startTime : contract.createdTime}
-            addLeadingBetPoint={true}
           />
         )}
         {promotedData && canAdPay && (

--- a/web/lib/supabase/feed-timeline/feed-market-movement-display.ts
+++ b/web/lib/supabase/feed-timeline/feed-market-movement-display.ts
@@ -1,7 +1,8 @@
 import { Contract } from 'common/contract'
-import { DAY_MS } from 'common/util/time'
+import { DAY_MS, HOUR_MS } from 'common/util/time'
 import { FeedTimelineItem } from 'web/hooks/use-feed-timeline'
 import { ProbChangeData } from 'common/feed'
+import dayjs from 'dayjs'
 
 const PROB_CHANGE_THRESHOLD = 0.05
 export const getMarketMovementInfo = (
@@ -94,5 +95,9 @@ export const getMarketMovementInfo = (
 
   const probChange = Math.round(probChangeSinceAdd * 100)
 
-  return { ignore: false, probChange, startTime }
+  // idk blame ian
+  const leadingBetDays = dayjs(contract.lastBetTime).diff(startTime, 'day')
+  const realStart = startTime - leadingBetDays * HOUR_MS
+
+  return { ignore: false, probChange, startTime: realStart }
 }


### PR DESCRIPTION
If we grab by created time, it will either bunch up at the start or the end if there's enough trades. For instance, here https://discord.com/channels/915138780216823849/1210629468130123836 users point out that the charts on manifold.markets/calibration are wrong in this way

This is something that the old code using `getBetPoints` did correctly, by ordering by id rather than created time

@IanPhilips I don't understand why you add two points for every bet, with a millisecond difference. I am also not sure why `leadingBetTime` is needed. So idk if ordering by id would break that calculation.