### PR TITLE
Set resolution for independent MC to CANCEL if it's cancelled

### DIFF
--- a/backend/shared/src/resolve-market-helpers.ts
+++ b/backend/shared/src/resolve-market-helpers.ts
@@ -98,6 +98,7 @@ export const resolveMarketHelper = async (
       outcome === 'YES'
     const marketCancelled = unresolvedContract.answers
       .every((a) => a.resolution === 'CANCEL')
+    const finalResolution = marketCancelled ? 'CANCEL' : 'MKT'
     if (
       allAnswersResolved &&
       outcomeType !== 'NUMBER' &&
@@ -106,7 +107,7 @@ export const resolveMarketHelper = async (
     )
       updatedContractAttrs = {
         ...updatedContractAttrs,
-        resolution: marketCancelled ? 'CANCEL' : 'MKT',
+        resolution: finalResolution,
       }
     else updatedContractAttrs = undefined
 

--- a/backend/shared/src/resolve-market-helpers.ts
+++ b/backend/shared/src/resolve-market-helpers.ts
@@ -96,6 +96,8 @@ export const resolveMarketHelper = async (
     const hasAnswerResolvedYes =
       unresolvedContract.answers.some((a) => a.resolution === 'YES') ||
       outcome === 'YES'
+    const marketCancelled = unresolvedContract.answers
+      .every((a) => a.resolution === 'CANCEL')
     if (
       allAnswersResolved &&
       outcomeType !== 'NUMBER' &&
@@ -104,7 +106,7 @@ export const resolveMarketHelper = async (
     )
       updatedContractAttrs = {
         ...updatedContractAttrs,
-        resolution: 'MKT',
+        resolution: marketCancelled ? 'CANCEL' : 'MKT',
       }
     else updatedContractAttrs = undefined
 


### PR DESCRIPTION
Helps fix the bug where you can't delete independent MC markets because their resolution type is MKT even if they are all resolved