### PR TITLE
The Merge: add scripts to merge and delete groups

### DIFF
--- a/backend/functions/src/triggers/on-update-contract.ts
+++ b/backend/functions/src/triggers/on-update-contract.ts
@@ -1,5 +1,6 @@
 import * as functions from 'firebase-functions'
 import {
+  getContractSupabase,
   getUser,
   log,
   processPaginated,
@@ -8,9 +9,15 @@ import {
 import { createCommentOrUpdatedContractNotification } from 'shared/create-notification'
 import { Contract, CPMMMultiContract, MultiContract } from 'common/contract'
 import * as admin from 'firebase-admin'
-import { isEqual, pick } from 'lodash'
+import { difference, isEqual, pick } from 'lodash'
 import { secrets } from 'common/secrets'
-import { createSupabaseClient } from 'shared/supabase/init'
+import {
+  createSupabaseClient,
+  createSupabaseDirectClient,
+} from 'shared/supabase/init'
+import { upsertGroupEmbedding } from 'shared/helpers/embeddings'
+import { addContractToFeed } from 'shared/create-feed'
+import { DAY_MS } from 'common/util/time'
 
 type AnyContract = Contract & CPMMMultiContract & MultiContract
 const propsThatTriggerRevalidation: (keyof AnyContract)[] = [
@@ -45,9 +52,43 @@ export const onUpdateContract = functions
     const contract = change.after.data() as Contract
     const previousContract = change.before.data() as Contract
     const { eventId } = context
-    const { closeTime, question } = contract
+    const { closeTime, question, groupLinks } = contract
 
     const db = createSupabaseClient()
+    const pg = createSupabaseDirectClient()
+
+    // Update group embeddings if group links changed
+    const previousGroupIds = (previousContract.groupLinks ?? []).map(
+      (gl) => gl.groupId
+    )
+    const currentGroupIds = (groupLinks ?? []).map((gl) => gl.groupId)
+    const onlyNewGroupIds = difference(currentGroupIds, previousGroupIds)
+    const differentGroupIds = onlyNewGroupIds.concat(
+      difference(previousGroupIds, currentGroupIds)
+    )
+    await Promise.all(
+      differentGroupIds.map(async (groupId) =>
+        upsertGroupEmbedding(pg, groupId)
+      )
+    )
+    // Adding a contract to a group is ~similar~ to creating a new contract in that group
+    if (
+      onlyNewGroupIds.length > 0 &&
+      contract.createdTime > Date.now() - 2 * DAY_MS &&
+      contract.visibility === 'public'
+    ) {
+      const contractWithScore = await getContractSupabase(contract.id)
+      if (!contractWithScore) return
+      await addContractToFeed(
+        contractWithScore,
+        ['contract_in_group_you_are_in'],
+        'new_contract',
+        [contractWithScore.creatorId],
+        {
+          idempotencyKey: contractWithScore.id + '_new_contract',
+        }
+      )
+    }
 
     if (
       (previousContract.closeTime !== closeTime ||

--- a/backend/scripts/delete-group.ts
+++ b/backend/scripts/delete-group.ts
@@ -1,0 +1,49 @@
+import { updateGroupLinksOnContracts } from 'merge-groups'
+import { runScript } from 'run-script'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+async function deleteGroup(
+  pg: SupabaseDirectClient,
+  firestore: any,
+  slug: string
+) {
+  const groupId = await pg.one(
+    'select id from groups where slug = $1',
+    [slug],
+    (row) => row.id
+  )
+
+  console.log('removing group from posts')
+  await pg.none('update old_posts set group_id = null where group_id = $1', [
+    groupId,
+  ])
+
+  const contracts = await pg.map(
+    'select contract_id from group_contracts where group_id = $1',
+    [groupId],
+    (row) => row.contract_id
+  )
+
+  if (contracts.length > 0) {
+    console.log('removing group from contracts')
+    await pg.none('delete from group_contracts where group_id = $1', [groupId])
+    console.log('correcting contract group slugs')
+    await updateGroupLinksOnContracts(pg, firestore, contracts)
+  }
+
+  console.log('removing group members')
+  await pg.none('delete from group_members where group_id = $1', [groupId])
+  console.log('deleting group')
+  await pg.none('delete from groups where id = $1', [groupId])
+}
+
+if (require.main === module) {
+  if (process.argv.length < 3) {
+    console.error('usage: delete-group.ts <group slug>')
+    process.exit(1)
+  }
+
+  runScript(async ({ pg, firestore }) => {
+    await deleteGroup(pg, firestore, process.argv[2])
+  })
+}

--- a/backend/scripts/merge-all-dupe-names.ts
+++ b/backend/scripts/merge-all-dupe-names.ts
@@ -1,0 +1,43 @@
+import { mergeGroups } from 'merge-groups'
+import { runScript } from 'run-script'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+const findDupeNames = async (pg: SupabaseDirectClient, firestore: any) => {
+  const dupeNames = await pg.manyOrNone<{
+    name: string
+    slug: string
+    id: string
+    importance_score: number
+    rank: number
+  }>(
+    `SELECT
+        name, slug, id, importance_score,
+        ROW_NUMBER() OVER(PARTITION BY name ORDER BY importance_score DESC, total_members DESC) AS rank
+      FROM groups
+      WHERE
+        privacy_status = 'public'
+        and name in (
+          select name
+            from groups
+            where privacy_status = 'public'
+            group by name
+            having count(*) > 1
+        )`
+  )
+
+  let top = dupeNames[0]
+  for (const group of dupeNames) {
+    if (group.rank == 1) {
+      top = group
+    } else if (group.name == top.name) {
+      console.log('merge', group.slug, top.slug)
+      await mergeGroups(pg, firestore, group.slug, top.slug)
+    }
+  }
+}
+
+if (require.main === module) {
+  runScript(async ({ pg, firestore }) => {
+    await findDupeNames(pg, firestore)
+  })
+}

--- a/backend/scripts/merge-all-dupe-names.ts
+++ b/backend/scripts/merge-all-dupe-names.ts
@@ -2,34 +2,53 @@ import { mergeGroups } from 'merge-groups'
 import { runScript } from 'run-script'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 
-const findDupeNames = async (pg: SupabaseDirectClient, firestore: any) => {
+const mergeAllDupes = async (pg: SupabaseDirectClient, firestore: any) => {
   const dupeNames = await pg.manyOrNone<{
-    name: string
+    name_fts: string
     slug: string
     id: string
     importance_score: number
     rank: number
   }>(
     `SELECT
-        name, slug, id, importance_score,
-        ROW_NUMBER() OVER(PARTITION BY name ORDER BY importance_score DESC, total_members DESC) AS rank
-      FROM groups
-      WHERE
-        privacy_status = 'public'
-        and name in (
-          select name
-            from groups
-            where privacy_status = 'public'
-            group by name
-            having count(*) > 1
-        )`
+      name_fts, name, slug, id, importance_score,
+      ROW_NUMBER() OVER(PARTITION BY name_fts ORDER BY importance_score DESC, total_members DESC) AS rank
+    FROM groups
+    WHERE
+      privacy_status = 'public'
+      and name_fts in (
+        select name_fts
+          from groups
+          where privacy_status = 'public'
+          and name_fts != ''
+          and name not in (
+            'Anime',
+            'Animals',
+            'Animation',
+            'Avatars',
+            'Avatar',
+            'Disney+',
+            'Disney',
+            'Curling',
+            'Curl',
+            'Musicals',
+            'Personal',
+            'Personality',
+            'Production',
+            'Productivity',
+            'Products',
+            'tests'
+          )
+          group by name_fts
+          having count(*) > 1
+      )`
   )
 
   let top = dupeNames[0]
   for (const group of dupeNames) {
     if (group.rank == 1) {
       top = group
-    } else if (group.name == top.name) {
+    } else if (group.name_fts == top.name_fts) {
       console.log('merge', group.slug, top.slug)
       await mergeGroups(pg, firestore, group.slug, top.slug)
     }
@@ -38,6 +57,6 @@ const findDupeNames = async (pg: SupabaseDirectClient, firestore: any) => {
 
 if (require.main === module) {
   runScript(async ({ pg, firestore }) => {
-    await findDupeNames(pg, firestore)
+    await mergeAllDupes(pg, firestore)
   })
 }

--- a/backend/scripts/merge-groups.ts
+++ b/backend/scripts/merge-groups.ts
@@ -1,0 +1,139 @@
+import { SafeBulkWriter } from 'shared/safe-bulk-writer'
+import { type SupabaseDirectClient } from 'shared/supabase/init'
+import { bulkUpsert } from 'shared/supabase/utils'
+import { runScript } from 'run-script'
+import { upsertGroupEmbedding } from 'shared/helpers/embeddings'
+
+// note: you should turn off the on-update-contract trigger (notifications, embedding recalculation) if it's a ton of contracts
+
+async function mergeGroups(
+  pg: SupabaseDirectClient,
+  firestore: any,
+  fromSlug: string,
+  toSlug: string
+) {
+  const from = await pg.one(
+    'select id from groups where slug = $1',
+    [fromSlug],
+    (row) => row.id
+  )
+
+  const to = await pg.one(
+    'select id from groups where slug = $1',
+    [toSlug],
+    (row) => row.id
+  )
+
+  console.log(`merging ${from} into ${to}`)
+
+  // console.log('update posts')
+  // await pg.none('update old_posts set group_id = $1 where group_id = $2', [
+  //   to,
+  //   from,
+  // ])
+
+  const contracts: string[] = await pg.map(
+    'select contract_id from group_contracts where group_id = $1',
+    [from],
+    (row) => row.contract_id
+  )
+
+  // if (contracts.length > 7) {
+  //   throw new Error(
+  //     `found ${contracts.length} contracts in group ${from}. are you sure?`
+  //   )
+  // }
+
+  if (contracts.length > 0) {
+    console.log(`re-tagging ${contracts.length} contracts`)
+    console.log(contracts)
+
+    await bulkUpsert(
+      pg,
+      'group_contracts',
+      ['group_id', 'contract_id'],
+      contracts.map((contract) => ({ group_id: to, contract_id: contract }))
+    )
+
+    console.log('removing old group contracts')
+    await pg.none('delete from group_contracts where group_id = $1', [from])
+
+    console.log('correcting contract group slugs')
+    await updateGroupLinksOnContracts(pg, firestore, contracts)
+
+    console.log('recalculating group embedding')
+    upsertGroupEmbedding(pg, to)
+  } else {
+    console.log('no contracts to re-tag')
+  }
+
+  // move members
+
+  const members: string[] = await pg.map(
+    'select member_id from group_members where group_id = $1',
+    [from],
+    (row) => row.member_id
+  )
+
+  console.log(`moving ${members.length} members`)
+
+  await bulkUpsert(
+    pg,
+    'group_members',
+    ['group_id', 'member_id'],
+    members.map((member) => ({ group_id: to, member_id: member }))
+  )
+
+  console.log('correcting group member count')
+
+  await pg.none(
+    'update groups set total_members = (select count(*) from group_members where group_id = $1) where id = $1',
+    [to]
+  )
+
+  console.log('removing old group members')
+  await pg.none('delete from group_members where group_id = $1', [from])
+  console.log('removing old group')
+  await pg.none('delete from groups where id = $1', [from])
+}
+
+async function updateGroupLinksOnContracts(
+  pg: SupabaseDirectClient,
+  firestore: any,
+  contractIds: string[]
+) {
+  const bulkWriter = new SafeBulkWriter()
+
+  for (const contractId of contractIds) {
+    const contractRef = firestore.collection('contracts').doc(contractId)
+
+    const groups = await pg.manyOrNone<{
+      group_id: string
+      slug: string
+      name: string
+    }>(
+      `select g.id as group_id, g.slug, g.name from groups g join group_contracts gc
+      on g.id = gc.group_id where gc.contract_id = $1
+      order by g.importance_score desc`,
+      [contractId]
+    )
+
+    bulkWriter.update(contractRef, {
+      groupSlugs: groups.map((g) => g.slug),
+      groupLinks: groups,
+    })
+  }
+
+  await bulkWriter.flush()
+}
+
+if (require.main === module) {
+  if (process.argv.length < 4) {
+    console.error('usage: merge-groups.ts <from> <to>')
+    process.exit(1)
+  }
+
+  runScript(async ({ pg, firestore }) => {
+    await mergeGroups(pg, firestore, process.argv[2], process.argv[3])
+  })
+}

--- a/backend/scripts/merge-groups.ts
+++ b/backend/scripts/merge-groups.ts
@@ -6,12 +6,16 @@ import { upsertGroupEmbedding } from 'shared/helpers/embeddings'
 
 // note: you should turn off the on-update-contract trigger (notifications, embedding recalculation) if it's a ton of contracts
 
-async function mergeGroups(
+export async function mergeGroups(
   pg: SupabaseDirectClient,
   firestore: any,
   fromSlug: string,
   toSlug: string
 ) {
+  if (fromSlug === toSlug) {
+    return
+  }
+
   const from = await pg.one(
     'select id from groups where slug = $1',
     [fromSlug],
@@ -26,11 +30,11 @@ async function mergeGroups(
 
   console.log(`merging ${from} into ${to}`)
 
-  // console.log('update posts')
-  // await pg.none('update old_posts set group_id = $1 where group_id = $2', [
-  //   to,
-  //   from,
-  // ])
+  console.log('update posts')
+  await pg.none('update old_posts set group_id = $1 where group_id = $2', [
+    to,
+    from,
+  ])
 
   const contracts: string[] = await pg.map(
     'select contract_id from group_contracts where group_id = $1',

--- a/backend/scripts/merge-groups.ts
+++ b/backend/scripts/merge-groups.ts
@@ -124,7 +124,11 @@ export async function updateGroupLinksOnContracts(
 
     bulkWriter.update(contractRef, {
       groupSlugs: groups.map((g) => g.slug),
-      groupLinks: groups,
+      groupLinks: groups.map((g) => ({
+        groupId: g.group_id,
+        slug: g.slug,
+        name: g.name,
+      })),
     })
   }
 

--- a/backend/scripts/merge-groups.ts
+++ b/backend/scripts/merge-groups.ts
@@ -42,7 +42,7 @@ export async function mergeGroups(
     (row) => row.contract_id
   )
 
-  // if (contracts.length > 10) {
+  // if (contracts.length > 100) {
   //   throw new Error(
   //     `found ${contracts.length} contracts in group ${from}. are you sure?`
   //   )
@@ -66,7 +66,7 @@ export async function mergeGroups(
     await updateGroupLinksOnContracts(pg, firestore, contracts)
 
     console.log('recalculating group embedding')
-    upsertGroupEmbedding(pg, to)
+    await upsertGroupEmbedding(pg, to)
   } else {
     console.log('no contracts to re-tag')
   }

--- a/backend/scripts/merge-groups.ts
+++ b/backend/scripts/merge-groups.ts
@@ -42,7 +42,7 @@ export async function mergeGroups(
     (row) => row.contract_id
   )
 
-  // if (contracts.length > 7) {
+  // if (contracts.length > 10) {
   //   throw new Error(
   //     `found ${contracts.length} contracts in group ${from}. are you sure?`
   //   )
@@ -101,7 +101,7 @@ export async function mergeGroups(
   await pg.none('delete from groups where id = $1', [from])
 }
 
-async function updateGroupLinksOnContracts(
+export async function updateGroupLinksOnContracts(
   pg: SupabaseDirectClient,
   firestore: any,
   contractIds: string[]

--- a/backend/shared/src/supabase/utils.ts
+++ b/backend/shared/src/supabase/utils.ts
@@ -71,9 +71,12 @@ export async function bulkUpsert<
 
   const primaryKey = Array.isArray(idField) ? idField.join(', ') : idField
   const upsertAssigns = cs.assignColumns({ from: 'excluded', skip: idField })
-  const query = `${baseQueryReplaced} on ${
-    onConflict ? onConflict : `conflict(${primaryKey})`
-  } do update set ${upsertAssigns}`
+  const query =
+    `${baseQueryReplaced} on ` +
+    (onConflict ? onConflict : `conflict(${primaryKey})`) +
+    ' ' +
+    (upsertAssigns ? `do update set ${upsertAssigns}` : `do nothing`)
+
   await db.none(query)
 }
 


### PR DESCRIPTION
### Notable hand-merged groups
- nonpredictive, non-predictive -> Unranked
- DGG, dggL, Destiny.gg Stocks, Daliban HQ -> Destiny.gg
- Musicians -> Music Artists 
- Donald Trump, Trump Legal Defense -> Trump
- Trump conviction -> Trump indictments
- United Kingdom -> UK
- USA, #america -> United States

(maybe these synonyms should be keywords on the group for search! or go the whole AO3 route and let multiple names point to the same tag...)

### All hand-merged groups (slug from, slug to)
```
twitch-ad6be7215259 twitch
-unranked nonpredictive
-unranked nonpredictive
nonpredictive-7760d7a025a1 nonpredictive
nonpredictive-20971ec2bf35 nonpredictive-profits
nonpredictive-d7f37225e3b6 nonpredictive
unsubsidized-1df19678470d unsubsidized
spain-6086cefc2bdd spain
spain-df5197aa9fca spain
spain-24f3808c4276 spain
mr-beast-0b1d3e75b4b9 mr-beast
destinygg-cc254c41a061 destinygg
destinygg-6232e435c913 destinygg
destinygg-6232e435c913 destinygg
far-right-392d357fc6ee far-right
far-right-1af212877228 far-right
fox-predicts fox-predicts-9deb216bf6ac
lula-59c2a7a04d3a lula
manifoldlove-relationships-bfc650471701 manifoldlove
bayesian conditional-markets
manifund manifund-5e8e6bc749f7
one-piece-ac50f96e4694 one-piece-bde612bb5170
one-piece-457cbe7061c9 one-piece-bde612bb5170
one-piece one-piece-bde612bb5170 
all-stonks-dac8bf1703f5 all-stonks
-df553e66b99a poop
wa seattle
palestine-5c174f9e4f40 palestine
ye kanye
who world-health-organization-who
me-12f36ce270a4 me
jjk jujutsu-kaisen
jjk-4ebd7e6dbc63 jujutsu-kaisen
meta-4b3e8508df66 meta-facebook
ice-cream-17eeafe6f88a ice-cream
mars-01b396eb84da mars    
metal-633a8b029eae metal
mormonism-807bf21e4057 mormonism
optic-f2df9ca62e2b optic
nintendo-30268d6dc197 ninetendo
nintendo-30268d6dc197 nintendo
meanjoeads-b5c2d29bd1a6 meanjoeads
sp-500 sp-500-439f18dbc885
trump-vp-1aa8f191730b trump-vp
oregon oregon-3ad789ce7df0
debatecon-4 debatecon-4-4fa0a51a2203 
mechanistic-interpretability-e5aced0b433f mechanistic-interpretability
2023-us-elections-599de0c1b640 2023-us-elections
new-years-resolution-2025 new-years-resolutions-2025
osrs old-school-runescape-osrs
xcom twitter
x twitter
x-cafdeda96789 twitter
stock-market stocks
buisiness-finance business
business-finance business 
business-and-finance business
united-kingdom uk
manifold-nba nba
manifold-markets-nba nba
nba-basketball nba
opensource open-source
us usa
us-government us-politics
usa united-states
usa united-states
america united-states
dggl destinygg
dggscape dgg
dgg destinygg
dgg destiny destinygg
destiny destinygg
destinygg-stocks destinygg
daliban-hq destinygg
musicians music-artists
donald-trump-adb8f1bbf890 donald-trump
donald-trump-adb8f1bbf890 donald-trump
trump-legal-defense donald-trump
trump-on-the-ballot 14thamendmentsection3
trump-convviction trump-indictments
trump-conviction trump-indictments 
chinese-space space
space-mining space
space-pollution space
space-travel space-exploration
space-wars space-violence
space-launch space
space-race space
```
but actually most groups (536 of them) were merged automatically from having the same `name` or `name_fts`
I have the logs for this saved on my computer just in case.

### Hand deleted groups (incomplete)
```
cakewalk-capital-markets
haas
stock-marjet-finance
stock-market-finance
assignment-help
testing-3755ab1c40ee
markets-2cdcef41ecac
-0e8fcde3fb98
world-religions
test123
catsdogs
ttt
evergreen
chance-me
manifund-383b9db94a31
d
-f36a9744dd6f
magic-proxies
nrl
based
jinglius-charity-circle
mormon
harvard-ai-safety-team
testcat
testcategory
-9e762b9cc348
-673cc7590599
-fcdbd6182133
v
-7a6472bdd652
stuff
-4d449de384d4
-29603a89b1ea
-0ce45bbe44e6
ko
dg
jj
-d68f6b786d27
ms
metaculus-clone
metaculus-clones
no
-800a1b829ec2
animes
birds
cumming
house
science
teach-me
watching
sp-forecasting-august
new-years-resolution-2024
na
living-space
```
Some of these's markets I recategorized before deleting the group. Most of the empty slugs are single-emojis (usually Levi) or pure whitespace (tumbles)


### Other stuff I did
- delete private groups with 0 contracts
- delete most curated groups with 0 contracts
- make public some curated groups in common subjects (like Mechanistic Interpretability)
```sql
update groups
set data = data || jsonb_build_object('name', trim(name))
where name != trim(name)
```

p.s. i now have a bunch of handy sql queries for conveniently viewing a group's members, contracts, and details about the group including about and num contracts. not checking them in tho.
