### PR TITLE
Avoid overlaps with the Android gesture bar

### DIFF
--- a/web/components/layout/page.tsx
+++ b/web/components/layout/page.tsx
@@ -42,7 +42,8 @@ export function Page(props: {
       <FirstStreakModalManager />
       <Col
         className={clsx(
-          !hideBottomBar && 'pb-[58px] lg:pb-0', // bottom bar padding
+          !hideBottomBar &&
+            'pb-[calc(58px+env(safe-area-inset-bottom))] lg:pb-[env(safe-area-inset-bottom)]',
           'text-ink-1000 mx-auto min-h-screen w-full max-w-[1440px] lg:grid lg:grid-cols-12'
         )}
       >

--- a/web/components/nav/bottom-nav-bar.tsx
+++ b/web/components/nav/bottom-nav-bar.tsx
@@ -101,7 +101,7 @@ export function BottomNavBar() {
   const navigationOptions = user ? getNavigation(user) : signedOutNavigation()
 
   return (
-    <nav className="border-ink-200 dark:border-ink-300 text-ink-700 bg-canvas-0 fixed inset-x-0 bottom-0 z-50 flex select-none items-center justify-between border-t-2 text-xs lg:hidden">
+    <nav className="border-ink-200 dark:border-ink-300 text-ink-700 bg-canvas-0 fixed inset-x-0 bottom-0 z-50 flex select-none items-center justify-between border-t-2 pb-[env(safe-area-inset-bottom)] text-xs lg:hidden">
       {navigationOptions.map((item) => (
         <NavBarItem
           key={item.name}

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -158,7 +158,7 @@ function MyApp({ Component, pageProps }: AppProps<ManifoldPageProps>) {
         />
         <meta
           name="viewport"
-          content="width=device-width, initial-scale=1,maximum-scale=1, user-scalable=no"
+          content="width=device-width, initial-scale=1,maximum-scale=1, user-scalable=no, viewport-fit=cover"
         />
         <meta name="apple-itunes-app" content="app-id=6444136749" />
         {/* set safari overscroll/address bar to canvas-0. TODO: change based on site theme preference */}

--- a/web/pages/home/index.tsx
+++ b/web/pages/home/index.tsx
@@ -31,7 +31,7 @@ export default function Home() {
           className={clsx(
             'focus:ring-primary-500 fixed  right-3 z-20 inline-flex items-center rounded-full border  border-transparent  p-4 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 lg:hidden',
             'disabled:bg-ink-300 text-ink-0 from-primary-500 hover:from-primary-700 to-blue-500 hover:to-blue-700 enabled:bg-gradient-to-r',
-            'bottom-[64px]'
+            'bottom-[calc(64px+env(safe-area-inset-bottom))]'
           )}
           onClick={() => {
             Router.push('/create')


### PR DESCRIPTION
A few months ago, Chrome on Android made [some changes](https://developer.chrome.com/docs/css-ui/edge-to-edge) to their user interface. By default, the gesture bar at the bottom of the screen dynamically expands or retracts as the user scrolls. But even when it retracts, the gesture handle remains on screen and overlaps the website's content:

![Screenshot_20250605-203357](https://github.com/user-attachments/assets/e3372462-2874-4d84-9abc-0926dddcb635)

This PR sets the gesture bar to be permanently retracted and adds some padding or an offset to the Manifold bottom navigation, market-creation button and main content in order to avoid an overlap with the gesture handle:

![Screenshot_20250605-203324](https://github.com/user-attachments/assets/be1b8a6b-1568-4fde-b8b2-444222edd96f)

