### PR TITLE
fix: split referral payout into M250 first-bet + M1000 verify

### DIFF
--- a/backend/api/src/get-referral-earnings.ts
+++ b/backend/api/src/get-referral-earnings.ts
@@ -1,0 +1,60 @@
+import { APIHandler } from 'api/helpers/endpoint'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+
+export const getReferralEarnings: APIHandler<'get-referral-earnings'> = async (
+  _props,
+  auth
+) => {
+  const pg = createSupabaseDirectClient()
+  // Hits the (category, to_id) index on txns; GROUP BY is cheap because the
+  // result set is bounded by this user's referral count.
+  // referredUserId / referralMultiplier / bonusType are nested at data->'data'
+  // (legacy double-wrapping in txnToRow). One row per (referredUser, bonusType)
+  // pair, so the frontend can tell apart "M250 first_bet only — verify still
+  // possible" vs "M1250 fully paid".
+  const rows = await pg.manyOrNone<{
+    referred_user_id: string | null
+    bonus_type: 'first_bet' | 'verify' | null
+    amount_sum: string
+    max_multiplier: string | null
+  }>(
+    `select data->'data'->>'referredUserId' as referred_user_id,
+            data->'data'->>'bonusType' as bonus_type,
+            sum(amount)::bigint as amount_sum,
+            max((data->'data'->>'referralMultiplier')::numeric) as max_multiplier
+     from txns
+     where to_id = $1
+       and category = 'REFERRAL'
+     group by data->'data'->>'referredUserId',
+              data->'data'->>'bonusType'`,
+    [auth.uid]
+  )
+
+  type Entry = {
+    amount: number
+    maxMultiplier: number
+    bonusTypes: ('first_bet' | 'verify' | 'legacy')[]
+  }
+  const byReferredUserId: Record<string, Entry> = {}
+  let total = 0
+  for (const row of rows) {
+    const amount = Number(row.amount_sum)
+    total += amount
+    if (!row.referred_user_id) continue
+    const entry = (byReferredUserId[row.referred_user_id] ??= {
+      amount: 0,
+      maxMultiplier: 1,
+      bonusTypes: [],
+    })
+    entry.amount += amount
+    if (row.max_multiplier) {
+      entry.maxMultiplier = Math.max(
+        entry.maxMultiplier,
+        Number(row.max_multiplier)
+      )
+    }
+    const type = row.bonus_type ?? 'legacy'
+    if (!entry.bonusTypes.includes(type)) entry.bonusTypes.push(type)
+  }
+  return { total, byReferredUserId }
+}

--- a/backend/api/src/idenfy/callback.ts
+++ b/backend/api/src/idenfy/callback.ts
@@ -5,7 +5,8 @@ import { updateUser } from 'shared/supabase/users'
 import { getUser, log, getContractSupabase } from 'shared/utils'
 import { broadcastUpdatedPrivateUser } from 'shared/websockets/helpers'
 import { runTxnFromBank } from 'shared/txn/run-txn'
-import { STARTING_BALANCE, REFERRAL_AMOUNT } from 'common/economy'
+import { runTransactionWithRetries } from 'shared/transact-with-retries'
+import { STARTING_BALANCE, REFERRAL_VERIFY_BONUS } from 'common/economy'
 import { SignupBonusTxn } from 'common/txn'
 import { canReceiveBonuses } from 'common/user'
 import { createReferralNotification } from 'shared/create-notification'
@@ -281,7 +282,12 @@ export const idenfyCallback = async (req: Request, res: Response) => {
         ? await getContractSupabase(user.referredByContractId)
         : undefined
       
-      const { referralBonusAmount } = await pg.tx(async (tx) => {
+      // SERIALIZABLE isolation + retry: protects the signup-bonus and
+      // referral-verify dedupe SELECTs against concurrent iDenfy webhook
+      // retries (timeouts trigger retries, and the same scanRef can arrive
+      // multiple times). Without this, two concurrent callbacks could both
+      // miss the dedup and double-pay.
+      const { referralBonusAmount } = await runTransactionWithRetries(async (tx) => {
         // Update bonus eligibility
         await updateUser(tx, userId, { bonusEligibility: 'verified' })
         
@@ -309,19 +315,24 @@ export const idenfyCallback = async (req: Request, res: Response) => {
           log(`Paid signup bonus of ${STARTING_BALANCE} to user ${userId} after identity verification`)
         }
         
-        // Pay referral bonus if:
-        // 1. User was referred by someone
+        // Pay the verify portion of the referral bonus if:
+        // 1. User was referred by someone (not themselves)
         // 2. Referrer can receive bonuses (verified or grandfathered)
-        // 3. Referral bonus hasn't already been paid for this user
-        if (referrerId && referrer && canReceiveBonuses(referrer)) {
-          // Check if referral bonus was already paid
+        // 3. Verify bonus hasn't already been paid for this user
+        // The first-bet portion is paid separately in on-create-bet.ts.
+        if (referrerId === userId) {
+          log(`Skipped referral verify bonus - self-referral for ${userId}`)
+        } else if (referrerId && referrer && canReceiveBonuses(referrer)) {
+          // Legacy single-payment REFERRAL txns (data.bonusType IS NULL) already
+          // covered the full bonus, so they block the new verify payout too.
           const existingReferralTxn = await tx.oneOrNone(
             `SELECT 1 FROM txns WHERE to_id = $1
              AND category = 'REFERRAL'
-             AND data->>'referredUserId' = $2`,
+             AND data->'data'->>'referredUserId' = $2
+             AND (data->'data'->>'bonusType' IS NULL OR data->'data'->>'bonusType' = 'verify')`,
             [referrer.id, userId]
           )
-          
+
           if (!existingReferralTxn) {
             // Fetch referrer's supporter entitlements for bonus multiplier
             const supporterEntitlementRows = await tx.manyOrNone(
@@ -332,14 +343,14 @@ export const idenfyCallback = async (req: Request, res: Response) => {
                AND (expires_time IS NULL OR expires_time > NOW())`,
               [referrer.id, SUPPORTER_ENTITLEMENT_IDS]
             )
-            
+
             // Convert to UserEntitlement format for getBenefit
             const entitlements = supporterEntitlementRows.map(convertEntitlement)
-            
+
             // Get tier-specific referral multiplier (1x for non-supporters)
             const referralMultiplier = getBenefit(entitlements, 'referralMultiplier')
-            const referralAmount = Math.floor(REFERRAL_AMOUNT * referralMultiplier)
-            
+            const referralAmount = Math.floor(REFERRAL_VERIFY_BONUS * referralMultiplier)
+
             const txnData = {
               fromType: 'BANK',
               toId: referrer.id,
@@ -347,23 +358,24 @@ export const idenfyCallback = async (req: Request, res: Response) => {
               amount: referralAmount,
               token: 'M$',
               category: 'REFERRAL',
-              description: `Referred new user id: ${userId} for ${referralAmount}`,
+              description: `Referral verify bonus for new user ${userId}: ${referralAmount}`,
               data: removeUndefinedProps({
                 referredUserId: userId,
                 referredContractId: referredByContract?.id,
+                bonusType: 'verify',
                 supporterBonus: referralMultiplier > 1,
                 referralMultiplier,
               }),
             } as const
-            
+
             await runTxnFromBank(tx, txnData)
-            log(`Paid referral bonus of ${referralAmount} to referrer ${referrer.id} for verified user ${userId}`)
+            log(`Paid referral verify bonus of ${referralAmount} to referrer ${referrer.id} for verified user ${userId}`)
             return { referralBonusAmount: referralAmount }
           }
         } else if (referrer && !canReceiveBonuses(referrer)) {
-          log(`Skipped referral bonus for referrer ${referrer.id} - not eligible for bonuses`)
+          log(`Skipped referral verify bonus for referrer ${referrer.id} - not eligible for bonuses`)
         }
-        
+
         return { referralBonusAmount: null }
       })
       
@@ -373,7 +385,8 @@ export const idenfyCallback = async (req: Request, res: Response) => {
           referrer.id,
           user,
           referralBonusAmount.toString(),
-          referredByContract ?? undefined
+          referredByContract ?? undefined,
+          'verify'
         )
       }
     }

--- a/backend/api/src/on-create-bet.ts
+++ b/backend/api/src/on-create-bet.ts
@@ -2,6 +2,7 @@ import {
   log,
   revalidateContractStaticProps,
   getContract,
+  getUser,
   getUsers,
 } from 'shared/utils'
 import { Bet, LimitBet } from 'common/bet'
@@ -16,11 +17,13 @@ import {
   createFollowSuggestionNotification,
   createLimitBetCanceledNotification,
   createNewBettorNotification,
+  createReferralNotification,
 } from 'shared/create-notification'
 import {
   createSupabaseDirectClient,
   SupabaseDirectClient,
 } from 'shared/supabase/init'
+import { runTransactionWithRetries } from 'shared/transact-with-retries'
 import { addToLeagueIfNotInOne } from 'shared/generate-leagues'
 import { getCommentSafe } from 'shared/supabase/contract-comments'
 import { getBetsRepliedToComment } from 'shared/supabase/bets'
@@ -29,10 +32,15 @@ import {
   BETTING_STREAK_BONUS_AMOUNT,
   BETTING_STREAK_BONUS_MAX,
   MAX_TRADERS_FOR_BIG_BONUS,
+  REFERRAL_BET_BONUS,
   SMALL_UNIQUE_BETTOR_LIQUIDITY,
   UNIQUE_BETTOR_LIQUIDITY,
 } from 'common/economy'
-import { BettingStreakBonusTxn, UniqueBettorBonusTxn } from 'common/txn'
+import {
+  BettingStreakBonusTxn,
+  ReferralTxn,
+  UniqueBettorBonusTxn,
+} from 'common/txn'
 import { getBenefit } from 'common/supporter-config'
 import { getActiveSupporterEntitlements } from 'shared/supabase/entitlements'
 import { runTxnFromBank } from 'shared/txn/run-txn'
@@ -190,6 +198,9 @@ export const onCreateBets = async (result: ExecuteNewBetResult) => {
         contract,
         pg
       )),
+    !originalBettor.lastBetTime &&
+      originalBettor.referredByUserId &&
+      (await payReferralBetBonus(originalBettor)),
     streakIncremented &&
       (await payBettingStreak(originalBettor, earliestBet, contract)),
     replyBet &&
@@ -206,6 +217,81 @@ export const onCreateBets = async (result: ExecuteNewBetResult) => {
       ),
     addToLeagueIfNotInOne(pg, originalBettor.id),
   ])
+}
+
+// Pays the referrer the first-bet portion (REFERRAL_BET_BONUS) when the
+// referred user places their very first bet. The remaining verify portion
+// is paid in idenfy/callback.ts when the user completes ID verification.
+const payReferralBetBonus = async (referredUser: User) => {
+  const referrerId = referredUser.referredByUserId
+  if (!referrerId) return
+  if (referrerId === referredUser.id) {
+    log(`Skipped referral first-bet bonus - self-referral for ${referredUser.id}`)
+    return
+  }
+
+  const referrer = await getUser(referrerId)
+  if (!referrer) return
+  if (!canReceiveBonuses(referrer)) {
+    log(
+      `Skipped referral first-bet bonus for referrer ${referrerId} - not eligible for bonuses`
+    )
+    return
+  }
+
+  // SERIALIZABLE isolation + retry: protects the dedupe SELECT against
+  // concurrent first-bet calls (e.g. two tabs, parallel API requests) that
+  // would otherwise both miss the dedup and double-pay. Matches the pattern
+  // used in refer-user.ts and runTransactionWithRetries.
+  const result = await runTransactionWithRetries(async (tx) => {
+    // Dedupe against any prior REFERRAL payout for this referred user:
+    // - legacy single-payment txns (no bonusType) covered the full bonus
+    // - explicit 'first_bet' txns from this code path
+    const existing = await tx.oneOrNone(
+      `SELECT 1 FROM txns WHERE to_id = $1
+       AND category = 'REFERRAL'
+       AND data->'data'->>'referredUserId' = $2
+       AND (data->'data'->>'bonusType' IS NULL OR data->'data'->>'bonusType' = 'first_bet')`,
+      [referrer.id, referredUser.id]
+    )
+    if (existing) return null
+
+    const entitlements = await getActiveSupporterEntitlements(tx, referrer.id)
+    const referralMultiplier = getBenefit(entitlements, 'referralMultiplier')
+    const amount = Math.floor(REFERRAL_BET_BONUS * referralMultiplier)
+
+    const bonusTxn: Omit<ReferralTxn, 'id' | 'createdTime' | 'fromId'> = {
+      fromType: 'BANK',
+      toId: referrer.id,
+      toType: 'USER',
+      amount,
+      token: 'M$',
+      category: 'REFERRAL',
+      description: `Referral first-bet bonus for new user ${referredUser.id}: ${amount}`,
+      data: {
+        referredUserId: referredUser.id,
+        referredContractId: referredUser.referredByContractId,
+        bonusType: 'first_bet',
+        supporterBonus: referralMultiplier > 1,
+        referralMultiplier,
+      },
+    }
+    await runTxnFromBank(tx, bonusTxn)
+    log(
+      `Paid referral first-bet bonus of ${amount} to ${referrer.id} for ${referredUser.id}`
+    )
+    return amount
+  })
+
+  if (result) {
+    await createReferralNotification(
+      referrer.id,
+      referredUser,
+      result.toString(),
+      undefined,
+      'first_bet'
+    )
+  }
 }
 
 const debounceRevalidateContractStaticProps = (contract: Contract) => {

--- a/backend/api/src/refer-user.ts
+++ b/backend/api/src/refer-user.ts
@@ -24,6 +24,9 @@ export const referUser: APIHandler<'refer-user'> = async (props, auth) => {
   if (!referredByUser) {
     throw new APIError(404, `User ${referredByUsername} not found`)
   }
+  if (referredByUser.id === auth.uid) {
+    throw new APIError(400, `Cannot refer yourself`)
+  }
   if (referredByUser.isBannedFromPosting) {
     throw new APIError(
       404,

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -263,6 +263,7 @@ import {
 } from './pending-clarifications'
 import { purchaseContractBoost } from './purchase-boost'
 import { referUser } from './refer-user'
+import { getReferralEarnings } from './get-referral-earnings'
 import { cancelMerchOrder } from './cancel-merch-order'
 import { getMerchOrders } from './get-merch-orders'
 import { getMerchStockStatus } from './get-merch-stock-status'
@@ -490,6 +491,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'generate-concise-title': generateConciseTitle,
   'get-close-date': getCloseDateEndpoint,
   'refer-user': referUser,
+  'get-referral-earnings': getReferralEarnings,
   'create-post-comment': createPostComment,
   'create-post': createPost,
   'update-post': updatePost,

--- a/backend/scripts/backfill-referral-bonuses.ts
+++ b/backend/scripts/backfill-referral-bonuses.ts
@@ -1,0 +1,190 @@
+// One-shot backfill for the referral payout gap introduced on 2026-04-08 by PR
+// #3747 (Prize drawing). The pipeline was changed so the referral bonus only
+// fires on iDenfy verification, but `canSetReferrer` was simultaneously gated
+// on `canReceiveBonuses`, which blocks brand-new users — so most referrals
+// since then never got attributed and even the ones that did never got paid.
+//
+// This script pays:
+//  - REFERRAL_BET_BONUS to the referrer for every user with referredByUserId
+//    set who has placed at least one bet, if no first-bet/legacy REFERRAL txn
+//    already exists for that referrer/referredUser pair.
+//  - REFERRAL_VERIFY_BONUS to the referrer for every such user who is also
+//    bonus-eligible (verified or grandfathered), if no verify/legacy REFERRAL
+//    txn already exists.
+// Referrer must be bonus-eligible in both cases. Supporter multiplier is
+// applied using the referrer's current entitlements.
+
+import { runScript } from 'run-script'
+import { runTxnFromBank } from 'shared/txn/run-txn'
+import { getActiveSupporterEntitlements } from 'shared/supabase/entitlements'
+import { getBenefit } from 'common/supporter-config'
+import { canReceiveBonuses, User } from 'common/user'
+import { convertUser } from 'common/supabase/users'
+import {
+  REFERRAL_BET_BONUS,
+  REFERRAL_VERIFY_BONUS,
+} from 'common/economy'
+import { ReferralTxn } from 'common/txn'
+import { createReferralNotification } from 'shared/create-notification'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+type BonusType = 'first_bet' | 'verify'
+
+const DRY_RUN = process.env.DRY_RUN !== 'false'
+
+// PR #3747 (Prize drawing) shipped 2026-04-08 17:46 PT and broke referral
+// attribution + payouts. Scope the backfill to users signed up from a few
+// days before that deploy through today so we don't accidentally pay out
+// historical referrals that were skipped for unrelated reasons (referrer
+// banned at the time, deleted accounts, etc.) and have since become eligible.
+const BUG_WINDOW_START = process.env.BUG_WINDOW_START ?? '2026-04-01'
+
+if (require.main === module) {
+  runScript(async ({ pg }) => {
+    if (DRY_RUN) {
+      console.log('DRY_RUN=true — no txns will be written. Set DRY_RUN=false to apply.')
+    }
+    console.log(`Scoped to users with created_time >= ${BUG_WINDOW_START}`)
+
+    const referredUsers = await pg.map(
+      `SELECT * FROM users
+       WHERE data->>'referredByUserId' IS NOT NULL
+       AND created_time >= $1`,
+      [BUG_WINDOW_START],
+      (row) => convertUser(row)
+    )
+    console.log(`Found ${referredUsers.length} users with a referredByUserId in window`)
+
+    let firstBetPaid = 0
+    let verifyPaid = 0
+    let firstBetTotalMana = 0
+    let verifyTotalMana = 0
+    let skipped = 0
+
+    for (const user of referredUsers) {
+      const referrerId = user.referredByUserId
+      if (!referrerId) continue
+      if (referrerId === user.id) {
+        skipped++
+        continue
+      }
+
+      const referrer = await pg.oneOrNone(
+        `SELECT * FROM users WHERE id = $1`,
+        [referrerId],
+        (row) => (row ? convertUser(row) : null)
+      )
+      if (!referrer) {
+        skipped++
+        continue
+      }
+      if (!canReceiveBonuses(referrer)) {
+        skipped++
+        continue
+      }
+
+      const existingTxns = await pg.manyOrNone<{ bonus_type: string | null }>(
+        `SELECT data->'data'->>'bonusType' AS bonus_type
+         FROM txns
+         WHERE to_id = $1
+         AND category = 'REFERRAL'
+         AND data->'data'->>'referredUserId' = $2`,
+        [referrer.id, user.id]
+      )
+
+      const hasLegacy = existingTxns.some((t) => t.bonus_type == null)
+      const hasFirstBet =
+        hasLegacy || existingTxns.some((t) => t.bonus_type === 'first_bet')
+      const hasVerify =
+        hasLegacy || existingTxns.some((t) => t.bonus_type === 'verify')
+
+      const userHasBet = !!user.lastBetTime
+      const userIsVerified = canReceiveBonuses(user)
+
+      if (!hasFirstBet && userHasBet) {
+        const amount = await payBonus(pg, referrer, user, 'first_bet')
+        if (amount > 0) {
+          firstBetPaid++
+          firstBetTotalMana += amount
+        }
+      }
+      if (!hasVerify && userIsVerified) {
+        const amount = await payBonus(pg, referrer, user, 'verify')
+        if (amount > 0) {
+          verifyPaid++
+          verifyTotalMana += amount
+        }
+      }
+    }
+
+    console.log(
+      `Done. first_bet payouts: ${firstBetPaid} (M${firstBetTotalMana} total), ` +
+        `verify payouts: ${verifyPaid} (M${verifyTotalMana} total), ` +
+        `skipped (no referrer or referrer ineligible): ${skipped}`
+    )
+    if (DRY_RUN) console.log('DRY_RUN was on — nothing was actually written.')
+  })
+}
+
+async function payBonus(
+  pg: SupabaseDirectClient,
+  referrer: User,
+  referredUser: User,
+  bonusType: BonusType
+): Promise<number> {
+  const baseAmount =
+    bonusType === 'first_bet' ? REFERRAL_BET_BONUS : REFERRAL_VERIFY_BONUS
+
+  if (DRY_RUN) {
+    console.log(
+      `[dry-run] would pay ${baseAmount} (${bonusType}) to ${referrer.username} for ${referredUser.username}`
+    )
+    return baseAmount
+  }
+
+  return pg.tx(async (tx) => {
+    // Re-check inside txn to avoid double-pay if script is run twice.
+    const dup = await tx.oneOrNone(
+      `SELECT 1 FROM txns WHERE to_id = $1
+       AND category = 'REFERRAL'
+       AND data->'data'->>'referredUserId' = $2
+       AND (data->'data'->>'bonusType' IS NULL OR data->'data'->>'bonusType' = $3)`,
+      [referrer.id, referredUser.id, bonusType]
+    )
+    if (dup) return 0
+
+    const entitlements = await getActiveSupporterEntitlements(tx, referrer.id)
+    const multiplier = getBenefit(entitlements, 'referralMultiplier')
+    const amount = Math.floor(baseAmount * multiplier)
+
+    const txn: Omit<ReferralTxn, 'id' | 'createdTime' | 'fromId'> = {
+      fromType: 'BANK',
+      toId: referrer.id,
+      toType: 'USER',
+      amount,
+      token: 'M$',
+      category: 'REFERRAL',
+      description: `Referral ${bonusType} bonus (backfill) for new user ${referredUser.id}: ${amount}`,
+      data: {
+        referredUserId: referredUser.id,
+        referredContractId: referredUser.referredByContractId,
+        bonusType,
+        backfill: true,
+        supporterBonus: multiplier > 1,
+        referralMultiplier: multiplier,
+      },
+    }
+    await runTxnFromBank(tx, txn)
+    console.log(
+      `Paid ${amount} (${bonusType}) to ${referrer.username} for ${referredUser.username}`
+    )
+    await createReferralNotification(
+      referrer.id,
+      referredUser,
+      amount.toString(),
+      undefined,
+      bonusType
+    )
+    return amount
+  })
+}

--- a/backend/shared/src/create-notification.ts
+++ b/backend/shared/src/create-notification.ts
@@ -306,7 +306,12 @@ export const createReferralNotification = async (
   toUserId: string,
   referredUser: User,
   bonusAmount: string,
-  referredByContract?: Contract
+  referredByContract?: Contract,
+  // Suffix the notification id so the split payout (first_bet + verify) emits
+  // two notifications instead of having the second silently dropped by the
+  // ON CONFLICT DO NOTHING insert. Defaults to 'legacy' so existing callers
+  // and backfilled rows keep their stable id.
+  bonusType: 'first_bet' | 'verify' | 'legacy' = 'legacy'
 ) => {
   const privateUser = await getPrivateUser(toUserId)
   if (!privateUser) return
@@ -317,7 +322,7 @@ export const createReferralNotification = async (
   if (!sendToBrowser) return
 
   const notification: Notification = {
-    id: referredUser.id + '-signup-referral-bonus',
+    id: `${referredUser.id}-signup-referral-bonus-${bonusType}`,
     userId: toUserId,
     reason:
       referredByContract?.creatorId === toUserId

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -2901,6 +2901,26 @@ export const API = (_apiTypeCheck = {
       .strict(),
     returns: {} as { success: boolean },
   },
+  'get-referral-earnings': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({}).strict(),
+    returns: {} as {
+      total: number
+      byReferredUserId: Record<
+        string,
+        {
+          amount: number
+          maxMultiplier: number
+          // Which bonus types this referrer has been paid for this referred
+          // user. 'first_bet'/'verify' are the new split; 'legacy' means a
+          // pre-split single-payment txn exists (treated as fully paid).
+          bonusTypes: ('first_bet' | 'verify' | 'legacy')[]
+        }
+      >
+    },
+  },
 
   'save-market-draft': {
     method: 'POST',

--- a/common/src/economy.ts
+++ b/common/src/economy.ts
@@ -44,7 +44,12 @@ export const STARTING_BALANCE = 1000
 export const SUS_STARTING_BALANCE = 10
 export const PHONE_VERIFICATION_BONUS = 1000
 
-export const REFERRAL_AMOUNT = 1_000
+// Referral payout is split: M250 when the referred user places their first bet,
+// M1000 when they complete identity verification.
+export const REFERRAL_BET_BONUS = 250
+export const REFERRAL_VERIFY_BONUS = 1000
+// Total a referrer can earn per referred user across both events.
+export const REFERRAL_AMOUNT = REFERRAL_BET_BONUS + REFERRAL_VERIFY_BONUS
 
 const TRADER_BONUS_PROMO_MULTIPLIER = 2
 const uniqueBettorBonusAmounts = [3, 10, 15, 20].map(

--- a/web/lib/firebase/users.ts
+++ b/web/lib/firebase/users.ts
@@ -1,10 +1,5 @@
 import { Contract } from 'common/contract'
-import {
-  canReceiveBonuses,
-  MINUTES_ALLOWED_TO_REFER,
-  PrivateUser,
-  User,
-} from 'common/user'
+import { MINUTES_ALLOWED_TO_REFER, PrivateUser, User } from 'common/user'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import {
@@ -143,8 +138,11 @@ export const isContractBlocked = (
 }
 
 export const canSetReferrer = (user: User) => {
+  // Attribution must happen at signup so the referrer can be paid later when
+  // the referred user bets or verifies. Don't gate on bonus eligibility here:
+  // brand-new users haven't completed iDenfy yet, but we still want to record
+  // who referred them. The bonus payout itself is gated separately.
   if (user.referredByUserId) return false
-  if (!canReceiveBonuses(user)) return false
   const now = dayjs().utc()
   const userCreatedTime = dayjs(user.createdTime)
   return now.diff(userCreatedTime, 'minute') < MINUTES_ALLOWED_TO_REFER

--- a/web/pages/referrals.tsx
+++ b/web/pages/referrals.tsx
@@ -7,7 +7,11 @@ import { redirectIfLoggedOut } from 'web/lib/firebase/server-auth'
 import { CopyLinkRow } from 'web/components/buttons/copy-link-button'
 import { ENV_CONFIG } from 'common/envs/constants'
 import { QRCode } from 'web/components/widgets/qr-code'
-import { REFERRAL_AMOUNT } from 'common/economy'
+import {
+  REFERRAL_AMOUNT,
+  REFERRAL_BET_BONUS,
+  REFERRAL_VERIFY_BONUS,
+} from 'common/economy'
 import { formatMoney } from 'common/util/format'
 import { TokenNumber } from 'web/components/widgets/token-number'
 import { referralQuery } from 'common/util/share'
@@ -24,6 +28,8 @@ import { DisplayUser } from 'common/api/user-types'
 import { Avatar } from 'web/components/widgets/avatar'
 import { UserLink } from 'web/components/widgets/user-link'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import { useAPIGetter } from 'web/hooks/use-api-getter'
+import { Tooltip } from 'web/components/widgets/tooltip'
 
 export const getServerSideProps = redirectIfLoggedOut('/')
 
@@ -39,19 +45,33 @@ export default function ReferralsPage() {
     }
   }, [user?.id])
 
+  const { data: earnings } = useAPIGetter(
+    'get-referral-earnings',
+    user ? {} : undefined
+  )
+
   const url = `https://${ENV_CONFIG.domain}${referralQuery(
     user?.username ?? ''
   )}`
 
   const referralCount = referredUsers?.length ?? 0
+  const totalEarned = earnings?.total ?? 0
+  const earnedByUserId: Record<
+    string,
+    {
+      amount: number
+      maxMultiplier: number
+      bonusTypes: ('first_bet' | 'verify' | 'legacy')[]
+    }
+  > = earnings?.byReferredUserId ?? {}
 
   return (
     <Page trackPageView={'referrals'} className="p-3">
       <SEO
         title="Refer a friend"
-        description={`Invite new users to Manifold and get ${formatMoney(
+        description={`Invite new users to Manifold and earn up to ${formatMoney(
           REFERRAL_AMOUNT
-        )} if they sign up and place a trade!`}
+        )} per friend who signs up, places a trade, and verifies their identity.`}
         url="/referrals"
       />
 
@@ -73,9 +93,13 @@ export default function ReferralsPage() {
             <p className="mb-6 max-w-md text-white/90">
               Invite friends to join Manifold and earn{' '}
               <span className="font-semibold text-white">
-                {formatMoney(REFERRAL_AMOUNT)}
+                {formatMoney(REFERRAL_BET_BONUS)}
               </span>{' '}
-              for each friend who signs up and places their first trade.
+              when they place their first trade, plus{' '}
+              <span className="font-semibold text-white">
+                {formatMoney(REFERRAL_VERIFY_BONUS)}
+              </span>{' '}
+              when they verify their identity.
             </p>
 
             {/* Stats row */}
@@ -88,7 +112,7 @@ export default function ReferralsPage() {
               </div>
               <div className="bg-white/15 rounded-xl px-4 py-3 backdrop-blur-sm">
                 <div className="text-2xl font-bold">
-                  {formatMoney(referralCount * REFERRAL_AMOUNT)}
+                  {formatMoney(totalEarned)}
                 </div>
                 <div className="text-sm text-white/80">Total earned</div>
               </div>
@@ -143,7 +167,16 @@ export default function ReferralsPage() {
             <HowItWorksStep
               number={3}
               title="They place a trade"
-              description="Once they make their first prediction, you both get rewarded!"
+              description={`Earn ${formatMoney(
+                REFERRAL_BET_BONUS
+              )} the moment they make their first prediction.`}
+            />
+            <HowItWorksStep
+              number={4}
+              title="They verify their identity"
+              description={`Earn another ${formatMoney(
+                REFERRAL_VERIFY_BONUS
+              )} when they complete identity verification.`}
             />
           </div>
         </div>
@@ -185,7 +218,10 @@ export default function ReferralsPage() {
           ) : referredUsers.length === 0 ? (
             <EmptyReferralsState />
           ) : (
-            <ReferralsList users={referredUsers} />
+            <ReferralsList
+              users={referredUsers}
+              earnedByUserId={earnedByUserId}
+            />
           )}
         </div>
       </Col>
@@ -226,33 +262,91 @@ function EmptyReferralsState() {
   )
 }
 
-function ReferralsList(props: { users: DisplayUser[] }) {
-  const { users } = props
+function ReferralsList(props: {
+  users: DisplayUser[]
+  earnedByUserId: Record<
+    string,
+    {
+      amount: number
+      maxMultiplier: number
+      bonusTypes: ('first_bet' | 'verify' | 'legacy')[]
+    }
+  >
+}) {
+  const { users, earnedByUserId } = props
   return (
     <Col className="divide-ink-100 dark:divide-ink-300 -mx-2 max-h-64 divide-y overflow-y-auto">
-      {users.map((user) => (
-        <Row
-          key={user.id}
-          className="hover:bg-canvas-50 items-center gap-3 rounded-lg px-2 py-3 transition-colors"
-        >
-          <Avatar
-            username={user.username}
-            avatarUrl={user.avatarUrl}
-            size="sm"
-          />
-          <Col className="min-w-0 flex-1">
-            <UserLink user={user} className="font-medium" />
-            <span className="text-ink-500 text-xs">@{user.username}</span>
-          </Col>
-          <div className="text-ink-500 flex-shrink-0 text-xs">
-            <TokenNumber
-              coinType="MANA"
-              amount={REFERRAL_AMOUNT}
-              className="text-teal-600"
+      {users.map((user) => {
+        const entry = earnedByUserId[user.id]
+        const amount = entry?.amount ?? 0
+        const multiplier = entry?.maxMultiplier ?? 1
+        const bonusTypes = entry?.bonusTypes ?? []
+        // Verify portion is still claimable if we've ONLY paid the first-bet
+        // bonus and never a verify or legacy txn for this referred user.
+        const verifyPending =
+          amount > 0 &&
+          bonusTypes.includes('first_bet') &&
+          !bonusTypes.includes('verify') &&
+          !bonusTypes.includes('legacy')
+        return (
+          <Row
+            key={user.id}
+            className="hover:bg-canvas-50 items-center gap-3 rounded-lg px-2 py-3 transition-colors"
+          >
+            <Avatar
+              username={user.username}
+              avatarUrl={user.avatarUrl}
+              size="sm"
             />
-          </div>
-        </Row>
-      ))}
+            <Col className="min-w-0 flex-1">
+              <UserLink user={user} className="font-medium" />
+              <span className="text-ink-500 text-xs">@{user.username}</span>
+            </Col>
+            <Row className="flex-shrink-0 items-center justify-end gap-1.5 text-xs">
+              {verifyPending && (
+                <Tooltip
+                  text={`First-trade bonus paid. They haven't verified their identity yet — you'll earn ${formatMoney(
+                    REFERRAL_VERIFY_BONUS
+                  )} more when they do.`}
+                >
+                  <span className="cursor-default rounded-full bg-indigo-100 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                    Verify pending
+                  </span>
+                </Tooltip>
+              )}
+              {amount > 0 && multiplier > 1 && (
+                <Tooltip
+                  text={`Boosted by your supporter membership at payout time (${multiplier}× referral multiplier).`}
+                >
+                  <span className="cursor-default rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                    {multiplier}×
+                  </span>
+                </Tooltip>
+              )}
+              {amount === 0 && (
+                <Tooltip text="They haven't placed a trade or verified their identity yet — no referral bonus has been paid for them.">
+                  <span className="bg-ink-100 text-ink-500 dark:bg-ink-800 dark:text-ink-400 cursor-default rounded-full px-1.5 py-0.5 text-[10px] font-semibold">
+                    ?
+                  </span>
+                </Tooltip>
+              )}
+              <div className="w-20">
+                {amount > 0 ? (
+                  <div className="text-right">
+                    <TokenNumber
+                      coinType="MANA"
+                      amount={amount}
+                      className="text-teal-600"
+                    />
+                  </div>
+                ) : (
+                  <span className="text-ink-400 italic">Pending</span>
+                )}
+              </div>
+            </Row>
+          </Row>
+        )
+      })}
     </Col>
   )
 }


### PR DESCRIPTION
PR #3747 (Apr 8) broke referral attribution by gating canSetReferrer on canReceiveBonuses, which blocked signup-time attribution — so no new referrals have been paying since the deploy.

This branch restores attribution at signup and splits the payout into two events so referrers get something quickly even if the new user never completes iDenfy verification:

- M250 paid on the referred user's first non-API bet (on-create-bet.ts)
- M1000 paid on iDenfy approval (idenfy/callback.ts)

Both payment sites:
- block self-referral (also blocked upstream in refer-user.ts)
- wrap dedupe + insert in runTransactionWithRetries (SERIAL_MODE + retry-on-40001) so two-tab and webhook-retry races can't double-pay
- use data->'data'->>'referredUserId' (correct nested path; the old dedupe queries used data->>'referredUserId' which never matched anything — silently broken since the original refactor)
- tag txns with data.bonusType = 'first_bet' | 'verify' so the two legs can be dedup'd independently and legacy single-payment txns still block both new payouts

Adds get-referral-earnings endpoint that returns total + per-user breakdown (amount, maxMultiplier, bonusTypes[]). Referrals page now shows actual amounts paid per referral plus badges:
- Verify pending (indigo) when first-bet paid but verify still open
- N× boost (amber) when supporter multiplier was applied
- ? (grey) for zero / not-yet-earned

Notification IDs suffixed by bonusType so both legs emit a separate notification instead of the second being eaten by ON CONFLICT DO NOTHING.

backfill-referral-bonuses.ts (one-shot) covers users whose referrals fell through the bug. Scoped to created_time >= BUG_WINDOW_START (default 2026-04-01), DRY_RUN=true by default, idempotent on re-run.