### PR TITLE
fix: Speed up prize page loading by limiting leaderboard and geofence queries

### DIFF
--- a/backend/api/src/get-sweepstakes.ts
+++ b/backend/api/src/get-sweepstakes.ts
@@ -8,6 +8,8 @@ import {
   SWEEPSTAKES_MIN_MANA_INVESTED,
 } from 'common/sweepstakes'
 
+const TOP_PARTICIPANTS_LIMIT = 100
+
 export const getSweepstakes: APIHandler<'get-sweepstakes'> = async (
   props,
   auth
@@ -28,8 +30,8 @@ export const getSweepstakes: APIHandler<'get-sweepstakes'> = async (
   }>(
     sweepstakesNum
       ? `SELECT * FROM sweepstakes WHERE sweepstakes_num = $1`
-      : `SELECT * FROM sweepstakes 
-         ORDER BY 
+      : `SELECT * FROM sweepstakes
+         ORDER BY
            CASE WHEN close_time > NOW() THEN 0 ELSE 1 END,
            close_time DESC
          LIMIT 1`,
@@ -37,30 +39,50 @@ export const getSweepstakes: APIHandler<'get-sweepstakes'> = async (
   )
 
   if (!sweepstakes) {
-    return { userStats: [], totalTickets: 0 }
+    return {
+      userStats: [],
+      totalTickets: 0,
+      totalManaSpent: 0,
+      participantCount: 0,
+    }
   }
 
-  // Get ticket stats per user for this sweepstakes
+  const totals = await pg.one<{
+    total_tickets: string
+    total_mana_spent: string
+    participant_count: number
+  }>(
+    `SELECT
+       COALESCE(SUM(num_tickets), 0) as total_tickets,
+       COALESCE(SUM(mana_spent), 0) as total_mana_spent,
+       COUNT(DISTINCT user_id)::int as participant_count
+     FROM sweepstakes_tickets
+     WHERE sweepstakes_num = $1`,
+    [sweepstakes.sweepstakes_num]
+  )
+
+  // Only the top participants are needed for the distribution chart. Returning
+  // every participant can make /prize slow as old drawings accumulate entries.
   const userStats = await pg.manyOrNone<{
     user_id: string
     total_tickets: string
     total_mana_spent: string
   }>(
-    `SELECT 
+    `SELECT
        user_id,
        SUM(num_tickets) as total_tickets,
        SUM(mana_spent) as total_mana_spent
      FROM sweepstakes_tickets
      WHERE sweepstakes_num = $1
      GROUP BY user_id
-     ORDER BY total_tickets DESC`,
-    [sweepstakes.sweepstakes_num]
+     ORDER BY total_tickets DESC
+     LIMIT $2`,
+    [sweepstakes.sweepstakes_num, TOP_PARTICIPANTS_LIMIT]
   )
 
-  const totalTickets = userStats.reduce(
-    (sum, s) => sum + parseFloat(s.total_tickets),
-    0
-  )
+  const totalTickets = parseFloat(totals.total_tickets)
+  const totalManaSpent = parseFloat(totals.total_mana_spent)
+  const participantCount = totals.participant_count
 
   // If there are winning tickets, get the winner details
   let winners: SweepstakesWinner[] | undefined
@@ -72,10 +94,9 @@ export const getSweepstakes: APIHandler<'get-sweepstakes'> = async (
     const winningTickets = await pg.manyOrNone<{
       id: string
       user_id: string
-    }>(
-      `SELECT id, user_id FROM sweepstakes_tickets WHERE id = ANY($1)`,
-      [sweepstakes.winning_ticket_ids]
-    )
+    }>(`SELECT id, user_id FROM sweepstakes_tickets WHERE id = ANY($1)`, [
+      sweepstakes.winning_ticket_ids,
+    ])
 
     // Create a map for quick lookup
     const ticketMap = new Map(winningTickets.map((t) => [t.id, t]))
@@ -129,6 +150,25 @@ export const getSweepstakes: APIHandler<'get-sweepstakes'> = async (
   let meetsInvestmentRequirement: boolean | undefined
 
   if (auth) {
+    const userInTopStats = userStats.some((s) => s.user_id === auth.uid)
+    if (!userInTopStats) {
+      const currentUserStats = await pg.oneOrNone<{
+        user_id: string
+        total_tickets: string
+        total_mana_spent: string
+      }>(
+        `SELECT
+           user_id,
+           SUM(num_tickets) as total_tickets,
+           SUM(mana_spent) as total_mana_spent
+         FROM sweepstakes_tickets
+         WHERE sweepstakes_num = $1 AND user_id = $2
+         GROUP BY user_id`,
+        [sweepstakes.sweepstakes_num, auth.uid]
+      )
+      if (currentUserStats) userStats.push(currentUserStats)
+    }
+
     const freeTicket = await pg.oneOrNone(
       `SELECT 1 FROM sweepstakes_free_tickets WHERE sweepstakes_num = $1 AND user_id = $2`,
       [sweepstakes.sweepstakes_num, auth.uid]
@@ -162,6 +202,8 @@ export const getSweepstakes: APIHandler<'get-sweepstakes'> = async (
       totalManaSpent: parseFloat(s.total_mana_spent),
     })),
     totalTickets,
+    totalManaSpent,
+    participantCount,
     winners,
     // Provably fair: nonce contains the Bitcoin block hash used for winner selection
     // Only revealed AFTER winners are selected. Users verify by finding first block after closeTime.

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -3419,6 +3419,8 @@ export const API = (_apiTypeCheck = {
         totalManaSpent: number
       }[]
       totalTickets: number
+      totalManaSpent?: number
+      participantCount?: number
       winners?: {
         rank: number
         label: string
@@ -3639,12 +3641,7 @@ export const API = (_apiTypeCheck = {
         claimId: z.string().optional(),
         sweepstakesNum: z.number().int().optional(),
         userId: z.string().optional(),
-        paymentStatus: z.enum([
-          'awaiting',
-          'sent',
-          'rejected',
-          'opted_out',
-        ]),
+        paymentStatus: z.enum(['awaiting', 'sent', 'rejected', 'opted_out']),
         paymentTxnHash: z.string().optional(),
       })
       .strict()

--- a/web/pages/prize.tsx
+++ b/web/pages/prize.tsx
@@ -165,7 +165,8 @@ export default function SweepstakesPage({
   const meetsInvestmentRequirement = data?.meetsInvestmentRequirement ?? true
   const userTotalManaInvested = data?.userTotalManaInvested ?? 0
   const minManaInvested = data?.minManaInvested ?? 1000
-  const totalManaSpent = userStats.reduce((sum, s) => sum + s.totalManaSpent, 0)
+  const totalManaSpent = data?.totalManaSpent ?? 0
+  const participantCount = data?.participantCount ?? userStats.length
 
   // Calculate time remaining
   const [timeRemaining, setTimeRemaining] = useState<string>('')
@@ -542,6 +543,7 @@ export default function SweepstakesPage({
             totalTickets={totalTickets}
             hoveredUserId={hoveredUserId}
             onHoverUser={setHoveredUserId}
+            participantCount={participantCount}
             myEntries={
               user
                 ? userStats.find((s) => s.userId === user.id)?.totalTickets
@@ -1108,10 +1110,17 @@ function UserDistributionChart(props: {
   totalTickets: number
   hoveredUserId: string | null
   onHoverUser: (userId: string | null) => void
+  participantCount: number
   myEntries?: number
 }) {
-  const { userStats, totalTickets, hoveredUserId, onHoverUser, myEntries } =
-    props
+  const {
+    userStats,
+    totalTickets,
+    hoveredUserId,
+    onHoverUser,
+    participantCount,
+    myEntries,
+  } = props
 
   if (userStats.length === 0) {
     return (
@@ -1236,9 +1245,9 @@ function UserDistributionChart(props: {
                 />
               )
             })}
-            {segments.length > 8 && (
+            {participantCount > 8 && (
               <div className="text-ink-400 px-3 py-1 text-xs">
-                +{userStats.length - 8} more
+                +{participantCount - 8} more
               </div>
             )}
           </Col>

--- a/web/pages/prize.tsx
+++ b/web/pages/prize.tsx
@@ -76,9 +76,13 @@ export const getSweepstakesServerSideProps: GetServerSideProps<
 
   try {
     const fields = 'status,message,countryCode,region'
+    // Set a timeout here to prevent a slow API response from stalling the page load during SSR
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 1500)
     const response = await fetch(
-      `https://pro.ip-api.com/json/${ip}?key=${apiKey}&fields=${fields}`
-    )
+      `https://pro.ip-api.com/json/${ip}?key=${apiKey}&fields=${fields}`,
+      { signal: controller.signal }
+    ).finally(() => clearTimeout(timeout))
     const geo: GeoLocationResult = await response.json()
     const { allowed } = checkSweepstakesGeofence(geo)
 


### PR DESCRIPTION
- Limits the maximum users fetched for the leaderboard to prevent loading data for hundreds of users
- Aggregates all other information that was previously calculated during SSR with raw participant data
- Sets a timeout on the geofence API lookup call, if this fails we assume the user is eligible temporarily and then double-check at purchase time