### PR TITLE
leagues: show scroll arrows + edge fade on division tabs

### DIFF
--- a/web/components/widgets/carousel.tsx
+++ b/web/components/widgets/carousel.tsx
@@ -1,7 +1,7 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
 import { throttle } from 'lodash'
-import { useState, useEffect, forwardRef, useRef, Ref, ReactNode } from 'react'
+import { useState, useEffect, forwardRef, Ref, ReactNode } from 'react'
 import { Row } from '../layout/row'
 import { VisibilityObserver } from 'web/components/widgets/visibility-observer'
 
@@ -25,14 +25,13 @@ export function Carousel(props: CarouselProps) {
     ...rest
   } = props
 
-  const ref = useRef<HTMLDivElement>(null)
+  // Callback ref so attachment triggers a re-render — needed for atFront/atBack to measure on mount.
+  const [el, setEl] = useState<HTMLDivElement | null>(null)
   const [isHovered, setIsHovered] = useState(false)
 
-  const { scrollLeft, scrollRight, atFront, atBack, onScroll } = useCarousel(
-    ref.current
-  )
+  const { scrollLeft, scrollRight, atFront, atBack, onScroll } = useCarousel(el)
 
-  useEffect(onScroll, [children])
+  useEffect(onScroll, [children, el])
 
   const showArrows = showArrowsOnHover ? isHovered : !fadeEdges
 
@@ -58,7 +57,7 @@ export function Carousel(props: CarouselProps) {
             'scrollbar-hide w-full snap-x overflow-x-auto scroll-smooth',
             labelsParentClassName ?? 'gap-4'
           )}
-          ref={ref}
+          ref={setEl}
           onScroll={onScroll}
         >
           {children}

--- a/web/pages/leagues/[[...leagueSlugs]].tsx
+++ b/web/pages/leagues/[[...leagueSlugs]].tsx
@@ -309,11 +309,7 @@ export default function Leagues(props: LeaguesProps) {
           <Col className="gap-4">
             {/* Division Tabs */}
             <div className="border-ink-200 border-b">
-              <Carousel
-                fadeEdges
-                showArrowsOnHover
-                labelsParentClassName="-mb-px gap-1"
-              >
+              <Carousel labelsParentClassName="-mb-px gap-1">
                 {divisions.map((div) => {
                   const isSelected = div === division
                   const isUserDivision = div === userDivision

--- a/web/pages/leagues/[[...leagueSlugs]].tsx
+++ b/web/pages/leagues/[[...leagueSlugs]].tsx
@@ -42,6 +42,7 @@ import { InfoTooltip } from 'web/components/widgets/info-tooltip'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
 import { SelectDropdown } from 'web/components/widgets/select-dropdown'
 import { useEffectCheckEquality } from 'web/hooks/use-effect-check-equality'
+import { useIsMobile } from 'web/hooks/use-is-mobile'
 import { useUser } from 'web/hooks/use-user'
 import { useUsers } from 'web/hooks/use-user-supabase'
 import { api } from 'web/lib/api/api'
@@ -90,6 +91,7 @@ interface LeaguesProps {
 export default function Leagues(props: LeaguesProps) {
   const { initialSeasonInfo, currentSeasonInfo } = props
   const user = useUser()
+  const isMobile = useIsMobile()
 
   const [rows, setRows] = usePersistentInMemoryState<league_user_info[]>(
     [],
@@ -309,7 +311,11 @@ export default function Leagues(props: LeaguesProps) {
           <Col className="gap-4">
             {/* Division Tabs */}
             <div className="border-ink-200 border-b">
-              <Carousel labelsParentClassName="-mb-px gap-1">
+              <Carousel
+                fadeEdges={!isMobile}
+                showArrowsOnHover={!isMobile}
+                labelsParentClassName="-mb-px gap-1"
+              >
                 {divisions.map((div) => {
                   const isSelected = div === division
                   const isUserDivision = div === userDivision

--- a/web/pages/leagues/[[...leagueSlugs]].tsx
+++ b/web/pages/leagues/[[...leagueSlugs]].tsx
@@ -34,6 +34,7 @@ import { LeagueFeed } from 'web/components/leagues/league-feed'
 import { PrizesModal } from 'web/components/leagues/prizes-modal'
 import { SEO } from 'web/components/SEO'
 import { Avatar } from 'web/components/widgets/avatar'
+import { Carousel } from 'web/components/widgets/carousel'
 import { UserBadge } from 'web/components/widgets/user-link'
 import { UserHovercard } from 'web/components/user/user-hovercard'
 import { Countdown } from 'web/components/widgets/countdown'
@@ -308,7 +309,11 @@ export default function Leagues(props: LeaguesProps) {
           <Col className="gap-4">
             {/* Division Tabs */}
             <div className="border-ink-200 border-b">
-              <Row className="scrollbar-hide -mb-px gap-1 overflow-x-auto">
+              <Carousel
+                fadeEdges
+                showArrowsOnHover
+                labelsParentClassName="-mb-px gap-1"
+              >
                 {divisions.map((div) => {
                   const isSelected = div === division
                   const isUserDivision = div === userDivision
@@ -333,7 +338,7 @@ export default function Leagues(props: LeaguesProps) {
                     </button>
                   )
                 })}
-              </Row>
+              </Carousel>
             </div>
 
             {/* Cohort Selector */}


### PR DESCRIPTION
Wraps the division tab strip in the same Carousel pattern used by the home page topic scroll so it's discoverable that the headings can be scrolled horizontally.