### PR TITLE
Remove creator fee for sweepstakes

### DIFF
--- a/common/src/fees.ts
+++ b/common/src/fees.ts
@@ -1,4 +1,5 @@
 import { addObjects } from 'common/util/object'
+import { TWOMBA_ENABLED } from './envs/constants'
 
 export const FEE_START_TIME = 1713292320000
 
@@ -12,6 +13,14 @@ export const getFeesSplit = (
   totalFees: number,
   previouslyCollectedFees: Fees
 ) => {
+  if (TWOMBA_ENABLED) {
+    return {
+      creatorFee: 0,
+      platformFee: totalFees,
+      liquidityFee: 0,
+    }
+  }
+
   const before1k = Math.max(
     0,
     CREATORS_EARN_WHOLE_FEE_UP_TO - previouslyCollectedFees.creatorFee

--- a/web/components/bet/fees.tsx
+++ b/web/components/bet/fees.tsx
@@ -1,4 +1,4 @@
-import { TRADE_TERM } from 'common/envs/constants'
+import { TRADE_TERM, TWOMBA_ENABLED } from 'common/envs/constants'
 import { InfoTooltip } from '../widgets/info-tooltip'
 import { MoneyDisplay } from './money-display'
 
@@ -20,7 +20,11 @@ export const FeeDisplay = (props: {
       <InfoTooltip
         text={`${(amount ? (100 * totalFees) / amount : 0).toFixed(
           2
-        )}% fee. Goes to the market creator up to 1000, then is split 50-50 with Manifold. Fees range from 0% to 7% of your ${TRADE_TERM} amount increasing the more unlikely your ${TRADE_TERM} is to pay out.`}
+        )}% fee. Goes to ${
+          TWOMBA_ENABLED
+            ? ''
+            : 'the market creator up to 1000, then is split 50-50 with '
+        }Manifold. Fees range from 0% to 7% of your ${TRADE_TERM} amount increasing the more unlikely your ${TRADE_TERM} is to pay out.`}
         className="text-ink-600 ml-1 mt-0.5"
         size="sm"
       />

--- a/web/components/contract/creator-fees-display.tsx
+++ b/web/components/contract/creator-fees-display.tsx
@@ -10,6 +10,10 @@ export const CreatorFeesDisplay = (props: {
   const { contract, className } = props
   const { collectedFees } = contract
   const isCashContract = contract.token === 'CASH'
+
+  // cash contracts have no creator fees
+  if (isCashContract) return null
+
   return (
     <Tooltip
       text={'Fees earned from trade volume'}
@@ -19,8 +23,8 @@ export const CreatorFeesDisplay = (props: {
     >
       {formatWithToken({
         amount: collectedFees.creatorFee,
-        token: isCashContract ? 'CASH' : 'M$',
-        toDecimal: isCashContract ? 4 : 2,
+        token: 'M$',
+        toDecimal: 2,
       })}{' '}
       earned
     </Tooltip>


### PR DESCRIPTION
- we will be providing liquidity for all the sweepcash markets rather than the creator anyways
- a sweepcash bonus would prevent us from sweepifying a market made by some creators - creators outside of the US for instance. doing a currency conversion would be fine, but more effort than its worth

we should definitely revisit the unique trader bonus though