### PR TITLE
Migrate liquidity to supabase

### DIFF
--- a/backend/api/src/add-subsidy.ts
+++ b/backend/api/src/add-subsidy.ts
@@ -8,6 +8,8 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { getContractSupabase, getUser } from 'shared/utils'
 import { broadcastNewSubsidy } from 'shared/websockets/helpers'
 import { onCreateLiquidityProvision } from './on-update-liquidity-provision'
+import { insertLiquidity } from 'shared/supabase/liquidity'
+import { convertLiquidity } from 'common/supabase/liquidity'
 
 export const addLiquidity: APIHandler<
   'market/:contractId/add-liquidity'
@@ -51,33 +53,20 @@ export const addContractLiquidity = async (
       fromType: 'USER',
     })
 
-    const liquidity = await firestore.runTransaction(async (transaction) => {
-      const contractDoc = firestore.doc(`contracts/${contractId}`)
+    const subsidyAmount = (1 - SUBSIDY_FEE) * amount
 
-      const newLiquidityProvisionDoc = firestore
-        .collection(`contracts/${contractId}/liquidity`)
-        .doc()
+    const { newLiquidityProvision, newTotalLiquidity, newSubsidyPool } =
+      getNewLiquidityProvision(userId, subsidyAmount, contract)
 
-      const subsidyAmount = (1 - SUBSIDY_FEE) * amount
+    const liquidityRow = await insertLiquidity(tx, newLiquidityProvision)
+    const liquidity = convertLiquidity(liquidityRow)
 
-      const { newLiquidityProvision, newTotalLiquidity, newSubsidyPool } =
-        getNewLiquidityProvision(
-          userId,
-          subsidyAmount,
-          contract,
-          newLiquidityProvisionDoc.id
-        )
+    await firestore.doc(`contracts/${contractId}`).update({
+      subsidyPool: newSubsidyPool,
+      totalLiquidity: newTotalLiquidity,
+    } as Partial<CPMMContract>)
 
-      transaction.update(contractDoc, {
-        subsidyPool: newSubsidyPool,
-        totalLiquidity: newTotalLiquidity,
-      } as Partial<CPMMContract>)
-
-      transaction.create(newLiquidityProvisionDoc, newLiquidityProvision)
-
-      broadcastNewSubsidy(contract, subsidyAmount)
-      return newLiquidityProvision
-    })
+    broadcastNewSubsidy(contract, subsidyAmount)
 
     return {
       result: liquidity,

--- a/backend/api/src/create-answer-cpmm.ts
+++ b/backend/api/src/create-answer-cpmm.ts
@@ -31,6 +31,8 @@ import {
 } from 'shared/supabase/bets'
 import { convertBet } from 'common/supabase/bets'
 import { betsQueue } from 'shared/helpers/fn-queue'
+import { convertAnswer } from 'common/supabase/contracts'
+import { insertLiquidity } from 'shared/supabase/liquidity'
 
 export const createAnswerCPMM: APIHandler<'market/:contractId/answer'> = async (
   props,
@@ -172,18 +174,16 @@ export const createAnswerCpmmMain = async (
         fbTrans.update(contractDoc, {
           totalLiquidity: FieldValue.increment(ANSWER_COST),
         })
-        const liquidityDoc = firestore
-          .collection(`contracts/${contract.id}/liquidity`)
-          .doc()
+
         const lp = getCpmmInitialLiquidity(
           user.id,
           contract,
-          liquidityDoc.id,
           ANSWER_COST,
           createdTime,
           newAnswer.id
         )
-        fbTrans.create(liquidityDoc, lp)
+
+        await insertLiquidity(pgTrans, lp)
       }
 
       return { newAnswerId: newAnswer.id, user }

--- a/backend/api/src/create-user.ts
+++ b/backend/api/src/create-user.ts
@@ -68,7 +68,7 @@ export const createuser: APIHandler<'createuser'> = async (
 
   const ip = getIp(req)
   const deviceToken = testUserAKAEmailPasswordUser
-    ? randomString(20)
+    ? randomString() + randomString()
     : preDeviceToken
 
   const fbUser = await admin.auth().getUser(auth.uid)

--- a/backend/shared/src/helpers/add-house-subsidy.ts
+++ b/backend/shared/src/helpers/add-house-subsidy.ts
@@ -10,6 +10,7 @@ import {
 import { getNewLiquidityProvision } from 'common/add-liquidity'
 import { insertLiquidity } from 'shared/supabase/liquidity'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { APIError } from 'common/api/utils'
 
 const firestore = admin.firestore()
 
@@ -17,63 +18,69 @@ export const addHouseSubsidy = async (contractId: string, amount: number) => {
   const pg = createSupabaseDirectClient()
 
   const contract = await getContractSupabase(contractId)
+  if (!contract) {
+    throw new APIError(500, 'Contract not found')
+  }
 
   const providerId = isProd()
     ? HOUSE_LIQUIDITY_PROVIDER_ID
     : DEV_HOUSE_LIQUIDITY_PROVIDER_ID
 
-  const { newLiquidityProvision, newTotalLiquidity, newSubsidyPool } =
-    getNewLiquidityProvision(
-      providerId,
-      amount,
-      contract as CPMMContract | CPMMMultiContract
-    )
+  const newLiquidityProvision = getNewLiquidityProvision(
+    providerId,
+    amount,
+    contract as CPMMContract | CPMMMultiContract
+  )
 
-  await insertLiquidity(pg, newLiquidityProvision)
+  await pg.tx(async (tx) => {
+    await insertLiquidity(tx, newLiquidityProvision)
 
-  await firestore.doc(`contracts/${contractId}`).update({
-    subsidyPool: newSubsidyPool,
-    totalLiquidity: newTotalLiquidity,
-  } as Partial<CPMMContract>)
+    await firestore.doc(`contracts/${contractId}`).update({
+      subsidyPool: FieldValue.increment(amount),
+      totalLiquidity: FieldValue.increment(amount),
+    })
+  })
 }
 
-export const addHouseSubsidyToAnswer = (
+export const addHouseSubsidyToAnswer = async (
   contractId: string,
   answerId: string,
   amount: number
 ) => {
-  return firestore.runTransaction(async (transaction) => {
-    const newLiquidityProvisionDoc = firestore
-      .collection(`contracts/${contractId}/liquidity`)
-      .doc()
+  const pg = createSupabaseDirectClient()
 
-    const providerId = isProd()
-      ? HOUSE_LIQUIDITY_PROVIDER_ID
-      : DEV_HOUSE_LIQUIDITY_PROVIDER_ID
+  const contract = await getContractSupabase(contractId)
+  if (!contract) {
+    throw new APIError(500, 'Contract not found')
+  }
 
-    const contractDoc = firestore.doc(`contracts/${contractId}`)
-    const snap = await transaction.get(contractDoc)
-    const contract = snap.data() as CPMMContract | CPMMMultiContract
+  const providerId = isProd()
+    ? HOUSE_LIQUIDITY_PROVIDER_ID
+    : DEV_HOUSE_LIQUIDITY_PROVIDER_ID
 
-    const { newLiquidityProvision } = getNewLiquidityProvision(
-      providerId,
-      amount,
-      contract,
-      answerId
-    )
+  const newLiquidityProvision = getNewLiquidityProvision(
+    providerId,
+    amount,
+    contract as CPMMContract | CPMMMultiContract,
+    answerId
+  )
 
-    transaction.update(contractDoc, {
-      totalLiquidity: FieldValue.increment(amount),
+  await pg.tx(async (tx) => {
+    await insertLiquidity(tx, newLiquidityProvision)
+
+    return firestore.runTransaction(async (transaction) => {
+      const contractDoc = firestore.doc(`contracts/${contractId}`)
+      transaction.update(contractDoc, {
+        totalLiquidity: FieldValue.increment(amount),
+      })
+
+      const answerDoc = firestore.doc(
+        `contracts/${contractId}/answersCpmm/${answerId}`
+      )
+      transaction.update(answerDoc, {
+        totalLiquidity: FieldValue.increment(amount),
+        subsidyPool: FieldValue.increment(amount),
+      })
     })
-
-    const answerDoc = firestore.doc(
-      `contracts/${contractId}/answersCpmm/${answerId}`
-    )
-    transaction.update(answerDoc, {
-      totalLiquidity: FieldValue.increment(amount),
-      subsidyPool: FieldValue.increment(amount),
-    })
-
-    transaction.create(newLiquidityProvisionDoc, newLiquidityProvision)
   })
 }

--- a/backend/shared/src/helpers/add-house-subsidy.ts
+++ b/backend/shared/src/helpers/add-house-subsidy.ts
@@ -2,44 +2,39 @@ import * as admin from 'firebase-admin'
 import { FieldValue } from 'firebase-admin/firestore'
 
 import { CPMMContract, CPMMMultiContract } from 'common/contract'
-import { isProd } from 'shared/utils'
+import { getContractSupabase, isProd } from 'shared/utils'
 import {
   DEV_HOUSE_LIQUIDITY_PROVIDER_ID,
   HOUSE_LIQUIDITY_PROVIDER_ID,
 } from 'common/antes'
 import { getNewLiquidityProvision } from 'common/add-liquidity'
+import { insertLiquidity } from 'shared/supabase/liquidity'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
 
 const firestore = admin.firestore()
 
-export const addHouseSubsidy = (contractId: string, amount: number) => {
-  return firestore.runTransaction(async (transaction) => {
-    const newLiquidityProvisionDoc = firestore
-      .collection(`contracts/${contractId}/liquidity`)
-      .doc()
+export const addHouseSubsidy = async (contractId: string, amount: number) => {
+  const pg = createSupabaseDirectClient()
 
-    const providerId = isProd()
-      ? HOUSE_LIQUIDITY_PROVIDER_ID
-      : DEV_HOUSE_LIQUIDITY_PROVIDER_ID
+  const contract = await getContractSupabase(contractId)
 
-    const contractDoc = firestore.doc(`contracts/${contractId}`)
-    const snap = await transaction.get(contractDoc)
-    const contract = snap.data() as CPMMContract | CPMMMultiContract
+  const providerId = isProd()
+    ? HOUSE_LIQUIDITY_PROVIDER_ID
+    : DEV_HOUSE_LIQUIDITY_PROVIDER_ID
 
-    const { newLiquidityProvision, newTotalLiquidity, newSubsidyPool } =
-      getNewLiquidityProvision(
-        providerId,
-        amount,
-        contract,
-        newLiquidityProvisionDoc.id
-      )
+  const { newLiquidityProvision, newTotalLiquidity, newSubsidyPool } =
+    getNewLiquidityProvision(
+      providerId,
+      amount,
+      contract as CPMMContract | CPMMMultiContract
+    )
 
-    transaction.update(contractDoc, {
-      subsidyPool: newSubsidyPool,
-      totalLiquidity: newTotalLiquidity,
-    } as Partial<CPMMContract>)
+  await insertLiquidity(pg, newLiquidityProvision)
 
-    transaction.create(newLiquidityProvisionDoc, newLiquidityProvision)
-  })
+  await firestore.doc(`contracts/${contractId}`).update({
+    subsidyPool: newSubsidyPool,
+    totalLiquidity: newTotalLiquidity,
+  } as Partial<CPMMContract>)
 }
 
 export const addHouseSubsidyToAnswer = (
@@ -64,7 +59,6 @@ export const addHouseSubsidyToAnswer = (
       providerId,
       amount,
       contract,
-      newLiquidityProvisionDoc.id,
       answerId
     )
 

--- a/backend/shared/src/supabase/liquidity.ts
+++ b/backend/shared/src/supabase/liquidity.ts
@@ -1,0 +1,18 @@
+import { LiquidityProvision } from 'common/liquidity-provision'
+import { insert } from './utils'
+import { SupabaseDirectClient } from './init'
+import { randomUUID } from 'crypto'
+import { removeUndefinedProps } from 'common/util/object'
+
+export const insertLiquidity = async (
+  pg: SupabaseDirectClient,
+  liquidity: Omit<LiquidityProvision, 'id'>
+) => {
+  const doc = { id: randomUUID(), ...liquidity }
+
+  return await insert(pg, 'contract_liquidity', {
+    liquidity_id: doc.id,
+    contract_id: doc.contractId,
+    data: JSON.stringify(removeUndefinedProps(doc)) + '::jsonb',
+  })
+}

--- a/backend/shared/src/supabase/liquidity.ts
+++ b/backend/shared/src/supabase/liquidity.ts
@@ -1,14 +1,15 @@
 import { LiquidityProvision } from 'common/liquidity-provision'
 import { insert } from './utils'
 import { SupabaseDirectClient } from './init'
-import { randomUUID } from 'crypto'
 import { removeUndefinedProps } from 'common/util/object'
+import { randomString } from 'common/util/random'
 
 export const insertLiquidity = async (
   pg: SupabaseDirectClient,
   liquidity: Omit<LiquidityProvision, 'id'>
 ) => {
-  const doc = { id: randomUUID(), ...liquidity }
+  // TODO: generate ids in supabase instead
+  const doc = { id: randomString(), ...liquidity }
 
   return await insert(pg, 'contract_liquidity', {
     liquidity_id: doc.id,

--- a/backend/supabase/contract_liquidity.sql
+++ b/backend/supabase/contract_liquidity.sql
@@ -4,7 +4,7 @@ create table if not exists
                            contract_id text not null,
                            liquidity_id text not null,
                            data jsonb not null,
-                           fs_updated_time timestamp not null,
+                           fs_updated_time timestamp,
                            primary key (contract_id, liquidity_id)
 );
 

--- a/common/src/add-liquidity.ts
+++ b/common/src/add-liquidity.ts
@@ -11,7 +11,6 @@ export const getNewLiquidityProvision = (
   userId: string,
   amount: number,
   contract: CPMMContract | CPMMMultiContract | CPMMNumericContract,
-  newLiquidityProvisionId: string,
   answerId?: string
 ) => {
   const { totalLiquidity, subsidyPool } = contract
@@ -29,16 +28,16 @@ export const getNewLiquidityProvision = (
     liquidity = newTotalLiquidity
   }
 
-  const newLiquidityProvision: LiquidityProvision = removeUndefinedProps({
-    id: newLiquidityProvisionId,
-    userId: userId,
-    contractId: contract.id,
-    answerId,
-    amount,
-    pool,
-    liquidity,
-    createdTime: Date.now(),
-  })
+  const newLiquidityProvision: Omit<LiquidityProvision, 'id'> =
+    removeUndefinedProps({
+      userId: userId,
+      contractId: contract.id,
+      answerId,
+      amount,
+      pool,
+      liquidity,
+      createdTime: Date.now(),
+    })
 
   return { newLiquidityProvision, newTotalLiquidity, newSubsidyPool }
 }

--- a/common/src/add-liquidity.ts
+++ b/common/src/add-liquidity.ts
@@ -1,4 +1,3 @@
-import { getCpmmLiquidity } from './calculate-cpmm'
 import {
   CPMMContract,
   CPMMMultiContract,
@@ -13,19 +12,9 @@ export const getNewLiquidityProvision = (
   contract: CPMMContract | CPMMMultiContract | CPMMNumericContract,
   answerId?: string
 ) => {
-  const { totalLiquidity, subsidyPool } = contract
-
-  const newTotalLiquidity = (totalLiquidity ?? 0) + amount
-  // If answerId is defined, amount will be added to the answer's subsidy pool
-  const newSubsidyPool = (subsidyPool ?? 0) + (answerId ? 0 : amount)
-
   let pool: { [outcome: string]: number } | undefined
-  let liquidity: number | undefined
   if (contract.mechanism === 'cpmm-1') {
     pool = contract.pool
-    liquidity = getCpmmLiquidity(pool, contract.p)
-  } else {
-    liquidity = newTotalLiquidity
   }
 
   const newLiquidityProvision: Omit<LiquidityProvision, 'id'> =
@@ -35,9 +24,8 @@ export const getNewLiquidityProvision = (
       answerId,
       amount,
       pool,
-      liquidity,
       createdTime: Date.now(),
     })
 
-  return { newLiquidityProvision, newTotalLiquidity, newSubsidyPool }
+  return newLiquidityProvision
 }

--- a/common/src/antes.ts
+++ b/common/src/antes.ts
@@ -1,5 +1,4 @@
 import { CPMMBinaryContract, CPMMMultiContract } from './contract'
-import { LiquidityProvision } from './liquidity-provision'
 import { removeUndefinedProps } from './util/object'
 
 export const HOUSE_LIQUIDITY_PROVIDER_ID = 'IPTOzEqrpkWmEzh6hwvAyY9PqFb2' // @ManifoldMarkets' id
@@ -8,7 +7,6 @@ export const DEV_HOUSE_LIQUIDITY_PROVIDER_ID = '94YYTk1AFWfbWMpfYcvnnwI1veP2' //
 export function getCpmmInitialLiquidity(
   providerId: string,
   contract: CPMMBinaryContract | CPMMMultiContract,
-  anteId: string,
   amount: number,
   createdTime: number,
   answerId?: string
@@ -17,8 +15,7 @@ export function getCpmmInitialLiquidity(
 
   const pool = mechanism === 'cpmm-1' ? { YES: 0, NO: 0 } : undefined
 
-  const lp: LiquidityProvision = removeUndefinedProps({
-    id: anteId,
+  const lp = removeUndefinedProps({
     userId: providerId,
     contractId: contract.id,
     isAnte: true,

--- a/common/src/liquidity-provision.ts
+++ b/common/src/liquidity-provision.ts
@@ -10,7 +10,8 @@ export type LiquidityProvision = {
   answerId?: string
   amount: number // Ṁ quantity
 
-  liquidity: number // change in constant k after provision
+  /** @deprecated change in constant k after provision*/
+  liquidity?: number
 
   // For cpmm-1:
   pool?: { [outcome: string]: number } // pool shares before provision

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -412,19 +412,19 @@ export type Database = {
         Row: {
           contract_id: string
           data: Json
-          fs_updated_time: string
+          fs_updated_time: string | null
           liquidity_id: string
         }
         Insert: {
           contract_id: string
           data: Json
-          fs_updated_time: string
+          fs_updated_time?: string | null
           liquidity_id: string
         }
         Update: {
           contract_id?: string
           data?: Json
-          fs_updated_time?: string
+          fs_updated_time?: string | null
           liquidity_id?: string
         }
         Relationships: []

--- a/common/src/supabase/utils.ts
+++ b/common/src/supabase/utils.ts
@@ -41,10 +41,8 @@ export type SubcollectionTableMapping = {
 }
 export const subcollectionTables: SubcollectionTableMapping = {
   contracts: {
-    answers: 'contract_answers',
     answersCpmm: 'answers',
     follows: 'contract_follows',
-    liquidity: 'contract_liquidity',
   },
 }
 

--- a/common/src/util/random.ts
+++ b/common/src/util/random.ts
@@ -1,6 +1,7 @@
-export const randomString = (length = 12) =>
+// max 10 length string. For longer, concat multiple
+export const randomString = (length = 10) =>
   Math.random()
-    .toString(16)
+    .toString(36)
     .substring(2, length + 2)
 
 export function genHash(str: string) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -46,10 +46,6 @@ service cloud.firestore {
       allow delete: if request.resource.data.creatorId == request.auth.uid || isAdmin();
     }
 
-    match /{somePath=**}/liquidity/{liquidityId} {
-      allow read;
-    }
-
     match /{somePath=**}/answersCpmm/{answerId} {
       allow read;
     }


### PR DESCRIPTION
This no longer reads/writes contract transactionally, so the recorded pool (and p?) may be off if someone bets at the same time. That doesn't matter since we don't use those fields.
Somewhat more concerning - I think the _subsidyPool_ could be off if someone adds a subsidy the same time that the house tries to add a subsidy. We could avoid this by making the pg.tx `SERIAL` but idc