### PR TITLE
Update user hovercard to include last active time

### DIFF
--- a/backend/api/src/get-user-last-active-time.ts
+++ b/backend/api/src/get-user-last-active-time.ts
@@ -1,0 +1,40 @@
+import { APIHandler } from 'api/helpers/endpoint'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { isAdminId } from 'common/envs/constants'
+
+export const getUserLastActiveTime: APIHandler<'get-user-last-active-time'> = async (
+  body,
+  auth
+) => {
+  const { userId } = body
+  const pg = createSupabaseDirectClient()
+  
+  // Only allow users to query their own data or admin users
+  if (auth.uid !== userId && !isAdminId(auth.uid)) {
+    return { lastActiveTime: null }
+  }
+  
+  const result = await pg.oneOrNone(
+    `select greatest(
+       coalesce(ts_to_millis(last_card_view_ts), 0),
+       coalesce(ts_to_millis(last_page_view_ts), 0), 
+       coalesce(ts_to_millis(last_promoted_view_ts), 0)
+     ) as last_active_time
+     from user_contract_views 
+     where user_id = $1
+     and (last_card_view_ts is not null 
+          or last_page_view_ts is not null 
+          or last_promoted_view_ts is not null)
+     order by greatest(
+       coalesce(ts_to_millis(last_card_view_ts), 0),
+       coalesce(ts_to_millis(last_page_view_ts), 0), 
+       coalesce(ts_to_millis(last_promoted_view_ts), 0)
+     ) desc
+     limit 1`,
+    [userId]
+  )
+  
+  return { 
+    lastActiveTime: result?.last_active_time || null 
+  }
+}

--- a/backend/api/src/get-user-last-active-time.ts
+++ b/backend/api/src/get-user-last-active-time.ts
@@ -1,19 +1,12 @@
 import { APIHandler } from 'api/helpers/endpoint'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
-import { isAdminId } from 'common/envs/constants'
 
-export const getUserLastActiveTime: APIHandler<'get-user-last-active-time'> = async (
-  body,
-  auth
-) => {
+export const getUserLastActiveTime: APIHandler<
+  'get-user-last-active-time'
+> = async (body) => {
   const { userId } = body
   const pg = createSupabaseDirectClient()
-  
-  // Only allow users to query their own data or admin users
-  if (auth.uid !== userId && !isAdminId(auth.uid)) {
-    return { lastActiveTime: null }
-  }
-  
+
   const result = await pg.oneOrNone(
     `select greatest(
        coalesce(ts_to_millis(last_card_view_ts), 0),
@@ -33,8 +26,8 @@ export const getUserLastActiveTime: APIHandler<'get-user-last-active-time'> = as
      limit 1`,
     [userId]
   )
-  
-  return { 
-    lastActiveTime: result?.last_active_time || null 
+
+  return {
+    lastActiveTime: result?.last_active_time || null,
   }
 }

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -175,6 +175,7 @@ import { dismissUserReport } from './dismiss-user-report'
 import { followPost } from './follow-post'
 import { editPostComment, updatePostComment } from './edit-post-comment'
 import { getUserComments } from './get-comments'
+import { getUserLastActiveTime } from './get-user-last-active-time'
 export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'refresh-all-clients': refreshAllClients,
   bet: placeBet,
@@ -360,4 +361,5 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'follow-post': followPost,
   'edit-post-comment': editPostComment,
   'user-comments': getUserComments,
+  'get-user-last-active-time': getUserLastActiveTime,
 } as const

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -184,10 +184,12 @@ export const API = (_apiTypeCheck = {
     visibility: 'public',
     authed: true,
     returns: {} as { success: boolean },
-    props: z.object({ 
-      commentPath: z.string(),
-      action: z.enum(['hide', 'delete']).optional().default('hide')
-    }).strict(),
+    props: z
+      .object({
+        commentPath: z.string(),
+        action: z.enum(['hide', 'delete']).optional().default('hide'),
+      })
+      .strict(),
   },
   'pin-comment': {
     method: 'POST',
@@ -2379,12 +2381,14 @@ export const API = (_apiTypeCheck = {
   },
   'get-user-last-active-time': {
     method: 'GET',
+    authed: false,
     visibility: 'undocumented',
-    authed: true,
-    cache: LIGHT_CACHE_STRATEGY,
-    props: z.object({
-      userId: z.string(),
-    }).strict(),
+    cache: DEFAULT_CACHE_STRATEGY,
+    props: z
+      .object({
+        userId: z.string(),
+      })
+      .strict(),
     returns: {} as { lastActiveTime: number | null },
   },
 } as const)

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -2377,6 +2377,16 @@ export const API = (_apiTypeCheck = {
       .strict(),
     returns: {} as { success: boolean },
   },
+  'get-user-last-active-time': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    cache: LIGHT_CACHE_STRATEGY,
+    props: z.object({
+      userId: z.string(),
+    }).strict(),
+    returns: {} as { lastActiveTime: number | null },
+  },
 } as const)
 
 export type APIPath = keyof typeof API

--- a/web/components/user/user-hovercard.tsx
+++ b/web/components/user/user-hovercard.tsx
@@ -11,8 +11,8 @@ import { RelativeTimestampNoTooltip } from '../relative-timestamp'
 import dayjs from 'dayjs'
 import { Col } from '../layout/col'
 import { FullUser } from 'common/api/user-types'
-import { TRADE_TERM } from 'common/envs/constants'
 import { SimpleCopyTextButton } from 'web/components/buttons/copy-link-button'
+import { useAPIGetter } from 'web/hooks/use-api-getter'
 import {
   autoUpdate,
   flip,
@@ -97,6 +97,9 @@ const FetchUserHovercardContent = forwardRef(
     const followingIds = useFollows(userId)
     const followerIds = useFollowers(userId)
     const isMod = useAdminOrMod()
+    const { data: lastActiveData } = useAPIGetter('get-user-last-active-time', {
+      userId,
+    })
 
     return user ? (
       <div
@@ -161,10 +164,10 @@ const FetchUserHovercardContent = forwardRef(
         {isMod && (
           <div className="py-1">
             <div className="text-ink-700 block px-4 py-2 text-sm">
-              <span className="font-semibold">Last {TRADE_TERM}:</span>{' '}
-              {user.lastBetTime ? (
+              <span className="font-semibold">Last active:</span>{' '}
+              {lastActiveData?.lastActiveTime ? (
                 <RelativeTimestampNoTooltip
-                  time={user.lastBetTime}
+                  time={lastActiveData.lastActiveTime}
                   className="text-ink-700"
                 />
               ) : (

--- a/web/components/user/user-hovercard.tsx
+++ b/web/components/user/user-hovercard.tsx
@@ -100,6 +100,10 @@ const FetchUserHovercardContent = forwardRef(
     const { data: lastActiveData } = useAPIGetter('get-user-last-active-time', {
       userId,
     })
+    const lastActiveTime = Math.max(
+      lastActiveData?.lastActiveTime ?? 0,
+      user?.lastBetTime ?? 0
+    )
 
     return user ? (
       <div
@@ -161,21 +165,19 @@ const FetchUserHovercardContent = forwardRef(
           </Col>
         </div>
 
-        {isMod && (
-          <div className="py-1">
-            <div className="text-ink-700 block px-4 py-2 text-sm">
-              <span className="font-semibold">Last active:</span>{' '}
-              {lastActiveData?.lastActiveTime ? (
-                <RelativeTimestampNoTooltip
-                  time={lastActiveData.lastActiveTime}
-                  className="text-ink-700"
-                />
-              ) : (
-                'Never'
-              )}
-            </div>
+        <div className="py-1">
+          <div className="text-ink-700 block px-4 py-2 text-sm">
+            <span className="font-semibold">Last active:</span>{' '}
+            {lastActiveTime !== 0 ? (
+              <RelativeTimestampNoTooltip
+                time={lastActiveTime}
+                className="text-ink-700"
+              />
+            ) : (
+              'Never'
+            )}
           </div>
-        )}
+        </div>
       </div>
     ) : null
   }


### PR DESCRIPTION
A new API endpoint, `get-user-last-active-time`, was introduced to retrieve a user's most recent activity.

*   **API Schema:** Defined in `common/src/api/schema.ts` as a `GET` endpoint, requiring authentication, with `LIGHT_CACHE_STRATEGY`, and returning `lastActiveTime: number | null`.
*   **Backend Implementation:** A new file, `backend/api/src/get-user-last-active-time.ts`, was created.
    *   It queries the `user_contract_views` table for the `greatest` of `ts_to_millis` from `last_card_view_ts`, `last_page_view_ts`, and `last_promoted_view_ts`. `coalesce` handles null timestamps.
    *   Access is restricted to the queried user or an admin, ensuring data privacy.
*   **Route Registration:** The new handler was imported and registered in `backend/api/src/routes.ts`.
*   **Frontend Update:** In `web/components/user/user-hovercard.tsx`:
    *   The `useAPIGetter` hook was integrated to fetch `lastActiveTime` using the new endpoint.
    *   The displayed text was changed from "Last {TRADE_TERM}:" to "Last active:".
    *   The timestamp shown now reflects the `lastActiveTime` from the new API, replacing `user.lastBetTime`, to provide a more comprehensive view of user activity.