### PR TITLE
shop: gild merch pill, add swipe to image carousel, flip AGGC default

### DIFF
--- a/common/src/shop/items.ts
+++ b/common/src/shop/items.ts
@@ -206,6 +206,10 @@ export type ShopItem = {
   // Keyed by the same `color` string used in `variants`. When set, the card
   // swaps the carousel as the user picks a colour. Falls back to merchImages.
   merchImagesByColor?: Record<string, { label: string; url: string }[]>
+  // Index of the image to show first in the carousel. Lets you keep the
+  // natural Front-then-Back ordering of dots while landing the user on a
+  // different image initially. Also used as the reset target on colour swap.
+  defaultImageIndex?: number
 }
 
 // Get the entitlement ID for a shop item (defaults to item.id)
@@ -868,9 +872,10 @@ export const SHOP_ITEMS: ShopItem[] = [
     slot: 'consumable',
     imageUrl: '/merch/AGGC-back-ghost.png',
     merchImages: [
-      { label: 'Back', url: '/merch/AGGC-back-ghost.png' },
       { label: 'Front', url: '/merch/AGGC-front-ghost.png' },
+      { label: 'Back', url: '/merch/AGGC-back-ghost.png' },
     ],
+    defaultImageIndex: 1,
     variants: [
       { size: 'S', printfulSyncVariantId: '69026b955ba991' },
       { size: 'M', printfulSyncVariantId: '69026b955baa12' },

--- a/common/src/shop/items.ts
+++ b/common/src/shop/items.ts
@@ -866,10 +866,10 @@ export const SHOP_ITEMS: ShopItem[] = [
     limit: 'one-time',
     category: 'merch',
     slot: 'consumable',
-    imageUrl: '/merch/AGGC-front-ghost.png',
+    imageUrl: '/merch/AGGC-back-ghost.png',
     merchImages: [
-      { label: 'Front', url: '/merch/AGGC-front-ghost.png' },
       { label: 'Back', url: '/merch/AGGC-back-ghost.png' },
+      { label: 'Front', url: '/merch/AGGC-front-ghost.png' },
     ],
     variants: [
       { size: 'S', printfulSyncVariantId: '69026b955ba991' },

--- a/common/src/shop/items.ts
+++ b/common/src/shop/items.ts
@@ -859,7 +859,7 @@ export const SHOP_ITEMS: ShopItem[] = [
       { size: '2XL', color: 'Navy', printfulSyncVariantId: '69026b379414b6' },
       { size: '3XL', color: 'Navy', printfulSyncVariantId: '69026b37941505' },
     ],
-    visibleSinceTime: new Date('2026-04-23T00:15:00+09:30').getTime(),
+    visibleSinceTime: new Date('2026-04-24T00:15:00+09:30').getTime(),
   },
   {
     id: 'merch-aggc-tshirt',
@@ -884,7 +884,7 @@ export const SHOP_ITEMS: ShopItem[] = [
       { size: '2XL', printfulSyncVariantId: '69026b955bab83' },
       { size: '3XL', printfulSyncVariantId: '69026b955bac08' },
     ],
-    visibleSinceTime: new Date('2026-04-23T00:15:00+09:30').getTime(),
+    visibleSinceTime: new Date('2026-04-24T00:15:00+09:30').getTime(),
   },
   {
     id: 'merch-cap-white-logo',
@@ -904,7 +904,7 @@ export const SHOP_ITEMS: ShopItem[] = [
     variants: [
       { size: 'One Size', printfulSyncVariantId: '699c7bf5859673' },
     ],
-    visibleSinceTime: new Date('2026-04-23T00:15:00+09:30').getTime(),
+    visibleSinceTime: new Date('2026-04-24T00:15:00+09:30').getTime(),
   },
   {
     id: 'merch-cap-purple-logo',
@@ -924,7 +924,7 @@ export const SHOP_ITEMS: ShopItem[] = [
     variants: [
       { size: 'One Size', printfulSyncVariantId: '699c786e6c50b2' },
     ],
-    visibleSinceTime: new Date('2026-04-23T00:15:00+09:30').getTime(),
+    visibleSinceTime: new Date('2026-04-24T00:15:00+09:30').getTime(),
   },
 
   // Tickets

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -1606,6 +1606,7 @@ function MerchItemCard(props: {
     touchStartRef.current = null
     if (!wasActive) {
       setDragOffset(0)
+      setIsSwipeActive(false)
       return
     }
     if (Math.abs(dx) < SWIPE_COMMIT_THRESHOLD) {
@@ -1614,17 +1615,24 @@ function MerchItemCard(props: {
       setIsSwipeActive(false)
       return
     }
-    // Above threshold: flip index and zero the offset in the same render.
-    // isSwipeActive stays true for this render so the transition is suppressed
-    // (no animation from dx → 0 on the incoming image, which would look wrong).
-    // Re-enable transitions on the next frame for the snap-back of future swipes.
+    // Above threshold: flip index, then let the strip's transition slide it
+    // to the new resting position. Wrap-around (last → first or first → last)
+    // would slide the strip across every image in between, so for those we
+    // suppress the transition for one frame and snap to the target instead.
+    const isWrap =
+      (dx < 0 && currentImageIndex === images.length - 1) ||
+      (dx > 0 && currentImageIndex === 0)
     if (dx < 0) {
       setCurrentImageIndex((i) => (i === images.length - 1 ? 0 : i + 1))
     } else {
       setCurrentImageIndex((i) => (i === 0 ? images.length - 1 : i - 1))
     }
     setDragOffset(0)
-    requestAnimationFrame(() => setIsSwipeActive(false))
+    if (isWrap) {
+      requestAnimationFrame(() => setIsSwipeActive(false))
+    } else {
+      setIsSwipeActive(false)
+    }
   }
 
   // Pick the variant matching the user's colour + size selection.
@@ -1753,7 +1761,9 @@ function MerchItemCard(props: {
             </div>
           )}
 
-          {/* Image carousel */}
+          {/* Image carousel — all images laid out in a horizontal strip; we
+              translate the strip rather than the visible image so neighbouring
+              images slide in from the side as the user drags. */}
           <div
             className="relative aspect-square touch-pan-y overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800"
             onTouchStart={handleTouchStart}
@@ -1761,16 +1771,32 @@ function MerchItemCard(props: {
             onTouchEnd={handleTouchEnd}
             onTouchCancel={handleTouchEnd}
           >
-            <img
-              src={images[currentImageIndex].url}
-              alt={`${item.name} - ${images[currentImageIndex].label}`}
+            <div
               className={clsx(
-                'h-full w-full object-contain p-2 will-change-transform',
+                'flex h-full will-change-transform',
                 !isSwipeActive && 'transition-transform duration-200 ease-out'
               )}
-              style={{ transform: `translateX(${dragOffset}px)` }}
-              draggable={false}
-            />
+              style={{
+                width: `${images.length * 100}%`,
+                transform: `translateX(calc(${
+                  -currentImageIndex * (100 / images.length)
+                }% + ${dragOffset}px))`,
+              }}
+            >
+              {images.map((img, idx) => (
+                <img
+                  key={idx}
+                  src={img.url}
+                  alt={`${item.name} - ${img.label}`}
+                  className="h-full object-contain p-2"
+                  style={{
+                    width: `${100 / images.length}%`,
+                    flexShrink: 0,
+                  }}
+                  draggable={false}
+                />
+              ))}
+            </div>
             {images.length > 1 && (
               <div className="absolute left-2 top-2 rounded bg-black/60 px-1.5 py-0.5 text-xs font-medium text-white shadow-sm backdrop-blur-sm">
                 {images[currentImageIndex].label}

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -1567,27 +1567,64 @@ function MerchItemCard(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedColor])
 
-  // Touch-swipe gestures for the image carousel. Captures horizontal swipes
-  // past a threshold; ignores mostly-vertical motion so page scroll still
-  // works when the finger starts on the image.
+  // Touch-swipe gestures for the image carousel. The image translates with
+  // the finger in real time for tactile feedback; on release we either commit
+  // (if dragged past the threshold) or snap back with a transition.
+  // Direction is locked after 8px of motion — mostly-vertical motion is
+  // ignored so page scroll still works when the finger starts on the image.
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const [dragOffset, setDragOffset] = useState(0)
+  const [isSwipeActive, setIsSwipeActive] = useState(false)
+  const SWIPE_COMMIT_THRESHOLD = 40
+  const SWIPE_DIRECTION_LOCK = 8
+
   const handleTouchStart = (e: React.TouchEvent) => {
     const t = e.touches[0]
     touchStartRef.current = { x: t.clientX, y: t.clientY }
+    setIsSwipeActive(false)
   }
-  const handleTouchEnd = (e: React.TouchEvent) => {
+  const handleTouchMove = (e: React.TouchEvent) => {
     const start = touchStartRef.current
-    touchStartRef.current = null
     if (!start || images.length <= 1) return
-    const t = e.changedTouches[0]
+    const t = e.touches[0]
     const dx = t.clientX - start.x
     const dy = t.clientY - start.y
-    if (Math.abs(dx) < 40 || Math.abs(dx) <= Math.abs(dy)) return
+    if (!isSwipeActive) {
+      if (Math.abs(dx) < SWIPE_DIRECTION_LOCK && Math.abs(dy) < SWIPE_DIRECTION_LOCK) return
+      if (Math.abs(dx) <= Math.abs(dy)) {
+        // User is scrolling vertically — abandon this gesture for the carousel.
+        touchStartRef.current = null
+        return
+      }
+      setIsSwipeActive(true)
+    }
+    setDragOffset(dx)
+  }
+  const handleTouchEnd = () => {
+    const dx = dragOffset
+    const wasActive = isSwipeActive
+    touchStartRef.current = null
+    if (!wasActive) {
+      setDragOffset(0)
+      return
+    }
+    if (Math.abs(dx) < SWIPE_COMMIT_THRESHOLD) {
+      // Below threshold: snap back with the transition.
+      setDragOffset(0)
+      setIsSwipeActive(false)
+      return
+    }
+    // Above threshold: flip index and zero the offset in the same render.
+    // isSwipeActive stays true for this render so the transition is suppressed
+    // (no animation from dx → 0 on the incoming image, which would look wrong).
+    // Re-enable transitions on the next frame for the snap-back of future swipes.
     if (dx < 0) {
       setCurrentImageIndex((i) => (i === images.length - 1 ? 0 : i + 1))
     } else {
       setCurrentImageIndex((i) => (i === 0 ? images.length - 1 : i - 1))
     }
+    setDragOffset(0)
+    requestAnimationFrame(() => setIsSwipeActive(false))
   }
 
   // Pick the variant matching the user's colour + size selection.
@@ -1720,12 +1757,19 @@ function MerchItemCard(props: {
           <div
             className="relative aspect-square touch-pan-y overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800"
             onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
+            onTouchCancel={handleTouchEnd}
           >
             <img
               src={images[currentImageIndex].url}
               alt={`${item.name} - ${images[currentImageIndex].label}`}
-              className="h-full w-full object-contain p-2"
+              className={clsx(
+                'h-full w-full object-contain p-2 will-change-transform',
+                !isSwipeActive && 'transition-transform duration-200 ease-out'
+              )}
+              style={{ transform: `translateX(${dragOffset}px)` }}
+              draggable={false}
             />
             {images.length > 1 && (
               <div className="absolute left-2 top-2 rounded bg-black/60 px-1.5 py-0.5 text-xs font-medium text-white shadow-sm backdrop-blur-sm">

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -817,6 +817,7 @@ export default function ShopPage() {
             )
               return null
             const isSeasonal = filter === 'seasonal'
+            const isMerch = filter === 'merch'
             const isActive = filterOption === filter
             return (
               <button
@@ -826,10 +827,14 @@ export default function ShopPage() {
                   'rounded-full px-3 py-1 text-sm font-medium transition-colors',
                   isActive && isSeasonal
                     ? 'bg-gradient-to-r from-pink-500 to-rose-400 text-white shadow-sm'
+                    : isActive && isMerch
+                    ? 'bg-gradient-to-r from-amber-400 via-yellow-400 to-amber-500 text-white shadow-sm ring-1 ring-amber-300/60'
                     : isActive
                     ? 'bg-primary-500 text-white'
                     : isSeasonal
                     ? 'bg-gradient-to-r from-pink-100 to-rose-100 text-pink-700 hover:from-pink-200 hover:to-rose-200 dark:from-pink-900/30 dark:to-rose-900/30 dark:text-pink-300'
+                    : isMerch
+                    ? 'bg-gradient-to-r from-amber-100 via-yellow-100 to-amber-200 text-amber-800 shadow-sm ring-1 ring-amber-300/50 hover:from-amber-200 hover:via-yellow-200 hover:to-amber-300 dark:from-amber-900/40 dark:via-yellow-900/30 dark:to-amber-900/50 dark:text-amber-200 dark:ring-amber-500/40'
                     : 'bg-canvas-50 text-ink-600 hover:bg-canvas-100'
                 )}
               >
@@ -1560,6 +1565,29 @@ function MerchItemCard(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedColor])
 
+  // Touch-swipe gestures for the image carousel. Captures horizontal swipes
+  // past a threshold; ignores mostly-vertical motion so page scroll still
+  // works when the finger starts on the image.
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const handleTouchStart = (e: React.TouchEvent) => {
+    const t = e.touches[0]
+    touchStartRef.current = { x: t.clientX, y: t.clientY }
+  }
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const start = touchStartRef.current
+    touchStartRef.current = null
+    if (!start || images.length <= 1) return
+    const t = e.changedTouches[0]
+    const dx = t.clientX - start.x
+    const dy = t.clientY - start.y
+    if (Math.abs(dx) < 40 || Math.abs(dx) <= Math.abs(dy)) return
+    if (dx < 0) {
+      setCurrentImageIndex((i) => (i === images.length - 1 ? 0 : i + 1))
+    } else {
+      setCurrentImageIndex((i) => (i === 0 ? images.length - 1 : i - 1))
+    }
+  }
+
   // Pick the variant matching the user's colour + size selection.
   const findSelectedVariant = () =>
     variants.find(
@@ -1687,7 +1715,11 @@ function MerchItemCard(props: {
           )}
 
           {/* Image carousel */}
-          <div className="relative aspect-square overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800">
+          <div
+            className="relative aspect-square touch-pan-y overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800"
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+          >
             <img
               src={images[currentImageIndex].url}
               alt={`${item.name} - ${images[currentImageIndex].label}`}

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -1774,7 +1774,11 @@ function MerchItemCard(props: {
             <div
               className={clsx(
                 'flex h-full will-change-transform',
-                !isSwipeActive && 'transition-transform duration-200 ease-out'
+                // Soft ease-out-quint (cubic-bezier(0.22, 1, 0.36, 1)) +
+                // ~400ms feels deliberate: small swipes glide back, commits
+                // settle into place rather than snapping.
+                !isSwipeActive &&
+                  'transition-transform duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)]'
               )}
               style={{
                 width: `${images.length * 100}%`,

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -1771,36 +1771,51 @@ function MerchItemCard(props: {
             onTouchEnd={handleTouchEnd}
             onTouchCancel={handleTouchEnd}
           >
-            <div
-              className={clsx(
-                'flex h-full will-change-transform',
-                // Soft ease-out-quint (cubic-bezier(0.22, 1, 0.36, 1)) +
-                // ~400ms feels deliberate: small swipes glide back, commits
-                // settle into place rather than snapping.
-                !isSwipeActive &&
-                  'transition-transform duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)]'
-              )}
-              style={{
-                width: `${images.length * 100}%`,
-                transform: `translateX(calc(${
-                  -currentImageIndex * (100 / images.length)
-                }% + ${dragOffset}px))`,
-              }}
-            >
-              {images.map((img, idx) => (
-                <img
-                  key={idx}
-                  src={img.url}
-                  alt={`${item.name} - ${img.label}`}
-                  className="h-full object-contain p-2"
+            {(() => {
+              // Pad the strip with wrap-around clones so a swipe at either
+              // edge reveals the image it'll wrap to (last image pulls in
+              // from the left at index 0; first image pulls in from the right
+              // at the last index). After commit, the index flips and the
+              // strip silently snaps to the real position of the same image
+              // (see isWrap branch in handleTouchEnd) — no visible jump since
+              // both padded positions display the same URL.
+              const hasMultiple = images.length > 1
+              const padded = hasMultiple
+                ? [images[images.length - 1], ...images, images[0]]
+                : images
+              const slot = hasMultiple ? currentImageIndex + 1 : 0
+              return (
+                <div
+                  className={clsx(
+                    'flex h-full will-change-transform',
+                    // Soft ease-out-quint (cubic-bezier(0.22, 1, 0.36, 1)) +
+                    // ~400ms: small swipes glide back, commits settle in.
+                    !isSwipeActive &&
+                      'transition-transform duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)]'
+                  )}
                   style={{
-                    width: `${100 / images.length}%`,
-                    flexShrink: 0,
+                    width: `${padded.length * 100}%`,
+                    transform: `translateX(calc(${
+                      -slot * (100 / padded.length)
+                    }% + ${dragOffset}px))`,
                   }}
-                  draggable={false}
-                />
-              ))}
-            </div>
+                >
+                  {padded.map((img, idx) => (
+                    <img
+                      key={idx}
+                      src={img.url}
+                      alt={`${item.name} - ${img.label}`}
+                      className="h-full object-contain p-2"
+                      style={{
+                        width: `${100 / padded.length}%`,
+                        flexShrink: 0,
+                      }}
+                      draggable={false}
+                    />
+                  ))}
+                </div>
+              )
+            })()}
             {images.length > 1 && (
               <div className="absolute left-2 top-2 rounded bg-black/60 px-1.5 py-0.5 text-xs font-medium text-white shadow-sm backdrop-blur-sm">
                 {images[currentImageIndex].label}

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -1515,7 +1515,9 @@ function MerchItemCard(props: {
     // sizesForSelection rebuilds every render — depend on selectedColor instead
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedColor])
-  const [currentImageIndex, setCurrentImageIndex] = useState(0)
+  const [currentImageIndex, setCurrentImageIndex] = useState(
+    item.defaultImageIndex ?? 0
+  )
   const [showPurchaseModal, setShowPurchaseModal] = useState(false)
   const [showShippingModal, setShowShippingModal] = useState(false)
   const [purchasing, setPurchasing] = useState(false)
@@ -1559,9 +1561,9 @@ function MerchItemCard(props: {
     item.merchImagesByColor?.[selectedColor]) ||
     item.merchImages || [{ label: 'Front', url: item.imageUrl || '' }]
   // Reset the carousel when the user swaps colours so they always start on
-  // the new colour's first image.
+  // the new colour's default image (or the first image when no default set).
   useEffect(() => {
-    setCurrentImageIndex(0)
+    setCurrentImageIndex(item.defaultImageIndex ?? 0)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedColor])
 
@@ -1725,6 +1727,11 @@ function MerchItemCard(props: {
               alt={`${item.name} - ${images[currentImageIndex].label}`}
               className="h-full w-full object-contain p-2"
             />
+            {images.length > 1 && (
+              <div className="absolute left-2 top-2 rounded bg-black/60 px-1.5 py-0.5 text-xs font-medium text-white shadow-sm backdrop-blur-sm">
+                {images[currentImageIndex].label}
+              </div>
+            )}
             <Row className="absolute bottom-2 left-1/2 -translate-x-1/2 gap-1.5">
               {images.map((_, idx) => (
                 <button


### PR DESCRIPTION
- Merch filter pill gets a gold/amber gradient + ring to draw the eye, mirroring the seasonal pill's gradient pattern
- Merch image carousel now responds to horizontal touch swipes (40px threshold, ignores mostly-vertical motion so page scroll still works)
- AGGC tee defaults to the "Back" image (the AGGC print) since that's the more distinctive face — front still reachable via swipe/dots