### PR TITLE
fix: Correct UI inconsistencies in 2-answer MC markets

### DIFF
--- a/web/components/answers/binary-multi-answers-panel.tsx
+++ b/web/components/answers/binary-multi-answers-panel.tsx
@@ -171,10 +171,10 @@ function BinaryMultiChoiceBetPanel(props: {
       className="bg-canvas-50"
     >
       <Row className="items-baseline justify-between">
-        <div className={'group mr-6 text-2xl'}>
-          {answer.text}
+        <Row className={'group mr-6 items-center gap-2 text-2xl'}>
+          <span>{answer.text}</span>
           {canEdit && user && (
-            <div>
+            <>
               <Button
                 color="gray-white"
                 aria-label={`Edit answer ${answer.text}`}
@@ -191,9 +191,9 @@ function BinaryMultiChoiceBetPanel(props: {
                 answer={answer}
                 color={color}
               />
-            </div>
+            </>
           )}
-        </div>
+        </Row>
         <span className="text-2xl">{formatPercent(answer.prob)}</span>
       </Row>
     </BuyPanelBody>

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -1044,12 +1044,18 @@ export const BuyPanelBody = (
               contract,
               lastBetDetails.outcome as 'YES' | 'NO'
             )}
-            answer={multiProps?.answerToBuy.text}
-            avgPrice={formatPercent(
-              lastBetDetails.outcome === 'YES'
-                ? lastBetDetails.amount / lastBetDetails.shares
-                : 1 - lastBetDetails.amount / lastBetDetails.shares
-            )}
+            answer={
+              isBinaryMC ? multiProps?.answerText : multiProps?.answerToBuy.text
+            }
+            avgPrice={
+              lastBetDetails.limitProb !== undefined
+                ? formatPercent(lastBetDetails.limitProb)
+                : formatPercent(
+                    lastBetDetails.outcome === 'YES'
+                      ? lastBetDetails.amount / lastBetDetails.shares
+                      : 1 - lastBetDetails.amount / lastBetDetails.shares
+                  )
+            }
             betAmount={lastBetDetails.amount}
             winAmount={lastBetDetails.shares}
             bettor={{

--- a/web/components/bet/contract-bets-table.tsx
+++ b/web/components/bet/contract-bets-table.tsx
@@ -26,7 +26,7 @@ import { formatTimeShort } from 'client-common/lib/time'
 import { Pagination } from '../widgets/pagination'
 import { MoneyDisplay } from './money-display'
 import { ContractMetric } from 'common/contract-metric'
-import { getPseudonym } from '../charts/contract/choice'
+import { getAnswerColor, getPseudonym } from '../charts/contract/choice'
 import { DateTimeTooltip } from '../widgets/datetime-tooltip'
 
 export function ContractBetsTable(props: {
@@ -208,6 +208,17 @@ function BetRow(props: { bet: Bet; contract: Contract }) {
 
   const isCashContract = contract.token === 'CASH'
   const sharesOrShortSellShares = Math.abs(shares)
+  const binaryMCAnswer =
+    isBinaryMC && contract.mechanism === 'cpmm-multi-1'
+      ? (() => {
+          const answer =
+            contract.answers.find((a) => a.id === bet.answerId) ??
+            contract.answers[0]
+          return outcome === 'YES'
+            ? answer
+            : contract.answers.find((a) => a.id !== answer.id)
+        })()
+      : undefined
   return (
     <tr>
       {(isCPMM || isCpmmMulti) && (
@@ -219,12 +230,18 @@ function BetRow(props: { bet: Bet; contract: Contract }) {
         </td>
       )}
       <td className="font-medium">
-        <OutcomeLabel
-          pseudonym={getPseudonym(contract)}
-          outcome={outcome}
-          contract={contract}
-          truncate="short"
-        />
+        {binaryMCAnswer ? (
+          <span style={{ color: getAnswerColor(binaryMCAnswer) }}>
+            {binaryMCAnswer.text}
+          </span>
+        ) : (
+          <OutcomeLabel
+            pseudonym={getPseudonym(contract)}
+            outcome={outcome}
+            contract={contract}
+            truncate="short"
+          />
+        )}
       </td>
       <td className="text-right font-medium tabular-nums">
         <MoneyDisplay
@@ -262,8 +279,6 @@ function BetRow(props: { bet: Bet; contract: Contract }) {
               <span>{formatPercent(probAfter)}</span>
             </span>
           )
-        ) : isBinaryMC ? (
-          formatPercent(getBinaryMCProb(bet.limitProb ?? 0, outcome))
         ) : (
           formatPercent(bet.limitProb ?? 0)
         )}

--- a/web/components/contract/user-positions-table.tsx
+++ b/web/components/contract/user-positions-table.tsx
@@ -43,7 +43,7 @@ import TriangleDownFillIcon from 'web/lib/icons/triangle-down-fill-icon.svg'
 import { track } from 'web/lib/service/analytics'
 import { db } from 'web/lib/supabase/db'
 import { MoneyDisplay } from '../bet/money-display'
-import { getPseudonym } from '../charts/contract/choice'
+import { getAnswerColor, getPseudonym } from '../charts/contract/choice'
 import { RelativeTimestamp } from '../relative-timestamp'
 import { Select } from '../widgets/select'
 
@@ -483,6 +483,10 @@ const BinaryUserPositionsTable = memo(
     const isStonk = contract.outcomeType === 'STONK'
     const isPseudoNumeric = contract.outcomeType === 'PSEUDO_NUMERIC'
     const mainBinaryMCAnswer = getMainBinaryMCAnswer(contract)
+    const otherBinaryMCAnswer =
+      isBinaryMulti(contract) && contract.mechanism === 'cpmm-multi-1'
+        ? contract.answers.find((a) => a.id !== mainBinaryMCAnswer?.id)
+        : undefined
     const getPositionsTitle = (outcome: 'YES' | 'NO') => {
       return outcome === 'YES' ? (
         <span>
@@ -576,9 +580,14 @@ const BinaryUserPositionsTable = memo(
                       key={position.userId + outcome}
                       position={position}
                       colorClassName={
-                        isBinaryMulti(contract)
-                          ? 'text-indigo-500'
-                          : 'text-teal-500'
+                        sortBy === 'profit' || !isBinaryMulti(contract)
+                          ? 'text-teal-500'
+                          : undefined
+                      }
+                      color={
+                        sortBy === 'shares' && isBinaryMulti(contract)
+                          ? getAnswerColor(mainBinaryMCAnswer)
+                          : undefined
                       }
                       currentUser={currentUser}
                       followedUsers={followedUsers}
@@ -629,9 +638,14 @@ const BinaryUserPositionsTable = memo(
                       key={position.userId + outcome}
                       position={position}
                       colorClassName={
-                        isBinaryMulti(contract)
-                          ? 'text-amber-600'
-                          : 'text-scarlet-600'
+                        sortBy === 'profit' || !isBinaryMulti(contract)
+                          ? 'text-scarlet-600'
+                          : undefined
+                      }
+                      color={
+                        sortBy === 'shares' && isBinaryMulti(contract)
+                          ? getAnswerColor(otherBinaryMCAnswer)
+                          : undefined
                       }
                       currentUser={currentUser}
                       followedUsers={followedUsers}
@@ -683,7 +697,8 @@ const PositionRow = memo(function PositionRow(props: {
   invested: number
   currentUser: User | undefined | null
   followedUsers: string[] | undefined
-  colorClassName: string
+  colorClassName?: string
+  color?: string
   isCashContract: boolean
   setGraphUser?: (user: DisplayUser | undefined) => void
   setHideGraph?: (hide: boolean) => void
@@ -691,6 +706,7 @@ const PositionRow = memo(function PositionRow(props: {
   const {
     position,
     colorClassName,
+    color,
     currentUser,
     followedUsers,
     numberToShow,
@@ -772,7 +788,10 @@ const PositionRow = memo(function PositionRow(props: {
           </Row>
         </div>
         <Col>
-          <span className={clsx(colorClassName, 'shrink-0', 'text-right')}>
+          <span
+            className={clsx(colorClassName, 'shrink-0', 'text-right')}
+            style={color ? { color } : undefined}
+          >
             {numberToShow}
           </span>
           {invested > -99999999 && invested < 9999999999 && (

--- a/web/components/feed/feed-bets.tsx
+++ b/web/components/feed/feed-bets.tsx
@@ -42,7 +42,7 @@ import { api } from 'web/lib/api/api'
 import { track } from 'web/lib/service/analytics'
 import { MoneyDisplay } from '../bet/money-display'
 import { ShareBetModal } from '../bet/share-bet'
-import { getPseudonym } from '../charts/contract/choice'
+import { getAnswerColor, getPseudonym } from '../charts/contract/choice'
 import { UserHovercard } from '../user/user-hovercard'
 import { InfoTooltip } from '../widgets/info-tooltip'
 import { DisplayContext } from 'common/shop/display-config'
@@ -56,6 +56,42 @@ const getAnswerFromContract = (contract: Contract, answerId?: string) =>
   contract.mechanism === 'cpmm-multi-1' && answerId && 'answers' in contract
     ? contract.answers?.find((answer) => answer.id === answerId)
     : undefined
+
+const getBinaryMCAnswerForBet = (
+  contract: Contract,
+  answerId: string | undefined,
+  outcome: string
+) => {
+  if (!isBinaryMulti(contract) || contract.mechanism !== 'cpmm-multi-1') {
+    return undefined
+  }
+
+  const answer =
+    getAnswerFromContract(contract, answerId) ?? contract.answers[0]
+  if (outcome === 'YES') return answer
+
+  return contract.answers.find((a) => a.id !== answer.id)
+}
+
+const getBinaryMCPseudonymForBet = (
+  contract: Contract,
+  answerId: string | undefined,
+  outcome: string
+):
+  | {
+      YES: { pseudonymName: string; pseudonymColor: string }
+      NO: { pseudonymName: string; pseudonymColor: string }
+    }
+  | undefined => {
+  const answer = getBinaryMCAnswerForBet(contract, answerId, outcome)
+  if (!answer) return getPseudonym(contract)
+
+  const pseudonym = {
+    pseudonymName: answer.text,
+    pseudonymColor: getAnswerColor(answer),
+  }
+  return { YES: pseudonym, NO: pseudonym }
+}
 
 function BetTooltipContent(props: {
   bet: Bet
@@ -142,7 +178,11 @@ function BetTooltipContent(props: {
           Order: {isOrderSale ? 'Sell ' : ''}
           {formatAmount(Math.abs(bet.orderAmount))}{' '}
           <OutcomeLabel
-            pseudonym={getPseudonym(contract)}
+            pseudonym={getBinaryMCPseudonymForBet(
+              contract,
+              answerId,
+              bet.outcome
+            )}
             outcome={bet.outcome}
             answer={answer}
             contract={contract}
@@ -292,7 +332,7 @@ function BetActionText(props: { bet: Bet; contract: Contract }) {
         </>
       )}
       <OutcomeLabel
-        pseudonym={getPseudonym(contract)}
+        pseudonym={getBinaryMCPseudonymForBet(contract, answerId, outcome)}
         outcome={outcome}
         answer={answer}
         contract={contract}
@@ -315,11 +355,11 @@ function BetDetailsText(props: { bet: Bet; contract: Contract }) {
 
   const probBefore = getProb(bet.probBefore)
   const probAfter = getProb(bet.probAfter)
-  const limitProb =
-    bet.limitProb === undefined || !isBinaryMulti(contract)
-      ? bet.limitProb
-      : getBinaryMCProb(bet.limitProb, outcome)
-  const hadPoolMatch = bet.fills?.length ?? false
+  const limitProb = bet.limitProb
+  const hadPoolMatch =
+    (bet.limitProb === undefined ||
+      bet.fills?.some((fill) => fill.matchedBetId === null)) ??
+    false
 
   const fromProb = hadPoolMatch
     ? getFormattedMappedValue(contract, probBefore)
@@ -701,10 +741,7 @@ export function BetStatusText(props: {
 
   const probBefore = getProb(bet.probBefore)
   const probAfter = getProb(bet.probAfter)
-  const limitProb =
-    bet.limitProb === undefined || !isBinaryMulti(contract)
-      ? bet.limitProb
-      : getBinaryMCProb(bet.limitProb, outcome)
+  const limitProb = bet.limitProb
   const bought = amount >= 0 ? 'bought' : 'sold'
   const absAmount = Math.abs(amount)
   const money = (
@@ -719,7 +756,10 @@ export function BetStatusText(props: {
     ) : null
   const anyFilled = limitOrderStatus.hasAnyFill
 
-  const hadPoolMatch = bet.fills?.length ?? false
+  const hadPoolMatch =
+    (bet.limitProb === undefined ||
+      bet.fills?.some((fill) => fill.matchedBetId === null)) ??
+    false
 
   const fromProb = hadPoolMatch
     ? getFormattedMappedValue(contract, probBefore)
@@ -767,7 +807,7 @@ export function BetStatusText(props: {
             <>placed order for {orderAmount}</>
           )}{' '}
           <OutcomeLabel
-            pseudonym={getPseudonym(contract)}
+            pseudonym={getBinaryMCPseudonymForBet(contract, answerId, outcome)}
             outcome={outcome}
             answer={answer}
             contract={contract}
@@ -784,7 +824,7 @@ export function BetStatusText(props: {
           {orderAmount ? '/' : ''}
           {orderAmount}{' '}
           <OutcomeLabel
-            pseudonym={getPseudonym(contract)}
+            pseudonym={getBinaryMCPseudonymForBet(contract, answerId, outcome)}
             outcome={outcome}
             answer={answer}
             contract={contract}
@@ -810,6 +850,11 @@ function BetActions(props: {
   const user = useUser()
   const [isSharing, setIsSharing] = useState(false)
   const bettor = useDisplayUserById(bet.userId)
+  const shareAnswer = isBinaryMulti(contract)
+    ? getBinaryMCAnswerForBet(contract, bet.answerId, bet.outcome)?.text
+    : contract.mechanism === 'cpmm-multi-1'
+    ? contract.answers?.find((a) => a.id === bet.answerId)?.text
+    : undefined
 
   return (
     <Row className="shrink-0 items-center gap-0.5 sm:gap-1">
@@ -906,6 +951,11 @@ function BetActionsWithGraph(props: {
   } = props
   const currentUser = useUser()
   const [isSharing, setIsSharing] = useState(false)
+  const shareAnswer = isBinaryMulti(contract)
+    ? getBinaryMCAnswerForBet(contract, bet.answerId, bet.outcome)?.text
+    : contract.mechanism === 'cpmm-multi-1'
+    ? contract.answers?.find((a) => a.id === bet.answerId)?.text
+    : undefined
 
   const handleGraphTrades = () => {
     if (!bettor) return


### PR DESCRIPTION
- Use correct limit order percent for NO side bets
- Show correct answer name on trade table for NO side bets
- Move answer edit pencil to side of answer text instead of underneath
- Use custom colors on position table, green/red on profit