### PR TITLE
Add ability to delete groups with no markets

### DIFF
--- a/backend/api/src/app.ts
+++ b/backend/api/src/app.ts
@@ -154,6 +154,7 @@ import { createPublicChatMessage } from 'api/create-public-chat-message'
 import { createAnswerDpm } from 'api/create-answer-dpm'
 import { getFollowedGroups } from './get-followed-groups'
 import { getUniqueBetGroupCount } from 'api/get-unique-bet-groups'
+import { deleteGroup } from './delete-group'
 
 const allowCorsUnrestricted: RequestHandler = cors({})
 
@@ -227,6 +228,8 @@ const handlers: { [k in APIPath]: APIHandler<k> } = {
   'group/by-id/:id': getGroup,
   'group/by-id/:id/markets': ({ id, limit }, ...rest) =>
     getMarkets({ groupId: id, limit }, ...rest),
+  'group/:slug/delete': deleteGroup,
+  'group/by-id/:id/delete': deleteGroup,
   groups: getGroups,
   'market/:id': getMarket,
   'market/:id/lite': ({ id }) => getMarket({ id, lite: true }),

--- a/backend/api/src/delete-group.ts
+++ b/backend/api/src/delete-group.ts
@@ -1,0 +1,43 @@
+import { createSupabaseClient } from 'shared/supabase/init'
+import { APIError } from './helpers/endpoint'
+import { run } from 'common/supabase/utils'
+import { log } from 'shared/log'
+
+export const deleteGroup = async (props: { id: string } | { slug: string }) => {
+  const db = createSupabaseClient()
+
+  const q = db.from('groups').select('id')
+  if ('id' in props) {
+    q.eq('id', props.id)
+  } else {
+    q.eq('slug', props.slug)
+  }
+
+  const { data: groups } = await run(q)
+
+  if (groups.length == 0) {
+    throw new APIError(404, 'Group not found')
+  }
+
+  const id = groups[0].id
+
+  // check if any contracts tagged with this
+  const { count: contractCount } = await run(
+    db
+      .from('contract_groups')
+      .select('*', { head: true, count: 'exact' })
+      .eq('groupId', id)
+  )
+
+  if (contractCount > 0) {
+    throw new APIError(
+      400,
+      `Only topics with no questions can be deleted. There are still ${contractCount} questions tagged with this topic.`
+    )
+  }
+
+  log('removing group members')
+  await db.from('group_members').delete().eq('group_id', id)
+  log('deleting group ', id)
+  await db.from('groups').delete().eq('id', id)
+}

--- a/backend/api/src/delete-group.ts
+++ b/backend/api/src/delete-group.ts
@@ -14,7 +14,7 @@ export const deleteGroup = async (
   const db = createSupabaseClient()
   const pg = createSupabaseDirectClient()
 
-  const q = db.from('groups').select('id')
+  const q = db.from('groups').select()
   if ('id' in props) {
     q.eq('id', props.id)
   } else {
@@ -27,7 +27,14 @@ export const deleteGroup = async (
     throw new APIError(404, 'Group not found')
   }
 
-  const id = groups[0].id
+  const group = groups[0]
+
+  log(
+    `delete group ${group.name} ${group.slug} initiated by ${auth.uid}`,
+    group
+  )
+
+  const id = group.id
 
   if (!isModId(auth.uid)) {
     const requester = await pg.oneOrNone(

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -245,6 +245,18 @@ export const API = (_apiTypeCheck = {
       })
       .strict(),
   },
+  'group/:slug/delete': {
+    method: 'POST',
+    visibility: 'public',
+    authed: true,
+    props: z.object({ slug: z.string() }),
+  },
+  'group/by-id/:id/delete': {
+    method: 'POST',
+    visibility: 'public',
+    authed: true,
+    props: z.object({ id: z.string() }),
+  },
   groups: {
     method: 'GET',
     visibility: 'public',

--- a/web/components/topics/delete-topic-modal.tsx
+++ b/web/components/topics/delete-topic-modal.tsx
@@ -1,0 +1,77 @@
+import { type PrivacyStatusType } from 'common/group'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { api } from 'web/lib/firebase/api'
+import { Button } from '../buttons/button'
+import { Modal } from '../layout/modal'
+import { Input } from '../widgets/input'
+import { Title } from '../widgets/title'
+
+export function DeleteTopicModal(props: {
+  group: { id: string; name: string; privacyStatus: PrivacyStatusType }
+  open: boolean
+  setOpen: (open: boolean) => void
+}) {
+  const { open, setOpen } = props
+  const { name, id, privacyStatus } = props.group
+
+  const [loading, setLoading] = useState(false)
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState('')
+
+  const router = useRouter()
+
+  return (
+    <Modal
+      open={open}
+      setOpen={setOpen}
+      className="bg-canvas-50 rounded-xl p-4 sm:p-6"
+      size="md"
+    >
+      <Title>Delete {name}?</Title>
+      <p className="mb-2">
+        Deleting a topic is permanent. All members will be removed and no one
+        will be able to find this topic.
+      </p>
+      {privacyStatus === 'public' && (
+        <p className="mb-2">
+          Topics should only be deleted if they are low quality or duplicate.
+          Ask #moderators channel on discord if you aren't sure.
+        </p>
+      )}
+
+      <Input
+        placeholder="Type the name of this group to confirm"
+        className="mb-2 mt-2 w-full"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+      />
+
+      <Button
+        onClick={() => {
+          setLoading(true)
+          api('group/by-id/:id/delete', { id })
+            .then(() => {
+              setLoading(false)
+              toast.success('Topic deleted')
+              router.push('/browse')
+            })
+            .catch((e) => {
+              setLoading(false)
+              console.error(e)
+              setError(e.message || 'Failed to delete topic')
+            })
+        }}
+        color="red"
+        disabled={loading || confirm != name}
+        size="xl"
+        className="w-full"
+      >
+        {loading ? 'Deleting...' : 'Delete Topic'}
+      </Button>
+
+      {error && <p className="mt-2 text-red-500">{error}</p>}
+    </Modal>
+  )
+}

--- a/web/components/topics/delete-topic-modal.tsx
+++ b/web/components/topics/delete-topic-modal.tsx
@@ -31,18 +31,22 @@ export function DeleteTopicModal(props: {
     >
       <Title>Delete {name}?</Title>
       <p className="mb-2">
-        Deleting a topic is permanent. All members will be removed and no one
-        will be able to find this topic.
+        Deleting a topic is permanent. All admins and followers will be removed
+        and no one will be able to find this topic anywhere.
       </p>
       {privacyStatus === 'public' && (
         <p className="mb-2">
           Topics should only be deleted if they are low quality or duplicate.
-          Ask #moderators channel on discord if you aren't sure.
+          Ask @moderators on discord if you aren't sure.
         </p>
       )}
+      <p className="mb-2">
+        To delete, first untag all questions tagged with this topic, then type "
+        {name}" below to confirm.
+      </p>
 
       <Input
-        placeholder="Type the name of this group to confirm"
+        placeholder="The name of this group"
         className="mb-2 mt-2 w-full"
         value={confirm}
         onChange={(e) => setConfirm(e.target.value)}

--- a/web/components/topics/delete-topic-modal.tsx
+++ b/web/components/topics/delete-topic-modal.tsx
@@ -59,7 +59,7 @@ export function DeleteTopicModal(props: {
             .then(() => {
               setLoading(false)
               toast.success('Topic deleted')
-              router.push('/browse')
+              router.replace('/browse')
             })
             .catch((e) => {
               setLoading(false)

--- a/web/components/topics/topic-options.tsx
+++ b/web/components/topics/topic-options.tsx
@@ -7,6 +7,7 @@ import {
   DotsVerticalIcon,
   PencilIcon,
   PlusCircleIcon,
+  TrashIcon,
 } from '@heroicons/react/solid'
 import DropdownMenu, {
   DropdownItem,
@@ -25,6 +26,7 @@ import { BiSolidVolumeMute } from 'react-icons/bi'
 import { usePrivateUser } from 'web/hooks/use-user'
 import { blockGroup, unBlockGroup } from 'web/components/topics/topic-dropdown'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
+import { DeleteTopicModal } from './delete-topic-modal'
 
 export function TopicOptions(props: {
   group: Group
@@ -36,6 +38,7 @@ export function TopicOptions(props: {
   const privateUser = usePrivateUser()
   const [editingName, setEditingName] = useState(false)
   const [showAddContract, setShowAddContract] = useState(false)
+  const [showDelete, setShowDelete] = useState(false)
   const userRole = useGroupRole(group.id, user)
   const isCreator = group.creatorId == user?.id
   const isMobile = useIsMobile()
@@ -68,7 +71,12 @@ export function TopicOptions(props: {
           privateUser.blockedGroupSlugs?.includes(group.slug)
             ? unBlockGroup(privateUser, group.slug)
             : blockGroup(privateUser, group.slug),
-      }
+      },
+    userRole === 'admin' && {
+      name: 'Delete',
+      icon: <TrashIcon className="text-scarlet-500 h-5 w-5" />,
+      onClick: () => setShowDelete(true),
+    }
   ) as DropdownItem[]
   return (
     <Col onClick={(e) => e.stopPropagation()}>
@@ -101,6 +109,11 @@ export function TopicOptions(props: {
           user={user}
         />
       )}
+      <DeleteTopicModal
+        group={group}
+        open={showDelete}
+        setOpen={setShowDelete}
+      />
     </Col>
   )
 }


### PR DESCRIPTION
I haven't really thought about _who_ should be able to delete groups. should be same "mod level" as renaming groups probably, but for some reason that is manifold admin / group admin only right now