### PR TITLE
Calculate prize cash portfolio metrics

### DIFF
--- a/backend/api/src/get-user-portfolio-history.ts
+++ b/backend/api/src/get-user-portfolio-history.ts
@@ -14,7 +14,7 @@ export const getUserPortfolioHistory: APIHandler<
   const startDate = new Date(getCutoff(period)).toISOString()
 
   const data = await pg.map(
-    `select ts, investment_value, total_deposits, balance, spice_balance, loan_total, profit
+    `select *
     from user_portfolio_history
     where
       user_id = $1

--- a/backend/api/src/unresolve.ts
+++ b/backend/api/src/unresolve.ts
@@ -230,13 +230,14 @@ const undoResolution = async (
     balance?: number
     cashBalance?: number
     totalDeposits: number
+    totalCashDeposits: number
     id: string
   }[] = []
   const txns: TxnData[] = []
 
   for (const txnToRevert of manaTxns) {
     const { balanceUpdate, txn } = getUndoOldContractPayout(txnToRevert)
-    balanceUpdates.push(balanceUpdate)
+    balanceUpdates.push(balanceUpdate as any)
     txns.push(txn)
   }
 
@@ -321,7 +322,7 @@ export function getUndoOldContractPayout(
 
   const balanceUpdate = {
     [token === 'CASH' ? 'cashBalance' : 'balance']: -amount,
-    totalDeposits: -(deposit ?? 0),
+    [token === 'CASH' ? 'totalCashDeposits' : 'totalDeposits']: -(deposit ?? 0),
     id: toId,
   }
 

--- a/backend/scripts/add-cash-balance-column.sql
+++ b/backend/scripts/add-cash-balance-column.sql
@@ -1,0 +1,38 @@
+-- Add cash_balance column to user_portfolio_history table
+alter table user_portfolio_history
+add column if not exists cash_investment_value numeric not null default 0,
+add column if not exists total_cash_deposits numeric not null default 0,
+add column if not exists cash_balance numeric not null default 0;
+
+-- Add cash_balance column to user_portfolio_history_latest table
+alter table user_portfolio_history_latest
+add column if not exists cash_investment_value numeric not null default 0.0,
+add column if not exists total_cash_deposits numeric not null default 0.0,
+add column if not exists cash_balance numeric not null default 0.0;
+
+alter table users
+add column if not exists cash_balance numeric not null default 0,
+add column if not exists total_cash_deposits numeric not null default 0;
+
+-- Functions
+create
+or replace function public.update_user_portfolio_history_latest () returns trigger language plpgsql as $function$
+begin
+    insert into user_portfolio_history_latest (user_id, ts, investment_value, cash_investment_value, balance, total_deposits, total_cash_deposits, cash_balance, spice_balance, loan_total, profit, last_calculated)
+    values (new.user_id, new.ts, new.investment_value, new.cash_investment_value, new.balance, new.total_deposits, new.total_cash_deposits, new.cash_balance, new.spice_balance, new.loan_total, new.profit, new.ts)
+    on conflict (user_id) do update
+        set ts = excluded.ts,
+            investment_value = excluded.investment_value,
+            cash_investment_value = excluded.cash_investment_value,
+            total_deposits = excluded.total_deposits,
+            total_cash_deposits = excluded.total_cash_deposits,
+            balance = excluded.balance,
+            cash_balance = excluded.cash_balance,
+            spice_balance = excluded.spice_balance,
+            loan_total = excluded.loan_total,
+            profit = excluded.profit,
+            last_calculated = excluded.ts
+    where user_portfolio_history_latest.ts < excluded.ts;
+    return new;
+end;
+$function$;

--- a/backend/shared/src/create-user-main.ts
+++ b/backend/shared/src/create-user-main.ts
@@ -117,6 +117,7 @@ export const createUserMain = async (
       cashBalance: 0,
       spiceBalance: 0,
       totalDeposits: 0,
+      totalCashDeposits: 0,
       createdTime: Date.now(),
       profitCached: { daily: 0, weekly: 0, monthly: 0, allTime: 0 },
       nextLoanCached: 0,

--- a/backend/shared/src/get-user-portfolio-internal.ts
+++ b/backend/shared/src/get-user-portfolio-internal.ts
@@ -91,7 +91,10 @@ export const getUserPortfolioInternal = async (userId: string) => {
   const loanTotal = sumBy(unresolvedBets, (b) => b.loanAmount ?? 0)
 
   const contractsById = keyBy(contracts, 'id')
-  const investmentValue = computeInvestmentValue(unresolvedBets, contractsById)
+  const { investmentValue } = computeInvestmentValue(
+    unresolvedBets,
+    contractsById
+  )
   const dayAgoPortfolio = first(
     await getPortfolioHistory(userId, Date.now() - DAY_MS, 1, pg)
   )

--- a/backend/shared/src/helpers/portfolio.ts
+++ b/backend/shared/src/helpers/portfolio.ts
@@ -1,32 +1,15 @@
-import { tsToMillis } from 'common/supabase/utils'
 import { SupabaseDirectClient } from 'shared/supabase/init'
+import { type Row } from 'common/supabase/utils'
+import { convertPortfolioHistory } from 'common/supabase/portfolio-metrics'
 
 export const getCurrentPortfolio = async (
   pg: SupabaseDirectClient,
   userId: string
 ) => {
-  const portfolio = await pg.oneOrNone<{
-    investment_value: number
-    balance: number
-    total_deposits: number
-    user_id: string
-    ts: Date
-  }>(
-    `select * from user_portfolio_history
-      where user_id = $1
-      order by ts desc
-      limit 1
-    `,
+  const portfolio = await pg.oneOrNone<Row<'user_portfolio_history_latest'>>(
+    `select * from user_portfolio_history_latest where user_id = $1`,
     [userId]
   )
   if (!portfolio) return null
-  return {
-    // mqp: hack for temporary unwise choice of postgres timestamp without time zone type
-    // -- we have to make it look like an ISO9601 date or the JS date constructor will
-    // assume that it's in local time. will fix this up soon
-    timestamp: tsToMillis(portfolio.ts! + '+0000'),
-    investmentValue: +portfolio.investment_value!,
-    totalDeposits: +portfolio.total_deposits!,
-    balance: +portfolio.balance!,
-  }
+  return convertPortfolioHistory(portfolio)
 }

--- a/backend/shared/src/supabase/portfolio-metrics.ts
+++ b/backend/shared/src/supabase/portfolio-metrics.ts
@@ -9,9 +9,9 @@ export async function getPortfolioHistory(
   pg: SupabaseDirectClient
 ) {
   return pg.map(
-    `select ts, investment_value, total_deposits, balance, loan_total, spice_balance
+    `select *
     from user_portfolio_history
-    where user_id = $1 
+    where user_id = $1
     and ts > $2
     order by ts
     limit $3

--- a/backend/shared/src/supabase/users.ts
+++ b/backend/shared/src/supabase/users.ts
@@ -99,6 +99,7 @@ export const incrementBalance = async (
     cashBalance?: number
     spiceBalance?: number
     totalDeposits?: number
+    totalCashDeposits?: number
   }
 ) => {
   const updates = [
@@ -106,6 +107,7 @@ export const incrementBalance = async (
     ['cash_balance', deltas.cashBalance],
     ['spice_balance', deltas.spiceBalance],
     ['total_deposits', deltas.totalDeposits],
+    ['total_cash_deposits', deltas.totalCashDeposits],
   ].filter(([_, v]) => v) // defined and not 0
 
   if (updates.length === 0) {
@@ -126,6 +128,7 @@ export const incrementBalance = async (
     cashBalance: result.cash_balance,
     spiceBalance: result.spice_balance,
     totalDeposits: result.total_deposits,
+    totalCashDeposits: result.total_cash_deposits,
   })
 }
 
@@ -137,6 +140,7 @@ export const bulkIncrementBalances = async (
     cashBalance?: number
     spiceBalance?: number
     totalDeposits?: number
+    totalCashDeposits?: number
   }[]
 ) => {
   if (userUpdates.length === 0) return
@@ -149,6 +153,7 @@ export const bulkIncrementBalances = async (
         update.cashBalance ?? 0,
         update.spiceBalance ?? 0,
         update.totalDeposits ?? 0,
+        update.totalCashDeposits ?? 0,
       ])
     )
     .join(',\n')

--- a/backend/shared/src/txn/run-txn.ts
+++ b/backend/shared/src/txn/run-txn.ts
@@ -64,7 +64,7 @@ export async function runTxn(
         }
         await incrementBalance(pgTransaction, fromId, {
           cashBalance: -amount,
-          totalDeposits: -amount,
+          totalCashDeposits: -amount,
         })
       } else {
         if (fromUser.balance < amount) {

--- a/backend/supabase/user_portfolio_history.sql
+++ b/backend/supabase/user_portfolio_history.sql
@@ -9,7 +9,10 @@ create table if not exists
     loan_total numeric,
     id bigint not null,
     spice_balance numeric default 0 not null,
-    profit numeric
+    profit numeric,
+    cash_balance numeric default 0 not null,
+    cash_investment_value numeric default 0 not null,
+    total_cash_deposits numeric default 0 not null
   );
 
 -- Triggers
@@ -21,13 +24,16 @@ execute function update_user_portfolio_history_latest ();
 create
 or replace function public.update_user_portfolio_history_latest () returns trigger language plpgsql as $function$
 begin
-    insert into user_portfolio_history_latest (user_id, ts, investment_value, balance, total_deposits, spice_balance, loan_total, profit, last_calculated)
-    values (new.user_id, new.ts, new.investment_value, new.balance, new.total_deposits, new.spice_balance, new.loan_total, new.profit, new.ts)
+    insert into user_portfolio_history_latest (user_id, ts, investment_value, cash_investment_value, balance, total_deposits, total_cash_deposits, cash_balance, spice_balance, loan_total, profit, last_calculated)
+    values (new.user_id, new.ts, new.investment_value, new.cash_investment_value, new.balance, new.total_deposits, new.total_cash_deposits, new.cash_balance, new.spice_balance, new.loan_total, new.profit, new.ts)
     on conflict (user_id) do update
         set ts = excluded.ts,
             investment_value = excluded.investment_value,
-            balance = excluded.balance,
+            cash_investment_value = excluded.cash_investment_value,
             total_deposits = excluded.total_deposits,
+            total_cash_deposits = excluded.total_cash_deposits,
+            balance = excluded.balance,
+            cash_balance = excluded.cash_balance,
             spice_balance = excluded.spice_balance,
             loan_total = excluded.loan_total,
             profit = excluded.profit,

--- a/backend/supabase/user_portfolio_history_latest.sql
+++ b/backend/supabase/user_portfolio_history_latest.sql
@@ -9,7 +9,10 @@ create table if not exists
     loan_total numeric,
     spice_balance numeric default 0.0 not null,
     last_calculated timestamp with time zone not null,
-    profit numeric
+    profit numeric,
+    cash_balance numeric default 0.0 not null,
+    cash_investment_value numeric default 0.0 not null,
+    total_cash_deposits numeric default 0.0 not null
   );
 
 -- Indexes

--- a/backend/supabase/users.sql
+++ b/backend/supabase/users.sql
@@ -16,7 +16,8 @@ create table if not exists
     total_deposits numeric default 0 not null,
     spice_balance numeric default 0 not null,
     resolved_profit_adjustment numeric,
-    cash_balance numeric default 0 not null
+    cash_balance numeric default 0 not null,
+    total_cash_deposits numeric default 0 not null
   );
 
 -- Policies

--- a/common/src/portfolio-metrics.ts
+++ b/common/src/portfolio-metrics.ts
@@ -1,8 +1,11 @@
 export type PortfolioMetrics = {
   investmentValue: number
+  cashInvestmentValue: number
   balance: number
+  cashBalance: number
   spiceBalance: number
   totalDeposits: number
+  totalCashDeposits: number
   loanTotal: number
   timestamp: number
   profit?: number

--- a/common/src/supabase/portfolio-metrics.ts
+++ b/common/src/supabase/portfolio-metrics.ts
@@ -23,11 +23,9 @@ export async function getPortfolioHistory(
 
 export async function getCurrentPortfolio(userId: string, db: SupabaseClient) {
   const query = db
-    .from('user_portfolio_history')
+    .from('user_portfolio_history_latest')
     .select('*')
     .eq('user_id', userId)
-    .order('ts', { ascending: false })
-    .limit(1)
 
   const { data } = await run(query)
   const [d] = data

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -2579,33 +2579,42 @@ export type Database = {
       user_portfolio_history: {
         Row: {
           balance: number | null
+          cash_balance: number
+          cash_investment_value: number
           id: number
           investment_value: number | null
           loan_total: number | null
           profit: number | null
           spice_balance: number
+          total_cash_deposits: number
           total_deposits: number | null
           ts: string | null
           user_id: string
         }
         Insert: {
           balance?: number | null
+          cash_balance?: number
+          cash_investment_value?: number
           id?: never
           investment_value?: number | null
           loan_total?: number | null
           profit?: number | null
           spice_balance?: number
+          total_cash_deposits?: number
           total_deposits?: number | null
           ts?: string | null
           user_id: string
         }
         Update: {
           balance?: number | null
+          cash_balance?: number
+          cash_investment_value?: number
           id?: never
           investment_value?: number | null
           loan_total?: number | null
           profit?: number | null
           spice_balance?: number
+          total_cash_deposits?: number
           total_deposits?: number | null
           ts?: string | null
           user_id?: string
@@ -2615,33 +2624,42 @@ export type Database = {
       user_portfolio_history_latest: {
         Row: {
           balance: number
+          cash_balance: number
+          cash_investment_value: number
           investment_value: number
           last_calculated: string
           loan_total: number | null
           profit: number | null
           spice_balance: number
+          total_cash_deposits: number
           total_deposits: number
           ts: string
           user_id: string
         }
         Insert: {
           balance: number
+          cash_balance?: number
+          cash_investment_value?: number
           investment_value: number
           last_calculated: string
           loan_total?: number | null
           profit?: number | null
           spice_balance?: number
+          total_cash_deposits?: number
           total_deposits: number
           ts: string
           user_id: string
         }
         Update: {
           balance?: number
+          cash_balance?: number
+          cash_investment_value?: number
           investment_value?: number
           last_calculated?: string
           loan_total?: number | null
           profit?: number | null
           spice_balance?: number
+          total_cash_deposits?: number
           total_deposits?: number
           ts?: string
           user_id?: string
@@ -2800,6 +2818,7 @@ export type Database = {
           name_username_vector: unknown | null
           resolved_profit_adjustment: number | null
           spice_balance: number
+          total_cash_deposits: number
           total_deposits: number
           username: string
         }
@@ -2813,6 +2832,7 @@ export type Database = {
           name_username_vector?: unknown | null
           resolved_profit_adjustment?: number | null
           spice_balance?: number
+          total_cash_deposits?: number
           total_deposits?: number
           username: string
         }
@@ -2826,6 +2846,7 @@ export type Database = {
           name_username_vector?: unknown | null
           resolved_profit_adjustment?: number | null
           spice_balance?: number
+          total_cash_deposits?: number
           total_deposits?: number
           username?: string
         }

--- a/common/src/supabase/users.ts
+++ b/common/src/supabase/users.ts
@@ -34,8 +34,10 @@ export function convertUser(row: Row<'users'> | null): User | null {
     username: row.username,
     name: row.name,
     balance: row.balance,
+    cashBalance: row.cash_balance,
     spiceBalance: row.spice_balance,
     totalDeposits: row.total_deposits,
+    totalCashDeposits: row.total_cash_deposits,
     resolvedProfitAdjustment: row.resolved_profit_adjustment,
   } as User
 }

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -19,6 +19,7 @@ export type User = {
   cashBalance: number // prize points
   spiceBalance: number
   totalDeposits: number
+  totalCashDeposits: number
   resolvedProfitAdjustment?: number
   profitCached: {
     daily: number


### PR DESCRIPTION
[manicode]

Overall, the changes are focused on implementing a separate cash (prize money) system alongside the existing mana system. Here's a summary of the key changes:

1. Database schema updates:
   - Added new columns to user_portfolio_history and user_portfolio_history_latest tables: cash_balance, cash_investment_value, and total_cash_deposits.
   - Updated the users table to include total_cash_deposits.
   - Modified SQL functions and triggers to handle the new cash-related columns.

2. Backend changes:
   - Updated portfolio calculation functions to handle cash metrics separately.
   - Modified transaction handling to account for cash transactions.
   - Updated user metric calculations to include cash-related data.

3. API and type updates:
   - Updated API endpoints to include cash-related data in responses.
   - Modified TypeScript types to include new cash-related fields.

4. Frontend changes:
   - Updated components to display and handle cash-related data (though these changes are minimal in the provided diff).

