### PR TITLE
feat: Allow custom colors for multiple choice answers

### DIFF
--- a/backend/api/src/edit-answer.ts
+++ b/backend/api/src/edit-answer.ts
@@ -16,7 +16,10 @@ const bodySchema = z
     contractId: z.string().max(MAX_ANSWER_LENGTH),
     answerId: z.string().max(MAX_ANSWER_LENGTH),
     text: z.string().min(1).max(MAX_ANSWER_LENGTH).optional(),
-    color: z.string().length(7).startsWith('#').optional(),
+    color: z
+      .string()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
   })
   .strict()
 
@@ -28,8 +31,7 @@ export const editanswercpmm = authEndpoint(async (req, auth) => {
   // Check for bans
   const user = await getUser(auth.uid)
   if (!user) throw new APIError(404, 'User not found')
-  if (user.userDeleted)
-    throw new APIError(403, 'Your account has been deleted')
+  if (user.userDeleted) throw new APIError(403, 'Your account has been deleted')
   const userBans = await getActiveUserBans(auth.uid)
   if (isUserBanned(userBans, 'marketControl') || user.isBannedFromPosting)
     throw new APIError(403, 'You are banned from editing answers')

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -347,7 +347,35 @@ export const EditAnswerModal = (props: {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const [text, setText] = useState(answer.text)
+  const [customHex, setCustomHex] = useState(color)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => setCustomHex(color), [color])
+
+  const saveColor = async (rawColor: string, close?: () => void) => {
+    const normalizedColor = rawColor.trim().startsWith('#')
+      ? rawColor.trim()
+      : `#${rawColor.trim()}`
+
+    if (!/^#[0-9a-fA-F]{6}$/.test(normalizedColor)) {
+      setError('Enter a valid 6-digit hex color, like #11b981.')
+      return
+    }
+
+    try {
+      await editAnswerCpmm({
+        answerId: answer.id,
+        contractId: contract.id,
+        color: normalizedColor,
+      })
+      setError(null)
+      close?.()
+    } catch (error) {
+      console.error(error)
+      setError('Error saving color')
+    }
+  }
+
   const editAnswer = async () => {
     if (isSubmitting) return
     setIsSubmitting(true)
@@ -400,22 +428,34 @@ export const EditAnswerModal = (props: {
             />
           )}
           dropdownMenuContent={(close) => (
-            <CirclePicker
-              className="w-[240px] py-2"
-              onChange={async (change) => {
-                try {
-                  await editAnswerCpmm({
-                    answerId: answer.id,
-                    contractId: contract.id,
-                    color: change.hex,
-                  })
-                } catch (error) {
-                  console.error(error)
-                } finally {
-                  close()
-                }
-              }}
-            />
+            <Col className="gap-2 p-2">
+              <CirclePicker
+                className="w-[240px]"
+                onChange={(change) => saveColor(change.hex, close)}
+              />
+              <Row className="border-ink-200 items-center gap-2 border-t pt-2">
+                <Input
+                  value={customHex}
+                  onChange={(e) => setCustomHex(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault()
+                      saveColor(customHex, close)
+                    }
+                  }}
+                  placeholder="#RRGGBB"
+                  className="!h-8 !px-2 font-mono text-xs"
+                  maxLength={7}
+                />
+                <Button
+                  size="2xs"
+                  color="gray-outline"
+                  onClick={() => saveColor(customHex, close)}
+                >
+                  Apply
+                </Button>
+              </Row>
+            </Col>
           )}
         />
 

--- a/web/components/answers/binary-multi-answers-panel.tsx
+++ b/web/components/answers/binary-multi-answers-panel.tsx
@@ -21,6 +21,7 @@ export function BinaryMultiAnswersPanel(props: {
 }) {
   const { feedReason, contract } = props
   const answers = contract.answers
+  const user = useUser()
 
   const [outcome, setOutcome] = useState<'YES' | 'NO' | undefined>(undefined)
 
@@ -52,7 +53,9 @@ export function BinaryMultiAnswersPanel(props: {
               setOutcome={setOutcome}
               key={answer.id}
               answer={answer}
+              contract={contract}
               color={getAnswerColor(answer)}
+              canEdit={!!canEditAnswer(answer, contract, user)}
             />
           ))}
         </div>
@@ -71,22 +74,25 @@ export function BinaryMultiAnswersPanel(props: {
 
 const BetButton = (props: {
   answer: Answer
+  contract: CPMMMultiContract
   outcome: 'YES' | 'NO'
   setOutcome: (outcome: 'YES' | 'NO') => void
   color?: string
   size?: SizeType
+  canEdit?: boolean
 }) => {
-  const { answer, size, outcome, setOutcome, color } = props
+  const { answer, contract, size, outcome, setOutcome, color, canEdit } = props
+  const [editing, setEditing] = useState(false)
 
   return (
-    <>
+    <div className="group relative flex flex-1">
       <Button
         size={size ?? 'xl'}
         color="none"
         aria-label={`Bet ${outcome} on ${answer.text}`}
         aria-haspopup="dialog"
         style={{ backgroundColor: color }}
-        className={'flex flex-1 items-center justify-between gap-1 text-white'}
+        className={'flex w-full items-center justify-between gap-1 text-white'}
         onClick={() => {
           // TODO: Twomba tracking bet terminology
           track('bet intent', { location: 'answer panel' })
@@ -98,7 +104,27 @@ const BetButton = (props: {
         </span>
         <span className={'text-xl'}>{formatPercent(answer.prob)}</span>
       </Button>
-    </>
+      {canEdit && (
+        <button
+          className="bg-canvas-0/80 hover:bg-canvas-0 absolute right-1 top-1 rounded p-1 opacity-80 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+          aria-label={`Edit answer ${answer.text}`}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setEditing(true)
+          }}
+        >
+          <PencilIcon className="text-primary-700 h-4 w-4" />
+        </button>
+      )}
+      <EditAnswerModal
+        open={editing}
+        setOpen={setEditing}
+        contract={contract}
+        answer={answer}
+        color={color ?? getAnswerColor(answer)}
+      />
+    </div>
   )
 }
 
@@ -117,6 +143,8 @@ function BinaryMultiChoiceBetPanel(props: {
   const canEdit = canEditAnswer(answer, contract, user)
   const mainAnswer = getMainBinaryMCAnswer(contract)!
   const otherAnswer = contract.answers.find((a) => a.id !== mainAnswer.id)!
+  const mainAnswerColor = getAnswerColor(mainAnswer) as `#${string}`
+  const otherAnswerColor = getAnswerColor(otherAnswer) as `#${string}`
   return (
     <BuyPanelBody
       contract={contract}
@@ -128,11 +156,11 @@ function BinaryMultiChoiceBetPanel(props: {
       pseudonym={{
         YES: {
           pseudonymName: mainAnswer.text,
-          pseudonymColor: 'azure',
+          pseudonymColor: mainAnswerColor,
         },
         NO: {
           pseudonymName: otherAnswer.text,
-          pseudonymColor: 'sienna',
+          pseudonymColor: otherAnswerColor,
         },
       }}
       outcome={outcome}

--- a/web/components/bet/bet-dialog.tsx
+++ b/web/components/bet/bet-dialog.tsx
@@ -19,7 +19,7 @@ import { BinaryMultiAnswersPanel } from 'web/components/answers/binary-multi-ans
 import { NumericBetPanel } from 'web/components/answers/numeric-bet-panel'
 import { Row } from 'web/components/layout/row'
 import { NumberResolutionOrExpectation } from 'web/components/contract/contract-price'
-import { sliderColors } from '../widgets/slider'
+import { SliderColor } from '../widgets/slider'
 import { getProbability } from 'common/calculate'
 import { formatPercent } from 'common/util/format'
 
@@ -32,11 +32,11 @@ export function BetDialog(props: {
   binaryPseudonym?: {
     YES: {
       pseudonymName: string
-      pseudonymColor: keyof typeof sliderColors
+      pseudonymColor: SliderColor
     }
     NO: {
       pseudonymName: string
-      pseudonymColor: keyof typeof sliderColors
+      pseudonymColor: SliderColor
     }
   }
   questionPseudonym?: string

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -65,7 +65,7 @@ import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 import { AmountInput, BuyAmountInput } from '../widgets/amount-input'
 import { ChoicesToggleGroup } from '../widgets/choices-toggle-group'
-import { sliderColors } from '../widgets/slider'
+import { SliderColor } from '../widgets/slider'
 import { Tooltip } from '../widgets/tooltip'
 import LimitOrderPanel from './limit-order-panel'
 import { MoneyDisplay } from './money-display'
@@ -91,11 +91,11 @@ type BuyPanelProps = {
   pseudonym?: {
     YES: {
       pseudonymName: string
-      pseudonymColor: keyof typeof sliderColors
+      pseudonymColor: SliderColor
     }
     NO: {
       pseudonymName: string
-      pseudonymColor: keyof typeof sliderColors
+      pseudonymColor: SliderColor
     }
   }
   children?: React.ReactNode

--- a/web/components/bet/bet-slider.tsx
+++ b/web/components/bet/bet-slider.tsx
@@ -1,6 +1,6 @@
 import { formatWithToken, InputTokenType } from 'common/util/format'
 import { BinaryOutcomes } from 'web/components/bet/bet-panel'
-import { Slider, sliderColors } from 'web/components/widgets/slider'
+import { Slider, SliderColor } from 'web/components/widgets/slider'
 
 export const LARGE_SLIDER_VALUES = [
   1, 25, 50, 75, 100, 150, 250, 350, 500, 750, 1000, 1250, 1500, 2000, 2500,
@@ -39,7 +39,7 @@ export const BetSlider = (props: {
   disabled?: boolean
   className?: string
   token?: InputTokenType
-  sliderColor?: keyof typeof sliderColors
+  sliderColor?: SliderColor
   ariaLabel?: string
 }) => {
   const {

--- a/web/components/bet/limit-order-panel.tsx
+++ b/web/components/bet/limit-order-panel.tsx
@@ -37,7 +37,7 @@ import { AmountInput, BuyAmountInput } from '../widgets/amount-input'
 import DropdownMenu from '../widgets/dropdown-menu'
 import { InfoTooltip } from '../widgets/info-tooltip'
 import { ProbabilitySlider } from '../widgets/probability-input'
-import { sliderColors } from '../widgets/slider'
+import { SliderColor } from '../widgets/slider'
 import { MoneyDisplay } from './money-display'
 import { ShareBetModal } from './share-bet'
 
@@ -66,11 +66,11 @@ export default function LimitOrderPanel(props: {
   pseudonym?: {
     YES: {
       pseudonymName: string
-      pseudonymColor: keyof typeof sliderColors
+      pseudonymColor: SliderColor
     }
     NO: {
       pseudonymName: string
-      pseudonymColor: keyof typeof sliderColors
+      pseudonymColor: SliderColor
     }
   }
   initialProb?: number

--- a/web/components/widgets/amount-input.tsx
+++ b/web/components/widgets/amount-input.tsx
@@ -15,7 +15,7 @@ import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 import { Input } from './input'
 import { LiveRegion } from './live-region'
-import { sliderColors } from './slider'
+import { SliderColor } from './slider'
 import { useCurrentPortfolio } from 'web/hooks/use-portfolio-history'
 import { buildArray } from 'common/util/array'
 
@@ -161,7 +161,7 @@ export function BuyAmountInput(props: {
   quickButtonAmountSize?: 'large' | 'small'
   disableQuickButtons?: boolean
   token?: InputTokenType
-  sliderColor?: keyof typeof sliderColors
+  sliderColor?: SliderColor
   fieldLabel?: string
 }) {
   const {

--- a/web/components/widgets/probability-input.tsx
+++ b/web/components/widgets/probability-input.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 
 import { Col } from '../layout/col'
 import { Input } from './input'
-import { Slider, sliderColors } from './slider'
+import { Slider, SliderColor } from './slider'
 export const PROBABILITY_SLIDER_VALUES = Array.from(
   { length: 99 },
   (_, i) => i + 1
@@ -15,7 +15,7 @@ export function ProbabilitySlider(props: {
   onProbChange: (newProb: number | undefined) => void
   disabled?: boolean
   className?: string
-  color?: keyof typeof sliderColors
+  color?: SliderColor
   outcome?: 'YES' | 'NO'
 }) {
   const { prob, onProbChange, disabled, className, outcome } = props

--- a/web/components/widgets/slider.tsx
+++ b/web/components/widgets/slider.tsx
@@ -20,6 +20,8 @@ export const sliderColors = {
   ],
   // light: ['primary-200', 'primary-300']
 } as const
+
+export type SliderColor = keyof typeof sliderColors | `#${string}`
 export type Mark = { value: number; label: string }
 
 export function Slider(props: {
@@ -29,7 +31,7 @@ export function Slider(props: {
   max?: number
   step?: number
   marks?: Mark[]
-  color?: keyof typeof sliderColors
+  color?: SliderColor
   className?: string
   disabled?: boolean
   inverted?: boolean
@@ -53,7 +55,10 @@ export function Slider(props: {
     ariaValueText,
   } = props
 
-  const [trackClasses, thumbClasses] = sliderColors[color]
+  const isCustomColor = color.startsWith('#')
+  const [trackClasses, thumbClasses] = isCustomColor
+    ? ['', '']
+    : sliderColors[color as keyof typeof sliderColors]
 
   return (
     <RxSlider.Root
@@ -72,7 +77,10 @@ export function Slider(props: {
       disabled={disabled}
       inverted={inverted}
     >
-      <Track className={trackClasses}>
+      <Track
+        className={trackClasses}
+        rangeStyle={isCustomColor ? { backgroundColor: color } : undefined}
+      >
         <div className="absolute left-2.5 right-2.5 h-full">
           {marks?.map(({ value, label }) => (
             <div
@@ -91,6 +99,12 @@ export function Slider(props: {
                     : 'bg-ink-400',
                   'h-2 w-2 rounded-full'
                 )}
+                style={
+                  isCustomColor &&
+                  (fillToRight ? amount <= value : amount >= value)
+                    ? { backgroundColor: color }
+                    : undefined
+                }
               />
               <span className="text-ink-400 absolute left-1/2 top-4 -translate-x-1/2 text-xs">
                 {label}
@@ -99,7 +113,10 @@ export function Slider(props: {
           ))}
         </div>
       </Track>
-      <Thumb className={thumbClasses} />
+      <Thumb
+        className={thumbClasses}
+        style={isCustomColor ? { backgroundColor: color } : undefined}
+      />
     </RxSlider.Root>
   )
 }
@@ -166,23 +183,29 @@ export function RangeSlider(props: {
   )
 }
 
-const Track = (props: { className: string; children?: ReactNode }) => {
-  const { className, children } = props
+const Track = (props: {
+  className: string
+  children?: ReactNode
+  rangeStyle?: React.CSSProperties
+}) => {
+  const { className, children, rangeStyle } = props
   return (
     <RxSlider.Track className="bg-ink-300 relative h-1 grow rounded-full">
       {children}
       <RxSlider.Range
         className={clsx(className, 'absolute h-full rounded-full')}
+        style={rangeStyle}
       />
     </RxSlider.Track>
   )
 }
 
-const Thumb = (props: { className: string }) => (
+const Thumb = (props: { className: string; style?: React.CSSProperties }) => (
   <RxSlider.Thumb
     className={clsx(
       props.className,
       'block h-5 w-5 cursor-col-resize rounded-full outline outline-4 outline-transparent transition-colors'
     )}
+    style={props.style}
   />
 )


### PR DESCRIPTION
- Adds a custom hex code color input for multiple choice answers
- Adds an edit button to the special two-answer multiple choice markets with the same inputs
- Checks the value when submitting through the API against `/^#[0-9a-fA-F]{6}$/`