### PR TITLE
Admin prize opted out status

### DIFF
--- a/backend/api/src/admin-delete-prize-claim.ts
+++ b/backend/api/src/admin-delete-prize-claim.ts
@@ -1,0 +1,27 @@
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { APIError, APIHandler } from './helpers/endpoint'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { log } from 'shared/utils'
+
+// Lets an admin remove a prize claim row outright — used to recover from
+// e.g. an accidental 'opted_out' marking. After deletion the user is back
+// in the "no claim" state and can submit a wallet again via the normal
+// /prize flow. Existing terminal rows (sent/rejected) can also be removed
+// this way if the admin determines the row was created in error.
+export const adminDeletePrizeClaim: APIHandler<
+  'admin-delete-prize-claim'
+> = async (body, auth) => {
+  throwErrorIfNotAdmin(auth.uid)
+
+  const { claimId } = body
+  const pg = createSupabaseDirectClient()
+
+  const result = await pg.oneOrNone(
+    `DELETE FROM sweepstakes_prize_claims WHERE id = $1 RETURNING id`,
+    [claimId]
+  )
+  if (!result) throw new APIError(404, 'Prize claim not found')
+
+  log(`Admin ${auth.uid} deleted prize claim ${claimId}`)
+  return { success: true }
+}

--- a/backend/api/src/admin-get-prize-claims.ts
+++ b/backend/api/src/admin-get-prize-claims.ts
@@ -35,7 +35,7 @@ export const adminGetPrizeClaims: APIHandler<'admin-get-prize-claims'> = async (
     rank: number
     prizeAmountUsdc: number
     walletAddress: string | null
-    paymentStatus: 'awaiting' | 'sent' | 'rejected' | null
+    paymentStatus: 'awaiting' | 'sent' | 'rejected' | 'opted_out' | null
     paymentTxnHash: string | null
     createdTime: number | null
   }> = []
@@ -80,8 +80,8 @@ export const adminGetPrizeClaims: APIHandler<'admin-get-prize-claims'> = async (
       id: string
       user_id: string
       rank: number
-      wallet_address: string
-      payment_status: 'awaiting' | 'sent' | 'rejected'
+      wallet_address: string | null
+      payment_status: 'awaiting' | 'sent' | 'rejected' | 'opted_out'
       payment_txn_hash: string | null
       created_time: string
     }>(

--- a/backend/api/src/admin-update-prize-payment.ts
+++ b/backend/api/src/admin-update-prize-payment.ts
@@ -2,38 +2,97 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { APIError, APIHandler } from './helpers/endpoint'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { log } from 'shared/utils'
+import { getPrizeForRank, SweepstakesPrize } from 'common/sweepstakes'
 
 export const adminUpdatePrizePayment: APIHandler<
   'admin-update-prize-payment'
 > = async (body, auth) => {
-  // Only admins can access this endpoint
   throwErrorIfNotAdmin(auth.uid)
 
-  const { claimId, paymentStatus, paymentTxnHash } = body
+  const { claimId, sweepstakesNum, userId, paymentStatus, paymentTxnHash } =
+    body
   const pg = createSupabaseDirectClient()
 
-  // Update the claim
-  const result = await pg.oneOrNone(
-    `UPDATE sweepstakes_prize_claims
-     SET payment_status = $1,
-         payment_txn_hash = COALESCE($2, payment_txn_hash),
-         updated_time = now()
-     WHERE id = $3
-     RETURNING id`,
-    [paymentStatus, paymentTxnHash || null, claimId]
-  )
+  // Path A — caller knows the claim row id (user submitted a wallet).
+  if (claimId) {
+    const result = await pg.oneOrNone(
+      `UPDATE sweepstakes_prize_claims
+         SET payment_status = $1,
+             payment_txn_hash = COALESCE($2, payment_txn_hash),
+             updated_time = now()
+         WHERE id = $3
+         RETURNING id`,
+      [paymentStatus, paymentTxnHash || null, claimId]
+    )
+    if (!result) throw new APIError(404, 'Prize claim not found')
 
-  if (!result) {
-    throw new APIError(404, 'Prize claim not found')
+    log(
+      `Admin ${auth.uid} updated prize claim ${claimId} to '${paymentStatus}'${
+        paymentTxnHash ? ` (txn ${paymentTxnHash})` : ''
+      }`
+    )
+    return { success: true }
   }
 
-  log(
-    `Admin ${
-      auth.uid
-    } updated prize claim ${claimId} to status '${paymentStatus}'${
-      paymentTxnHash ? ` with txn hash ${paymentTxnHash}` : ''
-    }`
+  // Path B — no claim row yet. Look up the winner's rank/prize from
+  // sweepstakes and upsert with NULL wallet_address. Used to record
+  // opted_out/rejected for winners who never submitted a wallet.
+  if (sweepstakesNum === undefined || !userId) {
+    // Schema-level refine should have caught this; defensive.
+    throw new APIError(400, 'Missing claim identifier')
+  }
+
+  const sweepstakes = await pg.oneOrNone<{
+    winning_ticket_ids: string[] | null
+    prizes: SweepstakesPrize[]
+  }>(
+    `SELECT winning_ticket_ids, prizes
+       FROM sweepstakes WHERE sweepstakes_num = $1`,
+    [sweepstakesNum]
+  )
+  if (!sweepstakes?.winning_ticket_ids?.length) {
+    throw new APIError(400, 'Sweepstakes has no winners')
+  }
+
+  // Rank = position of this user's winning ticket in the array (1-indexed).
+  const ticket = await pg.oneOrNone<{ id: string }>(
+    `SELECT id FROM sweepstakes_tickets
+       WHERE id = ANY($1) AND user_id = $2`,
+    [sweepstakes.winning_ticket_ids, userId]
+  )
+  if (!ticket) throw new APIError(400, 'User did not win this sweepstakes')
+
+  const rank = sweepstakes.winning_ticket_ids.indexOf(ticket.id) + 1
+  const prize = getPrizeForRank(sweepstakes.prizes, rank)
+  const prizeAmount = prize?.amountUsdc ?? 0
+
+  // Upsert: if a row already exists for this user (e.g. they submitted a
+  // wallet between the admin loading the page and clicking), just update
+  // its status — leave wallet_address untouched.
+  const result = await pg.one<{ id: string }>(
+    `INSERT INTO sweepstakes_prize_claims
+       (sweepstakes_num, user_id, rank, prize_amount_usdc,
+        wallet_address, payment_status, payment_txn_hash)
+       VALUES ($1, $2, $3, $4, NULL, $5, $6)
+     ON CONFLICT (sweepstakes_num, user_id) DO UPDATE
+       SET payment_status = EXCLUDED.payment_status,
+           payment_txn_hash = COALESCE(EXCLUDED.payment_txn_hash,
+                                       sweepstakes_prize_claims.payment_txn_hash),
+           updated_time = now()
+     RETURNING id`,
+    [
+      sweepstakesNum,
+      userId,
+      rank,
+      prizeAmount,
+      paymentStatus,
+      paymentTxnHash || null,
+    ]
   )
 
+  log(
+    `Admin ${auth.uid} upserted prize claim for user ${userId} ` +
+      `(sweepstakes #${sweepstakesNum}, rank ${rank}) to '${paymentStatus}'`
+  )
   return { success: true }
 }

--- a/backend/api/src/admin-update-prize-payment.ts
+++ b/backend/api/src/admin-update-prize-payment.ts
@@ -69,7 +69,7 @@ export const adminUpdatePrizePayment: APIHandler<
   // Upsert: if a row already exists for this user (e.g. they submitted a
   // wallet between the admin loading the page and clicking), just update
   // its status — leave wallet_address untouched.
-  const result = await pg.one<{ id: string }>(
+  await pg.none(
     `INSERT INTO sweepstakes_prize_claims
        (sweepstakes_num, user_id, rank, prize_amount_usdc,
         wallet_address, payment_status, payment_txn_hash)
@@ -78,8 +78,7 @@ export const adminUpdatePrizePayment: APIHandler<
        SET payment_status = EXCLUDED.payment_status,
            payment_txn_hash = COALESCE(EXCLUDED.payment_txn_hash,
                                        sweepstakes_prize_claims.payment_txn_hash),
-           updated_time = now()
-     RETURNING id`,
+           updated_time = now()`,
     [
       sweepstakesNum,
       userId,

--- a/backend/api/src/get-sweepstakes-prize-claim.ts
+++ b/backend/api/src/get-sweepstakes-prize-claim.ts
@@ -56,8 +56,8 @@ export const getSweepstakesPrizeClaim: APIHandler<
     id: string
     rank: number
     prize_amount_usdc: string
-    wallet_address: string
-    payment_status: 'awaiting' | 'sent' | 'rejected'
+    wallet_address: string | null
+    payment_status: 'awaiting' | 'sent' | 'rejected' | 'opted_out'
     payment_txn_hash: string | null
     created_time: string
   } | null = null

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -193,6 +193,7 @@ import { claimSweepstakesPrize } from './claim-sweepstakes-prize'
 import { getSweepstakesPrizeClaim } from './get-sweepstakes-prize-claim'
 import { adminGetPrizeClaims } from './admin-get-prize-claims'
 import { adminUpdatePrizePayment } from './admin-update-prize-payment'
+import { adminDeletePrizeClaim } from './admin-delete-prize-claim'
 import { adminGetManaSales } from './admin-get-mana-sales'
 import { adminGetTopWhaleUsers } from './admin-get-top-whale-users'
 import { adminGetNewUsers } from './admin-get-new-users'
@@ -529,6 +530,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'admin-update-charity-giveaway-prize': adminUpdateCharityGiveawayPrize,
   'admin-get-prize-claims': adminGetPrizeClaims,
   'admin-update-prize-payment': adminUpdatePrizePayment,
+  'admin-delete-prize-claim': adminDeletePrizeClaim,
   'admin-get-mana-sales': adminGetManaSales,
   'admin-get-top-whale-users': adminGetTopWhaleUsers,
   'admin-get-new-users': adminGetNewUsers,

--- a/backend/supabase/migrations/2026050901_prize_claim_opted_out_status.sql
+++ b/backend/supabase/migrations/2026050901_prize_claim_opted_out_status.sql
@@ -1,0 +1,19 @@
+-- Add 'opted_out' as a valid payment_status, and allow wallet_address to be
+-- NULL on sweepstakes_prize_claims rows.
+--
+-- Why: when a winner forfeits their crypto prize (e.g. donates the equivalent
+-- to charity instead), we still need a row to record that decision so admins
+-- can mark them as resolved. Until now, no row existed for users who never
+-- submitted a wallet, and 'rejected' was the only non-success status —
+-- conflating "ineligible" and "voluntarily forfeited". This adds an explicit
+-- 'opted_out' status and lets the row exist without a wallet address.
+
+alter table sweepstakes_prize_claims
+  drop constraint if exists sweepstakes_prize_claims_payment_status_check;
+
+alter table sweepstakes_prize_claims
+  add constraint sweepstakes_prize_claims_payment_status_check
+  check (payment_status in ('awaiting', 'sent', 'rejected', 'opted_out'));
+
+alter table sweepstakes_prize_claims
+  alter column wallet_address drop not null;

--- a/backend/supabase/sweepstakes_prize_claims.sql
+++ b/backend/supabase/sweepstakes_prize_claims.sql
@@ -8,9 +8,11 @@ create table if not exists
     user_id text not null references users (id),
     rank integer not null,
     prize_amount_usdc numeric not null,
-    wallet_address text not null,
+    -- Nullable: admins can mark users as 'opted_out' or 'rejected' before
+    -- they ever submit a wallet (e.g. winner forfeits to charity instead).
+    wallet_address text,
     payment_status text not null default 'awaiting' check (
-      payment_status in ('awaiting', 'sent', 'rejected')
+      payment_status in ('awaiting', 'sent', 'rejected', 'opted_out')
     ),
     payment_txn_hash text,
     created_time timestamptz not null default now(),

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -3572,8 +3572,10 @@ export const API = (_apiTypeCheck = {
         id: string
         rank: number
         prizeAmountUsdc: number
-        walletAddress: string
-        paymentStatus: 'awaiting' | 'sent' | 'rejected'
+        // Null when admin recorded an opted_out / rejected status before
+        // the user ever submitted a wallet.
+        walletAddress: string | null
+        paymentStatus: 'awaiting' | 'sent' | 'rejected' | 'opted_out'
         paymentTxnHash: string | null
         createdTime: number
       } | null

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -3635,6 +3635,13 @@ export const API = (_apiTypeCheck = {
       ),
     returns: {} as { success: boolean },
   },
+  'admin-delete-prize-claim': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({ claimId: z.string() }).strict(),
+    returns: {} as { success: boolean },
+  },
   'admin-get-mana-sales': {
     method: 'GET',
     visibility: 'undocumented',

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -3599,7 +3599,7 @@ export const API = (_apiTypeCheck = {
         rank: number
         prizeAmountUsdc: number
         walletAddress: string | null
-        paymentStatus: 'awaiting' | 'sent' | 'rejected' | null
+        paymentStatus: 'awaiting' | 'sent' | 'rejected' | 'opted_out' | null
         paymentTxnHash: string | null
         createdTime: number | null
       }>
@@ -3609,13 +3609,28 @@ export const API = (_apiTypeCheck = {
     method: 'POST',
     visibility: 'undocumented',
     authed: true,
+    // Identify the claim by either an existing claimId (user already
+    // submitted a wallet) or by (sweepstakesNum, userId) — the latter lets
+    // admins record opted_out/rejected decisions for winners who never
+    // submitted a wallet, by upserting a row with NULL wallet_address.
     props: z
       .object({
-        claimId: z.string(),
-        paymentStatus: z.enum(['awaiting', 'sent', 'rejected']),
+        claimId: z.string().optional(),
+        sweepstakesNum: z.number().int().optional(),
+        userId: z.string().optional(),
+        paymentStatus: z.enum([
+          'awaiting',
+          'sent',
+          'rejected',
+          'opted_out',
+        ]),
         paymentTxnHash: z.string().optional(),
       })
-      .strict(),
+      .strict()
+      .refine(
+        (v) => !!v.claimId || (v.sweepstakesNum !== undefined && !!v.userId),
+        { message: 'Provide either claimId or (sweepstakesNum, userId)' }
+      ),
     returns: {} as { success: boolean },
   },
   'admin-get-mana-sales': {

--- a/web/pages/admin/prize.tsx
+++ b/web/pages/admin/prize.tsx
@@ -12,6 +12,7 @@ import { UserLink } from 'web/components/widgets/user-link'
 import { api } from 'web/lib/api/api'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
+import { ConfirmationButton } from 'web/components/buttons/confirmation-button'
 
 type PaymentStatus = 'awaiting' | 'sent' | 'rejected' | 'opted_out'
 
@@ -87,6 +88,20 @@ function PrizeClaimsTable() {
     navigator.clipboard.writeText(address)
     toast.success('Wallet address copied')
     if (claimId) setCopiedClaimId(claimId)
+  }
+
+  const handleResetClaim = async (claimId: string) => {
+    setUpdatingId(claimId)
+    try {
+      await api('admin-delete-prize-claim', { claimId })
+      toast.success('Claim reset')
+      setCopiedClaimId((id) => (id === claimId ? null : id))
+      refresh()
+    } catch (e) {
+      toast.error('Failed to reset claim')
+    } finally {
+      setUpdatingId(null)
+    }
   }
 
   if (data === undefined) {
@@ -212,6 +227,17 @@ function PrizeClaimsTable() {
                               handleStatusChange(claim, status)
                             }
                           />
+                          {claim.id && (
+                            <ResetClaimButton
+                              hasWallet={!!claim.walletAddress}
+                              currentStatus={claim.paymentStatus}
+                              username={claim.username}
+                              disabled={updatingId !== null}
+                              onConfirm={() =>
+                                handleResetClaim(claim.id as string)
+                              }
+                            />
+                          )}
                           {copiedClaimId === claim.id &&
                             claim.id &&
                             claim.paymentStatus === 'awaiting' && (
@@ -293,6 +319,78 @@ function WalletAddressCell(props: {
     >
       {truncated}
     </button>
+  )
+}
+
+// Wipes the claim row entirely. Used to recover from accidentally-set
+// statuses (e.g. opted_out) — after delete the user is back in the "no
+// claim" state and can submit a wallet again via the normal /prize flow.
+function ResetClaimButton(props: {
+  hasWallet: boolean
+  currentStatus: PaymentStatus | null
+  username: string
+  disabled: boolean
+  onConfirm: () => Promise<void> | void
+}) {
+  const { hasWallet, currentStatus, username, disabled, onConfirm } = props
+  const isTerminal =
+    currentStatus === 'sent' ||
+    currentStatus === 'rejected' ||
+    currentStatus === 'opted_out'
+
+  return (
+    <ConfirmationButton
+      openModalBtn={{
+        label: 'Reset',
+        color: 'gray-outline',
+        size: 'xs',
+        disabled,
+      }}
+      cancelBtn={{ label: 'Cancel' }}
+      submitBtn={{ label: 'Reset claim', color: 'red' }}
+      onSubmit={() => onConfirm()}
+    >
+      <Col className="gap-3">
+        <h3 className="text-lg font-semibold">Reset prize claim?</h3>
+        <p className="text-ink-700 text-sm">
+          This will <b>delete the prize claim row</b> for{' '}
+          <span className="font-mono">@{username}</span>
+          {currentStatus && (
+            <>
+              {' '}
+              (currently <b>{currentStatus}</b>)
+            </>
+          )}
+          . Use this to undo an accidentally-set status — for example, if
+          you marked someone <b>opted out</b> by mistake.
+        </p>
+        <ul className="text-ink-700 list-disc space-y-1 pl-5 text-sm">
+          <li>
+            Their{' '}
+            {hasWallet ? (
+              <>submitted wallet address will be erased</>
+            ) : (
+              <>row (with no wallet) will be erased</>
+            )}
+            .
+          </li>
+          <li>
+            They'll be returned to the "no claim" state and can submit a
+            wallet again on /prize.
+          </li>
+          {isTerminal && (
+            <li>
+              Existing <b>{currentStatus}</b> status — including any payment
+              transaction record — will be lost.
+            </li>
+          )}
+        </ul>
+        <p className="text-ink-500 text-xs">
+          This does not refund anything. If a payment was already sent
+          on-chain, deleting this row only removes the audit record.
+        </p>
+      </Col>
+    </ConfirmationButton>
   )
 }
 

--- a/web/pages/admin/prize.tsx
+++ b/web/pages/admin/prize.tsx
@@ -13,7 +13,7 @@ import { api } from 'web/lib/api/api'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 
-type PaymentStatus = 'awaiting' | 'sent' | 'rejected'
+type PaymentStatus = 'awaiting' | 'sent' | 'rejected' | 'opted_out'
 
 export default function AdminPrizePage() {
   const user = useUser()
@@ -45,23 +45,36 @@ function PrizeClaimsTable() {
   const [updatingId, setUpdatingId] = useState<string | null>(null)
   const [copiedClaimId, setCopiedClaimId] = useState<string | null>(null)
 
+  // Updating a row keyed by (sweepstakesNum + userId) instead of claimId
+  // when no claim exists yet — used as the busy-marker for the dropdown.
+  const rowKey = (sweepstakesNum: number, userId: string) =>
+    `${sweepstakesNum}:${userId}`
+
   const handleStatusChange = async (
-    claimId: string | null,
+    claim: {
+      id: string | null
+      sweepstakesNum: number
+      userId: string
+    },
     newStatus: PaymentStatus
   ) => {
-    if (!claimId) {
-      toast.error('User has not submitted their wallet address yet')
-      return
-    }
-
-    setUpdatingId(claimId)
+    const key = claim.id ?? rowKey(claim.sweepstakesNum, claim.userId)
+    setUpdatingId(key)
     try {
-      await api('admin-update-prize-payment', {
-        claimId,
-        paymentStatus: newStatus,
-      })
+      // Send claimId when we have one; otherwise let the server upsert by
+      // (sweepstakesNum, userId). The server validates the user actually won.
+      await api(
+        'admin-update-prize-payment',
+        claim.id
+          ? { claimId: claim.id, paymentStatus: newStatus }
+          : {
+              sweepstakesNum: claim.sweepstakesNum,
+              userId: claim.userId,
+              paymentStatus: newStatus,
+            }
+      )
       toast.success(`Status updated to ${newStatus}`)
-      setCopiedClaimId((id) => (id === claimId ? null : id))
+      setCopiedClaimId((id) => (id === claim.id ? null : id))
       refresh()
     } catch (e) {
       toast.error('Failed to update status')
@@ -171,10 +184,7 @@ function PrizeClaimsTable() {
                         {claim.walletAddress ? (
                           <WalletAddressCell
                             address={claim.walletAddress}
-                            copyable={
-                              claim.paymentStatus !== 'sent' &&
-                              claim.paymentStatus !== 'rejected'
-                            }
+                            copyable={claim.paymentStatus === 'awaiting'}
                             onCopy={() =>
                               handleCopyAddress(
                                 claim.id,
@@ -192,12 +202,14 @@ function PrizeClaimsTable() {
                         <Row className="items-center gap-2">
                           <StatusSelector
                             currentStatus={claim.paymentStatus}
-                            disabled={
-                              !claim.walletAddress || updatingId !== null
+                            disabled={updatingId !== null}
+                            loading={
+                              updatingId ===
+                              (claim.id ??
+                                rowKey(claim.sweepstakesNum, claim.userId))
                             }
-                            loading={updatingId === claim.id}
                             onChange={(status) =>
-                              handleStatusChange(claim.id, status)
+                              handleStatusChange(claim, status)
                             }
                           />
                           {copiedClaimId === claim.id &&
@@ -206,7 +218,7 @@ function PrizeClaimsTable() {
                               <MarkSentPrompt
                                 disabled={updatingId !== null}
                                 onMarkSent={() =>
-                                  handleStatusChange(claim.id, 'sent')
+                                  handleStatusChange(claim, 'sent')
                                 }
                                 onDismiss={() => setCopiedClaimId(null)}
                               />
@@ -313,6 +325,10 @@ function MarkSentPrompt(props: {
   )
 }
 
+// Sentinel used when no row exists yet (the user never submitted a wallet).
+// Renders as "—" but lets the admin pick a real status to upsert one.
+const UNSET = '__unset__'
+
 function StatusSelector(props: {
   currentStatus: PaymentStatus | null
   disabled: boolean
@@ -320,15 +336,16 @@ function StatusSelector(props: {
   onChange: (status: PaymentStatus) => void
 }) {
   const { currentStatus, disabled, loading, onChange } = props
-
-  if (!currentStatus) {
-    return <span className="text-ink-400 text-sm">—</span>
-  }
+  const value = currentStatus ?? UNSET
 
   return (
     <select
-      value={currentStatus}
-      onChange={(e) => onChange(e.target.value as PaymentStatus)}
+      value={value}
+      onChange={(e) => {
+        const v = e.target.value
+        if (v === UNSET) return
+        onChange(v as PaymentStatus)
+      }}
       disabled={disabled || loading}
       className={clsx(
         'min-w-[120px] rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors',
@@ -337,12 +354,20 @@ function StatusSelector(props: {
         currentStatus === 'sent' &&
           'border-green-200 bg-green-50 text-green-700',
         currentStatus === 'rejected' && 'border-red-200 bg-red-50 text-red-700',
+        currentStatus === 'opted_out' &&
+          'border-indigo-200 bg-indigo-50 text-indigo-700',
+        currentStatus === null &&
+          'border-ink-200 bg-canvas-50 text-ink-500',
         disabled && 'cursor-not-allowed opacity-50'
       )}
     >
+      {currentStatus === null && (
+        <option value={UNSET}>—</option>
+      )}
       <option value="awaiting">Awaiting</option>
       <option value="sent">Sent</option>
-      <option value="rejected">Rejected</option>
+      <option value="rejected">Rejected (ineligible)</option>
+      <option value="opted_out">Opted out (forfeited)</option>
     </select>
   )
 }

--- a/web/pages/prize.tsx
+++ b/web/pages/prize.tsx
@@ -1627,20 +1627,22 @@ function WinnerClaimSection(props: { sweepstakesNum: number; userId: string }) {
           </p>
         </div>
         <Col className="gap-4 p-5">
-          <div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/30">
-            <Row className="items-center gap-2">
-              <span className="text-lg">✓</span>
-              <Col className="gap-1">
-                <span className="font-medium text-green-800 dark:text-green-300">
-                  Claim Submitted
-                </span>
-                <span className="text-sm text-green-700 dark:text-green-400">
-                  Wallet: {claim.walletAddress.slice(0, 6)}...
-                  {claim.walletAddress.slice(-4)}
-                </span>
-              </Col>
-            </Row>
-          </div>
+          {claim.walletAddress && (
+            <div className="rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-950/30">
+              <Row className="items-center gap-2">
+                <span className="text-lg">✓</span>
+                <Col className="gap-1">
+                  <span className="font-medium text-green-800 dark:text-green-300">
+                    Claim Submitted
+                  </span>
+                  <span className="text-sm text-green-700 dark:text-green-400">
+                    Wallet: {claim.walletAddress.slice(0, 6)}...
+                    {claim.walletAddress.slice(-4)}
+                  </span>
+                </Col>
+              </Row>
+            </div>
+          )}
 
           <Row className="items-center justify-between">
             <span className="text-ink-600 text-sm">Payment Status:</span>
@@ -1652,12 +1654,15 @@ function WinnerClaimSection(props: { sweepstakesNum: number; userId: string }) {
                 claim.paymentStatus === 'sent' &&
                   'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300',
                 claim.paymentStatus === 'rejected' &&
-                  'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300'
+                  'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300',
+                claim.paymentStatus === 'opted_out' &&
+                  'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300'
               )}
             >
               {claim.paymentStatus === 'awaiting' && '⏳ Awaiting Payment'}
               {claim.paymentStatus === 'sent' && '✓ Payment Sent'}
               {claim.paymentStatus === 'rejected' && '✗ Rejected'}
+              {claim.paymentStatus === 'opted_out' && 'Opted out'}
             </span>
           </Row>
 


### PR DESCRIPTION
Adds ability for admins to mark someone as opted-out from a payment in the prize backend. Removes the ability for them to insert a wallet, treats it as complete. 

Adds 'reset' button in case someone is erroneously marked as 'opted out', also allows admins to reset a given wallet if someone needs to resubmit a new one.