### PR TITLE
Add IsaacKing to conscientiousCreatorIds

### DIFF
--- a/backend/api/src/on-create-comment-on-contract.ts
+++ b/backend/api/src/on-create-comment-on-contract.ts
@@ -73,6 +73,7 @@ export const onCreateCommentOnContract = async (props: {
 
 const conscientiousCreatorIds = [
   'hqdXgp0jK2YMMhPs067eFK4afEH3', // Eliza
+  'y1hb6k7txdZPV5mgyxPFApZ7nQl2', // IsaacKing
 ]
 
 const getReplyInfo = async (


### PR DESCRIPTION
This adds [IsaacKing](https://manifold.markets/IsaacKing)'s `userId` to the list at `conscientiousCreatorIds` which already contained [Eliza](https://manifold.markets/Eliza).

Process used to reproduce the user id:
- Navigate to [the user profile](https://manifold.markets/IsaacKing)
- In the Network tab, search for `get-user-portfolio-history`
- Retrieve the `userId` used for this query (for Eliza it's `hqdXgp0jK2YMMhPs067eFK4afEH3` as expected; for IsaacKing it's `y1hb6k7txdZPV5mgyxPFApZ7nQl2`)

Shameless attempt to resolve the market [Will Manifold stop using AI to make my questions worse by the end of 2025?](https://manifold.markets/IsaacKing/will-manifold-stop-using-ai-to-make) in my favor as a market participant ;)

In comments on that market, IsaacKing consents to being added to this list, and expresses that he will make sure to post all clarifications in his description if Manifold were to add him to the list.