### PR TITLE
feat: load MCP postgres connection strings from GCP Secret Manager

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "postgres-dev": {
+      "command": "node",
+      "args": ["./scripts/mcp-postgres.js", "dev-mantic-markets", "mcp-postgres-conn"]
+    },
+    "postgres-prod": {
+      "command": "node",
+      "args": ["./scripts/mcp-postgres.js", "mantic-markets", "mcp-postgres-conn"]
+    }
+  }
+}

--- a/scripts/mcp-postgres.js
+++ b/scripts/mcp-postgres.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+const { execSync, spawn } = require('child_process')
+
+const [, , project, secret] = process.argv
+if (!project || !secret) {
+  console.error('usage: mcp-postgres.js <gcp-project> <secret-name>')
+  process.exit(2)
+}
+
+let conn
+try {
+  conn = execSync(
+    `gcloud secrets versions access latest --secret=${secret} --project=${project}`,
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] }
+  ).trim()
+} catch (err) {
+  console.error(`failed to fetch secret ${secret} from ${project}`)
+  process.exit(1)
+}
+
+const child = spawn(
+  'npx',
+  ['-y', '@modelcontextprotocol/server-postgres', conn],
+  { stdio: 'inherit', shell: true }
+)
+child.on('exit', (code) => process.exit(code ?? 1))


### PR DESCRIPTION
Replaces inline credentials in .mcp.json with a Node wrapper that fetches them from GCP Secret Manager at MCP server startup. Lets the team share access via IAM (per-secret accessor grants) instead of distributing a file with credentials.

- scripts/mcp-postgres.js: shells out to gcloud, then execs npx
- .mcp.json: invokes the wrapper for postgres-dev and postgres-prod