### PR TITLE
Clean up contracts table stuff

### DIFF
--- a/backend/supabase/contracts.sql
+++ b/backend/supabase/contracts.sql
@@ -55,8 +55,6 @@ create index if not exists contracts_unique_bettors on contracts (((data->>'uniq
 
 create index if not exists contracts_close_time on contracts (close_time desc);
 
-create index if not exists contracts_popularity_score on contracts (popularity_score desc);
-
 create index if not exists contracts_visibility on contracts (visibility);
 
 create index if not exists description_fts on contracts using gin (description_fts);

--- a/backend/supabase/contracts.sql
+++ b/backend/supabase/contracts.sql
@@ -53,8 +53,6 @@ create index if not exists contracts_created_time on contracts (created_time des
 
 create index if not exists contracts_close_time on contracts (close_time desc);
 
-create index if not exists contracts_visibility on contracts (visibility);
-
 create index if not exists description_fts on contracts using gin (description_fts);
 
 create index if not exists contracts_importance_score on contracts (importance_score desc);

--- a/backend/supabase/contracts.sql
+++ b/backend/supabase/contracts.sql
@@ -61,14 +61,6 @@ create index if not exists contracts_freshness_score on contracts (freshness_sco
 
 create index if not exists question_nostop_fts on contracts using gin (question_nostop_fts);
 
--- for calibration page
-create index if not exists contracts_sample_filtering on contracts (
-                                                                    outcome_type,
-                                                                    resolution,
-                                                                    visibility,
-                                                                    ((data ->> 'uniqueBettorCount')::int)
-    );
-
 create index if not exists idx_lover_user_id1 on contracts ((data ->> 'loverUserId1')) where data->>'loverUserId1' is not null;
 create index if not exists idx_lover_user_id2 on contracts ((data ->> 'loverUserId2')) where data->>'loverUserId2' is not null;
 

--- a/backend/supabase/contracts.sql
+++ b/backend/supabase/contracts.sql
@@ -69,8 +69,6 @@ create index if not exists contracts_sample_filtering on contracts (
                                                                     ((data ->> 'uniqueBettorCount')::int)
     );
 
-create index if not exists contracts_on_importance_score_and_resolution_time_idx on contracts(importance_score, resolution_time);
-
 create index if not exists idx_lover_user_id1 on contracts ((data ->> 'loverUserId1')) where data->>'loverUserId1' is not null;
 create index if not exists idx_lover_user_id2 on contracts ((data ->> 'loverUserId2')) where data->>'loverUserId2' is not null;
 

--- a/backend/supabase/contracts.sql
+++ b/backend/supabase/contracts.sql
@@ -59,8 +59,6 @@ create index if not exists contracts_visibility on contracts (visibility);
 
 create index if not exists description_fts on contracts using gin (description_fts);
 
-create index if not exists idx_contracts_close_time_resolution_time_visibility on contracts (close_time, resolution_time, visibility);
-
 create index if not exists contracts_importance_score on contracts (importance_score desc);
 
 create index if not exists contracts_freshness_score on contracts (freshness_score desc);

--- a/backend/supabase/contracts.sql
+++ b/backend/supabase/contracts.sql
@@ -51,8 +51,6 @@ create index if not exists contracts_creator_id on contracts (creator_id, create
 
 create index if not exists contracts_created_time on contracts (created_time desc);
 
-create index if not exists contracts_unique_bettors on contracts (((data->>'uniqueBettorCount')::integer) desc);
-
 create index if not exists contracts_close_time on contracts (close_time desc);
 
 create index if not exists contracts_visibility on contracts (visibility);

--- a/backend/supabase/contracts/indexes.sql
+++ b/backend/supabase/contracts/indexes.sql
@@ -8,8 +8,6 @@ create index if not exists contracts_created_time on contracts (created_time des
 
 create index if not exists contracts_close_time on contracts (close_time desc);
 
-create index if not exists contracts_popularity_score on contracts (popularity_score desc);
-
 create index if not exists contracts_daily_score on contracts (
   ((data ->> 'dailyScore')::numeric) desc nulls last
 );

--- a/backend/supabase/views.sql
+++ b/backend/supabase/views.sql
@@ -82,24 +82,6 @@ create or replace view
       cross join contract_embeddings
   );
 
-create or replace view
-  user_trending_contract as (
-    select
-      user_contract_distance.user_id,
-      user_contract_distance.contract_id,
-      distance,
-      public_open_contracts.popularity_score,
-      public_open_contracts.created_time,
-      public_open_contracts.close_time
-    from
-      user_contract_distance
-      join public_open_contracts on public_open_contracts.id = user_contract_distance.contract_id
-    where
-      public_open_contracts.popularity_score > 0
-    order by
-      popularity_score desc
-  );
-
 drop view if exists group_role;
 
 create view

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -3222,17 +3222,6 @@ export interface Database {
         }
         Relationships: []
       }
-      user_trending_contract: {
-        Row: {
-          close_time: string | null
-          contract_id: string | null
-          created_time: string | null
-          distance: number | null
-          popularity_score: number | null
-          user_id: string | null
-        }
-        Relationships: []
-      }
     }
     Functions: {
       add_creator_name_to_description: {

--- a/web/hooks/use-contract-supabase.ts
+++ b/web/hooks/use-contract-supabase.ts
@@ -12,7 +12,6 @@ import {
   getPublicContractIdsInTopics,
   getPublicContractsByIds,
   getRecentPublicContractRows,
-  getTrendingContracts,
 } from 'web/lib/supabase/contracts'
 import { useSubscription } from 'web/lib/supabase/realtime/use-subscription'
 import { useEffectCheckEquality } from './use-effect-check-equality'
@@ -146,12 +145,4 @@ export function useFirebasePublicContract(
     visibility != 'private' ? useContractFirebase(contractId) : undefined // useRealtimeContract(contractId)
 
   return contract
-}
-
-export function useTrendingContracts(limit: number) {
-  const [contracts, setContracts] = useState<Contract[] | undefined>(undefined)
-  useEffect(() => {
-    getTrendingContracts(limit).then(setContracts)
-  }, [limit])
-  return contracts
 }

--- a/web/lib/supabase/contracts.ts
+++ b/web/lib/supabase/contracts.ts
@@ -205,13 +205,3 @@ export async function getIsPrivateContractMember(
   })
   return data
 }
-
-export const getTrendingContracts = async (limit: number) => {
-  return await db
-    .from('contracts')
-    .select('data, importance_score')
-    .is('resolution_time', null)
-    .order('importance_score', { ascending: false })
-    .limit(limit)
-    .then((res) => res.data?.map((c) => convertContract(c)))
-}


### PR DESCRIPTION
Just glancing at it briefly I found these handful of contracts table indexes that are either no longer used, unnecessary, or redundant with other indexes on the table.

- Popularity score is no longer used.
- The index on visibility is pointless given that there is also an index with only visibility-public IDs and is of questionable utility anyway.
- The index on unique bettors serves only the partner progress page, which is easy to serve with the existing index on created time instead.
- The index on close time etc. isn't adding value over our existing index on just close time.
- The index on importance score and resolution time isn't adding value over the existing index on importance score.
- The calibration page index isn't relevant to the calibration page (whose query is mostly about getting bets).