### PR TITLE
api.md: Update /v0/comments limit parameter default

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -903,7 +903,7 @@ Parameters:
 
 - `contractId`: Optional. The ID of the market to read comments of.
 - `contractSlug`: Optional. The slug of the market to read comments of.
-- `limit`. Optional. How many comments to return. Default 5000.
+- `limit`. Optional. How many comments to return. The default and maximum are both 1000.
 - `page`. Optional. For pagination with `limit`
 - `userId`: Optional. Get only comments created by this user.
 


### PR DESCRIPTION
Official instance shows
```
{"message":"Error validating request.","details":[{"field":"limit","error":"Number must be less than or equal to 1000"}]}
```