### PR TITLE
fix: Validate replyToCommentId is a top-level comment

### DIFF
--- a/backend/api/src/create-comment.ts
+++ b/backend/api/src/create-comment.ts
@@ -82,12 +82,20 @@ export const createCommentOnContractInternal = async (
   const now = Date.now()
 
   if (replyToCommentId) {
-    const repliedComment = await pg.oneOrNone(
-      `select comment_id from contract_comments where comment_id = $1 and contract_id = $2`,
+    const repliedComment = await pg.oneOrNone<{
+      comment_id: string
+      reply_to_comment_id: string | null
+    }>(
+      `select comment_id, data->>'replyToCommentId' as reply_to_comment_id
+       from contract_comments
+       where comment_id = $1 and contract_id = $2`,
       [replyToCommentId, contractId]
     )
     if (!repliedComment) {
       throw new APIError(404, 'Comment to reply to not found')
+    }
+    if (repliedComment.reply_to_comment_id) {
+      throw new APIError(400, 'Can only reply to top-level comments')
     }
   }
 

--- a/backend/api/src/create-post-comment.ts
+++ b/backend/api/src/create-post-comment.ts
@@ -36,12 +36,20 @@ export const createPostComment: APIHandler<'create-post-comment'> =
     if (!post) throw new APIError(404, 'Post not found')
 
     if (replyToCommentId) {
-      const repliedComment = await pg.oneOrNone(
-        `select comment_id from old_post_comments where comment_id = $1 and post_id = $2`,
+      const repliedComment = await pg.oneOrNone<{
+        comment_id: string
+        reply_to_comment_id: string | null
+      }>(
+        `select comment_id, data->>'replyToCommentId' as reply_to_comment_id
+         from old_post_comments
+         where comment_id = $1 and post_id = $2`,
         [replyToCommentId, postId]
       )
       if (!repliedComment) {
         throw new APIError(404, 'Comment to reply to not found')
+      }
+      if (repliedComment.reply_to_comment_id) {
+        throw new APIError(400, 'Can only reply to top-level comments')
       }
     }
 


### PR DESCRIPTION
In #3804 we checked that replyToCommentId was present, but some bots would assume comments are deeply-threaded and reply to the latest comment in the thread. Here we check that replyToCommentId is a top-level comment so that it matches the UI commenting behavior.