### PR TITLE
Fix mobile notifications for profits rounding to 0

### DIFF
--- a/backend/shared/src/create-notification.ts
+++ b/backend/shared/src/create-notification.ts
@@ -1266,12 +1266,12 @@ export const createContractResolvedNotifications = async (
         profitRank && totalShareholders && betterThan > 0
           ? `, outperforming ${betterThan} other${betterThan > 1 ? 's' : ''}!`
           : '.'
-      const profit = Math.round(userPayout - userInvestment)
+      const profit = userPayout - userInvestment
       const profitPercent = Math.round((profit / userInvestment) * 100)
-      const profitString = ` You made M${getMoneyNumber(
+      const profitString = ` You made ${formatMoney(
         profit
       )} (+${profitPercent}%)`
-      const lossString = ` You lost M${getMoneyNumber(-profit)}`
+      const lossString = ` You lost ${formatMoney(-profit)}`
       await createPushNotification(
         notification,
         privateUser,

--- a/backend/shared/src/create-notification.ts
+++ b/backend/shared/src/create-notification.ts
@@ -1268,10 +1268,10 @@ export const createContractResolvedNotifications = async (
           : '.'
       const profit = userPayout - userInvestment
       const profitPercent = Math.round((profit / userInvestment) * 100)
-      const profitString = ` You made ${formatMoney(
+      const profitString = ` You made M${Math.round(
         profit
       )} (+${profitPercent}%)`
-      const lossString = ` You lost ${formatMoney(-profit)}`
+      const lossString = ` You lost M${Math.round(-profit)}`
       await createPushNotification(
         notification,
         privateUser,


### PR DESCRIPTION
If you make small bets or bets at 1% or 99%, the bet may end up profitable, while `Math.round(profit) === 0`. In that circumstance, the mobile notification will say "Resolved: {YOUR BET}. You **lost** M0, outperforming N others!" when it should say something like "Resolved: {YOUR BET}. You **made** M0 (+0.5%), outperforming N others!"

This changes `sendNotificationsIfSettingsPermit` to round profit only at display using `formatMoney`, rather than on computation, so the `profit > 0` check is correct even for profit in (M0, M0.5).

![8FE14002-FC05-439F-9292-EFCD96C7EE24_4_5005_c](https://github.com/manifoldmarkets/manifold/assets/27628/d5430ded-76b4-4b91-9a0d-b0842deec25f)

![FF6013F9-5EB9-4865-BE6C-A75F32D2E50F_1_201_a](https://github.com/manifoldmarkets/manifold/assets/27628/6c591c73-7674-440e-85ce-68704df07bef)

![F295785D-FA19-48CD-9BFE-9B8F867D9EEA_4_5005_c](https://github.com/manifoldmarkets/manifold/assets/27628/eaf44f63-0312-44f6-8e51-b678cee5ff3a)

And an additional note—this is my first time contributing, and I don't have everything set up, so I haven't tested the mobile notification code path. I would appreciate if one of the devs could run this before committing. I think it's all correct, but wouldn't want to break anything!