### PR TITLE
Reintroduce JWT signing of broadcast payloads

### DIFF
--- a/backend/shared/src/supabase/channel.ts
+++ b/backend/shared/src/supabase/channel.ts
@@ -1,4 +1,5 @@
 import { getInstanceId, getInstanceHostname } from './init'
+import { sign } from 'jsonwebtoken'
 
 type BroadcastMessage = {
   channel: string
@@ -6,11 +7,22 @@ type BroadcastMessage = {
   payload: object
 }
 
+// mqp: there's no built-in auth, so we sign the payload with a short expiry
+
+function signPayload(payload: object) {
+  const secret = process.env.BROADCAST_SECRET
+  if (!secret) {
+    throw new Error("Can't sign broadcasts; no process.env.BROADCAST_SECRET")
+  }
+  return sign(payload, secret, {
+    algorithm: 'HS256',
+    expiresIn: 3600, // seconds
+  })
+}
+
 // mqp: it's honestly easier to just post it ourselves than use the Supabase
 // client library, because then we don't have to do the song and dance of
 // creating the `SupabaseClient` and `RealtimeChannel` and such nonsense
-
-// TODO: apply Supabase's new auth stuff if you want to use this
 
 export async function broadcast(...messages: BroadcastMessage[]) {
   const key = process.env.SUPABASE_KEY
@@ -26,7 +38,7 @@ export async function broadcast(...messages: BroadcastMessage[]) {
     messages: messages.map((m) => ({
       topic: m.channel,
       event: m.event,
-      payload: m.payload,
+      payload: { jwt: signPayload(m.payload) },
     })),
   })
   return await fetch(endpoint, {

--- a/common/src/envs/dev.ts
+++ b/common/src/envs/dev.ts
@@ -22,6 +22,7 @@ export const DEV_CONFIG: EnvConfig = {
   supabaseInstanceId: 'mfodonznyfxllcezufgr',
   supabaseAnonKey:
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1mb2RvbnpueWZ4bGxjZXp1ZmdyIiwicm9sZSI6ImFub24iLCJpYXQiOjE2Njc5ODgxNjcsImV4cCI6MTk4MzU2NDE2N30.RK8CA3G2_yccgiIFoxzweEuJ2XU5SoB7x7wBzMKitvo',
+  supabaseBroadcastKey: '...',
   twitchBotEndpoint: 'https://dev-twitch-bot.manifold.markets',
   apiEndpoint: 'https://api.dev.manifold.markets',
   sprigEnvironmentId: 'Tu7kRZPm7daP',

--- a/common/src/envs/prod.ts
+++ b/common/src/envs/prod.ts
@@ -7,6 +7,7 @@ export type EnvConfig = {
   amplitudeApiKey: string
   supabaseInstanceId: string
   supabaseAnonKey: string
+  supabaseBroadcastKey: string
   twitchBotEndpoint: string
   apiEndpoint: string
   sprigEnvironmentId: string
@@ -54,6 +55,7 @@ export const PROD_CONFIG: EnvConfig = {
   supabaseInstanceId: 'pxidrgkatumlvfqaxcll',
   supabaseAnonKey:
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB4aWRyZ2thdHVtbHZmcWF4Y2xsIiwicm9sZSI6ImFub24iLCJpYXQiOjE2Njg5OTUzOTgsImV4cCI6MTk4NDU3MTM5OH0.d_yYtASLzAoIIGdXUBIgRAGLBnNow7JG2SoaNMQ8ySg',
+  supabaseBroadcastKey: '...',
   sprigEnvironmentId: 'sQcrq9TDqkib',
 
   firebaseConfig: {

--- a/web/package.json
+++ b/web/package.json
@@ -54,6 +54,7 @@
     "d3-zoom": "3.0.0",
     "dayjs": "1.11.4",
     "firebase": "9.19.1",
+    "jsonwebtoken": "9.0.0",
     "link-preview-js": "3.0.4",
     "nanoid": "^3.3.4",
     "next": "14.1.0",


### PR DESCRIPTION
The [broadcast authorization provided by Supabase](https://github.com/orgs/supabase/discussions/22484) seems overly complex for our needs. It's designed for people who want to authorize all kinds of different users into Phoenix channels, by looking up facts about them in Postgres based on their JWT. We don't care about anything so complicated right now; all we want is for nobody but our server to be able to send messages.

I think it's better to just implement what we want, which is simple enough, and not turn on their new authorization stuff until it's been fully baked.

We can try out their authorization later if we have an important reason why we want to use broadcasts on public channels for non-public info (e.g. contracts with special access rules, maybe private messages.)