### PR TITLE
Make separate timestamp columns for each kind of contract view

### DIFF
--- a/backend/api/src/create-user.ts
+++ b/backend/api/src/create-user.ts
@@ -222,8 +222,8 @@ async function addContractsToSeenMarketsTable(
   await Promise.all(
     visitedContractIds.map((contractId) =>
       pg.none(
-        `insert into user_contract_views (user_id, contract_id, page_views)
-            values ($1, $2, 1)`,
+        `insert into user_contract_views (user_id, contract_id, page_views, last_page_view_ts)
+            values ($1, $2, 1, now())`,
         [userId, contractId]
       )
     )

--- a/backend/supabase/user_contract_views.sql
+++ b/backend/supabase/user_contract_views.sql
@@ -3,11 +3,16 @@ create table if not exists user_contract_views (
     id bigint generated always as identity primary key,
     user_id text null, -- null means logged out view
     contract_id text not null,
-    last_view_ts timestamptz not null default now(),
     promoted_views bigint not null default 0 check (promoted_views >= 0),
     card_views bigint not null default 0 check (card_views >= 0),
     page_views bigint not null default 0 check (page_views >= 0),
+    last_promoted_view_ts timestamptz null,
+    last_card_view_ts timestamptz null,
+    last_page_view_ts timestamptz null,
     check (promoted_views + card_views + page_views > 0)
+    check (last_page_view_ts is not null or
+           last_card_view_ts is not null or
+           last_promoted_view_ts is not null)
 );
 
 alter table user_contract_views enable row level security;
@@ -19,18 +24,38 @@ create unique index if not exists user_contract_views_user_id on user_contract_v
 
 create index if not exists user_contract_views_contract_id on user_contract_views (contract_id, user_id);
 
--- insert into user_contract_views (user_id, contract_id, last_view_ts, promoted_views, card_views, page_views)
+-- insert into user_contract_views (user_id, contract_id, last_promoted_view_ts, promoted_views, last_card_view_ts, card_views, last_page_view_ts, page_views)
 --     select
---         usm.user_id,
---         usm.contract_id,
---         max(usm.created_time) as last_view_ts,
---         sum(case when usm.is_promoted then 1 else 0 end) as promoted_views,
---         sum(case when usm.type = 'view market card' and (usm.is_promoted is null or not usm.is_promoted) then 1 else 0 end) as card_views,
---         sum(case when usm.type = 'view market' and (usm.is_promoted is null or not usm.is_promoted) then 1 else 0 end) as page_views
---     from user_seen_markets as usm
---     group by usm.contract_id, usm.user_id
--- on conflict (user_id, contract_id) do update set
---     last_view_ts = greatest(user_contract_views.last_view_ts, excluded.last_view_ts),
---     promoted_views = user_contract_views.promoted_views + excluded.promoted_views,
---     card_views = user_contract_views.card_views + excluded.card_views,
---     page_views = user_contract_views.page_views + excluded.page_views;
+--          usm.user_id,
+--          usm.contract_id,
+--          max(case when usm.is_promoted then usm.created_time else null end) as last_promoted_view_ts,
+--          sum(case when usm.is_promoted then 1 else 0 end) as promoted_views,
+--          max(case when usm.type = 'view market card' and (usm.is_promoted is null or not usm.is_promoted) then usm.created_time else null end) as last_card_view_ts,
+--          sum(case when usm.type = 'view market card' and (usm.is_promoted is null or not usm.is_promoted) then 1 else 0 end) as card_views,
+--          max(case when usm.type = 'view market' and (usm.is_promoted is null or not usm.is_promoted) then usm.created_time else null end) as last_page_view_ts,
+--          sum(case when usm.type = 'view market' and (usm.is_promoted is null or not usm.is_promoted) then 1 else 0 end) as page_views
+--      from user_seen_markets as usm
+--      where usm.created_time < '2024-02-29 09:19:47.063522 +00:00'
+--      group by usm.contract_id, usm.user_id
+--      union all
+--      select
+--          null as user_id,
+--          ue.contract_id,
+--          max(case when (ue.data->'isPromoted')::boolean then ue.ts else null end) as last_promoted_view_ts,
+--          sum(case when (ue.data->'isPromoted')::boolean then 1 else 0 end) as promoted_views,
+--          max(case when ue.name = 'view market card' and ((ue.data->'isPromoted') is null or not (ue.data->'isPromoted')::boolean) then ue.ts else null end) as last_card_view_ts,
+--          sum(case when ue.name = 'view market card' and ((ue.data->'isPromoted') is null or not (ue.data->'isPromoted')::boolean) then 1 else 0 end) as card_views,
+--          max(case when ue.name = 'view market' and ((ue.data->'isPromoted') is null or not (ue.data->'isPromoted')::boolean) then ue.ts else null end) as last_page_view_ts,
+--          sum(case when ue.name = 'view market' and ((ue.data->'isPromoted') is null or not (ue.data->'isPromoted')::boolean) then 1 else 0 end) as page_views
+--      from user_events as ue
+--      where ue.ts < '2024-02-29 09:19:47.063522 +00:00'
+--      and ue.contract_id is not null
+--      and (ue.name = 'view market' or ue.name = 'view market card' )
+--      group by ue.contract_id
+--  on conflict (user_id, contract_id) do update set
+--      last_promoted_view_ts = greatest(user_contract_views.last_promoted_view_ts, excluded.last_promoted_view_ts),
+--      last_card_view_ts = greatest(user_contract_views.last_card_view_ts, excluded.last_card_view_ts),
+--      last_page_view_ts = greatest(user_contract_views.last_page_view_ts, excluded.last_page_view_ts),
+--      promoted_views = user_contract_views.promoted_views + excluded.promoted_views,
+--      card_views = user_contract_views.card_views + excluded.card_views,
+--      page_views = user_contract_views.page_views + excluded.page_views;

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -2254,7 +2254,9 @@ export type Database = {
           card_views: number
           contract_id: string
           id: number
-          last_view_ts: string
+          last_card_view_ts: string | null
+          last_page_view_ts: string | null
+          last_promoted_view_ts: string | null
           page_views: number
           promoted_views: number
           user_id: string | null
@@ -2263,7 +2265,9 @@ export type Database = {
           card_views?: number
           contract_id: string
           id?: never
-          last_view_ts?: string
+          last_card_view_ts?: string | null
+          last_page_view_ts?: string | null
+          last_promoted_view_ts?: string | null
           page_views?: number
           promoted_views?: number
           user_id?: string | null
@@ -2272,7 +2276,9 @@ export type Database = {
           card_views?: number
           contract_id?: string
           id?: never
-          last_view_ts?: string
+          last_card_view_ts?: string | null
+          last_page_view_ts?: string | null
+          last_promoted_view_ts?: string | null
           page_views?: number
           promoted_views?: number
           user_id?: string | null


### PR DESCRIPTION
There are especially some cases where we care what page views someone has done lately, and don't care about relatively "cheap" card views. So I think it's good to have this more detailed info about recent views.