### PR TITLE
Get metrics for Grafana from dev DB

### DIFF
--- a/backend/supabase-grafana-agent/agent.yaml
+++ b/backend/supabase-grafana-agent/agent.yaml
@@ -10,17 +10,26 @@ integrations:
 metrics:
   wal_directory: /tmp/wal
   configs:
-    - name: supa_prom_scraper
+    - name: supabase_scraper
       scrape_configs:
-        - job_name: supa_prom_scraper
+        - job_name: supabase_prod
           metrics_path: '/customer/v1/privileged/metrics'
           scrape_timeout: 30s
           scrape_interval: 30s
           basic_auth:
             username: service_role
-            password: ${SUPABASE_KEY}
+            password: ${SUPABASE_PROD_KEY}
           static_configs:
             - targets: ['pxidrgkatumlvfqaxcll.supabase.co']
+        - job_name: supabase_dev
+          metrics_path: '/customer/v1/privileged/metrics'
+          scrape_timeout: 30s
+          scrape_interval: 30s
+          basic_auth:
+            username: service_role
+            password: ${SUPABASE_DEV_KEY}
+          static_configs:
+            - targets: ['mfodonznyfxllcezufgr.supabase.co']
 
       remote_write:
         - url: https://prometheus-us-central1.grafana.net/api/prom/push

--- a/backend/supabase-grafana-agent/run.sh
+++ b/backend/supabase-grafana-agent/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-exec /bin/agent                                             \
+exec /bin/grafana-agent                                     \
   --config.file=/etc/agent/agent.yaml                       \
   --metrics.wal-directory=/etc/agent/data                   \
   --config.expand-env


### PR DESCRIPTION
Just wiring this up because something weird happened on dev and the obvious first step is to increase visibility.

There's a little dropdown on the top left of the Grafana dashboard that lets you switch between dev and prod now.

![image](https://github.com/manifoldmarkets/manifold/assets/428637/4d198b38-1637-49e2-a0b3-c00942488717)
