### PR TITLE
Let the frontend set a mana budget for buying prize entries

### DIFF
--- a/backend/api/src/buy-sweepstakes-tickets.ts
+++ b/backend/api/src/buy-sweepstakes-tickets.ts
@@ -4,6 +4,7 @@ import { runTxnInBetQueue } from 'shared/txn/run-txn'
 import { getUser } from 'shared/utils'
 import {
   calculateSweepstakesTicketCost,
+  calculateSweepstakesTicketsFromMana,
   getTotalPrizePool,
   SWEEPSTAKES_MIN_MANA_INVESTED,
   SweepstakesPrize,
@@ -13,118 +14,143 @@ import { isSweepstakesLocationAllowed } from 'shared/ip-geolocation'
 import { canReceiveBonuses } from 'common/user'
 import { isAdminId } from 'common/envs/constants'
 
-export const buySweepstakesTickets: APIHandler<'buy-sweepstakes-tickets'> =
-  async (props, auth, req) => {
-    const { sweepstakesNum, numTickets } = props
+export const buySweepstakesTickets: APIHandler<
+  'buy-sweepstakes-tickets'
+> = async (props, auth, req) => {
+  const { sweepstakesNum, maxManaSpent } = props
+  let { numTickets } = props
 
-    // Geofencing check
-    const ip = getIp(req)
-    const { allowed } = await isSweepstakesLocationAllowed(ip)
-    if (!allowed) {
-      throw new APIError(403, 'Sweepstakes is not available in your region')
-    }
+  // Geofencing check
+  const ip = getIp(req)
+  const { allowed } = await isSweepstakesLocationAllowed(ip)
+  if (!allowed) {
+    throw new APIError(403, 'Sweepstakes is not available in your region')
+  }
 
-    const pg = createSupabaseDirectClient()
+  const pg = createSupabaseDirectClient()
 
-    return await pg.tx(async (tx) => {
-      // Get sweepstakes and verify it's still open
-      const sweepstakes = await tx.oneOrNone<{
-        sweepstakes_num: number
-        close_time: string
-        prizes: SweepstakesPrize[]
-      }>(
-        `SELECT sweepstakes_num, close_time, prizes
+  return await pg.tx(async (tx) => {
+    // Get sweepstakes and verify it's still open
+    const sweepstakes = await tx.oneOrNone<{
+      sweepstakes_num: number
+      close_time: string
+      prizes: SweepstakesPrize[]
+    }>(
+      `SELECT sweepstakes_num, close_time, prizes
          FROM sweepstakes
          WHERE sweepstakes_num = $1
          FOR UPDATE`,
-        [sweepstakesNum]
-      )
+      [sweepstakesNum]
+    )
 
-      if (!sweepstakes) {
-        throw new APIError(404, 'Sweepstakes not found')
-      }
+    if (!sweepstakes) {
+      throw new APIError(404, 'Sweepstakes not found')
+    }
 
-      if (new Date(sweepstakes.close_time) <= new Date()) {
-        throw new APIError(400, 'Sweepstakes has closed')
-      }
+    if (new Date(sweepstakes.close_time) <= new Date()) {
+      throw new APIError(400, 'Sweepstakes has closed')
+    }
 
-      // Get total ticket count for this sweepstakes (for bonding curve)
-      const ticketStats = await tx.oneOrNone<{ total_tickets: string }>(
-        `SELECT COALESCE(SUM(num_tickets), 0) as total_tickets 
-         FROM sweepstakes_tickets 
+    // Get total ticket count for this sweepstakes (for bonding curve)
+    const ticketStats = await tx.oneOrNone<{ total_tickets: string }>(
+      `SELECT COALESCE(SUM(num_tickets), 0) as total_tickets
+         FROM sweepstakes_tickets
          WHERE sweepstakes_num = $1`,
-        [sweepstakesNum]
+      [sweepstakesNum]
+    )
+    const currentTickets = parseFloat(ticketStats?.total_tickets ?? '0')
+
+    // Calculate cost. If the caller provided a mana budget, compute the
+    // number of entries using the latest ticket count so concurrent purchases
+    // cannot make us spend more mana than the user confirmed in the UI.
+    const totalPrizeUsd = getTotalPrizePool(sweepstakes.prizes)
+    let manaSpent: number
+    if (maxManaSpent) {
+      manaSpent = maxManaSpent
+      numTickets = calculateSweepstakesTicketsFromMana(
+        currentTickets,
+        maxManaSpent,
+        totalPrizeUsd
       )
-      const currentTickets = parseFloat(ticketStats?.total_tickets ?? '0')
-
-      // Calculate cost
-      const totalPrizeUsd = getTotalPrizePool(sweepstakes.prizes)
-      const manaSpent = calculateSweepstakesTicketCost(currentTickets, numTickets, totalPrizeUsd)
-
-      // Check user balance and eligibility
-      const user = await getUser(auth.uid, tx)
-      if (!user) {
-        throw new APIError(404, 'User not found')
+    } else {
+      if (!numTickets || numTickets <= 0) {
+        throw new APIError(400, 'Ticket quantity must be positive')
       }
-      if (isAdminId(user.id)) {
-        throw new APIError(403, 'Admins cannot participate in the sweepstakes')
-      }
-      if (!canReceiveBonuses(user)) {
-        throw new APIError(
-          403,
-          'You must verify your identity to participate in the sweepstakes'
-        )
-      }
+      manaSpent = calculateSweepstakesTicketCost(
+        currentTickets,
+        numTickets,
+        totalPrizeUsd
+      )
+    }
 
-      // Check minimum mana invested requirement
-      const investedResult = await tx.oneOrNone<{ total_invested: string }>(
-        `SELECT COALESCE(SUM((data->>'totalAmountInvested')::numeric), 0) as total_invested
+    if (numTickets <= 0) {
+      throw new APIError(400, 'Ticket quantity must be positive')
+    }
+
+    // Check user balance and eligibility
+    const user = await getUser(auth.uid, tx)
+    if (!user) {
+      throw new APIError(404, 'User not found')
+    }
+    if (isAdminId(user.id)) {
+      throw new APIError(403, 'Admins cannot participate in the sweepstakes')
+    }
+    if (!canReceiveBonuses(user)) {
+      throw new APIError(
+        403,
+        'You must verify your identity to participate in the sweepstakes'
+      )
+    }
+
+    // Check minimum mana invested requirement
+    const investedResult = await tx.oneOrNone<{ total_invested: string }>(
+      `SELECT COALESCE(SUM((data->>'totalAmountInvested')::numeric), 0) as total_invested
          FROM user_contract_metrics
          WHERE user_id = $1`,
-        [auth.uid]
+      [auth.uid]
+    )
+    const totalManaInvested = parseFloat(investedResult?.total_invested ?? '0')
+    if (totalManaInvested < SWEEPSTAKES_MIN_MANA_INVESTED) {
+      throw new APIError(
+        403,
+        `You must have at least ${SWEEPSTAKES_MIN_MANA_INVESTED} mana invested to participate in the sweepstakes`
       )
-      const totalManaInvested = parseFloat(investedResult?.total_invested ?? '0')
-      if (totalManaInvested < SWEEPSTAKES_MIN_MANA_INVESTED) {
-        throw new APIError(
-          403,
-          `You must have at least ${SWEEPSTAKES_MIN_MANA_INVESTED} mana invested to participate in the sweepstakes`
-        )
-      }
+    }
 
-      if (user.balance < manaSpent) {
-        throw new APIError(403, 'Insufficient mana balance')
-      }
+    if (user.balance < manaSpent) {
+      throw new APIError(403, 'Insufficient mana balance')
+    }
 
-      // Insert ticket purchase record
-      const ticketRow = await tx.one<{ id: string }>(
-        `INSERT INTO sweepstakes_tickets (sweepstakes_num, user_id, num_tickets, mana_spent, is_free)
+    // Insert ticket purchase record
+    const ticketRow = await tx.one<{ id: string }>(
+      `INSERT INTO sweepstakes_tickets (sweepstakes_num, user_id, num_tickets, mana_spent, is_free)
          VALUES ($1, $2, $3, $4, false)
          RETURNING id`,
-        [sweepstakesNum, auth.uid, numTickets, manaSpent]
-      )
+      [sweepstakesNum, auth.uid, numTickets, manaSpent]
+    )
 
-      // Create transaction to deduct mana
-      const txn = {
-        category: 'SWEEPSTAKES_TICKET',
-        fromType: 'USER',
-        fromId: auth.uid,
-        toType: 'BANK',
-        toId: 'BANK',
-        amount: manaSpent,
-        token: 'M$',
-        data: {
-          sweepstakesNum,
-          numTickets,
-          ticketId: ticketRow.id,
-        },
-      } as const
-
-      await runTxnInBetQueue(tx, txn)
-
-      return {
-        ticketId: ticketRow.id,
+    // Create transaction to deduct mana
+    const txn = {
+      category: 'SWEEPSTAKES_TICKET',
+      fromType: 'USER',
+      fromId: auth.uid,
+      toType: 'BANK',
+      toId: 'BANK',
+      amount: manaSpent,
+      token: 'M$',
+      data: {
+        sweepstakesNum,
         numTickets,
-        manaSpent,
-      }
-    })
-  }
+        ticketId: ticketRow.id,
+      },
+    } as const
+
+    await runTxnInBetQueue(tx, txn)
+
+    return {
+      ticketId: ticketRow.id,
+      numTickets,
+      manaSpent,
+    }
+  })
+}

--- a/backend/api/src/buy-sweepstakes-tickets.ts
+++ b/backend/api/src/buy-sweepstakes-tickets.ts
@@ -63,29 +63,38 @@ export const buySweepstakesTickets: APIHandler<
     // Calculate cost. If the caller provided a mana budget, compute the
     // number of entries using the latest ticket count so concurrent purchases
     // cannot make us spend more mana than the user confirmed in the UI.
+    // If both numTickets and maxManaSpent are provided, take the lesser
+    // ticket count (i.e. whichever constraint is tighter).
     const totalPrizeUsd = getTotalPrizePool(sweepstakes.prizes)
-    let manaSpent: number
+
     if (maxManaSpent) {
-      manaSpent = maxManaSpent
-      numTickets = calculateSweepstakesTicketsFromMana(
+      const ticketsFromMana = calculateSweepstakesTicketsFromMana(
         currentTickets,
         maxManaSpent,
         totalPrizeUsd
       )
-    } else {
-      if (!numTickets || numTickets <= 0) {
-        throw new APIError(400, 'Ticket quantity must be positive')
-      }
-      manaSpent = calculateSweepstakesTicketCost(
-        currentTickets,
-        numTickets,
-        totalPrizeUsd
+      // If both are provided, use the lesser ticket count
+      numTickets = numTickets
+        ? Math.min(numTickets, ticketsFromMana)
+        : ticketsFromMana
+    }
+
+    if (!numTickets || numTickets <= 0) {
+      throw new APIError(
+        400,
+        maxManaSpent
+          ? 'Insufficient mana for any entries at the current price'
+          : 'Ticket quantity must be positive'
       )
     }
 
-    if (numTickets <= 0) {
-      throw new APIError(400, 'Ticket quantity must be positive')
-    }
+    // Always recalculate manaSpent from the final numTickets so the user
+    // is charged the exact cost (never more than maxManaSpent).
+    const manaSpent = calculateSweepstakesTicketCost(
+      currentTickets,
+      numTickets,
+      totalPrizeUsd
+    )
 
     // Check user balance and eligibility
     const user = await getUser(auth.uid, tx)

--- a/backend/api/src/buy-sweepstakes-tickets.ts
+++ b/backend/api/src/buy-sweepstakes-tickets.ts
@@ -90,11 +90,14 @@ export const buySweepstakesTickets: APIHandler<
 
     // Always recalculate manaSpent from the final numTickets so the user
     // is charged the exact cost (never more than maxManaSpent).
-    const manaSpent = calculateSweepstakesTicketCost(
+    let manaSpent = calculateSweepstakesTicketCost(
       currentTickets,
       numTickets,
       totalPrizeUsd
     )
+    if (maxManaSpent && manaSpent > maxManaSpent) {
+      manaSpent = maxManaSpent
+    }
 
     // Check user balance and eligibility
     const user = await getUser(auth.uid, tx)

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -3467,9 +3467,13 @@ export const API = (_apiTypeCheck = {
     props: z
       .object({
         sweepstakesNum: z.number(),
-        numTickets: z.number().positive(),
+        numTickets: z.number().positive().optional(),
+        maxManaSpent: z.number().positive().optional(),
       })
-      .strict(),
+      .strict()
+      .refine((props) => props.numTickets || props.maxManaSpent, {
+        message: 'Must provide numTickets or maxManaSpent',
+      }),
     returns: {} as {
       ticketId: string
       numTickets: number

--- a/web/pages/prize.tsx
+++ b/web/pages/prize.tsx
@@ -294,7 +294,7 @@ export default function SweepstakesPage({
     try {
       const result = await api('buy-sweepstakes-tickets', {
         sweepstakesNum: sweepstakes.sweepstakesNum,
-        numTickets,
+        maxManaSpent: manaAmount,
       })
       toast.success(
         `Gained ${formatEntries(result.numTickets)} entries for ${formatMoney(
@@ -1013,7 +1013,8 @@ function PurchaseForm(props: {
             <InfoTooltip
               text={`Current rate: ${formatMoneyWithDecimals(
                 currentPrice
-              )} per entry. Rates follow a bonding curve—earlier entries require less mana.`}
+              )} per entry. Rates follow a bonding curve—earlier entries require less mana.
+              Your mana spend is fixed; the final entry count is calculated at purchase time.`}
               size="sm"
             />
           </Row>
@@ -1064,7 +1065,8 @@ function PurchaseForm(props: {
           disabled={numTickets <= 0 || isSubmitting || disabled}
           className="w-full justify-center rounded-lg py-3 font-semibold"
         >
-          Get {formatEntries(numTickets)} entries for {formatMoney(manaAmount)}
+          Get up to {formatEntries(numTickets)} entries for{' '}
+          {formatMoney(manaAmount)}
         </Button>
       </Col>
     </div>


### PR DESCRIPTION
1. The API now accepts an optional mana budget alongside (or instead of) `numTickets`. At least one must be provided and if both are given, the tighter constraint wins.
2. When `maxManaSpent` is provided, the handler calls `calculateSweepstakesTicketsFromMana()` using the latest ticket count, ensuring the user isn't charged more than their confirmed budget. The final `manaSpent` is always recalculated from the resolved `numTickets`.
3. The purchase form now passes `maxManaSpent` instead of `numTickets`, and the UI copy is updated with a tooltip "Your mana spend is fixed; the final entry count is calculated at purchase time.".