### PR TITLE
notifications: show truthful default state for unset preferences

### DIFF
--- a/web/components/notification-settings.tsx
+++ b/web/components/notification-settings.tsx
@@ -17,6 +17,7 @@ import clsx from 'clsx'
 import { NOTIFICATION_DESCRIPTIONS } from 'common/notification'
 import { PrivateUser } from 'common/user'
 import {
+  getDefaultNotificationPreferences,
   notification_destination_types,
   notification_preference,
 } from 'common/user-notification-preferences'
@@ -605,5 +606,9 @@ export const getUsersSavedPreference = (
   key: notification_preference,
   privateUser: PrivateUser
 ) => {
-  return privateUser.notificationPreferences[key] ?? []
+  return (
+    privateUser.notificationPreferences[key] ??
+    getDefaultNotificationPreferences()[key] ??
+    []
+  )
 }


### PR DESCRIPTION
The settings UI read returned `[]` for any preference key the user had no stored value for, so toggles rendered OFF — even though the producer's gate falls back to `getDefaultNotificationPreferences()` and was happily sending. This made `prize_drawings` and `charity_giveaways` look disabled to every user whose `notificationPreferences` blob predated those keys, while they kept receiving them.

Mirror the gate's fallback in `getUsersSavedPreference` so the UI shows what the producer will actually do. Toggling off still writes `[]` and is honored as before.