### PR TITLE
Allow mods to delete comments

### DIFF
--- a/web/components/comments/comment-header.tsx
+++ b/web/components/comments/comment-header.tsx
@@ -12,7 +12,6 @@ import clsx from 'clsx'
 import { Bet } from 'common/bet'
 import { ContractComment } from 'common/comment'
 import { Contract } from 'common/contract'
-import { isAdminId } from 'common/envs/constants'
 import { buildArray } from 'common/util/array'
 import { formatPercent, formatWithToken } from 'common/util/format'
 import { useState } from 'react'
@@ -522,7 +521,7 @@ function DotMenu(props: {
               },
             },
           user &&
-            (comment.userId === user.id || isAdminId(user?.id)) && {
+            (comment.userId === user.id || isMod) && {
               name: 'Edit',
               icon: <PencilIcon className="h-5 w-5" />,
               onClick: () => setEditingComment(true),
@@ -533,7 +532,7 @@ function DotMenu(props: {
             onClick: async () => setAnnotating(true),
           },
           (isMod || isContractCreator) && {
-            name: comment.hidden ? 'Unhide' : 'Hide',
+            name: comment.hidden ? 'Undelete comment' : 'Delete comment',
             icon: <EyeOffIcon className="h-5 w-5 text-red-500" />,
             onClick: async () => {
               const commentPath = `contracts/${playContract.id}/comments/${comment.id}`
@@ -544,7 +543,7 @@ function DotMenu(props: {
                 await api('hide-comment', { commentPath })
               } catch (e) {
                 toast.error(
-                  wasHidden ? 'Error unhiding comment' : 'Error hiding comment'
+                  wasHidden ? 'Error undeleting comment' : 'Error deleting comment'
                 )
                 console.error(e)
                 // undo optimistic update

--- a/web/components/comments/comment.tsx
+++ b/web/components/comments/comment.tsx
@@ -329,6 +329,8 @@ function HideableContent(props: { comment: ContractComment }) {
   const initiallyHidden = majorityDislikes || comment.hidden
   const [showHidden, setShowHidden] = useState(false)
 
+  if (comment.hidden) return null
+
   return initiallyHidden && !showHidden ? (
     <div
       className="hover text-ink-600 text-sm font-thin italic hover:cursor-pointer"

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -248,7 +248,9 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
       ...props.comments,
     ],
     'id'
-  ).filter((c) => !blockedUserIds.includes(c.userId))
+  )
+    .filter((c) => !blockedUserIds.includes(c.userId))
+    .filter((c) => !c.hidden)
 
   const commentExistsLocally = comments.some((c) => c.id === highlightCommentId)
   const isLoadingHighlightedComment =
@@ -372,7 +374,9 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
 
   const loadMore = () => setParentCommentsToRender((prev) => prev + LOAD_MORE)
   const pinnedComments = uniqBy(
-    props.pinnedComments.concat(comments.filter((comment) => comment.pinned)),
+    props.pinnedComments
+      .filter((comment) => !comment.hidden)
+      .concat(comments.filter((comment) => comment.pinned)),
     'id'
   )
   const onVisibilityUpdated = useEvent((visible: boolean) => {


### PR DESCRIPTION
## Summary
- rename "Hide" to "Delete" in comment menu
- remove hidden comments from lists
- guard comment component against deleted comments
- allow mods to edit comments using `useAdminOrMod`

## Testing
- `yarn install --immutable` *(fails: could not reach network)*
- `yarn lint` *(fails: could not reach network)*