### PR TITLE
feat: Allow creators to block themselves from trading on a market

### DIFF
--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -20,7 +20,15 @@ import { UniqueBettorBonusTxn } from 'common/txn'
 import { canReceiveBonuses, User, UserBan } from 'common/user'
 import { floatingEqual } from 'common/util/math'
 import { removeUndefinedProps } from 'common/util/object'
-import { groupBy, mapValues, orderBy, sortBy, sumBy, uniq, uniqBy } from 'lodash'
+import {
+  groupBy,
+  mapValues,
+  orderBy,
+  sortBy,
+  sumBy,
+  uniq,
+  uniqBy,
+} from 'lodash'
 import { bulkUpdateUserMetricsWithNewBetsOnly } from 'shared/helpers/user-contract-metrics'
 import { log } from 'shared/monitoring/log'
 import {
@@ -83,7 +91,7 @@ export const fetchContractBetDataAndValidate = async (
     select b.*, u.balance from contract_bets b join users u on b.user_id = u.id
       where ${whereLimitOrderBets};
     -- My contract metrics
-    select data, margin_loan, loan from user_contract_metrics ucm where 
+    select data, margin_loan, loan from user_contract_metrics ucm where
       contract_id = $2 and user_id = $1
       and (
         -- Get metrics for selected answers
@@ -91,7 +99,7 @@ export const fetchContractBetDataAndValidate = async (
         or
         -- Get null answer metrics
         ucm.answer_id is null
-      ); 
+      );
     -- Limit orderers' contract metrics
     with matching_user_answer_pairs as (
       select distinct b.user_id, b.answer_id
@@ -202,6 +210,16 @@ export const fetchContractBetDataAndValidate = async (
   }
   if (contract.outcomeType === 'STONK' && isApi) {
     throw new APIError(403, 'API users cannot bet on STONK contracts.')
+  }
+  if (
+    contract.creatorBannedFromBetting &&
+    uid === contract.creatorId &&
+    !isAdminTrade
+  ) {
+    throw new APIError(
+      403,
+      'You have blocked yourself from betting on this market. Contact a moderator if you need this reversed.'
+    )
   }
   log(
     `Loaded user ${user.username} with id ${user.id} betting on slug ${contract.slug} with contract id: ${contract.id}.`

--- a/backend/api/src/multi-sell.ts
+++ b/backend/api/src/multi-sell.ts
@@ -40,6 +40,12 @@ const multiSellMain: APIHandler<'multi-sell'> = async (props, auth) => {
     if (closeTime && Date.now() > closeTime)
       throw new APIError(403, 'Trading is closed.')
     if (isResolved) throw new APIError(403, 'Market is resolved.')
+    if (contract.creatorBannedFromBetting && uid === contract.creatorId) {
+      throw new APIError(
+        403,
+        'You have blocked yourself from betting on this market. Contact a moderator if you need this reversed.'
+      )
+    }
     if (mechanism != 'cpmm-multi-1' || !('shouldAnswersSumToOne' in contract))
       throw new APIError(400, 'Contract type/mechanism not supported')
 

--- a/backend/api/src/rebalance-position.ts
+++ b/backend/api/src/rebalance-position.ts
@@ -55,6 +55,12 @@ export const rebalancePosition: APIHandler<
   if (contract.closeTime && Date.now() > contract.closeTime) {
     throw new APIError(403, 'Trading is closed.')
   }
+  if (contract.creatorBannedFromBetting && userId === contract.creatorId) {
+    throw new APIError(
+      403,
+      'You have blocked yourself from betting on this market. Contact a moderator if you need this reversed.'
+    )
+  }
 
   const { result } = await betsQueue.enqueueFn(
     () => rebalanceInTransaction(pg, userId, contract as MarketContract),

--- a/backend/api/src/update-market.ts
+++ b/backend/api/src/update-market.ts
@@ -36,6 +36,7 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
       display,
       homePageScoreAdjustment,
       homePageScoreAdjustmentDays,
+      creatorBannedFromBetting,
 
       description: raw,
       descriptionHtml: html,
@@ -86,6 +87,32 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
       }
     }
 
+    if (creatorBannedFromBetting !== undefined) {
+      // Only the creator or a mod/admin can set this flag
+      if (
+        contract.creatorId !== auth.uid &&
+        !isAdminId(auth.uid) &&
+        !isModId(auth.uid)
+      ) {
+        throw new APIError(
+          403,
+          'Only the creator or a moderator can set the creator betting ban'
+        )
+      }
+      // Only a mod/admin can unset it
+      if (
+        !creatorBannedFromBetting &&
+        contract.creatorId === auth.uid &&
+        !isAdminId(auth.uid) &&
+        !isModId(auth.uid)
+      ) {
+        throw new APIError(
+          403,
+          'Only a moderator or admin can reverse the creator betting ban'
+        )
+      }
+    }
+
     if (contract.isResolved && closeTime !== undefined) {
       throw new APIError(403, 'Cannot update closeTime for resolved contracts')
     }
@@ -112,6 +139,7 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
       sort,
       description,
       display,
+      creatorBannedFromBetting,
       lastUpdatedTime: Date.now(),
     })
     await updateContract(pg, contractId, {
@@ -135,6 +163,33 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
       })
     }
 
+    // Cancel creator's open limit orders when banning from betting
+    if (creatorBannedFromBetting === true) {
+      const { convertBet } = await import('common/supabase/bets')
+      const { cancelLimitOrdersQuery } = await import('shared/supabase/bets')
+      const { broadcastOrders } = await import('shared/websockets/helpers')
+      const creatorLimitOrders = await pg.map(
+        `select * from contract_bets
+         where contract_id = $1
+           and user_id = $2
+           and not is_filled
+           and not is_cancelled
+           and (expires_at is null or expires_at > now())`,
+        [contractId, contract.creatorId],
+        convertBet
+      )
+      if (creatorLimitOrders.length > 0) {
+        const { query, bets } = cancelLimitOrdersQuery(
+          creatorLimitOrders as any[]
+        )
+        await pg.none(query)
+        broadcastOrders(bets)
+        log(
+          `Cancelled ${creatorLimitOrders.length} limit orders for creator ${contract.creatorId} on contract ${contractId}`
+        )
+      }
+    }
+
     log(`updated fields: ${Object.keys(fields).join(', ')}`)
 
     return {
@@ -150,7 +205,8 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
           description,
           isUpdatingHomePageScoreAdjustment,
           homePageScoreAdjustment,
-          homePageScoreAdjustmentExpiresAt ?? undefined
+          homePageScoreAdjustmentExpiresAt ?? undefined,
+          creatorBannedFromBetting
         ),
     }
   })
@@ -166,7 +222,8 @@ export const updateMarketContinuation = async (
   description: JSONContent | undefined,
   isUpdatingHomePageScoreAdjustment: boolean,
   homePageScoreAdjustment: number | null | undefined,
-  homePageScoreAdjustmentExpiresAt: number | undefined
+  homePageScoreAdjustmentExpiresAt: number | undefined,
+  creatorBannedFromBetting: boolean | undefined
 ) => {
   log(`Revalidating contract ${contract.id}.`)
   await revalidateContractStaticProps(contract)
@@ -194,7 +251,13 @@ export const updateMarketContinuation = async (
       })
     )
   }
-  if (question || closeTime || visibility || description) {
+  if (
+    question ||
+    closeTime ||
+    visibility ||
+    description ||
+    creatorBannedFromBetting !== undefined
+  ) {
     await recordContractEdit(
       contract,
       userId,
@@ -203,6 +266,7 @@ export const updateMarketContinuation = async (
         closeTime && 'closeTime',
         visibility && 'visibility',
         description && 'description',
+        creatorBannedFromBetting !== undefined && 'creatorBannedFromBetting',
       ])
     )
   }

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -495,6 +495,7 @@ export const updateMarketProps = z
     display: z.enum(['clock', 'default']).optional(),
     homePageScoreAdjustment: z.number().gte(-1).lte(1).nullable().optional(),
     homePageScoreAdjustmentDays: z.number().int().positive().optional(),
+    creatorBannedFromBetting: z.boolean().optional(),
   })
   .strict()
 

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -92,6 +92,8 @@ export type Contract<T extends AnyContractType = AnyContractType> = {
   coverImageUrl?: string
   isRanked?: boolean
 
+  creatorBannedFromBetting?: boolean
+
   gptCommentSummary?: string
 
   token: ContractToken

--- a/web/components/answers/answer-components.tsx
+++ b/web/components/answers/answer-components.tsx
@@ -256,7 +256,16 @@ const YesNoBetButtons = (props: {
   feedReason?: string
 }) => {
   const { answer, contract, feedReason, fillColor } = props
+  const user = useUser()
+  const isCreatorBanned =
+    !!user &&
+    user.id === contract.creatorId &&
+    contract.creatorBannedFromBetting === true
   const [outcome, setOutcome] = useState<'YES' | 'NO' | undefined>(undefined)
+
+  if (isCreatorBanned) {
+    return null
+  }
 
   return (
     <>
@@ -561,7 +570,9 @@ export function AnswerPosition(props: {
   const noWinnings = totalShares.NO ?? 0
   const position = yesWinnings - noWinnings
   const isCashContract = contract.token === 'CASH'
-  const canSell = tradingAllowed(contract, answer)
+  const canSell =
+    tradingAllowed(contract, answer) &&
+    !(contract.creatorBannedFromBetting && user.id === contract.creatorId)
   const won =
     (position > 1e-7 && answer.resolution === 'YES') ||
     (position < -1e-7 && answer.resolution === 'NO')

--- a/web/components/answers/binary-multi-answers-panel.tsx
+++ b/web/components/answers/binary-multi-answers-panel.tsx
@@ -82,7 +82,20 @@ const BetButton = (props: {
   canEdit?: boolean
 }) => {
   const { answer, contract, size, outcome, setOutcome, color, canEdit } = props
+  const user = useUser()
+  const isCreatorBanned =
+    !!user &&
+    user.id === contract.creatorId &&
+    contract.creatorBannedFromBetting === true
   const [editing, setEditing] = useState(false)
+
+  if (isCreatorBanned) {
+    return (
+      <div className="flex flex-1 items-center justify-center rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+        <span className="font-medium">Betting disabled</span>
+      </div>
+    )
+  }
 
   return (
     <div className="group relative flex flex-1">

--- a/web/components/answers/numeric-bet-panel.tsx
+++ b/web/components/answers/numeric-bet-panel.tsx
@@ -40,6 +40,7 @@ import { MoneyDisplay } from '../bet/money-display'
 import { TRADE_TERM } from 'common/envs/constants'
 import { useUnfilledBetsAndBalanceByUserId } from 'client-common/hooks/use-bets'
 import { useIsPageVisible } from 'web/hooks/use-page-visible'
+import { useUser } from 'web/hooks/use-user'
 
 export const NumericBetPanel = (props: {
   contract: CPMMNumericContract
@@ -56,6 +57,11 @@ export const NumericBetPanel = (props: {
     },
   } = props
   const contract = useLiveContract(props.contract)
+  const user = useUser()
+  const isCreatorBanned =
+    !!user &&
+    user.id === contract.creatorId &&
+    contract.creatorBannedFromBetting === true
   const { answers, min: minimum, max: maximum } = contract
   const [expectedValue, setExpectedValue] = useState(
     getNumberExpectedValue(contract)
@@ -106,6 +112,10 @@ export const NumericBetPanel = (props: {
   const answersToBuy = answers.filter((a) => shouldIncludeAnswer(a))
 
   const placeBet = async () => {
+    if (isCreatorBanned) {
+      setError('You have blocked yourself from betting on this market.')
+      return
+    }
     if (!betAmount) {
       setError(`Please enter a ${TRADE_TERM} amount`)
       return
@@ -408,7 +418,7 @@ export const NumericBetPanel = (props: {
               className={'w-full'}
               loading={isSubmitting}
               onClick={placeBet}
-              disabled={isSubmitting}
+              disabled={isSubmitting || isCreatorBanned}
             >
               {capitalize(TRADE_TERM)}&nbsp;
               <MoneyDisplay

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -120,6 +120,10 @@ export function BuyPanel(
   } = props
 
   const user = useUser()
+  const isCreatorBanned =
+    !!user &&
+    user.id === contract.creatorId &&
+    contract.creatorBannedFromBetting === true
   const customYesText = getCustomYesButtonText(user?.entitlements)
   const customNoText = getCustomNoButtonText(user?.entitlements)
   const isPseudoNumeric = contract.outcomeType === 'PSEUDO_NUMERIC'
@@ -158,7 +162,13 @@ export function BuyPanel(
   }
   return (
     <Col>
-      {!isPanelBodyVisible && (
+      {isCreatorBanned ? (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm">
+          <span className="font-medium">Betting disabled:</span> You have
+          blocked yourself from betting on this market. Contact a moderator if
+          you need this reversed.
+        </div>
+      ) : !isPanelBodyVisible ? (
         <Col>
           <Row className={clsx('mb-2 w-full items-center gap-2')}>
             <YesNoSelector
@@ -187,8 +197,7 @@ export function BuyPanel(
             />
           </Row>
         </Col>
-      )}
-      {isPanelBodyVisible && (
+      ) : isPanelBodyVisible && !isCreatorBanned ? (
         <BuyPanelBody
           {...props}
           className={clsx('-mx-2 sm:mx-0', className)}
@@ -209,7 +218,7 @@ export function BuyPanel(
         >
           {children}
         </BuyPanelBody>
-      )}
+      ) : null}
     </Col>
   )
 }
@@ -238,6 +247,10 @@ export const BuyPanelBody = (
   } = props
 
   const user = useUser()
+  const isCreatorBanned =
+    !!user &&
+    user.id === contract.creatorId &&
+    contract.creatorBannedFromBetting === true
   const customYesText = getCustomYesButtonText(user?.entitlements)
   const customNoText = getCustomNoButtonText(user?.entitlements)
   const privateUser = usePrivateUser()
@@ -584,6 +597,7 @@ export const BuyPanelBody = (
     outcome === undefined ||
     error === 'Insufficient balance' ||
     showLocationMonitor ||
+    isCreatorBanned ||
     (isCashContract && verificationStatus !== 'success')
 
   const limits =

--- a/web/components/bet/sell-panel.tsx
+++ b/web/components/bet/sell-panel.tsx
@@ -67,6 +67,8 @@ export function SellPanel(props: {
     sellForUserId,
   } = props
   const { outcomeType } = contract
+  const isCreatorBanned =
+    user.id === contract.creatorId && contract.creatorBannedFromBetting === true
   const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
   const isStonk = outcomeType === 'STONK'
   const isMultiSumsToOne =
@@ -125,7 +127,10 @@ export function SellPanel(props: {
   const [wasSubmitted, setWasSubmitted] = useState(false)
 
   const betDisabled =
-    isSubmitting || !amount || (error && error.includes('Maximum'))
+    isSubmitting ||
+    !amount ||
+    (error && error.includes('Maximum')) ||
+    isCreatorBanned
 
   // Sell all shares if remaining shares would be < 1
   const isSellingAllShares = amount === Math.floor(shares)

--- a/web/components/bet/user-bet-summary.tsx
+++ b/web/components/bet/user-bet-summary.tsx
@@ -236,6 +236,10 @@ export function BetsSummary(props: {
 
         {includeSellButton &&
           !resolution &&
+          !(
+            contract.creatorBannedFromBetting &&
+            includeSellButton.id === contract.creatorId
+          ) &&
           (contract.mechanism !== 'cpmm-multi-1' ||
             isBinaryMulti(contract)) && (
             <Row className="items-center gap-2">
@@ -325,15 +329,21 @@ export function BetsSummary(props: {
           />
         )}
       </Row>
-      {mainBinaryMCAnswer && (
-        <BinaryMultiSellRow
-          answer={mainBinaryMCAnswer}
-          contract={contract as CPMMMultiContract}
-        />
-      )}
-      {includeSellButton && contract.outcomeType === 'NUMBER' && (
-        <MultiNumericSellPanel contract={contract} userId={metric.userId} />
-      )}
+      {mainBinaryMCAnswer &&
+        !(contract.creatorBannedFromBetting && areYourBets) && (
+          <BinaryMultiSellRow
+            answer={mainBinaryMCAnswer}
+            contract={contract as CPMMMultiContract}
+          />
+        )}
+      {includeSellButton &&
+        contract.outcomeType === 'NUMBER' &&
+        !(
+          contract.creatorBannedFromBetting &&
+          includeSellButton.id === contract.creatorId
+        ) && (
+          <MultiNumericSellPanel contract={contract} userId={metric.userId} />
+        )}
     </Col>
   )
 }

--- a/web/components/contract/contract-description.tsx
+++ b/web/components/contract/contract-description.tsx
@@ -1,7 +1,7 @@
 import { PencilIcon, PlusIcon } from '@heroicons/react/solid'
 import { JSONContent } from '@tiptap/core'
 import clsx from 'clsx'
-import { MAX_DESCRIPTION_LENGTH } from 'common/contract'
+import { MAX_DESCRIPTION_LENGTH, Contract } from 'common/contract'
 import { useEffect, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { TextEditor, useTextEditor } from 'web/components/widgets/editor'
@@ -13,14 +13,24 @@ import { LogoIcon } from '../icons/logo-icon'
 import { Row } from '../layout/row'
 import { CollapsibleContent } from '../widgets/collapsible-content'
 import { PendingClarifications } from './pending-clarifications'
+import { CreatorBannedFromBettingInfo } from './creator-banned-from-betting-info'
 
 export function ContractDescription(props: {
   contractId: string // the description is stored on this contract
   creatorId: string
   isSweeps: boolean
   description: string | JSONContent
+  creatorBannedFromBetting?: boolean
+  contract: Contract
 }) {
-  const { contractId, creatorId, isSweeps, description } = props
+  const {
+    contractId,
+    creatorId,
+    isSweeps,
+    description,
+    creatorBannedFromBetting,
+    contract,
+  } = props
 
   const isModOrAdmin = useAdminOrMod()
   const user = useUser()
@@ -55,6 +65,13 @@ export function ContractDescription(props: {
           <span>This question is managed and resolved by Manifold.</span>
           <LogoIcon className="h-5 w-5 text-indigo-600" />
         </div>
+
+        {creatorBannedFromBetting && (
+          <CreatorBannedFromBettingInfo
+            contract={contract}
+            creatorId={creatorId}
+          />
+        )}
       </div>
     </>
   )

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -460,7 +460,7 @@ export const Stats = (props: {
         {!hideAdvanced && isBettingContract && (
           <tr className={clsx(isMod && 'bg-purple-500/30')}>
             <td>
-              🚫 Creator self-ban{' '}
+              🚫 Disable creator betting{' '}
               <InfoTooltip
                 text={
                   'Prevent the creator from placing bets on this market. This cannot be undone except by a moderator or admin.'
@@ -469,7 +469,9 @@ export const Stats = (props: {
             </td>
             <td>
               <CheckOrSwitch
-                canToggle={isMod || isCreator}
+                canToggle={
+                  isMod || (isCreator && !contract.creatorBannedFromBetting)
+                }
                 on={contract.creatorBannedFromBetting === true}
                 setOn={(on) => {
                   if (on) {

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -470,13 +470,15 @@ export const Stats = (props: {
             <td>
               <CheckOrSwitch
                 canToggle={
-                  isMod || (isCreator && !contract.creatorBannedFromBetting)
+                  isAdmin ||
+                  (isMod && !isCreator) ||
+                  (isCreator && !contract.creatorBannedFromBetting)
                 }
                 on={contract.creatorBannedFromBetting === true}
                 setOn={(on) => {
                   if (on) {
                     onRequestCreatorBan?.()
-                  } else if (isMod) {
+                  } else if ((isMod && !isCreator) || isAdmin) {
                     toast.promise(
                       updateMarket({
                         contractId: contract.id,

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -25,6 +25,8 @@ import { ShareEmbedButton, ShareIRLButton } from '../buttons/share-embed-button'
 import { ShareQRButton } from '../buttons/share-qr-button'
 import { Modal } from '../layout/modal'
 import { Row } from '../layout/row'
+import { Col } from '../layout/col'
+import { Button } from '../buttons/button'
 import SuperBanControl from '../SuperBanControl'
 import { useSweepstakes } from '../sweepstakes-provider'
 import { InfoBox } from '../widgets/info-box'
@@ -37,8 +39,9 @@ import { ContractHistoryButton } from './contract-edit-history-button'
 export const Stats = (props: {
   contract: Contract
   user?: User | null | undefined
+  onRequestCreatorBan?: () => void
 }) => {
-  const { contract, user } = props
+  const { contract, user, onRequestCreatorBan } = props
   const { creatorId } = contract
   const shouldAnswersSumToOne =
     contract.mechanism === 'cpmm-multi-1'
@@ -454,6 +457,42 @@ export const Stats = (props: {
           </tr>
         )}
 
+        {!hideAdvanced && isBettingContract && (
+          <tr className={clsx(isMod && 'bg-purple-500/30')}>
+            <td>
+              🚫 Creator self-ban{' '}
+              <InfoTooltip
+                text={
+                  'Prevent the creator from placing bets on this market. This cannot be undone except by a moderator or admin.'
+                }
+              />
+            </td>
+            <td>
+              <CheckOrSwitch
+                canToggle={isMod || isCreator}
+                on={contract.creatorBannedFromBetting === true}
+                setOn={(on) => {
+                  if (on) {
+                    onRequestCreatorBan?.()
+                  } else if (isMod) {
+                    toast.promise(
+                      updateMarket({
+                        contractId: contract.id,
+                        creatorBannedFromBetting: false,
+                      }),
+                      {
+                        loading: 'Reversing creator betting ban...',
+                        success: 'Creator can now bet on this market.',
+                        error: 'Error reversing ban. Try again?',
+                      }
+                    )
+                  }
+                }}
+              />
+            </td>
+          </tr>
+        )}
+
         {!hideAdvanced && contract.outcomeType === 'DATE' && (
           <tr className={clsx(isMod && 'bg-purple-500/30')}>
             <td>
@@ -739,6 +778,7 @@ export function ContractInfoDialog(props: {
   const { contract, user, open, setOpen } = props
   const isAdmin = useAdmin()
   const isTrusted = useTrusted()
+  const [showCreatorBanConfirm, setShowCreatorBanConfirm] = useState(false)
 
   return (
     <Modal
@@ -746,7 +786,11 @@ export function ContractInfoDialog(props: {
       setOpen={setOpen}
       className="bg-canvas-0 flex flex-col gap-4 rounded p-6"
     >
-      <Stats contract={contract} user={user} />
+      <Stats
+        contract={contract}
+        user={user}
+        onRequestCreatorBan={() => setShowCreatorBanConfirm(true)}
+      />
 
       {!!user && (
         <Row className="flex-wrap gap-2">
@@ -760,6 +804,51 @@ export function ContractInfoDialog(props: {
       {(isAdmin || isTrusted) && (
         <SuperBanControl userId={contract.creatorId} />
       )}
+
+      <Modal
+        open={showCreatorBanConfirm}
+        setOpen={setShowCreatorBanConfirm}
+        className="bg-canvas-0 rounded-lg"
+      >
+        <Col className="gap-4 p-6">
+          <h3 className="text-ink-1000 text-lg font-semibold">
+            Block yourself from betting?
+          </h3>
+          <p className="text-ink-700 text-sm">
+            You are about to block yourself from betting on this market. This
+            action <strong>cannot be undone</strong> except by a moderator or
+            admin. Your existing limit orders will be cancelled and you will not
+            be able to buy or sell any shares.
+          </p>
+          <Row className="justify-end gap-2">
+            <Button
+              color="gray"
+              onClick={() => setShowCreatorBanConfirm(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              onClick={() => {
+                setShowCreatorBanConfirm(false)
+                toast.promise(
+                  updateMarket({
+                    contractId: contract.id,
+                    creatorBannedFromBetting: true,
+                  }),
+                  {
+                    loading: 'Blocking creator from betting...',
+                    success: 'You are now blocked from betting on this market.',
+                    error: 'Error setting ban. Try again?',
+                  }
+                )
+              }}
+            >
+              Confirm
+            </Button>
+          </Row>
+        </Col>
+      </Modal>
     </Modal>
   )
 }

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -481,6 +481,8 @@ export function ContractPageContent(props: ContractParams) {
                 creatorId={props.contract.creatorId}
                 isSweeps={isCashContract}
                 description={description}
+                creatorBannedFromBetting={liveContract.creatorBannedFromBetting}
+                contract={liveContract}
               />
             )}
             {props.contract.isRanked !== false && (

--- a/web/components/contract/creator-banned-from-betting-info.tsx
+++ b/web/components/contract/creator-banned-from-betting-info.tsx
@@ -1,0 +1,181 @@
+import { InformationCircleIcon } from '@heroicons/react/solid'
+import { ContractMetric } from 'common/contract-metric'
+import { Contract } from 'common/contract'
+import { formatMoney, formatShares } from 'common/util/format'
+import { useEffect, useState } from 'react'
+import { db } from 'web/lib/supabase/db'
+import { Col } from '../layout/col'
+import { Row } from '../layout/row'
+
+export function CreatorBannedFromBettingInfo(props: {
+  contract: Contract
+  creatorId: string
+}) {
+  const { contract, creatorId } = props
+  const [creatorMetrics, setCreatorMetrics] = useState<ContractMetric[]>([])
+  const [showPosition, setShowPosition] = useState(false)
+
+  useEffect(() => {
+    // Fetch the creator's metrics for all answers + summary
+    db.from('user_contract_metrics')
+      .select('data, margin_loan, loan')
+      .eq('contract_id', contract.id)
+      .eq('user_id', creatorId)
+      .then(({ data }) => {
+        if (data) {
+          const metrics = data.map((doc) => ({
+            ...(doc.data as ContractMetric),
+            loan: doc.loan ?? (doc.data as any).loan ?? 0,
+            marginLoan: doc.margin_loan ?? (doc.data as any).marginLoan ?? 0,
+          })) as ContractMetric[]
+          setCreatorMetrics(metrics)
+        }
+      })
+  }, [contract.id, creatorId])
+
+  // Separate summary metric from per-answer metrics
+  const summaryMetric = creatorMetrics.find((m) => m.answerId == null)
+  const answerMetrics = creatorMetrics.filter((m) => m.answerId != null)
+  const answers = 'answers' in contract ? contract.answers : []
+  const isMulti = answerMetrics.length > 0
+
+  // Filter out answer rows where both invested and profit are 0
+  const visibleAnswerMetrics = answerMetrics.filter(
+    (m) => m.invested > 0 || m.profit !== 0
+  )
+  const hasPosition =
+    visibleAnswerMetrics.length > 0 ||
+    (summaryMetric != null &&
+      (summaryMetric.invested > 0 || summaryMetric.profit !== 0))
+
+  return (
+    <div className="mt-2 rounded-md border border-green-200 bg-green-50 p-3">
+      <Row className="items-start gap-2">
+        <InformationCircleIcon className="h-5 w-5 flex-shrink-0 text-green-600" />
+        <Col className="items-start gap-1">
+          <span className="text-sm font-medium text-green-800">
+            The creator has blocked themselves from betting in this market.
+          </span>
+          {hasPosition && (
+            <>
+              <button
+                className="text-xs text-green-700 underline hover:text-green-900"
+                onClick={() => setShowPosition(!showPosition)}
+              >
+                {showPosition ? 'Hide' : 'View'} creator's existing position
+              </button>
+              {showPosition && (
+                <div className="mt-1 w-full rounded-md border border-green-200 bg-white p-2">
+                  {isMulti ? (
+                    <table className="w-full text-xs text-gray-700">
+                      <thead>
+                        <tr className="border-b border-gray-200 text-left text-gray-500">
+                          <th className="pb-1 pr-4 font-medium">Answer</th>
+                          <th className="pb-1 pr-4 font-medium">Spent</th>
+                          <th className="pb-1 pr-4 font-medium">Profit</th>
+                          <th className="pb-1 font-medium">Shares</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {visibleAnswerMetrics.map((metric) => {
+                          const answer = answers.find(
+                            (a) => a.id === metric.answerId
+                          )
+                          return (
+                            <tr
+                              key={metric.answerId}
+                              className="border-b border-gray-100 last:border-0"
+                            >
+                              <td className="py-1 pr-4 font-medium">
+                                {answer?.text ?? metric.answerId?.slice(0, 8)}
+                              </td>
+                              <td className="py-1 pr-4">
+                                {formatMoney(metric.invested)}
+                              </td>
+                              <td className="py-1 pr-4">
+                                {formatMoney(metric.profit)}
+                              </td>
+                              <td className="py-1">
+                                <SharesCell metric={metric} />
+                              </td>
+                            </tr>
+                          )
+                        })}
+                        {summaryMetric &&
+                          (summaryMetric.invested > 0 ||
+                            summaryMetric.profit !== 0) && (
+                            <tr className="border-t border-gray-200 font-medium">
+                              <td className="py-1 pr-4">Total</td>
+                              <td className="py-1 pr-4">
+                                {formatMoney(summaryMetric.invested)}
+                              </td>
+                              <td className="py-1 pr-4">
+                                {formatMoney(summaryMetric.profit)}
+                              </td>
+                              <td className="py-1">—</td>
+                            </tr>
+                          )}
+                      </tbody>
+                    </table>
+                  ) : summaryMetric ? (
+                    <CreatorMetricRow metric={summaryMetric} />
+                  ) : null}
+                </div>
+              )}
+            </>
+          )}
+        </Col>
+      </Row>
+    </div>
+  )
+}
+
+function CreatorMetricRow(props: { metric: ContractMetric }) {
+  const { metric } = props
+  const { invested, profit, profitPercent, totalShares } = metric
+  const isCashContract = false
+
+  const yesShares = totalShares?.YES ?? 0
+  const noShares = totalShares?.NO ?? 0
+  const hasShares = yesShares > 1 || noShares > 1
+
+  return (
+    <Row className="flex-wrap items-center gap-3 text-xs text-gray-700">
+      <Col>
+        <span className="text-gray-500">Spent</span>
+        <span>{formatMoney(invested)}</span>
+      </Col>
+      <Col>
+        <span className="text-gray-500">Profit</span>
+        <span>{formatMoney(profit)}</span>
+      </Col>
+      {hasShares && (
+        <Col>
+          <span className="text-gray-500">Shares</span>
+          <span>
+            {yesShares > 1 && `${formatShares(yesShares, isCashContract)} YES`}
+            {yesShares > 1 && noShares > 1 && ' / '}
+            {noShares > 1 && `${formatShares(noShares, isCashContract)} NO`}
+          </span>
+        </Col>
+      )}
+    </Row>
+  )
+}
+
+function SharesCell(props: { metric: ContractMetric }) {
+  const { totalShares } = props.metric
+  const isCashContract = false
+  const yesShares = totalShares?.YES ?? 0
+  const noShares = totalShares?.NO ?? 0
+
+  if (yesShares <= 1 && noShares <= 1) return <span>—</span>
+
+  return (
+    <span>
+      {yesShares > 1 && `${formatShares(yesShares, isCashContract)} YES`}
+      {yesShares > 1 && noShares > 1 && ' / '}
+      {noShares > 1 && `${formatShares(noShares, isCashContract)} NO`}
+    </span>
+  )
+}

--- a/web/components/contract/creator-banned-from-betting-info.tsx
+++ b/web/components/contract/creator-banned-from-betting-info.tsx
@@ -18,7 +18,7 @@ export function CreatorBannedFromBettingInfo(props: {
   useEffect(() => {
     // Fetch the creator's metrics for all answers + summary
     db.from('user_contract_metrics')
-      .select('data, margin_loan, loan')
+      .select('data, loan')
       .eq('contract_id', contract.id)
       .eq('user_id', creatorId)
       .then(({ data }) => {
@@ -26,7 +26,7 @@ export function CreatorBannedFromBettingInfo(props: {
           const metrics = data.map((doc) => ({
             ...(doc.data as ContractMetric),
             loan: doc.loan ?? (doc.data as any).loan ?? 0,
-            marginLoan: doc.margin_loan ?? (doc.data as any).marginLoan ?? 0,
+            marginLoan: (doc.data as any).marginLoan ?? 0,
           })) as ContractMetric[]
           setCreatorMetrics(metrics)
         }


### PR DESCRIPTION
Adds a toggle to the info panel where the creator can choose to block themselves from trading on the market. Upon confirmation, cancels all of the owner's open limit orders and hides or disables most betting UI elements. Also adds a dialog under the description that lets everyone know includes the creator's existing position and profit, if they have one.

<img width="551" height="220" alt="image" src="https://github.com/user-attachments/assets/b2c0a345-1451-41a7-91db-e44f49c5d83b" />

<img width="401" height="107" alt="image" src="https://github.com/user-attachments/assets/6f246d4a-42b6-42ca-8d34-ea39367fb392" />

<img width="400" height="249" alt="image" src="https://github.com/user-attachments/assets/1bb868c9-afb6-43dc-ae5a-2953f437950b" />
