### PR TITLE
feat: Paginate balance log items

### DIFF
--- a/backend/api/src/get-balance-changes.ts
+++ b/backend/api/src/get-balance-changes.ts
@@ -14,7 +14,7 @@ import { getContractsDirect } from 'shared/supabase/contracts'
 export const getBalanceChanges: APIHandler<'get-balance-changes'> = async (
   props
 ) => {
-  const { userId, before, after } = props
+  const { userId, before, after, limit, offset } = props
   const [betBalanceChanges, txnBalanceChanges, liquidityChanges] =
     await Promise.all([
       getBetBalanceChanges(before, after, userId),
@@ -26,7 +26,7 @@ export const getBalanceChanges: APIHandler<'get-balance-changes'> = async (
     (change) => change.createdTime,
     'desc'
   )
-  return allChanges
+  return allChanges.slice(offset, offset + limit)
 }
 
 const getTxnBalanceChanges = async (

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1744,6 +1744,8 @@ export const API = (_apiTypeCheck = {
       .object({
         before: z.coerce.number().optional(),
         after: z.coerce.number().default(0),
+        limit: z.coerce.number().gte(0).lte(1000).default(100),
+        offset: z.coerce.number().gte(0).default(0),
         userId: z.string(),
       })
       .strict(),
@@ -3639,12 +3641,7 @@ export const API = (_apiTypeCheck = {
         claimId: z.string().optional(),
         sweepstakesNum: z.number().int().optional(),
         userId: z.string().optional(),
-        paymentStatus: z.enum([
-          'awaiting',
-          'sent',
-          'rejected',
-          'opted_out',
-        ]),
+        paymentStatus: z.enum(['awaiting', 'sent', 'rejected', 'opted_out']),
         paymentTxnHash: z.string().optional(),
       })
       .strict()

--- a/web/components/portfolio/balance-change-table.tsx
+++ b/web/components/portfolio/balance-change-table.tsx
@@ -11,8 +11,7 @@ import {
 import { Row } from 'web/components/layout/row'
 import clsx from 'clsx'
 import { User } from 'common/user'
-import { ReactNode, useState } from 'react'
-import { DAY_MS } from 'common/util/time'
+import { ReactNode, useEffect, useState } from 'react'
 import {
   AnyBalanceChangeType,
   BetBalanceChange,
@@ -30,6 +29,7 @@ import {
 import { contractPathWithoutContract } from 'common/contract'
 import { linkClass } from 'web/components/widgets/site-link'
 import { ScaleIcon } from '@heroicons/react/outline'
+import { CalendarIcon } from '@heroicons/react/solid'
 import { Input } from 'web/components/widgets/input'
 import { customFormatTime, formatJustDateShort } from 'client-common/lib/time'
 import { assertUnreachable } from 'common/util/types'
@@ -39,29 +39,69 @@ import { Button } from 'web/components/buttons/button'
 import { Modal } from '../layout/modal'
 import { QuestType } from 'common/quest'
 import { PROFIT_FEE_FRACTION } from 'common/economy'
-import { CalendarIcon } from '@heroicons/react/solid'
 import DropdownMenu from '../widgets/dropdown-menu'
+import { PaginationNextPrev } from '../widgets/pagination'
+
+const BALANCE_CHANGES_PER_PAGE = 50
 
 export const BalanceChangeTable = (props: { user: User }) => {
   const { user } = props
 
-  const fourteenDaysAgo = dayjs().startOf('day').subtract(14, 'day').valueOf()
+  const [page, setPage] = useState(0)
   const [before, setBefore] = useState<number | undefined>(undefined)
-  const [after, setAfter] = useState(fourteenDaysAgo)
+  const [after, setAfter] = useState<number | undefined>(undefined)
   const [showDateFilters, setShowDateFilters] = useState(false)
+  const pageOffset = page * BALANCE_CHANGES_PER_PAGE
+  const pageLimit = BALANCE_CHANGES_PER_PAGE + 1
 
-  const { data: allBalanceChanges } = useAPIGetter('get-balance-changes', {
-    userId: user.id,
-    before,
-    after,
-  })
+  const { data: allBalanceChanges, loading } = useAPIGetter(
+    'get-balance-changes',
+    {
+      userId: user.id,
+      before,
+      after,
+      limit: pageLimit,
+      offset: pageOffset,
+    },
+    undefined,
+    `balance-changes-${user.id}-${pageOffset}-${pageLimit}-${
+      before ?? 'none'
+    }-${after ?? 'none'}`
+  )
+  const { data: previousBalanceChangesData } = useAPIGetter(
+    'get-balance-changes',
+    page === 0
+      ? undefined
+      : {
+          userId: user.id,
+          before,
+          after,
+          limit: pageOffset,
+        },
+    undefined,
+    `balance-changes-${user.id}-previous-${pageOffset}-${before ?? 'none'}-${
+      after ?? 'none'
+    }`,
+    page > 0
+  )
 
   const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    setPage(0)
+  }, [query, before, after])
   const { data: cashouts } = useAPIGetter('get-cashouts', {
     userId: user.id,
   })
   const [showCashoutModal, setShowCashoutModal] = useState(false)
-  const balanceChanges = (allBalanceChanges ?? []).filter((change) => {
+  const previousBalanceChanges = previousBalanceChangesData ?? []
+  const currentPageBalanceChanges = (allBalanceChanges ?? []).slice(
+    0,
+    BALANCE_CHANGES_PER_PAGE
+  )
+  const hasNextPage =
+    (allBalanceChanges?.length ?? 0) > BALANCE_CHANGES_PER_PAGE
+  const balanceChanges = currentPageBalanceChanges.filter((change) => {
     const { type } = change
     const contractQuestion =
       ('contract' in change && change.contract?.question) || ''
@@ -89,12 +129,12 @@ export const BalanceChangeTable = (props: { user: User }) => {
     cashouts?.filter((c) => c.txn.gidxStatus === 'Pending')?.length ?? 0
 
   const hasCashouts = cashouts && cashouts.length > 0
-
-  const relativeDateText = before
-    ? `${formatJustDateShort(after)} - ${formatJustDateShort(before)}`
-    : after === fourteenDaysAgo
-    ? 'Last 14 days'
-    : `Since ${formatJustDateShort(after)}`
+  const dateFilterText =
+    after || before
+      ? `${after ? formatJustDateShort(after) : 'Any date'} – ${
+          before ? formatJustDateShort(before) : 'Today'
+        }`
+      : 'Any date'
 
   return (
     <Col className={'w-full justify-center gap-4 py-1'}>
@@ -108,42 +148,61 @@ export const BalanceChangeTable = (props: { user: User }) => {
 
       <Row className="flex-wrap items-center justify-between gap-2">
         {showDateFilters ? (
-          <Row className="items-center gap-2">
-            <Input
-              type="date"
-              className="dark:date-range-input-white text-ink-700 !h-8 w-[120px] !px-2 !py-1 text-sm"
-              value={dayjs(after).format('YYYY-MM-DD')}
-              max={before ? dayjs(before).format('YYYY-MM-DD') : undefined}
-              onChange={(e) =>
-                setAfter(dayjs(e.target.value).startOf('day').valueOf())
-              }
-            />
-            <span className="text-ink-700 text-sm">to</span>
-            <Input
-              type="date"
-              className="dark:date-range-input-white text-ink-700 !h-8 w-[120px] !px-2 !py-1 text-sm"
-              value={before ? dayjs(before).format('YYYY-MM-DD') : ''}
-              min={dayjs(after).format('YYYY-MM-DD')}
-              onChange={(e) =>
-                setBefore(
-                  e.target.value
-                    ? dayjs(e.target.value).endOf('day').valueOf()
-                    : undefined
-                )
-              }
-            />
-            <Button
-              color="gray-outline"
-              className="whitespace-nowrap"
-              size="xs"
-              onClick={() => setShowDateFilters(false)}
-            >
-              Hide dates
-            </Button>
+          <Row className="flex-wrap items-center gap-2">
+            <Row className="flex-nowrap items-center gap-2">
+              <Input
+                type="date"
+                className="dark:date-range-input-white text-ink-700 !h-8 w-[120px] !px-2 !py-1 text-sm"
+                value={after ? dayjs(after).format('YYYY-MM-DD') : ''}
+                max={before ? dayjs(before).format('YYYY-MM-DD') : undefined}
+                onChange={(e) =>
+                  setAfter(
+                    e.target.value
+                      ? dayjs(e.target.value).startOf('day').valueOf()
+                      : undefined
+                  )
+                }
+              />
+              <span className="text-ink-700 whitespace-nowrap text-sm">to</span>
+              <Input
+                type="date"
+                className="dark:date-range-input-white text-ink-700 !h-8 w-[120px] !px-2 !py-1 text-sm"
+                value={before ? dayjs(before).format('YYYY-MM-DD') : ''}
+                min={after ? dayjs(after).format('YYYY-MM-DD') : undefined}
+                onChange={(e) =>
+                  setBefore(
+                    e.target.value
+                      ? dayjs(e.target.value).endOf('day').valueOf()
+                      : undefined
+                  )
+                }
+              />
+            </Row>
+            <Row className="flex-nowrap items-center gap-2">
+              <Button
+                color="gray-outline"
+                className="whitespace-nowrap"
+                size="xs"
+                onClick={() => {
+                  setAfter(undefined)
+                  setBefore(undefined)
+                }}
+              >
+                Clear dates
+              </Button>
+              <Button
+                color="gray-outline"
+                className="whitespace-nowrap"
+                size="xs"
+                onClick={() => setShowDateFilters(false)}
+              >
+                Hide dates
+              </Button>
+            </Row>
           </Row>
         ) : (
           <Row className="items-center gap-2">
-            <span className="text-ink-700 text-sm">{relativeDateText}</span>
+            <span className="text-ink-700 text-sm">{dateFilterText}</span>
             <Button
               color="gray-outline"
               size="xs"
@@ -170,59 +229,32 @@ export const BalanceChangeTable = (props: { user: User }) => {
           />
         )}
       </Row>
-      {!!before && before < Date.now() && (
-        <Row className="text-ink-400 mt-4 items-center justify-center gap-6">
-          <div className="border-ink-400 grow border" />
-          <span>Cutoff: {formatJustDateShort(before)}</span>
-          <span className="flex gap-2">
-            <button
-              className="text-primary-500 hover:underline"
-              onClick={() => setBefore(before + 7 * DAY_MS)}
-            >
-              Load 1W
-            </button>
-            <button
-              className="text-primary-500 hover:underline"
-              onClick={() => setBefore(undefined)}
-            >
-              Clear
-            </button>
-          </span>
-          <div className="border-ink-400 grow border" />
-        </Row>
-      )}
+
+      <span className="text-ink-700 text-sm">
+        {balanceChanges.length > 0
+          ? `Showing ${page * BALANCE_CHANGES_PER_PAGE + 1}–${
+              page * BALANCE_CHANGES_PER_PAGE + balanceChanges.length
+            }`
+          : loading
+          ? 'Loading balance changes…'
+          : 'No balance changes found'}
+      </span>
 
       <RenderBalanceChanges
         avatarSize={'md'}
         balanceChanges={balanceChanges}
+        previousBalanceChanges={previousBalanceChanges}
         user={user}
         hideBalance={!!query}
       />
-      <Row className="text-ink-400 mt-4 items-center justify-center gap-6">
-        <div className="border-ink-400 grow border" />
-        <span>Cutoff: {formatJustDateShort(after)}</span>
-        <span className="flex gap-2">
-          <button
-            className="text-primary-500 hover:underline"
-            onClick={() => setAfter(after - 7 * DAY_MS)}
-          >
-            Load 1W
-          </button>
-          <button
-            className="text-primary-500 hover:underline"
-            onClick={() => setAfter(after - 30 * DAY_MS)}
-          >
-            1M
-          </button>
-          <button
-            className="text-primary-500 hover:underline"
-            onClick={() => setAfter(after - 365 * DAY_MS)}
-          >
-            1Y
-          </button>
-        </span>
-        <div className="border-ink-400 grow border" />
-      </Row>
+      <PaginationNextPrev
+        isStart={page === 0}
+        isEnd={!hasNextPage}
+        isLoading={loading}
+        isComplete={!hasNextPage}
+        getPrev={() => setPage(page - 1)}
+        getNext={() => setPage(page + 1)}
+      />
 
       <Modal open={showCashoutModal} setOpen={setShowCashoutModal}>
         <Col className={'bg-canvas-0 gap-4 rounded-md p-4'}>
@@ -256,14 +288,35 @@ export const BalanceChangeTable = (props: { user: User }) => {
 
 function RenderBalanceChanges(props: {
   balanceChanges: AnyBalanceChangeType[]
+  previousBalanceChanges?: AnyBalanceChangeType[]
   user: User
   avatarSize: 'sm' | 'md'
   hideBalance?: boolean
 }) {
-  const { balanceChanges, user, avatarSize, hideBalance } = props
+  const {
+    balanceChanges,
+    previousBalanceChanges = [],
+    user,
+    avatarSize,
+    hideBalance,
+  } = props
   let currManaBalance = user.balance
   let currCashBalance = user.cashBalance
   let currSpiceBalance = user.spiceBalance
+
+  for (const change of previousBalanceChanges) {
+    if (isTxnChange(change) && change.token === 'SPICE') {
+      currSpiceBalance -= change.amount
+    } else if (
+      isTxnChange(change)
+        ? change.token === 'CASH'
+        : change.contract.token === 'CASH'
+    ) {
+      currCashBalance -= change.amount
+    } else {
+      currManaBalance -= change.amount
+    }
+  }
   const balanceRunningTotals = [
     { mana: currManaBalance, cash: currCashBalance, spice: currSpiceBalance },
     ...balanceChanges.map((change) => {


### PR DESCRIPTION
- Adds limit and offset parameters to the `get-balance-changes` endpoint
- Limits the number of items loaded to 50 like many other tables on the site with previous/next buttons for pagination
- Keeps the date filter option but defaults to no filtering by date