### PR TITLE
Ingawei/add option to upgrade after creation

### DIFF
--- a/backend/api/src/add-subsidy.ts
+++ b/backend/api/src/add-subsidy.ts
@@ -10,6 +10,7 @@ import { onCreateLiquidityProvision } from './on-update-liquidity-provision'
 import { insertLiquidity } from 'shared/supabase/liquidity'
 import { convertLiquidity } from 'common/supabase/liquidity'
 import { FieldValue } from 'firebase-admin/firestore'
+import {getTierFromLiquidity} from 'common/tier'
 
 export const addLiquidity: APIHandler<
   'market/:contractId/add-liquidity'
@@ -67,6 +68,7 @@ export const addContractLiquidity = async (
     await firestore.doc(`contracts/${contractId}`).update({
       subsidyPool: FieldValue.increment(subsidyAmount),
       totalLiquidity: FieldValue.increment(subsidyAmount),
+      marketTier: getTierFromLiquidity(contract, contract.totalLiquidity + subsidyAmount),
     })
 
     broadcastNewSubsidy(contract, subsidyAmount)

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -6,7 +6,6 @@ import {
   Contract,
   MARKET_TIER_TYPES,
   MAX_QUESTION_LENGTH,
-  MarketTierType,
   MultiContract,
   RESOLUTIONS,
   VISIBILITIES,
@@ -19,6 +18,7 @@ import { z } from 'zod'
 import { MAX_ID_LENGTH } from 'common/group'
 import { contentSchema } from './zod-types'
 import { MINIMUM_BOUNTY } from 'common/economy'
+import { MarketTierType } from 'common/tier'
 
 export type LiteMarket = {
   // Unique identifier for this market

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -13,6 +13,7 @@ import { PollOption } from './poll-option'
 import { ChartAnnotation } from 'common/supabase/chart-annotations'
 import { MINUTE_MS } from './util/time'
 import { getLiquidity } from './calculate-cpmm'
+import { MarketTierType } from './tier'
 
 /************************************************
 
@@ -68,15 +69,6 @@ export const SORTS = [
 ] as const
 
 export type SortType = (typeof SORTS)[number]['value']
-
-export type MarketTierType = 'basic' | 'plus' | 'premium' | 'crystal'
-
-export const MARKET_TIER_MULTIPLES = {
-  'basic' : 1,
-  'plus' : 10,
-  'premium' : 100,
-  'crystal' : 1000
-}
 
 export type Contract<T extends AnyContractType = AnyContractType> = {
   id: string

--- a/common/src/economy.ts
+++ b/common/src/economy.ts
@@ -1,9 +1,8 @@
 import {
   OutcomeType,
-  MarketTierType,
-  MARKET_TIER_MULTIPLES,
   CREATEABLE_NON_PREDICTIVE_OUTCOME_TYPES,
 } from 'common/contract'
+import { MARKET_TIER_MULTIPLES, MarketTierType } from './tier'
 
 export const FIXED_ANTE = 1000
 export const ANSWER_COST = FIXED_ANTE / 4

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -13,7 +13,6 @@ import {
   Stonk,
   Visibility,
   CPMMMultiNumeric,
-  MarketTierType,
 } from './contract'
 import { User } from './user'
 import { removeUndefinedProps } from './util/object'
@@ -22,6 +21,7 @@ import { randomString } from './util/random'
 import { PollOption } from './poll-option'
 import { Answer } from './answer'
 import { getMultiCpmmLiquidity } from './calculate-cpmm'
+import { MarketTierType } from './tier'
 
 export const NEW_MARKET_IMPORTANCE_SCORE = 0.25
 

--- a/common/src/tier.ts
+++ b/common/src/tier.ts
@@ -1,0 +1,47 @@
+import {
+  CPMMContract,
+  CPMMMultiContract,
+  CPMMNumericContract,
+} from './contract'
+import { getAnte, getTieredCost } from './economy'
+
+// Array of tiers in order
+export const tiers = ['play', 'basic', 'plus', 'premium', 'crystal']
+
+// Derive the MarketTierType from the array
+export type MarketTierType = (typeof tiers)[number]
+
+export const MARKET_TIER_MULTIPLES: Record<MarketTierType, number> = {
+  play: 0.1,
+  basic: 1,
+  plus: 10,
+  premium: 100,
+  crystal: 1000,
+}
+
+export function getTierFromLiquidity(
+  contract: CPMMContract | CPMMMultiContract | CPMMNumericContract,
+  liquidity: number
+): MarketTierType {
+  const { outcomeType } = contract
+
+  let numAnswers = undefined
+  if ('answers' in contract) {
+    numAnswers = contract.answers.length
+  }
+
+  const ante = getAnte(outcomeType, numAnswers)
+
+  // Iterate through the tiers from highest to lowest
+  for (let i = tiers.length - 1; i >= 0; i--) {
+    const tier = tiers[i]
+    const tierLiquidity = getTieredCost(ante, tier, outcomeType)
+    // Return the first tier where the liquidity is greater or equal to the tier's requirement
+    if (liquidity >= tierLiquidity) {
+      return tier as MarketTierType
+    }
+  }
+
+  // Default to the lowest tier if none of the conditions are met
+  return 'play'
+}

--- a/web/components/contract/creator-share-panel.tsx
+++ b/web/components/contract/creator-share-panel.tsx
@@ -1,18 +1,18 @@
-import { Contract } from 'common/contract'
-import { getShareUrl } from 'common/util/share'
-import { TweetButton } from '../buttons/tweet-button'
-import { GradientContainer } from '../widgets/gradient-container'
-import { BoostButton } from './boost-button'
-import { Button } from '../buttons/button'
 import { LinkIcon } from '@heroicons/react/outline'
-import { getIsNative } from 'web/lib/native/is-native'
-import { copyToClipboard } from 'web/lib/util/copy'
-import { trackShareEvent } from 'web/lib/service/analytics'
-import toast from 'react-hot-toast'
-import { Row } from '../layout/row'
-import { useUser } from 'web/hooks/use-user'
 import { ShareIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
+import { Contract } from 'common/contract'
+import { getShareUrl } from 'common/util/share'
+import toast from 'react-hot-toast'
+import { useUser } from 'web/hooks/use-user'
+import { getIsNative } from 'web/lib/native/is-native'
+import { trackShareEvent } from 'web/lib/service/analytics'
+import { copyToClipboard } from 'web/lib/util/copy'
+import { Button } from '../buttons/button'
+import { TweetButton } from '../buttons/tweet-button'
+import { Row } from '../layout/row'
+import { GradientContainer } from '../widgets/gradient-container'
+import { BoostButton } from './boost-button'
 import { AddBountyButton, CancelBountyButton } from './bountied-question'
 import { UpgradeTierButton } from './upgrade-tier-button'
 
@@ -26,7 +26,10 @@ export function CreatorShareBoostPanel(props: { contract: Contract }) {
         {contract.outcomeType == 'BOUNTIED_QUESTION' && (
           <AddBountyButton contract={contract} />
         )}
-        <UpgradeTierButton contract={contract}/>
+        {(contract.mechanism == 'cpmm-1' ||
+          contract.mechanism == 'cpmm-multi-1') && (
+          <UpgradeTierButton contract={contract} />
+        )}
         <ShareLinkButton contract={contract} />
         <TweetButton
           tweetText={

--- a/web/components/contract/creator-share-panel.tsx
+++ b/web/components/contract/creator-share-panel.tsx
@@ -14,6 +14,7 @@ import { useUser } from 'web/hooks/use-user'
 import { ShareIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
 import { AddBountyButton, CancelBountyButton } from './bountied-question'
+import { UpgradeTierButton } from './upgrade-tier-button'
 
 export function CreatorShareBoostPanel(props: { contract: Contract }) {
   const { contract } = props
@@ -25,8 +26,8 @@ export function CreatorShareBoostPanel(props: { contract: Contract }) {
         {contract.outcomeType == 'BOUNTIED_QUESTION' && (
           <AddBountyButton contract={contract} />
         )}
+        <UpgradeTierButton contract={contract}/>
         <ShareLinkButton contract={contract} />
-
         <TweetButton
           tweetText={
             'I created a question. ' +
@@ -34,7 +35,6 @@ export function CreatorShareBoostPanel(props: { contract: Contract }) {
           }
           className="hidden sm:flex"
         />
-
         {contract.outcomeType == 'BOUNTIED_QUESTION' && (
           <CancelBountyButton contract={contract} />
         )}

--- a/web/components/contract/upgrade-tier-button.tsx
+++ b/web/components/contract/upgrade-tier-button.tsx
@@ -20,10 +20,11 @@ import { LogoIcon } from '../icons/logo-icon'
 import { Row } from '../layout/row'
 import { TierIcon } from '../tiers/tier-tooltip'
 import { api } from 'web/lib/firebase/api'
-import { track } from '@amplitude/analytics-browser'
 import { useUser } from 'web/hooks/use-user'
 import { ENV_CONFIG } from 'common/envs/constants'
 import { AddFundsModal } from '../add-funds-modal'
+import { track } from 'web/lib/service/analytics'
+import toast from 'react-hot-toast'
 
 export type ContractWithLiquidity =
   | CPMMContract
@@ -109,6 +110,7 @@ export function AddLiquidityDialogue(props: {
             ante={ante}
             amount={amount}
             setAmount={setAmount}
+            setOpen={setOpen}
           />
         )}
       </Col>
@@ -122,6 +124,7 @@ function UpgradeTierContent(props: {
   ante: number
   amount: number | undefined
   setAmount: (amount: number | undefined) => void
+  setOpen: (open: boolean) => void
 }) {
   const { currentTierIndex, contract, ante, amount, setAmount } = props
   const { outcomeType, id: contractId, slug } = contract
@@ -144,7 +147,11 @@ function UpgradeTierContent(props: {
       })
       setIsSuccess(true)
       setError(undefined)
-      track('add liquidity', { amount, contractId, slug })
+      track('upgrade market', { amount, contractId, slug })
+      setOpen(false)
+      toast('Your market has been upgraded!', {
+        icon: '🚀',
+      })
     } catch (e) {
       setError('Server error')
     } finally {
@@ -179,7 +186,11 @@ function UpgradeTierContent(props: {
           />
         ))}
       </div>
-      <Button disabled={isLoading || !!error || !amount || notEnoughFunds}>
+      <Button
+        disabled={isLoading || !!error || !amount || notEnoughFunds}
+        onClick={submit}
+        loading={isLoading}
+      >
         Upgrade{' '}
         {amount &&
           `to ${getTierFromLiquidity(

--- a/web/components/contract/upgrade-tier-button.tsx
+++ b/web/components/contract/upgrade-tier-button.tsx
@@ -4,6 +4,7 @@ import {
   CPMMMultiContract,
   CPMMNumericContract,
   CreateableOutcomeType,
+  MarketContract,
 } from 'common/contract'
 import { MarketTierType, getTierFromLiquidity, tiers } from 'common/tier'
 import { ReactNode, useState } from 'react'
@@ -26,13 +27,8 @@ import { AddFundsModal } from '../add-funds-modal'
 import { track } from 'web/lib/service/analytics'
 import toast from 'react-hot-toast'
 
-export type ContractWithLiquidity =
-  | CPMMContract
-  | CPMMMultiContract
-  | CPMMNumericContract
-
 export function UpgradeTierButton(props: {
-  contract: ContractWithLiquidity
+  contract: MarketContract
   className?: string
 }) {
   const { contract, className } = props
@@ -67,7 +63,7 @@ export function UpgradeTierButton(props: {
 }
 
 export function AddLiquidityDialogue(props: {
-  contract: ContractWithLiquidity
+  contract: MarketContract
   isOpen: boolean
   setOpen: (open: boolean) => void
 }) {
@@ -120,7 +116,7 @@ export function AddLiquidityDialogue(props: {
 
 function UpgradeTierContent(props: {
   currentTierIndex: number
-  contract: ContractWithLiquidity
+  contract: MarketContract
   ante: number
   amount: number | undefined
   setAmount: (amount: number | undefined) => void
@@ -216,7 +212,7 @@ function UpgradeTierContent(props: {
 }
 
 function UpgradeTier(props: {
-  contract: ContractWithLiquidity
+  contract: MarketContract
   baseCost: number
   icon: ReactNode
   tier: MarketTierType

--- a/web/components/contract/upgrade-tier-button.tsx
+++ b/web/components/contract/upgrade-tier-button.tsx
@@ -1,0 +1,280 @@
+import { Contract } from 'common/contract'
+import { formatMoney, formatWithCommas } from 'common/util/format'
+import { AmountInput, BuyAmountInput } from '../widgets/amount-input'
+import { ReactNode, useState } from 'react'
+import { api, boostMarket, getAdAnalytics } from 'web/lib/firebase/api'
+import { Button } from '../buttons/button'
+import toast from 'react-hot-toast'
+import { LoadingIndicator } from '../widgets/loading-indicator'
+import { DEFAULT_AD_COST_PER_VIEW, MIN_AD_COST_PER_VIEW } from 'common/boost'
+import { Table } from '../widgets/table'
+import { Modal } from '../layout/modal'
+import { Col } from '../layout/col'
+import { Title } from '../widgets/title'
+import { Row } from '../layout/row'
+import { ENV_CONFIG } from 'common/envs/constants'
+import { InfoTooltip } from '../widgets/info-tooltip'
+import { track } from 'web/lib/service/analytics'
+import { useQuery } from 'web/hooks/use-query'
+import { TbRocket } from 'react-icons/tb'
+import clsx from 'clsx'
+import { ControlledTabs } from '../layout/tabs'
+import { AddLiquidityPanel } from './liquidity-modal'
+import { buildArray } from 'common/util/array'
+import { ShowMoreLessButton } from '../widgets/collapsible-content'
+import { SUBSIDY_FEE } from 'common/economy'
+import { APISchema } from 'common/api/schema'
+import { CrystalTier } from 'web/public/custom-components/tiers'
+
+export function UpgradeTierButton(props: { contract: Contract; className?: string }) {
+  const { contract, className } = props
+  const [open, setOpen] = useState(false)
+
+  const disabled =
+    contract.isResolved ||
+    (contract.closeTime ?? Infinity) < Date.now() ||
+    contract.visibility !== 'public'
+
+  if (disabled) return <></>
+
+  return (
+    <Button
+      onClick={() => setOpen(true)}
+      size="lg"
+      color="indigo-outline"
+      className={clsx(className, 'group')}
+    >
+      <CrystalTier className="mr-1 h-5 w-5" />
+      Upgrade Tier
+      <BoostDialog contract={contract} isOpen={open} setOpen={setOpen} />
+    </Button>
+  )
+}
+
+export function BoostDialog(props: {
+  contract: Contract
+  isOpen: boolean
+  setOpen: (open: boolean) => void
+}) {
+  const { contract, isOpen, setOpen } = props
+
+  const [index, setIndex] = useState(0)
+
+  const [amount, setAmount] = useState<number | undefined>(5000)
+
+  return (
+    <Modal open={isOpen} setOpen={setOpen} size="sm">
+      <Col className="bg-canvas-0 gap-2.5  rounded p-4 pb-8 sm:gap-4">
+        <Title className="!mb-2">🚀 Boost this question</Title>
+        <ControlledTabs
+          tabs={buildArray(
+            {
+              title: 'Feed promo',
+              content: (
+                <BoostFormRow
+                  contract={contract}
+                  amount={amount}
+                  setAmount={setAmount}
+                />
+              ),
+            },
+            {
+              title: 'Analytics',
+              content: <FeedAnalytics contractId={contract.id} />,
+            }
+          )}
+          activeIndex={index}
+          onClick={(_, i) => setIndex(i)}
+          trackingName="boost tabs"
+        />
+      </Col>
+    </Modal>
+  )
+}
+
+function BoostFormRow(props: {
+  contract: Contract
+  amount: number | undefined
+  setAmount: (amount: number | undefined) => void
+}) {
+  const { contract, amount, setAmount } = props
+
+  const [loading, setLoading] = useState(false)
+  const [showBid, setShowBid] = useState(true)
+  const [costPerView, setCostPerView] = useState<number | undefined>(
+    DEFAULT_AD_COST_PER_VIEW
+  )
+
+  const redeems = amount && costPerView ? Math.floor(amount / costPerView) : 0
+
+  const error =
+    !costPerView || costPerView < MIN_AD_COST_PER_VIEW
+      ? `Bid at least ${formatMoney(MIN_AD_COST_PER_VIEW)}`
+      : undefined
+
+  const onSubmit = async () => {
+    if (!amount || !costPerView) return
+
+    setLoading(true)
+    try {
+      await boostMarket({
+        marketId: contract.id,
+        totalCost: amount,
+        costPerView,
+      })
+      toast.success('Boosted!')
+      setAmount(undefined)
+
+      track('boost market', {
+        slug: contract.slug,
+        totalCost: amount,
+        costPerView,
+      })
+    } catch (e) {
+      toast.error(
+        (e as any).message ??
+          (typeof e === 'string' ? e : 'Error boosting market')
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="text-ink-600 mb-2">
+        Feed promotion boosts this question higher on the feed based on user
+        interests. Users earn a reward for clicking.
+      </div>
+
+      <Row className="items-center justify-between">
+        <BuyAmountInput
+          amount={amount}
+          onChange={setAmount}
+          error={error}
+          setError={(_e) => {}}
+          disabled={false}
+          quickButtonValues="large"
+        />
+      </Row>
+
+      {showBid && (
+        <>
+          <Row className="items-center justify-between">
+            <div>
+              Bid per click{' '}
+              <InfoTooltip text="Bid more to increase the priority of your boost. Uses a first-price auction mechanism." />
+            </div>
+            <AmountInput
+              amount={costPerView}
+              onChangeAmount={setCostPerView}
+              label={ENV_CONFIG.moneyMoniker}
+              error={!!error}
+              inputClassName="mr-2 w-36"
+            />
+          </Row>
+          {error && <div className="text-error text-right">{error}</div>}
+        </>
+      )}
+
+      <Col className="mb-2 gap-2">
+        <span className="text-ink-800 mr-2 text-lg">
+          = <strong>{redeems} clicks</strong>
+        </span>
+
+        {!showBid && (
+          <Row className="items-center text-sm">
+            at {formatMoney(costPerView ?? 0)} per click
+            <Button
+              onClick={() => setShowBid(true)}
+              size="2xs"
+              color="gray-outline"
+              className="ml-1"
+            >
+              Change
+            </Button>
+          </Row>
+        )}
+      </Col>
+
+      <Button onClick={onSubmit} disabled={!!error || !redeems || loading}>
+        Buy
+      </Button>
+      {loading && <LoadingIndicator />}
+    </>
+  )
+}
+
+function FeedAnalytics(props: { contractId: string }) {
+  const { contractId } = props
+  const {
+    data: adAnalytics,
+    error,
+    isLoading,
+  } = useQuery(async () =>
+    getAdAnalytics({
+      contractId,
+    })
+  )
+  if (error) {
+    return (
+      <div className="bg-scarlet-100 mb-2 rounded-md p-4">
+        Error loading analytics
+      </div>
+    )
+  }
+  if (isLoading || !adAnalytics) {
+    return (
+      <div className=" mb-2 p-4">
+        <LoadingIndicator />
+      </div>
+    )
+  }
+
+  const {
+    totalViews,
+    uniqueViewers,
+    totalPromotedViews,
+    uniquePromotedViewers,
+    redeemCount,
+    isBoosted,
+    totalFunds,
+    adCreatedTime,
+  } = adAnalytics as APISchema<'get-ad-analytics'>['returns']
+
+  return (
+    <div className="mt-4">
+      <div className="mb-2 text-lg">Feed Analytics</div>
+      <Table className="text-ink-900 max-w-sm table-fixed">
+        {adCreatedTime && (
+          <>
+            <TableItem
+              label="Campaign start"
+              value={new Date(adCreatedTime).toDateString()}
+            />
+            <TableItem label="Funds left" value={formatMoney(totalFunds)} />
+          </>
+        )}
+
+        <TableItem
+          label="Impressions"
+          value={`${totalViews} (${uniqueViewers} people)`}
+        />
+        {isBoosted && (
+          <TableItem
+            label="Boost Impressions"
+            value={`${totalPromotedViews} (${uniquePromotedViewers} people)`}
+          />
+        )}
+        {isBoosted && <TableItem label="Boost clicks" value={redeemCount} />}
+      </Table>
+    </div>
+  )
+}
+
+const TableItem = (props: { label: ReactNode; value?: ReactNode }) => (
+  <tr>
+    <td className="!pl-0 !pt-0">{props.label}</td>
+    <td className="!pl-0 !pt-0">{props.value ?? '...'}</td>
+  </tr>
+)

--- a/web/components/new-contract/contract-params-form.tsx
+++ b/web/components/new-contract/contract-params-form.tsx
@@ -9,7 +9,6 @@ import {
   contractPath,
   CREATEABLE_NON_PREDICTIVE_OUTCOME_TYPES,
   CreateableOutcomeType,
-  MarketTierType,
   MAX_DESCRIPTION_LENGTH,
   MAX_QUESTION_LENGTH,
   MULTI_NUMERIC_BUCKETS_MAX,
@@ -58,6 +57,7 @@ import { PseudoNumericRangeSection } from 'web/components/new-contract/pseudo-nu
 import { SimilarContractsSection } from 'web/components/new-contract/similar-contracts-section'
 import { MultiNumericRangeSection } from 'web/components/new-contract/multi-numeric-range-section'
 import { getMultiNumericAnswerBucketRangeNames } from 'common/multi-numeric'
+import { MarketTierType } from 'common/tier'
 
 export function ContractParamsForm(props: {
   creator: User

--- a/web/components/new-contract/cost-section.tsx
+++ b/web/components/new-contract/cost-section.tsx
@@ -1,4 +1,4 @@
-import { CreateableOutcomeType, MarketTierType } from 'common/contract'
+import { CreateableOutcomeType } from 'common/contract'
 import { ReactNode, useState } from 'react'
 import { Col } from 'web/components/layout/col'
 import { InfoTooltip } from 'web/components/widgets/info-tooltip'
@@ -16,6 +16,7 @@ import {
 } from 'web/public/custom-components/tiers'
 import { LogoIcon } from '../icons/logo-icon'
 import { CoinNumber } from '../widgets/manaCoinNumber'
+import { MarketTierType } from 'common/tier'
 
 export const CostSection = (props: {
   balance: number

--- a/web/components/tiers/tier-tooltip.tsx
+++ b/web/components/tiers/tier-tooltip.tsx
@@ -1,15 +1,16 @@
-import { Contract, MarketTierType } from 'common/contract'
-import { Tooltip } from '../widgets/tooltip'
-import { shortenNumber } from 'web/lib/util/formatNumber'
-import { getAnte, getTieredCost } from 'common/economy'
+import { Placement } from '@floating-ui/react'
 import clsx from 'clsx'
+import { Contract } from 'common/contract'
+import { getAnte, getTieredCost } from 'common/economy'
+import { capitalize } from 'lodash'
+import { shortenNumber } from 'web/lib/util/formatNumber'
 import {
   CrystalTier,
   PlusTier,
   PremiumTier,
 } from 'web/public/custom-components/tiers'
-import { capitalize } from 'lodash'
-import { Placement } from '@floating-ui/react'
+import { Tooltip } from '../widgets/tooltip'
+import { MarketTierType } from 'common/tier'
 
 export function TierTooltip(props: {
   tier: MarketTierType

--- a/web/public/custom-components/tiers.tsx
+++ b/web/public/custom-components/tiers.tsx
@@ -1,9 +1,4 @@
 import clsx from 'clsx'
-import { Contract, MarketTierType } from 'common/contract'
-import { Tooltip } from 'web/components/widgets/tooltip'
-import { capitalize } from 'lodash'
-import { getAnte, getTieredCost } from 'common/economy'
-import { shortenNumber } from 'web/lib/util/formatNumber'
 
 export function PlusTier(props: { className?: string }) {
   const { className } = props


### PR DESCRIPTION
<img width="727" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/46611122/e2a11f1e-91b5-4039-a446-68db5e6d5e64">
<img width="400" alt="image" src="https://github.com/manifoldmarkets/manifold/assets/46611122/eb84e80a-6af5-4e40-b7f6-e6c57949008e">

backwards calculates current tier for now, but hoping to get rid of that once we have a script that adds a tier to all markets