### PR TITLE
Revert "Revert "Fix dark theme (#2364)""

### DIFF
--- a/love/pages/_document.tsx
+++ b/love/pages/_document.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script'
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="en" className="no-js">
       <Head>
         <link rel="icon" href={ENV_CONFIG.faviconPath} />
         <Script src="/init-theme.js" strategy="beforeInteractive" />

--- a/love/public/init-theme.js
+++ b/love/public/init-theme.js
@@ -4,7 +4,12 @@
   const localTheme = localStorage.getItem('theme')
   const theme = localTheme ? JSON.parse(localTheme) : 'auto'
 
-  if (theme === 'dark' || (theme === 'auto' && autoDark)) {
+  document.documentElement.classList.remove('no-js')
+
+  if (
+    theme === 'dark' ||
+    ((theme === 'auto' || theme === 'loading') && autoDark)
+  ) {
     document.documentElement.classList.add('dark')
   }
 }

--- a/web/hooks/use-theme.ts
+++ b/web/hooks/use-theme.ts
@@ -34,6 +34,8 @@ const reRenderTheme = () => {
 
   const autoDark = window.matchMedia('(prefers-color-scheme: dark)').matches
 
+  document.documentElement.classList.remove('no-js')
+
   if (theme === 'dark' || ((theme === null || theme === 'auto') && autoDark)) {
     document.documentElement.classList.add('dark')
   } else {

--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script'
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="en" className="no-js">
       <Head>
         <link rel="icon" href={ENV_CONFIG.faviconPath} />
         <Script src="/init-theme.js" strategy="beforeInteractive" />

--- a/web/public/init-theme.js
+++ b/web/public/init-theme.js
@@ -4,7 +4,12 @@
   const localTheme = localStorage.getItem('theme')
   const theme = localTheme ? JSON.parse(localTheme) : 'auto'
 
-  if (theme === 'dark' || (theme === 'auto' && autoDark)) {
+  document.documentElement.classList.remove('no-js')
+
+  if (
+    theme === 'dark' ||
+    ((theme === 'auto' || theme === 'loading') && autoDark)
+  ) {
     document.documentElement.classList.add('dark')
   }
 }

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -61,6 +61,65 @@
     --color-yes-900: 19 78 74;
     --color-yes-950: 4 47 46;
   }
+  @media (prefers-color-scheme: dark) {
+    .no-js {
+      color-scheme: dark;
+
+      --color-ink-1000: 255 255 255;
+      --color-ink-950: 248 248 252;
+      --color-ink-900: 236 237 248;
+      --color-ink-800: 221 222 238;
+      --color-ink-700: 194 195 219;
+      --color-ink-600: 158 159 189;
+      --color-ink-500: 118 118 147;
+      --color-ink-400: 86 86 118;
+      --color-ink-300: 61 61 92;
+      --color-ink-200: 39 39 73;
+      --color-ink-100: 22 21 55;
+      --color-ink-50: 10 8 43;
+      --color-ink-0: 0 0 0;
+
+      --color-canvas-0: 30 41 59;
+      --color-canvas-50: 15 23 41;
+      --color-canvas-100: 51 65 85;
+
+      --color-primary-950: 238 242 255;
+      --color-primary-900: 224 231 255;
+      --color-primary-800: 199 210 254;
+      --color-primary-700: 165 180 252;
+      --color-primary-600: 129 140 248;
+      --color-primary-500: 99 102 241;
+      --color-primary-400: 79 70 229;
+      --color-primary-300: 67 56 202;
+      --color-primary-200: 55 48 163;
+      --color-primary-100: 49 46 129;
+      --color-primary-50: 30 27 75;
+
+      --color-no-950: 255 243 241;
+      --color-no-900: 255 235 231;
+      --color-no-800: 255 208 194;
+      --color-no-700: 255 164 151;
+      --color-no-600: 255 124 102;
+      --color-no-500: 247 88 54;
+      --color-no-400: 239 48 19;
+      --color-no-300: 209 30 12;
+      --color-no-200: 166 27 10;
+      --color-no-100: 132 29 13;
+      --color-no-50: 73 15 6;
+
+      --color-yes-950: 240 253 250;
+      --color-yes-900: 204 251 241;
+      --color-yes-800: 153 246 228;
+      --color-yes-700: 94 234 212;
+      --color-yes-600: 45 212 191;
+      --color-yes-500: 20 184 166;
+      --color-yes-400: 13 148 136;
+      --color-yes-300: 15 118 110;
+      --color-yes-200: 17 94 89;
+      --color-yes-100: 19 78 74;
+      --color-yes-50: 4 47 46;
+    }
+  }
   .dark {
     color-scheme: dark;
 


### PR DESCRIPTION
Not sure why #2364 was reverted. The both dark theme bugs came back after it was reverted.

# Problem 1

Almost exactly as stated in #2364 but was modified a little by https://github.com/manifoldmarkets/manifold/commit/1fcc593c20770353ded81097a9094fbe83d099f9

This video is recorded on an Android emulator.

https://github.com/manifoldmarkets/manifold/assets/8357970/09a6575b-7e45-4d35-a648-047a96cfae99

This is caused by the initial state of `theme` in local storage being set to `"loading"` in

https://github.com/manifoldmarkets/manifold/blob/744253f7f2c7d0c060b5769c713887420f76a5c3/web/hooks/use-theme.ts#L11

which is neither `"dark"` or `"auto"` thus not being set to dark theme in

https://github.com/manifoldmarkets/manifold/blob/744253f7f2c7d0c060b5769c713887420f76a5c3/web/public/init-theme.js#L7

# Problem 2

Exactly as stated in #2364

Even on my gigabit network, on both my Pixel 8 phone and my Android emulator (connected via ethernet), when the site is set to either `"auto"` or `"dark"`, it flashes the light theme on load.

https://github.com/manifoldmarkets/manifold/assets/8357970/a46f8b2b-a86f-4009-8b1d-dbad5719029a

