### PR TITLE
leagues: pay Silicon bots Platinum-tier prizes (top 6, M$100 floor)

### DIFF
--- a/backend/shared/src/create-notification.ts
+++ b/backend/shared/src/create-notification.ts
@@ -674,6 +674,7 @@ export const createLeagueChangedNotifications = async (
       previousLeague: item.previousLeague,
       newLeague: item.newLeague,
       bonusAmount: item.bonusAmount,
+      missedPrizeReason: item.missedPrizeReason,
     }
 
     const notification: Notification = {

--- a/backend/shared/src/payout-leagues.ts
+++ b/backend/shared/src/payout-leagues.ts
@@ -2,6 +2,7 @@ import {
   getLeaguePrize,
   league_user_info,
   LeagueChangeNotificationData,
+  SILICON_PRIZE_MIN_MANA_EARNED,
 } from 'common/leagues'
 import { SupabaseTransaction } from './supabase/init'
 import { createLeagueChangedNotifications } from './create-notification'
@@ -71,12 +72,21 @@ export const sendEndOfSeasonNotificationsAndBonuses = async (
         )
       : []
 
-  const eligibleUserIds = new Set(
-    usersWithEligibility
+  const siliconUserIds = newRows
+    .filter((row) => {
+      const prevRow = prevRowsByUserId[row.user_id]
+      return prevRow?.division === 0
+    })
+    .map((row) => row.user_id)
+
+  // Silicon (bots) bypasses iDenfy verification — bots can't be KYC'd.
+  const eligibleUserIds = new Set([
+    ...usersWithEligibility
       .map((row) => convertUser(row))
       .filter((user) => canReceiveBonuses(user))
-      .map((user) => user.id)
-  )
+      .map((user) => user.id),
+    ...siliconUserIds,
+  ])
 
   // Check eligibility for users in this chunk
   for (const newRow of newRows) {
@@ -98,6 +108,21 @@ export const sendEndOfSeasonNotificationsAndBonuses = async (
         previousLeague: prevRow,
         newLeague: newRow,
         bonusAmount: 0,
+      })
+      continue
+    }
+
+    // Silicon (bots): require minimum mana earned so idle bots can't win by default.
+    if (
+      prevRow.division === 0 &&
+      (prevRow.mana_earned ?? 0) < SILICON_PRIZE_MIN_MANA_EARNED
+    ) {
+      notificationData.push({
+        userId: newRow.user_id,
+        previousLeague: prevRow,
+        newLeague: newRow,
+        bonusAmount: 0,
+        missedPrizeReason: 'silicon_min_mana_not_met',
       })
       continue
     }

--- a/common/src/leagues.ts
+++ b/common/src/leagues.ts
@@ -326,7 +326,10 @@ export const getCohortSize = (division: number) => {
   return 25
 }
 
+// Indexed by division number. Silicon (0) pays only the top 6;
+// payout further requires mana_earned >= 100 (see payout-leagues.ts).
 export const prizesByDivisionAndRank = [
+  [800, 400, 360, 320, 280, 240],
   [100, 50, 40, 30, 20, 10, 5],
   [200, 100, 90, 80, 70, 60, 50, 40],
   [400, 200, 180, 160, 140, 120, 100, 80, 60],
@@ -335,8 +338,10 @@ export const prizesByDivisionAndRank = [
   [6400, 3200, 1600, 1440, 1200, 1120, 960, 800, 640, 480],
 ]
 
+export const SILICON_PRIZE_MIN_MANA_EARNED = 100
+
 export const getLeaguePrize = (division: number, rank: number) => {
-  const divisionPrizes = prizesByDivisionAndRank[division - 1]
+  const divisionPrizes = prizesByDivisionAndRank[division]
   if (!divisionPrizes) return 0
   return divisionPrizes[rank - 1] || 0
 }

--- a/common/src/notification.ts
+++ b/common/src/notification.ts
@@ -407,6 +407,7 @@ export type LeagueChangeData = {
   previousLeague: league_user_info | undefined
   newLeague: { season: number; division: number; cohort: string }
   bonusAmount: number
+  missedPrizeReason?: 'silicon_min_mana_not_met'
 }
 
 export type BetFillData = {

--- a/web/components/leagues/prizes-modal.tsx
+++ b/web/components/leagues/prizes-modal.tsx
@@ -23,8 +23,8 @@ export function PrizesModal(props: {
     6: '🎖️',
   }
   const divisions = sortBy(
-    Object.entries(DIVISION_NAMES).filter(([division]) => +division > 0),
-    ([division]) => division
+    Object.entries(DIVISION_NAMES),
+    ([division]) => +division
   )
 
   return (
@@ -44,7 +44,7 @@ export function PrizesModal(props: {
           {divisions.map(([divisionNum, divisionName]) => {
             const div = +divisionNum
             const style = DIVISION_STYLES[div] ?? DIVISION_STYLES[1]
-            const prizes = prizesByDivisionAndRank[div - 1] ?? []
+            const prizes = prizesByDivisionAndRank[div] ?? []
 
             return (
               <Col key={div} className="gap-3">

--- a/web/components/leagues/prizes-modal.tsx
+++ b/web/components/leagues/prizes-modal.tsx
@@ -63,6 +63,11 @@ export function PrizesModal(props: {
                   </div>
                   <span className="text-ink-900 font-medium">
                     {divisionName}
+                    {div === 0 && (
+                      <span className="text-ink-500 ml-1 font-normal">
+                        (bot only)
+                      </span>
+                    )}
                   </span>
                 </Row>
 

--- a/web/components/notifications/income-summary-notifications.tsx
+++ b/web/components/notifications/income-summary-notifications.tsx
@@ -36,7 +36,7 @@ import { Row } from 'web/components/layout/row'
 import { Avatar } from 'web/components/widgets/avatar'
 import { BetOutcomeLabel } from 'web/components/outcome-label'
 import { getFormattedMappedValue } from 'common/pseudo-numeric'
-import { DIVISION_NAMES } from 'common/leagues'
+import { DIVISION_NAMES, SILICON_PRIZE_MIN_MANA_EARNED } from 'common/leagues'
 import { Linkify } from 'web/components/widgets/linkify'
 import {
   PARTNER_UNIQUE_TRADER_BONUS,
@@ -631,7 +631,8 @@ export function LeagueChangedNotification(props: {
 }) {
   const { notification, isChildOfGroup, highlighted, setHighlighted } = props
   const { data } = notification
-  const { previousLeague, newLeague, bonusAmount } = data as LeagueChangeData
+  const { previousLeague, newLeague, bonusAmount, missedPrizeReason } =
+    data as LeagueChangeData
   const newlyAdded = previousLeague === undefined
   const promoted =
     previousLeague && previousLeague.division < newLeague.division
@@ -658,6 +659,13 @@ export function LeagueChangedNotification(props: {
             {previousLeague &&
               ` for placing Rank ${previousLeague.rank} this season`}
             .
+          </span>
+        ) : missedPrizeReason === 'silicon_min_mana_not_met' &&
+          previousLeague ? (
+          <span>
+            You placed Rank {previousLeague.rank} this season but didn't earn
+            the {formatMoney(SILICON_PRIZE_MIN_MANA_EARNED)} minimum required
+            for a Silicon prize.
           </span>
         ) : previousLeague ? (
           <span>You placed Rank {previousLeague.rank} this season.</span>


### PR DESCRIPTION
Silicon (division 0) previously had no rewards. Adds a top-6 prize ladder mirroring Platinum (M$800/400/360/320/280/240), gated on mana_earned >= 100 so idle bots can't win when other bots lose.

Bots bypass the iDenfy verification gate (canReceiveBonuses) for LEAGUE_PRIZE since they can't be KYC'd. Bypass is scoped to division 0 only.

When a bot ranks in the prize zone but misses the M$100 floor, the season-end notification carries a typed missedPrizeReason and the frontend renders explanatory copy instead of a silent zero bonus.

prizesByDivisionAndRank is now indexed by division directly (was division - 1) so Silicon fits naturally at index 0.