### PR TITLE
review-prompt: expand triggers, centralize gate, add opt-out

### DIFF
--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1265,6 +1265,7 @@ export const API = (_apiTypeCheck = {
         installedAppPlatforms: z.array(z.string()).optional(),
         paymentInfo: z.string().optional(),
         lastAppReviewTime: z.number().optional(),
+        optOutAppReviewPrompts: z.boolean().optional(),
       })
       .strict(),
   },

--- a/common/src/native-message.ts
+++ b/common/src/native-message.ts
@@ -55,6 +55,7 @@ export type MesageTypeMap = {
   hasReviewAction: {
     hasAction: boolean
     isAvailable: boolean
+    reason?: string
   }
   locationPermissionStatus: {
     status: 'granted' | 'denied' | 'undetermined'

--- a/common/src/store-review.ts
+++ b/common/src/store-review.ts
@@ -5,7 +5,9 @@ import { DAY_MS, HOUR_MS } from './util/time'
 // matches Apple's behavior on iOS.
 export const STORE_REVIEW_COOLDOWN_MS = 180 * DAY_MS
 
-export const STREAK_MILESTONES = [3, 5, 7, 14, 30, 60, 100] as const
+export const STREAK_MILESTONES = [
+  14, 30, 60, 100, 200, 365, 700, 1000,
+] as const
 
 // Threshold for the contract-page "you just won" trigger. Any positive M$25
 // profit on a market resolved within the last 48 hours counts as a fresh win.

--- a/common/src/store-review.ts
+++ b/common/src/store-review.ts
@@ -1,0 +1,26 @@
+import { DAY_MS, HOUR_MS } from './util/time'
+
+// At most ~2 prompts per user per year. iOS additionally silently caps at
+// ~3/365d at the OS level, so this is the binding constraint on Android and
+// matches Apple's behavior on iOS.
+export const STORE_REVIEW_COOLDOWN_MS = 180 * DAY_MS
+
+export const STREAK_MILESTONES = [3, 5, 7, 14, 30, 60, 100] as const
+
+// Threshold for the contract-page "you just won" trigger. Any positive M$25
+// profit on a market resolved within the last 48 hours counts as a fresh win.
+export const WIN_BET_MIN_PROFIT = 25
+export const WIN_BET_RECENT_RESOLUTION_MS = 48 * HOUR_MS
+
+// Suppress nudges within this window after we showed the user a push-permission
+// modal, so the two prompts don't pile up. Short window — a few hours later
+// the context has fully changed.
+export const PUSH_MODAL_RECENT_MS = 2 * HOUR_MS
+
+export type StoreReviewReason =
+  | 'shop-order'
+  | 'streak-milestone'
+  | 'streak-bonus-modal'
+  | 'win-bet'
+  | 'notifications-resolution'
+  | 'referral-bonus'

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -160,6 +160,8 @@ export type PrivateUser = {
   paymentInfo?: string
   // Timestamp of the last time the user was prompted for an app review or successfully reviewed.
   lastAppReviewTime?: number
+  // If true, suppress all in-app store-review prompts.
+  optOutAppReviewPrompts?: boolean
 
   /** @deprecated */
   kycFlags?: string[]

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -425,7 +425,12 @@ const App = () => {
       log('Has review action requested from web')
       const isAvailable = await StoreReview.isAvailableAsync()
       const hasAction = await StoreReview.hasAction()
-      communicateWithWebview('hasReviewAction', { hasAction, isAvailable })
+      const reason = payload?.reason
+      communicateWithWebview('hasReviewAction', {
+        hasAction,
+        isAvailable,
+        reason,
+      })
     } else if (type === 'versionRequested') {
       log('Version requested from web')
       const version = Constants.expoConfig?.version

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -30,6 +30,7 @@ import {
 import { CandidateBet } from 'common/new-bet'
 import { getFormattedMappedValue } from 'common/pseudo-numeric'
 import { getStonkDisplayShares, STONK_NO, STONK_YES } from 'common/stonk'
+import { STREAK_MILESTONES } from 'common/store-review'
 import {
   getCustomYesButtonText,
   getCustomNoButtonText,
@@ -52,6 +53,7 @@ import { useFocus } from 'web/hooks/use-focus'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
 import { useIsPageVisible } from 'web/hooks/use-page-visible'
 import { usePersistentLocalState } from 'web/hooks/use-persistent-local-state'
+import { useStoreReviewNudge } from 'web/hooks/use-store-review-nudge'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { api, APIError } from 'web/lib/api/api'
 import { firebaseLogin } from 'web/lib/firebase/users'
@@ -254,6 +256,17 @@ export const BuyPanelBody = (
   const customYesText = getCustomYesButtonText(user?.entitlements)
   const customNoText = getCustomNoButtonText(user?.entitlements)
   const privateUser = usePrivateUser()
+  const tryOfferReview = useStoreReviewNudge('streak-milestone')
+  const reviewNudgeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+  useEffect(() => {
+    return () => {
+      if (reviewNudgeTimeoutRef.current) {
+        clearTimeout(reviewNudgeTimeoutRef.current)
+      }
+    }
+  }, [])
   const liquidityTier =
     'answers' in contract
       ? getTierIndexFromLiquidityAndAnswers(
@@ -548,6 +561,25 @@ export const BuyPanelBody = (
             boosted: contract.boosted,
           })
         )
+        // The server may have just incremented the streak; the user object
+        // will reflect the new value within a beat. Defer past WAIT_TO_DISMISS
+        // so the bet-success modal isn't fighting the OS review modal.
+        if (
+          (STREAK_MILESTONES as readonly number[]).includes(
+            (user.currentBettingStreak ?? 0) + 1
+          ) ||
+          (STREAK_MILESTONES as readonly number[]).includes(
+            user.currentBettingStreak ?? 0
+          )
+        ) {
+          if (reviewNudgeTimeoutRef.current) {
+            clearTimeout(reviewNudgeTimeoutRef.current)
+          }
+          reviewNudgeTimeoutRef.current = setTimeout(
+            tryOfferReview,
+            WAIT_TO_DISMISS + 500
+          )
+        }
       } else {
         if (!toastId) {
           console.error('No toastId')

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -68,12 +68,17 @@ import { useSaveCampaign } from 'web/hooks/use-save-campaign'
 import { useSaveReferral } from 'web/hooks/use-save-referral'
 import { useSaveContractVisitsLocally } from 'web/hooks/use-save-visits'
 import { useSavedContractMetrics } from 'web/hooks/use-saved-contract-metrics'
+import { useStoreReviewNudge } from 'web/hooks/use-store-review-nudge'
 import { useTracking } from 'web/hooks/use-tracking'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { useDisplayUserById } from 'web/hooks/use-user-supabase'
 import { api } from 'web/lib/api/api'
 import { track } from 'web/lib/service/analytics'
 import { scrollIntoViewCentered } from 'web/lib/util/scroll'
+import {
+  WIN_BET_MIN_PROFIT,
+  WIN_BET_RECENT_RESOLUTION_MS,
+} from 'common/store-review'
 import { SpiceCoin } from 'web/public/custom-components/spiceCoin'
 import { FollowMarketButton } from '../buttons/follow-market-button'
 import { LogoIcon } from '../icons/logo-icon'
@@ -143,6 +148,21 @@ export function ContractPageContent(props: ContractParams) {
   const { isResolved, outcomeType, resolution, closeTime, creatorId } =
     liveContract
   const { coverImageUrl } = liveContract
+
+  const tryOfferReview = useStoreReviewNudge('win-bet')
+  // Boolean instead of raw profit so streaming-bet metric ticks don't
+  // re-arm the 3s timer; we only care about the threshold transition.
+  const winNudgeEligible =
+    isResolved &&
+    !!privateUser &&
+    (myContractMetrics?.profit ?? 0) >= WIN_BET_MIN_PROFIT &&
+    !!liveContract.resolutionTime &&
+    Date.now() - liveContract.resolutionTime <= WIN_BET_RECENT_RESOLUTION_MS
+  useEffect(() => {
+    if (!winNudgeEligible) return
+    const t = setTimeout(tryOfferReview, 3000)
+    return () => clearTimeout(t)
+  }, [winNudgeEligible, tryOfferReview])
 
   const description = liveContract.description
 

--- a/web/components/native-message-provider.tsx
+++ b/web/components/native-message-provider.tsx
@@ -20,6 +20,7 @@ import { postMessageToNative } from 'web/lib/native/post-message'
 import { MesageTypeMap, nativeToWebMessageType } from 'common/native-message'
 import { usePersistentLocalState } from 'web/hooks/use-persistent-local-state'
 import { api } from 'web/lib/api/api'
+import { track } from 'web/lib/service/analytics'
 
 type NativeContextType = {
   isNative: boolean
@@ -108,12 +109,16 @@ export const NativeMessageProvider = (props: { children: React.ReactNode }) => {
           console.log(`Error navigating to linked route`, e)
         }
       } else if (type === 'hasReviewAction') {
-        const { hasAction, isAvailable } =
+        const { hasAction, isAvailable, reason } =
           data as MesageTypeMap['hasReviewAction']
         if (hasAction && isAvailable) {
           console.log('Store review is available, requesting review.')
+          track('review_prompt_requested', { reason })
           postMessageToNative('storeReviewRequested', {})
-          // Update the user's last review time optimistically
+          // Update the user's last review time optimistically. Apple's
+          // requestReview() returns void and may silently no-op (3-prompts/year
+          // cap), so we can't know whether the modal was actually shown — we
+          // bump the timestamp regardless so cooldown logic stays predictable.
           api('me/private/update', { lastAppReviewTime: Date.now() }).catch(
             (e) => {
               console.error('Failed to update lastAppReviewTime', e)
@@ -124,6 +129,7 @@ export const NativeMessageProvider = (props: { children: React.ReactNode }) => {
             hasAction,
             isAvailable,
           })
+          track('review_prompt_skipped', { reason, hasAction, isAvailable })
         }
       }
     }

--- a/web/components/notification-settings.tsx
+++ b/web/components/notification-settings.tsx
@@ -35,6 +35,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { UserWatchedContractsButton } from 'web/components/notifications/watched-markets'
 import { SwitchSetting } from 'web/components/switch-setting'
+import ShortToggle from 'web/components/widgets/short-toggle'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { api } from 'web/lib/api/api'
 import TrophyIcon from 'web/lib/icons/trophy-icon.svg'
@@ -273,9 +274,62 @@ export function NotificationSettings(props: {
           icon={<ExclamationIcon className={'h-6 w-6'} />}
           data={optOutAll}
         />
+        <AppReviewPromptToggle privateUser={privateUser} />
         <FollowMarketModal open={showWatchModal} setOpen={setShowWatchModal} />
       </Col>
     </SectionRoutingContext.Provider>
+  )
+}
+
+function AppReviewPromptToggle(props: { privateUser: PrivateUser }) {
+  const { privateUser } = props
+  const { isNative } = useNativeInfo()
+  const serverOptedOut = privateUser.optOutAppReviewPrompts === true
+  const [optedOut, setOptedOut] = useState(serverOptedOut)
+  const [saving, setSaving] = useState(false)
+
+  // Re-sync if the prop updates from a websocket push (e.g. user toggled in
+  // another tab) and we're not mid-save.
+  useEffect(() => {
+    if (!saving) setOptedOut(serverOptedOut)
+  }, [serverOptedOut, saving])
+
+  // Web users never see the OS review prompt — hide the toggle so they
+  // aren't presented with a setting that has no observable effect for them.
+  // (Their preference still persists if they later install the native app.)
+  if (!isNative) return null
+
+  const handleChange = async (newOptedOut: boolean) => {
+    setOptedOut(newOptedOut)
+    setSaving(true)
+    try {
+      await api('me/private/update', {
+        optOutAppReviewPrompts: newOptedOut,
+      })
+    } catch (e) {
+      setOptedOut(!newOptedOut)
+      toast.error('Failed to update preference')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Col className="gap-2">
+      <Row className={'text-ink-700 gap-2 text-xl'}>
+        <span>App Store Review</span>
+      </Row>
+      <Row className="ml-3 items-center gap-3 text-sm">
+        <ShortToggle
+          on={!optedOut}
+          setOn={(on) => handleChange(!on)}
+          disabled={saving}
+        />
+        <span className="text-ink-700">
+          Ask me to rate the app on the store occasionally
+        </span>
+      </Row>
+    </Col>
   )
 }
 

--- a/web/components/notifications/income-summary-notifications.tsx
+++ b/web/components/notifications/income-summary-notifications.tsx
@@ -11,10 +11,13 @@ import {
   UniqueBettorData,
 } from 'common/notification'
 import { formatMoney, maybePluralize } from 'common/util/format'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import clsx from 'clsx'
 
+import { STREAK_MILESTONES } from 'common/store-review'
+import { DAY_MS } from 'common/util/time'
 import { UserLink } from 'web/components/widgets/user-link'
+import { useStoreReviewNudge } from 'web/hooks/use-store-review-nudge'
 import { useUser } from 'web/hooks/use-user'
 import { BettingStreakModal } from '../profile/betting-streak-modal'
 import { LoansModal } from '../profile/loans-modal'
@@ -288,15 +291,32 @@ export function BettingStreakBonusIncomeNotification(props: {
   setHighlighted: (highlighted: boolean) => void
 }) {
   const { notification, highlighted, setHighlighted } = props
-  const { sourceText } = notification
+  const { sourceText, createdTime } = notification
   const [open, setOpen] = useState(false)
   const user = useUser()
+  const tryOfferReview = useStoreReviewNudge('streak-bonus-modal')
   const {
     streak: streakInDays,
     cashAmount,
     bonusAmount,
   } = notification.data as BettingStreakData
   const noBonus = sourceText === '0'
+
+  const handleOpen = () => {
+    setOpen(true)
+    // Only nudge on a fresh milestone — clicking a year-old streak-7 notification
+    // should not arm the prompt.
+    const isFresh = Date.now() - createdTime < DAY_MS
+    if (
+      isFresh &&
+      !noBonus &&
+      streakInDays &&
+      (STREAK_MILESTONES as readonly number[]).includes(streakInDays)
+    ) {
+      // Let the celebration modal land before the OS review prompt overlays it.
+      setTimeout(tryOfferReview, 2500)
+    }
+  }
 
   // Get quest multiplier from membership tier (1x for non-supporters)
   const questMultiplier = getBenefit(user?.entitlements, 'questMultiplier')
@@ -331,7 +351,7 @@ export function BettingStreakBonusIncomeNotification(props: {
           }
         />
       }
-      onClick={() => setOpen(true)}
+      onClick={handleOpen}
     >
       {noBonus ? (
         <span className="line-clamp-3">
@@ -582,8 +602,20 @@ export function ReferralNotification(props: {
     sourceUserUsername,
     sourceText,
     data,
+    createdTime,
   } = notification
   const user = useUser()
+  const tryOfferReview = useStoreReviewNudge('referral-bonus')
+
+  // Fire once on mount when the user is viewing a fresh referral bonus.
+  // Multiple fresh referrals rendering at once are de-duped by the hook's
+  // module-level localLastFireTime + cooldown; stale referrals (>1d old) skip.
+  const isFresh = Date.now() - createdTime < DAY_MS
+  useEffect(() => {
+    if (!isFresh) return
+    const t = setTimeout(tryOfferReview, 1500)
+    return () => clearTimeout(t)
+  }, [isFresh, tryOfferReview])
   const isYourMarket = sourceContractCreatorUsername === user?.username
   // Use data.manaAmount if available, fall back to sourceText for old notifications
   const referralData = data as ReferralData | undefined

--- a/web/hooks/use-store-review-nudge.ts
+++ b/web/hooks/use-store-review-nudge.ts
@@ -1,0 +1,74 @@
+import { useEvent } from 'client-common/hooks/use-event'
+import {
+  PUSH_MODAL_RECENT_MS,
+  STORE_REVIEW_COOLDOWN_MS,
+  StoreReviewReason,
+} from 'common/store-review'
+import { usePrivateUser } from 'web/hooks/use-user'
+import { postMessageToNative } from 'web/lib/native/post-message'
+import { track } from 'web/lib/service/analytics'
+import { useNativeInfo } from 'web/components/native-message-provider'
+
+type BlockedBy =
+  | 'not-native'
+  | 'opt-out'
+  | 'cooldown'
+  | 'push-modal-recent'
+
+// Module-level guard so two trigger sites (e.g. bet-panel + contract-page)
+// firing within the same second can't both burn an Apple silent-cap slot
+// before the optimistic lastAppReviewTime write round-trips through the API
+// and AuthContext refetch. Cleared on full page reload (acceptable: the
+// server's lastAppReviewTime takes over by then).
+let localLastFireTime = 0
+
+const evaluateEligibility = (
+  isNative: boolean,
+  privateUser: NonNullable<ReturnType<typeof usePrivateUser>>
+): { eligible: true } | { eligible: false; blockedBy: BlockedBy } => {
+  if (!isNative) return { eligible: false, blockedBy: 'not-native' }
+  if (privateUser.optOutAppReviewPrompts === true)
+    return { eligible: false, blockedBy: 'opt-out' }
+
+  const serverLast = privateUser.lastAppReviewTime ?? 0
+  const effectiveLast = Math.max(serverLast, localLastFireTime)
+  if (Date.now() - effectiveLast < STORE_REVIEW_COOLDOWN_MS)
+    return { eligible: false, blockedBy: 'cooldown' }
+
+  const lastPushModal = privateUser.lastPromptedToEnablePushNotifications ?? 0
+  if (Date.now() - lastPushModal < PUSH_MODAL_RECENT_MS)
+    return { eligible: false, blockedBy: 'push-modal-recent' }
+
+  return { eligible: true }
+}
+
+export const useStoreReviewNudge = (reason: StoreReviewReason) => {
+  const { isNative } = useNativeInfo()
+  const privateUser = usePrivateUser()
+
+  return useEvent(() => {
+    // Silently no-op while privateUser is hydrating. Caller is expected to
+    // also gate on privateUser-defined.
+    if (!privateUser) return
+
+    // Web users are always blocked by 'not-native'; emitting a telemetry event
+    // for every contract-page mount, every notifications-list render, etc.
+    // would drown out the eligible cohort with predictable noise.
+    if (!isNative) return
+
+    const result = evaluateEligibility(isNative, privateUser)
+
+    if (!result.eligible) {
+      track('review_prompt_attempt', {
+        reason,
+        eligible: false,
+        blockedBy: result.blockedBy,
+      })
+      return
+    }
+
+    localLastFireTime = Date.now()
+    track('review_prompt_attempt', { reason, eligible: true })
+    postMessageToNative('hasReviewActionRequested', { reason })
+  })
+}

--- a/web/pages/notifications.tsx
+++ b/web/pages/notifications.tsx
@@ -1,6 +1,5 @@
 import { XIcon } from '@heroicons/react/outline'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/solid'
-import { useEvent } from 'client-common/hooks/use-event'
 import {
   NOTIFICATIONS_PER_PAGE,
   useGroupedNotifications,
@@ -16,7 +15,6 @@ import {
 } from 'common/notification'
 import { PrivateUser, User } from 'common/user'
 import { maybePluralize } from 'common/util/format'
-import dayjs from 'dayjs'
 import { groupBy, sortBy } from 'lodash'
 import { useRouter } from 'next/router'
 import { Fragment, ReactNode, useEffect, useMemo, useState } from 'react'
@@ -45,8 +43,8 @@ import { useUnseenPrivateMessageChannels } from 'web/hooks/use-private-messages'
 import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { api, markAllNotifications } from 'web/lib/api/api'
-import { postMessageToNative } from 'web/lib/native/post-message'
 import { track } from 'web/lib/service/analytics'
+import { useStoreReviewNudge } from 'web/hooks/use-store-review-nudge'
 import { PrivateMessagesList } from '../components/messaging/private-messages-list'
 
 export default function NotificationsPage() {
@@ -124,7 +122,7 @@ function NotificationsContent(props: {
     (params) => api('get-notifications', params),
     usePersistentLocalState
   )
-  const resolution = groupedNotifications?.some(
+  const hasFavorableResolution = groupedNotifications?.some(
     (ng) =>
       ng.notifications.some(
         (n) => n.reason === 'resolutions_on_watched_markets'
@@ -145,38 +143,16 @@ function NotificationsContent(props: {
         return false
       })
   )
-  const { isNative } = useNativeInfo()
-  const lastPushModalSeenTime =
-    privateUser.lastPromptedToEnablePushNotifications
 
-  const checkIfShouldPromptStoreReview = useEvent(() => {
-    const shownPushModalToday = lastPushModalSeenTime
-      ? dayjs(lastPushModalSeenTime).isSame(dayjs(), 'day')
-      : false
-
-    const yearAgo = dayjs().subtract(1, 'years').valueOf()
-    const recentlyReviewed = privateUser.lastAppReviewTime
-      ? privateUser.lastAppReviewTime > yearAgo
-      : false
-    const shouldCheckReviewAbility =
-      isNative && resolution && !recentlyReviewed && !shownPushModalToday
-
-    if (shouldCheckReviewAbility) {
-      postMessageToNative('hasReviewActionRequested', {})
-    }
-  })
+  const tryOfferReview = useStoreReviewNudge('notifications-resolution')
 
   useEffect(() => {
-    setTimeout(() => {
-      // Give the push notification modal time to show and the user to see their notifs
-      checkIfShouldPromptStoreReview()
-    }, 3000)
-  }, [
-    isNative,
-    resolution,
-    lastPushModalSeenTime,
-    privateUser.lastAppReviewTime,
-  ])
+    if (!hasFavorableResolution) return
+    if (!privateUser) return
+    // Give the push notification modal time to show and the user to see their notifs
+    const t = setTimeout(tryOfferReview, 3000)
+    return () => clearTimeout(t)
+  }, [hasFavorableResolution, privateUser, tryOfferReview])
 
   const [unseenNewMarketNotifs, setNewMarketNotifsAsSeen] = useState(
     groupedNewMarketNotifications?.filter((n) => !n.isSeen).length ?? 0

--- a/web/pages/shop.tsx
+++ b/web/pages/shop.tsx
@@ -115,6 +115,7 @@ import {
 } from 'web/components/shop/giveaway-promo-card'
 import { NewBadge } from 'web/components/shop/new-badge'
 import { useAPIGetter } from 'web/hooks/use-api-getter'
+import { useStoreReviewNudge } from 'web/hooks/use-store-review-nudge'
 import { getAnimationLocationText } from 'common/shop/display-config'
 import { getTotalPrizePool } from 'common/sweepstakes'
 
@@ -1554,6 +1555,7 @@ function MerchItemCard(props: {
     isNew,
     onPurchased,
   } = props
+  const tryOfferReview = useStoreReviewNudge('shop-order')
   const shopDiscount = getBenefit(allEntitlements, 'shopDiscount', 0)
   const discountedPrice =
     shopDiscount > 0 ? Math.floor(item.price * (1 - shopDiscount)) : item.price
@@ -1811,6 +1813,8 @@ function MerchItemCard(props: {
         email: '',
       })
       onPurchased?.()
+      // Let the success toast land before the OS modal pops over it.
+      setTimeout(tryOfferReview, 3000)
     } catch (e: any) {
       toast.error(e.message || 'Failed to place order')
       setShowConfirmOrderModal(false)


### PR DESCRIPTION
The in-app store-review prompt previously only fired on the notifications page after a favorable resolution with a 365d cooldown — almost never in practice. This adds a single eligibility hook and 5 more native trigger sites at higher-affinity moments (shop order success, win-bet contract page, streak-day bet, streak-bonus notification click, referral-bonus notification mount). Cooldown is shortened to 180d (~2/yr/user, with Apple's silent ~3/365d cap as the OS-level backstop on iOS).

- new web/hooks/use-store-review-nudge.ts centralizes eligibility (not-native, opt-out, cooldown, push-modal-recent) plus a module-level localLastFireTime to dedupe near-simultaneous trigger sites
- new optOutAppReviewPrompts on PrivateUser + toggle in notification settings (hidden for web-only users)
- telemetry: review_prompt_attempt, review_prompt_requested, review_prompt_skipped — tagged with reason
- native shell echoes reason back through the hasReviewAction bridge