### PR TITLE
feat: sports markets — admin panel, auto-resolve, dashboards, batch market creation

### DIFF
--- a/backend/api/src/admin-sports-community-market.ts
+++ b/backend/api/src/admin-sports-community-market.ts
@@ -1,0 +1,114 @@
+import { APIError, APIHandler } from './helpers/endpoint'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { TOURNAMENT_CONFIGS, ensureCommunityAssets } from 'shared/world-cup-markets'
+import { addGroupToContract } from 'shared/update-group-contracts-internal'
+import { getUser } from 'shared/utils'
+import { ENV } from 'common/envs/constants'
+
+export const adminSportsCommunityMarket: APIHandler<
+  'admin-sports-community-market'
+> = async (props, auth) => {
+  throwErrorIfNotAdmin(auth.uid)
+
+  const { competitionCode, contractId, action } = props
+
+  const config = TOURNAMENT_CONFIGS[competitionCode]
+  if (!config) throw new APIError(400, `Unknown competition code: ${competitionCode}`)
+
+  const pg = createSupabaseDirectClient()
+
+  // Fetch the community dashboard, auto-creating it if it doesn't exist yet
+  let dash = await pg.oneOrNone<{ id: string; title: string; items: string }>(
+    `select id, title, items from dashboards where slug = $1 limit 1`,
+    [config.communityDashboardSlug]
+  )
+  if (!dash) {
+    const creatorId =
+      ENV === 'DEV'
+        ? config.manifoldSportsUserId.dev
+        : config.manifoldSportsUserId.prod
+    const creatorUser = await getUser(creatorId)
+    if (!creatorUser)
+      throw new APIError(500, `ManifoldSports user ${creatorId} not found`)
+    await ensureCommunityAssets(
+      config,
+      creatorId,
+      creatorUser.username,
+      creatorUser.name,
+      creatorUser.avatarUrl ?? '',
+      pg
+    )
+    dash = await pg.one<{ id: string; title: string; items: string }>(
+      `select id, title, items from dashboards where slug = $1 limit 1`,
+      [config.communityDashboardSlug]
+    )
+  }
+
+  // Look up by ID or slug — search results may not be synced to local Supabase by ID
+  const contract = await pg.oneOrNone<{ id: string; slug: string }>(
+    `select id, data->>'slug' as slug from contracts where id = $1 or data->>'slug' = $1 limit 1`,
+    [contractId]
+  )
+  if (!contract) throw new APIError(404, `Contract ${contractId} not found`)
+
+  const rawItems = dash.items as unknown
+  const items: Array<{ type: string; slug?: string }> = Array.isArray(rawItems)
+    ? rawItems
+    : typeof rawItems === 'string'
+    ? JSON.parse(rawItems || '[]')
+    : []
+  const questionItem = { type: 'question', slug: contract.slug }
+
+  if (action === 'add') {
+    const alreadyPresent = items.some(
+      (i) => i.type === 'question' && i.slug === contract.slug
+    )
+    if (!alreadyPresent) {
+      items.push(questionItem)
+      await pg.none(
+        `update dashboards set items = $1 where id = $2`,
+        [JSON.stringify(items), dash.id]
+      )
+    }
+
+    // Also tag the market with the community group
+    const group = await pg.oneOrNone<{ id: string; slug: string }>(
+      `select id, slug from groups where slug = $1 limit 1`,
+      [config.communityGroupSlug]
+    )
+    if (group) {
+      const contractRow = await pg.oneOrNone<{ data: any; importance_score: number | null }>(
+        `select data, importance_score from contracts where id = $1`,
+        [contract.id]
+      )
+      if (contractRow) {
+        const { convertContract } = await import('common/supabase/contracts')
+        const fullContract = convertContract(contractRow)
+        await addGroupToContract(pg, fullContract, group)
+      }
+    }
+  } else {
+    const filtered = items.filter(
+      (i) => !(i.type === 'question' && i.slug === contract.slug)
+    )
+    await pg.none(
+      `update dashboards set items = $1 where id = $2`,
+      [JSON.stringify(filtered), dash.id]
+    )
+
+    // Remove community group tag from the market
+    const group = await pg.oneOrNone<{ id: string }>(
+      `select id from groups where slug = $1 limit 1`,
+      [config.communityGroupSlug]
+    )
+    if (group) {
+      await pg.none(
+        `delete from group_contracts where contract_id = $1 and group_id = $2`,
+        [contract.id, group.id]
+      )
+    }
+  }
+
+  return { success: true, dashboardId: dash.id, action, contractId }
+}

--- a/backend/api/src/admin-sports-create-markets.ts
+++ b/backend/api/src/admin-sports-create-markets.ts
@@ -1,0 +1,237 @@
+import { APIError, APIHandler } from './helpers/endpoint'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { getPrivateUser, getUser } from 'shared/utils'
+import { PrivateUser } from 'common/user'
+import { ENV } from 'common/envs/constants'
+import { liquidityTiers } from 'common/tier'
+import {
+  TOURNAMENT_CONFIGS,
+  buildMarketParams,
+  ensureOfficialGroup,
+  ensureCommunityAssets,
+  fetchAllCompetitionMatches,
+  matchSportsEventId,
+  StageLiquidityTiers,
+  LiquidityTierValue,
+} from 'shared/world-cup-markets'
+import { createMarketHelper } from './create-market'
+import { addGroupToContract } from 'shared/update-group-contracts-internal'
+import { AuthedUser } from './helpers/endpoint'
+
+export const adminSportsCreateMarkets: APIHandler<
+  'admin-sports-create-markets'
+> = async (props, auth) => {
+  throwErrorIfNotAdmin(auth.uid)
+
+  const apiKey = process.env.FOOTBALL_DATA_API_KEY ?? ''
+  if (!apiKey) throw new APIError(500, 'FOOTBALL_DATA_API_KEY not set on server')
+
+  const {
+    competitionCode,
+    matchIds,
+    dryRun,
+    customNote,
+    dashboardUrl,
+    liquidityTierOverrides,
+  } = props
+
+  const config = TOURNAMENT_CONFIGS[competitionCode]
+  if (!config) throw new APIError(400, `Unknown competition code: ${competitionCode}`)
+
+  const creatorId =
+    ENV === 'DEV'
+      ? config.manifoldSportsUserId.dev
+      : config.manifoldSportsUserId.prod
+
+  if (creatorId.startsWith('TODO_')) {
+    throw new APIError(
+      500,
+      'ManifoldSports user ID not configured. Set it in world-cup-markets.ts.'
+    )
+  }
+
+  const pg = createSupabaseDirectClient()
+
+  // Step 1: ensure the official group + community assets exist
+  const creatorUser = dryRun ? null : await getUser(creatorId)
+
+  const groupResult = dryRun
+    ? await (async () => {
+        const existing = await pg.oneOrNone<{
+          id: string
+          privacy_status: string
+        }>(
+          `select id, privacy_status from groups where slug = $1 limit 1`,
+          [config.officialGroupSlug]
+        )
+        if (existing) {
+          return {
+            id: existing.id,
+            created: false,
+            restricted: existing.privacy_status === 'curated',
+          }
+        }
+        return { id: 'dry-run-group', created: false, restricted: false }
+      })()
+    : await ensureOfficialGroup(config, creatorId, pg)
+
+  const communityResult = dryRun
+    ? { groupId: 'dry-run-community-group', groupCreated: false, dashboardId: 'dry-run-community-dash', dashboardCreated: false }
+    : await ensureCommunityAssets(
+        config,
+        creatorId,
+        creatorUser?.username ?? '',
+        creatorUser?.name ?? '',
+        creatorUser?.avatarUrl ?? '',
+        pg
+      )
+
+  // Step 2: fetch scheduled matches (status=SCHEDULED populates team names correctly)
+  const allMatches = await fetchAllCompetitionMatches(config, apiKey, { status: 'SCHEDULED' })
+  const matchById = new Map(allMatches.map((m) => [m.id, m]))
+
+  // Step 3: build auth for createMarketHelper (only uid matters)
+  let creatorAuth: AuthedUser | null = null
+  if (!dryRun) {
+    const privateUser = await getPrivateUser(creatorId)
+    if (!privateUser)
+      throw new APIError(500, `Private user ${creatorId} not found`)
+    creatorAuth = {
+      uid: creatorId,
+      creds: { kind: 'key', data: '', privateUser: privateUser as PrivateUser },
+    }
+  }
+
+  // Coerce overrides to valid LiquidityTierValue
+  const validLiqTiers = new Set<number>(liquidityTiers)
+  const safeOverrides = liquidityTierOverrides
+    ? Object.fromEntries(
+        Object.entries(liquidityTierOverrides).filter(([, v]) =>
+          validLiqTiers.has(v)
+        )
+      )
+    : undefined
+
+  const results: Array<{
+    matchId: number
+    status: 'created' | 'skipped' | 'dry-run' | 'error'
+    question: string
+    marketId: string | null
+    reason: string | null
+  }> = []
+
+  for (const matchId of matchIds) {
+    const match = matchById.get(matchId)
+    if (!match) {
+      results.push({
+        matchId,
+        status: 'error',
+        question: `Match ${matchId}`,
+        marketId: null,
+        reason: 'Match not found in competition fixtures',
+      })
+      continue
+    }
+
+    if (!match.homeTeam.name || !match.awayTeam.name) {
+      results.push({ matchId, status: 'skipped', question: `Match ${matchId}`, marketId: null, reason: 'Teams not yet determined' })
+      continue
+    }
+
+    const eventId = matchSportsEventId(match)
+
+    // Idempotency check
+    const existing = await pg.oneOrNone<{ id: string }>(
+      `select id from contracts where data->>'sportsEventId' = $1 and token = 'MANA' limit 1`,
+      [eventId]
+    )
+    if (existing) {
+      results.push({
+        matchId,
+        status: 'skipped',
+        question: `${match.homeTeam.name} vs ${match.awayTeam.name}`,
+        marketId: existing.id,
+        reason: 'Market already exists',
+      })
+      continue
+    }
+
+    const params = buildMarketParams(match, config, groupResult.id, {
+      customNote,
+      dashboardUrl,
+      liquidityTierOverrides: safeOverrides as Partial<StageLiquidityTiers>,
+    })
+
+    if (dryRun) {
+      results.push({
+        matchId,
+        status: 'dry-run',
+        question: params.question,
+        marketId: null,
+        reason: null,
+      })
+      continue
+    }
+
+    try {
+      const { contract } = await createMarketHelper(
+        {
+          question: params.question,
+          descriptionMarkdown: params.descriptionMarkdown,
+          outcomeType: 'MULTIPLE_CHOICE',
+          closeTime: params.closeTime,
+          answers: params.answers,
+          answerShortTexts: params.answerShortTexts,
+          answerImageUrls: params.answerImageUrls,
+          visibility: 'public',
+          liquidityTier: params.liquidityTier as LiquidityTierValue,
+          addAnswersMode: 'DISABLED',
+          shouldAnswersSumToOne: true,
+          sportsStartTimestamp: params.sportsStartTimestamp,
+          sportsEventId: params.sportsEventId,
+          sportsLeague: params.sportsLeague,
+          groupIds: params.groupIds,
+        },
+        creatorAuth!
+      )
+
+      // Attach group tags (createMarketHelper doesn't do this — only the full handler does)
+      await Promise.allSettled(
+        params.groupIds.map((gId) =>
+          pg.oneOrNone(
+            `select id from groups where id = $1 limit 1`,
+            [gId]
+          ).then((g) => g ? addGroupToContract(pg, contract, g) : null)
+        )
+      )
+
+      results.push({
+        matchId,
+        status: 'created',
+        question: params.question,
+        marketId: contract.id,
+        reason: null,
+      })
+    } catch (e) {
+      results.push({
+        matchId,
+        status: 'error',
+        question: params.question,
+        marketId: null,
+        reason: e instanceof Error ? e.message : String(e),
+      })
+    }
+  }
+
+  return {
+    groupId: groupResult.id,
+    groupCreated: groupResult.created,
+    groupRestricted: groupResult.restricted,
+    communityGroupId: communityResult.groupId,
+    communityGroupCreated: communityResult.groupCreated,
+    communityDashboardId: communityResult.dashboardId,
+    communityDashboardCreated: communityResult.dashboardCreated,
+    results,
+  }
+}

--- a/backend/api/src/admin-sports-fixtures.ts
+++ b/backend/api/src/admin-sports-fixtures.ts
@@ -1,0 +1,84 @@
+import { APIError, APIHandler } from './helpers/endpoint'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import {
+  TOURNAMENT_CONFIGS,
+  fetchAllCompetitionMatches,
+  stageLabel,
+  teamFlagFromArea,
+  computeCloseTime,
+  stageLiquidityForMatch,
+  matchSportsEventId,
+} from 'shared/world-cup-markets'
+
+export const adminSportsFixtures: APIHandler<'admin-sports-fixtures'> = async (
+  props,
+  auth
+) => {
+  throwErrorIfNotAdmin(auth.uid)
+
+  const apiKey = process.env.FOOTBALL_DATA_API_KEY ?? ''
+  if (!apiKey) throw new APIError(500, 'FOOTBALL_DATA_API_KEY not set on server')
+
+  const { competitionCode, dateFrom, dateTo, stage } = props
+
+  const config = TOURNAMENT_CONFIGS[competitionCode]
+  if (!config) throw new APIError(400, `Unknown competition code: ${competitionCode}`)
+
+  const pg = createSupabaseDirectClient()
+
+  const matches = await fetchAllCompetitionMatches(config, apiKey, {
+    dateFrom,
+    dateTo,
+    status: 'SCHEDULED',
+  })
+
+  const filtered = (stage ? matches.filter((m) => m.stage === stage) : matches)
+    .filter((m) => m.homeTeam.name && m.awayTeam.name)
+
+  // Batch-check which matches already have markets
+  const eventIds = filtered.map((m) => matchSportsEventId(m))
+  const existingRows = await pg.manyOrNone<{
+    event_id: string
+    market_id: string
+  }>(
+    `select data->>'sportsEventId' as event_id, id as market_id
+     from contracts
+     where data->>'sportsEventId' = any($1::text[])
+       and token = 'MANA'`,
+    [eventIds]
+  )
+  const marketByEventId = new Map(
+    existingRows.map((r) => [r.event_id, r.market_id])
+  )
+
+  const fixtures = filtered.map((m) => {
+    const eventId = matchSportsEventId(m)
+    return {
+      id: m.id,
+      homeTeam: {
+        name: m.homeTeam.name,
+        tla: m.homeTeam.tla,
+        crest: m.homeTeam.crest,
+      },
+      awayTeam: {
+        name: m.awayTeam.name,
+        tla: m.awayTeam.tla,
+        crest: m.awayTeam.crest,
+      },
+      homeFlag: teamFlagFromArea(m.homeTeam.area?.code ?? ''),
+      awayFlag: teamFlagFromArea(m.awayTeam.area?.code ?? ''),
+      utcDate: m.utcDate,
+      stageCode: m.stage,
+      stageLabel: stageLabel(m),
+      group: m.group,
+      status: m.status,
+      closeTime: computeCloseTime(m, config),
+      liquidityTier: stageLiquidityForMatch(m, config),
+      existingMarketId: marketByEventId.get(eventId) ?? null,
+      sportsEventId: eventId,
+    }
+  })
+
+  return { fixtures }
+}

--- a/backend/api/src/admin-sports-init-community.ts
+++ b/backend/api/src/admin-sports-init-community.ts
@@ -1,0 +1,35 @@
+import { APIError, APIHandler } from './helpers/endpoint'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { TOURNAMENT_CONFIGS, ensureCommunityAssets } from 'shared/world-cup-markets'
+import { getUser } from 'shared/utils'
+import { ENV } from 'common/envs/constants'
+
+export const adminSportsInitCommunity: APIHandler<
+  'admin-sports-init-community'
+> = async (props, auth) => {
+  throwErrorIfNotAdmin(auth.uid)
+
+  const { competitionCode } = props
+  const config = TOURNAMENT_CONFIGS[competitionCode]
+  if (!config) throw new APIError(400, `Unknown competition code: ${competitionCode}`)
+
+  const pg = createSupabaseDirectClient()
+  const creatorId =
+    ENV === 'DEV'
+      ? config.manifoldSportsUserId.dev
+      : config.manifoldSportsUserId.prod
+
+  const creatorUser = await getUser(creatorId)
+  if (!creatorUser)
+    throw new APIError(500, `ManifoldSports user ${creatorId} not found`)
+
+  return ensureCommunityAssets(
+    config,
+    creatorId,
+    creatorUser.username,
+    creatorUser.name,
+    creatorUser.avatarUrl ?? '',
+    pg
+  )
+}

--- a/backend/api/src/admin-sports-markets.ts
+++ b/backend/api/src/admin-sports-markets.ts
@@ -1,0 +1,75 @@
+import { APIHandler } from './helpers/endpoint'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { ENV_CONFIG } from 'common/envs/constants'
+
+export const adminSportsMarkets: APIHandler<'admin-sports-markets'> = async (
+  props
+) => {
+
+  const { sportsLeague } = props
+  const pg = createSupabaseDirectClient()
+
+  const rows = await pg.manyOrNone<{ data: any }>(
+    `select data
+     from contracts
+     where data->>'sportsLeague' = $1
+       and token = 'MANA'
+     order by (data->>'closeTime')::bigint asc`,
+    [sportsLeague]
+  )
+
+  const now = Date.now()
+  const attentionThresholdMs = 3 * 60 * 60 * 1000 // 3 hours
+
+  const markets = rows.map((r) => {
+    const d = r.data
+    const closeTime: number = parseInt(d.closeTime ?? '0', 10)
+    const resolution: string | null = d.resolution ?? null
+
+    // Determine the resolved answer text if available
+    let resolvedAnswer: string | null = null
+    if (resolution && d.answers) {
+      const answers: Array<{ id: string; text: string }> = d.answers
+      const winner = answers.find((a) => a.id === resolution)
+      resolvedAnswer = winner?.text ?? resolution
+    }
+
+    const needsAttention =
+      !resolution && closeTime > 0 && now - closeTime > attentionThresholdMs
+
+    const stageLabelStr = (d.sportsStageLabel as string) ?? ''
+
+    const answers: Array<{ id: string; text: string; prob: number }> =
+      (d.answers ?? []).map((a: { id: string; text: string; prob?: number }) => ({
+        id: a.id,
+        text: a.text,
+        prob: a.prob ?? 0,
+      }))
+
+    return {
+      id: d.id as string,
+      question: d.question as string,
+      stageLabel: stageLabelStr,
+      closeTime,
+      sportsStartTimestamp: (d.sportsStartTimestamp as string) ?? null,
+      resolution,
+      resolvedAnswer,
+      resolutionTime: d.resolutionTime ? parseInt(d.resolutionTime, 10) : null,
+      sportsHomeScore: d.sportsHomeScore != null ? (d.sportsHomeScore as number) : null,
+      sportsAwayScore: d.sportsAwayScore != null ? (d.sportsAwayScore as number) : null,
+      volume: d.volume ?? 0,
+      url: `https://${ENV_CONFIG.domain}/${d.creatorUsername}/${d.slug}`,
+      needsAttention,
+      answers,
+    }
+  })
+
+  // Surface "needs attention" markets first
+  markets.sort((a, b) => {
+    if (a.needsAttention && !b.needsAttention) return -1
+    if (!a.needsAttention && b.needsAttention) return 1
+    return a.closeTime - b.closeTime
+  })
+
+  return { markets }
+}

--- a/backend/api/src/admin-sports-resolve.ts
+++ b/backend/api/src/admin-sports-resolve.ts
@@ -1,0 +1,28 @@
+import { APIError, APIHandler } from './helpers/endpoint'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import {
+  TOURNAMENT_CONFIGS,
+  resolveTournamentMarkets,
+} from 'shared/world-cup-markets'
+
+export const adminSportsResolve: APIHandler<'admin-sports-resolve'> = async (
+  props,
+  auth
+) => {
+  throwErrorIfNotAdmin(auth.uid)
+
+  const apiKey = process.env.FOOTBALL_DATA_API_KEY ?? ''
+  if (!apiKey) throw new APIError(500, 'FOOTBALL_DATA_API_KEY not set on server')
+
+  const { competitionCode } = props
+
+  const config = TOURNAMENT_CONFIGS[competitionCode]
+  if (!config) throw new APIError(400, `Unknown competition code: ${competitionCode}`)
+
+  const { resolved, skipped, errors, log } = await resolveTournamentMarkets(
+    config,
+    apiKey
+  )
+
+  return { resolved, skipped, errors, log }
+}

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -197,6 +197,12 @@ import { adminDeletePrizeClaim } from './admin-delete-prize-claim'
 import { adminGetManaSales } from './admin-get-mana-sales'
 import { adminGetTopWhaleUsers } from './admin-get-top-whale-users'
 import { adminGetNewUsers } from './admin-get-new-users'
+import { adminSportsFixtures } from './admin-sports-fixtures'
+import { adminSportsCreateMarkets } from './admin-sports-create-markets'
+import { adminSportsMarkets } from './admin-sports-markets'
+import { adminSportsResolve } from './admin-sports-resolve'
+import { adminSportsCommunityMarket } from './admin-sports-community-market'
+import { adminSportsInitCommunity } from './admin-sports-init-community'
 import { getSweepstakesList } from './get-sweepstakes-list'
 import { adminCreateSweepstakes } from './admin-create-sweepstakes'
 import { getCharityGiveawayList } from './get-charity-giveaway-list'
@@ -534,6 +540,12 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'admin-get-mana-sales': adminGetManaSales,
   'admin-get-top-whale-users': adminGetTopWhaleUsers,
   'admin-get-new-users': adminGetNewUsers,
+  'admin-sports-fixtures': adminSportsFixtures,
+  'admin-sports-create-markets': adminSportsCreateMarkets,
+  'admin-sports-markets': adminSportsMarkets,
+  'admin-sports-resolve': adminSportsResolve,
+  'admin-sports-community-market': adminSportsCommunityMarket,
+  'admin-sports-init-community': adminSportsInitCommunity,
   'get-predictle-percentile': getPredictlePercentile,
   'get-shop-items': getShopItems,
   'get-shop-stats': getShopStats,

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -56,6 +56,7 @@ import { unbanUsers } from './unban-users'
 import { updateLeague } from './update-league'
 import { updateLeagueRanks } from './update-league-ranks'
 import { updateStatsCore } from './update-stats'
+import { resolveSportsMarkets } from './sports-resolve'
 
 export function createJobs() {
   return [
@@ -313,6 +314,12 @@ export function createJobs() {
       'downsample-portfolio-history',
       '0 50 4 * * *', // every day at 4:50am
       downsamplePortfolioHistory
+    ),
+    // All football-data.org tournaments: check for finished matches and auto-resolve every 15 minutes
+    createJob(
+      'sports-resolve',
+      '0 */15 * * * *', // every 15 minutes
+      resolveSportsMarkets
     ),
   ]
 }

--- a/backend/scheduler/src/jobs/sports-resolve.ts
+++ b/backend/scheduler/src/jobs/sports-resolve.ts
@@ -1,0 +1,30 @@
+import { log } from 'shared/monitoring/log'
+import { TOURNAMENT_CONFIGS, resolveTournamentMarkets } from 'shared/world-cup-markets'
+import { ENV } from 'common/envs/constants'
+
+export async function resolveSportsMarkets() {
+  const apiKey = process.env.FOOTBALL_DATA_API_KEY ?? ''
+  if (!apiKey) {
+    log.warn('[sports-resolve] FOOTBALL_DATA_API_KEY not set — skipping')
+    return
+  }
+
+  for (const config of Object.values(TOURNAMENT_CONFIGS)) {
+    const creatorId =
+      ENV === 'DEV'
+        ? config.manifoldSportsUserId.dev
+        : config.manifoldSportsUserId.prod
+
+    if (creatorId.startsWith('TODO_')) {
+      log.warn(`[sports-resolve] ${config.footballDataCode}: manifoldSportsUserId not configured — skipping`)
+      continue
+    }
+
+    try {
+      const { resolved, skipped, errors } = await resolveTournamentMarkets(config, apiKey)
+      log(`[sports-resolve] ${config.footballDataCode}: resolved=${resolved} skipped=${skipped} errors=${errors}`)
+    } catch (e) {
+      log.error(`[sports-resolve] ${config.footballDataCode}: unexpected error — ${(e as Error).message}`)
+    }
+  }
+}

--- a/backend/shared/src/world-cup-markets.ts
+++ b/backend/shared/src/world-cup-markets.ts
@@ -1,0 +1,820 @@
+import { ENV } from 'common/envs/constants'
+import { liquidityTiers } from 'common/tier'
+import { getUser } from 'shared/utils'
+import {
+  createSupabaseDirectClient,
+  SupabaseDirectClient,
+} from 'shared/supabase/init'
+import { resolveMarketHelper } from 'shared/resolve-market-helpers'
+import { anythingToRichText } from 'shared/tiptap'
+import { convertContract } from 'common/supabase/contracts'
+import { CPMMMultiContract } from 'common/contract'
+import { insert, bulkInsert } from 'shared/supabase/utils'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type LiquidityTierValue = (typeof liquidityTiers)[number]
+
+export interface StageLiquidityTiers {
+  REGULAR_SEASON?: LiquidityTierValue
+  GROUP_STAGE?: LiquidityTierValue
+  LEAGUE_PHASE?: LiquidityTierValue
+  ROUND_OF_16?: LiquidityTierValue
+  QUARTER_FINALS?: LiquidityTierValue
+  SEMI_FINALS?: LiquidityTierValue
+  THIRD_PLACE?: LiquidityTierValue
+  FINAL?: LiquidityTierValue
+}
+
+export interface TournamentConfig {
+  name: string
+  shortLabel: string
+  footballDataCode: string
+  sportsLeague: string
+  startDate: string
+  endDate: string
+  hasGroupStageDraws: boolean
+  /** When true, use team shortName instead of flag+TLA (for club tournaments) */
+  useTeamNames?: boolean
+  officialGroupSlug: string
+  officialGroupName: string
+  communityGroupSlug: string
+  communityDashboardSlug: string
+  additionalGroupIds: { dev: string[]; prod: string[] }
+  manifoldSportsUserId: { dev: string; prod: string }
+  closeTimeOffsetMs: number
+  stageLiquidityTiers: StageLiquidityTiers
+}
+
+export interface LiveMatchScore {
+  sportsEventId: string
+  homeScore: number | null
+  awayScore: number | null
+  status: 'IN_PLAY' | 'PAUSED' | 'HALF_TIME' | string
+}
+
+// football-data.org v4 match shape (subset used here)
+export interface FDMatch {
+  id: number
+  utcDate: string
+  status:
+    | 'SCHEDULED'
+    | 'TIMED'
+    | 'IN_PLAY'
+    | 'PAUSED'
+    | 'FINISHED'
+    | 'SUSPENDED'
+    | 'POSTPONED'
+    | 'CANCELLED'
+    | 'AWARDED'
+  matchday: number | null
+  stage: string
+  group: string | null
+  homeTeam: {
+    id: number
+    name: string
+    shortName: string
+    tla: string
+    crest: string
+    area?: { code: string }
+  }
+  awayTeam: {
+    id: number
+    name: string
+    shortName: string
+    tla: string
+    crest: string
+    area?: { code: string }
+  }
+  score: {
+    winner: 'HOME_TEAM' | 'AWAY_TEAM' | 'DRAW' | null
+    duration: 'REGULAR' | 'EXTRA_TIME' | 'PENALTY_SHOOTOUT'
+    fullTime: { home: number | null; away: number | null }
+    halfTime: { home: number | null; away: number | null }
+  }
+}
+
+export interface ResolveLogEntry {
+  question: string
+  result: string
+  status: 'resolved' | 'skipped' | 'error'
+}
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const MANIFOLD_SPORTS_USER_ID_PROD = 'NnVY8olowYMYQGr346dfmHXBSpx2' // @ManifoldSports
+const MANIFOLD_SPORTS_USER_ID_DEV = 'lu01Fs2BVnTQgFMMpS1qhYst9fs2' // @teststef
+
+export const WORLD_CUP_2026: TournamentConfig = {
+  name: 'FIFA World Cup 2026',
+  shortLabel: "World Cup '26",
+  footballDataCode: 'WC',
+  sportsLeague: 'FIFA World Cup',
+  startDate: '2026-06-11',
+  endDate: '2026-07-19',
+  hasGroupStageDraws: true,
+  officialGroupSlug: 'ms-official-wc2026',
+  officialGroupName: 'MS Official: World Cup 2026',
+  communityGroupSlug: 'ms-community-wc2026',
+  communityDashboardSlug: 'ms-community-wc2026',
+  additionalGroupIds: {
+    dev: [],
+    prod: [
+      '2hGlgVhIyvVaFyQAREPi', // sports_default
+      'ypd6vR44ZzJyN9xykx6e', // soccer
+    ],
+  },
+  manifoldSportsUserId: {
+    dev: MANIFOLD_SPORTS_USER_ID_DEV,
+    prod: MANIFOLD_SPORTS_USER_ID_PROD,
+  },
+  closeTimeOffsetMs: 2.5 * 60 * 60 * 1000,
+  stageLiquidityTiers: {
+    GROUP_STAGE: 1_000,
+    ROUND_OF_16: 10_000,
+    QUARTER_FINALS: 10_000,
+    SEMI_FINALS: 10_000,
+    THIRD_PLACE: 10_000,
+    FINAL: 10_000,
+  },
+}
+
+// Registry of all configured tournaments, keyed by footballDataCode.
+// Add new entries here when adding a new tournament.
+export const CHAMPIONS_LEAGUE_2026: TournamentConfig = {
+  name: 'UEFA Champions League 2025/26',
+  shortLabel: "UCL '26",
+  footballDataCode: 'CL',
+  sportsLeague: 'UEFA Champions League',
+  startDate: '2025-09-16',
+  endDate: '2026-05-31',
+  hasGroupStageDraws: true,
+  useTeamNames: true,
+  officialGroupSlug: 'ms-official-cl-2026',
+  officialGroupName: 'MS Official: Champions League 2026',
+  communityGroupSlug: 'ms-community-cl-2026',
+  communityDashboardSlug: 'ms-community-cl-2026',
+  additionalGroupIds: {
+    dev: [],
+    prod: [],
+  },
+  manifoldSportsUserId: {
+    dev: MANIFOLD_SPORTS_USER_ID_DEV,
+    prod: MANIFOLD_SPORTS_USER_ID_PROD,
+  },
+  closeTimeOffsetMs: 2.5 * 60 * 60 * 1000,
+  stageLiquidityTiers: {
+    GROUP_STAGE: 1_000,
+    LEAGUE_PHASE: 1_000,
+    ROUND_OF_16: 10_000,
+    QUARTER_FINALS: 10_000,
+    SEMI_FINALS: 10_000,
+    THIRD_PLACE: 10_000,
+    FINAL: 10_000,
+  },
+}
+
+export const PREMIER_LEAGUE_2526: TournamentConfig = {
+  name: 'Premier League 2025/26',
+  shortLabel: "PL '26",
+  footballDataCode: 'PL',
+  sportsLeague: 'Premier League',
+  startDate: '2025-08-16',
+  endDate: '2026-05-24',
+  hasGroupStageDraws: true,
+  useTeamNames: true,
+  officialGroupSlug: 'ms-official-pl-2526',
+  officialGroupName: 'MS Official: Premier League 2025/26',
+  communityGroupSlug: 'ms-community-pl-2526',
+  communityDashboardSlug: 'ms-community-pl-2526',
+  additionalGroupIds: { dev: [], prod: [] },
+  manifoldSportsUserId: {
+    dev: MANIFOLD_SPORTS_USER_ID_DEV,
+    prod: MANIFOLD_SPORTS_USER_ID_PROD,
+  },
+  closeTimeOffsetMs: 2.5 * 60 * 60 * 1000,
+  stageLiquidityTiers: {
+    REGULAR_SEASON: 1_000,
+    FINAL: 10_000,
+  },
+}
+
+// Dev-only test tournament — only included in TOURNAMENT_CONFIGS when ENV === 'DEV'.
+// Mock server (backend/scripts/mock-sports-server.mjs) serves 3 GROUP_STAGE matches as competition code TEST.
+export const TEST_TOURNAMENT_2026: TournamentConfig = {
+  name: 'Test Tournament [DEV]',
+  shortLabel: "Test '26",
+  footballDataCode: 'TEST',
+  sportsLeague: 'Test Tournament',
+  startDate: '2026-05-07',
+  endDate: '2026-05-07',
+  hasGroupStageDraws: true,
+  officialGroupSlug: 'ms-official-test-2026',
+  officialGroupName: 'MS Official: Test Tournament 2026',
+  communityGroupSlug: 'ms-community-test-2026',
+  communityDashboardSlug: 'ms-community-test-2026',
+  additionalGroupIds: { dev: [], prod: [] },
+  manifoldSportsUserId: {
+    dev: MANIFOLD_SPORTS_USER_ID_DEV,
+    prod: MANIFOLD_SPORTS_USER_ID_DEV, // dev user for both — test tournament only exists in dev
+  },
+  closeTimeOffsetMs: 2.5 * 60 * 60 * 1000,
+  stageLiquidityTiers: {
+    GROUP_STAGE: 1_000,
+  },
+}
+
+export const TOURNAMENT_CONFIGS: Record<string, TournamentConfig> = {
+  WC: WORLD_CUP_2026,
+  CL: CHAMPIONS_LEAGUE_2026,
+  PL: PREMIER_LEAGUE_2526,
+  ...(ENV === 'DEV' ? { TEST: TEST_TOURNAMENT_2026 } : {}),
+}
+
+// ─── Group auto-creation ──────────────────────────────────────────────────────
+
+export interface GroupEnsureResult {
+  id: string
+  created: boolean
+  restricted: boolean
+}
+
+/**
+ * Ensure the official tournament group exists and is curated (admin-restricted).
+ * Creates it if missing. Updates privacy_status to 'curated' if it exists but is public.
+ * Always runs before any market creation — idempotent.
+ */
+export async function ensureOfficialGroup(
+  config: TournamentConfig,
+  creatorId: string,
+  pg: SupabaseDirectClient
+): Promise<GroupEnsureResult> {
+  const slug = config.officialGroupSlug
+
+  const existing = await pg.oneOrNone<{
+    id: string
+    privacy_status: string
+  }>(
+    `select id, privacy_status from groups where slug = $1 limit 1`,
+    [slug]
+  )
+
+  if (existing) {
+    let restricted = existing.privacy_status === 'curated'
+    if (!restricted) {
+      await pg.none(
+        `update groups set privacy_status = 'curated' where id = $1`,
+        [existing.id]
+      )
+      restricted = true
+    }
+    return { id: existing.id, created: false, restricted }
+  }
+
+  const group = await insert(pg, 'groups', {
+    creator_id: creatorId,
+    slug,
+    name: config.officialGroupName,
+    about: anythingToRichText({ raw: `Official Manifold Sports markets for ${config.name}. Managed by @ManifoldSports.` }),
+    total_members: 1,
+    privacy_status: 'curated',
+  })
+
+  await bulkInsert(pg, 'group_members', [
+    { group_id: group.id, member_id: creatorId, role: 'admin' },
+  ])
+
+  return { id: group.id, created: true, restricted: true }
+}
+
+export interface CommunityAssetsResult {
+  groupId: string
+  groupCreated: boolean
+  dashboardId: string
+  dashboardCreated: boolean
+}
+
+/**
+ * Ensure the community group + dashboard exist for a tournament.
+ * Both are curated (admin-restricted for adding). Idempotent.
+ * Call this alongside ensureOfficialGroup when batch-creating markets.
+ */
+export async function ensureCommunityAssets(
+  config: TournamentConfig,
+  creatorId: string,
+  creatorUsername: string,
+  creatorName: string,
+  creatorAvatarUrl: string,
+  pg: SupabaseDirectClient
+): Promise<CommunityAssetsResult> {
+  // ── Community group ──────────────────────────────────────────────────────────
+  const groupSlug = config.communityGroupSlug
+  let groupCreated = false
+
+  const existingGroup = await pg.oneOrNone<{ id: string }>(
+    `select id from groups where slug = $1 limit 1`,
+    [groupSlug]
+  )
+
+  let groupId: string
+  if (existingGroup) {
+    groupId = existingGroup.id
+    await pg.none(
+      `update groups set privacy_status = 'curated' where id = $1`,
+      [groupId]
+    )
+  } else {
+    const group = await insert(pg, 'groups', {
+      creator_id: creatorId,
+      slug: groupSlug,
+      name: `MS Community: ${config.name}`,
+      about: anythingToRichText({ raw: `Community markets for ${config.name}. Curated by Manifold admins.` }),
+      total_members: 1,
+      privacy_status: 'curated',
+    })
+    await bulkInsert(pg, 'group_members', [
+      { group_id: group.id, member_id: creatorId, role: 'admin' },
+    ])
+    groupId = group.id
+    groupCreated = true
+  }
+
+  // ── Community dashboard ──────────────────────────────────────────────────────
+  const dashSlug = config.communityDashboardSlug
+  let dashboardCreated = false
+
+  const existingDash = await pg.oneOrNone<{ id: string }>(
+    `select id from dashboards where slug = $1 limit 1`,
+    [dashSlug]
+  )
+
+  let dashboardId: string
+  if (existingDash) {
+    dashboardId = existingDash.id
+  } else {
+    const dash = await pg.one<{ id: string }>(
+      `insert into dashboards(slug, creator_id, title, items, creator_username, creator_name, creator_avatar_url)
+       values ($1, $2, $3, $4, $5, $6, $7)
+       returning id`,
+      [
+        dashSlug,
+        creatorId,
+        `MS Community: ${config.name}`,
+        JSON.stringify([]),
+        creatorUsername,
+        creatorName,
+        creatorAvatarUrl,
+      ]
+    )
+    dashboardId = dash.id
+    dashboardCreated = true
+  }
+
+  return { groupId, groupCreated, dashboardId, dashboardCreated }
+}
+
+// ─── Flag / display helpers ───────────────────────────────────────────────────
+
+// Maps football-data.org area codes / TLAs that differ from ISO 3166-1 alpha-2
+const FD_CODE_TO_ISO2: Record<string, string> = {
+  // UK nations
+  ENG: 'GB', SCO: 'GB', WAL: 'GB', NIR: 'GB',
+  // TLA → ISO2 for all 48 WC 2026 teams + common extras
+  MEX: 'MX', USA: 'US', CAN: 'CA', BRA: 'BR', ARG: 'AR', FRA: 'FR',
+  ESP: 'ES', GER: 'DE', POR: 'PT', NED: 'NL', BEL: 'BE', ITA: 'IT',
+  URU: 'UY', COL: 'CO', CHI: 'CL', ECU: 'EC', PER: 'PE', VEN: 'VE',
+  PAR: 'PY', BOL: 'BO', JAM: 'JM', PAN: 'PA', CRC: 'CR', HON: 'HN',
+  SLV: 'SV', GTM: 'GT', CUB: 'CU', TRI: 'TT', HAI: 'HT',
+  MAR: 'MA', SEN: 'SN', NGA: 'NG', CMR: 'CM', CIV: 'CI', GHA: 'GH',
+  EGY: 'EG', TUN: 'TN', ALG: 'DZ', MLI: 'ML', RSA: 'ZA', COD: 'CD',
+  JPN: 'JP', KOR: 'KR', AUS: 'AU', IRN: 'IR', SAU: 'SA', QAT: 'QA',
+  UAE: 'AE', IDN: 'ID', UZB: 'UZ', CHN: 'CN', IND: 'IN', THA: 'TH',
+  KSA: 'SA', KUW: 'KW', IRQ: 'IQ', JOR: 'JO', LBN: 'LB', SYR: 'SY',
+  CRO: 'HR', SRB: 'RS', SVK: 'SK', SVN: 'SI', HUN: 'HU', ROU: 'RO',
+  GRE: 'GR', TUR: 'TR', UKR: 'UA', POL: 'PL', CZE: 'CZ', AUT: 'AT',
+  SWE: 'SE', NOR: 'NO', DEN: 'DK', SUI: 'CH', SCT: 'GB', FIN: 'FI',
+  BIH: 'BA', MKD: 'MK', ALB: 'AL', ISL: 'IS', IRL: 'IE',
+  CPV: 'CV', CUR: 'CW',
+}
+
+export function flagEmoji(iso2: string): string {
+  if (!iso2 || iso2.length !== 2) return ''
+  return [...iso2.toUpperCase()]
+    .map((c) => String.fromCodePoint(0x1f1e6 + c.charCodeAt(0) - 65))
+    .join('')
+}
+
+export function teamFlagFromArea(areaCode: string): string {
+  const iso2 = FD_CODE_TO_ISO2[areaCode] ?? areaCode
+  return flagEmoji(iso2)
+}
+
+function teamFlag(team: FDMatch['homeTeam']): string {
+  return teamFlagFromArea(team.area?.code ?? team.tla ?? '')
+}
+
+export function stageLabel(match: FDMatch): string {
+  switch (match.stage) {
+    case 'REGULAR_SEASON':
+      return match.matchday != null ? `MD ${match.matchday}` : 'Regular Season'
+    case 'GROUP_STAGE':
+      return (match.group ?? 'Group Stage').replace(/^GROUP_/, 'Group ')
+    case 'LEAGUE_PHASE':
+      return match.matchday != null ? `MD ${match.matchday}` : 'League Phase'
+    case 'ROUND_OF_16':
+      return 'R16'
+    case 'QUARTER_FINALS':
+      return 'QF'
+    case 'SEMI_FINALS':
+      return 'SF'
+    case 'THIRD_PLACE':
+      return 'Third Place'
+    case 'FINAL':
+      return 'Final'
+    default:
+      return match.stage
+  }
+}
+
+export function stageLiquidityForMatch(
+  match: FDMatch,
+  config: TournamentConfig,
+  overrides?: Partial<StageLiquidityTiers>
+): LiquidityTierValue {
+  const tiers = { ...config.stageLiquidityTiers, ...overrides }
+  return (
+    (tiers as Record<string, LiquidityTierValue | undefined>)[match.stage] ??
+    tiers.LEAGUE_PHASE ??
+    tiers.GROUP_STAGE ??
+    1_000
+  )
+}
+
+export function computeCloseTime(match: FDMatch, config: TournamentConfig): number {
+  return new Date(match.utcDate).getTime() + config.closeTimeOffsetMs
+}
+
+function isKnockoutStage(stage: string): boolean {
+  return ['ROUND_OF_16', 'QUARTER_FINALS', 'SEMI_FINALS', 'THIRD_PLACE', 'FINAL'].includes(stage)
+}
+
+function sportsEventId(match: FDMatch): string {
+  return `fd-${match.id}`
+}
+
+export { sportsEventId as matchSportsEventId }
+
+// ─── Description builder ─────────────────────────────────────────────────────
+
+const RESOLUTION_NOTE =
+  'This market resolves automatically after the match concludes based on official results.'
+
+export function buildDescription(
+  match: FDMatch,
+  config: TournamentConfig,
+  opts: { customNote?: string; dashboardUrl?: string } = {}
+): string {
+  const { homeTeam, awayTeam, utcDate, stage } = match
+  const knockout = isKnockoutStage(stage)
+  const dateStr = new Date(utcDate).toUTCString().replace(' GMT', ' UTC')
+  const stageName = stageLabel(match)
+
+  const matchLine = `**${homeTeam.name} vs ${awayTeam.name} · ${stageName} · Kickoff ${dateStr}**`
+  const resolveLine = knockout
+    ? `*Resolves to the advancing team*`
+    : `*Resolves to the winning team or draw (90 min regulation)*`
+
+  const parts = [matchLine, resolveLine]
+  if (opts.customNote?.trim()) parts.push(opts.customNote.trim())
+  parts.push(RESOLUTION_NOTE)
+  if (opts.dashboardUrl) {
+    let href = opts.dashboardUrl.trim()
+    try {
+      // Extract just the path so the link works on both localhost and prod
+      const u = new URL(
+        href.startsWith('/') || href.startsWith('http') ? href : `https://${href}`
+      )
+      href = u.pathname + u.search + u.hash
+    } catch {
+      if (!href.startsWith('/')) href = `/${href}`
+    }
+    parts.push(`[Visit the ${config.name} Dashboard](${href})`)
+  }
+  parts.push('Created and managed by [@ManifoldSports](https://manifold.markets/ManifoldSports)')
+
+  return parts.join('\n\n\n')
+}
+
+// ─── Football-data.org API ────────────────────────────────────────────────────
+
+async function fdFetch<T>(path: string, apiKey: string): Promise<T> {
+  // Read at call time so FOOTBALL_DATA_BASE_URL can be set after module load (e.g. test scripts)
+  const base = process.env.FOOTBALL_DATA_BASE_URL ?? 'https://api.football-data.org'
+  const res = await fetch(`${base}${path}`, {
+    headers: { 'X-Auth-Token': apiKey, connection: 'close' },
+  })
+  if (!res.ok) {
+    throw new Error(
+      `football-data.org ${path} → ${res.status} ${res.statusText}`
+    )
+  }
+  return res.json() as Promise<T>
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function fetchScheduledMatches(
+  config: TournamentConfig,
+  apiKey: string,
+  dateFrom: string,
+  dateTo: string
+): Promise<FDMatch[]> {
+  const data = await fdFetch<{ matches: FDMatch[] }>(
+    `/v4/competitions/${config.footballDataCode}/matches?status=SCHEDULED&dateFrom=${dateFrom}&dateTo=${dateTo}`,
+    apiKey
+  )
+  return data.matches ?? []
+}
+
+export async function fetchAllCompetitionMatches(
+  config: TournamentConfig,
+  apiKey: string,
+  opts: { dateFrom?: string; dateTo?: string; status?: string } = {}
+): Promise<FDMatch[]> {
+  let path = `/v4/competitions/${config.footballDataCode}/matches`
+  const params: string[] = []
+  if (opts.status) params.push(`status=${opts.status}`)
+  if (opts.dateFrom) params.push(`dateFrom=${opts.dateFrom}`)
+  if (opts.dateTo) params.push(`dateTo=${opts.dateTo}`)
+  if (params.length) path += '?' + params.join('&')
+
+  const data = await fdFetch<{ matches: FDMatch[] }>(path, apiKey)
+  return data.matches ?? []
+}
+
+export async function fetchFinishedMatches(
+  config: TournamentConfig,
+  apiKey: string
+): Promise<FDMatch[]> {
+  return fetchAllCompetitionMatches(config, apiKey, { status: 'FINISHED' })
+}
+
+export async function fetchSingleMatch(
+  matchId: number,
+  apiKey: string
+): Promise<FDMatch> {
+  const data = await fdFetch<{ match: FDMatch }>(`/v4/matches/${matchId}`, apiKey)
+  return data.match
+}
+
+export async function fetchInPlayMatches(
+  config: TournamentConfig,
+  apiKey: string
+): Promise<FDMatch[]> {
+  const data = await fdFetch<{ matches: FDMatch[] }>(
+    `/v4/competitions/${config.footballDataCode}/matches?status=IN_PLAY`,
+    apiKey
+  )
+  return data.matches ?? []
+}
+
+// ─── Market creation ──────────────────────────────────────────────────────────
+
+export interface MarketCreateParams {
+  question: string
+  descriptionMarkdown: string
+  answers: string[]
+  answerShortTexts: string[]
+  answerImageUrls: string[]
+  closeTime: number
+  sportsStartTimestamp: string
+  sportsEventId: string
+  sportsLeague: string
+  groupIds: string[]
+  liquidityTier: LiquidityTierValue
+}
+
+export function buildMarketParams(
+  match: FDMatch,
+  config: TournamentConfig,
+  officialGroupId: string,
+  opts: {
+    customNote?: string
+    dashboardUrl?: string
+    liquidityTierOverrides?: Partial<StageLiquidityTiers>
+  } = {}
+): MarketCreateParams {
+  const home = match.homeTeam
+  const away = match.awayTeam
+  const knockout = isKnockoutStage(match.stage)
+  const stage = stageLabel(match)
+
+  let question: string
+  let answers: string[]
+  let answerShortTexts: string[]
+
+  if (config.useTeamNames) {
+    // Club tournaments (e.g. CL): use shortName, no flag emoji
+    const homeName = home.shortName || home.name
+    const awayName = away.shortName || away.name
+    question = `${homeName} vs ${awayName} [${config.shortLabel}]`
+    answers = knockout
+      ? [home.name, away.name]
+      : [home.name, away.name, 'Draw']
+    answerShortTexts = knockout
+      ? [homeName, awayName]
+      : [homeName, awayName, 'Draw']
+  } else {
+    // International tournaments (e.g. WC): use flag + TLA
+    const homeFlag = teamFlag(home)
+    const awayFlag = teamFlag(away)
+    question = `${homeFlag}${home.tla} vs ${awayFlag}${away.tla} [${config.shortLabel}]`
+    answers = knockout
+      ? [`${homeFlag} ${home.name}`, `${awayFlag} ${away.name}`]
+      : [`${homeFlag} ${home.name}`, `${awayFlag} ${away.name}`, 'Draw']
+    answerShortTexts = knockout
+      ? [`${homeFlag}${home.tla}`, `${awayFlag}${away.tla}`]
+      : [`${homeFlag}${home.tla}`, `${awayFlag}${away.tla}`, 'Draw']
+  }
+
+  const crests = [home.crest, away.crest]
+  const answerImageUrls =
+    knockout && crests.every((u) => u && u.length > 0) ? crests : []
+
+  const additionalIds =
+    ENV === 'DEV' ? config.additionalGroupIds.dev : config.additionalGroupIds.prod
+
+  return {
+    question,
+    descriptionMarkdown: buildDescription(match, config, opts),
+    answers,
+    answerShortTexts,
+    answerImageUrls,
+    closeTime: computeCloseTime(match, config),
+    sportsStartTimestamp: match.utcDate,
+    sportsEventId: sportsEventId(match),
+    sportsLeague: config.sportsLeague,
+    groupIds: [officialGroupId, ...additionalIds],
+    liquidityTier: stageLiquidityForMatch(match, config, opts.liquidityTierOverrides),
+  }
+}
+
+// ─── Resolution ───────────────────────────────────────────────────────────────
+
+interface UnresolvedSportsMarket {
+  id: string
+  sportsEventId: string
+  answers: Array<{ id: string; text: string }>
+  question: string
+}
+
+type SportsContractData = CPMMMultiContract & { sportsEventId?: string }
+
+async function getUnresolvedSportsMarkets(
+  pg: SupabaseDirectClient,
+  config: TournamentConfig,
+  creatorId: string
+): Promise<UnresolvedSportsMarket[]> {
+  const rows = await pg.manyOrNone<{ data: SportsContractData }>(
+    `select data from contracts
+     where data->>'sportsLeague' = $1
+       and creator_id = $2
+       and resolution is null
+       and outcome_type = 'MULTIPLE_CHOICE'
+       and token = 'MANA'`,
+    [config.sportsLeague, creatorId]
+  )
+
+  return rows.map((r) => {
+    const data = r.data
+    return {
+      id: data.id,
+      sportsEventId: data.sportsEventId ?? '',
+      answers: (data.answers ?? []).map((a) => ({ id: a.id, text: a.text })),
+      question: data.question,
+    }
+  })
+}
+
+export async function resolveTournamentMarkets(
+  config: TournamentConfig,
+  apiKey: string,
+  opts: { dryRun?: boolean } = {}
+): Promise<{
+  resolved: number
+  skipped: number
+  errors: number
+  log: ResolveLogEntry[]
+}> {
+  const { dryRun = false } = opts
+  const pg = createSupabaseDirectClient()
+  const log: ResolveLogEntry[] = []
+
+  const creatorId =
+    ENV === 'DEV'
+      ? config.manifoldSportsUserId.dev
+      : config.manifoldSportsUserId.prod
+
+  const creatorUser = await getUser(creatorId)
+  if (!creatorUser) throw new Error(`ManifoldSports user ${creatorId} not found`)
+
+  const unresolvedMarkets = await getUnresolvedSportsMarkets(pg, config, creatorId)
+
+  if (unresolvedMarkets.length === 0)
+    return { resolved: 0, skipped: 0, errors: 0, log }
+
+  await sleep(1000)
+  const finishedMatches = await fetchFinishedMatches(config, apiKey)
+  const finishedById = new Map(finishedMatches.map((m) => [sportsEventId(m), m]))
+
+  let resolved = 0
+  let skipped = 0
+  let errors = 0
+
+  for (const market of unresolvedMarkets) {
+    const match = finishedById.get(market.sportsEventId)
+    if (!match) {
+      skipped++
+      log.push({ question: market.question, result: 'Match not finished yet', status: 'skipped' })
+      continue
+    }
+
+    const { winner } = match.score
+    if (!winner) {
+      skipped++
+      log.push({ question: market.question, result: 'No winner recorded', status: 'skipped' })
+      continue
+    }
+
+    const winningText =
+      winner === 'HOME_TEAM'
+        ? match.homeTeam.name
+        : winner === 'AWAY_TEAM'
+        ? match.awayTeam.name
+        : 'Draw'
+
+    const winningAnswer = market.answers.find(
+      (a) => a.text === winningText || a.text.endsWith(` ${winningText}`)
+    )
+    if (!winningAnswer) {
+      errors++
+      log.push({
+        question: market.question,
+        result: `No answer matching "${winningText}"`,
+        status: 'error',
+      })
+      continue
+    }
+
+    if (dryRun) {
+      resolved++
+      log.push({
+        question: market.question,
+        result: `Would resolve → ${winningText}`,
+        status: 'resolved',
+      })
+      continue
+    }
+
+    try {
+      const contractRow = await pg.oneOrNone<{
+        data: any
+        importance_score: number | null
+      }>(`select data, importance_score from contracts where id = $1`, [market.id])
+
+      if (!contractRow) {
+        errors++
+        log.push({ question: market.question, result: 'Contract not found in DB', status: 'error' })
+        continue
+      }
+
+      const contract = convertContract(contractRow) as CPMMMultiContract
+      await resolveMarketHelper(contract, creatorUser, creatorUser, {
+        outcome: winningAnswer.id,
+        resolutions: { [winningAnswer.id]: 100 },
+      })
+      // Store final score in contract data for dashboard display
+      const homeScore = match.score.fullTime.home
+      const awayScore = match.score.fullTime.away
+      if (homeScore !== null && awayScore !== null) {
+        await pg.none(
+          `update contracts set data = data || $1 where id = $2`,
+          [JSON.stringify({ sportsHomeScore: homeScore, sportsAwayScore: awayScore }), market.id]
+        )
+      }
+      resolved++
+      log.push({ question: market.question, result: winningText, status: 'resolved' })
+    } catch (e) {
+      errors++
+      log.push({
+        question: market.question,
+        result: e instanceof Error ? e.message : String(e),
+        status: 'error',
+      })
+    }
+  }
+
+  return { resolved, skipped, errors, log }
+}

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -4111,6 +4111,154 @@ export const API = (_apiTypeCheck = {
     props: z.object({}).strict(),
     returns: {} as { orders: ShopOrder[] },
   },
+
+  // ─── Sports Admin ────────────────────────────────────────────────────────────
+
+  'admin-sports-fixtures': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    props: z
+      .object({
+        competitionCode: z.string(),
+        dateFrom: z.string(),
+        dateTo: z.string(),
+        stage: z.string().optional(),
+      })
+      .strict(),
+    returns: {} as {
+      fixtures: Array<{
+        id: number
+        homeTeam: { name: string; tla: string; crest: string }
+        awayTeam: { name: string; tla: string; crest: string }
+        homeFlag: string
+        awayFlag: string
+        utcDate: string
+        stageCode: string
+        stageLabel: string
+        group: string | null
+        status: string
+        closeTime: number
+        liquidityTier: number
+        existingMarketId: string | null
+        sportsEventId: string
+      }>
+    },
+  },
+
+  'admin-sports-create-markets': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    props: z
+      .object({
+        competitionCode: z.string(),
+        matchIds: z.array(z.number()),
+        dryRun: z.boolean(),
+        customNote: z.string().optional(),
+        dashboardUrl: z.string().optional(),
+        liquidityTierOverrides: z.record(z.string(), z.number()).optional(),
+      })
+      .strict(),
+    returns: {} as {
+      groupId: string
+      groupCreated: boolean
+      groupRestricted: boolean
+      communityGroupId: string
+      communityGroupCreated: boolean
+      communityDashboardId: string
+      communityDashboardCreated: boolean
+      results: Array<{
+        matchId: number
+        status: 'created' | 'skipped' | 'dry-run' | 'error'
+        question: string
+        marketId: string | null
+        reason: string | null
+      }>
+    },
+  },
+
+  'admin-sports-community-market': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    props: z
+      .object({
+        competitionCode: z.string(),
+        contractId: z.string(),
+        action: z.enum(['add', 'remove']),
+      })
+      .strict(),
+    returns: {} as {
+      success: boolean
+      dashboardId: string
+      action: 'add' | 'remove'
+      contractId: string
+    },
+  },
+
+  'admin-sports-init-community': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({ competitionCode: z.string() }).strict(),
+    returns: {} as {
+      groupId: string
+      groupCreated: boolean
+      dashboardId: string
+      dashboardCreated: boolean
+    },
+  },
+
+  'admin-sports-markets': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: false,
+    props: z
+      .object({
+        sportsLeague: z.string(),
+      })
+      .strict(),
+    returns: {} as {
+      markets: Array<{
+        id: string
+        question: string
+        stageLabel: string
+        closeTime: number
+        sportsStartTimestamp: string | null
+        resolution: string | null
+        resolvedAnswer: string | null
+        resolutionTime: number | null
+        sportsHomeScore: number | null
+        sportsAwayScore: number | null
+        volume: number
+        url: string
+        needsAttention: boolean
+        answers: Array<{ id: string; text: string; prob: number }>
+      }>
+    },
+  },
+
+  'admin-sports-resolve': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    props: z
+      .object({
+        competitionCode: z.string(),
+      })
+      .strict(),
+    returns: {} as {
+      resolved: number
+      skipped: number
+      errors: number
+      log: Array<{
+        question: string
+        result: string
+        status: 'resolved' | 'skipped' | 'error'
+      }>
+    },
+  },
 } as const)
 
 export type APIPath = keyof typeof API

--- a/common/src/envs/dev.ts
+++ b/common/src/envs/dev.ts
@@ -41,5 +41,6 @@ export const DEV_CONFIG: EnvConfig = {
     '2cO953kN1sTBpfbhPVnTjRNqLJh2', // Sinclair
     'TabB6gJMYEUfaNWNS8i84PvMi2r2', // Genzy (Tod)
     'GQxeHBpah7dPuQ9fHvFIlcJzJ6T2', // wasabipesto
+    'lu01Fs2BVnTQgFMMpS1qhYst9fs2', // teststef (local dev)
   ],
 }

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -1,0 +1,1095 @@
+import { useEffect, useRef, useState } from 'react'
+import { Col } from 'web/components/layout/col'
+import { Row } from 'web/components/layout/row'
+import { Page } from 'web/components/layout/page'
+import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import {
+  SportsMatchCard,
+  PastMatchCard,
+  SportsMatch,
+  MatchOutcome,
+  SportsDashboardTabButton,
+} from 'web/components/sports/sports-match-card'
+import { Modal, MODAL_CLASS } from 'web/components/layout/modal'
+import { api, updateDashboard } from 'web/lib/api/api'
+import { useAdmin, useDev } from 'web/hooks/use-admin'
+import { getContracts, getAnswersForContracts } from 'common/supabase/contracts'
+import { db } from 'web/lib/supabase/db'
+import { useUser } from 'web/hooks/use-user'
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
+import type { DropResult } from '@hello-pangea/dnd'
+import { Dashboard, DashboardItem } from 'common/dashboard'
+import { Contract } from 'common/contract'
+import { Answer } from 'common/answer'
+import { TradesButton } from 'web/components/contract/trades-button'
+import { ReactButton } from 'web/components/contract/react-button'
+import { RepostButton } from 'web/components/comments/repost-modal'
+import { Button } from 'web/components/buttons/button'
+import { Tooltip } from 'web/components/widgets/tooltip'
+import { shortFormatNumber } from 'common/util/format'
+import { TbDroplet } from 'react-icons/tb'
+import { getAnswerColor } from 'web/components/charts/contract/choice'
+import { formatNumericProbability } from 'common/pseudo-numeric'
+import { getCpmmProbability } from 'common/calculate-cpmm'
+import { SearchInput } from 'web/components/search/search-input'
+import { ContractFilters } from 'web/components/search/contract-filters'
+import {
+  SearchParams,
+  QUERY_KEY,
+  SORT_KEY,
+  FILTER_KEY,
+  CONTRACT_TYPE_KEY,
+  SEARCH_TYPE_KEY,
+  PRIZE_MARKET_KEY,
+  FOR_YOU_KEY,
+  TOPIC_FILTER_KEY,
+  SWEEPIES_KEY,
+  GROUP_IDS_KEY,
+  LIQUIDITY_KEY,
+  HAS_BETS_KEY,
+} from 'web/components/search'
+import { ContractStatusLabel } from 'web/components/contract/contracts-table'
+import clsx from 'clsx'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ApiMarket = {
+  id: string
+  question: string
+  stageLabel: string
+  closeTime: number
+  sportsStartTimestamp: string | null
+  resolution: string | null
+  resolvedAnswer: string | null
+  resolutionTime: number | null
+  sportsHomeScore: number | null
+  sportsAwayScore: number | null
+  volume: number
+  url: string
+  needsAttention: boolean
+  answers: Array<{ id: string; text: string; prob: number }>
+}
+
+type DateSection = { label: string; matches: SportsMatch[] }
+type SortKey = 'manual' | 'date' | 'volume' | 'title'
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+const POLL_MS = 30_000
+const RECENT_THRESHOLD_MS = 12 * 60 * 60 * 1000
+
+function formatVolume(v: number): string {
+  if (v >= 1000) return (v / 1000).toFixed(1) + 'k'
+  return String(v)
+}
+
+function formatTime(isoOrMs: string | number): string {
+  const d = new Date(isoOrMs)
+  return (
+    d.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZone: 'UTC',
+    }) + ' UTC'
+  )
+}
+
+function formatDateLabel(isoOrMs: string | number): string {
+  return new Date(isoOrMs).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+function todayDateLabel(): string {
+  return formatDateLabel(Date.now())
+}
+
+function parseAnswerText(text: string): { flag: string; name: string } {
+  const chars = [...text.trim()]
+  if (
+    chars[0] &&
+    chars[1] &&
+    chars[0].codePointAt(0)! >= 0x1f1e6 &&
+    chars[1].codePointAt(0)! >= 0x1f1e6
+  ) {
+    const flag = chars[0] + chars[1]
+    return { flag, name: text.trim().slice(flag.length).trim() }
+  }
+  return { flag: '', name: text.trim() }
+}
+
+function toSportsMatch(m: ApiMarket): SportsMatch | null {
+  if (!m.answers || m.answers.length < 2) return null
+
+  const a0 = parseAnswerText(m.answers[0].text)
+  const a1 = parseAnswerText(m.answers[1].text)
+  const drawAnswer = m.answers.find((a) => a.text === 'Draw')
+
+  const resolved = !!m.resolution
+  let winner: MatchOutcome | undefined
+  if (resolved && m.resolvedAnswer) {
+    if (m.resolvedAnswer === m.answers[0].text) winner = 'teamA'
+    else if (m.resolvedAnswer === m.answers[1].text) winner = 'teamB'
+    else if (m.resolvedAnswer === 'Draw') winner = 'draw'
+  }
+
+  const kickoff = m.sportsStartTimestamp ?? m.closeTime
+  const closeTimeMs = typeof kickoff === 'number' ? kickoff : new Date(kickoff).getTime()
+
+  return {
+    id: m.id,
+    teamA: { name: a0.name, flag: a0.flag, prob: Math.round(m.answers[0].prob * 100) },
+    teamB: { name: a1.name, flag: a1.flag, prob: Math.round(m.answers[1].prob * 100) },
+    draw: { prob: drawAnswer ? Math.round(drawAnswer.prob * 100) : 0 },
+    hasDraw: !!drawAnswer,
+    closeTime: formatTime(kickoff),
+    closeDateLabel: formatDateLabel(kickoff),
+    closeTimeMs,
+    resolutionTime: m.resolutionTime ?? null,
+    finalScore:
+      m.sportsHomeScore != null && m.sportsAwayScore != null
+        ? { home: m.sportsHomeScore, away: m.sportsAwayScore }
+        : undefined,
+    volume: formatVolume(m.volume),
+    status: resolved ? 'resolved' : 'upcoming',
+    winner,
+    marketUrl: m.url,
+  }
+}
+
+function groupByDate(matches: SportsMatch[]): DateSection[] {
+  const map = new Map<string, SportsMatch[]>()
+  for (const m of matches) {
+    if (!map.has(m.closeDateLabel)) map.set(m.closeDateLabel, [])
+    map.get(m.closeDateLabel)!.push(m)
+  }
+  return Array.from(map.entries()).map(([label, ms]) => ({ label, matches: ms }))
+}
+
+function sortContracts(
+  contracts: Contract[],
+  slugOrder: string[],
+  sort: SortKey
+): Contract[] {
+  if (sort === 'manual') {
+    return slugOrder
+      .map((slug) => contracts.find((c) => c.slug === slug))
+      .filter((c): c is Contract => !!c)
+  }
+  const sorted = [...contracts]
+  if (sort === 'date') sorted.sort((a, b) => (a.closeTime ?? 0) - (b.closeTime ?? 0))
+  else if (sort === 'volume') sorted.sort((a, b) => (b.volume ?? 0) - (a.volume ?? 0))
+  else if (sort === 'title') sorted.sort((a, b) => a.question.localeCompare(b.question))
+  return sorted
+}
+
+// ─── Add Market Modal ─────────────────────────────────────────────────────────
+
+const DEFAULT_SEARCH_PARAMS: SearchParams = {
+  [QUERY_KEY]: '',
+  [SORT_KEY]: 'score',
+  [FILTER_KEY]: 'open',
+  [CONTRACT_TYPE_KEY]: 'ALL',
+  [SEARCH_TYPE_KEY]: undefined,
+  [PRIZE_MARKET_KEY]: '0',
+  [FOR_YOU_KEY]: '0',
+  [TOPIC_FILTER_KEY]: '',
+  [SWEEPIES_KEY]: '0',
+  [GROUP_IDS_KEY]: '',
+  [LIQUIDITY_KEY]: '',
+  [HAS_BETS_KEY]: '0',
+}
+
+function AddMarketModal({
+  existingSlugs,
+  onAdd,
+  onClose,
+}: {
+  existingSlugs: Set<string>
+  onAdd: (contractId: string) => Promise<void>
+  onClose: () => void
+}) {
+  const [params, setParams] = useState<SearchParams>(DEFAULT_SEARCH_PARAMS)
+  const [results, setResults] = useState<Contract[]>([])
+  const [searching, setSearching] = useState(false)
+  const [adding, setAdding] = useState<string | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function updateParams(changes: Partial<SearchParams>) {
+    setParams((prev) => ({ ...prev, ...changes }))
+  }
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true)
+      try {
+        const data = await api('search-markets-full', {
+          term: params[QUERY_KEY],
+          filter: params[FILTER_KEY],
+          sort: params[SORT_KEY],
+          contractType: params[CONTRACT_TYPE_KEY],
+          offset: 0,
+          limit: 20,
+          forYou: params[FOR_YOU_KEY],
+          token: 'MANA',
+          hasBets: params[HAS_BETS_KEY],
+          liquidity: params[LIQUIDITY_KEY] ? parseInt(params[LIQUIDITY_KEY]) : undefined,
+        } as any)
+        setResults((data as Contract[]) ?? [])
+      } catch {
+        setResults([])
+      } finally {
+        setSearching(false)
+      }
+    }, 200)
+  }, [
+    params[QUERY_KEY],
+    params[FILTER_KEY],
+    params[SORT_KEY],
+    params[CONTRACT_TYPE_KEY],
+    params[FOR_YOU_KEY],
+    params[HAS_BETS_KEY],
+    params[LIQUIDITY_KEY],
+  ])
+
+  // Client-side substring filter to catch hyphen/partial misses
+  const query = params[QUERY_KEY]
+  const displayed = query.trim()
+    ? results.filter((m) => m.question.toLowerCase().includes(query.toLowerCase()))
+    : results
+
+  async function handleAdd(contract: Contract) {
+    setAdding(contract.id)
+    try {
+      await onAdd(contract.slug)
+    } finally {
+      setAdding(null)
+    }
+  }
+
+  return (
+    <Modal open setOpen={(o) => { if (!o) onClose() }} size="md">
+      <Col className={clsx(MODAL_CLASS, 'gap-3')}>
+        <p className="text-ink-1000 text-base font-semibold">Add market to community tab</p>
+
+        <SearchInput
+          value={params[QUERY_KEY]}
+          setValue={(q) => updateParams({ [QUERY_KEY]: q })}
+          placeholder="Search questions"
+          autoFocus
+          loading={searching}
+        />
+
+        <ContractFilters
+          params={params}
+          updateParams={updateParams}
+          hideSweepsToggle
+        />
+
+        <Col className="max-h-80 gap-0.5 overflow-y-auto">
+          {displayed.length > 0 ? displayed.map((contract) => {
+            const already = existingSlugs.has(contract.slug)
+            return (
+              <Row
+                key={contract.id}
+                className={clsx(
+                  'items-center gap-3 rounded-lg px-2 py-2 transition-colors',
+                  already ? 'opacity-50' : 'hover:bg-canvas-50 cursor-pointer'
+                )}
+                onClick={() => !already && !adding && handleAdd(contract)}
+              >
+                <img
+                  src={contract.creatorAvatarUrl ?? '/default-avatar.png'}
+                  alt=""
+                  className="h-7 w-7 shrink-0 rounded-full object-cover"
+                />
+                <span className="text-ink-900 min-w-0 flex-1 truncate text-sm">
+                  {contract.question}
+                </span>
+                <ContractStatusLabel contract={contract} className="shrink-0 text-sm" />
+                <span
+                  className={clsx(
+                    'shrink-0 rounded px-2 py-0.5 text-xs font-medium',
+                    already
+                      ? 'text-ink-400'
+                      : adding === contract.id
+                      ? 'text-ink-400'
+                      : 'text-indigo-500 hover:text-indigo-700'
+                  )}
+                >
+                  {adding === contract.id ? '…' : already ? 'Added' : 'Add'}
+                </span>
+              </Row>
+            )
+          }) : (
+            !searching && (
+              <p className="text-ink-400 py-2 text-sm">
+                {query.trim() ? 'No markets found.' : 'Loading…'}
+              </p>
+            )
+          )}
+        </Col>
+
+        <button onClick={onClose} className="text-ink-500 hover:text-ink-700 self-end text-sm">
+          Done
+        </button>
+      </Col>
+    </Modal>
+  )
+}
+
+// ─── Community Market Card ─────────────────────────────────────────────────────
+
+type MarketMeta = { label: string; badgeBg: string; badgeText: string; accentText: string }
+
+function marketMeta(outcomeType: string): MarketMeta {
+  switch (outcomeType) {
+    case 'BINARY':
+      return { label: 'Binary', badgeBg: 'bg-indigo-100', badgeText: 'text-indigo-700', accentText: 'text-indigo-500' }
+    case 'MULTIPLE_CHOICE':
+      return { label: 'Multiple choice', badgeBg: 'bg-violet-100', badgeText: 'text-violet-700', accentText: 'text-violet-600' }
+    case 'PSEUDO_NUMERIC':
+    case 'NUMBER':
+    case 'MULTI_NUMERIC':
+    case 'DATE':
+      return { label: 'Numeric', badgeBg: 'bg-blue-100', badgeText: 'text-blue-700', accentText: 'text-blue-600' }
+    case 'POLL':
+      return { label: 'Poll', badgeBg: 'bg-teal-100', badgeText: 'text-teal-700', accentText: 'text-teal-600' }
+    case 'BOUNTIED_QUESTION':
+      return { label: 'Bounty', badgeBg: 'bg-amber-100', badgeText: 'text-amber-700', accentText: 'text-amber-600' }
+    case 'STONK':
+      return { label: 'Stock', badgeBg: 'bg-orange-100', badgeText: 'text-orange-700', accentText: 'text-orange-600' }
+    default:
+      return { label: 'Market', badgeBg: 'bg-gray-100', badgeText: 'text-gray-600', accentText: 'text-gray-500' }
+  }
+}
+
+function CommunityMarketCard({ contract }: { contract: Contract }) {
+  const user = useUser()
+  const meta = marketMeta(contract.outcomeType)
+  const isBinary = contract.outcomeType === 'BINARY'
+  const isMulti = contract.outcomeType === 'MULTIPLE_CHOICE'
+  const isPseudoNumeric = contract.outcomeType === 'PSEUDO_NUMERIC'
+  const isNumericBuckets =
+    contract.outcomeType === 'NUMBER' ||
+    contract.outcomeType === 'MULTI_NUMERIC' ||
+    contract.outcomeType === 'DATE'
+  const isPoll = contract.outcomeType === 'POLL'
+  const answers = (contract as any).answers as Answer[] | undefined
+  const pollOptions = isPoll
+    ? ((contract as any).options as Array<{ id: string; text: string }> | undefined)
+    : undefined
+
+  const binaryProb = isBinary ? Math.round((contract as any).prob * 100) : null
+  const binaryResolution = contract.resolution
+
+  const nonOtherAnswers = answers ? answers.filter((a) => !a.isOther) : []
+  const otherAnswer = answers?.find((a) => a.isOther)
+  const topThree = [...nonOtherAnswers].sort((a, b) => b.prob - a.prob).slice(0, 3)
+
+  const contractUrl = `/${contract.creatorUsername}/${contract.slug}`
+  const hasLiquidity = 'totalLiquidity' in contract
+
+  return (
+    <div className="bg-canvas-50 border-canvas-100 relative flex h-full flex-col overflow-hidden rounded-xl border">
+      {/* Header */}
+      <Row className="items-center justify-between gap-2 px-4 pt-4 pb-2">
+        <a
+          href={`/${contract.creatorUsername}`}
+          className="flex min-w-0 items-center gap-2 hover:opacity-70"
+        >
+          <img
+            src={contract.creatorAvatarUrl ?? '/default-avatar.png'}
+            alt=""
+            className="h-6 w-6 shrink-0 rounded-full object-cover"
+          />
+          <span className="text-ink-500 truncate text-[13px]">@{contract.creatorUsername}</span>
+        </a>
+        <span
+          className={clsx(
+            'shrink-0 rounded px-2 py-0.5 text-xs font-semibold',
+            meta.badgeBg,
+            meta.badgeText
+          )}
+        >
+          {meta.label}
+        </span>
+      </Row>
+
+      {/* Title */}
+      <a href={contractUrl} className="px-4 pb-2 pt-0.5 hover:opacity-80">
+        <p className="text-ink-900 line-clamp-2 text-[15px] font-semibold leading-snug">
+          {contract.question}
+        </p>
+      </a>
+
+      {/* Content — flex-1 so footer is always pinned to bottom */}
+      <div className="min-h-0 flex-1 overflow-hidden px-4 pb-3 pt-1">
+        {isBinary && (
+          <Col className="gap-1 py-1">
+            {binaryResolution && binaryResolution !== 'CANCEL' ? (
+              <>
+                <span
+                  className={clsx(
+                    'text-3xl font-bold',
+                    binaryResolution === 'YES' ? 'text-teal-500' : 'text-rose-500'
+                  )}
+                >
+                  {binaryResolution} ✓
+                </span>
+                <span className="text-ink-400 text-[13px]">resolved</span>
+              </>
+            ) : (
+              <>
+                <span className={clsx('text-4xl font-bold', meta.accentText)}>
+                  {binaryProb}%
+                </span>
+                <span className="text-ink-400 text-[13px]">chance · yes</span>
+              </>
+            )}
+          </Col>
+        )}
+
+        {isMulti && topThree.length > 0 && (
+          <Col className="gap-2 py-1">
+            {topThree.map((a) => {
+              const pct = Math.round(a.prob * 100)
+              const isWinner = a.resolution === 'YES'
+              const barColor = getAnswerColor(a)
+              return (
+                <Row key={a.id} className="items-center gap-3">
+                  <span className="text-ink-700 w-2/5 shrink-0 truncate text-[13px] leading-tight">
+                    {a.text}
+                  </span>
+                  <div className="bg-ink-200 flex-1 overflow-hidden rounded-full" style={{ height: '8px' }}>
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{ width: `${pct}%`, backgroundColor: barColor }}
+                    />
+                  </div>
+                  <span
+                    className={clsx(
+                      'w-8 shrink-0 text-right text-[13px] font-medium',
+                      isWinner ? 'text-teal-500' : 'text-ink-500'
+                    )}
+                  >
+                    {isWinner ? '✓' : `${pct}%`}
+                  </span>
+                </Row>
+              )
+            })}
+            {(() => {
+              const moreCount = Math.max(0, nonOtherAnswers.length - 3) + (otherAnswer ? 1 : 0)
+              return moreCount > 0 ? (
+                <a href={contractUrl} className="text-ink-400 hover:text-ink-600 text-[13px] transition-colors">
+                  +{moreCount} more →
+                </a>
+              ) : null
+            })()}
+          </Col>
+        )}
+
+        {isPseudoNumeric && (() => {
+          const c = contract as any
+          // `prob` is stored on CPMM contracts; fall back to computing from pool+p
+          const prob: number | undefined =
+            c.prob ?? (c.pool && c.p != null ? getCpmmProbability(c.pool, c.p) : undefined)
+          const hasRange = prob !== undefined && c.min !== undefined
+          const resolveProb = contract.resolutionProbability ?? prob
+          return (
+            <Col className="gap-1 py-1">
+              {contract.resolution ? (
+                <>
+                  <span className="text-ink-900 text-3xl font-bold">
+                    {hasRange && resolveProb !== undefined
+                      ? formatNumericProbability(resolveProb, c)
+                      : contract.resolution}
+                  </span>
+                  <span className="text-ink-400 text-[13px]">resolved</span>
+                </>
+              ) : (
+                <span className="text-ink-900 text-4xl font-bold">
+                  {hasRange && prob !== undefined
+                    ? formatNumericProbability(prob, c)
+                    : prob !== undefined
+                    ? `${Math.round(prob * 100)}%`
+                    : '—'}
+                </span>
+              )}
+            </Col>
+          )
+        })()}
+
+        {isNumericBuckets && (() => {
+          const topAnswer = nonOtherAnswers.length > 0
+            ? [...nonOtherAnswers].sort((a, b) => b.prob - a.prob)[0]
+            : null
+          if (!topAnswer) return null
+          const pct = Math.round(topAnswer.prob * 100)
+          const isResolved = !!contract.resolution || topAnswer.resolution === 'YES'
+          return (
+            <Col className="gap-1 py-1">
+              <span className={clsx('text-2xl font-bold leading-tight', meta.accentText)}>
+                {topAnswer.text}
+              </span>
+              <span className="text-ink-400 text-[13px]">
+                {isResolved ? 'resolved' : `${pct}% chance`}
+              </span>
+            </Col>
+          )
+        })()}
+
+        {isPoll && pollOptions && pollOptions.length > 0 && (
+          <Col className="gap-1.5 py-1">
+            {pollOptions.slice(0, 3).map((o) => (
+              <Row key={o.id} className="items-center gap-2">
+                <div className="bg-ink-300 h-1.5 w-1.5 shrink-0 rounded-full" />
+                <span className="text-ink-600 truncate text-[13px] leading-tight">{o.text}</span>
+              </Row>
+            ))}
+            {pollOptions.length > 3 && (
+              <a href={contractUrl} className="text-ink-400 hover:text-ink-600 text-[13px] transition-colors">
+                +{pollOptions.length - 3} more →
+              </a>
+            )}
+          </Col>
+        )}
+      </div>
+
+      {/* Footer — always at bottom */}
+      <Row className="border-canvas-100 items-center gap-0.5 border-t px-3 py-1.5">
+        <TradesButton contract={contract} size="sm" />
+        {hasLiquidity && (
+          <Button disabled size="2xs" color="gray-white">
+            <Tooltip text="Total liquidity" placement="top" noTap>
+              <Row className="text-ink-500 items-center gap-1">
+                <TbDroplet className="h-5 w-5 stroke-2" />
+                <span className="text-ink-600 text-[13px]">
+                  {shortFormatNumber((contract as any).totalLiquidity)}
+                </span>
+              </Row>
+            </Tooltip>
+          </Button>
+        )}
+        <RepostButton
+          playContract={contract}
+          size="2xs"
+          iconClassName="text-ink-500"
+        />
+        <ReactButton
+          contentId={contract.id}
+          contentCreatorId={contract.creatorId}
+          user={user}
+          contentType="contract"
+          contentText={contract.question}
+          size="2xs"
+          trackingLocation="community-tab"
+          placement="top"
+          contractId={contract.id}
+          heartClassName="stroke-ink-500"
+        />
+      </Row>
+    </div>
+  )
+}
+
+// ─── Community Tab ────────────────────────────────────────────────────────────
+
+function CommunityTab({
+  communityDashboardSlug,
+  competitionCode,
+  isAdmin,
+  onCountChange,
+}: {
+  communityDashboardSlug: string
+  competitionCode: string
+  isAdmin: boolean
+  onCountChange?: (n: number) => void
+}) {
+  const [dashboard, setDashboard] = useState<Dashboard | null | undefined>(undefined)
+  const [items, setItems] = useState<DashboardItem[]>([])
+  const [sort, setSort] = useState<SortKey>('manual')
+  const [showAdd, setShowAdd] = useState(false)
+  const [pastVisible, setPastVisible] = useState(false)
+  const [editMode, setEditMode] = useState(false)
+
+  async function fetchDashboard() {
+    try {
+      const d = await api('get-dashboard-from-slug', { dashboardSlug: communityDashboardSlug })
+      setDashboard(d as Dashboard)
+      const dashItems = (d as Dashboard).items ?? []
+      setItems(dashItems)
+      onCountChange?.(dashItems.filter((i) => i.type === 'question').length)
+    } catch {
+      setDashboard(null)
+    }
+  }
+
+  useEffect(() => { fetchDashboard() }, [communityDashboardSlug])
+
+  const questionSlugs = items
+    .filter((i): i is { type: 'question'; slug: string } => i.type === 'question')
+    .map((i) => i.slug)
+
+  const [contracts, setContracts] = useState<Contract[]>([])
+
+  useEffect(() => {
+    if (questionSlugs.length === 0) { setContracts([]); return }
+    getContracts(db, questionSlugs, 'slug').then(async (fetched) => {
+      const ids = fetched.map((c) => c.id)
+      const answersByContractId = await getAnswersForContracts(db, ids)
+      for (const c of fetched) {
+        // Merge answers for all cpmm-multi-1 markets (MC, NUMBER, MULTI_NUMERIC, DATE)
+        // regardless of whether 'answers' is already in the data blob
+        if ((c as any).mechanism === 'cpmm-multi-1') {
+          ;(c as any).answers = answersByContractId[c.id] ?? (c as any).answers ?? []
+        }
+      }
+      setContracts(fetched)
+    })
+  }, [questionSlugs.join(',')])
+
+  // Returns resolution timestamp, or null if still open.
+  // For cpmm-multi-1 sports markets, waits until all answers are resolved.
+  function contractResolvedAt(c: Contract): number | null {
+    if (c.resolution && c.resolutionTime) return c.resolutionTime
+    const answers = (c as any).answers as Array<{ resolution?: string; resolutionTime?: number }> | undefined
+    if (answers && answers.length > 0 && answers.every((a) => a.resolution)) {
+      const latest = Math.max(...answers.map((a) => a.resolutionTime ?? 0))
+      return latest || c.closeTime || null
+    }
+    return null
+  }
+
+  const now = Date.now()
+  const open = contracts.filter((c) => contractResolvedAt(c) === null)
+  const recentResolved = contracts.filter((c) => {
+    const t = contractResolvedAt(c)
+    return t !== null && now - t < RECENT_THRESHOLD_MS
+  })
+  const pastResolved = contracts.filter((c) => {
+    const t = contractResolvedAt(c)
+    return t !== null && now - t >= RECENT_THRESHOLD_MS
+  })
+
+  const sortedOpen = sortContracts(open, questionSlugs, sort)
+  const existingSlugs = new Set(questionSlugs)
+
+  async function onDragEnd(result: DropResult) {
+    if (!result.destination || !dashboard) return
+    const newItems = [...items]
+    const [removed] = newItems.splice(result.source.index, 1)
+    newItems.splice(result.destination.index, 0, removed)
+    setItems(newItems)
+    await updateDashboard({
+      dashboardId: dashboard.id,
+      title: dashboard.title,
+      items: newItems,
+      topics: dashboard.topics ?? [],
+    })
+  }
+
+  async function handleAdd(contractId: string) {
+    await api('admin-sports-community-market', {
+      competitionCode,
+      contractId,
+      action: 'add',
+    })
+    await fetchDashboard()
+  }
+
+  async function handleRemove(contract: Contract) {
+    if (!dashboard) return
+    await api('admin-sports-community-market', {
+      competitionCode,
+      contractId: contract.id,
+      action: 'remove',
+    })
+    await fetchDashboard()
+  }
+
+  if (dashboard === undefined) return <LoadingIndicator />
+
+  if (dashboard === null && !isAdmin) {
+    return (
+      <Col className="items-center gap-3 py-16">
+        <p className="text-ink-400 text-sm">No community markets yet.</p>
+      </Col>
+    )
+  }
+
+  const sortLabels: { key: SortKey; label: string }[] = [
+    { key: 'manual', label: 'Manual' },
+    { key: 'date', label: 'Close date' },
+    { key: 'volume', label: 'Volume' },
+    { key: 'title', label: 'Title' },
+  ]
+
+  return (
+    <Col className="gap-6">
+      {/* Controls row */}
+      <Row className="flex-wrap items-center justify-between gap-3">
+        {/* Sort toggles */}
+        <Row className="gap-1.5">
+          {sortLabels.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setSort(key)}
+              className={clsx(
+                'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+                sort === key
+                  ? 'bg-ink-200 text-ink-900'
+                  : 'text-ink-500 hover:text-ink-700'
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </Row>
+
+        {/* Admin controls */}
+        {isAdmin && (
+          <Row className="items-center gap-2">
+            <button
+              onClick={() => setEditMode((v) => !v)}
+              className="border-ink-200 text-ink-500 hover:bg-canvas-50 rounded border px-2 py-0.5 text-xs transition-colors"
+            >
+              {editMode ? 'done' : 'edit'}
+            </button>
+            <button
+              onClick={() => setShowAdd(true)}
+              className="bg-indigo-600 hover:bg-indigo-700 rounded-md px-3 py-1.5 text-xs font-medium text-white transition-colors"
+            >
+              + Add market
+            </button>
+          </Row>
+        )}
+      </Row>
+
+      {/* Not initialized hint for admins */}
+      {dashboard === null && isAdmin && (
+        <p className="text-ink-400 text-xs">
+          No community dashboard yet — adding the first market will create it automatically.
+        </p>
+      )}
+
+      {/* Open markets */}
+      {dashboard !== null && sortedOpen.length === 0 && recentResolved.length === 0 && pastResolved.length === 0 && (
+        <Col className="items-center gap-2 py-12">
+          <p className="text-ink-400 text-sm">No community markets yet.</p>
+        </Col>
+      )}
+
+      {dashboard !== null && (
+        <>
+          {sortedOpen.length > 0 && (
+            sort === 'manual' && isAdmin && editMode ? (
+              <DragDropContext onDragEnd={onDragEnd}>
+                <Droppable droppableId="community">
+                  {(provided) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+                    >
+                      {sortedOpen.map((contract, index) => (
+                        <Draggable
+                          key={contract.id}
+                          draggableId={contract.id}
+                          index={index}
+                        >
+                          {(provided, snapshot) => (
+                            <div
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              className={clsx(
+                                'relative flex flex-col',
+                                snapshot.isDragging && 'opacity-80 shadow-lg'
+                              )}
+                            >
+                              <div
+                                {...provided.dragHandleProps}
+                                className="text-ink-300 hover:text-ink-500 absolute top-2 left-2 z-10 cursor-grab text-lg leading-none select-none"
+                                title="Drag to reorder"
+                              >
+                                ⠿
+                              </div>
+                              <button
+                                onClick={() => handleRemove(contract)}
+                                className="absolute top-2 right-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-ink-200 text-[11px] font-bold text-ink-600 hover:bg-red-100 hover:text-red-600 transition-colors"
+                              >
+                                ✕
+                              </button>
+                              <CommunityMarketCard contract={contract} />
+                            </div>
+                          )}
+                        </Draggable>
+                      ))}
+                      {provided.placeholder}
+                    </div>
+                  )}
+                </Droppable>
+              </DragDropContext>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {sortedOpen.map((contract) => (
+                  <div key={contract.id} className="relative flex flex-col">
+                    {isAdmin && editMode && (
+                      <button
+                        onClick={() => handleRemove(contract)}
+                        className="absolute top-2 right-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-ink-200 text-[11px] font-bold text-ink-600 hover:bg-red-100 hover:text-red-600 transition-colors"
+                      >
+                        ✕
+                      </button>
+                    )}
+                    <CommunityMarketCard contract={contract} />
+                  </div>
+                ))}
+              </div>
+            )
+          )}
+
+          {recentResolved.length > 0 && (
+            <Col className="gap-3">
+              <Row className="items-center gap-2.5">
+                <span className="text-ink-1000 text-base font-medium">Recent</span>
+                <span className="text-ink-500 text-xs">{recentResolved.length} resolved</span>
+              </Row>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {recentResolved.map((contract) => (
+                  <CommunityMarketCard key={contract.id} contract={contract} />
+                ))}
+              </div>
+            </Col>
+          )}
+
+          {pastResolved.length > 0 && (
+            <Col className="border-ink-200 gap-3 border-t pt-6">
+              <Row className="items-center gap-2.5">
+                <span className="text-ink-500 text-sm font-medium">Past</span>
+                <button
+                  onClick={() => setPastVisible((v) => !v)}
+                  className="border-ink-200 text-ink-500 hover:bg-canvas-50 rounded border px-2 py-0.5 text-xs transition-colors"
+                >
+                  {pastVisible ? 'hide' : 'show'}
+                </button>
+              </Row>
+              {pastVisible && (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {pastResolved.map((contract) => (
+                    <CommunityMarketCard key={contract.id} contract={contract} />
+                  ))}
+                </div>
+              )}
+            </Col>
+          )}
+        </>
+      )}
+
+      {showAdd && (
+        <AddMarketModal
+          existingSlugs={existingSlugs}
+          onAdd={handleAdd}
+          onClose={() => setShowAdd(false)}
+        />
+      )}
+    </Col>
+  )
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export function SportsDashboardPage({
+  sportsLeague,
+  title,
+  emoji,
+  trackPageView,
+  communityDashboardSlug,
+  competitionCode,
+  officialGroupSlug: _officialGroupSlug,
+}: {
+  sportsLeague: string
+  title: string
+  emoji: string
+  trackPageView: string
+  communityDashboardSlug?: string
+  competitionCode?: string
+  officialGroupSlug?: string
+}) {
+  const [markets, setMarkets] = useState<SportsMatch[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [pastVisible, setPastVisible] = useState(false)
+  const [activeTab, setActiveTab] = useState<'official' | 'community'>('official')
+  const [communityCount, setCommunityCount] = useState<number | undefined>(undefined)
+
+  useEffect(() => {
+    if (!communityDashboardSlug) return
+    api('get-dashboard-from-slug', { dashboardSlug: communityDashboardSlug } as any)
+      .then((d: any) => {
+        const count = (d?.items ?? []).filter((i: any) => i.type === 'question').length
+        setCommunityCount(count)
+      })
+      .catch(() => setCommunityCount(0))
+  }, [communityDashboardSlug])
+
+  const isAdmin = useAdmin() || useDev()
+
+  async function fetchMarkets() {
+    try {
+      const data = await api('admin-sports-markets', { sportsLeague })
+      const mapped = (data.markets as ApiMarket[]).flatMap((m) => {
+        const s = toSportsMatch(m)
+        return s ? [s] : []
+      })
+      setMarkets(mapped)
+      setError(null)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load markets')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchMarkets()
+    const interval = setInterval(fetchMarkets, POLL_MS)
+    return () => clearInterval(interval)
+  }, [])
+
+  const now = Date.now()
+  const upcoming = markets.filter((m) => m.status === 'upcoming')
+  const recentResolved = markets.filter(
+    (m) =>
+      m.status === 'resolved' &&
+      now - (m.resolutionTime ?? m.closeTimeMs) < RECENT_THRESHOLD_MS
+  )
+  const pastResolved = markets.filter(
+    (m) =>
+      m.status === 'resolved' &&
+      now - (m.resolutionTime ?? m.closeTimeMs) >= RECENT_THRESHOLD_MS
+  )
+  const upcomingSections = groupByDate(upcoming)
+  const today = todayDateLabel()
+
+  const hasCommunity = !!communityDashboardSlug && !!competitionCode
+
+  return (
+    <Page trackPageView={trackPageView}>
+      <Col className="mx-auto w-full max-w-5xl gap-8 px-4 py-6 sm:px-6">
+
+        <Row className="border-ink-200 bg-canvas-0 sticky top-0 z-10 -mt-6 items-center justify-between border-b pt-6 pb-5">
+          <Row className="items-center gap-3">
+            <span className="text-2xl">{emoji}</span>
+            <h1 className="text-ink-1000 text-xl font-medium tracking-tight">{title}</h1>
+          </Row>
+          <Row className="items-center gap-2">
+            <SportsDashboardTabButton
+              active={activeTab === 'official'}
+              count={upcoming.length}
+              onClick={() => setActiveTab('official')}
+            >
+              Official
+            </SportsDashboardTabButton>
+            <SportsDashboardTabButton
+              active={activeTab === 'community'}
+              count={communityCount}
+              onClick={() => setActiveTab('community')}
+            >
+              Community
+            </SportsDashboardTabButton>
+          </Row>
+        </Row>
+
+        {activeTab === 'community' ? (
+          hasCommunity ? (
+            <CommunityTab
+              communityDashboardSlug={communityDashboardSlug!}
+              competitionCode={competitionCode!}
+              isAdmin={isAdmin}
+              onCountChange={setCommunityCount}
+            />
+          ) : (
+            <Col className="items-center gap-3 py-16">
+              <span className="text-ink-400 text-sm">Community markets coming soon</span>
+            </Col>
+          )
+        ) : (
+          <>
+            {loading && <LoadingIndicator />}
+            {error && <p className="text-sm text-red-500">{error}</p>}
+
+            {upcomingSections.map(({ label, matches }, i) => (
+              <Col key={label} className="gap-3">
+                <Row className="items-center gap-2.5">
+                  <span className="text-ink-1000 text-base font-medium">
+                    {i === 0 && label === today ? `Today — ${label}` : label}
+                  </span>
+                  <span className="text-ink-500 text-xs">
+                    {matches.length} match{matches.length !== 1 ? 'es' : ''}
+                  </span>
+                </Row>
+                <div
+                  className="grid gap-3"
+                  style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}
+                >
+                  {matches.map((match) => (
+                    <SportsMatchCard key={match.id} match={match} />
+                  ))}
+                </div>
+              </Col>
+            ))}
+
+            {recentResolved.length > 0 && (
+              <Col className="gap-3">
+                <Row className="items-center gap-2.5">
+                  <span className="text-ink-1000 text-base font-medium">Recent</span>
+                  <span className="text-ink-500 text-xs">
+                    {recentResolved.length} resolved
+                  </span>
+                </Row>
+                <div
+                  className="grid gap-3"
+                  style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}
+                >
+                  {recentResolved.map((match) => (
+                    <SportsMatchCard key={match.id} match={match} />
+                  ))}
+                </div>
+              </Col>
+            )}
+
+            {pastResolved.length > 0 && (
+              <Col className="border-ink-200 gap-3 border-t pt-6">
+                <Row className="items-center gap-2.5">
+                  <span className="text-ink-500 text-sm font-medium">Past games</span>
+                  <button
+                    onClick={() => setPastVisible((v) => !v)}
+                    className="border-ink-200 text-ink-500 hover:bg-canvas-50 rounded border px-2 py-0.5 text-xs transition-colors"
+                  >
+                    {pastVisible ? 'hide' : 'show'}
+                  </button>
+                </Row>
+                {pastVisible && (
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {pastResolved.map((match) => (
+                      <PastMatchCard key={match.id} match={match} />
+                    ))}
+                  </div>
+                )}
+              </Col>
+            )}
+
+            {!loading && markets.length === 0 && !error && (
+              <p className="text-ink-400 text-sm">No markets found.</p>
+            )}
+          </>
+        )}
+
+      </Col>
+    </Page>
+  )
+}

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -1,0 +1,411 @@
+import { useState } from 'react'
+import clsx from 'clsx'
+import { Col } from 'web/components/layout/col'
+import { Row } from 'web/components/layout/row'
+import { Modal, MODAL_CLASS } from 'web/components/layout/modal'
+
+export type MatchOutcome = 'teamA' | 'teamB' | 'draw'
+
+export const SPORTS_COLORS = {
+  teamA: 'var(--sports-team-a)',
+  teamB: 'var(--sports-team-b)',
+  draw: 'var(--sports-draw)',
+  teamAVibrant: 'var(--sports-team-a-vibrant)',
+  teamBVibrant: 'var(--sports-team-b-vibrant)',
+  drawVibrant: 'var(--sports-draw-vibrant)',
+} as const
+
+function vibrantForOutcome(outcome: MatchOutcome | undefined): string | undefined {
+  if (outcome === 'teamA') return SPORTS_COLORS.teamAVibrant
+  if (outcome === 'teamB') return SPORTS_COLORS.teamBVibrant
+  if (outcome === 'draw') return SPORTS_COLORS.drawVibrant
+  return undefined
+}
+
+export type SportsMatch = {
+  id: string
+  teamA: { name: string; flag: string; prob: number }
+  teamB: { name: string; flag: string; prob: number }
+  draw: { prob: number }
+  hasDraw?: boolean
+  closeTime: string
+  closeDateLabel: string
+  closeTimeMs: number
+  resolutionTime?: number | null
+  volume: string
+  status: 'upcoming' | 'resolved'
+  winner?: MatchOutcome
+  marketUrl?: string
+  finalScore?: { home: number; away: number }
+}
+
+function MockBetPanel({
+  match,
+  initialOutcome,
+  onClose,
+}: {
+  match: SportsMatch
+  initialOutcome: MatchOutcome
+  onClose: () => void
+}) {
+  const [selected, setSelected] = useState<MatchOutcome>(
+    initialOutcome === 'draw' && match.hasDraw === false ? 'teamA' : initialOutcome
+  )
+  const [amount, setAmount] = useState(10)
+
+  const outcomes: { key: MatchOutcome; label: string; prob: number; color: string }[] = [
+    { key: 'teamA', label: `${match.teamA.flag} ${match.teamA.name}`.trim(), prob: match.teamA.prob, color: SPORTS_COLORS.teamA },
+    ...(match.hasDraw !== false ? [{ key: 'draw' as MatchOutcome, label: 'Draw', prob: match.draw.prob, color: SPORTS_COLORS.draw }] : []),
+    { key: 'teamB', label: `${match.teamB.flag} ${match.teamB.name}`.trim(), prob: match.teamB.prob, color: SPORTS_COLORS.teamB },
+  ]
+
+  const current = outcomes.find((o) => o.key === selected)!
+  const payout = Math.round(amount * (100 / Math.max(current.prob, 1)))
+
+  return (
+    <Modal open setOpen={(open) => { if (!open) onClose() }} size="sm">
+      <Col className={clsx(MODAL_CLASS, 'w-full gap-5')}>
+
+        {/* Match label */}
+        <p className="text-ink-1000 text-center text-base font-semibold">
+          {match.teamA.name} vs {match.teamB.name}
+        </p>
+
+        {/* Outcome toggle */}
+        <Row className="bg-canvas-100 items-stretch rounded-lg">
+          {outcomes.map((o) => (
+            <Row key={o.key} className="flex-1 items-stretch">
+              <button
+                onClick={() => setSelected(o.key)}
+                className={clsx(
+                  'flex-1 rounded-lg px-2 py-2.5 text-xs font-medium transition-colors',
+                  selected === o.key ? 'text-white' : 'text-ink-500 hover:text-ink-700'
+                )}
+                style={selected === o.key ? { backgroundColor: o.color } : undefined}
+              >
+                {o.label}
+              </button>
+            </Row>
+          ))}
+        </Row>
+
+        {/* Amount */}
+        <Col className="gap-2">
+          <label className="text-ink-700 text-xs font-medium">Bet amount</label>
+          <Row className="border-ink-300 bg-canvas-50 focus-within:border-primary-500 w-40 items-center rounded-md border px-3 py-2 transition-colors">
+            <span className="text-ink-500 mr-1 font-mana text-sm">Ṁ</span>
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(Math.max(1, parseInt(e.target.value) || 0))}
+              className="text-ink-1000 w-full bg-transparent text-sm outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              min="1"
+            />
+          </Row>
+        </Col>
+
+        {/* Stats */}
+        <Col className="bg-canvas-50 gap-1.5 rounded-md p-3">
+          <Row className="justify-between gap-4">
+            <span className="text-ink-500 text-xs">To win</span>
+            <span className="text-ink-1000 text-xs font-medium">
+              Ṁ{payout.toLocaleString()}
+            </span>
+          </Row>
+          <Row className="justify-between gap-4">
+            <span className="text-ink-500 text-xs">New probability</span>
+            <span className="text-ink-1000 text-xs font-medium">
+              ~{Math.min(current.prob + 1, 99)}%
+            </span>
+          </Row>
+        </Col>
+
+        {/* CTA + Cancel */}
+        <Row className="gap-2">
+          <button
+            onClick={onClose}
+            className="border-ink-300 text-ink-600 hover:bg-canvas-50 shrink-0 rounded-md border px-3 py-3 text-sm transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onClose}
+            className="text-ink-1000 hover:bg-ink-100/10 min-w-0 flex-1 rounded-md border-2 px-3 py-3 text-sm font-semibold transition-colors"
+            style={{ borderColor: current.color }}
+          >
+            Buy {current.label} to win Ṁ{payout.toLocaleString()}
+          </button>
+        </Row>
+
+        <p className="text-ink-400 text-center text-xs">
+          Prototype — betting not yet connected
+        </p>
+      </Col>
+    </Modal>
+  )
+}
+
+function OutcomeRow({
+  flag,
+  name,
+  prob,
+  score,
+  isWinner,
+  isDraw,
+  isFirstTeam,
+  resolved,
+  teamColor,
+  winnerColor,
+  onClick,
+}: {
+  flag?: string
+  name: string
+  prob: number
+  score?: number
+  isWinner?: boolean
+  isDraw?: boolean
+  isFirstTeam?: boolean
+  resolved?: boolean
+  teamColor?: string
+  winnerColor?: string
+  onClick?: () => void
+}) {
+  const barColor = isWinner
+    ? 'bg-green-400'
+    : isDraw
+    ? 'bg-ink-400'
+    : isFirstTeam
+    ? 'bg-yes-500'
+    : 'bg-no-500'
+
+  return (
+    <div
+      onClick={!resolved ? onClick : undefined}
+      className={clsx(
+        'flex items-center gap-2 rounded-lg border-2 px-2 py-1.5 transition-colors',
+        !resolved && 'cursor-pointer',
+        !resolved && !isWinner && 'hover:bg-canvas-100'
+      )}
+      style={{
+        borderColor: isWinner && winnerColor ? winnerColor : teamColor ?? undefined,
+        backgroundColor: isWinner && winnerColor ? `${winnerColor}1F` : undefined,
+      }}
+    >
+      {isDraw ? (
+        <div className="border-ink-300 bg-canvas-100 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border">
+          <span
+            className={clsx('text-[8px] font-bold leading-none', !isWinner && 'text-ink-500')}
+            style={isWinner && winnerColor ? { color: winnerColor } : undefined}
+          >
+            –
+          </span>
+        </div>
+      ) : (
+        <span className="flex-shrink-0 text-base leading-none">{flag}</span>
+      )}
+
+      <span
+        className={clsx(
+          'flex-1 truncate',
+          isWinner
+            ? 'text-[14px] font-medium'
+            : isDraw
+            ? 'text-ink-500 text-xs'
+            : 'text-ink-1000 text-[14px] font-medium'
+        )}
+        style={isWinner && winnerColor ? { color: winnerColor } : undefined}
+      >
+        {name}
+        {isWinner && <span className="ml-1.5 text-xs">✓</span>}
+      </span>
+
+      {resolved ? (
+        score !== undefined ? (
+          <span
+            className="text-sm font-semibold tabular-nums"
+            style={{ color: isWinner && winnerColor ? winnerColor : undefined }}
+          >
+            {score}
+          </span>
+        ) : (
+          <span
+            className="text-xs font-medium"
+            style={isWinner && winnerColor ? { color: winnerColor } : undefined}
+          >
+            {prob}%
+          </span>
+        )
+      ) : (
+        <div className="flex flex-col items-end gap-1">
+          <div className="bg-ink-200 h-0.5 w-14 rounded-full">
+            <div className={clsx('h-0.5 rounded-full', barColor)} style={{ width: `${prob}%` }} />
+          </div>
+          <span
+            className="text-xs font-medium"
+            style={isWinner && winnerColor ? { color: winnerColor } : undefined}
+          >
+            {prob}%
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function SportsMatchCard({ match }: { match: SportsMatch }) {
+  const [betOutcome, setBetOutcome] = useState<MatchOutcome | null>(null)
+  const resolved = match.status === 'resolved'
+  const homeScore = resolved ? match.finalScore?.home : undefined
+  const awayScore = resolved ? match.finalScore?.away : undefined
+  const winnerColor = resolved ? vibrantForOutcome(match.winner) : undefined
+
+  return (
+    <>
+      <div
+        className={clsx(
+          'bg-canvas-50 border-ink-200 flex flex-col gap-2.5 rounded-xl border p-[18px] transition-colors',
+          resolved ? 'opacity-70' : 'hover:border-ink-300'
+        )}
+      >
+        <Row className="justify-between">
+          <span className="text-ink-500 text-[11px]">
+            {resolved ? match.closeDateLabel : `Closes ${match.closeTime}`}
+          </span>
+          <span
+            className="text-[11px]"
+            style={{ color: winnerColor ?? '#6B7280' }}
+          >
+            {resolved ? 'Final' : 'Upcoming'}
+          </span>
+        </Row>
+
+        <Col className="gap-1">
+          <OutcomeRow
+            flag={match.teamA.flag}
+            name={match.teamA.name}
+            prob={match.teamA.prob}
+            score={homeScore}
+            isWinner={resolved && match.winner === 'teamA'}
+            isFirstTeam
+            resolved={resolved}
+            teamColor={SPORTS_COLORS.teamA}
+            winnerColor={match.winner === 'teamA' ? winnerColor : undefined}
+            onClick={() => setBetOutcome('teamA')}
+          />
+          <OutcomeRow
+            flag={match.teamB.flag}
+            name={match.teamB.name}
+            prob={match.teamB.prob}
+            score={awayScore}
+            isWinner={resolved && match.winner === 'teamB'}
+            resolved={resolved}
+            teamColor={SPORTS_COLORS.teamB}
+            winnerColor={match.winner === 'teamB' ? winnerColor : undefined}
+            onClick={() => setBetOutcome('teamB')}
+          />
+          {(match.hasDraw ?? true) && (
+            <OutcomeRow
+              name="Draw"
+              prob={match.draw.prob}
+              isWinner={resolved && match.winner === 'draw'}
+              isDraw
+              resolved={resolved}
+              teamColor={SPORTS_COLORS.draw}
+              winnerColor={match.winner === 'draw' ? winnerColor : undefined}
+              onClick={() => setBetOutcome('draw')}
+            />
+          )}
+        </Col>
+
+        <Row className="border-ink-200 justify-between border-t pt-2">
+          <span className="text-ink-500 text-[11px]">Ṁ {match.volume} vol</span>
+          {resolved ? (
+            <span className="text-[11px]" style={{ color: winnerColor }}>
+              ✓{' '}
+              {match.winner === 'teamA'
+                ? match.teamA.name
+                : match.winner === 'teamB'
+                ? match.teamB.name
+                : 'Draw'}
+            </span>
+          ) : (
+            <a
+              href={match.marketUrl ?? '#'}
+              className="text-ink-500 hover:text-yes-500 text-[11px] transition-colors"
+              onClick={(e) => e.stopPropagation()}
+            >
+              View market →
+            </a>
+          )}
+        </Row>
+      </div>
+
+      {betOutcome && (
+        <MockBetPanel
+          match={match}
+          initialOutcome={betOutcome}
+          onClose={() => setBetOutcome(null)}
+        />
+      )}
+    </>
+  )
+}
+
+export function PastMatchCard({ match }: { match: SportsMatch }) {
+  const winnerName =
+    match.winner === 'teamA'
+      ? match.teamA.name
+      : match.winner === 'teamB'
+      ? match.teamB.name
+      : 'Draw'
+
+  return (
+    <div className="bg-canvas-0 border-ink-200 flex items-center justify-between rounded-lg border px-3.5 py-2.5 opacity-60">
+      <Col className="gap-0.5">
+        <span className="text-ink-900 text-sm">
+          {match.teamA.name} vs {match.teamB.name}
+        </span>
+        <span className="text-ink-500 text-[11px]">
+          {match.closeDateLabel} · ✓ {winnerName}
+        </span>
+      </Col>
+      <span className="text-ink-500 text-[11px]">Resolved</span>
+    </div>
+  )
+}
+
+export function SportsDashboardTabButton({
+  active,
+  count,
+  onClick,
+  children,
+}: {
+  active: boolean
+  count?: number
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+        active
+          ? 'border-ink-700 text-ink-1000 border-2'
+          : 'border-ink-300 text-ink-500 hover:border-ink-400 hover:text-ink-700 border'
+      )}
+    >
+      {children}
+      {count !== undefined && (
+        <span
+          className={clsx(
+            'rounded-full px-1.5 py-0.5 text-xs font-semibold',
+            active ? 'bg-primary-100 text-primary-600' : 'bg-ink-100 text-ink-500'
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -182,6 +182,16 @@ module.exports = {
         permanent: true,
       },
       {
+        source: '/sports/world-cup',
+        destination: '/sports/world-cup-2026',
+        permanent: false,
+      },
+      {
+        source: '/news/ms-official-wc2026',
+        destination: '/sports/world-cup-2026',
+        permanent: false,
+      },
+      {
         source: '/home/:newsSlug*',
         has: [
           {

--- a/web/pages/admin/index.tsx
+++ b/web/pages/admin/index.tsx
@@ -90,6 +90,7 @@ export default function AdminPage() {
           title="💤 postgres logs"
           href="https://app.supabase.com/project/pxidrgkatumlvfqaxcll/logs/postgres-logs"
         />
+        <LabCard title="⚽ sports markets" href="/admin/sports" />
         <LabCard title="🤬 reports" href="/admin/reports" />
         <LabCard title="👕 merch management" href="/admin/merch" />
         <LabCard title="🎨 design system" href="/styles" />

--- a/web/pages/admin/sports.tsx
+++ b/web/pages/admin/sports.tsx
@@ -1,0 +1,1218 @@
+import { ChevronDownIcon } from '@heroicons/react/solid'
+import { useEffect, useState } from 'react'
+import { Page } from 'web/components/layout/page'
+import { Col } from 'web/components/layout/col'
+import { Row } from 'web/components/layout/row'
+import { Title } from 'web/components/widgets/title'
+import { Button } from 'web/components/buttons/button'
+import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import { Table } from 'web/components/widgets/table'
+import { AlertBox } from 'web/components/widgets/alert-box'
+import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
+import ShortToggle from 'web/components/widgets/short-toggle'
+import { NoSEO } from 'web/components/NoSEO'
+import { useAdmin, useDev } from 'web/hooks/use-admin'
+import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
+import { api } from 'web/lib/api/api'
+import { APIResponse } from 'common/api/schema'
+import clsx from 'clsx'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type Fixture = APIResponse<'admin-sports-fixtures'>['fixtures'][number]
+type Market = APIResponse<'admin-sports-markets'>['markets'][number]
+type CreateResult =
+  APIResponse<'admin-sports-create-markets'>['results'][number]
+type ResolveLogEntry = APIResponse<'admin-sports-resolve'>['log'][number]
+
+interface TournamentMeta {
+  code: string
+  name: string
+  shortLabel: string
+  sportsLeague: string
+  startDate: string
+  endDate: string
+  defaultGroupSlug: string
+  defaultDashboardUrl: string
+  defaultStageTiers: Record<string, number>
+}
+
+const TOURNAMENTS: TournamentMeta[] = [
+  {
+    code: 'WC',
+    name: 'FIFA World Cup 2026',
+    shortLabel: "World Cup '26",
+    sportsLeague: 'FIFA World Cup',
+    startDate: '2026-06-11',
+    endDate: '2026-07-19',
+    defaultGroupSlug: 'ms-official-wc2026',
+    defaultDashboardUrl: 'manifold.markets/sports/world-cup-2026',
+    defaultStageTiers: {
+      GROUP_STAGE: 1000,
+      ROUND_OF_16: 10000,
+      QUARTER_FINALS: 10000,
+      SEMI_FINALS: 10000,
+      THIRD_PLACE: 10000,
+      FINAL: 10000,
+    },
+  },
+  {
+    code: 'CL',
+    name: 'UEFA Champions League 2025/26',
+    shortLabel: "UCL '26",
+    sportsLeague: 'UEFA Champions League',
+    startDate: '2025-09-17',
+    endDate: '2026-05-30',
+    defaultGroupSlug: 'ms-official-cl-2026',
+    defaultDashboardUrl: 'manifold.markets/sports/cl-2026',
+    defaultStageTiers: {
+      LEAGUE_PHASE: 1000,
+      ROUND_OF_16: 10000,
+      QUARTER_FINALS: 10000,
+      SEMI_FINALS: 10000,
+      FINAL: 10000,
+    },
+  },
+  {
+    code: 'PL',
+    name: 'Premier League 2025/26',
+    shortLabel: "PL '26",
+    sportsLeague: 'Premier League',
+    startDate: '2025-08-16',
+    endDate: '2026-05-24',
+    defaultGroupSlug: 'ms-official-pl-2526',
+    defaultDashboardUrl: 'manifold.markets/sports/pl-2526',
+    defaultStageTiers: {
+      REGULAR_SEASON: 1000,
+      FINAL: 10000,
+    },
+  },
+  ...(process.env.NEXT_PUBLIC_FIREBASE_ENV === 'DEV'
+    ? [
+        {
+          code: 'TEST',
+          name: 'Test Tournament [DEV ONLY]',
+          shortLabel: "Test '26",
+          sportsLeague: 'Test Tournament',
+          startDate: '2026-05-07',
+          endDate: '2026-05-07',
+          defaultGroupSlug: 'ms-official-test-2026',
+          defaultDashboardUrl: '/sports/test-2026',
+          defaultStageTiers: {
+            GROUP_STAGE: 1000,
+          },
+        } as TournamentMeta,
+      ]
+    : []),
+]
+
+const STAGE_LABELS: Record<string, string> = {
+  REGULAR_SEASON: 'Regular Season',
+  GROUP_STAGE: 'Group Stage',
+  LEAGUE_PHASE: 'League Phase',
+  ROUND_OF_16: 'Round of 16',
+  QUARTER_FINALS: 'Quarterfinal',
+  SEMI_FINALS: 'Semifinal',
+  THIRD_PLACE: 'Third Place',
+  FINAL: 'Final',
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  created: 'text-green-600',
+  'dry-run': 'text-blue-600',
+  skipped: 'text-ink-400',
+  error: 'text-red-600',
+}
+
+function todayStr() {
+  return new Date().toISOString().slice(0, 10)
+}
+function plusDays(date: string, n: number) {
+  const d = new Date(date)
+  d.setDate(d.getDate() + n)
+  return d.toISOString().slice(0, 10)
+}
+
+// ─── Section wrapper ──────────────────────────────────────────────────────────
+
+function Section(props: {
+  title: string
+  children: React.ReactNode
+  defaultOpen?: boolean
+}) {
+  const [open, setOpen] = useState(props.defaultOpen ?? true)
+  return (
+    <div className="border-ink-200 mb-6 rounded-lg border">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="bg-ink-50 hover:bg-ink-100 flex w-full items-center justify-between rounded-t-lg px-4 py-3 text-left"
+      >
+        <span className="text-ink-800 font-semibold">{props.title}</span>
+        <span className="text-ink-400 text-sm">{open ? '▲' : '▼'}</span>
+      </button>
+      {open && <div className="p-4">{props.children}</div>}
+    </div>
+  )
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export default function SportsAdminPage() {
+  useRedirectIfSignedOut()
+  const isAdmin = useAdmin() || useDev()
+
+  const [tournament, setTournament] = useState<TournamentMeta>(TOURNAMENTS[0])
+
+  // Tournament settings (persist to localStorage)
+  const settingsKey = `sports_settings_${tournament.code}`
+  const [groupSlug, setGroupSlug] = useState(tournament.defaultGroupSlug)
+  const [dashboardUrl, setDashboardUrl] = useState(tournament.defaultDashboardUrl)
+  const [customNote, setCustomNote] = useState('')
+  const [stageTiers, setStageTiers] = useState<Record<string, number>>(
+    tournament.defaultStageTiers
+  )
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(settingsKey)
+      if (saved) {
+        const s = JSON.parse(saved)
+        if (s.groupSlug) setGroupSlug(s.groupSlug)
+        if (s.dashboardUrl) setDashboardUrl(s.dashboardUrl)
+        if (s.customNote !== undefined) setCustomNote(s.customNote)
+        if (s.stageTiers) setStageTiers(s.stageTiers)
+      }
+    } catch {}
+  }, [settingsKey])
+
+  function saveSettings() {
+    localStorage.setItem(
+      settingsKey,
+      JSON.stringify({ groupSlug, dashboardUrl, customNote, stageTiers })
+    )
+    alert('Settings saved.')
+  }
+
+  // Fixtures state
+  const [dateFrom, setDateFrom] = useState(todayStr())
+  const [dateTo, setDateTo] = useState(plusDays(todayStr(), 14))
+  const [stageFilter, setStageFilter] = useState<string>('ALL')
+  const [dryRun, setDryRun] = useState(true)
+  const [fixtures, setFixtures] = useState<Fixture[]>([])
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [fixturesLoading, setFixturesLoading] = useState(false)
+  const [fixturesError, setFixturesError] = useState<string | null>(null)
+
+  // Creation state
+  const [dryRunReviewed, setDryRunReviewed] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [createResults, setCreateResults] = useState<CreateResult[]>([])
+  const [groupStatus, setGroupStatus] = useState<{
+    id: string
+    created: boolean
+    restricted: boolean
+  } | null>(null)
+
+  // Markets state
+  const [markets, setMarkets] = useState<Market[]>([])
+  const [marketsLoading, setMarketsLoading] = useState(false)
+  const [marketFilter, setMarketFilter] = useState<string>('ALL')
+
+  // Community markets state
+  const [communitySearch, setCommunitySearch] = useState('')
+  const [communityAllMarkets, setCommunityAllMarkets] = useState<
+    Array<{ id: string; question: string; slug: string; outcomeType: string }>
+  >([])
+  const [communitySearching, setCommunitySearching] = useState(false)
+  const [communityAdding, setCommunityAdding] = useState<string | null>(null)
+  const [communityGroupMode, setCommunityGroupMode] = useState(true)
+  const [communityInitStatus, setCommunityInitStatus] = useState<{
+    groupId: string
+    groupCreated: boolean
+    dashboardId: string
+  } | null>(null)
+  const [communityIniting, setCommunityIniting] = useState(false)
+
+  // Load all group markets once; filter client-side to support substring/hyphen matching
+  useEffect(() => {
+    if (!isAdmin) return
+    const slug = communityGroupMode ? tournament.defaultGroupSlug : null
+    if (!slug) { setCommunityAllMarkets([]); return }
+    let cancelled = false
+    setCommunitySearch('')
+    setCommunitySearching(true)
+    ;(api('search-markets', {
+      topicSlug: slug,
+      limit: 200,
+      filter: 'all',
+      sort: 'newest',
+    } as any) as Promise<any[]>)
+      .then((data) => { if (!cancelled) setCommunityAllMarkets(data ?? []) })
+      .catch(() => { if (!cancelled) setCommunityAllMarkets([]) })
+      .finally(() => { if (!cancelled) setCommunitySearching(false) })
+    return () => { cancelled = true }
+  }, [tournament.defaultGroupSlug, communityGroupMode, isAdmin])
+
+  // Resolution state
+  const [resolveLog, setResolveLog] = useState<ResolveLogEntry[]>([])
+  const [resolving, setResolving] = useState(false)
+  const [lastResolved, setLastResolved] = useState<string | null>(null)
+
+  // Alerts: markets needing attention
+  const alertMarkets = markets.filter((m) => m.needsAttention)
+  const [handledAlerts, setHandledAlerts] = useState<Set<string>>(new Set())
+
+  if (!isAdmin) return <></>
+
+  async function fetchFixtures() {
+    setFixturesLoading(true)
+    setFixturesError(null)
+    setDryRunReviewed(false)
+    try {
+      const data = await api('admin-sports-fixtures', {
+        competitionCode: tournament.code,
+        dateFrom,
+        dateTo,
+        stage: stageFilter === 'ALL' ? undefined : stageFilter,
+      })
+      setFixtures(data.fixtures)
+      setSelectedIds(
+        new Set(
+          data.fixtures
+            .filter((f) => !f.existingMarketId && f.status === 'SCHEDULED')
+            .map((f) => f.id)
+        )
+      )
+    } catch (e: unknown) {
+      setFixturesError(e instanceof Error ? e.message : 'Failed to fetch fixtures')
+    } finally {
+      setFixturesLoading(false)
+    }
+  }
+
+  async function fetchMarkets() {
+    setMarketsLoading(true)
+    try {
+      const data = await api('admin-sports-markets', {
+        sportsLeague: tournament.sportsLeague,
+      })
+      setMarkets(data.markets)
+    } catch {}
+    setMarketsLoading(false)
+  }
+
+  async function runCreate() {
+    if (selectedIds.size === 0) return
+    setCreating(true)
+    setCreateResults([])
+    try {
+      const data = await api('admin-sports-create-markets', {
+        competitionCode: tournament.code,
+        matchIds: [...selectedIds],
+        dryRun,
+        customNote: customNote || undefined,
+        dashboardUrl: dashboardUrl || undefined,
+        liquidityTierOverrides: stageTiers,
+      })
+      setCreateResults(data.results)
+      setGroupStatus({
+        id: data.groupId,
+        created: data.groupCreated,
+        restricted: data.groupRestricted,
+      })
+      if (!dryRun) {
+        setDryRunReviewed(false)
+        await fetchMarkets()
+      } else {
+        setDryRunReviewed(true)
+      }
+    } catch (e: unknown) {
+      alert(`Error: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function runResolve() {
+    setResolving(true)
+    try {
+      const data = await api('admin-sports-resolve', {
+        competitionCode: tournament.code,
+      })
+      setResolveLog(data.log)
+      setLastResolved(new Date().toLocaleString())
+      await fetchMarkets()
+    } catch (e: unknown) {
+      alert(`Resolution error: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    } finally {
+      setResolving(false)
+    }
+  }
+
+  function onCommunitySearch(val: string) {
+    setCommunitySearch(val)
+  }
+
+  const communityResults = communitySearch.trim()
+    ? communityAllMarkets.filter((m) =>
+        m.question.toLowerCase().includes(communitySearch.toLowerCase())
+      )
+    : communityAllMarkets
+
+  async function addCommunityMarket(contractId: string) {
+    setCommunityAdding(contractId)
+    try {
+      await api('admin-sports-community-market', {
+        competitionCode: tournament.code,
+        contractId,
+        action: 'add',
+      })
+      alert('Market added to community tab.')
+    } catch (e: unknown) {
+      alert(`Error: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    } finally {
+      setCommunityAdding(null)
+    }
+  }
+
+  async function removeCommunityMarket(contractId: string) {
+    if (!confirm('Remove this market from the community tab?')) return
+    try {
+      await api('admin-sports-community-market', {
+        competitionCode: tournament.code,
+        contractId,
+        action: 'remove',
+      })
+      alert('Market removed.')
+    } catch (e: unknown) {
+      alert(`Error: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    }
+  }
+
+  async function initCommunity() {
+    setCommunityIniting(true)
+    try {
+      const result = await api('admin-sports-init-community', {
+        competitionCode: tournament.code,
+      })
+      setCommunityInitStatus(result)
+    } catch (e: unknown) {
+      alert(`Error: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    } finally {
+      setCommunityIniting(false)
+    }
+  }
+
+  const filteredMarkets =
+    marketFilter === 'ALL'
+      ? markets
+      : marketFilter === 'NEEDS_ATTENTION'
+      ? markets.filter((m) => m.needsAttention)
+      : marketFilter === 'RESOLVED'
+      ? markets.filter((m) => m.resolution)
+      : markets.filter((m) => !m.resolution)
+
+  // Description preview — uses tournament-specific sample teams
+  const sampleTeams =
+    tournament.code === 'CL'
+      ? { home: 'Arsenal FC', away: 'Club Atlético de Madrid', stage: 'SF', date: 'Tue, 05 May 2026 19:00:00 UTC' }
+      : { home: 'Brazil', away: 'Argentina', stage: 'Group E', date: 'Thu, 02 Jul 2026 19:00:00 UTC' }
+  const sampleDashboardHref = dashboardUrl
+    ? (() => {
+        try {
+          const u = new URL(dashboardUrl.startsWith('/') || dashboardUrl.startsWith('http') ? dashboardUrl : `https://${dashboardUrl}`)
+          return u.pathname + u.search + u.hash
+        } catch {
+          return dashboardUrl.startsWith('/') ? dashboardUrl : `/${dashboardUrl}`
+        }
+      })()
+    : null
+  const sampleDesc = [
+    `**${sampleTeams.home} vs ${sampleTeams.away} · ${sampleTeams.stage} · Kickoff ${sampleTeams.date}**`,
+    `*Resolves to the winning team or draw (90 min regulation).*`,
+    customNote || '[Your custom tournament note will appear here]',
+    'This market resolves automatically after the match concludes based on official results.',
+    sampleDashboardHref ? `[Visit the ${tournament.name} Dashboard](${sampleDashboardHref})` : '',
+    'Created and managed by [@ManifoldSports](https://manifold.markets/ManifoldSports)',
+  ]
+    .filter((l) => l !== undefined && l !== '')
+    .join('\n\n\n')
+
+  return (
+    <Page trackPageView={'sports admin page'}>
+      <NoSEO />
+      <div className="mx-auto max-w-5xl px-4 pb-16">
+        <Title>Sports Admin</Title>
+
+        {/* ── 1. Tournament Selector ── */}
+        <Section title="1. Tournament" defaultOpen>
+          <Row className="flex-wrap items-end gap-4">
+            <Col className="gap-1">
+              <label className="text-ink-600 text-xs font-medium">Tournament</label>
+              <div className="relative">
+              <select
+                value={tournament.code}
+                onChange={(e) => {
+                  const t = TOURNAMENTS.find((t) => t.code === e.target.value)
+                  if (t) {
+                    setTournament(t)
+                    setGroupSlug(t.defaultGroupSlug)
+                    setDashboardUrl(t.defaultDashboardUrl)
+                    setStageTiers(t.defaultStageTiers)
+                    setCustomNote('')
+                    setFixtures([])
+                    setMarkets([])
+                    setCreateResults([])
+                  }
+                }}
+                className="border-ink-300 bg-canvas-0 text-ink-900 w-full appearance-none rounded border px-3 py-2 pr-8 text-sm"
+              >
+                {TOURNAMENTS.map((t) => (
+                  <option key={t.code} value={t.code}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+              <ChevronDownIcon className="text-ink-400 pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2" />
+              </div>
+            </Col>
+            <Col className="text-ink-500 gap-0.5 text-xs">
+              <span>
+                {tournament.startDate} → {tournament.endDate}
+              </span>
+              <span className="font-mono">{tournament.code}</span>
+            </Col>
+          </Row>
+        </Section>
+
+        {/* ── 2. Tournament Settings ── */}
+        <Section title="2. Tournament Settings">
+          <Col className="gap-5">
+            {/* Tag + group status */}
+            <Col className="gap-1.5">
+              <label className="text-ink-700 text-sm font-medium">
+                Official group tag
+              </label>
+              <Row className="gap-2">
+                <input
+                  type="text"
+                  value={groupSlug}
+                  onChange={(e) => setGroupSlug(e.target.value)}
+                  placeholder="ms-official-wc2026"
+                  className="border-ink-300 bg-canvas-0 text-ink-900 w-72 rounded border px-3 py-1.5 font-mono text-sm"
+                />
+              </Row>
+              <p className="text-ink-400 text-xs">
+                Convention: <code>ms-official-[tournament]-[year]</code>.
+                Group is auto-created as curated (admin-restricted) on first
+                creation run.
+              </p>
+              {groupStatus && (
+                <span
+                  className={clsx(
+                    'mt-1 text-xs font-medium',
+                    groupStatus.restricted ? 'text-green-600' : 'text-yellow-600'
+                  )}
+                >
+                  {groupStatus.created
+                    ? `✅ Group created (${groupStatus.id}) — admin-restricted`
+                    : groupStatus.restricted
+                    ? `✅ Group exists and restricted (${groupStatus.id})`
+                    : `⚠️ Group exists but will be restricted on next run`}
+                </span>
+              )}
+            </Col>
+
+            {/* Dashboard URL */}
+            <Col className="gap-1.5">
+              <label className="text-ink-700 text-sm font-medium">
+                Dashboard URL
+              </label>
+              <input
+                type="text"
+                value={dashboardUrl}
+                onChange={(e) => setDashboardUrl(e.target.value)}
+                placeholder="manifold.markets/dashboard/ms-official-wc2026"
+                className="border-ink-300 bg-canvas-0 text-ink-900 w-full max-w-lg rounded border px-3 py-1.5 text-sm"
+              />
+              <p className="text-ink-400 text-xs">
+                Auto-appended to every market description.
+              </p>
+            </Col>
+
+            {/* Custom note */}
+            <Col className="gap-1.5">
+              <label className="text-ink-700 text-sm font-medium">
+                Custom tournament note
+              </label>
+              <p className="text-ink-400 text-xs">
+                Tokens available:{' '}
+                <code className="bg-ink-100 rounded px-1 text-xs">
+                  {'{team1}'} {'{team2}'} {'{kickoff}'} {'{stage}'}{' '}
+                  {'{dashboard_url}'}
+                </code>
+                . Written once, appears in all market descriptions.
+              </p>
+              <textarea
+                value={customNote}
+                onChange={(e) => setCustomNote(e.target.value)}
+                rows={3}
+                placeholder="e.g. 48 teams, 104 matches, 3 host nations (USA, Canada, Mexico). This is the first ever World Cup with a 48-team format."
+                className="border-ink-300 bg-canvas-0 text-ink-900 w-full rounded border px-3 py-2 text-sm"
+              />
+            </Col>
+
+            {/* Description preview */}
+            <Col className="gap-1.5">
+              <label className="text-ink-700 text-sm font-medium">
+                Description preview
+              </label>
+              <pre className="bg-ink-50 border-ink-200 text-ink-600 whitespace-pre-wrap rounded border p-3 text-xs leading-relaxed">
+                {sampleDesc}
+              </pre>
+            </Col>
+
+            {/* Liquidity tiers per stage */}
+            <Col className="gap-2">
+              <label className="text-ink-700 text-sm font-medium">
+                Liquidity tiers (mana)
+              </label>
+              <p className="text-ink-400 text-xs">
+                Valid Manifold tiers: 100 · 1,000 · 10,000 · 100,000
+              </p>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {Object.entries(STAGE_LABELS).map(([code, label]) => (
+                  <Col key={code} className="gap-1">
+                    <label className="text-ink-500 text-xs">{label}</label>
+                    <input
+                      type="number"
+                      value={stageTiers[code] ?? 1000}
+                      onChange={(e) =>
+                        setStageTiers((t) => ({
+                          ...t,
+                          [code]: parseInt(e.target.value) || 1000,
+                        }))
+                      }
+                      className="border-ink-300 bg-canvas-0 text-ink-900 w-full rounded border px-2 py-1 text-sm"
+                    />
+                  </Col>
+                ))}
+              </div>
+            </Col>
+
+            <Row>
+              <Button size="sm" onClick={saveSettings}>
+                Save settings
+              </Button>
+            </Row>
+          </Col>
+        </Section>
+
+        {/* ── 3. Match Preview Panel ── */}
+        <Section title="3. Match Preview &amp; Creation" defaultOpen>
+          <Col className="gap-4">
+            {/* Controls */}
+            <Row className="flex-wrap items-end gap-4">
+              <Col className="gap-1">
+                <label className="text-ink-600 text-xs">Date from</label>
+                <input
+                  type="date"
+                  value={dateFrom}
+                  onChange={(e) => {
+                    const next = e.target.value
+                    setDateFrom(next)
+                    if (next > dateTo) setDateTo(plusDays(next, 7))
+                  }}
+                  className="border-ink-300 bg-canvas-0 text-ink-900 rounded border px-2 py-1.5 text-sm"
+                />
+              </Col>
+              <Col className="gap-1">
+                <label className="text-ink-600 text-xs">Date to</label>
+                <input
+                  type="date"
+                  value={dateTo}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  className="border-ink-300 bg-canvas-0 text-ink-900 rounded border px-2 py-1.5 text-sm"
+                />
+              </Col>
+              <Col className="gap-1">
+                <label className="text-ink-600 text-xs">Stage</label>
+                <select
+                  value={stageFilter}
+                  onChange={(e) => setStageFilter(e.target.value)}
+                  className="border-ink-300 bg-canvas-0 text-ink-900 rounded border px-2 py-1.5 text-sm"
+                >
+                  <option value="ALL">All stages</option>
+                  {Object.entries(STAGE_LABELS).map(([code, label]) => (
+                    <option key={code} value={code}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </Col>
+              <Row className="items-center gap-2">
+                <span className="text-ink-600 text-xs">Dry run</span>
+                <ShortToggle
+                  on={dryRun}
+                  setOn={(v) => {
+                    setDryRun(v)
+                    setDryRunReviewed(false)
+                  }}
+                />
+                {dryRun && (
+                  <span className="text-blue-600 text-xs font-medium">ON</span>
+                )}
+              </Row>
+              <Button size="sm" onClick={fetchFixtures} disabled={fixturesLoading}>
+                {fixturesLoading ? 'Fetching…' : 'Fetch games'}
+              </Button>
+            </Row>
+
+            {fixturesError && (
+              <AlertBox title="Error fetching games">{fixturesError}</AlertBox>
+            )}
+
+            {fixtures.length > 0 && (
+              <>
+                {/* Select all */}
+                <Row className="items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={
+                      fixtures
+                        .filter((f) => !f.existingMarketId)
+                        .every((f) => selectedIds.has(f.id))
+                    }
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setSelectedIds(
+                          new Set(
+                            fixtures
+                              .filter((f) => !f.existingMarketId)
+                              .map((f) => f.id)
+                          )
+                        )
+                      } else {
+                        setSelectedIds(new Set())
+                      }
+                    }}
+                  />
+                  <span className="text-ink-600">
+                    Select all ({selectedIds.size} selected /{' '}
+                    {fixtures.filter((f) => !f.existingMarketId).length} new)
+                  </span>
+                </Row>
+
+                <div className="overflow-x-auto">
+                  <Table>
+                    <thead>
+                      <tr>
+                        <th />
+                        <th>Home</th>
+                        <th>Away</th>
+                        <th>Kickoff (UTC)</th>
+                        <th>Stage</th>
+                        <th>Close</th>
+                        <th>Liquidity</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {fixtures.map((f) => (
+                        <tr
+                          key={f.id}
+                          className={clsx(
+                            f.existingMarketId && 'opacity-50',
+                            f.status === 'POSTPONED' && 'opacity-40'
+                          )}
+                        >
+                          <td>
+                            <input
+                              type="checkbox"
+                              disabled={!!f.existingMarketId}
+                              checked={selectedIds.has(f.id)}
+                              onChange={(e) => {
+                                setSelectedIds((prev) => {
+                                  const next = new Set(prev)
+                                  e.target.checked
+                                    ? next.add(f.id)
+                                    : next.delete(f.id)
+                                  return next
+                                })
+                              }}
+                            />
+                          </td>
+                          <td>
+                            <span className="mr-1">{f.homeFlag}</span>
+                            {f.homeTeam.name}
+                          </td>
+                          <td>
+                            <span className="mr-1">{f.awayFlag}</span>
+                            {f.awayTeam.name}
+                          </td>
+                          <td className="text-xs">
+                            {new Date(f.utcDate).toLocaleString('en-GB', {
+                              day: '2-digit',
+                              month: 'short',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                              timeZone: 'UTC',
+                            })}{' '}
+                            UTC
+                          </td>
+                          <td className="text-xs">{f.stageLabel}</td>
+                          <td className="text-xs">
+                            {new Date(f.closeTime).toLocaleString('en-GB', {
+                              day: '2-digit',
+                              month: 'short',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                              timeZone: 'UTC',
+                            })}{' '}
+                            UTC
+                          </td>
+                          <td className="text-xs">
+                            {f.liquidityTier.toLocaleString()}
+                          </td>
+                          <td className="text-xs">
+                            {f.existingMarketId ? (
+                              <span className="text-ink-400">exists</span>
+                            ) : f.status === 'POSTPONED' ? (
+                              <span className="text-yellow-600">postponed</span>
+                            ) : (
+                              <span className="text-green-600">will create</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </div>
+
+                {/* Create button */}
+                <Row className="items-center gap-3">
+                  <Button
+                    color={dryRun ? 'blue' : 'green'}
+                    disabled={
+                      creating ||
+                      selectedIds.size === 0 ||
+                      (!dryRun && !dryRunReviewed)
+                    }
+                    onClick={runCreate}
+                  >
+                    {creating ? (
+                      <Row className="gap-2">
+                        <LoadingIndicator size="sm" /> Creating…
+                      </Row>
+                    ) : dryRun ? (
+                      `Preview ${selectedIds.size} markets (dry run)`
+                    ) : (
+                      `Create ${selectedIds.size} markets`
+                    )}
+                  </Button>
+                  {!dryRun && !dryRunReviewed && (
+                    <span className="text-ink-500 text-xs">
+                      Run a dry run first, then toggle dry run off to create.
+                    </span>
+                  )}
+                </Row>
+
+                {/* Creation log */}
+                {createResults.length > 0 && (
+                  <Col className="gap-1">
+                    <p className="text-ink-600 text-sm font-medium">
+                      {dryRun ? 'Dry run preview' : 'Creation log'} (
+                      {createResults.length} items)
+                    </p>
+                    <div className="bg-ink-50 border-ink-200 max-h-64 overflow-y-auto rounded border p-3">
+                      {createResults.map((r, i) => (
+                        <Row key={i} className="gap-2 py-0.5 text-xs">
+                          <span
+                            className={clsx(
+                              'w-16 shrink-0 font-medium',
+                              STATUS_COLORS[r.status]
+                            )}
+                          >
+                            {r.status}
+                          </span>
+                          <span className="text-ink-700 truncate">
+                            {r.question}
+                          </span>
+                          {r.reason && (
+                            <span className="text-ink-400 shrink-0">
+                              — {r.reason}
+                            </span>
+                          )}
+                        </Row>
+                      ))}
+                    </div>
+                    {dryRun && (
+                      <Row className="mt-2 items-center gap-2">
+                        <Button
+                          size="sm"
+                          color="green"
+                          onClick={() => {
+                            setDryRunReviewed(true)
+                            setDryRun(false)
+                          }}
+                        >
+                          Looks good — switch to live mode
+                        </Button>
+                        <span className="text-ink-400 text-xs">
+                          Toggle dry run off and click Create to proceed.
+                        </span>
+                      </Row>
+                    )}
+                  </Col>
+                )}
+              </>
+            )}
+          </Col>
+        </Section>
+
+        {/* ── 4. Market Status Monitor ── */}
+        <Section title="4. Market Status">
+          <Col className="gap-3">
+            <Row className="items-center gap-3">
+              <ChoicesToggleGroup
+                currentChoice={marketFilter}
+                choicesMap={{
+                  All: 'ALL',
+                  Open: 'OPEN',
+                  Resolved: 'RESOLVED',
+                  'Needs attention': 'NEEDS_ATTENTION',
+                }}
+                setChoice={(v) => setMarketFilter(v as string)}
+                color="indigo-dark"
+              />
+              <Button size="sm" color="gray-outline" onClick={fetchMarkets}>
+                {marketsLoading ? 'Loading…' : 'Refresh'}
+              </Button>
+            </Row>
+
+            {alertMarkets.length > 0 && (
+              <AlertBox title={`${alertMarkets.length} market(s) need attention`}>
+                Past close time and unresolved — check the Alerts section below.
+              </AlertBox>
+            )}
+
+            {marketsLoading ? (
+              <LoadingIndicator />
+            ) : filteredMarkets.length === 0 ? (
+              <p className="text-ink-400 text-sm">
+                {markets.length === 0
+                  ? 'No markets found. Click Refresh to load.'
+                  : 'No markets match this filter.'}
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <thead>
+                    <tr>
+                      <th>Market</th>
+                      <th>Stage</th>
+                      <th>Close (UTC)</th>
+                      <th>Status</th>
+                      <th>Resolved to</th>
+                      <th>Volume</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredMarkets.map((m) => (
+                      <tr
+                        key={m.id}
+                        className={clsx(m.needsAttention && 'bg-red-50')}
+                      >
+                        <td>
+                          <a
+                            href={m.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-primary-600 hover:underline"
+                          >
+                            {m.question}
+                          </a>
+                          {m.needsAttention && (
+                            <span className="ml-2 text-xs text-red-600 font-medium">
+                              ⚠ overdue
+                            </span>
+                          )}
+                        </td>
+                        <td className="text-xs">{m.stageLabel}</td>
+                        <td className="text-xs">
+                          {new Date(m.closeTime).toLocaleString('en-GB', {
+                            day: '2-digit',
+                            month: 'short',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            timeZone: 'UTC',
+                          })}
+                        </td>
+                        <td className="text-xs">
+                          {m.resolution ? (
+                            <span className="text-green-600">resolved</span>
+                          ) : (
+                            <span className="text-blue-600">open</span>
+                          )}
+                        </td>
+                        <td className="text-xs">{m.resolvedAnswer ?? '—'}</td>
+                        <td className="text-xs">
+                          {m.volume.toLocaleString()}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </div>
+            )}
+          </Col>
+        </Section>
+
+        {/* ── 5. Resolution Monitor ── */}
+        <Section title="5. Resolution Monitor">
+          <Col className="gap-4">
+            <Row className="flex-wrap items-center gap-4 text-sm">
+              <Col className="gap-0.5">
+                <span className="text-ink-500 text-xs">Last manual resolve</span>
+                <span className="font-medium">{lastResolved ?? 'Never'}</span>
+              </Col>
+              <Col className="gap-0.5">
+                <span className="text-ink-500 text-xs">Scheduler job</span>
+                <span className="font-medium">sports-resolve · every 15 min</span>
+              </Col>
+            </Row>
+
+            <Row className="items-center gap-3">
+              <Button
+                color="indigo"
+                onClick={runResolve}
+                disabled={resolving}
+              >
+                {resolving ? (
+                  <Row className="gap-2">
+                    <LoadingIndicator size="sm" /> Resolving…
+                  </Row>
+                ) : (
+                  'Force resolve now'
+                )}
+              </Button>
+              <span className="text-ink-400 text-xs">
+                Fetches finished matches from football-data.org and resolves any
+                matching open markets.
+              </span>
+            </Row>
+
+            {resolveLog.length > 0 && (
+              <Col className="gap-1">
+                <p className="text-ink-600 text-sm font-medium">
+                  Resolution log ({resolveLog.length} items)
+                </p>
+                <div className="bg-ink-50 border-ink-200 max-h-64 overflow-y-auto rounded border p-3">
+                  {resolveLog.map((entry, i) => (
+                    <Row key={i} className="gap-2 py-0.5 text-xs">
+                      <span
+                        className={clsx(
+                          'w-16 shrink-0 font-medium',
+                          entry.status === 'resolved'
+                            ? 'text-green-600'
+                            : entry.status === 'error'
+                            ? 'text-red-600'
+                            : 'text-ink-400'
+                        )}
+                      >
+                        {entry.status}
+                      </span>
+                      <span className="text-ink-700 flex-1 truncate">
+                        {entry.question}
+                      </span>
+                      <span className="text-ink-500 shrink-0">
+                        {entry.result}
+                      </span>
+                    </Row>
+                  ))}
+                </div>
+              </Col>
+            )}
+          </Col>
+        </Section>
+
+        {/* ── 6. Alerts ── */}
+        <Section title={`6. Alerts${alertMarkets.length > 0 ? ` (${alertMarkets.filter((m) => !handledAlerts.has(m.id)).length} active)` : ''}`}>
+          <Col className="gap-3">
+            {alertMarkets.filter((m) => !handledAlerts.has(m.id)).length ===
+            0 ? (
+              <p className="text-green-600 text-sm">✅ No active alerts.</p>
+            ) : (
+              alertMarkets
+                .filter((m) => !handledAlerts.has(m.id))
+                .map((m) => (
+                  <Row
+                    key={m.id}
+                    className="border-red-200 bg-red-50 items-start justify-between rounded border p-3"
+                  >
+                    <Col className="gap-1">
+                      <span className="text-red-700 text-sm font-medium">
+                        ⚠ Unresolved past close time
+                      </span>
+                      <a
+                        href={m.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-primary-600 text-sm hover:underline"
+                      >
+                        {m.question}
+                      </a>
+                      <span className="text-ink-500 text-xs">
+                        Closed:{' '}
+                        {new Date(m.closeTime).toLocaleString('en-GB', {
+                          timeZone: 'UTC',
+                        })}{' '}
+                        UTC
+                      </span>
+                    </Col>
+                    <Button
+                      size="xs"
+                      color="gray-outline"
+                      onClick={() =>
+                        setHandledAlerts((prev) => new Set([...prev, m.id]))
+                      }
+                    >
+                      Mark handled
+                    </Button>
+                  </Row>
+                ))
+            )}
+
+            {/* Handled alerts (collapsed) */}
+            {handledAlerts.size > 0 && (
+              <details className="text-ink-400 text-xs">
+                <summary className="cursor-pointer">
+                  {handledAlerts.size} handled alert(s)
+                </summary>
+                <Col className="mt-2 gap-1">
+                  {alertMarkets
+                    .filter((m) => handledAlerts.has(m.id))
+                    .map((m) => (
+                      <span key={m.id} className="line-through">
+                        {m.question}
+                      </span>
+                    ))}
+                </Col>
+              </details>
+            )}
+          </Col>
+        </Section>
+
+        {/* ── 7. Community Markets ── */}
+        <Section title="7. Community Markets">
+          <Col className="gap-4">
+            <Row className="flex-wrap items-start justify-between gap-3">
+              <p className="text-ink-500 text-sm">
+                Search for any market and add it to the community tab of the{' '}
+                <strong>{tournament.name}</strong> dashboard. Markets are also tagged
+                with <code className="bg-ink-100 rounded px-1 text-xs">{tournament.defaultGroupSlug.replace('ms-official', 'ms-community')}</code>.
+              </p>
+              <Col className="gap-1">
+                <Button
+                  size="sm"
+                  color="gray-outline"
+                  onClick={initCommunity}
+                  disabled={communityIniting}
+                >
+                  {communityIniting ? 'Setting up…' : 'Set up community group + dashboard'}
+                </Button>
+                {communityInitStatus && (
+                  <span className="text-green-600 text-xs">
+                    ✅ {communityInitStatus.groupCreated ? 'Group created' : 'Group already existed'} · ID {communityInitStatus.groupId.slice(0, 8)}…
+                  </span>
+                )}
+              </Col>
+            </Row>
+
+            <Row className="flex-wrap items-center gap-4">
+              <Col className="gap-1">
+                <label className="text-ink-600 text-xs">
+                  {communityGroupMode ? 'Filter within group' : 'Search all markets'}
+                </label>
+                <input
+                  type="text"
+                  value={communitySearch}
+                  onChange={(e) => onCommunitySearch(e.target.value)}
+                  placeholder={communityGroupMode ? 'Filter by title…' : 'Search by question…'}
+                  className="border-ink-300 bg-canvas-0 text-ink-900 w-72 rounded border px-3 py-1.5 text-sm"
+                />
+              </Col>
+              <Row className="items-center gap-2 self-end pb-1.5">
+                <input
+                  type="checkbox"
+                  id="community-group-mode"
+                  checked={communityGroupMode}
+                  onChange={(e) => setCommunityGroupMode(e.target.checked)}
+                  className="cursor-pointer"
+                />
+                <label htmlFor="community-group-mode" className="text-ink-600 cursor-pointer text-xs">
+                  Within {tournament.shortLabel} group only
+                </label>
+              </Row>
+              {communitySearching && <LoadingIndicator size="sm" className="self-end pb-2" />}
+            </Row>
+
+            {communityResults.length > 0 && (
+              <div className="overflow-x-auto">
+                <Table>
+                  <thead>
+                    <tr>
+                      <th>Market</th>
+                      <th>Type</th>
+                      <th>Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {communityResults.map((m) => (
+                      <tr key={m.id}>
+                        <td>
+                          <a
+                            href={`https://manifold.markets/${m.slug}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-primary-600 hover:underline"
+                          >
+                            {m.question}
+                          </a>
+                        </td>
+                        <td className="text-ink-500 text-xs">{m.outcomeType}</td>
+                        <td>
+                          <Row className="gap-2">
+                            <Button
+                              size="xs"
+                              color="indigo"
+                              disabled={communityAdding === m.id}
+                              onClick={() => addCommunityMarket(m.id)}
+                            >
+                              {communityAdding === m.id ? 'Adding…' : 'Add'}
+                            </Button>
+                            <Button
+                              size="xs"
+                              color="gray-outline"
+                              onClick={() => removeCommunityMarket(m.id)}
+                            >
+                              Remove
+                            </Button>
+                          </Row>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </div>
+            )}
+
+            {!communitySearching && communityResults.length === 0 && (communitySearch || communityGroupMode) && (
+              <p className="text-ink-400 text-sm">No markets found.</p>
+            )}
+          </Col>
+        </Section>
+      </div>
+    </Page>
+  )
+}

--- a/web/pages/sports/cl-2026.tsx
+++ b/web/pages/sports/cl-2026.tsx
@@ -1,0 +1,15 @@
+import { SportsDashboardPage } from 'web/components/sports/sports-dashboard-page'
+
+export default function ChampionsLeagueDashboard() {
+  return (
+    <SportsDashboardPage
+      sportsLeague="UEFA Champions League"
+      title="UEFA Champions League 2025/26"
+      emoji="🏆"
+      trackPageView="champions league dashboard"
+      competitionCode="CL"
+      communityDashboardSlug="ms-community-cl-2026"
+      officialGroupSlug="ms-official-cl-2026"
+    />
+  )
+}

--- a/web/pages/sports/pl-2526.tsx
+++ b/web/pages/sports/pl-2526.tsx
@@ -1,0 +1,15 @@
+import { SportsDashboardPage } from 'web/components/sports/sports-dashboard-page'
+
+export default function PremierLeagueDashboard() {
+  return (
+    <SportsDashboardPage
+      sportsLeague="Premier League"
+      title="Premier League 2025/26"
+      emoji="⚽"
+      trackPageView="premier league dashboard"
+      competitionCode="PL"
+      communityDashboardSlug="ms-community-pl-2526"
+      officialGroupSlug="ms-official-pl-2526"
+    />
+  )
+}

--- a/web/pages/sports/world-cup-2026.tsx
+++ b/web/pages/sports/world-cup-2026.tsx
@@ -1,0 +1,15 @@
+import { SportsDashboardPage } from 'web/components/sports/sports-dashboard-page'
+
+export default function WorldCupDashboard() {
+  return (
+    <SportsDashboardPage
+      sportsLeague="FIFA World Cup"
+      title="FIFA World Cup 2026"
+      emoji="⚽"
+      trackPageView="world cup dashboard"
+      competitionCode="WC"
+      communityDashboardSlug="ms-community-wc2026"
+      officialGroupSlug="ms-official-wc2026"
+    />
+  )
+}

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -95,6 +95,13 @@
     --color-yes-800: 17 94 89;
     --color-yes-900: 19 78 74;
     --color-yes-950: 4 47 46;
+
+    --sports-team-a: #1A7A9A;
+    --sports-team-a-vibrant: #0A8FAD;
+    --sports-team-b: #8B3A52;
+    --sports-team-b-vibrant: #C4436E;
+    --sports-draw: #6B7A8E;
+    --sports-draw-vibrant: #7A8CA0;
   }
   .dark {
     color-scheme: dark;
@@ -152,6 +159,13 @@
     --color-yes-200: 17 94 89;
     --color-yes-100: 19 78 74;
     --color-yes-50: 4 47 46;
+
+    --sports-team-a: #1A7A9A;
+    --sports-team-a-vibrant: #25C4E8;
+    --sports-team-b: #8B3A52;
+    --sports-team-b-vibrant: #E85A8A;
+    --sports-draw: #7A8A9E;
+    --sports-draw-vibrant: #A8AABF;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Admin panel** at `/admin/sports`: batch-fetch fixtures from football-data.org, dry-run preview, create markets, monitor status, manual resolve, community dashboard management
- **Auto-resolve scheduler** (`sports-resolve`, every 15 min): polls football-data.org for FINISHED matches; only resolves @ManifoldSports-created markets — community markets never auto-resolved
- **Dashboard pages** at `/sports/world-cup-2026`, `/sports/cl-2026`, `/sports/pl-2526`: Official tab (match cards with probabilities) + Community tab (curated markets; CommunityMarketCard for Binary/MC/Numeric/Poll; Add Market modal with SearchInput + ContractFilters)
- **Tournaments**: FIFA World Cup 2026, UEFA Champions League 2025/26, Premier League 2025/26

## Deployment checklist

- [ ] Set `FOOTBALL_DATA_API_KEY` env var on the GCE scheduler instance
- [ ] `@ManifoldSports` prod user ID already set in code (`NnVY8olowYMYQGr346dfmHXBSpx2`)
- [ ] Create markets and community dashboards via `/admin/sports` using @ManifoldSports — nothing pre-created in this PR

## Notes

- TEST tournament (local dev + mock server) is `ENV === 'DEV'` guarded, not visible in production
- Live scores feature built but excluded — follow-up PR
- `/dashboard` redirect to `/news` is a separate TODO; sports pages currently at `/sports/*`