### PR TITLE
Update user metrics for unbet contracts

### DIFF
--- a/backend/shared/src/update-user-metric-periods.ts
+++ b/backend/shared/src/update-user-metric-periods.ts
@@ -1,22 +1,22 @@
+import {
+  calculateMetricsByContractAndAnswer,
+  calculateMetricsFromProbabilityChanges,
+  isEmptyMetric,
+} from 'common/calculate-metrics'
+import { Contract, CPMMMultiContract } from 'common/contract'
+import { ContractMetric } from 'common/contract-metric'
+import { convertBet } from 'common/supabase/bets'
+import { convertAnswer, convertContract } from 'common/supabase/contracts'
+import { filterDefined } from 'common/util/array'
+import { hasSignificantDeepChanges } from 'common/util/object'
 import { DAY_MS } from 'common/util/time'
+import { chunk, groupBy, sortBy, sumBy, uniq, uniqBy } from 'lodash'
 import {
   createSupabaseDirectClient,
   SupabaseDirectClient,
 } from 'shared/supabase/init'
 import { contractColumnsToSelect, isProd, log } from 'shared/utils'
-import { chunk, groupBy, sortBy, sumBy, uniq, uniqBy } from 'lodash'
-import { Contract, CPMMMultiContract } from 'common/contract'
-import {
-  calculateMetricsByContractAndAnswer,
-  isEmptyMetric,
-  calculateProfitMetricsAtProbOrCancel,
-} from 'common/calculate-metrics'
-import { filterDefined } from 'common/util/array'
-import { hasSignificantDeepChanges } from 'common/util/object'
-import { convertBet } from 'common/supabase/bets'
-import { ContractMetric } from 'common/contract-metric'
 import { bulkUpdateDataQuery, bulkUpdateQuery } from './supabase/utils'
-import { convertAnswer, convertContract } from 'common/supabase/contracts'
 
 const CHUNK_SIZE = isProd() ? 400 : 10
 export async function updateUserMetricPeriods(
@@ -27,7 +27,6 @@ export async function updateUserMetricPeriods(
   log('Starting user period metrics update')
   const now = Date.now()
   const eightDays = DAY_MS * 8
-  const oneDayAgo = now - DAY_MS
   const since = customSince ?? now - eightDays
   const daysAgo = Math.round((now - since) / DAY_MS)
   const pg = createSupabaseDirectClient()
@@ -80,24 +79,25 @@ export async function updateUserMetricPeriods(
   const chunks = chunk(allActiveUserIds, CHUNK_SIZE)
   const metricsByUser: Record<string, ContractMetric[]> = {}
   const contractsById: Record<string, Contract> = {}
-  
+
   for (const activeUserIds of chunks) {
     log(`Processing ${activeUserIds.length} users`)
-    
-    // Get contracts where users haven't bet in the past 24 hours
-    const contractsWithoutRecentBets = await getContractsWithoutRecentBets(
+
+    // First, find contracts that users have bet on recently
+    log(`Finding contracts with recent betting activity...`)
+    const contractIdsWithRecentBets = await getContractIdsWithRecentBets(
       pg,
       activeUserIds,
-      oneDayAgo
+      since
     )
-    
-    // Get contracts where users have bet in the past 24 hours
-    log(`Loading bets for ${activeUserIds.length} users`)
+
+    // Load bets for contracts with recent activity
+    log(`Loading bets for contracts with recent activity...`)
     const metricRelevantBets = await getUnresolvedOrRecentlyResolvedBets(
       pg,
       activeUserIds,
       since,
-      oneDayAgo // Only get bets for contracts with recent activity
+      contractIdsWithRecentBets
     )
     log(
       `Loaded ${sumBy(
@@ -106,13 +106,26 @@ export async function updateUserMetricPeriods(
       )} bets.`
     )
 
-    const allBets = Object.values(metricRelevantBets).flat()
-    const contractIdsWithBets = uniq(allBets.map((b) => b.contractId))
-    const contractIdsWithoutBets = uniq(contractsWithoutRecentBets.map(m => m.contractId))
-    const allContractIds = uniq([...contractIdsWithBets, ...contractIdsWithoutBets])
-    
+    // Get metrics for contracts WITHOUT recent betting activity
+    log(`Loading metrics for contracts without recent betting activity...`)
+    const contractMetricsWithoutRecentBets =
+      await getContractMetricsWithoutRecentBets(
+        pg,
+        activeUserIds,
+        since,
+        contractIdsWithRecentBets
+      )
+
+    const contractIdsWithoutBets = uniq(
+      contractMetricsWithoutRecentBets.map((m) => m.contractId)
+    )
+    const allContractIds = uniq([
+      ...contractIdsWithRecentBets,
+      ...contractIdsWithoutBets,
+    ])
+
     if (allContractIds.length === 0) continue
-    
+
     const newContractIds: string[] = allContractIds.filter(
       (c) => !contractsById[c]
     )
@@ -133,9 +146,13 @@ export async function updateUserMetricPeriods(
 
       select id, data from user_contract_metrics
       where user_id in ($2:list)
-      and contract_id in ($3:list);
+      and contract_id in ($3:list)
     `,
-      [newContractIds, activeUserIds, allContractIds]
+      [
+        newContractIds,
+        activeUserIds,
+        allContractIds.filter((c) => !contractIdsWithoutBets.includes(c)),
+      ]
     )
     const contracts = results[0].map(convertContract)
     const answers = results[1].map(convertAnswer)
@@ -148,9 +165,9 @@ export async function updateUserMetricPeriods(
       else contractsById[c.id] = c
     })
 
-    const currentContractMetrics = results[2].map(
-      (r) => ({ id: r.id, ...r.data } as ContractMetric)
-    )
+    const currentContractMetrics = results[2]
+      .map((r) => ({ id: r.id, ...r.data } as ContractMetric))
+      .concat(contractMetricsWithoutRecentBets)
 
     log(
       `Loaded ${contracts.length} contracts,
@@ -171,7 +188,9 @@ export async function updateUserMetricPeriods(
     log('Computing metric updates...')
     for (const userId of activeUserIds) {
       const userMetricRelevantBets = metricRelevantBets[userId] ?? []
-      const userMetricsWithoutBets = contractsWithoutRecentBets.filter(m => m.userId === userId)
+      const userMetricsWithoutBets = contractMetricsWithoutRecentBets.filter(
+        (m) => m.userId === userId
+      )
 
       // Calculate metrics for contracts with recent bets (existing logic)
       const metricRelevantBetsByContract = groupBy(
@@ -187,13 +206,17 @@ export async function updateUserMetricPeriods(
       )
 
       // Calculate metrics for contracts without recent bets using probability changes
-      const freshMetricsFromProbChanges = calculateMetricsFromProbabilityChanges(
-        userMetricsWithoutBets,
-        contractsById
-      )
+      const freshMetricsFromProbChanges =
+        calculateMetricsFromProbabilityChanges(
+          userMetricsWithoutBets,
+          contractsById
+        )
 
-      const freshMetrics = [...freshMetricsFromBets, ...freshMetricsFromProbChanges]
-      
+      const freshMetrics = [
+        ...freshMetricsFromBets,
+        ...freshMetricsFromProbChanges,
+      ]
+
       metricsByUser[userId] = uniqBy(
         [...freshMetrics, ...currentMetricsForUser],
         (m) => m.contractId + m.answerId
@@ -265,15 +288,40 @@ export async function updateUserMetricPeriods(
   return { metricsByUser, contractsById }
 }
 
-// New function to get contracts where users haven't bet recently
-const getContractsWithoutRecentBets = async (
+// New function to get contract IDs with recent betting activity
+const getContractIdsWithRecentBets = async (
   pg: SupabaseDirectClient,
   userIds: string[],
-  oneDayAgo: number
+  since: number
 ) => {
+  const contractIds = await pg.map(
+    `
+    select distinct cb.contract_id
+    from contract_bets cb
+      where cb.user_id in ($1:list)
+      and cb.created_time > $2
+    `,
+    [userIds, new Date(since).toISOString()],
+    (r) => r.contract_id as string
+  )
+
+  return contractIds
+}
+
+const getContractMetricsWithoutRecentBets = async (
+  pg: SupabaseDirectClient,
+  userIds: string[],
+  since: number,
+  contractIdsWithRecentBets: string[]
+) => {
+  const excludeClause =
+    contractIdsWithRecentBets.length > 0
+      ? 'and ucm.contract_id not in ($3:list)'
+      : ''
+
   const metrics = await pg.map(
     `
-    select ucm.id, ucm.data, ucm.user_id, ucm.contract_id, ucm.answer_id
+    select ucm.id, ucm.data
     from user_contract_metrics ucm
     join contracts c on ucm.contract_id = c.id
     left join answers a on ucm.answer_id = a.id
@@ -281,106 +329,29 @@ const getContractsWithoutRecentBets = async (
       and ucm.has_shares = true
       and (c.resolution_time is null or c.resolution_time > $2)
       and (a is null or a.resolution_time is null or a.resolution_time > $2)
-      and not exists (
-        select 1 from contract_bets cb 
-        where cb.user_id = ucm.user_id 
-          and cb.contract_id = ucm.contract_id 
-          and cb.created_time > $2
-          and (ucm.answer_id is null or cb.answer_id = ucm.answer_id)
-      )
+      ${excludeClause}
     `,
-    [userIds, new Date(oneDayAgo).toISOString()],
-    (r) => ({
-      id: r.id as number,
-      userId: r.user_id as string,
-      contractId: r.contract_id as string,
-      answerId: r.answer_id as string | null,
-      ...r.data
-    } as ContractMetric)
+    [userIds, new Date(since).toISOString(), contractIdsWithRecentBets],
+    (r) =>
+      ({
+        id: r.id as number,
+        ...r.data,
+      } as ContractMetric)
   )
 
   return metrics
-}
-
-// New function to calculate metrics changes using probability changes
-const calculateMetricsFromProbabilityChanges = (
-  userMetrics: ContractMetric[],
-  contractsById: Record<string, Contract>
-): ContractMetric[] => {
-  return userMetrics.map(metric => {
-    const contract = contractsById[metric.contractId]
-    if (!contract) return metric
-
-    let newProb: number
-    if (contract.mechanism === 'cpmm-multi-1' && metric.answerId) {
-      const answer = (contract as CPMMMultiContract).answers.find(a => a.id === metric.answerId)
-      if (!answer) return metric
-      newProb = answer.prob
-    } else if (contract.mechanism === 'cpmm-1') {
-      newProb = (contract as any).prob
-    } else {
-      return metric
-    }
-
-    // Calculate new metrics based on probability change
-    const updatedMetric = calculateProfitMetricsAtProbOrCancel(newProb, metric)
-    
-    // Calculate period profit changes (from calculatePeriodProfit logic)
-    const calculatePeriodChange = (period: 'day' | 'week' | 'month') => {
-      let probChange: number
-      if (contract.mechanism === 'cpmm-multi-1' && metric.answerId) {
-        const answer = (contract as CPMMMultiContract).answers.find(a => a.id === metric.answerId)
-        probChange = answer?.probChanges[period] ?? 0
-      } else if (contract.mechanism === 'cpmm-1') {
-        probChange = (contract as any).probChanges?.[period] ?? 0
-      } else {
-        probChange = 0
-      }
-
-      const prevProb = newProb - probChange
-      const { totalShares, totalAmountInvested = 0 } = metric
-      
-      // Calculate value change based on shares and probability change
-      const yesShares = totalShares.YES ?? 0
-      const noShares = totalShares.NO ?? 0
-      
-      const prevValue = yesShares * prevProb + noShares * (1 - prevProb)
-      const currentValue = yesShares * newProb + noShares * (1 - newProb)
-      const valueChange = currentValue - prevValue
-      
-      const profit = valueChange
-      const invested = totalAmountInvested > 0 ? totalAmountInvested : Math.abs(totalAmountInvested) || 1
-      const profitPercent = (profit / invested) * 100
-
-      return {
-        profit,
-        profitPercent,
-        invested: totalAmountInvested,
-        prevValue,
-        value: currentValue,
-      }
-    }
-
-    // Update the from field with period changes
-    const from = {
-      day: calculatePeriodChange('day'),
-      week: calculatePeriodChange('week'),
-      month: calculatePeriodChange('month'),
-    }
-
-    return {
-      ...updatedMetric,
-      from,
-    }
-  })
 }
 
 const getUnresolvedOrRecentlyResolvedBets = async (
   pg: SupabaseDirectClient,
   userIds: string[],
   since: number,
-  oneDayAgo?: number
+  contractIds: string[]
 ) => {
+  if (contractIds.length === 0) {
+    return {}
+  }
+
   const bets = await pg.map(
     `
     select cb.amount, cb.shares, cb.outcome, cb.loan_amount, cb.user_id, cb.answer_id, cb.contract_id, cb.created_time, cb.is_redemption
@@ -389,11 +360,12 @@ const getUnresolvedOrRecentlyResolvedBets = async (
     left join answers as a on cb.answer_id = a.id
     where
       cb.user_id in ($1:list)
+      and cb.contract_id in ($3:list)
+      and (c.mechanism != 'cpmm-multi-1' or not cb.is_redemption)
       and (c.resolution_time is null or c.resolution_time > $2)
       and (a is null or a.resolution_time is null or a.resolution_time > $2)
-      ${oneDayAgo ? 'and cb.created_time > $3' : ''}
     `,
-    [userIds, new Date(since).toISOString(), oneDayAgo ? new Date(oneDayAgo).toISOString() : undefined].filter(Boolean),
+    [userIds, new Date(since).toISOString(), contractIds],
     convertBet
   )
 

--- a/backend/shared/src/update-user-metric-periods.ts
+++ b/backend/shared/src/update-user-metric-periods.ts
@@ -9,6 +9,7 @@ import { Contract, CPMMMultiContract } from 'common/contract'
 import {
   calculateMetricsByContractAndAnswer,
   isEmptyMetric,
+  calculateProfitMetricsAtProbOrCancel,
 } from 'common/calculate-metrics'
 import { filterDefined } from 'common/util/array'
 import { hasSignificantDeepChanges } from 'common/util/object'
@@ -26,6 +27,7 @@ export async function updateUserMetricPeriods(
   log('Starting user period metrics update')
   const now = Date.now()
   const eightDays = DAY_MS * 8
+  const oneDayAgo = now - DAY_MS
   const since = customSince ?? now - eightDays
   const daysAgo = Math.round((now - since) / DAY_MS)
   const pg = createSupabaseDirectClient()
@@ -78,12 +80,24 @@ export async function updateUserMetricPeriods(
   const chunks = chunk(allActiveUserIds, CHUNK_SIZE)
   const metricsByUser: Record<string, ContractMetric[]> = {}
   const contractsById: Record<string, Contract> = {}
+  
   for (const activeUserIds of chunks) {
+    log(`Processing ${activeUserIds.length} users`)
+    
+    // Get contracts where users haven't bet in the past 24 hours
+    const contractsWithoutRecentBets = await getContractsWithoutRecentBets(
+      pg,
+      activeUserIds,
+      oneDayAgo
+    )
+    
+    // Get contracts where users have bet in the past 24 hours
     log(`Loading bets for ${activeUserIds.length} users`)
     const metricRelevantBets = await getUnresolvedOrRecentlyResolvedBets(
       pg,
       activeUserIds,
-      since
+      since,
+      oneDayAgo // Only get bets for contracts with recent activity
     )
     log(
       `Loaded ${sumBy(
@@ -93,9 +107,13 @@ export async function updateUserMetricPeriods(
     )
 
     const allBets = Object.values(metricRelevantBets).flat()
-    const contractIds = uniq(allBets.map((b) => b.contractId))
-    if (contractIds.length === 0) continue
-    const newContractIds: string[] = contractIds.filter(
+    const contractIdsWithBets = uniq(allBets.map((b) => b.contractId))
+    const contractIdsWithoutBets = uniq(contractsWithoutRecentBets.map(m => m.contractId))
+    const allContractIds = uniq([...contractIdsWithBets, ...contractIdsWithoutBets])
+    
+    if (allContractIds.length === 0) continue
+    
+    const newContractIds: string[] = allContractIds.filter(
       (c) => !contractsById[c]
     )
     log('Loading contracts, answers, users, and current contract metrics...')
@@ -117,7 +135,7 @@ export async function updateUserMetricPeriods(
       where user_id in ($2:list)
       and contract_id in ($3:list);
     `,
-      [newContractIds, activeUserIds, contractIds]
+      [newContractIds, activeUserIds, allContractIds]
     )
     const contracts = results[0].map(convertContract)
     const answers = results[1].map(convertAnswer)
@@ -153,18 +171,29 @@ export async function updateUserMetricPeriods(
     log('Computing metric updates...')
     for (const userId of activeUserIds) {
       const userMetricRelevantBets = metricRelevantBets[userId] ?? []
+      const userMetricsWithoutBets = contractsWithoutRecentBets.filter(m => m.userId === userId)
 
+      // Calculate metrics for contracts with recent bets (existing logic)
       const metricRelevantBetsByContract = groupBy(
         userMetricRelevantBets,
         (b) => b.contractId
       )
       const currentMetricsForUser = currentMetricsByUserId[userId] ?? []
-      const freshMetrics = calculateMetricsByContractAndAnswer(
+      const freshMetricsFromBets = calculateMetricsByContractAndAnswer(
         metricRelevantBetsByContract,
         contractsById,
         userId,
         currentMetricsForUser
       )
+
+      // Calculate metrics for contracts without recent bets using probability changes
+      const freshMetricsFromProbChanges = calculateMetricsFromProbabilityChanges(
+        userMetricsWithoutBets,
+        contractsById
+      )
+
+      const freshMetrics = [...freshMetricsFromBets, ...freshMetricsFromProbChanges]
+      
       metricsByUser[userId] = uniqBy(
         [...freshMetrics, ...currentMetricsForUser],
         (m) => m.contractId + m.answerId
@@ -236,10 +265,121 @@ export async function updateUserMetricPeriods(
   return { metricsByUser, contractsById }
 }
 
+// New function to get contracts where users haven't bet recently
+const getContractsWithoutRecentBets = async (
+  pg: SupabaseDirectClient,
+  userIds: string[],
+  oneDayAgo: number
+) => {
+  const metrics = await pg.map(
+    `
+    select ucm.id, ucm.data, ucm.user_id, ucm.contract_id, ucm.answer_id
+    from user_contract_metrics ucm
+    join contracts c on ucm.contract_id = c.id
+    left join answers a on ucm.answer_id = a.id
+    where ucm.user_id in ($1:list)
+      and ucm.has_shares = true
+      and (c.resolution_time is null or c.resolution_time > $2)
+      and (a is null or a.resolution_time is null or a.resolution_time > $2)
+      and not exists (
+        select 1 from contract_bets cb 
+        where cb.user_id = ucm.user_id 
+          and cb.contract_id = ucm.contract_id 
+          and cb.created_time > $2
+          and (ucm.answer_id is null or cb.answer_id = ucm.answer_id)
+      )
+    `,
+    [userIds, new Date(oneDayAgo).toISOString()],
+    (r) => ({
+      id: r.id as number,
+      userId: r.user_id as string,
+      contractId: r.contract_id as string,
+      answerId: r.answer_id as string | null,
+      ...r.data
+    } as ContractMetric)
+  )
+
+  return metrics
+}
+
+// New function to calculate metrics changes using probability changes
+const calculateMetricsFromProbabilityChanges = (
+  userMetrics: ContractMetric[],
+  contractsById: Record<string, Contract>
+): ContractMetric[] => {
+  return userMetrics.map(metric => {
+    const contract = contractsById[metric.contractId]
+    if (!contract) return metric
+
+    let newProb: number
+    if (contract.mechanism === 'cpmm-multi-1' && metric.answerId) {
+      const answer = (contract as CPMMMultiContract).answers.find(a => a.id === metric.answerId)
+      if (!answer) return metric
+      newProb = answer.prob
+    } else if (contract.mechanism === 'cpmm-1') {
+      newProb = (contract as any).prob
+    } else {
+      return metric
+    }
+
+    // Calculate new metrics based on probability change
+    const updatedMetric = calculateProfitMetricsAtProbOrCancel(newProb, metric)
+    
+    // Calculate period profit changes (from calculatePeriodProfit logic)
+    const calculatePeriodChange = (period: 'day' | 'week' | 'month') => {
+      let probChange: number
+      if (contract.mechanism === 'cpmm-multi-1' && metric.answerId) {
+        const answer = (contract as CPMMMultiContract).answers.find(a => a.id === metric.answerId)
+        probChange = answer?.probChanges[period] ?? 0
+      } else if (contract.mechanism === 'cpmm-1') {
+        probChange = (contract as any).probChanges?.[period] ?? 0
+      } else {
+        probChange = 0
+      }
+
+      const prevProb = newProb - probChange
+      const { totalShares, totalAmountInvested = 0 } = metric
+      
+      // Calculate value change based on shares and probability change
+      const yesShares = totalShares.YES ?? 0
+      const noShares = totalShares.NO ?? 0
+      
+      const prevValue = yesShares * prevProb + noShares * (1 - prevProb)
+      const currentValue = yesShares * newProb + noShares * (1 - newProb)
+      const valueChange = currentValue - prevValue
+      
+      const profit = valueChange
+      const invested = totalAmountInvested > 0 ? totalAmountInvested : Math.abs(totalAmountInvested) || 1
+      const profitPercent = (profit / invested) * 100
+
+      return {
+        profit,
+        profitPercent,
+        invested: totalAmountInvested,
+        prevValue,
+        value: currentValue,
+      }
+    }
+
+    // Update the from field with period changes
+    const from = {
+      day: calculatePeriodChange('day'),
+      week: calculatePeriodChange('week'),
+      month: calculatePeriodChange('month'),
+    }
+
+    return {
+      ...updatedMetric,
+      from,
+    }
+  })
+}
+
 const getUnresolvedOrRecentlyResolvedBets = async (
   pg: SupabaseDirectClient,
   userIds: string[],
-  since: number
+  since: number,
+  oneDayAgo?: number
 ) => {
   const bets = await pg.map(
     `
@@ -251,8 +391,9 @@ const getUnresolvedOrRecentlyResolvedBets = async (
       cb.user_id in ($1:list)
       and (c.resolution_time is null or c.resolution_time > $2)
       and (a is null or a.resolution_time is null or a.resolution_time > $2)
+      ${oneDayAgo ? 'and cb.created_time > $3' : ''}
     `,
-    [userIds, new Date(since).toISOString()],
+    [userIds, new Date(since).toISOString(), oneDayAgo ? new Date(oneDayAgo).toISOString() : undefined].filter(Boolean),
     convertBet
   )
 


### PR DESCRIPTION
Optimize user metric period updates by calculating changes for inactive contracts using probability changes, reducing bet queries.

---

[Open in Web](https://cursor.com/agents?id=bc-f8a5bc7d-69b3-4c84-9c60-8ad8f398fb6e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f8a5bc7d-69b3-4c84-9c60-8ad8f398fb6e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)