### PR TITLE
Adding an idempotency key for contract creation.

### DIFF
--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -33,6 +33,7 @@ import { slugify } from 'common/util/slugify'
 import { getCloseDate } from 'shared/helpers/openai-utils'
 import {
   generateContractEmbeddings,
+  getContractsDirect,
   updateContract,
 } from 'shared/supabase/contracts'
 import {
@@ -103,6 +104,7 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
     visibility,
     specialLiquidityPerAnswer,
     marketTier,
+    idempotencyKey,
   } = validateMarketBody(body)
 
   if (outcomeType === 'BOUNTIED_QUESTION') {
@@ -155,6 +157,10 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
     : unmodifiedAnte
   const ante = Math.min(unmodifiedAnte, totalMarketCost)
 
+  if (await isDuplicateSubmission(idempotencyKey, pg)) {
+    throw new APIError(400, 'Contract has already been created')
+  }
+
   return await pg.tx(async (tx) => {
     const user = await getUser(userId, tx)
     if (!user) throw new APIError(401, 'Your account was not found')
@@ -173,7 +179,8 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
 
     const contract = getNewContract(
       removeUndefinedProps({
-        id: randomString(),
+        // Risk: idempotencyKey comes from the client, mischievous users could pass unexpected strings.
+        id: idempotencyKey ?? randomString(),
         slug,
         creator: user,
         question,
@@ -294,6 +301,15 @@ const runCreateMarketTxn = async (args: {
   }
 }
 
+async function isDuplicateSubmission(
+  idempotencyKey: string | undefined,
+  pg: SupabaseDirectClient
+) {
+  if (!idempotencyKey) return false
+  const contracts = await getContractsDirect([idempotencyKey], pg)
+  return contracts.length > 0
+}
+
 async function getCloseTimestamp(
   closeTime: number | Date | undefined,
   question: string,
@@ -341,6 +357,7 @@ function validateMarketBody(body: Body) {
     matchCreatorId,
     isLove,
     marketTier,
+    idempotencyKey,
   } = body
 
   if (groupIds && groupIds.length > MAX_GROUPS_PER_MARKET)
@@ -467,6 +484,7 @@ function validateMarketBody(body: Body) {
     isLove,
     specialLiquidityPerAnswer,
     marketTier,
+    idempotencyKey,
   }
 }
 

--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -179,7 +179,6 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
 
     const contract = getNewContract(
       removeUndefinedProps({
-        // Risk: idempotencyKey comes from the client, mischievous users could pass unexpected strings.
         id: idempotencyKey ?? randomString(),
         slug,
         creator: user,

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -319,6 +319,7 @@ export const createMarketProps = z
     matchCreatorId: z.string().optional(),
     isLove: z.boolean().optional(),
     marketTier: z.enum(tiers).optional(),
+    idempotencyKey: z.string().optional(),
   })
   .and(
     z.union([

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -18,6 +18,7 @@ import { removeUndefinedProps } from 'common/util/object'
 import { richTextToString } from 'common/util/parse'
 import { z } from 'zod'
 import { contentSchema } from './zod-types'
+import { randomStringRegex } from 'common/util/random'
 
 export type LiteMarket = {
   // Unique identifier for this market
@@ -319,7 +320,7 @@ export const createMarketProps = z
     matchCreatorId: z.string().optional(),
     isLove: z.boolean().optional(),
     marketTier: z.enum(tiers).optional(),
-    idempotencyKey: z.string().optional(),
+    idempotencyKey: z.string().regex(randomStringRegex).length(10).optional(),
   })
   .and(
     z.union([

--- a/common/src/util/random.ts
+++ b/common/src/util/random.ts
@@ -1,8 +1,12 @@
 // max 10 length string. For longer, concat multiple
+// Often used as a unique identifier.
 export const randomString = (length = 10) =>
   Math.random()
     .toString(36)
     .substring(2, length + 2)
+
+// Matches the output of the randomString function, for validation purposes.
+export const randomStringRegex = /[0-9a-z]+/
 
 export function genHash(str: string) {
   // xmur3

--- a/common/src/util/random.ts
+++ b/common/src/util/random.ts
@@ -6,7 +6,7 @@ export const randomString = (length = 10) =>
     .substring(2, length + 2)
 
 // Matches the output of the randomString function, for validation purposes.
-export const randomStringRegex = /[0-9a-z]+/
+export const randomStringRegex = /^[0-9a-z]+$/
 
 export function genHash(str: string) {
   // xmur3

--- a/web/components/new-contract/contract-params-form.tsx
+++ b/web/components/new-contract/contract-params-form.tsx
@@ -60,8 +60,9 @@ export function ContractParamsForm(props: {
   creator: User
   outcomeType: CreateableOutcomeType
   params?: NewQuestionParams
+  idempotencyKey: string
 }) {
-  const { creator, params, outcomeType } = props
+  const { creator, params, outcomeType, idempotencyKey } = props
   const DEFAULT_TIER = CREATEABLE_NON_PREDICTIVE_OUTCOME_TYPES.includes(
     outcomeType
   )
@@ -386,6 +387,7 @@ export function ContractParamsForm(props: {
           outcomeType === 'BOUNTIED_QUESTION' ? isAutoBounty : undefined,
         precision,
         marketTier,
+        idempotencyKey,
       })
 
       const newContract = await api('market', createProps as any)

--- a/web/components/new-contract/contract-params-form.tsx
+++ b/web/components/new-contract/contract-params-form.tsx
@@ -55,14 +55,14 @@ import { SimilarContractsSection } from 'web/components/new-contract/similar-con
 import { MultiNumericRangeSection } from 'web/components/new-contract/multi-numeric-range-section'
 import { getMultiNumericAnswerBucketRangeNames } from 'common/multi-numeric'
 import { MarketTierType } from 'common/tier'
+import { randomString } from 'common/util/random'
 
 export function ContractParamsForm(props: {
   creator: User
   outcomeType: CreateableOutcomeType
   params?: NewQuestionParams
-  idempotencyKey: string
 }) {
-  const { creator, params, outcomeType, idempotencyKey } = props
+  const { creator, params, outcomeType } = props
   const DEFAULT_TIER = CREATEABLE_NON_PREDICTIVE_OUTCOME_TYPES.includes(
     outcomeType
   )
@@ -98,6 +98,10 @@ export function ContractParamsForm(props: {
     params?.initValue?.toString(),
     'new-init-value' + paramsKey
   )
+
+  // Don't use the usePersistentLocalState hook for this, because there's too high a risk that it will survive in local storage
+  // longer than it should under a trivial paramsKey like '', and improperly prevent users from creating any new contracts.
+  const [idempotencyKey] = useState(randomString())
 
   // For multiple choice, init to 2 empty answers
   const defaultAnswers =

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -13,6 +13,7 @@ import { track } from 'web/lib/service/analytics'
 import { FaQuestion, FaUsers } from 'react-icons/fa'
 import { ExpandSection } from 'web/components/explainer-panel'
 import { WEEK_MS } from 'common/util/time'
+import { randomString } from 'common/util/random'
 
 export type NewQuestionParams = {
   groupIds?: string[]
@@ -50,6 +51,10 @@ export function NewContractPanel(props: {
     params?.outcomeType ? 'filling contract params' : 'choosing contract'
   )
 
+  // Don't use the usePersistentLocalState hook for this, because there's too high a risk that it will survive in local storage
+  // longer than it should under a trivial paramsKey like '', and improperly prevent users from creating any new contracts.
+  const [idempotencyKey] = useState(randomString())
+
   useEffect(() => {
     if (outcomeType !== params?.outcomeType) {
       setOutcomeType(params?.outcomeType)
@@ -82,6 +87,7 @@ export function NewContractPanel(props: {
             outcomeType={outcomeType}
             creator={creator}
             params={params}
+            idempotencyKey={idempotencyKey}
           />
         )}
       </Col>

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -13,7 +13,6 @@ import { track } from 'web/lib/service/analytics'
 import { FaQuestion, FaUsers } from 'react-icons/fa'
 import { ExpandSection } from 'web/components/explainer-panel'
 import { WEEK_MS } from 'common/util/time'
-import { randomString } from 'common/util/random'
 
 export type NewQuestionParams = {
   groupIds?: string[]
@@ -51,10 +50,6 @@ export function NewContractPanel(props: {
     params?.outcomeType ? 'filling contract params' : 'choosing contract'
   )
 
-  // Don't use the usePersistentLocalState hook for this, because there's too high a risk that it will survive in local storage
-  // longer than it should under a trivial paramsKey like '', and improperly prevent users from creating any new contracts.
-  const [idempotencyKey] = useState(randomString())
-
   useEffect(() => {
     if (outcomeType !== params?.outcomeType) {
       setOutcomeType(params?.outcomeType)
@@ -87,7 +82,6 @@ export function NewContractPanel(props: {
             outcomeType={outcomeType}
             creator={creator}
             params={params}
-            idempotencyKey={idempotencyKey}
           />
         )}
       </Col>


### PR DESCRIPTION
This is related to the bug discussed at https://manifoldmarkets.notion.site/Market-creation-outage-d6c0ed5a001a4057bcb89f82787a5b84

I'm intending to mitigate the effect of any future bugs by preventing duplicate contract creation.

This change is NOT properly tested on the backend because I don't have a suitable dev environment set up (is this possible?) but maybe the magic Vercel PR validation environment will help.

