### PR TITLE
Substantially improve `usePagination` machinery

### DIFF
--- a/web/pages/charity/[charitySlug].tsx
+++ b/web/pages/charity/[charitySlug].tsx
@@ -90,7 +90,7 @@ function CharityPage(props: {
   const pagination = usePagination({
     pageSize: PAGE_SIZE,
     q: paginationCallback,
-    preload: donations,
+    prefix: donations,
   })
   return (
     <Page
@@ -124,7 +124,7 @@ function CharityPage(props: {
             stateKey={`isCollapsed-charity-${charity.id}`}
           />
           <Spacer h={8} />
-          {(pagination.items ?? []).map((d, i) => (
+          {pagination.items.map((d, i) => (
             <Donation key={i} user={d.user} ts={d.ts} amount={d.amount} />
           ))}
           <PaginationNextPrev {...pagination} />


### PR DESCRIPTION
This is mainly designed to make the pagination stuff capable of handling the case where you have a mix of things you are adding to the front manually (e.g. when you make a bet) and live updates to the rest of the list (e.g. bets and updates you are receiving over the wire.) It keeps track of your manually added "prefix" separately from the rest of the items, so that it doesn't get wiped out if the rest of the list changes. This should make it appropriate for using in some new places.

The implementation is also cleaned up in general and documented.