### PR TITLE
fix(shop): make state/zip optional in createPrintfulOrder signature

### DIFF
--- a/backend/api/src/shop-purchase-merch.ts
+++ b/backend/api/src/shop-purchase-merch.ts
@@ -271,8 +271,8 @@ async function createPrintfulOrder(
       address1: string
       address2?: string
       city: string
-      state: string
-      zip: string
+      state?: string
+      zip?: string
       country: string
     }
     externalId: string


### PR DESCRIPTION
## Summary
- PR #3774 relaxed the schema's \`zip\` and \`state\` to \`.optional()\` but missed the internal \`createPrintfulOrder\` helper's own param type in [backend/api/src/shop-purchase-merch.ts](backend/api/src/shop-purchase-merch.ts#L269-L277), which still declared them as required strings.
- That caused a \`tsc\` build error blocking the prod backend deploy:
  \`Types of property 'state' are incompatible. Type 'string | undefined' is not assignable to type 'string'.\`