### PR TITLE
Add 'TreemoondusBot' to bot constants

### DIFF
--- a/common/src/envs/constants.ts
+++ b/common/src/envs/constants.ts
@@ -182,6 +182,7 @@ export const BOT_USERNAMES = [
   'Evansbot',
   'PugBot',
   'cot',
+  'TreemoondusBot',
 ]
 
 export const MOD_IDS = [


### PR DESCRIPTION
Adding TreemoondusBot as a registered bot account for automated prediction market trading on Manifold.