### PR TITLE
Tidy up user comments list code

### DIFF
--- a/web/components/comments/comments-list.tsx
+++ b/web/components/comments/comments-list.tsx
@@ -1,7 +1,7 @@
+import { useCallback } from 'react'
 import { ContractComment } from 'common/comment'
 import { User } from 'common/user'
 import { groupConsecutive } from 'common/util/array'
-import { useEffect, useState } from 'react'
 import { UserLink } from 'web/components/widgets/user-link'
 import { Col } from '../layout/col'
 import { RelativeTimestamp } from '../relative-timestamp'
@@ -9,10 +9,9 @@ import { Avatar } from '../widgets/avatar'
 import { Content } from '../widgets/editor'
 import { PaginationNextPrev } from '../widgets/pagination'
 import Link from 'next/link'
-import { useIsAuthorized } from 'web/hooks/use-user'
+import { usePagination } from 'web/hooks/use-pagination'
 import { api } from 'web/lib/firebase/api'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
-import { sum } from 'lodash'
 import { getCommentLink } from 'web/components/feed/copy-link-date-time'
 import clsx from 'clsx'
 import { linkClass } from 'web/components/widgets/site-link'
@@ -32,80 +31,46 @@ function contractPath(slug: string) {
 
 export function UserCommentsList(props: { user: User; isPolitics?: boolean }) {
   const { user, isPolitics } = props
-  const pageSize = 50
-  const [pageNum, setPageNum] = useState(0)
-  const [groupedComments, setGroupedComments] = useState<
-    {
-      key: {
-        contractId: string
-        contractQuestion: string
-        contractSlug: string
-      }
-      items: ContractComment[]
-    }[]
-  >([])
-  const [isLoading, setIsLoading] = useState(false)
-  const isAuth = useIsAuthorized()
 
-  useEffect(() => {
-    setIsLoading(true)
-    api('comments', {
-      userId: user.id,
-      limit: pageSize,
-      page: pageNum,
-      isPolitics,
-    })
-      .then((result) =>
-        setGroupedComments(
-          groupConsecutive(result, (c) => {
-            return {
-              contractId: c.contractId,
-              contractQuestion: c.contractQuestion,
-              contractSlug: c.contractSlug,
-            }
-          })
-        )
-      )
-      .finally(() => setIsLoading(false))
-  }, [pageNum, isAuth])
+  const q = useCallback(
+    async (p: { limit: number; offset: number }) => {
+      const page = p.offset / p.limit
+      return await api('comments', {
+        userId: user.id,
+        limit: p.limit,
+        page,
+        isPolitics,
+      })
+    },
+    [user.id, isPolitics]
+  )
+  const pagination = usePagination({ pageSize: 50, q })
 
-  if (groupedComments.length === 0) {
-    if (pageNum == 0) {
+  const items = groupConsecutive(pagination.items, (c) => {
+    return {
+      contractId: c.contractId,
+      contractQuestion: c.contractQuestion,
+      contractSlug: c.contractSlug,
+    }
+  })
+
+  if (items.length === 0) {
+    if (pagination.isComplete) {
       return <p className="text-ink-500 mt-4">No comments yet</p>
     } else {
-      // this can happen if their comment count is a multiple of page size
-      return <p className="text-ink-500 mt-4">No more comments to display</p>
+      return <LoadingIndicator className="mt-4" />
     }
   }
-  const totalItems = sum(
-    Object.values(groupedComments).map((c) => c.items.length)
-  )
+
   return (
     <Col className={'bg-canvas-50'}>
-      {isLoading && <LoadingIndicator className="mt-4" />}
-      {!isLoading &&
-        groupedComments.map(({ key, items }, i) => {
-          return (
-            <ProfileCommentGroup
-              key={i}
-              groupKey={key}
-              items={items as ContractComment[]}
-            />
-          )
-        })}
-
-      <nav
+      {items.map(({ key, items }, i) => {
+        return <ProfileCommentGroup key={i} groupKey={key} items={items} />
+      })}
+      <PaginationNextPrev
         className="border-ink-200 border-t px-4 py-3 sm:px-6"
-        aria-label="Pagination"
-      >
-        <PaginationNextPrev
-          getNext={() => setPageNum(pageNum + 1)}
-          getPrev={() => setPageNum(pageNum - 1)}
-          isEnd={totalItems < pageSize}
-          isLoading={isLoading}
-          isStart={pageNum === 0}
-        />
-      </nav>
+        {...pagination}
+      />
     </Col>
   )
 }

--- a/web/components/widgets/pagination.tsx
+++ b/web/components/widgets/pagination.tsx
@@ -23,6 +23,7 @@ export function PaginationNextPrev(props: {
     props
   return (
     <Row
+      aria-label="Pagination"
       className={clsx(className, 'flex-1 justify-between gap-2 sm:justify-end')}
     >
       <button

--- a/web/components/widgets/pagination.tsx
+++ b/web/components/widgets/pagination.tsx
@@ -15,10 +15,12 @@ export function PaginationNextPrev(props: {
   isStart: boolean
   isEnd: boolean
   isLoading: boolean
+  isComplete: boolean
   getPrev: () => void
   getNext: () => void
 }) {
-  const { className, isStart, isEnd, isLoading, getPrev, getNext } = props
+  const { className, isStart, isEnd, isLoading, isComplete, getPrev, getNext } =
+    props
   return (
     <Row
       className={clsx(className, 'flex-1 justify-between gap-2 sm:justify-end')}
@@ -33,9 +35,9 @@ export function PaginationNextPrev(props: {
       <button
         className={buttonClass('lg', 'gray-outline')}
         onClick={getNext}
-        disabled={isLoading || isEnd}
+        disabled={isEnd && (isLoading || isComplete)}
       >
-        {isLoading ? <LoadingIndicator size="sm" /> : 'Next'}
+        {isEnd && isLoading ? <LoadingIndicator size="sm" /> : 'Next'}
       </button>
     </Row>
   )

--- a/web/hooks/use-pagination.ts
+++ b/web/hooks/use-pagination.ts
@@ -3,7 +3,10 @@
 
 import { useCallback, useEffect, useReducer } from 'react'
 
-type DataSource<T> = (limit: number, after?: T) => PromiseLike<T[]>
+// you can wire up the pagination to a data source that either knows how to
+// get the next N items after the first M, or the next N after item X
+export type PageSpec<T = unknown> = { limit: number; offset: number; after?: T }
+export type DataSource<T> = (page: PageSpec<T>) => PromiseLike<T[]>
 
 interface State<T> {
   // items we were given from outside that are always at the front of the list
@@ -11,7 +14,9 @@ interface State<T> {
   // items we have loaded in the list during the course of events
   items: T[]
   // the index of the start of the requested page. may or may not have loaded items
-  at: number
+  index: number
+  // whether we are currently loading the next page
+  isLoading: boolean
   // whether we believe we have loaded all items
   isComplete: boolean
 }
@@ -20,33 +25,24 @@ type ActionBase<K, V = void> = V extends void ? { type: K } : { type: K } & V
 
 type Action<T> =
   | ActionBase<'PREFIX', { prefix: T[] }>
-  | ActionBase<'LOAD', { items: T[]; isComplete: boolean }>
-  | ActionBase<'PREV', { distance: number }>
-  | ActionBase<'NEXT', { distance: number }>
-
-// whether the pagination should try right now to load some more items,
-// i.e. if it's not complete and it doesn't have enough to match desired
-function shouldLoadMore<T>(state: State<T>, desired: number) {
-  const itemCount = state.prefix.length + state.items.length
-  return !state.isComplete && itemCount < state.at + desired
-}
+  | ActionBase<'LOADING'>
+  | ActionBase<'LOADED', { items: T[]; isComplete: boolean }>
+  | ActionBase<'MOVE', { index: number }>
 
 function getReducer<T>() {
   return (state: State<T>, action: Action<T>): State<T> => {
     switch (action.type) {
       case 'PREFIX': {
-        return { ...state, prefix: action.prefix }
+        return { ...state, ...action }
       }
-      case 'LOAD': {
-        return { ...state, items: action.items, isComplete: action.isComplete }
+      case 'LOADING': {
+        return { ...state, isLoading: true }
       }
-      case 'PREV': {
-        // it's meaningless to let them page to before the start
-        return { ...state, at: Math.max(0, state.at - action.distance) }
+      case 'LOADED': {
+        return { ...state, isLoading: false, ...action }
       }
-      case 'NEXT': {
-        // but let them page past the end -- it indicates they want some amount more
-        return { ...state, at: state.at + action.distance }
+      case 'MOVE': {
+        return { ...state, ...action }
       }
       default:
         throw new Error('Invalid action.')
@@ -75,17 +71,24 @@ export type PaginationOptions<T> = {
 }
 
 function getInitialState<T>(opts: PaginationOptions<T>): State<T> {
-  return { prefix: opts.prefix ?? [], items: [], at: 0, isComplete: false }
+  return {
+    prefix: opts.prefix ?? [],
+    items: [],
+    index: 0,
+    isLoading: false,
+    isComplete: false,
+  }
 }
 
 export function usePagination<T>(opts: PaginationOptions<T>) {
   const [state, dispatch] = useReducer(getReducer<T>(), opts, getInitialState)
 
-  const loading = shouldLoadMore(state, opts.pageSize)
   const allItems = [...state.prefix, ...state.items]
   const lastItem = allItems[allItems.length - 1]
   const itemCount = allItems.length
-  const pageStart = Math.max(0, Math.min(state.at, itemCount - opts.pageSize))
+  const pagesCount = Math.ceil(itemCount / opts.pageSize)
+  const pageIndex = Math.min(state.index, pagesCount - 1)
+  const pageStart = pageIndex * opts.pageSize
   const pageEnd = pageStart + opts.pageSize
   const pageItems = allItems.slice(pageStart, pageEnd)
 
@@ -96,23 +99,28 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
   // note: i guess if q changed we would probably want to wipe existing items,
   // and ignore the results of in-progress queries here? unclear with no example
 
+  const shouldLoad = !state.isComplete && state.index >= pagesCount
+  console.log(state.index, shouldLoad)
   useEffect(() => {
-    if (loading) {
-      opts.q(opts.pageSize, lastItem).then((newItems) => {
+    if (shouldLoad) {
+      const offset = state.index * opts.pageSize
+      const spec = { limit: opts.pageSize, offset, after: lastItem }
+      dispatch({ type: 'LOADING' })
+      opts.q(spec).then((newItems) => {
         const isComplete = newItems.length < opts.pageSize
         const items = [...state.items, ...newItems]
-        dispatch({ type: 'LOAD', items, isComplete })
+        dispatch({ type: 'LOADED', items, isComplete })
       })
     }
-  }, [loading, lastItem, opts.q, opts.pageSize])
+  }, [shouldLoad, state.index, opts.pageSize, lastItem, opts.q])
 
   const getPrev = useCallback(
-    () => dispatch({ type: 'PREV', distance: opts.pageSize }),
-    [dispatch, opts.pageSize]
+    () => dispatch({ type: 'MOVE', index: Math.max(0, pageIndex - 1) }),
+    [dispatch, pageIndex]
   )
   const getNext = useCallback(
-    () => dispatch({ type: 'NEXT', distance: opts.pageSize }),
-    [dispatch, opts.pageSize]
+    () => dispatch({ type: 'MOVE', index: pageIndex + 1 }), // allow page past the end
+    [dispatch, pageIndex]
   )
   const prepend = useCallback(
     (...items: T[]) =>
@@ -122,13 +130,14 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
 
   return {
     items: pageItems,
+    pageIndex,
     pageStart,
     pageEnd,
     pageSize: opts.pageSize,
-    isLoading: loading,
+    isLoading: state.isLoading,
     isComplete: state.isComplete,
     isStart: pageStart === 0,
-    isEnd: state.isComplete && pageEnd >= itemCount,
+    isEnd: pageEnd >= itemCount,
     getPrev,
     getNext,
     prepend,

--- a/web/hooks/use-pagination.ts
+++ b/web/hooks/use-pagination.ts
@@ -42,7 +42,7 @@ function getReducer<T>() {
         return { ...state, isLoading: false, ...action }
       }
       case 'MOVE': {
-        return { ...state, ...action }
+        return { ...state, index: Math.max(0, action.index) }
       }
       default:
         throw new Error('Invalid action.')
@@ -114,14 +114,22 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
     }
   }, [shouldLoad, state.index, opts.pageSize, lastItem, opts.q])
 
+  const getPage = useCallback(
+    (index: number) => dispatch({ type: 'MOVE', index }),
+    [dispatch]
+  )
+
   const getPrev = useCallback(
-    () => dispatch({ type: 'MOVE', index: Math.max(0, pageIndex - 1) }),
+    () => dispatch({ type: 'MOVE', index: pageIndex - 1 }),
     [dispatch, pageIndex]
   )
+
   const getNext = useCallback(
-    () => dispatch({ type: 'MOVE', index: pageIndex + 1 }), // allow page past the end
+    // allow page past the end -- we'll load the new page
+    () => dispatch({ type: 'MOVE', index: pageIndex + 1 }),
     [dispatch, pageIndex]
   )
+
   const prepend = useCallback(
     (...items: T[]) =>
       dispatch({ type: 'PREFIX', prefix: [...items, ...state.prefix] }),
@@ -138,6 +146,7 @@ export function usePagination<T>(opts: PaginationOptions<T>) {
     isComplete: state.isComplete,
     isStart: pageStart === 0,
     isEnd: pageEnd >= itemCount,
+    getPage,
     getPrev,
     getNext,
     prepend,

--- a/web/lib/supabase/txns.ts
+++ b/web/lib/supabase/txns.ts
@@ -18,17 +18,17 @@ export async function getDonationsByCharity() {
 }
 
 export function getDonationsPageQuery(charityId: string) {
-  return async (limit: number, after?: { ts: number }) => {
+  return async (p: { limit: number; after?: { ts: number } }) => {
     let q = db
       .from('txns')
       .select('from_id, created_time, amount')
       .eq('category', 'CHARITY')
       .eq('to_id', charityId)
       .order('created_time', { ascending: false } as any)
-      .limit(limit)
+      .limit(p.limit)
 
-    if (after?.ts) {
-      q = q.lt('created_time', millisToTs(after.ts))
+    if (p.after?.ts) {
+      q = q.lt('created_time', millisToTs(p.after.ts))
     }
     const txnData = (await run(q)).data
     const userIds = uniq(txnData.map((t) => t.from_id!))

--- a/web/pages/charity/[charitySlug].tsx
+++ b/web/pages/charity/[charitySlug].tsx
@@ -52,8 +52,9 @@ export async function getStaticProps(ctx: { params: { charitySlug: string } }) {
     numSupporters: 0,
     total: 0,
   }
-  console.log(charity.id, stats)
-  const donations = await getDonationsPageQuery(charity.id)(PAGE_SIZE)
+  const donations = await getDonationsPageQuery(charity.id)({
+    limit: PAGE_SIZE,
+  })
   return {
     props: { charity, donations, stats },
     revalidate: 60,


### PR DESCRIPTION
I was interested in doing this because Ian mentioned that he tried to use the `usePagination` stuff here but had a hard time.

I modified `usePagination` to be easier to use for `limit`/`offset` style queries like the comments list API, and fixed some small bugs I noticed (e.g. if you went back and forth from the end of the list it would fire off a duplicate query for the next page.)

The end result is a less buggy comment list (the old one did stuff like flashing "No comments yet" before first load, and wiping out the list in between loads) and a better `usePagination` for adapting to later stuff elsewhere.

By the way, I note that this used to check for being authorized for no obvious reason? You don't need to be authorized to call this API and get comments.

FYI @IanPhilips 