### PR TITLE
Fix Android market link handling

### DIFF
--- a/mani/android/app/src/main/AndroidManifest.xml
+++ b/mani/android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
       </intent-filter>
       <intent-filter android:autoVerify="true" data-generated="true">
         <action android:name="android.intent.action.VIEW"/>
-        <data android:scheme="https" android:host="manifold.markets"/>
+        <data android:scheme="https" android:host="manifold.markets" android:pathPrefix="/"/>
         <category android:name="android.intent.category.BROWSABLE"/>
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>

--- a/mani/app.json
+++ b/mani/app.json
@@ -67,7 +67,8 @@
           "data": [
             {
               "scheme": "https",
-              "host": "manifold.markets"
+              "host": "manifold.markets",
+              "pathPrefix": "/"
             }
           ],
           "category": ["BROWSABLE", "DEFAULT"]

--- a/native/android/app/src/main/AndroidManifest.xml
+++ b/native/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
       </intent-filter>
       <intent-filter android:autoVerify="true" data-generated="true">
         <action android:name="android.intent.action.VIEW"/>
-        <data android:scheme="https" android:host="manifold.markets"/>
+        <data android:scheme="https" android:host="manifold.markets" android:pathPrefix="/"/>
         <category android:name="android.intent.category.BROWSABLE"/>
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>

--- a/native/app.json
+++ b/native/app.json
@@ -47,7 +47,8 @@
           "data": [
             {
               "scheme": "https",
-              "host": "manifold.markets"
+              "host": "manifold.markets",
+              "pathPrefix": "/"
             }
           ],
           "category": ["BROWSABLE", "DEFAULT"]


### PR DESCRIPTION
## Summary
- open all https://manifold.markets paths in the native app

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6870b1a5f85483318d0415948a184b0b