### PR TITLE
Compute partner progress for ≥20 trader markets correctly

### DIFF
--- a/web/lib/supabase/users.ts
+++ b/web/lib/supabase/users.ts
@@ -143,7 +143,7 @@ export const getContractsCreatedProgress = async (
       .gte('created_time', startIsoString)
       .lt('created_time', endIsoString)
       .not('mechanism', 'eq', 'none')
-      .gte('data->>uniqueBettorCount', minTraders)
+      .gte('data->uniqueBettorCount', minTraders)
   )
   return count
 }


### PR DESCRIPTION
`getContractsCreatedProgress` checks for markets where `data->>uniqueBettorCount` is ≥20, but it should be checking `data->uniqueBettorCount`.

`->>` casts the count to a string, which results in the unique bettor count being lexicographically compared to "20", when it should be numerically compared to 20. As a result, the query includes all markets where the first digit of the bettor count is 2 to 9. (e.g. bettor counts of 5 and 50 are included, but 1 and 100 aren't).

cc @jahooma 