### PR TITLE
Catch errors from random `getStaticProps` that talk to DB, API

### DIFF
--- a/backend/scheduler/src/jobs/update-stats.ts
+++ b/backend/scheduler/src/jobs/update-stats.ts
@@ -336,11 +336,10 @@ export const updateStatsCore = async () => {
     if (today.length === 0) return 0
 
     const yesterday = dailyUserIds[i - 1]
-
     const retainedCount = sumBy(yesterday, (userId) =>
       today.includes(userId) ? 1 : 0
     )
-    return retainedCount / yesterday.length
+    return yesterday.length === 0 ? 0 : retainedCount / yesterday.length
   })
 
   const d1WeeklyAvg = d1.map((_, i) => {

--- a/common/src/util/math.ts
+++ b/common/src/util/math.ts
@@ -21,7 +21,7 @@ export function median(xs: number[]) {
 }
 
 export function average(xs: number[]) {
-  return sum(xs) / xs.length
+  return xs.length === 0 ? 0 : sum(xs) / xs.length
 }
 
 export const EPSILON = 0.00000001

--- a/web/pages/admin/reports.tsx
+++ b/web/pages/admin/reports.tsx
@@ -20,18 +20,20 @@ import { db } from 'web/lib/supabase/db'
 import { getUser } from 'web/lib/supabase/user'
 
 export async function getStaticProps() {
-  const { data } = await run(
-    db
-      .from('reports')
-      .select()
-      .order('created_time', { ascending: false })
-      .limit(500)
-  )
-  const reports = await getReports(data).catch((e) => {
+  try {
+    const { data } = await run(
+      db
+        .from('reports')
+        .select()
+        .order('created_time', { ascending: false })
+        .limit(500)
+    )
+    const reports = await getReports(data)
+    return { props: { reports }, revalidate: 60 }
+  } catch (e) {
     console.error(e)
-    return []
-  })
-  return { props: { reports } }
+    return { props: { reports: [] }, revalidate: 60 }
+  }
 }
 
 export default function Reports(props: { reports: LiteReport[] }) {

--- a/web/pages/calibration.tsx
+++ b/web/pages/calibration.tsx
@@ -22,27 +22,42 @@ const TRADER_THRESHOLD = 15
 const SAMPLING_P = 0.02
 
 export const getStaticProps = async () => {
-  const result = await db
-    .from('platform_calibration')
-    .select('*')
-    .order('created_time', { ascending: false })
-    .limit(1)
+  try {
+    const result = await db
+      .from('platform_calibration')
+      .select('*')
+      .order('created_time', { ascending: false })
+      .limit(1)
 
-  const { points, score, n } = result.data?.[0]?.data as any
-  const trumpMarket = await getContract('AiEh38dIYVV5tOs1RmN3')
-  const gazaMarket = await getContract('KmWz1wvC8AmNX3a1iiUF')
-  const sbfMarket = await getContract('dRdXZtj8UXiXxkoF2rXE')
+    const { points, score, n } = result.data?.[0]?.data as any
+    const trumpMarket = await getContract('AiEh38dIYVV5tOs1RmN3')
+    const gazaMarket = await getContract('KmWz1wvC8AmNX3a1iiUF')
+    const sbfMarket = await getContract('dRdXZtj8UXiXxkoF2rXE')
 
-  return {
-    props: {
-      points,
-      score,
-      n,
-      trumpMarket,
-      gazaMarket,
-      sbfMarket,
-    },
-    revalidate: 60 * 60, // Regenerate after an hour
+    return {
+      props: {
+        points,
+        score,
+        n,
+        trumpMarket,
+        gazaMarket,
+        sbfMarket,
+      },
+      revalidate: 60 * 60, // Regenerate after an hour
+    }
+  } catch (err) {
+    console.error(err)
+    return {
+      props: {
+        points: [],
+        score: 0,
+        n: 0,
+        trumpMarket: null,
+        gazaMarket: null,
+        sbfMarket: null,
+      },
+      revalidate: 60,
+    }
   }
 }
 

--- a/web/pages/charity/index.tsx
+++ b/web/pages/charity/index.tsx
@@ -19,17 +19,29 @@ import { ENV_CONFIG } from 'common/envs/constants'
 import { DisplayUser, getUserById } from 'web/lib/supabase/users'
 
 export async function getStaticProps() {
-  const [totalsByCharity, mostRecentDonation] = await Promise.all([
-    getDonationsByCharity(),
-    getMostRecentDonation(),
-  ]).catch(() => [{}, { toId: '', fromId: '' }] as const)
-  return {
-    props: {
-      totalsByCharity,
-      mostRecentCharityId: mostRecentDonation.toId,
-      mostRecentDonor: await getUserById(mostRecentDonation.fromId),
-    },
-    revalidate: 60,
+  try {
+    const [totalsByCharity, mostRecentDonation] = await Promise.all([
+      getDonationsByCharity(),
+      getMostRecentDonation(),
+    ])
+    return {
+      props: {
+        totalsByCharity,
+        mostRecentCharityId: mostRecentDonation.toId,
+        mostRecentDonor: await getUserById(mostRecentDonation.fromId),
+      },
+      revalidate: 60,
+    }
+  } catch (err) {
+    console.error(err)
+    return {
+      props: {
+        totalsByCharity: {},
+        mostRecentCharityId: null,
+        mostRecentDonor: null,
+      },
+      revalidate: 60,
+    }
   }
 }
 
@@ -68,7 +80,7 @@ function DonatedStats(props: { stats: Stat[] }) {
 export default function Charity(props: {
   totalsByCharity: { [k: string]: { total: number; numSupporters: number } }
   mostRecentDonor?: DisplayUser | null
-  mostRecentCharityId?: string
+  mostRecentCharityId?: string | null
 }) {
   const { totalsByCharity, mostRecentCharityId, mostRecentDonor } = props
 

--- a/web/pages/home/index.tsx
+++ b/web/pages/home/index.tsx
@@ -18,12 +18,16 @@ import { DAY_MS } from 'common/util/time'
 import { useSaveScroll } from 'web/hooks/use-save-scroll'
 
 export async function getStaticProps() {
-  const headlines = await api('headlines', {})
-  return {
-    props: {
-      headlines,
-      revalidate: 30 * 60, // 30 minutes
-    },
+  try {
+    const headlines = await api('headlines', {})
+    return {
+      props: {
+        headlines,
+        revalidate: 30 * 60, // 30 minutes
+      },
+    }
+  } catch (err) {
+    return { props: { headlines: [] }, revalidate: 60 }
   }
 }
 

--- a/web/pages/newbies.tsx
+++ b/web/pages/newbies.tsx
@@ -5,9 +5,14 @@ import { Title } from 'web/components/widgets/title'
 import { db } from 'web/lib/supabase/db'
 
 export const getStaticProps = async () => {
-  const { data } = await db.rpc('get_noob_questions')
+  try {
+    const { data } = await db.rpc('get_noob_questions')
 
-  return { props: { contracts: data } }
+    return { props: { contracts: data }, revalidate: 60 * 60 }
+  } catch (err) {
+    console.error(err)
+    return { props: { contracts: [] }, revalidate: 60 }
+  }
 }
 
 export default function Newbies(props: { contracts: Contract[] }) {

--- a/web/pages/stats.tsx
+++ b/web/pages/stats.tsx
@@ -16,17 +16,23 @@ import Link from 'next/link'
 import { linkClass } from 'web/components/widgets/site-link'
 
 export const getStaticProps = async () => {
-  const stats = await getStats().catch((e) => {
-    console.error('Failed to get stats', e)
-    return {}
-  })
-  return {
-    props: stats,
-    revalidate: 60 * 60, // One hour
+  try {
+    const stats = await getStats()
+    return {
+      props: { stats },
+      revalidate: 60 * 60, // One hour
+    }
+  } catch (err) {
+    console.error(err)
+    return { props: { stats: null }, revalidate: 60 }
   }
 }
 
-export default function Analytics(props: Stats) {
+export default function Analytics(props: { stats: Stats | null }) {
+  const { stats } = props
+  if (!stats) {
+    return null
+  }
   return (
     <Page trackPageView={'site stats page'}>
       <SEO
@@ -34,12 +40,12 @@ export default function Analytics(props: Stats) {
         description="See site-wide usage statistics."
         url="/stats"
       />
-      <CustomAnalytics {...props} />
+      <CustomAnalytics stats={stats} />
     </Page>
   )
 }
 
-export function CustomAnalytics(props: Stats) {
+export function CustomAnalytics(props: { stats: Stats }) {
   const {
     dailyActiveUsers,
     dailyActiveUsersWeeklyAvg,
@@ -69,9 +75,9 @@ export function CustomAnalytics(props: Stats) {
     dailyNewRealUserSignups,
     d1BetAverage,
     d1Bet3DayAverage,
-  } = props
+  } = props.stats
 
-  const startDate = props.startDate[0]
+  const startDate = props.stats.startDate[0]
 
   const dailyDividedByWeekly = dailyActiveUsers.map(
     (dailyActive, i) => dailyActive / weeklyActiveUsers[i]


### PR DESCRIPTION
Besides planned downtime, it seems bad to not be able to deploy the website if the backend is having problems... Probably we should just catch errors from all of these as a matter of course.