### PR TITLE
Add userId to get-user-portfolio-internal

### DIFF
--- a/backend/shared/src/get-user-portfolio-internal.ts
+++ b/backend/shared/src/get-user-portfolio-internal.ts
@@ -69,6 +69,7 @@ export const getUserPortfolioInternal = async (userId: string) => {
     totalCashDeposits,
   } = user
   return {
+    userId,
     loanTotal,
     investmentValue,
     cashInvestmentValue,


### PR DESCRIPTION
I have no idea what I'm doing. Someone should probably stop me. Why was this not flagged by whatever linter/static analysis  typescript uses? The field is defined on PortfolioMetrics.