### PR TITLE
EQUALITY IS INCOMPATIBLE WITH CAPTURING THE STATE

### DIFF
--- a/web/hooks/use-persistent-in-memory-state.ts
+++ b/web/hooks/use-persistent-in-memory-state.ts
@@ -1,6 +1,5 @@
 import { safeJsonParse } from 'common/util/json'
-import { useEffect } from 'react'
-import { useStateCheckEquality } from './use-state-check-equality'
+import { useEffect, useState } from 'react'
 import { useEvent } from 'web/hooks/use-event'
 
 const store: { [key: string]: any } = {}
@@ -10,7 +9,7 @@ export function isFunction<T>(
   return typeof value === 'function'
 }
 export const usePersistentInMemoryState = <T>(initialValue: T, key: string) => {
-  const [state, setState] = useStateCheckEquality<T>(
+  const [state, setState] = useState<T>(
     safeJsonParse(store[key]) ?? initialValue
   )
 

--- a/web/hooks/use-persistent-local-state.ts
+++ b/web/hooks/use-persistent-local-state.ts
@@ -1,14 +1,13 @@
 import { safeJsonParse } from 'common/util/json'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { safeLocalStorage } from 'web/lib/util/local'
 import { isFunction } from 'web/hooks/use-persistent-in-memory-state'
-import { useStateCheckEquality } from 'web/hooks/use-state-check-equality'
 import { useEvent } from 'web/hooks/use-event'
 import { useIsClient } from 'web/hooks/use-is-client'
 
 export const usePersistentLocalState = <T>(initialValue: T, key: string) => {
   const isClient = useIsClient()
-  const [state, setState] = useStateCheckEquality<T>(
+  const [state, setState] = useState<T>(
     (isClient && safeJsonParse(safeLocalStorage?.getItem(key))) || initialValue
   )
   const saveState = useEvent((newState: T | ((prevState: T) => T)) => {

--- a/web/hooks/use-state-check-equality.ts
+++ b/web/hooks/use-state-check-equality.ts
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash'
-import { SetStateAction, useMemo, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 export const useStateCheckEquality = <T>(initialState: T) => {
   const [state, setState] = useState(initialState)
@@ -7,12 +7,11 @@ export const useStateCheckEquality = <T>(initialState: T) => {
   const stateRef = useRef(state)
   stateRef.current = state
 
-  const checkSetState = useMemo(
-    () => (next: SetStateAction<T>) => {
+  const checkSetState = useCallback(
+    (next: T) => {
       const state = stateRef.current
-      const newState = next instanceof Function ? next(state) : next
-      if (!isEqual(state, newState)) {
-        setState(newState)
+      if (!isEqual(state, next)) {
+        setState(next)
       }
     },
     [stateRef]


### PR DESCRIPTION
react always rerenders when you call `setState`. so once upon a time, someone wrote a hook that checks if the thing has changed before calling setState. nevermind whether this use case is common or whether the overhead of adding a ref is worth it. I honestly don't know! there are many places we send requests to the server or db on the first render of a component, so while  _rerendering UI_ is very cheap, rerendering at all may not be? did anyone actually profile this??

anyways, to do the equality check you need to have an `if(state != newState)` before you call `setState()` which means you can't consistently do `setState((capturedState) => ...` correctly since the state inside the setState may differ from the state outside it, but what you really want to condition on is the inside state having changed, not the outside state.