### PR TITLE
feat: Add sort and filter options for "close to 50%"

### DIFF
--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -234,7 +234,7 @@ export function getSearchContractSQL(
     where(
       `
     exists (
-      select 1 from group_contracts gc 
+      select 1 from group_contracts gc
       where ${
         token === 'CASH'
           ? "gc.contract_id = contracts.data->>'siblingContractId'"
@@ -348,6 +348,7 @@ function getSearchContractWhereSQL(args: {
     'closing-90-days': `close_time > now() AND close_time < (now() + interval '90 days' + interval '7 hours') AND resolution_time IS NULL`,
     resolved: 'resolution_time IS NOT NULL',
     news: '', // News filter uses a different approach with a join
+    uncertain: `outcome_type = 'BINARY' AND resolution_time IS NULL AND (close_time > NOW() or close_time is null) AND (contracts.data->>'prob')::numeric BETWEEN 0.3 AND 0.7`,
     all: '',
   }
   const contractTypeFilter =
@@ -373,6 +374,8 @@ function getSearchContractWhereSQL(args: {
       ? 'close_time > NOW()'
       : sort === '24-hour-vol'
       ? "(contracts.data->>'volume24Hours')::numeric > 0"
+      : sort === 'prob-50'
+      ? "outcome_type = 'BINARY' AND (contracts.data->>'prob') is not null"
       : ''
   const creatorFilter = creatorId ? `creator_id = '${creatorId}'` : ''
   const visibilitySQL = getContractPrivacyWhereSQLFilter(
@@ -511,13 +514,19 @@ export const sortFields: SortFields = {
     order: 'DESC',
   },
   'prob-descending': {
-    sql: "resolution DESC, (contracts.data->>'p')::numeric",
-    sortCallback: (c: Contract) => ('p' in c && c.p) || 0,
+    sql: "resolution DESC, (contracts.data->>'prob')::numeric",
+    sortCallback: (c: Contract) => ('prob' in c && c.prob) || 0,
     order: 'DESC NULLS LAST',
   },
   'prob-ascending': {
-    sql: "resolution DESC, (contracts.data->>'p')::numeric",
-    sortCallback: (c: Contract) => ('p' in c && c.p) || 0,
+    sql: "resolution DESC, (contracts.data->>'prob')::numeric",
+    sortCallback: (c: Contract) => ('prob' in c && c.prob) || 0,
+    order: 'ASC',
+  },
+  'prob-50': {
+    sql: "abs((contracts.data->>'prob')::numeric - 0.5)",
+    sortCallback: (c: Contract) =>
+      Math.abs(((('prob' in c && c.prob) || 0) as number) - 0.5),
     order: 'ASC',
   },
 }

--- a/common/src/api/market-search-types.ts
+++ b/common/src/api/market-search-types.ts
@@ -17,6 +17,7 @@ export const searchProps = z
         z.literal('resolved'),
         z.literal('all'),
         z.literal('news'),
+        z.literal('uncertain'),
       ])
       .default('all'),
     sort: z
@@ -37,6 +38,7 @@ export const searchProps = z
         z.literal('bounty-amount'),
         z.literal('prob-descending'),
         z.literal('prob-ascending'),
+        z.literal('prob-50'),
       ])
       .default('score'),
     contractType: z

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -63,6 +63,7 @@ export const SORTS = [
   { label: 'Bounty amount', value: 'bounty-amount' },
   { label: 'High %', value: 'prob-descending' },
   { label: 'Low %', value: 'prob-ascending' },
+  { label: 'Mid 50%', value: 'prob-50' },
   { label: '🎲 Random!', value: 'random' },
 ] as const
 
@@ -78,12 +79,13 @@ export const predictionMarketSorts = new Set([
   'most-popular',
   'prob-descending',
   'prob-ascending',
+  'prob-50',
   'freshness-score',
 ])
 
 export const bountySorts = new Set(['bounty-amount'])
 
-const probSorts = new Set(['prob-descending', 'prob-ascending'])
+const probSorts = new Set(['prob-descending', 'prob-ascending', 'prob-50'])
 
 export const BOUNTY_MARKET_SORTS = SORTS.filter(
   (item) => !predictionMarketSorts.has(item.value)
@@ -112,6 +114,7 @@ export const FILTERS = [
   { label: 'Closed', value: 'closed' },
   { label: 'Resolved', value: 'resolved' },
   { label: 'Recently changed', value: 'news' },
+  { label: 'Uncertain', value: 'uncertain' },
 ] as const
 
 export type Filter = (typeof FILTERS)[number]['value']

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -63,7 +63,7 @@ export const SORTS = [
   { label: 'Bounty amount', value: 'bounty-amount' },
   { label: 'High %', value: 'prob-descending' },
   { label: 'Low %', value: 'prob-ascending' },
-  { label: 'Mid 50%', value: 'prob-50' },
+  { label: 'Mid %', value: 'prob-50' },
   { label: '🎲 Random!', value: 'random' },
 ] as const
 


### PR DESCRIPTION
- Adds a sort option called "Uncertain" which only shows binary markets with probabilities 30-70%
- Adds a filter option called "Mid %" which sorts binary markets by how close they are to 50%