### PR TITLE
Do all of create market within a transaction

### DIFF
--- a/backend/api/src/add-topic-to-market.ts
+++ b/backend/api/src/add-topic-to-market.ts
@@ -25,6 +25,7 @@ export const addOrRemoveTopicFromContract: APIHandler<
   const { contractId, groupId, remove } = props
 
   const db = createSupabaseClient()
+  const pg = createSupabaseDirectClient()
 
   const { data: membership } = await db
     .from('group_members')
@@ -76,9 +77,9 @@ export const addOrRemoveTopicFromContract: APIHandler<
   }
 
   if (remove) {
-    await removeGroupFromContract(contract, group, auth.uid)
+    await removeGroupFromContract(pg, contract, group, auth.uid)
   } else {
-    await addGroupToContract(contract, group, auth.uid)
+    await addGroupToContract(pg, contract, group, auth.uid)
   }
 
   const continuation = async () => {

--- a/backend/api/src/helpers/on-create-market.ts
+++ b/backend/api/src/helpers/on-create-market.ts
@@ -64,6 +64,7 @@ export const onCreateMarket = async (
   const isNonPredictive = isContractNonPredictive(contract)
   if (isNonPredictive) {
     await addGroupToContract(
+      pg,
       contract,
       {
         id: UNRANKED_GROUP_ID,
@@ -72,6 +73,7 @@ export const onCreateMarket = async (
       HOUSE_LIQUIDITY_PROVIDER_ID
     )
     await addGroupToContract(
+      pg,
       contract,
       {
         id: UNSUBSIDIZED_GROUP_ID,

--- a/backend/shared/src/update-group-contracts-internal.ts
+++ b/backend/shared/src/update-group-contracts-internal.ts
@@ -1,6 +1,6 @@
 import { Contract } from 'common/contract'
 import { GroupResponse } from 'common/group'
-import { createSupabaseDirectClient } from './supabase/init'
+import { SupabaseDirectClient } from './supabase/init'
 import {
   UNRANKED_GROUP_ID,
   UNSUBSIDIZED_GROUP_ID,
@@ -13,12 +13,11 @@ import { updateContract } from './supabase/contracts'
 import { FieldVal } from './supabase/utils'
 
 export async function addGroupToContract(
+  pg: SupabaseDirectClient,
   contract: Contract,
   group: { id: string; slug: string },
   userId?: string
 ) {
-  const pg = createSupabaseDirectClient()
-
   await pg.none(
     `insert into group_contracts (contract_id, group_id) values ($1, $2)`,
     [contract.id, group.id]
@@ -54,12 +53,11 @@ export async function addGroupToContract(
 }
 
 export async function removeGroupFromContract(
+  pg: SupabaseDirectClient,
   contract: Contract,
   group: { id: string; slug: string },
   userId: string
 ) {
-  const pg = createSupabaseDirectClient()
-
   // delete from group_contracts table
   await pg.none(
     `delete from group_contracts where contract_id = $1 and group_id = $2`,


### PR DESCRIPTION
The most important thing is that running the create market txn and create liquidity antes happen in the same transaction

I was considering *just* putting the finance stuff in the same tx, and leaving create group etc out of it, but i think that if the client shouldn't get an error if the create market succeeds. we could put things in a continuation i suppose, but it seems unnecessary performance wise