### PR TITLE
conditional orderbook tab and button

### DIFF
--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -10,7 +10,14 @@ import {
 } from 'common/antes'
 import { Bet } from 'common/bet'
 import { ContractComment } from 'common/comment'
-import { BinaryContract, Contract, CPMMNumericContract } from 'common/contract'
+import {
+  BinaryContract,
+  Contract,
+  CPMMMultiContract,
+  CPMMNumericContract,
+  PseudoNumericContract,
+  StonkContract,
+} from 'common/contract'
 import { buildArray } from 'common/util/array'
 import { shortFormatNumber, maybePluralize } from 'common/util/format'
 import { MINUTE_MS } from 'common/util/time'
@@ -43,6 +50,8 @@ import generateFilterDropdownItems from '../search/search-dropdown-helpers'
 import { useAPIGetter } from 'web/hooks/use-api-getter'
 import { api } from 'web/lib/api/api'
 import { TRADE_TERM } from 'common/envs/constants'
+import { useUnfilledBets } from 'web/hooks/use-bets'
+import { OrderBookPanel } from '../bet/order-book'
 
 export function ContractTabs(props: {
   mainContract: Contract
@@ -94,6 +103,8 @@ export function ContractTabs(props: {
     (totalPositions > 0 ? `${shortFormatNumber(totalPositions)} ` : '') +
     maybePluralize('Holder', totalPositions)
 
+  const unfilledBets = useUnfilledBets(liveContract.id) ?? []
+
   return (
     <ControlledTabs
       className="mb-4"
@@ -108,6 +119,8 @@ export function ContractTabs(props: {
               ? 'trades'
               : title === positionsTitle
               ? 'positions'
+              : title === 'Order book'
+              ? 'orderbook'
               : 'contract'
           } tab`
         )
@@ -162,7 +175,24 @@ export function ContractTabs(props: {
               />
             </Col>
           ),
-        }
+        },
+        totalBets > 0 &&
+          liveContract.mechanism === 'cpmm-1' && {
+            title: 'Order book',
+            className: 'hidden md:block',
+            content: (
+              <OrderBookPanel
+                contract={
+                  liveContract as
+                    | BinaryContract
+                    | PseudoNumericContract
+                    | StonkContract
+                    | CPMMNumericContract
+                }
+                limitBets={unfilledBets}
+              />
+            ),
+          }
       )}
     />
   )

--- a/web/components/layout/tabs.tsx
+++ b/web/components/layout/tabs.tsx
@@ -152,7 +152,8 @@ export function ControlledTabs(props: TabProps & { activeIndex: number }) {
                 : 'text-ink-500 hover:border-ink-300 hover:text-ink-700 border-transparent',
               'mr-4 inline-flex cursor-pointer flex-row gap-1 whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium ',
               labelClassName,
-              'flex-shrink-0'
+              'flex-shrink-0',
+              tab.className
             )}
             aria-current={activeIndex === i ? 'page' : undefined}
           >


### PR DESCRIPTION
One thing to note is that logged out mobile users still can't see the orderbook. This was an intentional choice as there wasn't a good spot to put it and I don't think a logged out mobile user cares that much.

Signed out desktop users, non-eligible sweeps signed-in desktop users, and non-eligible sweeps signed-in mobile users can now see the orderbook (although this is limited to binary markets rn - which should be fine since those are the only sweeps markets).