### PR TITLE
shop: gate Printful endpoints behind isProd

### DIFF
--- a/backend/api/src/cancel-merch-order.ts
+++ b/backend/api/src/cancel-merch-order.ts
@@ -5,6 +5,7 @@ import { runTransactionWithRetries } from 'shared/transact-with-retries'
 import { betsQueue } from 'shared/helpers/fn-queue'
 import { PRINTFUL_API_URL, getShopItem } from 'common/shop/items'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { isProd } from 'shared/utils'
 import { Notification } from 'common/notification'
 import { insertNotificationToSupabase } from 'shared/supabase/notifications'
 import {
@@ -93,7 +94,8 @@ export const cancelMerchOrder: APIHandler<'cancel-merch-order'> = async (
 
   // Best-effort Printful cancellation after the DB transaction commits.
   // If this fails, the mana refund still stands — admin can cancel manually in Printful.
-  if (printfulOrderId) {
+  // Skip outside prod so dev refunds never reach the real Printful API.
+  if (printfulOrderId && isProd()) {
     const printfulToken = process.env.PRINTFUL_API_TOKEN
     if (printfulToken) {
       try {

--- a/backend/api/src/shop-purchase-merch.ts
+++ b/backend/api/src/shop-purchase-merch.ts
@@ -2,7 +2,7 @@ import { APIError, type APIHandler } from './helpers/endpoint'
 import { runTxnOutsideBetQueue, type TxnData } from 'shared/txn/run-txn'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { runTransactionWithRetries } from 'shared/transact-with-retries'
-import { getUser } from 'shared/utils'
+import { getUser, isProd } from 'shared/utils'
 import { getShopItem, isMerchItem, PRINTFUL_API_URL } from 'common/shop/items'
 import { requiresPostalCode } from 'common/shop/printful-address'
 import { getBenefit } from 'common/supporter-config'
@@ -13,6 +13,12 @@ export const shopPurchaseMerch: APIHandler<'shop-purchase-merch'> = async (
   { itemId, variantId, shippingCost, shipping },
   auth
 ) => {
+  // Merch orders create real Printful drafts that staff have to clean up.
+  // Block outside prod so test users can't pollute the orders list.
+  if (!isProd()) {
+    throw new APIError(403, 'Merch ordering is disabled outside of production')
+  }
+
   const item = getShopItem(itemId)
   if (!item) {
     throw new APIError(404, 'Item not found')

--- a/backend/api/src/shop-shipping-rates.ts
+++ b/backend/api/src/shop-shipping-rates.ts
@@ -1,6 +1,7 @@
 import { APIError, type APIHandler } from './helpers/endpoint'
 import { SHOP_ITEMS, PRINTFUL_API_URL } from 'common/shop/items'
 import { requiresPostalCode } from 'common/shop/printful-address'
+import { isProd } from 'shared/utils'
 
 export const shopShippingRates: APIHandler<'shop-shipping-rates'> = async (
   { variantId, address },
@@ -8,6 +9,12 @@ export const shopShippingRates: APIHandler<'shop-shipping-rates'> = async (
 ) => {
   if (!auth) {
     throw new APIError(401, 'Must be logged in')
+  }
+
+  // Shipping rate lookups call Printful with our prod API key. Block outside
+  // prod so the dev project doesn't depend on the secret being populated.
+  if (!isProd()) {
+    throw new APIError(403, 'Merch shipping is disabled outside of production')
   }
 
   // Validate that the variantId belongs to a Manifold shop item


### PR DESCRIPTION
Prevent dev/local environments from creating real Printful drafts or hitting the Printful API with the prod token. shop-purchase-merch and shop-shipping-rates now reject outside prod; cancel-merch-order skips just the Printful DELETE so admins can still refund test orders on dev.

This lets us re-enable PRINTFUL_API_TOKEN in the dev secret manager without risking test users polluting the live orders list.