### PR TITLE
Say "for M̶250" not "for $M̶250", again

### DIFF
--- a/web/components/buttons/referrals-button.tsx
+++ b/web/components/buttons/referrals-button.tsx
@@ -57,7 +57,7 @@ export function Referrals(props: { user: User }) {
           <span className={'text-primary-700 pb-2 text-xl'}>
             Refer a friend for{' '}
             <span className={'text-teal-500'}>
-              ${formatMoney(REFERRAL_AMOUNT)}
+              {formatMoney(REFERRAL_AMOUNT)}
             </span>{' '}
             each!
           </span>


### PR DESCRIPTION
This PR is identical to #2577, which was (accidentally?) reverted by @jahooma in d3483dfba19f601a34bd1cfadfe446e48e529f80.