### PR TITLE
Independent MC created with full starting liquidity per answer

### DIFF
--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -149,7 +149,9 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
   const totalMarketCost = marketTier
     ? getTieredCost(unmodifiedAnte, marketTier, outcomeType)
     : unmodifiedAnte
-  const ante = Math.min(unmodifiedAnte, totalMarketCost)
+  const ante = outcomeType === 'MULTIPLE_CHOICE' && !shouldAnswersSumToOne
+    ? totalMarketCost
+    : Math.min(unmodifiedAnte, totalMarketCost)
 
   const duplicateSubmissionUrl = await getDuplicateSubmissionUrl(
     idempotencyKey,


### PR DESCRIPTION
Context: [bounty](https://manifold.markets/ian/make-answers-created-during-market).

Simple/minimal fix. 

Previously: for higher tier markets, `ante` would be capped at `unmodifiedAnte` (i.e. numAnswers * 100 for MC). 

Now: for independent MC, `ante` is allowed to scale with the full `totalMarketCost`. For other question types, functionality is unchanged. 