### PR TITLE
charts: scale numeric y-axis to data extent, not full contract range

### DIFF
--- a/web/components/charts/contract/multi-date.tsx
+++ b/web/components/charts/contract/multi-date.tsx
@@ -1,9 +1,14 @@
 import { useMemo } from 'react'
-import { last, map, max, sum, zip, min, keyBy, sortBy } from 'lodash'
+import { last, map, sum, zip, keyBy, sortBy } from 'lodash'
 import { scaleLinear, scaleTime } from 'd3-scale'
 import { MultiDateContract } from 'common/contract'
 import { NUMERIC_GRAPH_COLOR } from 'common/numeric-constants'
-import { getEndDate, getRightmostVisibleDate, ZoomParams } from '../helpers'
+import {
+  getEndDate,
+  getRightmostVisibleDate,
+  getVisibleNumericYRange,
+  ZoomParams,
+} from '../helpers'
 import { SingleValueHistoryChart } from '../generic-charts'
 import { SingleContractChartTooltip } from './single-value'
 
@@ -113,8 +118,17 @@ export const MultiDateContractChart = (props: {
   height: number
   zoomParams?: ZoomParams
   showZoomer?: boolean
+  zoomY?: boolean
 }) => {
-  const { contract, width, multiPoints, height, zoomParams, showZoomer } = props
+  const {
+    contract,
+    width,
+    multiPoints,
+    height,
+    zoomParams,
+    showZoomer,
+    zoomY,
+  } = props
   const start = contract.createdTime
   const end = getEndDate(contract)
   const endP = getExpectedDate(contract)
@@ -136,14 +150,20 @@ export const MultiDateContractChart = (props: {
     [betPoints, end, endP, now]
   )
   const { min: answerMin, max: answerMax } = getMinMax(contract)
-  const allYs = singlePointData.map((p) => p.y)
-  const minY = min([...allYs, answerMin])!
-  const maxY = max([...allYs, answerMax])!
+  const [minY, maxY] = getVisibleNumericYRange({
+    data: singlePointData,
+    contractMin: answerMin,
+    contractMax: answerMax,
+    zoomY,
+    zoomParams,
+  })
+  const isYZoomed = minY !== answerMin || maxY !== answerMax
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 
   // Scale for dates on Y-axis (time values in milliseconds)
   const yScale = scaleLinear([minY, maxY], [height, 0])
+  if (isYZoomed) yScale.nice()
 
   return (
     <SingleValueHistoryChart

--- a/web/components/charts/contract/multi-numeric.tsx
+++ b/web/components/charts/contract/multi-numeric.tsx
@@ -4,9 +4,9 @@ import { scaleLinear, scaleTime } from 'd3-scale'
 import { MultiNumericContract } from 'common/contract'
 import { NUMERIC_GRAPH_COLOR } from 'common/numeric-constants'
 import {
-  getDataPaddedYRange,
   getEndDate,
   getRightmostVisibleDate,
+  getVisibleNumericYRange,
   ZoomParams,
 } from '../helpers'
 import { SingleValueHistoryChart } from '../generic-charts'
@@ -96,8 +96,17 @@ export const MultiNumericContractChart = (props: {
   height: number
   zoomParams?: ZoomParams
   showZoomer?: boolean
+  zoomY?: boolean
 }) => {
-  const { contract, width, multiPoints, height, zoomParams, showZoomer } = props
+  const {
+    contract,
+    width,
+    multiPoints,
+    height,
+    zoomParams,
+    showZoomer,
+    zoomY,
+  } = props
   const start = contract.createdTime
   const end = getEndDate(contract)
   const endP = getExpectedValue(contract)
@@ -119,11 +128,13 @@ export const MultiNumericContractChart = (props: {
     [betPoints, end, endP, now]
   )
   const { min: answerMin, max: answerMax } = getMinMax(contract)
-  const [minY, maxY] = getDataPaddedYRange(
-    singlePointData,
-    answerMin,
-    answerMax
-  )
+  const [minY, maxY] = getVisibleNumericYRange({
+    data: singlePointData,
+    contractMin: answerMin,
+    contractMax: answerMax,
+    zoomY,
+    zoomParams,
+  })
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 

--- a/web/components/charts/contract/multi-numeric.tsx
+++ b/web/components/charts/contract/multi-numeric.tsx
@@ -135,10 +135,12 @@ export const MultiNumericContractChart = (props: {
     zoomY,
     zoomParams,
   })
+  const isYZoomed = minY !== answerMin || maxY !== answerMax
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 
-  const yScale = scaleLinear([minY, maxY], [height, 0]).nice()
+  const yScale = scaleLinear([minY, maxY], [height, 0])
+  if (isYZoomed) yScale.nice()
   return (
     <SingleValueHistoryChart
       w={width}

--- a/web/components/charts/contract/multi-numeric.tsx
+++ b/web/components/charts/contract/multi-numeric.tsx
@@ -1,9 +1,14 @@
 import { useMemo } from 'react'
-import { last, map, sum, zip, keyBy, max, min, sortBy } from 'lodash'
+import { last, map, sum, zip, keyBy, sortBy } from 'lodash'
 import { scaleLinear, scaleTime } from 'd3-scale'
 import { MultiNumericContract } from 'common/contract'
 import { NUMERIC_GRAPH_COLOR } from 'common/numeric-constants'
-import { getEndDate, getRightmostVisibleDate, ZoomParams } from '../helpers'
+import {
+  getDataPaddedYRange,
+  getEndDate,
+  getRightmostVisibleDate,
+  ZoomParams,
+} from '../helpers'
 import { SingleValueHistoryChart } from '../generic-charts'
 import { SingleContractChartTooltip } from './single-value'
 
@@ -114,14 +119,15 @@ export const MultiNumericContractChart = (props: {
     [betPoints, end, endP, now]
   )
   const { min: answerMin, max: answerMax } = getMinMax(contract)
-  const allYs = singlePointData.map((p) => p.y)
-  const minY = min([...allYs, answerMin])!
-  const maxY = max([...allYs, answerMax])!
+  const [minY, maxY] = getDataPaddedYRange(
+    singlePointData,
+    answerMin,
+    answerMax
+  )
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 
-  // clamp log scale to make sure zeroes go to the bottom
-  const yScale = scaleLinear([minY, maxY], [height, 0])
+  const yScale = scaleLinear([minY, maxY], [height, 0]).nice()
   return (
     <SingleValueHistoryChart
       w={width}

--- a/web/components/charts/contract/number.tsx
+++ b/web/components/charts/contract/number.tsx
@@ -3,7 +3,12 @@ import { keyBy, last, sum } from 'lodash'
 import { scaleLinear, scaleTime } from 'd3-scale'
 import { CPMMNumericContract } from 'common/contract'
 import { NUMERIC_GRAPH_COLOR } from 'common/numeric-constants'
-import { getEndDate, getRightmostVisibleDate, ZoomParams } from '../helpers'
+import {
+  getDataPaddedYRange,
+  getEndDate,
+  getRightmostVisibleDate,
+  ZoomParams,
+} from '../helpers'
 import { SingleValueHistoryChart } from '../generic-charts'
 import { SingleContractChartTooltip } from './single-value'
 import { map, zip } from 'd3-array'
@@ -78,8 +83,8 @@ export const NumberContractChart = (props: {
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 
-  // clamp log scale to make sure zeroes go to the bottom
-  const yScale = scaleLinear([min, max], [height, 0])
+  const [yMin, yMax] = getDataPaddedYRange(singlePointData, min, max)
+  const yScale = scaleLinear([yMin, yMax], [height, 0]).nice()
   return (
     <SingleValueHistoryChart
       w={width}

--- a/web/components/charts/contract/number.tsx
+++ b/web/components/charts/contract/number.tsx
@@ -4,9 +4,9 @@ import { scaleLinear, scaleTime } from 'd3-scale'
 import { CPMMNumericContract } from 'common/contract'
 import { NUMERIC_GRAPH_COLOR } from 'common/numeric-constants'
 import {
-  getDataPaddedYRange,
   getEndDate,
   getRightmostVisibleDate,
+  getVisibleNumericYRange,
   ZoomParams,
 } from '../helpers'
 import { SingleValueHistoryChart } from '../generic-charts'
@@ -62,8 +62,10 @@ export const NumberContractChart = (props: {
   height: number
   zoomParams?: ZoomParams
   showZoomer?: boolean
+  zoomY?: boolean
 }) => {
-  const { contract, width, multiPoints, height, zoomParams, showZoomer } = props
+  const { contract, width, multiPoints, height, zoomParams, showZoomer, zoomY } =
+    props
   const { min, max } = contract
   const start = contract.createdTime
   const end = getEndDate(contract)
@@ -83,7 +85,13 @@ export const NumberContractChart = (props: {
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 
-  const [yMin, yMax] = getDataPaddedYRange(singlePointData, min, max)
+  const [yMin, yMax] = getVisibleNumericYRange({
+    data: singlePointData,
+    contractMin: min,
+    contractMax: max,
+    zoomY,
+    zoomParams,
+  })
   const yScale = scaleLinear([yMin, yMax], [height, 0]).nice()
   return (
     <SingleValueHistoryChart

--- a/web/components/charts/contract/number.tsx
+++ b/web/components/charts/contract/number.tsx
@@ -92,7 +92,9 @@ export const NumberContractChart = (props: {
     zoomY,
     zoomParams,
   })
-  const yScale = scaleLinear([yMin, yMax], [height, 0]).nice()
+  const isYZoomed = yMin !== min || yMax !== max
+  const yScale = scaleLinear([yMin, yMax], [height, 0])
+  if (isYZoomed) yScale.nice()
   return (
     <SingleValueHistoryChart
       w={width}

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -6,9 +6,9 @@ import { formatLargeNumber } from 'common/util/format'
 import { PseudoNumericContract } from 'common/contract'
 import { NUMERIC_GRAPH_COLOR } from 'common/numeric-constants'
 import {
-  getDataPaddedYRange,
   getEndDate,
   getRightmostVisibleDate,
+  getVisibleNumericYRange,
   ZoomParams,
 } from '../helpers'
 import { SingleValueHistoryChart } from '../generic-charts'
@@ -39,8 +39,9 @@ export const PseudoNumericContractChart = (props: {
   height: number
   zoomParams?: ZoomParams
   showZoomer?: boolean
+  zoomY?: boolean
 }) => {
-  const { contract, width, height, zoomParams, showZoomer } = props
+  const { contract, width, height, zoomParams, showZoomer, zoomY } = props
   const { min, max, isLogScale } = contract
   const start = contract.createdTime
   const end = getEndDate(contract)
@@ -64,7 +65,13 @@ export const PseudoNumericContractChart = (props: {
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 
-  const [yMin, yMax] = getDataPaddedYRange(data, min, max)
+  const [yMin, yMax] = getVisibleNumericYRange({
+    data,
+    contractMin: min,
+    contractMax: max,
+    zoomY,
+    zoomParams,
+  })
 
   // clamp log scale to make sure zeroes go to the bottom
   const yScale = isLogScale

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -5,7 +5,12 @@ import { getInitialProbability, getProbability } from 'common/calculate'
 import { formatLargeNumber } from 'common/util/format'
 import { PseudoNumericContract } from 'common/contract'
 import { NUMERIC_GRAPH_COLOR } from 'common/numeric-constants'
-import { getEndDate, getRightmostVisibleDate, ZoomParams } from '../helpers'
+import {
+  getDataPaddedYRange,
+  getEndDate,
+  getRightmostVisibleDate,
+  ZoomParams,
+} from '../helpers'
 import { SingleValueHistoryChart } from '../generic-charts'
 import { SingleContractChartTooltip, SingleContractPoint } from './single-value'
 
@@ -59,10 +64,12 @@ export const PseudoNumericContractChart = (props: {
   const rightmostDate = getRightmostVisibleDate(end, last(betPoints)?.x, now)
   const xScale = scaleTime([start, rightmostDate], [0, width])
 
+  const [yMin, yMax] = getDataPaddedYRange(data, min, max)
+
   // clamp log scale to make sure zeroes go to the bottom
   const yScale = isLogScale
-    ? scaleLog([Math.max(min, 1), max], [height, 0]).clamp(true)
-    : scaleLinear([min, max], [height, 0])
+    ? scaleLog([Math.max(yMin, 1), yMax], [height, 0]).clamp(true).nice()
+    : scaleLinear([yMin, yMax], [height, 0]).nice()
   return (
     <SingleValueHistoryChart
       w={width}

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -72,11 +72,13 @@ export const PseudoNumericContractChart = (props: {
     zoomY,
     zoomParams,
   })
+  const isYZoomed = yMin !== min || yMax !== max
 
   // clamp log scale to make sure zeroes go to the bottom
-  const yScale = isLogScale
-    ? scaleLog([Math.max(yMin, 1), yMax], [height, 0]).clamp(true).nice()
-    : scaleLinear([yMin, yMax], [height, 0]).nice()
+  const baseYScale = isLogScale
+    ? scaleLog([Math.max(yMin, 1), yMax], [height, 0]).clamp(true)
+    : scaleLinear([yMin, yMax], [height, 0])
+  const yScale = isYZoomed ? baseYScale.nice() : baseYScale
   return (
     <SingleValueHistoryChart
       w={width}

--- a/web/components/charts/contract/pseudo-numeric.tsx
+++ b/web/components/charts/contract/pseudo-numeric.tsx
@@ -74,11 +74,13 @@ export const PseudoNumericContractChart = (props: {
   })
   const isYZoomed = yMin !== min || yMax !== max
 
-  // clamp log scale to make sure zeroes go to the bottom
-  const baseYScale = isLogScale
+  // clamp log scale to make sure zeroes go to the bottom.
+  // Skip .nice() on log scale: it rounds to powers of 10 and would expand
+  // a zoomed range like [10, 14] back out to [10, 100].
+  const yScale = isLogScale
     ? scaleLog([Math.max(yMin, 1), yMax], [height, 0]).clamp(true)
     : scaleLinear([yMin, yMax], [height, 0])
-  const yScale = isYZoomed ? baseYScale.nice() : baseYScale
+  if (isYZoomed && !isLogScale) yScale.nice()
   return (
     <SingleValueHistoryChart
       w={width}

--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -622,24 +622,48 @@ export const getRightmostVisibleDate = (
   }
 }
 
-// Compute a y-axis range that fits the data with some headroom on each side,
-// so small movements aren't squashed against the contract's full min/max.
-// Result is clamped to [contractMin, contractMax]. Falls back to the full
-// contract range if there's no data or the data is degenerate.
-export const getDataPaddedYRange = (
-  data: { y: number }[],
-  contractMin: number,
-  contractMax: number,
-  paddingFraction = 0.1
-): [number, number] => {
-  const contractRange = contractMax - contractMin
-  if (data.length === 0 || !Number.isFinite(contractRange)) {
+// Numeric analogue of binary.tsx's getVisibleYRange. Returns the full contract
+// range by default; when the user has zoomed the x-axis (e.g. by clicking 1D /
+// 1W), returns a padded y-range fit to the visible-window data, clamped to
+// [contractMin, contractMax]. Mirrors binary's "only auto-scale-Y when zoomed"
+// behavior so the default view of a numeric market is unchanged.
+export const getVisibleNumericYRange = (params: {
+  data: { x: number; y: number }[]
+  contractMin: number
+  contractMax: number
+  zoomY?: boolean
+  zoomParams?: ZoomParams
+  paddingFraction?: number
+}): [number, number] => {
+  const {
+    data,
+    contractMin,
+    contractMax,
+    zoomY,
+    zoomParams,
+    paddingFraction = 0.1,
+  } = params
+
+  if (!zoomY || !zoomParams?.xScale) return [contractMin, contractMax]
+
+  const [minXDate, maxXDate] = zoomParams.viewXScale.domain() ?? [null, null]
+  const [fullMin, fullMax] = zoomParams.xScale.domain()
+  if (
+    !minXDate ||
+    !maxXDate ||
+    (minXDate.getTime() === fullMin.getTime() &&
+      maxXDate.getTime() === fullMax.getTime())
+  ) {
     return [contractMin, contractMax]
   }
 
+  const minXMs = minXDate.getTime()
+  const maxXMs = maxXDate.getTime()
+
   let dataMin = Infinity
   let dataMax = -Infinity
-  for (const { y } of data) {
+  for (const { x, y } of data) {
+    if (x < minXMs || x > maxXMs) continue
     if (!Number.isFinite(y)) continue
     if (y < dataMin) dataMin = y
     if (y > dataMax) dataMax = y
@@ -648,10 +672,9 @@ export const getDataPaddedYRange = (
     return [contractMin, contractMax]
   }
 
-  // Flat data: pad with a small slice of the contract range so the line isn't
-  // pinned to one edge.
+  const contractRange = contractMax - contractMin
   if (dataMin === dataMax) {
-    const flatPad = contractRange * 0.05
+    const flatPad = Number.isFinite(contractRange) ? contractRange * 0.05 : 0
     return [
       Math.max(dataMin - flatPad, contractMin),
       Math.min(dataMax + flatPad, contractMax),

--- a/web/components/charts/helpers.tsx
+++ b/web/components/charts/helpers.tsx
@@ -622,6 +622,49 @@ export const getRightmostVisibleDate = (
   }
 }
 
+// Compute a y-axis range that fits the data with some headroom on each side,
+// so small movements aren't squashed against the contract's full min/max.
+// Result is clamped to [contractMin, contractMax]. Falls back to the full
+// contract range if there's no data or the data is degenerate.
+export const getDataPaddedYRange = (
+  data: { y: number }[],
+  contractMin: number,
+  contractMax: number,
+  paddingFraction = 0.1
+): [number, number] => {
+  const contractRange = contractMax - contractMin
+  if (data.length === 0 || !Number.isFinite(contractRange)) {
+    return [contractMin, contractMax]
+  }
+
+  let dataMin = Infinity
+  let dataMax = -Infinity
+  for (const { y } of data) {
+    if (!Number.isFinite(y)) continue
+    if (y < dataMin) dataMin = y
+    if (y > dataMax) dataMax = y
+  }
+  if (!Number.isFinite(dataMin) || !Number.isFinite(dataMax)) {
+    return [contractMin, contractMax]
+  }
+
+  // Flat data: pad with a small slice of the contract range so the line isn't
+  // pinned to one edge.
+  if (dataMin === dataMax) {
+    const flatPad = contractRange * 0.05
+    return [
+      Math.max(dataMin - flatPad, contractMin),
+      Math.min(dataMax + flatPad, contractMax),
+    ]
+  }
+
+  const padding = (dataMax - dataMin) * paddingFraction
+  return [
+    Math.max(dataMin - padding, contractMin),
+    Math.min(dataMax + padding, contractMax),
+  ]
+}
+
 export const formatPct = (n: number) => {
   return `${(n * 100).toFixed(0)}%`
 }

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -848,6 +848,7 @@ const MultiDateOverview = (props: {
             zoomParams={zoomParams}
             contract={contract}
             showZoomer={showZoomer}
+            zoomY
           />
         )}
       </SizedContainer>

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -689,6 +689,7 @@ const NumberOverview = (props: {
                   zoomParams={zoomParams}
                   contract={contract}
                   showZoomer={true}
+                  zoomY
                 />
               </div>
             </>
@@ -765,6 +766,7 @@ const MultiNumericOverview = (props: {
             zoomParams={zoomParams}
             contract={contract}
             showZoomer={showZoomer}
+            zoomY
           />
         )}
       </SizedContainer>
@@ -1090,6 +1092,7 @@ const PseudoNumericOverview = (props: {
             zoomParams={zoomParams}
             contract={contract}
             showZoomer={showZoomer}
+            zoomY
           />
         )}
       </SizedContainer>

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -123,6 +123,7 @@ export const CONTRACT_TYPES = [
   { label: 'Set', value: 'INDEPENDENT_MULTIPLE_CHOICE' },
   { label: 'Dependent MC', value: 'DEPENDENT_MULTIPLE_CHOICE' },
   { label: 'Numeric', value: 'PSEUDO_NUMERIC' },
+  { label: 'Date', value: 'DATE' },
   { label: 'Bounty', value: 'BOUNTIED_QUESTION' },
   { label: 'Stock', value: 'STONK' },
   { label: 'Poll', value: 'POLL' },


### PR DESCRIPTION
Numeric markets ranging 1-100 with values moving 10 → 14 previously rendered as a near-flat line because the y-axis spanned the entire contract range. Add a shared getDataPaddedYRange helper that fits the domain to the data with 10% headroom (clamped to contract bounds), and apply it in pseudo-numeric, number, and multi-numeric charts. Call .nice() on the resulting d3 scales so ticks land on round numbers.