### PR TITLE
Fix referral info when no rows found

### DIFF
--- a/common/src/supabase/referrals.ts
+++ b/common/src/supabase/referrals.ts
@@ -20,5 +20,13 @@ export async function getUserReferralsInfo(userId: string, db: SupabaseClient) {
     db.from('user_referrals_profit').select('*').eq('id', userId)
   )
 
-  return { ...data[0], rank: data[0]?.rank ?? 0 }
+  const info = data[0]
+  return info
+    ? { ...info, rank: info.rank ?? 0 }
+    : {
+        rank: 0,
+        total_referrals: 0,
+        total_referred_cash_profit: 0,
+        total_referred_profit: 0,
+      }
 }


### PR DESCRIPTION
## Summary
- prevent undefined spread in `getUserReferralsInfo`

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*