### PR TITLE
shop: collect recipient email on merch orders, required for Brazil

### DIFF
--- a/backend/api/src/shop-purchase-merch.ts
+++ b/backend/api/src/shop-purchase-merch.ts
@@ -4,7 +4,10 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { runTransactionWithRetries } from 'shared/transact-with-retries'
 import { getUser, isProd } from 'shared/utils'
 import { getShopItem, isMerchItem, PRINTFUL_API_URL } from 'common/shop/items'
-import { requiresPostalCode } from 'common/shop/printful-address'
+import {
+  requiresPostalCode,
+  requiresRecipientEmail,
+} from 'common/shop/printful-address'
 import { getBenefit } from 'common/supporter-config'
 import { convertEntitlement } from 'common/shop/types'
 import { betsQueue } from 'shared/helpers/fn-queue'
@@ -42,6 +45,13 @@ export const shopPurchaseMerch: APIHandler<'shop-purchase-merch'> = async (
   // the case where the country actually requires one.
   if (requiresPostalCode(shipping.country) && !shipping.zip?.trim()) {
     throw new APIError(400, 'Postal code is required for this country')
+  }
+
+  // Per-country email enforcement — Brazilian customs notifies recipients
+  // by email about CPF/duty resolution. Schema keeps email optional so most
+  // checkouts skip it; this catches the case where it's actually required.
+  if (requiresRecipientEmail(shipping.country) && !shipping.email?.trim()) {
+    throw new APIError(400, 'Email is required for this country')
   }
 
   const printfulToken = process.env.PRINTFUL_API_TOKEN
@@ -282,6 +292,7 @@ async function createPrintfulOrder(
       zip?: string
       country: string
       taxNumber?: string
+      email?: string
     }
     externalId: string
     confirm: boolean
@@ -305,6 +316,7 @@ async function createPrintfulOrder(
         country_code: params.shipping.country,
         zip: params.shipping.zip || undefined,
         tax_number: params.shipping.taxNumber || undefined,
+        email: params.shipping.email || undefined,
       },
       items: [
         {

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -3836,6 +3836,7 @@ export const API = (_apiTypeCheck = {
           zip: z.string().max(20).optional(),
           country: z.string().regex(/^[A-Z]{2}$/),
           taxNumber: z.string().max(50).optional(),
+          email: z.string().email().max(254).optional(),
         }),
       })
       .strict(),

--- a/common/src/shop/printful-address.ts
+++ b/common/src/shop/printful-address.ts
@@ -24,3 +24,26 @@ const POSTAL_CODE_OPTIONAL_COUNTRIES = new Set<string>([
 // purchase/rates handlers.
 export const requiresPostalCode = (countryCode: string): boolean =>
   !POSTAL_CODE_OPTIONAL_COUNTRIES.has(countryCode.toUpperCase())
+
+// Countries where the destination's customs authority uses the recipient's
+// email to notify them about duties/documents needed to release the parcel.
+// Without an email, packages can be delayed, returned, or cancelled — so we
+// make the form field mandatory. Printful's API accepts orders without email
+// (the requirement is enforced downstream by customs/carriers), and the
+// public /countries endpoint doesn't expose per-field requirement flags, so
+// this list is curated from Printful's help center documentation.
+//
+// Canary Islands also require email per Printful, but they ship under
+// Spain's ES code; distinguishing them requires a state-code check
+// (GC/TF) which we don't currently do. Spanish customers can still type
+// an email — it's just not enforced by this list.
+const EMAIL_REQUIRED_COUNTRIES = new Set<string>([
+  'BR', // Brazil — Receita Federal emails recipient about CPF/import duties
+])
+
+// True when the given ISO-2 country code requires a recipient email for
+// customs notifications. The email is always forwarded to Printful when
+// supplied; this flag only controls whether the client form treats it as
+// mandatory.
+export const requiresRecipientEmail = (countryCode: string): boolean =>
+  EMAIL_REQUIRED_COUNTRIES.has(countryCode.toUpperCase())

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -24,7 +24,10 @@ import {
   getTicketItems,
 } from 'common/shop/items'
 import { UserEntitlement } from 'common/shop/types'
-import { requiresPostalCode } from 'common/shop/printful-address'
+import {
+  requiresPostalCode,
+  requiresRecipientEmail,
+} from 'common/shop/printful-address'
 import { User } from 'common/user'
 import { formatMoney } from 'common/util/format'
 import {
@@ -1607,6 +1610,8 @@ function MerchItemCard(props: {
   const [selectedShipping, setSelectedShipping] = useState<ShippingRate | null>(
     null
   )
+  const privateUser = usePrivateUser()
+  const accountEmail = privateUser?.email ?? ''
   const [shippingInfo, setShippingInfo] = useState({
     name: '',
     address1: '',
@@ -1616,7 +1621,16 @@ function MerchItemCard(props: {
     zip: '',
     country: 'US',
     taxNumber: '',
+    email: '',
   })
+  // Prefill email from the logged-in user once their privateUser hydrates.
+  // Only fills when the field is still blank so we never clobber typing.
+  useEffect(() => {
+    if (accountEmail && !shippingInfo.email) {
+      setShippingInfo((s) => (s.email ? s : { ...s, email: accountEmail }))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountEmail])
   const [showConfirmOrderModal, setShowConfirmOrderModal] = useState(false)
   const [countdown, setCountdown] = useState(5)
 
@@ -1800,6 +1814,7 @@ function MerchItemCard(props: {
         zip: '',
         country: 'US',
         taxNumber: '',
+        email: accountEmail,
       })
       onPurchased?.()
     } catch (e: any) {
@@ -1811,6 +1826,13 @@ function MerchItemCard(props: {
   }
 
   const zipRequired = requiresPostalCode(shippingInfo.country)
+  const emailRequired = requiresRecipientEmail(shippingInfo.country)
+  // Loose check: must contain an @ and a dot in the domain. Server-side
+  // schema does the strict RFC validation; this is just to gate the UI.
+  const emailLooksValid =
+    !shippingInfo.email || /^\S+@\S+\.\S+$/.test(shippingInfo.email.trim())
+  const emailFieldOk =
+    (!emailRequired || !!shippingInfo.email.trim()) && emailLooksValid
   const taxIdConfig = TAX_ID_COUNTRIES[shippingInfo.country]
   const taxIdValid = taxIdConfig
     ? taxIdConfig.validate(shippingInfo.taxNumber)
@@ -1819,7 +1841,8 @@ function MerchItemCard(props: {
     shippingInfo.address1 &&
     shippingInfo.city &&
     (!zipRequired || shippingInfo.zip) &&
-    taxIdValid
+    taxIdValid &&
+    emailFieldOk
 
   return (
     <>
@@ -2291,6 +2314,36 @@ function MerchItemCard(props: {
                 )}
               </Col>
             )}
+            <Col className="gap-1">
+              <input
+                type="email"
+                placeholder={
+                  emailRequired ? 'Email' : 'Email (optional)'
+                }
+                value={shippingInfo.email}
+                maxLength={254}
+                onChange={(e) =>
+                  setShippingInfo((s) => ({ ...s, email: e.target.value }))
+                }
+                className="border-ink-300 bg-canvas-0 w-full rounded-md border px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              />
+              {emailRequired ? (
+                <p className="text-ink-500 text-xs">
+                  Required: customs in this country emails the recipient about
+                  duties and documents needed to release the parcel.
+                </p>
+              ) : (
+                <p className="text-ink-500 text-xs">
+                  Optional. Forwarded to our fulfillment partner so the carrier
+                  can reach you about delivery issues.
+                </p>
+              )}
+              {shippingInfo.email.length > 0 && !emailLooksValid && (
+                <p className="text-xs text-red-600 dark:text-red-400">
+                  Enter a valid email address.
+                </p>
+              )}
+            </Col>
           </Col>
 
           {!shippingRates && (
@@ -2365,7 +2418,12 @@ function MerchItemCard(props: {
             </Button>
             <Button
               color="indigo"
-              disabled={!shippingInfo.name || !selectedShipping || !taxIdValid}
+              disabled={
+                !shippingInfo.name ||
+                !selectedShipping ||
+                !taxIdValid ||
+                !emailFieldOk
+              }
               onClick={() => {
                 setAcceptedTerms(false)
                 setShowConfirmOrderModal(true)
@@ -2416,6 +2474,12 @@ function MerchItemCard(props: {
                 {COUNTRIES.find((c) => c.code === shippingInfo.country)?.name}
               </span>
             </Row>
+            {shippingInfo.email && (
+              <Row className="justify-between">
+                <span className="text-ink-500">Email:</span>
+                <span className="font-medium">{shippingInfo.email}</span>
+              </Row>
+            )}
             {selectedShipping && (
               <Row className="justify-between">
                 <span className="text-ink-500">Shipping method:</span>

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -1610,8 +1610,6 @@ function MerchItemCard(props: {
   const [selectedShipping, setSelectedShipping] = useState<ShippingRate | null>(
     null
   )
-  const privateUser = usePrivateUser()
-  const accountEmail = privateUser?.email ?? ''
   const [shippingInfo, setShippingInfo] = useState({
     name: '',
     address1: '',
@@ -1623,14 +1621,6 @@ function MerchItemCard(props: {
     taxNumber: '',
     email: '',
   })
-  // Prefill email from the logged-in user once their privateUser hydrates.
-  // Only fills when the field is still blank so we never clobber typing.
-  useEffect(() => {
-    if (accountEmail && !shippingInfo.email) {
-      setShippingInfo((s) => (s.email ? s : { ...s, email: accountEmail }))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accountEmail])
   const [showConfirmOrderModal, setShowConfirmOrderModal] = useState(false)
   const [countdown, setCountdown] = useState(5)
 
@@ -1814,7 +1804,7 @@ function MerchItemCard(props: {
         zip: '',
         country: 'US',
         taxNumber: '',
-        email: accountEmail,
+        email: '',
       })
       onPurchased?.()
     } catch (e: any) {


### PR DESCRIPTION
Adds an optional email field to the shipping form, prefilled from the logged-in user's account email. Email is forwarded to Printful on every order so customs/carriers can reach the recipient about delivery issues. For Brazil specifically the field is mandatory — Receita Federal emails recipients about CPF/duty resolution and parcels stall without it. Pattern mirrors the existing requiresPostalCode helper; extending the country list later is one line.