### PR TITLE
admin/merch: sales summary stats + date-range view tabs

### DIFF
--- a/backend/api/src/get-merch-orders.ts
+++ b/backend/api/src/get-merch-orders.ts
@@ -3,8 +3,30 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { isAdminId } from 'common/envs/constants'
 import { convertShopOrder } from 'common/shop/types'
 
+// Statuses that represent "real revenue" for stats purposes — mirrors the
+// merchSales filter in get-shop-stats.ts so admin numbers match /stats.
+const REVENUE_STATUSES_SQL = `status not in ('CANCELLED', 'REFUNDED', 'FAILED')`
+
+// Map dateRange prop -> Postgres interval. 'all' returns null (no filter).
+const dateRangeToInterval = (
+  dateRange: 'all' | 'month' | '3-months' | '6-months' | 'year'
+): string | null => {
+  switch (dateRange) {
+    case 'month':
+      return '1 month'
+    case '3-months':
+      return '3 months'
+    case '6-months':
+      return '6 months'
+    case 'year':
+      return '1 year'
+    default:
+      return null
+  }
+}
+
 export const getMerchOrders: APIHandler<'get-merch-orders'> = async (
-  { limit, offset },
+  { limit, offset, dateRange },
   auth
 ) => {
   if (!isAdminId(auth.uid)) {
@@ -13,18 +35,62 @@ export const getMerchOrders: APIHandler<'get-merch-orders'> = async (
 
   const pg = createSupabaseDirectClient()
 
-  const [orders, countResult] = await Promise.all([
+  const interval = dateRangeToInterval(dateRange)
+  // Built once and reused across all 4 queries so the orders list, count,
+  // per-item stats, and overall stats all reflect the same time window.
+  // The `interval` value comes from a fixed enum mapping — no user-supplied
+  // SQL ever reaches this string, so interpolation is safe.
+  const dateClause = (prefix: string) =>
+    interval ? `and ${prefix}created_time >= now() - interval '${interval}'` : ''
+
+  const [orders, countResult, perItemStats, overallStats] = await Promise.all([
     pg.manyOrNone(
       `SELECT so.*, u.username, u.name as display_name
        FROM shop_orders so
        JOIN users u ON u.id = so.user_id
        WHERE so.item_id LIKE 'merch-%'
+       ${dateClause('so.')}
        ORDER BY so.created_time DESC
        LIMIT $1 OFFSET $2`,
       [limit, offset]
     ),
     pg.one(
-      `SELECT count(*)::int as total FROM shop_orders WHERE item_id LIKE 'merch-%'`
+      `SELECT count(*)::int as total FROM shop_orders
+       WHERE item_id LIKE 'merch-%' ${dateClause('')}`
+    ),
+    // Per-item stats exclude refunded/cancelled/failed so they reflect real
+    // revenue (matches the merchSales filter in get-shop-stats.ts).
+    pg.manyOrNone<{
+      itemId: string
+      orderCount: number
+      totalMana: number
+      avgMana: number
+    }>(
+      `SELECT
+         item_id as "itemId",
+         count(*)::int as "orderCount",
+         sum(price_mana)::bigint as "totalMana",
+         avg(price_mana)::float as "avgMana"
+       FROM shop_orders
+       WHERE item_id LIKE 'merch-%'
+         AND ${REVENUE_STATUSES_SQL}
+         ${dateClause('')}
+       GROUP BY item_id
+       ORDER BY sum(price_mana) DESC`
+    ),
+    pg.one<{
+      orderCount: number
+      totalMana: number
+      avgMana: number | null
+    }>(
+      `SELECT
+         count(*)::int as "orderCount",
+         coalesce(sum(price_mana), 0)::bigint as "totalMana",
+         avg(price_mana)::float as "avgMana"
+       FROM shop_orders
+       WHERE item_id LIKE 'merch-%'
+         AND ${REVENUE_STATUSES_SQL}
+         ${dateClause('')}`
     ),
   ])
 
@@ -35,5 +101,18 @@ export const getMerchOrders: APIHandler<'get-merch-orders'> = async (
       displayName: row.display_name as string,
     })),
     total: countResult.total as number,
+    stats: {
+      perItem: (perItemStats ?? []).map((row) => ({
+        itemId: row.itemId,
+        orderCount: Number(row.orderCount),
+        totalMana: Number(row.totalMana),
+        avgMana: Number(row.avgMana),
+      })),
+      overall: {
+        orderCount: Number(overallStats.orderCount),
+        totalMana: Number(overallStats.totalMana),
+        avgMana: overallStats.avgMana == null ? 0 : Number(overallStats.avgMana),
+      },
+    },
   }
 }

--- a/backend/api/src/get-merch-orders.ts
+++ b/backend/api/src/get-merch-orders.ts
@@ -3,15 +3,13 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { isAdminId } from 'common/envs/constants'
 import { convertShopOrder } from 'common/shop/types'
 
-// Statuses that represent "real revenue" for stats purposes — mirrors the
-// merchSales filter in get-shop-stats.ts so admin numbers match /stats.
-const REVENUE_STATUSES_SQL = `status not in ('CANCELLED', 'REFUNDED', 'FAILED')`
-
 // Map dateRange prop -> Postgres interval. 'all' returns null (no filter).
 const dateRangeToInterval = (
-  dateRange: 'all' | 'month' | '3-months' | '6-months' | 'year'
+  dateRange: 'all' | 'week' | 'month' | '3-months' | '6-months' | 'year'
 ): string | null => {
   switch (dateRange) {
+    case 'week':
+      return '1 week'
     case 'month':
       return '1 month'
     case '3-months':
@@ -36,61 +34,29 @@ export const getMerchOrders: APIHandler<'get-merch-orders'> = async (
   const pg = createSupabaseDirectClient()
 
   const interval = dateRangeToInterval(dateRange)
-  // Built once and reused across all 4 queries so the orders list, count,
-  // per-item stats, and overall stats all reflect the same time window.
   // The `interval` value comes from a fixed enum mapping — no user-supplied
   // SQL ever reaches this string, so interpolation is safe.
-  const dateClause = (prefix: string) =>
-    interval ? `and ${prefix}created_time >= now() - interval '${interval}'` : ''
+  const dateClause = interval
+    ? `and so.created_time >= now() - interval '${interval}'`
+    : ''
+  const dateClauseNoPrefix = interval
+    ? `and created_time >= now() - interval '${interval}'`
+    : ''
 
-  const [orders, countResult, perItemStats, overallStats] = await Promise.all([
+  const [orders, countResult] = await Promise.all([
     pg.manyOrNone(
       `SELECT so.*, u.username, u.name as display_name
        FROM shop_orders so
        JOIN users u ON u.id = so.user_id
        WHERE so.item_id LIKE 'merch-%'
-       ${dateClause('so.')}
+       ${dateClause}
        ORDER BY so.created_time DESC
        LIMIT $1 OFFSET $2`,
       [limit, offset]
     ),
     pg.one(
       `SELECT count(*)::int as total FROM shop_orders
-       WHERE item_id LIKE 'merch-%' ${dateClause('')}`
-    ),
-    // Per-item stats exclude refunded/cancelled/failed so they reflect real
-    // revenue (matches the merchSales filter in get-shop-stats.ts).
-    pg.manyOrNone<{
-      itemId: string
-      orderCount: number
-      totalMana: number
-      avgMana: number
-    }>(
-      `SELECT
-         item_id as "itemId",
-         count(*)::int as "orderCount",
-         sum(price_mana)::bigint as "totalMana",
-         avg(price_mana)::float as "avgMana"
-       FROM shop_orders
-       WHERE item_id LIKE 'merch-%'
-         AND ${REVENUE_STATUSES_SQL}
-         ${dateClause('')}
-       GROUP BY item_id
-       ORDER BY sum(price_mana) DESC`
-    ),
-    pg.one<{
-      orderCount: number
-      totalMana: number
-      avgMana: number | null
-    }>(
-      `SELECT
-         count(*)::int as "orderCount",
-         coalesce(sum(price_mana), 0)::bigint as "totalMana",
-         avg(price_mana)::float as "avgMana"
-       FROM shop_orders
-       WHERE item_id LIKE 'merch-%'
-         AND ${REVENUE_STATUSES_SQL}
-         ${dateClause('')}`
+       WHERE item_id LIKE 'merch-%' ${dateClauseNoPrefix}`
     ),
   ])
 
@@ -101,18 +67,5 @@ export const getMerchOrders: APIHandler<'get-merch-orders'> = async (
       displayName: row.display_name as string,
     })),
     total: countResult.total as number,
-    stats: {
-      perItem: (perItemStats ?? []).map((row) => ({
-        itemId: row.itemId,
-        orderCount: Number(row.orderCount),
-        totalMana: Number(row.totalMana),
-        avgMana: Number(row.avgMana),
-      })),
-      overall: {
-        orderCount: Number(overallStats.orderCount),
-        totalMana: Number(overallStats.totalMana),
-        avgMana: overallStats.avgMana == null ? 0 : Number(overallStats.avgMana),
-      },
-    },
   }
 }

--- a/backend/api/src/get-merch-orders.ts
+++ b/backend/api/src/get-merch-orders.ts
@@ -3,7 +3,8 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { isAdminId } from 'common/envs/constants'
 import { convertShopOrder } from 'common/shop/types'
 
-// Map dateRange prop -> Postgres interval. 'all' returns null (no filter).
+// Map dateRange prop -> Postgres interval string ('1 week', '3 months', ...).
+// 'all' returns null which the SQL treats as "no date filter".
 const dateRangeToInterval = (
   dateRange: 'all' | 'week' | 'month' | '3-months' | '6-months' | 'year'
 ): string | null => {
@@ -33,30 +34,30 @@ export const getMerchOrders: APIHandler<'get-merch-orders'> = async (
 
   const pg = createSupabaseDirectClient()
 
+  // Passed as a bind parameter and cast to `interval` server-side. When
+  // dateRange = 'all' the interval is null, so the cast is null and the
+  // `IS NULL` arm of the OR short-circuits the date filter without
+  // branching the query string. No user-supplied SQL anywhere in the path.
   const interval = dateRangeToInterval(dateRange)
-  // The `interval` value comes from a fixed enum mapping — no user-supplied
-  // SQL ever reaches this string, so interpolation is safe.
-  const dateClause = interval
-    ? `and so.created_time >= now() - interval '${interval}'`
-    : ''
-  const dateClauseNoPrefix = interval
-    ? `and created_time >= now() - interval '${interval}'`
-    : ''
 
   const [orders, countResult] = await Promise.all([
     pg.manyOrNone(
       `SELECT so.*, u.username, u.name as display_name
-       FROM shop_orders so
-       JOIN users u ON u.id = so.user_id
-       WHERE so.item_id LIKE 'merch-%'
-       ${dateClause}
-       ORDER BY so.created_time DESC
-       LIMIT $1 OFFSET $2`,
-      [limit, offset]
+         FROM shop_orders so
+         JOIN users u ON u.id = so.user_id
+        WHERE so.item_id LIKE 'merch-%'
+          AND ($3::interval IS NULL
+               OR so.created_time >= now() - $3::interval)
+        ORDER BY so.created_time DESC
+        LIMIT $1 OFFSET $2`,
+      [limit, offset, interval]
     ),
     pg.one(
       `SELECT count(*)::int as total FROM shop_orders
-       WHERE item_id LIKE 'merch-%' ${dateClauseNoPrefix}`
+        WHERE item_id LIKE 'merch-%'
+          AND ($1::interval IS NULL
+               OR created_time >= now() - $1::interval)`,
+      [interval]
     ),
   ])
 

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -4066,13 +4066,29 @@ export const API = (_apiTypeCheck = {
     authed: true,
     props: z
       .object({
-        limit: z.coerce.number().int().min(1).max(200).default(50),
+        limit: z.coerce.number().int().min(1).max(2000).default(25),
         offset: z.coerce.number().int().min(0).default(0),
+        dateRange: z
+          .enum(['all', 'month', '3-months', '6-months', 'year'])
+          .default('all'),
       })
       .strict(),
     returns: {} as {
       orders: (ShopOrder & { username: string; displayName: string })[]
       total: number
+      stats: {
+        perItem: {
+          itemId: string
+          orderCount: number
+          totalMana: number
+          avgMana: number
+        }[]
+        overall: {
+          orderCount: number
+          totalMana: number
+          avgMana: number
+        }
+      }
     },
   },
   'get-merch-stock-status': {

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -4069,26 +4069,13 @@ export const API = (_apiTypeCheck = {
         limit: z.coerce.number().int().min(1).max(2000).default(25),
         offset: z.coerce.number().int().min(0).default(0),
         dateRange: z
-          .enum(['all', 'month', '3-months', '6-months', 'year'])
+          .enum(['all', 'week', 'month', '3-months', '6-months', 'year'])
           .default('all'),
       })
       .strict(),
     returns: {} as {
       orders: (ShopOrder & { username: string; displayName: string })[]
       total: number
-      stats: {
-        perItem: {
-          itemId: string
-          orderCount: number
-          totalMana: number
-          avgMana: number
-        }[]
-        overall: {
-          orderCount: number
-          totalMana: number
-          avgMana: number
-        }
-      }
     },
   },
   'get-merch-stock-status': {

--- a/web/pages/admin/merch.tsx
+++ b/web/pages/admin/merch.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Button } from 'web/components/buttons/button'
 import { Page } from 'web/components/layout/page'
 import { Col } from 'web/components/layout/col'
@@ -127,23 +127,85 @@ function StockManagement() {
   )
 }
 
-type ViewMode = 'recent' | 'month' | '3-months' | '6-months' | 'year' | 'all'
+type ViewMode =
+  | 'recent'
+  | 'week'
+  | 'month'
+  | '3-months'
+  | '6-months'
+  | 'year'
+  | 'all'
 // Each view maps to a (dateRange, limit) pair sent to the backend. 'recent'
 // is the cheap default — newest 25, no date filter. Wider ranges raise the
 // limit to surface all qualifying orders (capped at 2000 by the schema).
 const VIEW_MODES: {
   value: ViewMode
   label: string
-  dateRange: 'all' | 'month' | '3-months' | '6-months' | 'year'
+  dateRange: 'all' | 'week' | 'month' | '3-months' | '6-months' | 'year'
   limit: number
 }[] = [
   { value: 'recent', label: 'Last 25', dateRange: 'all', limit: 25 },
+  { value: 'week', label: 'Last week', dateRange: 'week', limit: 2000 },
   { value: 'month', label: 'Last month', dateRange: 'month', limit: 2000 },
   { value: '3-months', label: 'Last 3 months', dateRange: '3-months', limit: 2000 },
   { value: '6-months', label: 'Last 6 months', dateRange: '6-months', limit: 2000 },
   { value: 'year', label: 'Last year', dateRange: 'year', limit: 2000 },
   { value: 'all', label: 'All time', dateRange: 'all', limit: 2000 },
 ]
+
+// Statuses excluded from stats. Mirrors REVENUE_STATUSES_SQL in
+// get-merch-orders.ts and the merchSales filter in get-shop-stats.ts.
+const REVENUE_EXCLUDED: ReadonlySet<ShopOrder['status']> = new Set([
+  'CANCELLED',
+  'REFUNDED',
+  'FAILED',
+] as const)
+
+type MerchStats = {
+  perItem: {
+    itemId: string
+    orderCount: number
+    totalMana: number
+    avgMana: number
+  }[]
+  overall: {
+    orderCount: number
+    totalMana: number
+    avgMana: number
+  }
+}
+
+function computeStats(orders: ShopOrder[]): MerchStats {
+  const revenue = orders.filter((o) => !REVENUE_EXCLUDED.has(o.status))
+
+  const byItem = new Map<string, number[]>()
+  for (const o of revenue) {
+    const arr = byItem.get(o.itemId)
+    if (arr) arr.push(o.priceMana)
+    else byItem.set(o.itemId, [o.priceMana])
+  }
+
+  const perItem = Array.from(byItem.entries())
+    .map(([itemId, prices]) => {
+      const totalMana = prices.reduce((s, p) => s + p, 0)
+      return {
+        itemId,
+        orderCount: prices.length,
+        totalMana,
+        avgMana: totalMana / prices.length,
+      }
+    })
+    .sort((a, b) => b.totalMana - a.totalMana)
+
+  const totalMana = revenue.reduce((s, o) => s + o.priceMana, 0)
+  const overall = {
+    orderCount: revenue.length,
+    totalMana,
+    avgMana: revenue.length === 0 ? 0 : totalMana / revenue.length,
+  }
+
+  return { perItem, overall }
+}
 
 function OrderManagement() {
   const [viewMode, setViewMode] = useState<ViewMode>('recent')
@@ -156,7 +218,11 @@ function OrderManagement() {
   })
   const orders = data?.orders ?? []
   const total = data?.total ?? 0
-  const stats = data?.stats
+  // Stats are computed from the visible orders, not the underlying
+  // date-filtered set, so 'Last 25' shows stats for those 25 (matches
+  // what's on screen) rather than all-time. For wider ranges the visible
+  // set IS the full window (up to the 2000 cap), so this is equivalent.
+  const stats = useMemo(() => computeStats(orders), [orders])
   const [cancelingId, setCancelingId] = useState<string | null>(null)
 
   const handleCancel = async (
@@ -208,7 +274,7 @@ function OrderManagement() {
         ))}
       </Row>
 
-      {stats && <OrderStats stats={stats} />}
+      <OrderStats stats={stats} />
 
       <Row className="items-center justify-between">
         <h2 className="text-lg font-semibold">Orders ({total})</h2>

--- a/web/pages/admin/merch.tsx
+++ b/web/pages/admin/merch.tsx
@@ -127,15 +127,36 @@ function StockManagement() {
   )
 }
 
+type ViewMode = 'recent' | 'month' | '3-months' | '6-months' | 'year' | 'all'
+// Each view maps to a (dateRange, limit) pair sent to the backend. 'recent'
+// is the cheap default — newest 25, no date filter. Wider ranges raise the
+// limit to surface all qualifying orders (capped at 2000 by the schema).
+const VIEW_MODES: {
+  value: ViewMode
+  label: string
+  dateRange: 'all' | 'month' | '3-months' | '6-months' | 'year'
+  limit: number
+}[] = [
+  { value: 'recent', label: 'Last 25', dateRange: 'all', limit: 25 },
+  { value: 'month', label: 'Last month', dateRange: 'month', limit: 2000 },
+  { value: '3-months', label: 'Last 3 months', dateRange: '3-months', limit: 2000 },
+  { value: '6-months', label: 'Last 6 months', dateRange: '6-months', limit: 2000 },
+  { value: 'year', label: 'Last year', dateRange: 'year', limit: 2000 },
+  { value: 'all', label: 'All time', dateRange: 'all', limit: 2000 },
+]
+
 function OrderManagement() {
-  const [offset, setOffset] = useState(0)
-  const limit = 25
+  const [viewMode, setViewMode] = useState<ViewMode>('recent')
+  const mode = VIEW_MODES.find((m) => m.value === viewMode) ?? VIEW_MODES[0]
+
   const { data, refresh } = useAPIGetter('get-merch-orders', {
-    limit,
-    offset,
+    limit: mode.limit,
+    offset: 0,
+    dateRange: mode.dateRange,
   })
   const orders = data?.orders ?? []
   const total = data?.total ?? 0
+  const stats = data?.stats
   const [cancelingId, setCancelingId] = useState<string | null>(null)
 
   const handleCancel = async (
@@ -150,7 +171,7 @@ function OrderManagement() {
         `Cancel order for @${username}?\n\nItem: ${itemName}\nRefund: ${formatMoney(
           amount
         )}\nPrintful: ${
-          printfulOrderId ?? '\u2014'
+          printfulOrderId ?? '—'
         }\n\nThis will refund the full amount to the user and cancel the draft on Printful.`
       )
     )
@@ -173,34 +194,28 @@ function OrderManagement() {
 
   return (
     <Col className="gap-4">
+      <Row className="flex-wrap items-center gap-2">
+        <span className="text-ink-500 text-sm">View:</span>
+        {VIEW_MODES.map((opt) => (
+          <Button
+            key={opt.value}
+            size="xs"
+            color={viewMode === opt.value ? 'indigo' : 'gray-outline'}
+            onClick={() => setViewMode(opt.value)}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </Row>
+
+      {stats && <OrderStats stats={stats} />}
+
       <Row className="items-center justify-between">
         <h2 className="text-lg font-semibold">Orders ({total})</h2>
-        <Row className="gap-2">
-          <Button
-            size="xs"
-            color="gray-outline"
-            disabled={offset === 0}
-            onClick={() => setOffset(Math.max(0, offset - limit))}
-          >
-            Previous
-          </Button>
-          <span className="text-ink-500 self-center text-sm">
-            {total === 0
-              ? '0'
-              : `${offset + 1}\u2013${Math.min(
-                  offset + limit,
-                  total
-                )} of ${total}`}
-          </span>
-          <Button
-            size="xs"
-            color="gray-outline"
-            disabled={offset + limit >= total}
-            onClick={() => setOffset(offset + limit)}
-          >
-            Next
-          </Button>
-        </Row>
+        <span className="text-ink-500 self-center text-sm">
+          Showing {orders.length}
+          {orders.length >= mode.limit && ` (capped at ${mode.limit})`}
+        </span>
       </Row>
 
       {orders.length === 0 ? (
@@ -232,6 +247,103 @@ function OrderManagement() {
           </table>
         </div>
       )}
+    </Col>
+  )
+}
+
+function OrderStats(props: {
+  stats: {
+    perItem: {
+      itemId: string
+      orderCount: number
+      totalMana: number
+      avgMana: number
+    }[]
+    overall: {
+      orderCount: number
+      totalMana: number
+      avgMana: number
+    }
+  }
+}) {
+  const { perItem, overall } = props.stats
+
+  return (
+    <Col className="border-ink-200 gap-3 rounded-lg border p-4">
+      <Row className="flex-wrap items-baseline gap-x-6 gap-y-1">
+        <h3 className="text-base font-semibold">Sales summary</h3>
+        <span className="text-ink-500 text-xs">
+          Excludes cancelled, refunded, and failed orders.
+        </span>
+      </Row>
+
+      <Row className="flex-wrap gap-6">
+        <StatBlock
+          label="Orders"
+          value={overall.orderCount.toLocaleString()}
+        />
+        <StatBlock
+          label="Total mana"
+          value={formatMoney(overall.totalMana)}
+        />
+        <StatBlock
+          label="Average per order"
+          value={formatMoney(Math.round(overall.avgMana))}
+        />
+      </Row>
+
+      {perItem.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-ink-200 border-b text-left">
+                <th className="px-3 py-2">Item</th>
+                <th className="px-3 py-2 text-right">Orders</th>
+                <th className="px-3 py-2 text-right">Total mana</th>
+                <th className="px-3 py-2 text-right">Average mana</th>
+              </tr>
+            </thead>
+            <tbody>
+              {perItem.map((row) => {
+                const item = getShopItem(row.itemId)
+                return (
+                  <tr
+                    key={row.itemId}
+                    className="border-ink-200 border-b last:border-b-0"
+                  >
+                    <td className="px-3 py-2">
+                      {item?.name ?? row.itemId}
+                      <span className="text-ink-500 ml-2 text-xs">
+                        {row.itemId}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {row.orderCount.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {formatMoney(row.totalMana)}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {formatMoney(Math.round(row.avgMana))}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Col>
+  )
+}
+
+function StatBlock(props: { label: string; value: string }) {
+  return (
+    <Col className="gap-0.5">
+      <span className="text-ink-500 text-xs uppercase tracking-wide">
+        {props.label}
+      </span>
+      <span className="text-lg font-semibold">{props.value}</span>
     </Col>
   )
 }
@@ -302,11 +414,11 @@ function OrderRow(props: {
             cross-reference both without widening the table. */}
         <div>
           <span className="text-ink-500">Printful:</span>{' '}
-          {order.printfulOrderId ?? '\u2014'}
+          {order.printfulOrderId ?? '—'}
         </div>
         <div>
           <span className="text-ink-500">Manifold:</span>{' '}
-          {order.txnId ? `manifold-${order.txnId}` : '\u2014'}
+          {order.txnId ? `manifold-${order.txnId}` : '—'}
         </div>
       </td>
       <td className="px-3 py-2">

--- a/web/pages/admin/merch.tsx
+++ b/web/pages/admin/merch.tsx
@@ -87,9 +87,11 @@ function StockManagement() {
   }
 
   return (
-    <Col className="gap-4">
-      <h2 className="text-lg font-semibold">Stock Status</h2>
-      <div className="border-ink-200 rounded-lg border">
+    <details className="border-ink-200 rounded-lg border">
+      <summary className="cursor-pointer px-4 py-3 text-lg font-semibold">
+        Stock Status
+      </summary>
+      <div className="border-ink-200 border-t">
         {merchItems.map((item) => {
           const isOutOfStock = outOfStockSet.has(item.id)
           return (
@@ -123,7 +125,7 @@ function StockManagement() {
           )
         })}
       </div>
-    </Col>
+    </details>
   )
 }
 
@@ -147,8 +149,18 @@ const VIEW_MODES: {
   { value: 'recent', label: 'Last 25', dateRange: 'all', limit: 25 },
   { value: 'week', label: 'Last week', dateRange: 'week', limit: 2000 },
   { value: 'month', label: 'Last month', dateRange: 'month', limit: 2000 },
-  { value: '3-months', label: 'Last 3 months', dateRange: '3-months', limit: 2000 },
-  { value: '6-months', label: 'Last 6 months', dateRange: '6-months', limit: 2000 },
+  {
+    value: '3-months',
+    label: 'Last 3 months',
+    dateRange: '3-months',
+    limit: 2000,
+  },
+  {
+    value: '6-months',
+    label: 'Last 6 months',
+    dateRange: '6-months',
+    limit: 2000,
+  },
   { value: 'year', label: 'Last year', dateRange: 'year', limit: 2000 },
   { value: 'all', label: 'All time', dateRange: 'all', limit: 2000 },
 ]
@@ -335,71 +347,73 @@ function OrderStats(props: {
   const { perItem, overall } = props.stats
 
   return (
-    <Col className="border-ink-200 gap-3 rounded-lg border p-4">
-      <Row className="flex-wrap items-baseline gap-x-6 gap-y-1">
-        <h3 className="text-base font-semibold">Sales summary</h3>
+    <details className="border-ink-200 rounded-lg border">
+      <summary className="cursor-pointer px-4 py-3 text-base font-semibold">
+        Sales summary
+      </summary>
+      <Col className="border-ink-200 gap-3 border-t p-4">
         <span className="text-ink-500 text-xs">
           Excludes cancelled, refunded, and failed orders.
         </span>
-      </Row>
 
-      <Row className="flex-wrap gap-6">
-        <StatBlock
-          label="Orders"
-          value={overall.orderCount.toLocaleString()}
-        />
-        <StatBlock
-          label="Total mana"
-          value={formatMoney(overall.totalMana)}
-        />
-        <StatBlock
-          label="Average per order"
-          value={formatMoney(Math.round(overall.avgMana))}
-        />
-      </Row>
+        <Row className="flex-wrap gap-6">
+          <StatBlock
+            label="Orders"
+            value={overall.orderCount.toLocaleString()}
+          />
+          <StatBlock
+            label="Total mana"
+            value={formatMoney(overall.totalMana)}
+          />
+          <StatBlock
+            label="Average per order"
+            value={formatMoney(Math.round(overall.avgMana))}
+          />
+        </Row>
 
-      {perItem.length > 0 && (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-ink-200 border-b text-left">
-                <th className="px-3 py-2">Item</th>
-                <th className="px-3 py-2 text-right">Orders</th>
-                <th className="px-3 py-2 text-right">Total mana</th>
-                <th className="px-3 py-2 text-right">Average mana</th>
-              </tr>
-            </thead>
-            <tbody>
-              {perItem.map((row) => {
-                const item = getShopItem(row.itemId)
-                return (
-                  <tr
-                    key={row.itemId}
-                    className="border-ink-200 border-b last:border-b-0"
-                  >
-                    <td className="px-3 py-2">
-                      {item?.name ?? row.itemId}
-                      <span className="text-ink-500 ml-2 text-xs">
-                        {row.itemId}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2 text-right">
-                      {row.orderCount.toLocaleString()}
-                    </td>
-                    <td className="px-3 py-2 text-right">
-                      {formatMoney(row.totalMana)}
-                    </td>
-                    <td className="px-3 py-2 text-right">
-                      {formatMoney(Math.round(row.avgMana))}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </Col>
+        {perItem.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-ink-200 border-b text-left">
+                  <th className="px-3 py-2">Item</th>
+                  <th className="px-3 py-2 text-right">Orders</th>
+                  <th className="px-3 py-2 text-right">Total mana</th>
+                  <th className="px-3 py-2 text-right">Average mana</th>
+                </tr>
+              </thead>
+              <tbody>
+                {perItem.map((row) => {
+                  const item = getShopItem(row.itemId)
+                  return (
+                    <tr
+                      key={row.itemId}
+                      className="border-ink-200 border-b last:border-b-0"
+                    >
+                      <td className="px-3 py-2">
+                        {item?.name ?? row.itemId}
+                        <span className="text-ink-500 ml-2 text-xs">
+                          {row.itemId}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        {row.orderCount.toLocaleString()}
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        {formatMoney(row.totalMana)}
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        {formatMoney(Math.round(row.avgMana))}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Col>
+    </details>
   )
 }
 


### PR DESCRIPTION
Add an aggregate Sales summary card (overall + per-item: orders, total mana, average mana) above the orders table on /admin/merch. Stats use the same revenue filter as get-shop-stats.ts (excludes CANCELLED, REFUNDED, FAILED).

Replace pagination with a view selector: Last 25 (default, cheap) / Last month / 3 / 6 months / year / All time. Wider views load up to 2000 orders in one shot; default stays at 25 so the page is fast.