### PR TITLE
Fix limit order double spending

### DIFF
--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -54,6 +54,7 @@ import { convertTxn } from 'common/supabase/txns'
 import {
   fetchContractBetDataAndValidate,
   getMakerIdsFromBetResult,
+  validateMakerBalances,
   getRoundedLimitProb,
   getUniqueBettorBonusQuery,
   getUserBalancesAndMetrics,
@@ -189,6 +190,8 @@ export const placeBetMain = async (
       log.warn('Matched limit orders changed from simulated values.')
       throw new APIError(503, 'Please try betting again.')
     }
+
+    validateMakerBalances(newBetResult, balanceByUserId)
 
     const betGroupId =
       contract.mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne

--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -14,6 +14,7 @@ import { ContractMetric } from 'common/contract-metric'
 import {
   fetchContractBetDataAndValidate,
   getMakerIdsFromBetResult,
+  validateMakerBalances,
   getUserBalancesAndMetrics,
 } from 'api/helpers/bets'
 import { randomString } from 'common/util/random'
@@ -195,6 +196,8 @@ const sellSharesMain: APIHandler<'market/:contractId/sell'> = async (
       log.warn('Matched limit orders changed from simulated values.')
       throw new APIError(503, 'Please try betting again.')
     }
+
+    validateMakerBalances(newBetResult, balanceByUserId)
     const betGroupId = randomString(12)
 
     return await executeNewBetResult(


### PR DESCRIPTION
## Summary
- validate maker balances before applying limit order fills
- reject bets and sells if makers don't have enough balance

## Testing
- `yarn verify` *(fails: package not in lockfile)*