### PR TITLE
feat: replace hardcoded BOT_USERNAMES with proper bot toggle

### DIFF
--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -10,7 +10,6 @@ import { ContractMetric, isSummary } from 'common/contract-metric'
 import { getUniqueBettorBonusAmount } from 'common/economy'
 import {
   BANNED_TRADING_USER_IDS,
-  BOT_USERNAMES,
   PARTNER_USER_IDS,
 } from 'common/envs/constants'
 import { CandidateBet } from 'common/new-bet'
@@ -447,7 +446,7 @@ export const getUniqueBettorBonusQuery = (
 ) => {
   const { answerId, isRedemption, isApi } = bet
 
-  const isBot = BOT_USERNAMES.includes(bettor.username)
+  const isBot = bettor.isBot ?? false
   const isUnlisted = contract.visibility === 'unlisted'
 
   const answer =

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -51,6 +51,7 @@ import { addOrRemoveTopicFromContract } from './add-topic-to-market'
 import { addOrRemoveTopicFromTopic } from './add-topic-to-topic'
 import { awardBounty } from './award-bounty'
 import { banuser } from './ban-user'
+import { setbotstatus } from './set-bot-status'
 import { blockGroup, unblockGroup } from './block-group'
 import { blockMarket, unblockMarket } from './block-market'
 import { blockUser, unblockUser } from './block-user'
@@ -349,6 +350,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'get-related-markets': getRelatedMarkets,
   'get-related-markets-by-group': getRelatedMarketsByGroup,
   'get-market-context': getMarketContext,
+  'set-bot-status': setbotstatus,
   'ban-user': banuser,
   'dismiss-mod-alert': dismissmodalert,
   'super-ban-user': superBanUser,

--- a/backend/api/src/set-bot-status.ts
+++ b/backend/api/src/set-bot-status.ts
@@ -1,0 +1,27 @@
+import { APIError, type APIHandler } from 'api/helpers/endpoint'
+import { isAdminId } from 'common/envs/constants'
+import { trackPublicEvent } from 'shared/analytics'
+import { throwErrorIfNotMod } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { updateUser } from 'shared/supabase/users'
+import { getUser, log } from 'shared/utils'
+
+export const setbotstatus: APIHandler<'set-bot-status'> = async (
+  props,
+  auth
+) => {
+  const { userId, isBot } = props
+  throwErrorIfNotMod(auth.uid)
+  if (isAdminId(userId))
+    throw new APIError(403, 'Cannot modify admin bot status')
+
+  const user = await getUser(userId)
+  if (!user) throw new APIError(404, 'User not found')
+
+  const pg = createSupabaseDirectClient()
+  await updateUser(pg, userId, { isBot })
+
+  await trackPublicEvent(auth.uid, 'set bot status', { userId, isBot })
+  log('set bot status', { userId, isBot, by: auth.uid })
+  return { success: true }
+}

--- a/backend/scripts/add-reactivated-to-league.ts
+++ b/backend/scripts/add-reactivated-to-league.ts
@@ -1,4 +1,3 @@
-import { BOT_USERNAMES } from 'common/envs/constants'
 import { groupBy, mapValues } from 'lodash'
 import { runScript } from 'run-script'
 import {
@@ -37,9 +36,8 @@ const _reassignBots = (pg: SupabaseDirectClient) => {
         cohort = 'bots'
     where user_id in (
         select id from users
-        where username in ($1:csv)
+        where is_bot = true
         limit 40
-    )`,
-    [BOT_USERNAMES]
+    )`
   )
 }

--- a/backend/shared/src/generate-leagues.ts
+++ b/backend/shared/src/generate-leagues.ts
@@ -1,4 +1,4 @@
-import { BOT_USERNAMES, OPTED_OUT_OF_LEAGUES } from 'common/envs/constants'
+import { OPTED_OUT_OF_LEAGUES } from 'common/envs/constants'
 import {
   getCohortSize,
   getDemotionAndPromotionCount,
@@ -50,9 +50,9 @@ export async function generateNextSeason(
     join users on users.id = user_id
     where coalesce(users.data->>'isBannedFromPosting', 'false') = 'false'
     and coalesce(users.data->>'userDeleted', 'false') = 'false'
-    and users.username not in ($2:csv)
+    and users.is_bot = false
     `,
-    [startDate, BOT_USERNAMES]
+    [startDate]
   )
   const activeUserIdsSet = new Set(activeUserIds.map((u) => u.user_id))
 
@@ -218,7 +218,6 @@ export const insertBots = async (pg: SupabaseDirectClient, season: number) => {
 
   // console.log('alreadyAssignedBotIds', alreadyAssignedBotIds)
 
-  const botUsernamesExcludingAcc = BOT_USERNAMES.filter((u) => u !== 'acc')
   const prevBoundaries = await getSeasonStartAndEnd(pg, prevSeason)
   if (!prevBoundaries) {
     log(`Error: Season ${prevSeason} not found in leagues_season_end_times`)
@@ -232,10 +231,11 @@ export const insertBots = async (pg: SupabaseDirectClient, season: number) => {
         where contract_bets.created_time > $1
       )
       select id from users
-      where users.username in ($2:csv)
+      where users.is_bot = true
+      and users.username != 'acc'
       and id in (select user_id from active_user_ids)
     `,
-    [startDate, botUsernamesExcludingAcc],
+    [startDate],
     (r) => r.id
   )
 

--- a/backend/shared/src/importance-score.ts
+++ b/backend/shared/src/importance-score.ts
@@ -20,7 +20,7 @@ import {
 import { getRecentContractLikes } from 'shared/supabase/likes'
 import { log, prefixedContractColumnsToSelect } from 'shared/utils'
 
-import { BOT_USERNAMES } from 'common/envs/constants'
+
 import { convertContract } from 'common/supabase/contracts'
 import { Row } from 'common/supabase/utils'
 import { convertPost } from 'common/top-level-post'
@@ -289,10 +289,10 @@ export const getContractTraders = async (
        from contract_bets cb
                 join users u on cb.user_id = u.id
        where cb.created_time >= millis_to_ts($1)
-         and u.username <> ANY(ARRAY[$2])
-          and cb.contract_id = ANY(ARRAY[$3])
+         and u.is_bot = false
+          and cb.contract_id = ANY(ARRAY[$2])
        group by cb.contract_id`,
-      [since, BOT_USERNAMES, inContractIds],
+      [since, inContractIds],
       (r) => [r.contract_id as string, r.n as number]
     )
   )
@@ -309,10 +309,10 @@ export const getContractVoters = async (
        from votes cb
                 join users u on cb.user_id = u.id
        where cb.created_time >= millis_to_ts($1)
-         and u.username <> ANY(ARRAY[$2])
-          and cb.contract_id = ANY(ARRAY[$3])
+         and u.is_bot = false
+          and cb.contract_id = ANY(ARRAY[$2])
        group by cb.contract_id`,
-      [since, BOT_USERNAMES, inContractIds],
+      [since, inContractIds],
       (r) => [r.contract_id as string, r.n as number]
     )
   )

--- a/backend/shared/src/supabase/users.ts
+++ b/backend/shared/src/supabase/users.ts
@@ -86,11 +86,11 @@ export const updateUser = async (
   id: string,
   update: Partial<User>
 ) => {
-  const { name, username, ...rest } = update
+  const { name, username, isBot, ...rest } = update
 
-  // name and username are top-level columns, not in the data JSONB.
+  // name, username, and is_bot are top-level columns, not in the data JSONB.
   // Set them directly so they don't silently land in the wrong place.
-  if (name !== undefined || username !== undefined) {
+  if (name !== undefined || username !== undefined || isBot !== undefined) {
     const setClauses: string[] = []
     const values: any[] = []
     let idx = 1
@@ -101,6 +101,10 @@ export const updateUser = async (
     if (username !== undefined) {
       setClauses.push(`username = $${idx++}`)
       values.push(username)
+    }
+    if (isBot !== undefined) {
+      setClauses.push(`is_bot = $${idx++}`)
+      values.push(isBot)
     }
     values.push(id)
     await db.none(

--- a/backend/supabase/migrations/2026040101_add_users_is_bot.sql
+++ b/backend/supabase/migrations/2026040101_add_users_is_bot.sql
@@ -1,0 +1,28 @@
+alter table users add column if not exists is_bot boolean not null default false;
+
+-- Seed from the existing BOT_USERNAMES list (109 entries, case-sensitive match)
+update users set is_bot = true
+where username in (
+  'TenShinoBot', 'JDVance1', 'Merchant', 'benedict', 'subooferbot',
+  'pos', 'v', 'acc', 'jerk', 'snap',
+  'ArbitrageBot', 'MarketManagerBot', 'Botlab', 'JuniorBot', 'ManifoldDream',
+  'ManifoldBugs', 'ACXBot', 'JamesBot', 'jimbot', 'RyanBot',
+  'trainbot', 'runebot', 'LiquidityBonusBot', '538', 'FairlyRandom',
+  'Anatolii', 'JeremyK', 'Botmageddon', 'GenAIBot', 'SmartBot',
+  'ShifraGazsi', 'NiciusBot', 'Bot', 'Mason', 'VersusBot',
+  'GPT4', 'EntropyBot', 'veat', 'ms_test', 'arb',
+  'Turbot', 'MetaculusBot', 'burkebot', 'Botflux', '7',
+  'hyperkaehler', 'NcyBot', 'ithaca', 'GigaGaussian', 'BottieMcBotface',
+  'Seldon', 'OnePercentBot', 'arrbit', 'ManaMaximizer', 'rita',
+  'uhh', 'ArkPoint', 'EliBot', 'manifestussy', 'mirrorbot',
+  'JakeBot', 'loopsbot', 'breezybot', 'echo', 'Sayaka',
+  'cc7', 'Yuna', 'ManifoldLove', 'a', 'bonkbot',
+  'NermitBundaloy', 'FirstBot', 'bawt', 'FireTheCEO', 'JointBot',
+  'WrenTec', 'TigerMcBot', 'Euclidean', 'manakin', 'LUCAtheory',
+  'TunglBot', 'timetraveler', 'bayesianbot', 'CharlesLienBot', 'JaguarMcBot',
+  'AImogus', 'HakariBot', 'brake', 'brontobot', 'OracleBot',
+  'spacedroplet', 'AriZernerBot', 'PV_bot', 'draaglom_bot', 'SiriusBOT',
+  'bradbot', 'ShrimpLute', 'kbot', 'ataribot', 'RISKBOT',
+  'harmonia', 'Dagonet', 'Galahad', 'zn_bot', 'abot',
+  'GoodheartLabsBot', 'Evansbot', 'PugBot', 'cot'
+);

--- a/backend/supabase/migrations/2026040101_add_users_is_bot.sql
+++ b/backend/supabase/migrations/2026040101_add_users_is_bot.sql
@@ -1,6 +1,6 @@
 alter table users add column if not exists is_bot boolean not null default false;
 
--- Seed from the existing BOT_USERNAMES list (109 entries, case-sensitive match)
+-- Seed from the existing BOT_USERNAMES list (116 entries, case-sensitive match)
 update users set is_bot = true
 where username in (
   'TenShinoBot', 'JDVance1', 'Merchant', 'benedict', 'subooferbot',
@@ -24,5 +24,7 @@ where username in (
   'spacedroplet', 'AriZernerBot', 'PV_bot', 'draaglom_bot', 'SiriusBOT',
   'bradbot', 'ShrimpLute', 'kbot', 'ataribot', 'RISKBOT',
   'harmonia', 'Dagonet', 'Galahad', 'zn_bot', 'abot',
-  'GoodheartLabsBot', 'Evansbot', 'PugBot', 'cot'
+  'GoodheartLabsBot', 'Evansbot', 'PugBot', 'cot',
+  'Cvillsbot', 'Gluten', 'Rice', 'Terminator2', 'XBot',
+  'pythia', 'timestwo'
 );

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1490,6 +1490,16 @@ export const API = (_apiTypeCheck = {
       context: JSONContent | undefined
     },
   },
+  'set-bot-status': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({
+      userId: z.string(),
+      isBot: z.boolean(),
+    }),
+    returns: {} as { success: boolean },
+  },
   'ban-user': {
     method: 'POST',
     visibility: 'undocumented',

--- a/common/src/api/user-types.ts
+++ b/common/src/api/user-types.ts
@@ -25,7 +25,7 @@ export function toUserAPIResponse(user: User): FullUser {
   return {
     ...user,
     url: `https://${ENV_CONFIG.domain}/${user.username}`,
-    isBot: BOT_USERNAMES.includes(user.username),
+    isBot: user.isBot ?? BOT_USERNAMES.includes(user.username),
     isAdmin: ENV_CONFIG.adminIds.includes(user.id),
     isTrustworthy: MOD_IDS.includes(user.id),
   }

--- a/common/src/envs/constants.ts
+++ b/common/src/envs/constants.ts
@@ -72,6 +72,7 @@ export const CORS_ORIGIN_VERCEL = new RegExp(
 export const CORS_ORIGIN_LOCALHOST = /^http:\/\/localhost:\d+$/
 
 // TODO: These should maybe be part of the env config?
+/** @deprecated Use is_bot column on users table. Kept only as fallback during transition. */
 export const BOT_USERNAMES = [
   'TenShinoBot',
   'JDVance1',

--- a/common/src/supabase/users.ts
+++ b/common/src/supabase/users.ts
@@ -43,6 +43,12 @@ export function convertUser(row: Row<'users'> | null): User | null {
     spiceBalance: row.spice_balance,
     totalDeposits: row.total_deposits,
     totalCashDeposits: row.total_cash_deposits,
+    isBot:
+      'is_bot' in row
+        ? (row as any).is_bot
+        : 'isBot' in row
+        ? (row as any).isBot
+        : undefined,
   } as User)
 }
 
@@ -54,7 +60,7 @@ export function convertPrivateUser(
   return row.data as PrivateUser
 }
 
-export const displayUserColumns = `id,name,username,data->>'avatarUrl' as "avatarUrl",data->'isBannedFromPosting' as "isBannedFromPosting"`
+export const displayUserColumns = `id,name,username,is_bot as "isBot",data->>'avatarUrl' as "avatarUrl",data->'isBannedFromPosting' as "isBannedFromPosting"`
 export const prefixedDisplayUserColumns = displayUserColumns
   .split(',')
   .map((col) => `u.${col}`)

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -112,6 +112,7 @@ export type User = {
   userDeleted?: boolean
   optOutBetWarnings?: boolean
   signupBonusPaid?: number
+  isBot?: boolean
   isAdvancedTrader?: boolean
   purchasedMana?: boolean
   verifiedPhone?: boolean

--- a/web/components/buttons/user-settings-button.tsx
+++ b/web/components/buttons/user-settings-button.tsx
@@ -8,6 +8,7 @@ import { User, UserBan } from 'common/user'
 import { buildArray } from 'common/util/array'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import { toast } from 'react-hot-toast'
 import { Button } from 'web/components/buttons/button'
 import { SimpleCopyTextButton } from 'web/components/buttons/copy-link-button'
 import {
@@ -37,6 +38,7 @@ export function UserSettingButton(props: { user: User }) {
   const [tabIndex, setTabIndex] = useState(0)
   const [showBanModal, setShowBanModal] = useState(false)
   const [bans, setBans] = useState<UserBan[]>([])
+  const [togglingBot, setTogglingBot] = useState(false)
   const isAdmin = useAdmin()
   const isTrusted = useTrusted()
   const numReferrals = useReferralCount(user)
@@ -131,6 +133,38 @@ export function UserSettingButton(props: { user: User }) {
                     onClick={() => setShowBanModal(true)}
                   >
                     Manage Bans
+                  </Button>
+                  <Button
+                    color={user.isBot ? 'green' : 'yellow'}
+                    size="xs"
+                    disabled={togglingBot}
+                    onClick={async () => {
+                      const confirmed = confirm(
+                        user.isBot
+                          ? `Remove bot status from ${user.username}?`
+                          : `Mark ${user.username} as a bot?`
+                      )
+                      if (!confirmed) return
+                      setTogglingBot(true)
+                      try {
+                        await api('set-bot-status', {
+                          userId,
+                          isBot: !user.isBot,
+                        })
+                        toast.success(
+                          user.isBot
+                            ? 'Bot status removed'
+                            : 'Marked as bot'
+                        )
+                        router.reload()
+                      } catch (e: any) {
+                        toast.error(e.message ?? 'Failed to update bot status')
+                      } finally {
+                        setTogglingBot(false)
+                      }
+                    }}
+                  >
+                    {user.isBot ? 'Unmark Bot' : 'Mark Bot'}
                   </Button>
                 </Row>
               )}

--- a/web/components/widgets/user-link.tsx
+++ b/web/components/widgets/user-link.tsx
@@ -279,6 +279,7 @@ export function RestrictedBadge({
 export function UserBadge(props: {
   userId: string
   username: string
+  isBot?: boolean
   fresh?: boolean
   marketCreator?: boolean
   entitlements?: UserEntitlement[]
@@ -289,6 +290,7 @@ export function UserBadge(props: {
   const {
     userId,
     username,
+    isBot,
     fresh,
     marketCreator,
     entitlements,
@@ -308,7 +310,7 @@ export function UserBadge(props: {
     : false
 
   const badges = []
-  if (BOT_USERNAMES.includes(username)) {
+  if (isBot ?? BOT_USERNAMES.includes(username)) {
     badges.push(<BotBadge key="bot" />)
   }
   if (ENV_CONFIG.adminIds.includes(userId)) {


### PR DESCRIPTION
Adds is_bot column to users table with mod/admin toggle endpoint, replacing the 109-entry hardcoded username list that required PRs to update.

- Migration: adds is_bot column, seeds existing bot usernames
- New set-bot-status API endpoint (mod/admin gated)
- Backend queries use is_bot column instead of BOT_USERNAMES array
- Frontend: Mark Bot / Unmark Bot button in user settings modal
- BOT_USERNAMES kept as fallback during transition, marked @deprecated