### PR TITLE
feat: add Manifest 2026 ticket shop items

### DIFF
--- a/backend/api/src/get-ticket-orders.ts
+++ b/backend/api/src/get-ticket-orders.ts
@@ -1,0 +1,58 @@
+import { type APIHandler } from './helpers/endpoint'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+
+export const getTicketOrders: APIHandler<'get-ticket-orders'> = async (
+  { itemId },
+  auth
+) => {
+  throwErrorIfNotAdmin(auth.uid)
+
+  const pg = createSupabaseDirectClient()
+
+  const itemFilter = itemId ? `AND so.item_id = $1` : `AND so.item_id = 'manifest-ticket'`
+  const params = itemId ? [itemId] : []
+
+  const rows = await pg.manyOrNone<{
+    id: string
+    user_id: string
+    username: string
+    display_name: string
+    email: string | null
+    item_id: string
+    price_mana: string
+    status: string
+    created_time: Date
+  }>(
+    `SELECT
+       so.id,
+       so.user_id,
+       u.username,
+       u.data->>'name' as display_name,
+       pu.data->>'email' as email,
+       so.item_id,
+       so.price_mana,
+       so.status,
+       so.created_time
+     FROM shop_orders so
+     JOIN users u ON u.id = so.user_id
+     LEFT JOIN private_users pu ON pu.id = so.user_id
+     WHERE 1=1 ${itemFilter}
+     ORDER BY so.created_time DESC`,
+    params
+  )
+
+  const orders = rows.map((row) => ({
+    id: row.id,
+    userId: row.user_id,
+    username: row.username,
+    displayName: row.display_name ?? row.username,
+    email: row.email,
+    itemId: row.item_id,
+    priceMana: Number(row.price_mana),
+    status: row.status,
+    createdTime: new Date(row.created_time).getTime(),
+  }))
+
+  return { orders, total: orders.length }
+}

--- a/backend/api/src/get-ticket-stock.ts
+++ b/backend/api/src/get-ticket-stock.ts
@@ -1,0 +1,27 @@
+import { APIError, type APIHandler } from './helpers/endpoint'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { getShopItem, isTicketItem } from 'common/shop/items'
+
+export const getTicketStock: APIHandler<'get-ticket-stock'> = async ({
+  itemId,
+}) => {
+  const item = getShopItem(itemId)
+  if (!item || !isTicketItem(item)) {
+    throw new APIError(404, 'Ticket item not found')
+  }
+  const maxStock = item.maxStock ?? 0
+
+  const pg = createSupabaseDirectClient()
+  const { count } = await pg.one<{ count: number }>(
+    `SELECT count(*)::int AS count FROM shop_orders
+     WHERE item_id = $1
+     AND status NOT IN ('FAILED', 'REFUNDED', 'CANCELLED')`,
+    [itemId]
+  )
+
+  return {
+    sold: count,
+    maxStock,
+    available: Math.max(0, maxStock - count),
+  }
+}

--- a/backend/api/src/get-user-ticket-purchased.ts
+++ b/backend/api/src/get-user-ticket-purchased.ts
@@ -1,0 +1,20 @@
+import { type APIHandler } from './helpers/endpoint'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { getTicketItems } from 'common/shop/items'
+
+export const getUserTicketPurchased: APIHandler<
+  'get-user-ticket-purchased'
+> = async (_props, auth) => {
+  // Returns true if the user has purchased ANY Manifest ticket — all variants
+  // share one purchase slot (early-bird blocks standard and vice versa).
+  const pg = createSupabaseDirectClient()
+  const allTicketIds = getTicketItems().map((t) => t.id)
+  const row = await pg.oneOrNone(
+    `SELECT 1 FROM shop_orders
+     WHERE user_id = $1 AND item_id = ANY($2::text[])
+     AND status NOT IN ('FAILED', 'REFUNDED', 'CANCELLED')
+     LIMIT 1`,
+    [auth.uid, allTicketIds]
+  )
+  return { purchased: !!row }
+}

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -258,6 +258,10 @@ import { referUser } from './refer-user'
 import { shopCancelSubscription } from './shop-cancel-subscription'
 import { shopPurchase } from './shop-purchase'
 import { shopPurchaseMerch } from './shop-purchase-merch'
+import { shopPurchaseTicket } from './shop-purchase-ticket'
+import { getTicketStock } from './get-ticket-stock'
+import { getTicketOrders } from './get-ticket-orders'
+import { getUserTicketPurchased } from './get-user-ticket-purchased'
 import { shopResetAll } from './shop-reset-all'
 import { shopShippingRates } from './shop-shipping-rates'
 import { shopToggle } from './shop-toggle'
@@ -524,6 +528,10 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'get-shop-stats': getShopStats,
   'shop-purchase': shopPurchase,
   'shop-purchase-merch': shopPurchaseMerch,
+  'shop-purchase-ticket': shopPurchaseTicket,
+  'get-ticket-stock': getTicketStock,
+  'get-ticket-orders': getTicketOrders,
+  'get-user-ticket-purchased': getUserTicketPurchased,
   'shop-shipping-rates': shopShippingRates,
   'shop-reset-all': shopResetAll,
   'shop-toggle': shopToggle,

--- a/backend/api/src/shop-purchase-ticket.ts
+++ b/backend/api/src/shop-purchase-ticket.ts
@@ -1,0 +1,128 @@
+import { APIError, type APIHandler } from './helpers/endpoint'
+import { runTxnOutsideBetQueue, type TxnData } from 'shared/txn/run-txn'
+import { runTransactionWithRetries } from 'shared/transact-with-retries'
+import { getUser } from 'shared/utils'
+import { getShopItem, getTicketItems, isTicketItem } from 'common/shop/items'
+import { betsQueue } from 'shared/helpers/fn-queue'
+import { getActiveSupporterEntitlements } from 'shared/supabase/entitlements'
+import { getBenefit } from 'common/supporter-config'
+
+export const shopPurchaseTicket: APIHandler<'shop-purchase-ticket'> = async (
+  { itemId },
+  auth
+) => {
+  const item = getShopItem(itemId)
+  if (!item) throw new APIError(404, 'Item not found')
+  if (!isTicketItem(item)) throw new APIError(400, 'Item is not a ticket')
+  if (item.comingSoon) throw new APIError(403, 'This ticket is not yet available')
+  if (!auth) throw new APIError(401, 'Must be logged in')
+
+  // Serialize ALL ticket purchases for this item globally (not per-user) so two
+  // different users racing for the last slot can't both pass the stock check.
+  const { orderId, remainingStock } = await betsQueue.enqueueFn(
+    () =>
+      runTransactionWithRetries(async (tx) => {
+        const user = await getUser(auth.uid, tx)
+        if (!user) throw new APIError(401, 'Your account was not found')
+        if (user.isBannedFromPosting)
+          throw new APIError(403, 'Your account is banned')
+
+        // One-per-user check across ALL ticket variants — buying early-bird
+        // blocks standard (and vice versa). Unique partial index handles the
+        // same-item case; this handles cross-variant.
+        const allTicketIds = getTicketItems().map((t) => t.id)
+        const existing = await tx.oneOrNone(
+          `SELECT item_id FROM shop_orders
+           WHERE user_id = $1 AND item_id = ANY($2::text[])
+           AND status NOT IN ('FAILED', 'REFUNDED', 'CANCELLED')
+           LIMIT 1`,
+          [auth.uid, allTicketIds]
+        )
+        if (existing) {
+          throw new APIError(
+            403,
+            'You have already purchased a Manifest ticket (limit 1 per person)'
+          )
+        }
+
+        // Global stock check. Safe without FOR UPDATE because betsQueue serializes
+        // all ticket purchases for this itemId, and runTransactionWithRetries uses
+        // serializable isolation as a backstop.
+        if (item.maxStock) {
+          const { count } = await tx.one<{ count: number }>(
+            `SELECT count(*)::int AS count FROM shop_orders
+             WHERE item_id = $1
+             AND status NOT IN ('FAILED', 'REFUNDED', 'CANCELLED')`,
+            [itemId]
+          )
+          if (count >= item.maxStock) {
+            throw new APIError(403, 'Sold out — all tickets have been claimed')
+          }
+        }
+
+        const supporterEntitlements = await getActiveSupporterEntitlements(
+          tx,
+          auth.uid
+        )
+        const shopDiscount = getBenefit(
+          supporterEntitlements,
+          'shopDiscount',
+          0
+        )
+        const price =
+          shopDiscount > 0
+            ? Math.floor(item.price * (1 - shopDiscount))
+            : item.price
+
+        if (user.balance < price) {
+          throw new APIError(403, 'Insufficient balance')
+        }
+
+        const discountPct = Math.round(shopDiscount * 100)
+        const description =
+          discountPct > 0
+            ? `Purchased ${item.name} (${discountPct}% supporter discount)`
+            : `Purchased ${item.name}`
+
+        const txnData: TxnData = {
+          category: 'SHOP_PURCHASE',
+          fromType: 'USER',
+          fromId: auth.uid,
+          toType: 'BANK',
+          toId: 'BANK',
+          amount: price,
+          token: 'M$',
+          description,
+          data: { itemId, ticketOrder: true, supporterDiscount: shopDiscount },
+        }
+        const txn = await runTxnOutsideBetQueue(tx, txnData)
+
+        const order = await tx.one<{ id: string }>(
+          `INSERT INTO shop_orders (user_id, item_id, price_mana, txn_id, status)
+           VALUES ($1, $2, $3, $4, 'COMPLETED')
+           RETURNING id`,
+          [auth.uid, itemId, price, txn.id]
+        )
+
+        const { count: newCount } = await tx.one<{ count: number }>(
+          `SELECT count(*)::int AS count FROM shop_orders
+           WHERE item_id = $1
+           AND status NOT IN ('FAILED', 'REFUNDED', 'CANCELLED')`,
+          [itemId]
+        )
+
+        return {
+          orderId: order.id,
+          remainingStock: Math.max(0, (item.maxStock ?? 0) - newCount),
+        }
+      }),
+    [`ticket:${itemId}`]
+  )
+
+  return {
+    success: true,
+    orderId,
+    discountCode: process.env.MANIFEST_DISCOUNT_CODE ?? null,
+    remainingStock,
+  }
+}

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -3735,6 +3735,57 @@ export const API = (_apiTypeCheck = {
     props: z.object({}).strict(),
     returns: {} as { success: boolean; refundedAmount: number },
   },
+  'shop-purchase-ticket': {
+    method: 'POST',
+    visibility: 'public',
+    authed: true,
+    props: z
+      .object({
+        itemId: z.string(),
+      })
+      .strict(),
+    returns: {} as {
+      success: boolean
+      orderId: string
+      discountCode: string | null
+      remainingStock: number
+    },
+  },
+  'get-ticket-stock': {
+    method: 'GET',
+    visibility: 'public',
+    authed: false,
+    cache: 'public, max-age=2, stale-while-revalidate=10',
+    props: z.object({ itemId: z.string() }).strict(),
+    returns: {} as { sold: number; maxStock: number; available: number },
+  },
+  'get-user-ticket-purchased': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({}).strict(),
+    returns: {} as { purchased: boolean },
+  },
+  'get-ticket-orders': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({ itemId: z.string().optional() }).strict(),
+    returns: {} as {
+      orders: Array<{
+        id: string
+        userId: string
+        username: string
+        displayName: string
+        email: string | null
+        itemId: string
+        priceMana: number
+        status: string
+        createdTime: number
+      }>
+      total: number
+    },
+  },
   'shop-purchase-merch': {
     method: 'POST',
     visibility: 'public',

--- a/common/src/secrets.ts
+++ b/common/src/secrets.ts
@@ -48,6 +48,7 @@ export const secrets = (
     'DAIMO_HOT_WALLET_ADDRESS',
     'IP_API_PRO_KEY',
     'PRINTFUL_API_TOKEN',
+    'MANIFEST_DISCOUNT_CODE',
     // Some typescript voodoo to keep the string literal types while being not readonly.
   ] as const
 ).concat()

--- a/common/src/shop/items.ts
+++ b/common/src/shop/items.ts
@@ -16,6 +16,7 @@ export type ShopItemCategory =
   | 'consumable'
   | 'hovercard'
   | 'merch'
+  | 'ticket'
 
 // Merch size variant for clothing items
 export type MerchVariant = {
@@ -100,6 +101,7 @@ export const CATEGORY_LABELS: Record<ShopItemCategory, string> = {
   consumable: 'Consumable',
   hovercard: 'Hovercard',
   merch: 'Merch',
+  ticket: 'Ticket',
 }
 
 // Get all entitlement IDs for items in a given category
@@ -172,6 +174,10 @@ export type ShopItem = {
   animationTypes?: AnimationType[]
   // If true, item is hidden from shop unless user owns it
   hidden?: boolean
+  // Global stock cap — total active purchases across all users (optional)
+  maxStock?: number
+  // If true, item is shown in UI but not purchasable (for "coming soon" states)
+  comingSoon?: boolean
   // Merch-specific fields
   variants?: MerchVariant[]
   // Image carousel for merch cards: [{label, url}, ...]
@@ -840,7 +846,39 @@ export const SHOP_ITEMS: ShopItem[] = [
       { size: 'One Size', printfulSyncVariantId: '699c786e6c50b2' },
     ],
   },
+
+  // Tickets
+  {
+    id: 'manifest-ticket',
+    name: 'Manifest 2026 — Early Bird Ticket',
+    description:
+      'Claim your spot at Manifest 2026 — Lighthaven, Berkeley · June 12–14. You will receive a 100% off early-bird discount code, redeemable on manifest.is. Limited to the first 10 Manifold early-bird claims — more tickets at standard pricing will be added later. Code is single-use and non-transferable; the email on your manifest.is ticket must match your Manifold email.',
+    price: 55000,
+    type: 'instant',
+    limit: 'one-time',
+    category: 'ticket',
+    slot: 'unique',
+    maxStock: 10,
+  },
+  {
+    id: 'manifest-ticket-standard',
+    name: 'Manifest 2026 — Standard Ticket',
+    description:
+      'Standard-pricing discount code for Manifest 2026 — Lighthaven, Berkeley · June 12–14. Available after early-bird sells out.',
+    price: 67500,
+    type: 'instant',
+    limit: 'one-time',
+    category: 'ticket',
+    slot: 'unique',
+    comingSoon: true,
+  },
 ]
+
+export const getTicketItems = (): ShopItem[] =>
+  SHOP_ITEMS.filter((item) => item.category === 'ticket')
+
+export const isTicketItem = (item: ShopItem): boolean =>
+  item.category === 'ticket'
 
 // Available options for custom button text
 export const YES_BUTTON_OPTIONS = [

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -48,6 +48,9 @@ export const SPEND_MANA_ENABLED = true
 // Set to true to show a "NEW" badge on the Shop nav item
 const SHOW_SHOP_NEW_BADGE = false
 
+// Set to true to show a "Manifest" badge on the Shop nav item (early-bird tickets)
+const SHOW_SHOP_MANIFEST_BADGE = true
+
 const BADGE_COLORS = [
   'bg-red-500 text-white',
   'bg-amber-400 text-amber-900',
@@ -275,7 +278,14 @@ const getDesktopNav = (
         name: 'Shop',
         href: '/shop',
         icon: LuGem,
-        children: SHOW_SHOP_NEW_BADGE ? (
+        children: SHOW_SHOP_MANIFEST_BADGE ? (
+          <>
+            Shop
+            <span className="ml-2 rounded-full bg-blue-500 px-2 py-0.5 text-xs font-medium text-white">
+              Manifest
+            </span>
+          </>
+        ) : SHOW_SHOP_NEW_BADGE ? (
           <>
             Shop
             <span className="ml-2 rounded-full bg-amber-400 px-1.5 py-0.5 text-[10px] font-bold text-amber-900">
@@ -346,7 +356,14 @@ const getMobileNav = (
       name: 'Shop',
       href: '/shop',
       icon: LuGem,
-      children: SHOW_SHOP_NEW_BADGE ? (
+      children: SHOW_SHOP_MANIFEST_BADGE ? (
+        <>
+          Shop
+          <span className="ml-2 rounded-full bg-blue-500 px-2 py-0.5 text-xs font-medium text-white">
+            Manifest
+          </span>
+        </>
+      ) : SHOW_SHOP_NEW_BADGE ? (
         <>
           Shop
           <span className="ml-2 rounded-full bg-amber-400 px-1.5 py-0.5 text-[10px] font-bold text-amber-900">

--- a/web/pages/admin/index.tsx
+++ b/web/pages/admin/index.tsx
@@ -72,6 +72,7 @@ export default function AdminPage() {
         </Row>
 
         <LabCard title="🧾 sales" href="/admin/sales" />
+        <LabCard title="🎟️ manifest tickets" href="/admin/tickets" />
         <LabCard title="🆕 new users" href="/admin/new-users" />
         <LabCard title="🎁 prize payouts" href="/admin/prize" />
         <LabCard title="🐋 whales" href="/admin/whales" />

--- a/web/pages/admin/tickets.tsx
+++ b/web/pages/admin/tickets.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import { Page } from 'web/components/layout/page'
+import { Col } from 'web/components/layout/col'
+import { Row } from 'web/components/layout/row'
+import { Title } from 'web/components/widgets/title'
+import { NoSEO } from 'web/components/NoSEO'
+import { Button } from 'web/components/buttons/button'
+import { useAdmin } from 'web/hooks/use-admin'
+import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
+import { useAPIGetter } from 'web/hooks/use-api-getter'
+import { formatMoney } from 'common/util/format'
+import Link from 'next/link'
+
+export default function AdminTicketsPage() {
+  useRedirectIfSignedOut()
+  const isAdmin = useAdmin()
+
+  const { data, loading } = useAPIGetter('get-ticket-orders', {
+    itemId: 'manifest-ticket',
+  })
+  const { data: stockData } = useAPIGetter('get-ticket-stock', {
+    itemId: 'manifest-ticket',
+  })
+
+  const [copying, setCopying] = useState(false)
+
+  if (!isAdmin) return <></>
+
+  const orders = data?.orders ?? []
+
+  const copyEmails = async () => {
+    const emails = orders
+      .map((o) => o.email)
+      .filter((e): e is string => !!e)
+      .join(', ')
+    if (!emails) {
+      toast.error('No emails to copy')
+      return
+    }
+    setCopying(true)
+    try {
+      await navigator.clipboard.writeText(emails)
+      toast.success(`Copied ${orders.length} email${orders.length === 1 ? '' : 's'}`)
+    } catch {
+      toast.error('Copy failed')
+    } finally {
+      setCopying(false)
+    }
+  }
+
+  return (
+    <Page trackPageView="admin tickets page">
+      <NoSEO />
+      <Col className="mx-8 gap-6">
+        <Title>Manifest Ticket Orders</Title>
+
+        <div className="rounded-lg bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+          <span className="text-amber-700 dark:text-amber-300">
+            Refresh the page before taking action — data does not live-update.
+          </span>
+        </div>
+
+        {stockData && (
+          <Row className="items-center gap-4">
+            <div className="text-lg">
+              <b>{stockData.sold}</b> of <b>{stockData.maxStock}</b> tickets
+              sold
+            </div>
+            <div className="text-ink-500">
+              ({stockData.available} remaining)
+            </div>
+          </Row>
+        )}
+
+        <Row className="gap-2">
+          <Button color="indigo" onClick={copyEmails} disabled={copying || orders.length === 0}>
+            Copy all emails
+          </Button>
+        </Row>
+
+        {loading && <div className="text-ink-500">Loading…</div>}
+
+        {!loading && orders.length === 0 && (
+          <div className="text-ink-500">No ticket orders yet.</div>
+        )}
+
+        {orders.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-ink-200 border-b text-left">
+                  <th className="px-3 py-2">Date</th>
+                  <th className="px-3 py-2">User</th>
+                  <th className="px-3 py-2">Email</th>
+                  <th className="px-3 py-2">Amount</th>
+                  <th className="px-3 py-2">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orders.map((o) => (
+                  <tr
+                    key={o.id}
+                    className="border-ink-200 border-b last:border-b-0"
+                  >
+                    <td className="whitespace-nowrap px-3 py-2">
+                      {new Date(o.createdTime).toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2">
+                      <Link
+                        href={`/${o.username}`}
+                        className="text-primary-700 hover:underline"
+                      >
+                        {o.displayName || o.username}
+                      </Link>
+                      <div className="text-ink-500 text-xs">@{o.username}</div>
+                    </td>
+                    <td className="px-3 py-2 font-mono text-xs">
+                      {o.email ?? '—'}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2">
+                      {formatMoney(o.priceMana)}
+                    </td>
+                    <td className="px-3 py-2">{o.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Col>
+    </Page>
+  )
+}

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -17,11 +17,11 @@ import {
   YesButtonOption,
   NoButtonOption,
   SLOT_LABELS,
-  getCompatibleSlots,
   EXCLUSIVE_SLOTS,
   getEntitlementIdsForSlot,
   CROWN_POSITION_OPTIONS,
   getMerchItems,
+  getTicketItems,
 } from 'common/shop/items'
 import { UserEntitlement } from 'common/shop/types'
 import { User } from 'common/user'
@@ -81,7 +81,7 @@ import {
 import { Card } from 'web/components/widgets/card'
 import { InfoTooltip } from 'web/components/widgets/info-tooltip'
 import { FullscreenConfetti } from 'web/components/widgets/fullscreen-confetti'
-import { useUser } from 'web/hooks/use-user'
+import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { useAdminOrMod } from 'web/hooks/use-admin'
 import { useOptimisticEntitlements } from 'web/hooks/use-optimistic-entitlements'
 import { api } from 'web/lib/api/api'
@@ -154,6 +154,7 @@ type FilterOption =
   | 'buttons'
   | 'other'
   | 'merch'
+  | 'ticket'
   | 'seasonal'
 
 const FILTER_CONFIG: Record<
@@ -170,6 +171,7 @@ const FILTER_CONFIG: Record<
   buttons: { label: 'Buttons', slots: ['button-yes', 'button-no'] },
   other: { label: 'Other', slots: ['consumable', 'badge'] },
   merch: { label: 'Merch', slots: [], special: true },
+  ticket: { label: 'Tickets', slots: [], special: true },
   seasonal: { label: 'Seasonal', slots: [], special: true },
 }
 
@@ -178,6 +180,7 @@ const filterItems = (items: ShopItem[], filter: FilterOption): ShopItem[] => {
   if (filter === 'seasonal')
     return items.filter((item) => item.seasonalAvailability)
   if (filter === 'merch') return [] // merch handled by separate section
+  if (filter === 'ticket') return [] // tickets handled by separate section
   const allowedSlots = FILTER_CONFIG[filter].slots
   return items.filter((item) => allowedSlots.includes(item.slot))
 }
@@ -192,6 +195,9 @@ const hasVisibleItems = (
   if (filter === 'all') return true
   if (filter === 'merch') {
     return getMerchItems().some((item) => !item.hidden || showHidden)
+  }
+  if (filter === 'ticket') {
+    return getTicketItems().some((item) => !item.hidden || showHidden)
   }
   if (filter === 'seasonal') {
     return allItems.some(
@@ -624,8 +630,26 @@ export default function ShopPage() {
           })}
         </Row>
 
-        {/* Shop items grid — hidden when merch filter is active */}
-        {filterOption !== 'merch' && (
+        {/* Tickets — shown first on 'all' and 'ticket' filters */}
+        {(filterOption === 'all' || filterOption === 'ticket') &&
+          getTicketItems().filter((item) => !item.hidden || showHidden).length >
+            0 && (
+            <div className="mb-4 grid grid-cols-1 gap-4 min-[480px]:grid-cols-2">
+              {getTicketItems()
+                .filter((item) => !item.hidden || showHidden)
+                .map((item) => (
+                  <TicketItemCard
+                    key={item.id}
+                    item={item}
+                    user={user}
+                    allEntitlements={effectiveEntitlements}
+                  />
+                ))}
+            </div>
+          )}
+
+        {/* Shop items grid — hidden when merch or ticket filter is active */}
+        {filterOption !== 'merch' && filterOption !== 'ticket' && (
           <div className="grid grid-cols-1 gap-4 min-[480px]:grid-cols-2">
             {sortItems(
               filterItems(
@@ -636,6 +660,7 @@ export default function ShopPage() {
                     ) &&
                     item.id !== 'charity-champion-trophy' &&
                     item.category !== 'merch' &&
+                    item.category !== 'ticket' &&
                     (!item.hidden ||
                       showHidden ||
                       ownedItemIds.has(getEntitlementId(item)) ||
@@ -703,6 +728,7 @@ export default function ShopPage() {
               </div>
             </>
           )}
+
 
         {/* Charity giveaway and champion cards */}
         <div className="mt-8 grid gap-4 sm:grid-cols-2">
@@ -783,6 +809,393 @@ type ShippingRate = {
   currency: string
   minDeliveryDays: number
   maxDeliveryDays: number
+}
+
+function TicketItemCard(props: {
+  item: ShopItem
+  user: User | null | undefined
+  allEntitlements?: UserEntitlement[]
+}) {
+  const { item, user, allEntitlements } = props
+  const shopDiscount = getBenefit(allEntitlements, 'shopDiscount', 0)
+  const discountedPrice =
+    shopDiscount > 0 ? Math.floor(item.price * (1 - shopDiscount)) : item.price
+  const hasDiscount = shopDiscount > 0
+  const [showPurchaseModal, setShowPurchaseModal] = useState(false)
+  const [purchasing, setPurchasing] = useState(false)
+  const [acceptedTerms, setAcceptedTerms] = useState(false)
+  const privateUser = usePrivateUser()
+  const userEmail = privateUser?.email ?? null
+  const [purchaseResult, setPurchaseResult] = useState<{
+    discountCode: string | null
+    remainingStock: number
+  } | null>(null)
+  const [doneCountdown, setDoneCountdown] = useState(10)
+
+  useEffect(() => {
+    if (!purchaseResult) {
+      setDoneCountdown(10)
+      return
+    }
+    if (doneCountdown <= 0) return
+    const t = setTimeout(() => setDoneCountdown((c) => c - 1), 1000)
+    return () => clearTimeout(t)
+  }, [purchaseResult, doneCountdown])
+
+  const {
+    data: stockData,
+    refresh: refreshStock,
+  } = useAPIGetter('get-ticket-stock', { itemId: item.id })
+
+  const { data: purchasedData, refresh: refreshPurchased } = useAPIGetter(
+    'get-user-ticket-purchased',
+    {},
+    undefined,
+    undefined,
+    !!user
+  )
+  const alreadyPurchased = !!purchasedData?.purchased
+
+  const available = stockData?.available ?? null
+  const maxStock = stockData?.maxStock ?? item.maxStock ?? 0
+  const soldOut = available !== null && available <= 0
+  const comingSoon = !!item.comingSoon
+  const canPurchase =
+    user &&
+    user.balance >= discountedPrice &&
+    !soldOut &&
+    !comingSoon &&
+    !alreadyPurchased
+
+  const handleBuy = async () => {
+    if (!acceptedTerms) {
+      toast.error('Please accept the terms')
+      return
+    }
+    setPurchasing(true)
+    try {
+      const result = await api('shop-purchase-ticket', {
+        itemId: item.id,
+      })
+      setPurchaseResult({
+        discountCode: result.discountCode,
+        remainingStock: result.remainingStock,
+      })
+      toast.success('Ticket purchased!')
+    } catch (e: unknown) {
+      toast.error(
+        e instanceof Error ? e.message : 'Failed to purchase ticket'
+      )
+    } finally {
+      setPurchasing(false)
+      refreshStock()
+      refreshPurchased?.()
+    }
+  }
+
+  const closeAndReset = () => {
+    setShowPurchaseModal(false)
+    setPurchaseResult(null)
+    setAcceptedTerms(false)
+  }
+
+  const pctClaimed =
+    maxStock > 0 && available !== null
+      ? Math.round(((maxStock - available) / maxStock) * 100)
+      : 0
+
+  return (
+    <>
+      <div
+        className={clsx(
+          'bg-canvas-0 text-ink-900 relative overflow-hidden rounded-xl border-2 shadow-sm',
+          comingSoon
+            ? 'border-ink-300 opacity-80'
+            : 'border-amber-400'
+        )}
+      >
+        {/* Top banner */}
+        <div
+          className={clsx(
+            'flex items-center justify-between px-4 py-1.5 text-xs font-bold uppercase tracking-widest',
+            comingSoon
+              ? 'bg-gradient-to-r from-indigo-500 to-indigo-400 text-indigo-950'
+              : 'bg-gradient-to-r from-amber-500 to-amber-400 text-amber-950'
+          )}
+        >
+          <span>
+            {comingSoon ? '⏳ Standard — Available Soon' : 'Early Bird'}
+          </span>
+          {soldOut && !comingSoon && (
+            <span className="text-scarlet-800">Sold Out</span>
+          )}
+        </div>
+
+        {/* Decorative header with title */}
+        <Col
+          className={clsx(
+            'items-center justify-center gap-1 px-4 py-6 text-center',
+            comingSoon
+              ? 'bg-canvas-50'
+              : 'bg-amber-200/50 dark:bg-amber-500/10'
+          )}
+        >
+          <div
+            className={clsx(
+              'text-sm font-semibold uppercase tracking-widest',
+              comingSoon ? 'text-ink-500' : 'text-amber-700 dark:text-amber-500'
+            )}
+          >
+            Manifest 2026
+          </div>
+          <div className="text-lg font-bold leading-tight">
+            {comingSoon ? 'Standard Ticket' : 'Early Bird Ticket'}
+          </div>
+        </Col>
+
+        {/* Details */}
+        <Col className="gap-3 p-4">
+          <Row className="text-ink-600 flex-wrap gap-x-3 gap-y-0.5 text-xs">
+            <span>📍 Lighthaven</span>
+            <span>📅 Jun 12–14</span>
+          </Row>
+
+          <div className="text-ink-700 text-xs leading-relaxed">
+            Full access to Manifest, Friday through Sunday. 5 meals included.
+            Get a{' '}
+            <b
+              className={
+                comingSoon
+                  ? 'text-ink-900'
+                  : 'text-amber-700 dark:text-amber-500'
+              }
+            >
+              100% off code
+            </b>{' '}
+            for{' '}
+            <a
+              href="https://manifest.is"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-700 dark:text-primary-500 underline"
+            >
+              manifest.is
+            </a>
+            .
+          </div>
+
+          {/* Stock progress (early bird only) */}
+          {!comingSoon && available !== null && (
+            <Col className="gap-1">
+              <Row className="text-ink-600 justify-between text-[11px]">
+                <span>
+                  {maxStock - available}/{maxStock} claimed
+                </span>
+                <span className="text-amber-700 dark:text-amber-500">
+                  {available} left
+                </span>
+              </Row>
+              <div className="bg-ink-200 h-1.5 overflow-hidden rounded-full">
+                <div
+                  className="h-full bg-gradient-to-r from-amber-500 to-amber-400 transition-all"
+                  style={{ width: `${pctClaimed}%` }}
+                />
+              </div>
+            </Col>
+          )}
+
+          {/* Price + CTA */}
+          <Col className="mt-auto gap-2">
+            <Row className="items-baseline justify-between">
+              <div className="text-ink-500 text-[10px] uppercase tracking-wider">
+                {comingSoon ? 'Price' : 'Your cost'}
+              </div>
+              <Row className="items-baseline gap-2">
+                {hasDiscount && (
+                  <span className="text-ink-500 text-sm line-through opacity-70">
+                    {formatMoney(item.price)}
+                  </span>
+                )}
+                <div className="text-ink-900 text-xl font-bold">
+                  {formatMoney(discountedPrice)}
+                </div>
+              </Row>
+            </Row>
+            <Button
+              color={comingSoon ? 'gray' : 'amber'}
+              size="sm"
+              disabled={!canPurchase}
+              onClick={() => setShowPurchaseModal(true)}
+            >
+              {comingSoon
+                ? 'Available Soon'
+                : alreadyPurchased
+                ? 'Purchased'
+                : soldOut
+                ? 'Sold Out'
+                : !user
+                ? 'Sign in to claim'
+                : user.balance < discountedPrice
+                ? 'Insufficient balance'
+                : 'Claim Early Bird Code'}
+            </Button>
+          </Col>
+        </Col>
+      </div>
+
+      <Modal
+        open={showPurchaseModal}
+        setOpen={(open) => {
+          if (!open) {
+            // Block accidental dismissal while mid-purchase or during countdown
+            if (purchasing) return
+            if (purchaseResult && doneCountdown > 0) return
+            closeAndReset()
+          }
+        }}
+        size="md"
+      >
+        <Col className="bg-canvas-0 gap-4 rounded-md p-6">
+          {purchaseResult ? (
+            <>
+              <div className="text-lg font-semibold">
+                {purchaseResult.discountCode
+                  ? 'Your discount code'
+                  : 'Purchase successful'}
+              </div>
+              {purchaseResult.discountCode ? (
+                <Row className="items-stretch gap-2">
+                  <div className="flex flex-1 items-center justify-center rounded-lg border-2 border-teal-500 bg-white p-4">
+                    <div className="text-2xl font-bold tracking-widest text-teal-700">
+                      {purchaseResult.discountCode}
+                    </div>
+                  </div>
+                  <Button
+                    color="indigo"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(
+                          purchaseResult.discountCode!
+                        )
+                        toast.success('Code copied!')
+                      } catch {
+                        toast.error('Copy failed')
+                      }
+                    }}
+                  >
+                    Copy
+                  </Button>
+                </Row>
+              ) : (
+                <div className="border-scarlet-400 bg-scarlet-100 dark:border-scarlet-500/50 dark:bg-scarlet-500/20 rounded-lg border-2 p-4 text-sm leading-relaxed">
+                  <div className="text-scarlet-900 dark:text-scarlet-100 font-semibold">
+                    Your purchase was successful, but we couldn't find a code.
+                  </div>
+                  <div className="text-scarlet-800 dark:text-scarlet-200 mt-1">
+                    Contact{' '}
+                    <a
+                      href="mailto:tod@manifold.markets"
+                      className="font-semibold underline"
+                    >
+                      tod@manifold.markets
+                    </a>{' '}
+                    or{' '}
+                    <Link href="/Genzy" className="font-semibold underline">
+                      @Genzy
+                    </Link>{' '}
+                    on site to get your code.
+                  </div>
+                </div>
+              )}
+              <div className="rounded-lg bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+                <div className="font-semibold text-amber-800 dark:text-amber-200">
+                  Important:
+                </div>
+                <ul className="ml-4 mt-1 list-disc space-y-1 text-amber-700 dark:text-amber-300">
+                  <li>
+                    This code is <b>single-use per person</b>.
+                  </li>
+                  <li>
+                    <b>Non-transferable</b> — the email on your manifest.is
+                    ticket must match your Manifold email.
+                  </li>
+                  <li>
+                    Apply it at checkout on the Manifest ticket page for 100%
+                    off.
+                  </li>
+                  <li>
+                    Save this code now — it will not be shown again.
+                  </li>
+                </ul>
+              </div>
+              <div className="text-ink-500 text-sm">
+                {purchaseResult.remainingStock} ticket
+                {purchaseResult.remainingStock === 1 ? '' : 's'} remaining.
+              </div>
+              <Button
+                color="indigo"
+                disabled={doneCountdown > 0}
+                onClick={closeAndReset}
+              >
+                {doneCountdown > 0 ? `Done (${doneCountdown})` : 'Done'}
+              </Button>
+            </>
+          ) : (
+            <>
+              <div className="text-lg font-semibold">Buy {item.name}</div>
+              <div className="text-ink-600 text-sm">
+                You will be charged {formatMoney(discountedPrice)}
+                {hasDiscount && ' (supporter discount applied)'} and receive a
+                100%-off discount code for Manifest 2026.
+              </div>
+              <Col className="gap-1">
+                <div className="text-sm font-medium">Your email</div>
+                <div className="bg-canvas-50 border-ink-200 rounded border px-3 py-2 text-sm font-mono">
+                  {userEmail ?? '—'}
+                </div>
+                <div className="text-ink-500 text-xs">
+                  The email on your manifest.is ticket must match this email,
+                  or it may be invalidated. Contact{' '}
+                  <a
+                    href="mailto:info@manifold.markets"
+                    className="underline"
+                  >
+                    info@manifold.markets
+                  </a>{' '}
+                  if this is an issue.
+                </div>
+              </Col>
+              <label className="flex cursor-pointer items-start gap-2 rounded-lg bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+                <input
+                  type="checkbox"
+                  checked={acceptedTerms}
+                  onChange={(e) => setAcceptedTerms(e.target.checked)}
+                  className="mt-0.5"
+                />
+                <span className="text-amber-700 dark:text-amber-300">
+                  I understand the discount code is single-use and
+                  non-transferable.
+                </span>
+              </label>
+              <Row className="justify-end gap-2">
+                <Button color="gray" onClick={closeAndReset}>
+                  Cancel
+                </Button>
+                <Button
+                  color="indigo"
+                  loading={purchasing}
+                  disabled={purchasing || !acceptedTerms || !userEmail}
+                  onClick={handleBuy}
+                >
+                  Confirm Purchase ({formatMoney(discountedPrice)})
+                </Button>
+              </Row>
+            </>
+          )}
+        </Col>
+      </Modal>
+    </>
+  )
 }
 
 function MerchItemCard(props: {


### PR DESCRIPTION
Adds a new 'ticket' shop category with maxStock (global cap) and comingSoon (disabled purchase) fields on ShopItem. Ships two items: Manifest 2026 Early Bird (M55k, 10 available) and Manifest 2026 Standard (M67.5k, coming soon).

On purchase the user is charged mana, a shop_orders row is recorded, and a discount code from the MANIFEST_DISCOUNT_CODE secret is shown in-modal with a 10-second countdown and copy button. Users are told the email on their manifest.is ticket must match their Manifold email; we cross-reference via the admin page at /admin/tickets.

Stock enforced via betsQueue serialization on ['ticket:<itemId>'] plus serializable isolation. Mutual exclusion across ticket variants prevents buying both early-bird and standard. Supporter shop discount applied server-side.

New endpoints: shop-purchase-ticket, get-ticket-stock, get-user-ticket-purchased, get-ticket-orders (admin). New sidebar 'Manifest' badge on the Shop nav. No DB migrations needed (reuses existing shop_orders table).