### PR TITLE
Have client calculate dependencies and pass to API

### DIFF
--- a/backend/api/src/on-create-bet.ts
+++ b/backend/api/src/on-create-bet.ts
@@ -5,7 +5,7 @@ import {
   getBettingStreakResetTimeBeforeNow,
   getUser,
 } from 'shared/utils'
-import { Bet, LimitBet } from 'common/bet'
+import { Bet, LimitBet, maker } from 'common/bet'
 import {
   CPMMContract,
   CPMMMultiContract,
@@ -31,7 +31,6 @@ import {
   SupabaseDirectClient,
 } from 'shared/supabase/init'
 import { convertBet } from 'common/supabase/bets'
-import { maker } from 'api/place-bet'
 import { BOT_USERNAMES } from 'common/envs/constants'
 import { addUserToContractFollowers } from 'shared/follow-market'
 import { updateUserInterestEmbedding } from 'shared/helpers/embeddings'

--- a/backend/shared/src/short-transaction.ts
+++ b/backend/shared/src/short-transaction.ts
@@ -1,12 +1,12 @@
 import {
   SupabaseTransaction,
   createSupabaseDirectClient,
+  SERIAL_MODE,
 } from './supabase/init'
-import { DEFAULT_QUEUE_TIME_LIMIT } from 'shared/helpers/fn-queue'
 
 export const runShortTrans = async <T>(
   callback: (trans: SupabaseTransaction) => Promise<T>
 ) => {
   const pg = createSupabaseDirectClient()
-  return await pg.timeout(DEFAULT_QUEUE_TIME_LIMIT / 2, callback, false)
+  return await pg.tx({ mode: SERIAL_MODE }, callback)
 }

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -161,6 +161,7 @@ export const API = (_apiTypeCheck = {
         //Multi
         answerId: z.string().optional(),
         dryRun: z.boolean().optional(),
+        deps: z.array(z.string()).optional(),
       })
       .strict(),
   },

--- a/common/src/bet.ts
+++ b/common/src/bet.ts
@@ -93,3 +93,9 @@ export const calculateMultiBets = (
     )
   )
 }
+export type maker = {
+  bet: LimitBet
+  amount: number
+  shares: number
+  timestamp: number
+}

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -24,7 +24,7 @@ const noFillsReturn = (
     answer,
     takers: [],
     makers: [] as maker[],
-    ordersToCancel: [],
+    ordersToCancel: [] as LimitBet[],
     cpmmState: {
       pool: { YES: answer.poolYes, NO: answer.poolNo },
       p: 0.5,

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -1,6 +1,6 @@
 import { Dictionary, first, groupBy, mapValues, sum, sumBy } from 'lodash'
 import { Answer } from './answer'
-import { Bet, LimitBet } from './bet'
+import { Bet, LimitBet, maker } from './bet'
 import {
   calculateAmountToBuySharesFixedP,
   getCpmmProbability,
@@ -23,7 +23,7 @@ const noFillsReturn = (
     outcome,
     answer,
     takers: [],
-    makers: [],
+    makers: [] as maker[],
     ordersToCancel: [],
     cpmmState: {
       pool: { YES: answer.poolYes, NO: answer.poolNo },

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { sumBy } from 'lodash'
 import toast from 'react-hot-toast'
 import { CheckIcon } from '@heroicons/react/solid'
@@ -55,6 +55,7 @@ import { FeeDisplay } from './fees'
 import { floatingEqual } from 'common/util/math'
 import { getTierFromLiquidity } from 'common/tier'
 import { getAnswerColor } from '../charts/contract/choice'
+import { maker } from 'common/bet'
 
 export type BinaryOutcomes = 'YES' | 'NO' | undefined
 
@@ -234,6 +235,7 @@ export const BuyPanelBody = (props: {
 
   const [error, setError] = useState<string | undefined>()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const makers = useRef<maker[]>()
 
   const [inputRef, focusAmountInput] = useFocus()
 
@@ -285,6 +287,7 @@ export const BuyPanelBody = (props: {
         contractId: contract.id,
         answerId: multiProps?.answerToBuy.id,
         replyToCommentId,
+        deps: makers.current?.map((m) => m.bet.userId),
       })
     )
       .then((r) => {
@@ -373,6 +376,9 @@ export const BuyPanelBody = (props: {
       fees =
         getFeeTotal(newBetResult.totalFees) +
         sumBy(otherBetResults, (result) => getFeeTotal(result.totalFees))
+      makers.current = newBetResult.makers.concat(
+        otherBetResults.flatMap((r) => r.makers)
+      )
     } else {
       const cpmmState = isCpmmMulti
         ? {
@@ -403,6 +409,7 @@ export const BuyPanelBody = (props: {
       probBefore = result.probBefore
       probAfter = result.probAfter
       fees = getFeeTotal(result.fees)
+      makers.current = result.makers
     }
   } catch (err: any) {
     console.error('Error in calculateCpmmMultiArbitrageBet:', err)

--- a/web/components/bet/limit-order-panel.tsx
+++ b/web/components/bet/limit-order-panel.tsx
@@ -487,6 +487,8 @@ const getBetReturns = (
     betDeps = newBetResult.makers
       .map((m) => m.bet)
       .concat(otherBetResults.flatMap((r) => r.makers.map((m) => m.bet)))
+      .concat(newBetResult.ordersToCancel)
+      .concat(otherBetResults.flatMap((r) => r.ordersToCancel))
     fees = addObjects(
       newBetResult.totalFees,
       otherBetResults.reduce(


### PR DESCRIPTION
This has the client calculate its deps, letting us avoid the case where the API bricks bc it can't get a pg connection from the pool bc of too many concurrent website users. This doesn't handle the case where the API server is being hammered from bots/API users and runs out of connections trying to simulate the deps. We could use the cache from the bet-cache branch if we think this case is worth handling now with the extra complexity.

![Screenshot 2024-07-31 at 3 37 33 PM](https://github.com/user-attachments/assets/e77351dc-5197-4492-b31d-853dba8198d5)
