### PR TITLE
feat: Increase freeze cap per tier

### DIFF
--- a/common/src/supporter-config.ts
+++ b/common/src/supporter-config.ts
@@ -90,7 +90,7 @@ export const SUPPORTER_BENEFITS: Record<
     questMultiplier: 1.5,
     referralMultiplier: 1,
     shopDiscount: 0,
-    maxStreakFreezes: 2, // +1 over non-supporter
+    maxStreakFreezes: 5,
     badgeAnimation: false,
     freeLoanRate: 0.01, // 1% (same as free users)
     marginLoanAccess: true,
@@ -100,7 +100,7 @@ export const SUPPORTER_BENEFITS: Record<
     questMultiplier: 2,
     referralMultiplier: 1.5,
     shopDiscount: 0.05,
-    maxStreakFreezes: 3, // +2 over non-supporter
+    maxStreakFreezes: 10,
     badgeAnimation: false,
     freeLoanRate: 0.02, // 2%
     marginLoanAccess: true,
@@ -110,7 +110,7 @@ export const SUPPORTER_BENEFITS: Record<
     questMultiplier: 3,
     referralMultiplier: 2,
     shopDiscount: 0.1,
-    maxStreakFreezes: 10, // +9 over non-supporter
+    maxStreakFreezes: 25,
     badgeAnimation: true,
     freeLoanRate: 0.03, // 3%
     marginLoanAccess: true,
@@ -154,7 +154,9 @@ export function getUserSupporterTier(
 }
 
 // Get specific benefit value for user
-export function getBenefit<K extends keyof (typeof SUPPORTER_BENEFITS)['basic']>(
+export function getBenefit<
+  K extends keyof (typeof SUPPORTER_BENEFITS)['basic']
+>(
   entitlements: UserEntitlement[] | undefined,
   benefit: K,
   defaultValue?: (typeof SUPPORTER_BENEFITS)['basic'][K]
@@ -243,7 +245,6 @@ export function getTierInfo(tier: SupporterTier) {
 export const TIER_ORDER: SupporterTier[] = ['basic', 'plus', 'premium']
 
 // Get max streak freezes for a user based on their tier
-// Non-supporters: 1, Plus: 2, Pro: 3, Premium: 5
 export function getMaxStreakFreezes(
   entitlements: UserEntitlement[] | undefined
 ): number {

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -4936,9 +4936,11 @@ function StreakFreezePreview(props: {
   // Max is only a purchase cap, not an accumulation cap
   const maxPurchasable = getMaxStreakFreezes(allEntitlements)
   const isAtPurchaseMax = currentFreezes >= maxPurchasable
+  const currentTier = getUserSupporterTier(allEntitlements)
+  const canUpgradeTier = currentTier !== 'premium'
 
   return (
-    <div className="bg-canvas-50 flex items-center justify-center rounded-lg p-4 transition-colors duration-200 group-hover:bg-indigo-50 dark:group-hover:bg-indigo-950/50">
+    <div className="bg-canvas-50 flex flex-col items-center justify-center gap-2 rounded-lg p-4 transition-colors duration-200 group-hover:bg-indigo-50 dark:group-hover:bg-indigo-950/50">
       <Row className="flex-wrap items-center justify-center gap-x-2 gap-y-1">
         <span className="text-ink-600 text-xs sm:text-sm">Your freezes:</span>
         <Row className="items-center gap-1.5">
@@ -4958,6 +4960,17 @@ function StreakFreezePreview(props: {
           )}
         </Row>
       </Row>
+      {isAtPurchaseMax && canUpgradeTier && (
+        <div className="text-center text-xs text-indigo-600 dark:text-indigo-400">
+          <Link
+            href="/membership"
+            className="underline hover:text-indigo-800 dark:hover:text-indigo-300"
+          >
+            Upgrade your membership
+          </Link>{' '}
+          to hold more freezes
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Increases freeze caps to 1/5/10/25 and gives the users a nudge to upgrade their membership when at the max.