### PR TITLE
fix: queue push notifications on cold start until WebView is ready

### DIFF
--- a/native/App.tsx
+++ b/native/App.tsx
@@ -71,6 +71,12 @@ const App = () => {
   // This tracks if the app has its nativeMessageListener set up
   // NOTE: After the webview is killed on android due to OOM, this will always be false, see: https://github.com/react-native-webview/react-native-webview/issues/2680
   const listeningToNative = useRef(false)
+  // Stores a notification that arrived before the webview was ready (cold start).
+  // Delivered once the web app signals 'startedListening'.
+  const pendingNotification = useRef<{
+    notification: Notification
+    destination: string
+  } | null>(null)
   const [baseUri, setBaseUri] = useState(BASE_URI)
 
   // Auth
@@ -169,15 +175,19 @@ const App = () => {
       return
     }
 
-    // If the webview is already loaded and listening, forward the message so
-    // the web client can mark the notification as seen, etc.
     if (hasLoadedWebView && listeningToNative.current) {
+      // Webview is ready — deliver immediately via message bridge
       communicateWithWebview('notification', notification)
+      setEndpointWithNativeQuery(destination)
+    } else {
+      // Cold start: webview isn't ready yet. Stash the notification so we can
+      // deliver it once the web app signals 'startedListening'. We intentionally
+      // do NOT call setEndpointWithNativeQuery here because on Android the
+      // WebView ignores rapid source prop changes during its initial mount,
+      // causing the notification URL to be silently dropped.
+      log('Queuing notification for delivery after webview is ready')
+      pendingNotification.current = { notification, destination }
     }
-
-    // Always set the URL so that, even if the message is missed, the webview
-    // navigates to the correct page when it becomes active.
-    setEndpointWithNativeQuery(destination)
   }
 
   useEffect(() => {
@@ -390,6 +400,14 @@ const App = () => {
       log('Client started listening')
       listeningToNative.current = true
       if (fbUser) sendWebviewAuthInfo(fbUser)
+      // Deliver any notification that arrived during cold start
+      if (pendingNotification.current) {
+        const { notification, destination } = pendingNotification.current
+        pendingNotification.current = null
+        log('Delivering pending cold-start notification:', notification.reason)
+        communicateWithWebview('notification', notification)
+        setEndpointWithNativeQuery(destination)
+      }
     } else if (type === 'locationPermissionStatusRequested') {
       log('Location permission status requested from web')
       const status = await checkLocationPermission()


### PR DESCRIPTION
On Android, tapping a push notification during cold start would navigate to the home screen instead of the notification target. The WebView silently drops source prop changes during initial mount, so the notification URL was lost. This fix queues the notification in a ref and delivers it via the message bridge once the web app signals 'startedListening'.