### PR TITLE
fix: wait for images above target to load before scrolling to comment

### DIFF
--- a/web/lib/util/scroll.ts
+++ b/web/lib/util/scroll.ts
@@ -3,10 +3,36 @@ const isIOSDevice = () =>
   /iPad|iPhone|iPod/.test(navigator.userAgent) &&
   !(window as any).MSStream
 
+const waitForImagesAbove = (element: HTMLElement, timeoutMs: number) => {
+  const elementTop = element.getBoundingClientRect().top + window.scrollY
+  const pending = Array.from(document.images).filter((img) => {
+    const imgTop = img.getBoundingClientRect().top + window.scrollY
+    return imgTop < elementTop && !img.complete
+  })
+  if (pending.length === 0) return Promise.resolve()
+
+  return Promise.race([
+    Promise.all(
+      pending.map(
+        (img) =>
+          new Promise<void>((resolve) => {
+            img.addEventListener('load', () => resolve(), { once: true })
+            img.addEventListener('error', () => resolve(), { once: true })
+          })
+      )
+    ),
+    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+  ])
+}
+
 export const scrollIntoViewCentered = (element: HTMLElement) => {
   // Small delay to ensure iOS scroll container is set up (it's applied via useEffect)
   // and layout is complete
-  setTimeout(() => {
+  setTimeout(async () => {
+    // Wait for images above the target to load so the layout settles before we scroll;
+    // otherwise late-loading images push the target below the centered position.
+    await waitForImagesAbove(element, 1500)
+
     // On iOS, we use a .page-scroll-container with position:fixed and overflow-y:auto,
     // so we need to scroll that container instead of the window.
     const scrollContainer = document.querySelector(


### PR DESCRIPTION
When navigating directly to a comment (via #commentId hash), images in comments above the target would load after the scroll fired, pushing the highlighted comment below the centered position. Now scrollIntoViewCentered waits for unloaded images above the target to settle (with a 1.5s timeout fallback) before scrolling, so the layout is stable when we land.