### PR TITLE
Allow mods to delete comments

### DIFF
--- a/backend/api/src/delete-comment.ts
+++ b/backend/api/src/delete-comment.ts
@@ -1,0 +1,52 @@
+import { isAdminId, isModId } from 'common/envs/constants'
+import {
+  getContract,
+  getUser,
+  revalidateContractStaticProps,
+} from 'shared/utils'
+import { getComment } from 'shared/supabase/contract-comments'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { updateData } from 'shared/supabase/utils'
+import { APIError, type APIHandler } from './helpers/endpoint'
+
+export const deleteComment: APIHandler<'delete-comment'> = async (
+  { commentPath },
+  auth
+) => {
+  const [, contractId, , commentId] = commentPath.split('/')
+  if (!contractId || !commentId) {
+    throw new APIError(
+      400,
+      'Invalid comment path. If you can read this, tell sinclair to change this endpoint to have more sensible inputs'
+    )
+  }
+
+  const pg = createSupabaseDirectClient()
+  const user = await getUser(auth.uid)
+  if (!user) throw new APIError(404, 'User not found')
+  if (user.isBannedFromPosting || user.userDeleted)
+    throw new APIError(
+      403,
+      'You are banned from posting or your account has been deleted'
+    )
+
+  if (!isAdminId(auth.uid) && !isModId(auth.uid)) {
+    throw new APIError(403, 'Only mods or admins can delete comments')
+  }
+
+  const contract = await getContract(pg, contractId)
+  if (!contract) throw new APIError(404, 'Contract not found')
+
+  const comment = await getComment(pg, commentId)
+
+  const del = !comment.deleted
+  await updateData(pg, 'contract_comments', 'comment_id', {
+    comment_id: commentId,
+    deleted: del,
+    deletedTime: del ? Date.now() : undefined,
+    deleterId: auth.uid,
+  })
+
+  await revalidateContractStaticProps(contract)
+  return { success: true }
+}

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -22,6 +22,7 @@ import { updateMarket } from 'api/update-market'
 import { type APIPath } from 'common/api/schema'
 import { getMarkets } from 'api/markets'
 import { hideComment } from './hide-comment'
+import { deleteComment } from './delete-comment'
 import { pinComment } from './pin-comment'
 import { getManagrams } from './get-managrams'
 import { getGroups } from './get-groups'
@@ -195,6 +196,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'get-contract': getContract,
   comment: createComment,
   'hide-comment': hideComment,
+  'delete-comment': deleteComment,
   'pin-comment': pinComment,
   comments: getComments,
   market: createMarket,

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -180,6 +180,13 @@ export const API = (_apiTypeCheck = {
     returns: {} as { success: boolean },
     props: z.object({ commentPath: z.string() }).strict(),
   },
+  'delete-comment': {
+    method: 'POST',
+    visibility: 'public',
+    authed: true,
+    returns: {} as { success: boolean },
+    props: z.object({ commentPath: z.string() }).strict(),
+  },
   'pin-comment': {
     method: 'POST',
     visibility: 'undocumented',

--- a/common/src/comment.ts
+++ b/common/src/comment.ts
@@ -30,6 +30,9 @@ export type Comment<T extends AnyCommentType = AnyCommentType> = {
   pinned?: boolean
   pinnedTime?: number
   pinnerId?: string
+  deleted?: boolean
+  deletedTime?: number
+  deleterId?: string
   visibility: Visibility
   editedTime?: number
   isApi?: boolean

--- a/web/components/comments/comment-header.tsx
+++ b/web/components/comments/comment-header.tsx
@@ -449,6 +449,7 @@ function DotMenu(props: {
   const user = useUser()
   const privateUser = usePrivateUser()
   const isMod = useAdminOrMod()
+  const isAdmin = isAdminId(user?.id)
   const isContractCreator = privateUser?.id === playContract.creatorId
   const [editingComment, setEditingComment] = useState(false)
   const [tipping, setTipping] = useState(false)
@@ -549,6 +550,25 @@ function DotMenu(props: {
                 console.error(e)
                 // undo optimistic update
                 updateComment({ hidden: wasHidden })
+              }
+            },
+          },
+          (isAdmin || isMod) && {
+            name: comment.deleted ? 'Undelete comment' : 'Delete comment',
+            icon: <EyeOffIcon className="h-5 w-5 text-red-500" />,
+            onClick: async () => {
+              const commentPath = `contracts/${playContract.id}/comments/${comment.id}`
+              const wasDeleted = comment.deleted
+              updateComment({ deleted: !wasDeleted })
+
+              try {
+                await api('delete-comment', { commentPath })
+              } catch (e) {
+                toast.error(
+                  wasDeleted ? 'Error undeleting comment' : 'Error deleting comment'
+                )
+                console.error(e)
+                updateComment({ deleted: wasDeleted })
               }
             },
           },

--- a/web/components/comments/comment.tsx
+++ b/web/components/comments/comment.tsx
@@ -329,6 +329,8 @@ function HideableContent(props: { comment: ContractComment }) {
   const initiallyHidden = majorityDislikes || comment.hidden
   const [showHidden, setShowHidden] = useState(false)
 
+  if (comment.deleted) return null
+
   return initiallyHidden && !showHidden ? (
     <div
       className="hover text-ink-600 text-sm font-thin italic hover:cursor-pointer"

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -248,7 +248,9 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
       ...props.comments,
     ],
     'id'
-  ).filter((c) => !blockedUserIds.includes(c.userId))
+  )
+    .filter((c) => !blockedUserIds.includes(c.userId))
+    .filter((c) => !c.deleted)
 
   const commentExistsLocally = comments.some((c) => c.id === highlightCommentId)
   const isLoadingHighlightedComment =
@@ -372,7 +374,9 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
 
   const loadMore = () => setParentCommentsToRender((prev) => prev + LOAD_MORE)
   const pinnedComments = uniqBy(
-    props.pinnedComments.concat(comments.filter((comment) => comment.pinned)),
+    props.pinnedComments
+      .filter((comment) => !comment.deleted)
+      .concat(comments.filter((comment) => comment.pinned)),
     'id'
   )
   const onVisibilityUpdated = useEvent((visible: boolean) => {


### PR DESCRIPTION
## Summary
- add deleted flags to ContractComment type
- implement delete-comment API endpoint
- expose new route in schema
- show Delete comment option for mods/admins
- hide deleted comments in comment lists

## Testing
- `yarn install --immutable` *(fails: could not reach network)*
- `yarn lint` *(fails: package not in lockfile)*