### PR TITLE
Fix OpenSearch XML

### DIFF
--- a/web/public/opensearch.xml
+++ b/web/public/opensearch.xml
@@ -6,5 +6,5 @@
   <Image width="16" height="16" type="image/x-icon">https://manifold.markets/favicon.ico</Image>
   <InputEncoding>UTF-8</InputEncoding>
   <Url type="text/html" template="https://manifold.markets/browse?q={searchTerms}"/>
-  <moz:SearchForm>https://manifold.markets/browse</SearchForm>
+  <moz:SearchForm>https://manifold.markets/browse</moz:SearchForm>
 </OpenSearchDescription> 


### PR DESCRIPTION
The OpenSearch search engine specification has mismatched open/closing tags, which makes it invalid XML and thus doesn't work. This PR fixes the XML, making it valid.