### PR TITLE
feat: Show timezones for market close dates

### DIFF
--- a/client-common/src/lib/time.ts
+++ b/client-common/src/lib/time.ts
@@ -13,7 +13,26 @@ const FORMATTER = new Intl.DateTimeFormat('default', {
   timeStyle: 'medium',
 })
 
+const FORMATTER_WITH_TIMEZONE = new Intl.DateTimeFormat('default', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  timeZoneName: 'short',
+})
+
 export const formatTime = FORMATTER.format
+export const formatTimeWithTimezone = FORMATTER_WITH_TIMEZONE.format
+
+export function getLocalTimezoneShort() {
+  return new Intl.DateTimeFormat('default', {
+    timeZoneName: 'short',
+  })
+    .formatToParts(new Date())
+    .find((part) => part.type === 'timeZoneName')?.value
+}
 
 export function formatJustDateShort(time: number) {
   return dayjs(time).format('MMM D, YYYY')

--- a/web/components/contract/contract-details.tsx
+++ b/web/components/contract/contract-details.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 import { Row } from '../layout/row'
 import { Contract } from 'common/contract'
 import { DateTimeTooltip } from '../widgets/datetime-tooltip'
-import { fromNow } from 'client-common/lib/time'
+import { fromNow, getLocalTimezoneShort } from 'client-common/lib/time'
 import { useState } from 'react'
 import { Button } from 'web/components/buttons/button'
 import { Modal } from 'web/components/layout/modal'
@@ -199,6 +199,7 @@ export const EditCloseTimeModal = (props: {
     : undefined
 
   const isPoll = contract.outcomeType === 'POLL'
+  const timezone = getLocalTimezoneShort()
   const isCurrentlyOpen = (contract.closeTime ?? Date.now() + 1) > Date.now()
   const hasChanges = newCloseTime !== closeTime
 
@@ -280,6 +281,7 @@ export const EditCloseTimeModal = (props: {
                 at{' '}
                 <span className="text-ink-900 font-medium">
                   {dayjs(newCloseTime).format('h:mm A')}
+                  {timezone ? ` ${timezone}` : ''}
                 </span>
               </div>
             )}

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -1,4 +1,4 @@
-import { formatTime } from 'client-common/lib/time'
+import { formatTimeWithTimezone } from 'client-common/lib/time'
 import clsx from 'clsx'
 import { ELASTICITY_BET_AMOUNT } from 'common/calculate-metrics'
 import { Contract, contractPool } from 'common/contract'
@@ -144,7 +144,7 @@ export const Stats = (props: {
 
         <tr>
           <td>Question created</td>
-          <td>{formatTime(createdTime)}</td>
+          <td>{formatTimeWithTimezone(createdTime)}</td>
         </tr>
 
         {contract.outcomeType == 'BOUNTIED_QUESTION' && (
@@ -187,7 +187,7 @@ export const Stats = (props: {
                   dayjs(contract.createdTime).add(dayjs.duration(900, 'year'))
                 )
                   ? 'Never'
-                  : formatTime(closeTime)}
+                  : formatTimeWithTimezone(closeTime)}
               </td>
             </tr>
           )}
@@ -195,7 +195,7 @@ export const Stats = (props: {
         {resolutionTime && isBettingContract && (
           <tr>
             <td>Question resolved</td>
-            <td>{formatTime(resolutionTime)}</td>
+            <td>{formatTimeWithTimezone(resolutionTime)}</td>
           </tr>
         )}
 
@@ -627,13 +627,15 @@ function AdminHomePageScoreAdjustmentRows(props: {
               {hasActiveAdjustment ? (
                 <span>
                   {contract.homePageScoreAdjustment?.toFixed(3)}
-                  {hasValidExpiry ? ` until ${formatTime(expiresAt)}` : ''}
+                  {hasValidExpiry
+                    ? ` until ${formatTimeWithTimezone(expiresAt)}`
+                    : ''}
                 </span>
               ) : contract.homePageScoreAdjustment !== undefined ? (
                 <span>
                   {contract.homePageScoreAdjustment.toFixed(3)}
                   {hasValidExpiry
-                    ? ` (expired ${formatTime(expiresAt)})`
+                    ? ` (expired ${formatTimeWithTimezone(expiresAt)})`
                     : ' (expired)'}
                 </span>
               ) : (

--- a/web/components/new-contract/close-time-section.tsx
+++ b/web/components/new-contract/close-time-section.tsx
@@ -6,6 +6,7 @@ import { Row } from 'web/components/layout/row'
 import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
 import clsx from 'clsx'
 import { Input } from 'web/components/widgets/input'
+import { getLocalTimezoneShort } from 'client-common/lib/time'
 
 export const CloseTimeSection = (props: {
   closeDate: string | undefined
@@ -42,6 +43,7 @@ export const CloseTimeSection = (props: {
     setCloseDate(newCloseDate)
   }
 
+  const timezone = getLocalTimezoneShort()
   const NEVER = 'Never'
   if (outcomeType == 'POLL') {
     closeDateMap['Never'] = NEVER
@@ -57,7 +59,7 @@ export const CloseTimeSection = (props: {
           text={
             outcomeType == 'POLL'
               ? 'Voting on this poll will be halted and resolve to the most voted option'
-              : 'Trading will be halted after this time (local timezone).'
+              : `Trading will be halted at this time, you will then be able to resolve the market or extend the close date.`
           }
         />
       </label>
@@ -90,32 +92,39 @@ export const CloseTimeSection = (props: {
         />
       </Row>
       {!neverCloses && (
-        <Row className="mt-4 gap-2">
-          <Input
-            type={'date'}
-            className="dark:date-range-input-white"
-            onClick={(e) => e.stopPropagation()}
-            onChange={(e) => {
-              setCloseDate(e.target.value)
-              if (!closeHoursMinutes) {
-                setCloseHoursMinutes(initTime)
-              }
-            }}
-            min={dayjs().format('YYYY-MM-DD')}
-            max="9999-12-31"
-            disabled={submitState === 'LOADING'}
-            value={closeDate}
-          />
-          {/*<Input*/}
-          {/*  type={'time'}*/}
-          {/* className="dark:date-range-input-white"*/}
-          {/*  onClick={(e) => e.stopPropagation()}*/}
-          {/*  onChange={(e) => setCloseHoursMinutes(e.target.value)}*/}
-          {/*  min={'00:00'}*/}
-          {/*  disabled={isSubmitting}*/}
-          {/*  value={closeHoursMinutes}*/}
-          {/*/>*/}
-        </Row>
+        <Col className="mt-4 gap-2">
+          <Row className="flex-wrap items-center gap-2">
+            <Input
+              type={'date'}
+              className="dark:date-range-input-white"
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => {
+                setCloseDate(e.target.value)
+                if (!closeHoursMinutes) {
+                  setCloseHoursMinutes(initTime)
+                }
+              }}
+              min={dayjs().format('YYYY-MM-DD')}
+              max="9999-12-31"
+              disabled={submitState === 'LOADING'}
+              value={closeDate}
+            />
+            <Input
+              type={'time'}
+              className="dark:date-range-input-white"
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => setCloseHoursMinutes(e.target.value)}
+              min={'00:00'}
+              disabled={submitState === 'LOADING'}
+              value={closeHoursMinutes}
+            />
+          </Row>
+          {timezone && (
+            <span className="text-ink-500 px-1 text-xs">
+              Times are shown in your local timezone ({timezone}).
+            </span>
+          )}
+        </Col>
       )}
     </Col>
   )

--- a/web/components/new-contract/market-preview.tsx
+++ b/web/components/new-contract/market-preview.tsx
@@ -15,6 +15,7 @@ import { User } from 'common/user'
 import { formatMoney } from 'common/util/format'
 import { removeEmojis } from 'common/util/string'
 import dayjs from 'dayjs'
+import { getLocalTimezoneShort } from 'client-common/lib/time'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { VisibilityIcon } from 'web/components/contract/contracts-table'
 import { Col } from 'web/components/layout/col'
@@ -185,6 +186,7 @@ export function MarketPreview(props: {
     useState(false) // Could be used for loading indicator
   const questionTextareaRef = useRef<HTMLTextAreaElement>(null)
   const isMobile = useIsMobile()
+  const timezone = getLocalTimezoneShort()
 
   // Notify parent when topics modal opens/closes
   const handleSetTopicsModal = (open: boolean) => {
@@ -510,7 +512,11 @@ export function MarketPreview(props: {
                   className="text-ink-600 hover:text-ink-700 flex items-center gap-1 text-xs transition-colors"
                 >
                   <span>
-                    {closeDate
+                    {data.closeTime
+                      ? `${dayjs(data.closeTime).format('MMM D, YYYY h:mm A')}${
+                          timezone ? ` ${timezone}` : ''
+                        }`
+                      : closeDate
                       ? dayjs(closeDate).format('MMM D, YYYY')
                       : 'close date'}
                   </span>

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -1023,7 +1023,9 @@ export function NewContractPanel(props: {
     answers: formState.answers.map((text) => ({ text })),
     closeTime: formState.closeDate
       ? (() => {
-          const time = new Date(formState.closeDate + 'T23:59').getTime()
+          const time = new Date(
+            formState.closeDate + 'T' + (formState.closeHoursMinutes || '23:59')
+          ).getTime()
           return isNaN(time) ? undefined : time
         })()
       : undefined,

--- a/web/components/widgets/datetime-tooltip.tsx
+++ b/web/components/widgets/datetime-tooltip.tsx
@@ -1,6 +1,6 @@
 import { Placement } from '@floating-ui/react'
 import { ReactNode } from 'react'
-import { formatTime } from 'client-common/lib/time'
+import { formatTimeWithTimezone } from 'client-common/lib/time'
 import { Tooltip } from './tooltip'
 
 export function DateTimeTooltip(props: {
@@ -14,7 +14,7 @@ export function DateTimeTooltip(props: {
 }) {
   const { time, text, ...rest } = props
 
-  const formattedTime = formatTime(time)
+  const formattedTime = formatTimeWithTimezone(time)
   const toolTip = text ? `${text} ${formattedTime}` : formattedTime
 
   return (


### PR DESCRIPTION
Show short timezone in a few locations:

- Hovering over a market close time
- In the market info pane
- When creating a market

Also re-enables time entry in most cases when manually setting the close date while creating a market.

The intention here is to educate users that the timezones are set by their current location and clarify market closing times in particular.