### PR TITLE
Don't let opengraph image embeds go stale

### DIFF
--- a/common/src/contract-seo.ts
+++ b/common/src/contract-seo.ts
@@ -17,6 +17,7 @@ export const getContractOGProps = (
     creatorName,
     outcomeType,
     creatorAvatarUrl,
+    id,
   } = contract
 
   const topAnswer =
@@ -58,6 +59,7 @@ export const getContractOGProps = (
     resolution,
     topAnswer: topAnswer?.text,
     bountyLeft: bountyLeft,
+    contractId: id,
   }
 }
 
@@ -73,6 +75,7 @@ export type OgCardProps = {
   topAnswer?: string
   bountyLeft?: string // number
   points?: string // base64ified points
+  contractId?: string
 }
 
 export function getSeoDescription(contract: Contract) {

--- a/web/pages/api/og/market.tsx
+++ b/web/pages/api/og/market.tsx
@@ -6,9 +6,10 @@ import { classToTw } from 'web/components/og/utils'
 import { OgCardProps } from 'common/contract-seo'
 
 export const config = { runtime: 'edge' }
-export const getCardOptions = async () => {
+export const getCardOptions = async (): Promise<ImageResponseOptions> => {
   const [light, med] = await Promise.all([figtreeLightData, figtreeMediumData])
 
+  // https://vercel.com/docs/functions/og-image-generation/og-image-api
   return {
     width: 600,
     height: 315,
@@ -24,6 +25,11 @@ export const getCardOptions = async () => {
         style: 'normal',
       },
     ],
+    headers: {
+      // max-age is in seconds. Vercel defaults to a very large value, but
+      // we want to show fresh data, so we override here.
+      'cache-control': 'public, no-transform, max-age=30',
+    },
   }
 }
 
@@ -45,7 +51,7 @@ export default async function handler(req: NextRequest) {
     ) as OgCardProps
     const image = OgMarket(OgMarketProps)
 
-    return new ImageResponse(classToTw(image), options as ImageResponseOptions)
+    return new ImageResponse(classToTw(image), options)
   } catch (e: any) {
     console.log(`${e.message}`)
     return new Response(`Failed to generate the image`, {


### PR DESCRIPTION
This is another attempt of this prior pull request: https://github.com/manifoldmarkets/manifold/pull/2731

Folks are reporting that the og image embeds show stale data.

That's expected because the image is rendered entirely based on data provided in the URL params. I'm changing it to try loading fresh data from the database, and to cache with an appropriate TTL.

When looking at an opengraph image preview like [this one](https://manifold.markets/api/og/market?question=Will+Donald+Trump+win+the+2024+presidential+election%3F&numTraders=2498&volume=2964275&probability=58%25&creatorName=crystal+ball&creatorAvatarUrl=https%3A%2F%2Ffirebasestorage.googleapis.com%2Fv0%2Fb%2Fmantic-markets.appspot.com%2Fo%2Fuser-images%252FOndrejSojka%252FDALL%25C2%25B7E%25202022-05-14%252015.59.28.png%3Falt%3Dmedia%26token%3D4f7945a6-f67b-483f-b23f-d21632687c4b&points=mYbCUwiZOD7ilcJTKFdNPiylwlMoV00-dbTCUyhXTT6_w8JTKFdNPgnTwlMoV00-UuLCUyhXTT6c8cJTKFdNPuUAw1MoV00-LxDDUyhXTT54H8NTKFdNPsIuw1MoV00-Cz7DUyhXTT5VTcNTKFdNPp5cw1MoV00-6GvDUyhXTT4xe8NTaiMmPnuKw1Pvyjc-xJnDU-_KNz4OqcNTqLdCPle4w1NORF8-ocfDU6BhPz7r1sNTItpOPjTmw1PGF2U-fvXDU0XYVD7HBMRTPlZiPhEUxFNhzX0-WiPEU4XMfT6kMsRTguZwPu1BxFP8UXI-N1HEU64Gez6AYMRT-l9tPspvxFPJ7YU-E3_EUwoLgj5djsRTDhx9PqadxFO6C3Q-8KzEU9p8fj45vMRToWyNPoPLxFOzjYk-zdrEUyOfgj4W6sRT_EKFPmD5xFPbEno-qQjFU4VoiD7zF8VTBN6BPjwnxVNfwpA-hjbFUxjInj7PRcVT8n-QPhlVxVOxz5A-YmTFU384mz6sc8VTGaecPvWCxVPZqpo-P5LFU5mFmj6IocVTGVmXPtKwxVP3iZk-HMDFUyx0mj5lz8VTUmicPq_exVPBvaM--O3FUxW2pz5C_cVTMsCuPosMxlOa07E-1RvGU1yytD4eK8ZTZ92-Pmg6xlM4SM0-sUnGU_w70j77WMZTIIDSPkRoxlMhzso-jnfGUzLvzD7XhsZTpg_UPiGWxlNjktk-aqXGUzBu2j60tMZT6driPv7DxlN2ROU-R9PGU1st6z6R4sZTZJ3nPtrxxlMynOo-JAHHUy0a8T5tEMdT4W_9Prcfx1N2CQA_AC_HU2JnAz9KPsdTJBQAP5NNx1MxNP8-3VzHU-dCAT8mbMdTqfsAP3B7x1MyqwA_uYrHU9yj-T4DmsdTDQ7wPkypx1OtAvA-lrjHUw_c7D7gx8dT79T5PinXx1OwCPw-c-bHUzhn_T689cdTsKv1PgYFyFPrQAA_TxTIUzUsAT-ZI8hTlrv7PuIyyFNZHxE_LELIU5XmEj91UchTEVoaP79gyFNO9Cs_CHDIU_QYGj8), we can inspect the response headers and see that cache-control is `public, immutable, no-transform, max-age=31536000`. That's one year expressed in seconds. This appears to be a default set by the Vercel og library, per https://vercel.com/docs/functions/og-image-generation/og-image-api:
> By default, the following headers will be included by @vercel/og:
> ```
> 'content-type': 'image/png',
> 'cache-control': 'public, immutable, no-transform, max-age=31536000',
> ```

Updating the max-age to 30 seconds to get freshness while still limiting load on the API server.

### Testing

This is not tested yet because I don't have dev credentials; I'm hoping the vercel PR environment will help me do a little testing.