### PR TITLE
feat: enable standard Manifest tickets with code rotation and stats

### DIFF
--- a/backend/api/src/get-shop-stats.ts
+++ b/backend/api/src/get-shop-stats.ts
@@ -1,6 +1,7 @@
 import { APIHandler } from 'api/helpers/endpoint'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { SUPPORTER_ENTITLEMENT_IDS } from 'common/supporter-config'
+import { getTicketItems } from 'common/shop/items'
 import * as dayjs from 'dayjs'
 import * as utc from 'dayjs/plugin/utc'
 import * as timezone from 'dayjs/plugin/timezone'
@@ -9,6 +10,7 @@ dayjs.extend(timezone)
 
 // Re-use the canonical list from supporter-config
 const SUBSCRIPTION_ITEM_IDS = [...SUPPORTER_ENTITLEMENT_IDS]
+const TICKET_ITEM_IDS = getTicketItems().map((t) => t.id)
 
 export type ShopStats = {
   // Daily subscription sales (supporter tiers)
@@ -18,9 +20,15 @@ export type ShopStats = {
     quantity: number
     revenue: number
   }[]
-  // Daily digital goods sales (non-subscription items)
+  // Daily digital goods sales (non-subscription, non-ticket items)
   digitalGoodsSales: {
     date: string
+    itemId: string
+    quantity: number
+    revenue: number
+  }[]
+  // Ticket sales (all-time, grouped by item)
+  ticketSales: {
     itemId: string
     quantity: number
     revenue: number
@@ -80,7 +88,8 @@ export const getShopStats: APIHandler<'get-shop-stats'> = async (props) => {
     [start, SUBSCRIPTION_ITEM_IDS]
   )
 
-  // Get daily digital goods sales (non-subscription items)
+  // Get daily digital goods sales (non-subscription, non-ticket items)
+  const excludeFromGoods = [...SUBSCRIPTION_ITEM_IDS, ...TICKET_ITEM_IDS]
   const digitalGoodsSales = await pg.manyOrNone<{
     date: string
     itemId: string
@@ -88,7 +97,7 @@ export const getShopStats: APIHandler<'get-shop-stats'> = async (props) => {
     revenue: number
   }>(
     `
-    select 
+    select
       date_trunc('day', created_time at time zone 'America/Los_Angeles')::date::text as date,
       item_id as "itemId",
       sum(quantity)::int as quantity,
@@ -100,7 +109,26 @@ export const getShopStats: APIHandler<'get-shop-stats'> = async (props) => {
     group by date, item_id
     order by date, item_id
     `,
-    [start, SUBSCRIPTION_ITEM_IDS]
+    [start, excludeFromGoods]
+  )
+
+  // Get ticket sales
+  const ticketSales = await pg.manyOrNone<{
+    itemId: string
+    quantity: number
+    revenue: number
+  }>(
+    `
+    select
+      item_id as "itemId",
+      count(*)::int as quantity,
+      sum(price_mana)::bigint as revenue
+    from shop_orders
+    where status = 'COMPLETED'
+      and item_id = any($1)
+    group by item_id
+    `,
+    [TICKET_ITEM_IDS]
   )
 
   // Get current active subscriber counts by tier
@@ -183,6 +211,7 @@ export const getShopStats: APIHandler<'get-shop-stats'> = async (props) => {
   return {
     subscriptionSales: subscriptionSales ?? [],
     digitalGoodsSales: digitalGoodsSales ?? [],
+    ticketSales: ticketSales ?? [],
     subscribersByTier: subscribersByTier ?? [],
     subscriptionsOverTime: subscriptionsOverTime ?? [],
   }

--- a/backend/api/src/shop-purchase-ticket.ts
+++ b/backend/api/src/shop-purchase-ticket.ts
@@ -19,7 +19,7 @@ export const shopPurchaseTicket: APIHandler<'shop-purchase-ticket'> = async (
 
   // Serialize ALL ticket purchases for this item globally (not per-user) so two
   // different users racing for the last slot can't both pass the stock check.
-  const { orderId, remainingStock } = await betsQueue.enqueueFn(
+  const { orderId, remainingStock, orderPosition } = await betsQueue.enqueueFn(
     () =>
       runTransactionWithRetries(async (tx) => {
         const user = await getUser(auth.uid, tx)
@@ -114,15 +114,33 @@ export const shopPurchaseTicket: APIHandler<'shop-purchase-ticket'> = async (
         return {
           orderId: order.id,
           remainingStock: Math.max(0, (item.maxStock ?? 0) - newCount),
+          orderPosition: newCount,
         }
       }),
     [`ticket:${itemId}`]
   )
 
+  // Support comma-separated codes (e.g. "CODE1,CODE2") — each covers 10 uses.
+  // First 10 buyers get CODE1, next 10 get CODE2, etc.
+  const CODES_PER_BATCH = 10
+  const codes = (process.env.MANIFEST_DISCOUNT_CODE ?? '')
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean)
+  const discountCode =
+    codes.length > 0
+      ? codes[
+          Math.min(
+            Math.floor((orderPosition - 1) / CODES_PER_BATCH),
+            codes.length - 1
+          )
+        ]
+      : null
+
   return {
     success: true,
     orderId,
-    discountCode: process.env.MANIFEST_DISCOUNT_CODE ?? null,
+    discountCode,
     remainingStock,
   }
 }

--- a/common/src/shop/items.ts
+++ b/common/src/shop/items.ts
@@ -864,13 +864,13 @@ export const SHOP_ITEMS: ShopItem[] = [
     id: 'manifest-ticket-standard',
     name: 'Manifest 2026 — Standard Ticket',
     description:
-      'Standard-pricing discount code for Manifest 2026 — Lighthaven, Berkeley · June 12–14. Available after early-bird sells out.',
+      'Discount code for Manifest 2026 — Lighthaven, Berkeley · June 12–14. Code is single-use and non-transferable; the email on your manifest.is ticket must match your Manifold email.',
     price: 67500,
     type: 'instant',
     limit: 'one-time',
     category: 'ticket',
     slot: 'unique',
-    comingSoon: true,
+    maxStock: 20,
   },
 ]
 

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -859,6 +859,7 @@ function TicketItemCard(props: {
   const maxStock = stockData?.maxStock ?? item.maxStock ?? 0
   const soldOut = available !== null && available <= 0
   const comingSoon = !!item.comingSoon
+  const isEarlyBird = item.id === 'manifest-ticket'
   const canPurchase =
     user &&
     user.balance >= discountedPrice &&
@@ -906,7 +907,11 @@ function TicketItemCard(props: {
       <div
         className={clsx(
           'bg-canvas-0 text-ink-900 relative overflow-hidden rounded-xl border-2 shadow-sm',
-          comingSoon ? 'border-ink-300 opacity-80' : 'border-amber-400'
+          comingSoon
+            ? 'border-ink-300 opacity-80'
+            : isEarlyBird
+            ? 'border-amber-400'
+            : 'border-indigo-400'
         )}
       >
         {/* Top banner */}
@@ -915,11 +920,17 @@ function TicketItemCard(props: {
             'flex items-center justify-between px-4 py-1.5 text-xs font-bold uppercase tracking-widest',
             comingSoon
               ? 'bg-gradient-to-r from-indigo-500 to-indigo-400 text-indigo-950'
-              : 'bg-gradient-to-r from-amber-500 to-amber-400 text-amber-950'
+              : isEarlyBird
+              ? 'bg-gradient-to-r from-amber-500 to-amber-400 text-amber-950'
+              : 'bg-gradient-to-r from-indigo-500 to-indigo-400 text-indigo-950'
           )}
         >
           <span>
-            {comingSoon ? '⏳ Standard — Available Soon' : 'Early Bird'}
+            {comingSoon
+              ? '⏳ Available Soon'
+              : isEarlyBird
+              ? 'Early Bird'
+              : 'Standard'}
           </span>
           {soldOut && !comingSoon && (
             <span className="text-scarlet-800">Sold Out</span>
@@ -930,19 +941,27 @@ function TicketItemCard(props: {
         <Col
           className={clsx(
             'items-center justify-center gap-1 px-4 py-6 text-center',
-            comingSoon ? 'bg-canvas-50' : 'bg-amber-200/50 dark:bg-amber-500/10'
+            comingSoon
+              ? 'bg-canvas-50'
+              : isEarlyBird
+              ? 'bg-amber-200/50 dark:bg-amber-500/10'
+              : 'bg-indigo-200/50 dark:bg-indigo-500/10'
           )}
         >
           <div
             className={clsx(
               'text-sm font-semibold uppercase tracking-widest',
-              comingSoon ? 'text-ink-500' : 'text-amber-700 dark:text-amber-500'
+              comingSoon
+                ? 'text-ink-500'
+                : isEarlyBird
+                ? 'text-amber-700 dark:text-amber-500'
+                : 'text-indigo-700 dark:text-indigo-400'
             )}
           >
             Manifest 2026
           </div>
           <div className="text-lg font-bold leading-tight">
-            {comingSoon ? 'Standard Ticket' : 'Early Bird Ticket'}
+            {isEarlyBird ? 'Early Bird Ticket' : 'Standard Ticket'}
           </div>
         </Col>
 
@@ -977,24 +996,43 @@ function TicketItemCard(props: {
             .
           </div>
 
-          {/* Stock progress (early bird only) */}
+          {/* Stock display */}
           {!comingSoon && available !== null && (
-            <Col className="gap-1">
-              <Row className="text-ink-600 justify-between text-[11px]">
-                <span>
-                  {maxStock - available}/{maxStock} claimed
-                </span>
-                <span className="text-amber-700 dark:text-amber-500">
-                  {available} left
-                </span>
-              </Row>
-              <div className="bg-ink-200 h-1.5 overflow-hidden rounded-full">
-                <div
-                  className="h-full bg-gradient-to-r from-amber-500 to-amber-400 transition-all"
-                  style={{ width: `${pctClaimed}%` }}
-                />
+            isEarlyBird ? (
+              <Col className="gap-1">
+                <Row className="text-ink-600 justify-between text-[11px]">
+                  <span>
+                    {maxStock - available}/{maxStock} claimed
+                  </span>
+                  <span className="text-amber-700 dark:text-amber-500">
+                    {available} left
+                  </span>
+                </Row>
+                <div className="bg-ink-200 h-1.5 overflow-hidden rounded-full">
+                  <div
+                    className="h-full bg-gradient-to-r from-amber-500 to-amber-400 transition-all"
+                    style={{ width: `${pctClaimed}%` }}
+                  />
+                </div>
+              </Col>
+            ) : (
+              <div
+                className={clsx(
+                  'text-xs',
+                  soldOut
+                    ? 'text-scarlet-600'
+                    : available <= 5
+                    ? 'text-scarlet-600 dark:text-scarlet-400'
+                    : 'text-teal-600 dark:text-teal-400'
+                )}
+              >
+                {soldOut
+                  ? 'Sold out'
+                  : available <= 5
+                  ? 'Less than 5 remaining — limited stock'
+                  : 'More than 5 remaining — limited stock'}
               </div>
-            </Col>
+            )
           )}
 
           {/* Price + CTA */}
@@ -1030,7 +1068,9 @@ function TicketItemCard(props: {
                 ? 'Sign in to claim'
                 : user.balance < discountedPrice
                 ? 'Insufficient balance'
-                : 'Claim Early Bird Code'}
+                : isEarlyBird
+                ? 'Claim Early Bird Code'
+                : 'Claim Ticket Code'}
             </Button>
           </Col>
         </Col>

--- a/web/pages/stats.tsx
+++ b/web/pages/stats.tsx
@@ -108,6 +108,11 @@ type ShopStats = {
     quantity: number
     revenue: number
   }[]
+  ticketSales: {
+    itemId: string
+    quantity: number
+    revenue: number
+  }[]
   subscribersByTier: {
     tier: 'basic' | 'plus' | 'premium'
     count: number
@@ -806,6 +811,7 @@ function PurchasesTab(props: { shopStats?: ShopStats }) {
   const {
     subscriptionSales,
     digitalGoodsSales,
+    ticketSales,
     subscribersByTier,
     subscriptionsOverTime,
   } = shopStats
@@ -1051,6 +1057,23 @@ function PurchasesTab(props: { shopStats?: ShopStats }) {
         items={goodsItemSalesArray}
         itemDisplayNames={itemDisplayNames}
       />
+
+      {/* MANIFEST TICKETS SECTION */}
+      {ticketSales.length > 0 && (
+        <>
+          <Spacer h={12} />
+          <Title>Manifest Tickets</Title>
+          <Spacer h={4} />
+          <SalesTable
+            title="Ticket Sales"
+            items={ticketSales}
+            itemDisplayNames={{
+              'manifest-ticket': 'Early Bird Ticket',
+              'manifest-ticket-standard': 'Standard Ticket',
+            }}
+          />
+        </>
+      )}
     </Col>
   )
 }


### PR DESCRIPTION
Activates manifest-ticket-standard (M67.5k, maxStock=20). Backend supports comma-separated discount codes in MANIFEST_DISCOUNT_CODE env var — first 10 buyers get code 1, next 10 get code 2. Standard card uses indigo styling with fuzzy stock display ("more/less than 5 remaining") instead of exact count. Stats page separates ticket sales into their own section, excluded from digital goods.