### PR TITLE
comments: unlock commenting for users who have purchased mana

### DIFF
--- a/backend/api/src/create-comment.ts
+++ b/backend/api/src/create-comment.ts
@@ -5,7 +5,7 @@ import { type Contract } from 'common/contract'
 import { FLAT_COMMENT_FEE } from 'common/fees'
 import { convertBet } from 'common/supabase/bets'
 import { millisToTs } from 'common/supabase/utils'
-import { canReceiveBonuses } from 'common/user'
+import { canComment } from 'common/user'
 import { buildArray } from 'common/util/array'
 import { removeUndefinedProps } from 'common/util/object'
 import { first } from 'lodash'
@@ -223,11 +223,12 @@ export const validateComment = async (
   if (!contract) throw new APIError(404, 'Contract not found')
 
   // Allow market creators to comment on their own markets even if they
-  // cannot receive bonuses; require bonus eligibility for everyone else.
-  if (!canReceiveBonuses(you) && contract.creatorId !== you.id) {
+  // cannot comment elsewhere; everyone else must be verified or have ever
+  // purchased mana.
+  if (!canComment(you) && contract.creatorId !== you.id) {
     throw new APIError(
       403,
-      'Please verify your identity to comment on other users\' markets.'
+      'Verify your identity or purchase mana to comment on other users\' markets.'
     )
   }
   if (contract.token !== 'MANA') {

--- a/backend/api/src/create-post-comment.ts
+++ b/backend/api/src/create-post-comment.ts
@@ -1,6 +1,6 @@
 import { APIError, APIHandler } from './helpers/endpoint'
 import { PostComment } from 'common/comment'
-import { canReceiveBonuses } from 'common/user'
+import { canComment } from 'common/user'
 import { onlyUsersWhoCanPerformAction } from './helpers/rate-limit'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { getUser, getPrivateUser, revalidateStaticProps, sanitizeJsonContent } from 'shared/utils'
@@ -23,11 +23,11 @@ export const createPostComment: APIHandler<'create-post-comment'> =
     if (!creator) throw new APIError(401, 'Your account was not found')
     if (creator.userDeleted) throw new APIError(403, 'Your account is deleted')
 
-    // Require bonus eligibility (verified or grandfathered) to comment
-    if (!canReceiveBonuses(creator)) {
+    // Require verification or a prior mana purchase to comment on posts.
+    if (!canComment(creator)) {
       throw new APIError(
         403,
-        'Please verify your identity to comment on posts.'
+        'Verify your identity or purchase mana to comment on posts.'
       )
     }
 

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -213,6 +213,12 @@ export const canReceiveBonuses = (user: User) =>
   user.bonusEligibility === 'verified' ||
   user.bonusEligibility === 'grandfathered'
 
+// Users unlock commenting by verifying identity OR by ever purchasing mana.
+// Purchasing mana is a strong anti-spam signal, so we treat it as equivalent
+// to verification for the purpose of leaving comments.
+export const canComment = (user: User) =>
+  canReceiveBonuses(user) || user.purchasedMana === true
+
 // expires: sep 26th, ~530pm PT
 const LIMITED_TIME_DEAL_END = 1727311753233 + DAY_MS
 export const introductoryTimeWindow = (user: User) =>

--- a/web/components/comments/comment-input.tsx
+++ b/web/components/comments/comment-input.tsx
@@ -8,7 +8,7 @@ import { Bet } from 'common/bet'
 import { ContractComment, MAX_COMMENT_LENGTH } from 'common/comment'
 import { Contract } from 'common/contract'
 import { STARTING_BALANCE } from 'common/economy'
-import { canReceiveBonuses, User } from 'common/user'
+import { canComment, User } from 'common/user'
 import { formatMoney } from 'common/util/format'
 import { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
@@ -110,7 +110,7 @@ export function CommentInput(props: {
 
   if (
     user &&
-    !canReceiveBonuses(user) &&
+    !canComment(user) &&
     user.bonusEligibility !== 'ineligible'
   )
     return <VerifyToCommentPrompt className={className} />
@@ -304,6 +304,7 @@ function VerifyToCommentPrompt(props: { className?: string }) {
           <span className="font-semibold">
             {formatMoney(STARTING_BALANCE, 'MANA')}
           </span>
+          . Purchasing mana also unlocks commenting.
         </span>
         <Button
           size="xs"


### PR DESCRIPTION
Previously only identity-verified (or grandfathered) users could comment. Now commenting is also unlocked by a prior mana purchase, an anti-spam proxy for verification.

- add canComment(user) helper: canReceiveBonuses OR purchasedMana
- swap backend gates in create-comment + create-post-comment to canComment
- swap frontend gate in comment-input; banner copy notes that purchasing mana also unlocks commenting