### PR TITLE
Say "for M̶250" not "for $M̶250"

### DIFF
--- a/web/components/buttons/referrals-button.tsx
+++ b/web/components/buttons/referrals-button.tsx
@@ -57,7 +57,7 @@ export function Referrals(props: { user: User }) {
           <span className={'text-primary-700 pb-2 text-xl'}>
             Refer a friend for{' '}
             <span className={'text-teal-500'}>
-              ${formatMoney(REFERRAL_AMOUNT)}
+              {formatMoney(REFERRAL_AMOUNT)}
             </span>{' '}
             each!
           </span>


### PR DESCRIPTION
There shouldn't be a dollar sign here:

![Refer a friend for for $M̶250 each!](https://github.com/manifoldmarkets/manifold/assets/10530973/90abab65-1a0f-445f-8980-1ef250848501)

The code does `${formatMoney(REFERRAL_AMOUNT)}` as if it was in a format string, but it's actually in a JSX markup expression which doesn't require a `$` there.