### PR TITLE
Add Evansbot to BOT_USERNAMES list

### DIFF
--- a/common/src/envs/constants.ts
+++ b/common/src/envs/constants.ts
@@ -173,6 +173,7 @@ export const BOT_USERNAMES = [
   'zn_bot',
   'abot',
   'GoodheartLabsBot',
+  'Evansbot',
 ]
 
 export const MOD_IDS = [


### PR DESCRIPTION
This will display a 'Bot' badge next to the account name and exclude it from market importance calculations, as requested in the Manifold API documentation.