### PR TITLE
feat: make Restricted user badge visible to everyone

### DIFF
--- a/backend/api/knowledge.md
+++ b/backend/api/knowledge.md
@@ -342,7 +342,7 @@ When a mod clears a user's alert, it goes through the ban-user endpoint with `ba
 - `common/src/user.ts` - `BanType` and `UserBan` type definitions
 - `backend/api/src/helpers/rate-limit.ts` - `getActiveUserBans()`, `onlyUsersWhoCanPerformAction()`
 - `backend/api/src/ban-user.ts` - Admin endpoint to ban/unban users and send mod alerts
-- `backend/api/src/get-user-bans.ts` - Endpoint to fetch user bans (users can fetch their own, mods can fetch anyone's)
+- `backend/api/src/get-user-bans.ts` - Endpoint to fetch user bans (mods get full data; self gets bans with mod identity hidden; public viewers get sanitized blocking bans — no reason, no mod identity, modAlerts omitted — so the Restricted badge can render)
 - `backend/api/src/dismiss-mod-alert.ts` - User endpoint to dismiss their own mod alert
 - `backend/scheduler/src/jobs/unban-users.ts` - Scheduled job to expire temporary bans
 - `web/components/moderation/ban-banner.tsx` - User-facing banner showing bans and mod alerts

--- a/backend/api/src/get-user-bans.ts
+++ b/backend/api/src/get-user-bans.ts
@@ -11,26 +11,34 @@ export const getUserBans: APIHandler<'get-user-bans'> = async (
   const isMod = isModId(auth.uid) || isAdminId(auth.uid)
   const isSelf = auth.uid === userId
 
-  // Users can fetch their own bans, mods can fetch anyone's bans
-  if (!isSelf && !isMod) {
-    // Non-mods can only fetch their own bans
-    return { bans: [] }
-  }
-
   const bans = await pg.manyOrNone<UserBan>(
     `SELECT * FROM user_bans WHERE user_id = $1 ORDER BY created_at DESC`,
     [userId]
   )
 
-  // For self-viewing, sanitize sensitive data (hide who banned them)
-  if (isSelf && !isMod) {
-    const sanitizedBans = bans.map(ban => ({
+  if (isMod) {
+    return { bans }
+  }
+
+  if (isSelf) {
+    // Self-viewing: hide mod identity but keep reasons and own alert dismissals
+    const sanitizedBans = bans.map((ban) => ({
       ...ban,
-      created_by: null, // Hide mod identity
-      ended_by: ban.ended_by === auth.uid ? auth.uid : null, // Show if user dismissed their own alert
+      created_by: null,
+      ended_by: ban.ended_by === auth.uid ? auth.uid : null,
     }))
     return { bans: sanitizedBans }
   }
 
-  return { bans }
+  // Public viewers: expose only what the Restricted badge needs to render.
+  // Drop modAlerts (internal-only) and strip reasons + mod identities.
+  const publicBans = bans
+    .filter((ban) => ban.ban_type !== 'modAlert')
+    .map((ban) => ({
+      ...ban,
+      reason: null,
+      created_by: null,
+      ended_by: null,
+    }))
+  return { bans: publicBans }
 }


### PR DESCRIPTION
Non-mod, non-self callers of get-user-bans previously got an empty array, hiding the Restricted badge from the public. Now they get a sanitized list of blocking bans (reason, mod identities, and modAlerts stripped) so the badge can render on profile pages and hovercards while keeping moderator-only context private.