### PR TITLE
New watermark on SVG graphs.

### DIFF
--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -477,6 +477,29 @@ export const SVGChart = <X, TT extends { x: number; y: number }>(props: {
           </clipPath>
         </defs>
 
+        {!noWatermark && (
+          <svg x={10} y={h - 35} opacity={0.15}>
+            <g transform='scale(1.5)'>
+              <path
+                d="M5.24854 17.0952L18.7175 6.80301L14.3444 20M5.24854 17.0952L9.79649 18.5476M5.24854 17.0952L4.27398 6.52755M14.3444 20L9.79649 18.5476M14.3444 20L22 12.638L16.3935 13.8147M9.79649 18.5476L12.3953 15.0668M4.27398 6.52755L10.0714 13.389M4.27398 6.52755L2 9.0818L4.47389 8.85643M12.9451 11.1603L10.971 5L8.65369 11.6611"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                fill='none'
+                className="stroke-gray-900 dark:stroke-white"
+              ></path>
+            </g>
+            <text
+              x={40}
+              y={25}
+              fontSize="18"
+              fill="currentColor"
+              className='font-bold dark:font-semibold'
+            >
+              manifold.markets
+            </text>
+          </svg>
+        )}
+
         <g>
           {!hideXAxis && <XAxis axis={xAxis} w={w} h={h} />}
 
@@ -550,30 +573,6 @@ export const SVGChart = <X, TT extends { x: number; y: number }>(props: {
                 ))}
           </g>
         </g>
-        {!noWatermark && (
-          <>
-            <rect
-              x={4}
-              y={h - 23}
-              width={150}
-              height={18}
-              className="fill-canvas-0"
-              rx={4}
-              ry={4}
-              opacity={0.85}
-            />
-            <text
-              x={10}
-              y={h - 10}
-              fontSize="12"
-              fill="currentColor"
-              opacity={0.5}
-              fontWeight={'semibold'}
-            >
-              Source: manifold.markets
-            </text>
-          </>
-        )}
       </svg>
     </div>
   )


### PR DESCRIPTION
Updating the watermark:
- In the background, behind the graph data
- Larger, so you can still read it if the graph data is in front of it
- Included the logo

Related suggestions in discord:
- [The watermark blocks some of the content](https://discord.com/channels/915138780216823849/1269095533956563014/1269095533956563014)
- [I appreciate the addition of a watermark but obscuring the chart with branding is bad](https://discord.com/channels/915138780216823849/1263557326326206554/1268663914669932675)

![image](https://github.com/user-attachments/assets/3dc7be80-85be-45fb-bf50-da1436c7accf)

![image](https://github.com/user-attachments/assets/f9ec76cd-30dc-4c37-af9d-37b0f648aa6b)


There's another file, probability-needle.tsx, that has the old watermark; I haven't touched it because I think it looks fine on the probability needle.