### PR TITLE
Fix broken contract metrics updating

### DIFF
--- a/common/src/supabase/bets.ts
+++ b/common/src/supabase/bets.ts
@@ -18,6 +18,7 @@ export const convertBet = (row: Row<'contract_bets'>) =>
   convertSQLtoTS<'contract_bets', Bet>(row, {
     fs_updated_time: false,
     created_time: tsToMillis as any,
+    answer_id: (a) => (a != null ? a : undefined),
   })
 
 export async function getBet(db: SupabaseClient, id: string) {

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -159,7 +159,9 @@ export const convertSQLtoTS = <
 
       const convert = converters[key]
       if (convert === false) return null
-      return [shouldCamelize ? camelize(key) : key, convert?.(val) ?? val]
+      const jsProp = shouldCamelize ? camelize(key) : key
+      const jsVal = convert != null ? convert(val) : val
+      return [jsProp, jsVal]
     })
     .filter((x) => x != null)
 


### PR DESCRIPTION
Our `convertSQLToTS` helper will by default write `null` into Javascript properties that have `null` in the corresponding SQL row, but we have many Typescript types that have optional properties that don't accept `null`. That can lead to JS objects that violate the Typescript types, which can easily produce bugs.

In this case, `calculateUserMetrics` was doing a `groupBy(bets, 'answerId')` on bets, and a mix of bets with `null` and `undefined` answer ID would produce a broken grouping, which would then blow up the bulk insert later on.

By creating the JS objects to have `undefined` instead of `null` we avert this problem.

Note that the analogous problem still exists elsewhere in our codebase. I just wanted contract metrics to work.