### PR TITLE
Allow most post-KYC permissions on dev

### DIFF
--- a/common/src/economy.ts
+++ b/common/src/economy.ts
@@ -1,4 +1,5 @@
 import { OutcomeType } from 'common/contract'
+import { ENV } from 'common/envs/constants'
 import {
   answerCostTiers,
   getTierIndexFromLiquidity,
@@ -38,7 +39,7 @@ export const BETTING_STREAK_SWEEPS_BONUS_AMOUNT = 0.05
 export const BETTING_STREAK_SWEEPS_BONUS_MAX = 0.25
 
 /* Mana bonuses */
-export const PRE_KYC_STARTING_BALANCE = 50
+export const PRE_KYC_STARTING_BALANCE = ENV === 'DEV' ? 10000 : 50
 export const STARTING_BALANCE = 1000
 // for sus users, i.e. multiple sign ups for same person
 export const SUS_STARTING_BALANCE = 10

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -1,4 +1,4 @@
-import { ENV_CONFIG } from './envs/constants'
+import { ENV, ENV_CONFIG } from './envs/constants'
 import { notification_preferences } from './user-notification-preferences'
 import { UserEntitlement } from './shop/types'
 import { DAY_MS, HOUR_MS } from './util/time'
@@ -209,9 +209,14 @@ export const isUserLikelySpammer = (
 export const humanish = (user: User) => user.verifiedPhone !== false
 
 // Check if user can receive site bonuses (verified via iDenfy or grandfathered)
-export const canReceiveBonuses = (user: User) =>
-  user.bonusEligibility === 'verified' ||
-  user.bonusEligibility === 'grandfathered'
+// On DEV, all non-bot users are treated as bonus-eligible so they don't need to verify.
+export const canReceiveBonuses = (user: User) => {
+  if (ENV === 'DEV' && !user.isBot) return true
+  return (
+    user.bonusEligibility === 'verified' ||
+    user.bonusEligibility === 'grandfathered'
+  )
+}
 
 // Users who can comment on markets: bonus-eligible (verified/grandfathered)
 // OR anyone who has purchased mana.


### PR DESCRIPTION
- Allows `canReceiveBonuses` for all users on dev, acting as though all are grandfathered
- Sets starting balance to M$10,000 on dev to give them more room for experimentation