### PR TITLE
Fix gemini sdk migration

### DIFF
--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -28,7 +28,7 @@
     "@giphy/js-fetch-api": "5.0.0",
     "@google-cloud/monitoring": "4.0.0",
     "@google-cloud/secret-manager": "4.2.1",
-    "@google/generative-ai": "0.22.0",
+    "@google/genai": "2.6.0",
     "@mendable/firecrawl-js": "1.8.5",
     "@modelcontextprotocol/sdk": "1.17.1",
     "@supabase/supabase-js": "2.38.5",

--- a/backend/api/src/check-poll-suggestion.ts
+++ b/backend/api/src/check-poll-suggestion.ts
@@ -13,38 +13,53 @@ export const checkPollSuggestion: APIHandler<'check-poll-suggestion'> =
 
       log('checkPollSuggestion:', { question, answersString })
 
-      const prompt = `You are an expert at determining whether a question is objective (has a verifiable factual answer) or subjective (based on opinions, preferences, or personal judgment).
+      const prompt = `You are classifying whether a prediction market question should instead be a poll.
 
 Today is ${new Date().toISOString()}.
 
 Question: "${question}"
 ${answersString ? `Possible answers: ${answersString}` : ''}
 
-Analyze this question and determine:
-1. Is this question OBJECTIVE (can be verified with facts, has a definite answer that will be known in the future) or SUBJECTIVE (based on opinions, preferences, or personal judgment)?
+THE TEST — apply this single rule:
+- OBJECTIVE: the answer becomes known through observation, counting, measurement, or a public record. A neutral third party could look at the outcome and agree on the answer. The question is OBJECTIVE even if:
+  * It is about a single person, including the asker themselves ("How many presents will I get for Christmas?", "Will I run a marathon this year?", "How much will I weigh on Jan 1?")
+  * Only the asker can observe the outcome ("Will I quit my job in 2026?")
+  * The outcome depends on the asker's choices or luck — choices and outcomes are still facts
+  * It is hard to predict, uncertain, or unusual
+  * The resolution requires the creator to self-report — self-reporting is a resolution mechanism, not subjectivity
 
-Examples of OBJECTIVE questions (should be prediction markets):
-- "Will Biden win the 2024 election?" - factually verifiable outcome
-- "Will SpaceX launch Starship by 2025?" - factually verifiable event
-- "Will the S&P 500 close above 5000 on Dec 31?" - measurable outcome
-- "Which team will win the Super Bowl?" - factually verifiable
-- "When will GPT-5 be released?" - factually verifiable date
+- SUBJECTIVE: answering it requires the respondent's opinion, taste, values, or aesthetic judgment. There is no outcome to observe — different people give different valid answers because they value different things.
 
-Examples of SUBJECTIVE questions (should be polls):
-- "What is the best programming language?" - opinion-based
-- "Who is the greatest basketball player of all time?" - subjective judgment
-- "What's your favorite movie?" - personal preference
-- "Is pineapple good on pizza?" - matter of taste
-- "What do you think about AI art?" - personal opinion
-- "Which political party has better policies?" - value judgment
-- "Is remote work better than office work?" - depends on personal circumstances
+OBJECTIVE examples (NOT polls — these are valid prediction markets):
+- "Will Biden win the 2024 election?"
+- "How many presents will I get for Christmas?" — countable outcome, even though personal
+- "Will I get a girlfriend in 2026?" — observable outcome, even though personal
+- "How many books will I read this year?" — countable outcome
+- "Will it snow in NYC on Christmas Day?"
+- "What will the S&P 500 close at on Dec 31?"
+- "Will SpaceX launch Starship by 2026?"
 
-Return ONLY a JSON object with:
-- "isSubjective": boolean (true if the question is subjective/opinion-based, false if objective/factual)
-- "confidence": number between 0 and 1 (how confident you are in this classification)
-- "reason": string (brief explanation, max 100 characters)
+SUBJECTIVE examples (polls):
+- "What is the best programming language?" — pure opinion
+- "Is pineapple good on pizza?" — pure taste
+- "What's your favorite movie?" — pure preference
+- "Should the US adopt UBI?" — value judgment, no observable resolution
+- "Who is the greatest basketball player of all time?" — opinion, no objective metric
+- "What do you think about AI art?" — explicitly asks for opinion
 
-Only suggest a poll (isSubjective: true) when you're reasonably confident the question is asking for opinions or preferences rather than predictions about future events.`
+DO NOT classify a question as subjective merely because:
+- It is about the asker's personal life
+- It is hard to verify externally
+- It depends on someone's choices
+- The asker is the only person who knows the outcome
+- It uses words like "I", "my", "will I"
+
+Return ONLY a JSON object:
+- "isSubjective": boolean
+- "confidence": number 0-1
+- "reason": string (max 100 chars, must reference the TEST above, not "personal" or "hard to verify")
+
+Default to isSubjective: false when uncertain — a wrongly-suggested poll is worse than missing one.`
 
       try {
         const result = await promptAI<{

--- a/backend/api/src/generate-ai-answers.ts
+++ b/backend/api/src/generate-ai-answers.ts
@@ -61,7 +61,7 @@ export const generateAIAnswers: APIHandler<'generate-ai-answers'> =
           answers: string[]
           addAnswersMode: 'DISABLED' | 'ONLY_CREATOR' | 'ANYONE'
         }>(userPrompt, {
-          model: aiModels.flash,
+          model: aiModels.flashLite,
           webSearch: true,
           parseAsJson: true,
         })

--- a/backend/api/src/generate-ai-date-ranges.ts
+++ b/backend/api/src/generate-ai-date-ranges.ts
@@ -127,12 +127,12 @@ export const generateAIDateRanges: APIHandler<'generate-ai-date-ranges'> =
       // Generate both bucket and threshold ranges in parallel
       const [buckets, thresholds] = await Promise.all([
         promptAI<DateRangeResponse>(prompt, {
-          model: aiModels.flash,
+          model: aiModels.flashLite,
           system: bucketSystemPrompt,
           parseAsJson: true,
         }),
         promptAI<DateRangeResponse>(prompt, {
-          model: aiModels.flash,
+          model: aiModels.flashLite,
           system: thresholdSystemPrompt,
           parseAsJson: true,
         }),
@@ -192,7 +192,7 @@ export const regenerateDateMidpoints: APIHandler<'regenerate-date-midpoints'> =
       `
 
       const result = await promptAI<string[]>(prompt, {
-        model: aiModels.flash,
+        model: aiModels.flashLite,
         parseAsJson: true,
       })
       log('claudeResponse', result)

--- a/backend/api/src/generate-ai-numeric-ranges.ts
+++ b/backend/api/src/generate-ai-numeric-ranges.ts
@@ -48,12 +48,12 @@ export const generateAINumericRanges: APIHandler<'generate-ai-numeric-ranges'> =
 
       const [thresholds, buckets] = await Promise.all([
         promptAI<RangeResponse>(prompt, {
-          model: aiModels.flash,
+          model: aiModels.flashLite,
           system: thresholdSystemPrompt,
           parseAsJson: true,
         }),
         promptAI<RangeResponse>(prompt, {
-          model: aiModels.flash,
+          model: aiModels.flashLite,
           system: bucketSystemPrompt,
           parseAsJson: true,
         }),
@@ -108,7 +108,7 @@ export const regenerateNumericMidpoints: APIHandler<'regenerate-numeric-midpoint
       Return ONLY an array of midpoint numbers, one for each range, in the same order as the ranges, without any other text or formatting.`
 
       const result = await promptAI<number[]>(prompt, {
-        model: aiModels.flash,
+        model: aiModels.flashLite,
         parseAsJson: true,
       })
       log('claudeResponse', result)

--- a/backend/scheduler/package.json
+++ b/backend/scheduler/package.json
@@ -21,7 +21,7 @@
     "@anthropic-ai/sdk": "0.60.0",
     "@google-cloud/monitoring": "4.0.0",
     "@google-cloud/secret-manager": "4.2.1",
-    "@google/generative-ai": "0.24.0",
+    "@google/genai": "2.6.0",
     "@stdlib/math-base-special-betaincinv": "0.2.1",
     "@supabase/supabase-js": "2.38.5",
     "@tiptap/core": "2.0.0-beta.204",

--- a/backend/shared/package.json
+++ b/backend/shared/package.json
@@ -13,7 +13,7 @@
     "@anthropic-ai/sdk": "0.60.0",
     "@google-cloud/monitoring": "4.0.0",
     "@google-cloud/secret-manager": "4.2.1",
-    "@google/generative-ai": "0.22.0",
+    "@google/genai": "2.6.0",
     "@stdlib/math-base-special-betaincinv": "0.2.1",
     "@tiptap/core": "2.0.0-beta.204",
     "@tiptap/html": "2.0.0-beta.204",

--- a/backend/shared/src/helpers/gemini.ts
+++ b/backend/shared/src/helpers/gemini.ts
@@ -1,9 +1,10 @@
-import { GoogleGenerativeAI } from '@google/generative-ai'
+import { GoogleGenAI } from '@google/genai'
 import { APIError } from 'common/api/utils'
 import { log } from 'shared/utils'
 
 export const models = {
-  flash: 'gemini-3.1-flash-lite-preview' as const,
+  flashLite: 'gemini-3.1-flash-lite' as const,
+  flash: 'gemini-3.5-flash' as const,
   pro: 'gemini-3.1-pro-preview' as const,
 }
 
@@ -46,34 +47,27 @@ export const promptGemini = async (
     throw new APIError(500, 'Missing GEMINI_API_KEY')
   }
 
-  const genAI = new GoogleGenerativeAI(apiKey)
+  const ai = new GoogleGenAI({ apiKey })
 
-  // Configure model with optional Google Search grounding and thinking level
-  const modelConfig: any = { model }
+  const config: Record<string, any> = {}
+  if (system) {
+    config.systemInstruction = system
+  }
   if (webSearch) {
-    modelConfig.tools = [{ googleSearch: {} }]
+    config.tools = [{ googleSearch: {} }]
   }
-
-  // Configure thinking level for Gemini 3 models
-  // Note: 'minimal' and 'medium' are only supported by Gemini 3 Flash
   if (thinkingLevel) {
-    modelConfig.generationConfig = {
-      ...modelConfig.generationConfig,
-      thinkingConfig: {
-        thinkingLevel: thinkingLevel,
-      },
-    }
+    config.thinkingConfig = { thinkingLevel }
   }
-
-  const geminiModel = genAI.getGenerativeModel(modelConfig)
 
   try {
-    // Combine system prompt and user prompt if system is provided
-    const fullPrompt = system ? `${system}\n\n${prompt}` : prompt
+    const result = await ai.models.generateContent({
+      model,
+      contents: prompt,
+      ...(Object.keys(config).length > 0 ? { config } : {}),
+    })
 
-    const result = await geminiModel.generateContent(fullPrompt)
-    const response = result.response.text()
-
+    const response = result.text ?? ''
     log('Gemini returned message:', response)
     return response
   } catch (error: any) {

--- a/backend/shared/tsconfig.json
+++ b/backend/shared/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "composite": true,
+    "skipLibCheck": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,15 +2536,15 @@
     teeny-request "^8.0.0"
     uuid "^8.0.0"
 
-"@google/generative-ai@0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@google/generative-ai/-/generative-ai-0.22.0.tgz#e77a1a3911f4f98bf9e965ad7c4b1ee2130abd26"
-  integrity sha512-mLR3PDWCk5O/BWNyDvFDIiwKeXQmFGZ+kJFd9m73QrUPCFREttJyVbBPTW4y9CwTbaltLMDaLDfroCrRv5Bl8Q==
-
-"@google/generative-ai@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@google/generative-ai/-/generative-ai-0.24.0.tgz#4d27af7d944c924a27a593c17ad1336535d53846"
-  integrity sha512-fnEITCGEB7NdX0BhoYZ/cq/7WPZ1QS5IzJJfC3Tg/OwkvBetMiVJciyaan297OvE4B9Jg1xvo0zIazX/9sGu1Q==
+"@google/genai@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-2.6.0.tgz#a8d3fc3c1f40e4d0b4e8d400734289e2701c03bd"
+  integrity sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==
+  dependencies:
+    google-auth-library "^10.3.0"
+    p-retry "^4.6.2"
+    protobufjs "^7.5.4"
+    ws "^8.18.0"
 
 "@grpc/grpc-js@~1.10.0":
   version "1.10.6"
@@ -3686,10 +3686,20 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
   integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
 
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
   integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
@@ -3698,6 +3708,13 @@
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
     "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
@@ -3708,6 +3725,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
   integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+"@protobufjs/inquire@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
+  integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
@@ -3723,6 +3745,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
 "@radix-ui/number@1.1.0":
   version "1.1.0"
@@ -7858,6 +7885,11 @@
     "@types/node" "*"
     "@types/tough-cookie" "*"
     form-data "^2.5.0"
+
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/rimraf@^3.0.2":
   version "3.0.2"
@@ -12430,12 +12462,30 @@ gaxios@^6.0.0, gaxios@^6.1.1:
     node-fetch "^2.6.9"
     uuid "^9.0.1"
 
+gaxios@^7.0.0, gaxios@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.4.tgz#33a5b78e2c5c01cf5a5d17f58dd188839867fc9c"
+  integrity sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
 gcp-metadata@6.1.0, gcp-metadata@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-6.1.0.tgz#9b0dd2b2445258e7597f2024332d20611cbd6b8c"
   integrity sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==
   dependencies:
     gaxios "^6.0.0"
+    json-bigint "^1.0.0"
+
+gcp-metadata@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
     json-bigint "^1.0.0"
 
 gcp-metadata@^5.0.0:
@@ -12683,6 +12733,18 @@ goober@^2.1.10:
   resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.14.tgz#4a5c94fc34dc086a8e6035360ae1800005135acd"
   integrity sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==
 
+google-auth-library@^10.3.0:
+  version "10.6.2"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.6.2.tgz#44557c536aec626b7cda48a85b5d026e2c9b74c4"
+  integrity sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.1.4"
+    gcp-metadata "8.1.2"
+    google-logging-utils "1.1.3"
+    jws "^4.0.0"
+
 google-auth-library@^8.0.1, google-auth-library@^8.0.2:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-8.6.0.tgz#79cc4c8bacffee26bac244f25f4968ac87218bb8"
@@ -12748,6 +12810,11 @@ google-gax@^4.0.3:
     protobufjs "7.2.6"
     retry-request "^7.0.0"
     uuid "^9.0.1"
+
+google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 google-p12-pem@^4.0.0:
   version "4.0.1"
@@ -14572,6 +14639,11 @@ long@^5.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
   integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
 
+long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
+
 loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -15561,6 +15633,14 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-retry@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
@@ -16357,6 +16437,24 @@ protobufjs@7.2.6, protobufjs@^7.0.0, protobufjs@^7.2.4, protobufjs@^7.2.5:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
+protobufjs@^7.5.4:
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.1.tgz#6320bb08c3be7dcfc6f9193ee03d3a4643f1eb37"
+  integrity sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
+
 proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -17033,7 +17131,7 @@ retry-request@^7.0.0:
     extend "^3.0.2"
     teeny-request "^9.0.0"
 
-retry@0.13.1:
+retry@0.13.1, retry@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
   integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
@@ -17806,7 +17904,16 @@ string-similarity@4.0.4:
   resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
   integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17962,7 +18069,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19352,7 +19466,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19365,6 +19479,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -19419,6 +19542,11 @@ ws@^7.5.1, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+ws@^8.18.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 ws@^8.19.0, ws@^8.5.0:
   version "8.19.0"


### PR DESCRIPTION
## Summary

Prod's six AI endpoints (numeric ranges, date ranges, answers, descriptions, poll suggestion, market suggestions) have been broken since `gemini-3.1-flash-lite-preview` was shut down on **May 25, 2026** (yesterday). Root cause is two-layered:

1. **EOL'd SDK.** `@google/generative-ai` was EOL'd 2025-11-30; we were still on 0.22.0. Migrating to the unified replacement, `@google/genai 2.6.0`.
2. **Preview model rotation.** Ian's March 4 bump used `-preview` IDs. The Flash Lite preview went GA on May 7 and was killed May 25.

While in the file, I also fixed two AI quality issues that surfaced during testing: descriptions hallucinating sources, and the poll-suggestion banner misclassifying personal-but-objective questions ("How many presents will I get for Christmas?") as polls.

## Changes

**SDK migration**
- Replace `@google/generative-ai 0.22.0` with `@google/genai 2.6.0` in `backend/shared`, `backend/api`, `backend/scheduler`.
- Rewrite `promptGemini` against new SDK shape (`GoogleGenAI` client, `config.systemInstruction`, `config.thinkingConfig`, `response.text`). Same public API.
- `skipLibCheck: true` on `backend/shared/tsconfig.json` to suppress a gaxios/undici-types declaration clash from transitive deps.

**Model tier split**

| Tier | Model | Used by |
|---|---|---|
| `flashLite` | `gemini-3.1-flash-lite` (GA) | Structured JSON: numeric ranges, date ranges, answers |
| `flash` | `gemini-3.5-flash` (GA) | Poll suggestion, descriptions, market suggestions, close-date, spam, etc. |
| `pro` | `gemini-3.1-pro-preview` | Reserved; no current callers |

Flash Lite is great at filling a JSON schema but hallucinates on constraint-heavy prompts. Moving judgment endpoints off Lite fixes the WHO-dashboard hallucination in `generate-ai-description` and the Christmas-presents-as-poll misclassification in `check-poll-suggestion`.

**Poll-suggestion prompt rewrite**
- Replaced loose "objective vs. subjective" definitions with a single observable-outcome test.
- Removed the misleading "Is remote work better than office work? — depends on personal circumstances" example that was teaching the model to flag personal questions as subjective.
- Added personal-but-objective examples (presents, books read, marathon).
- Anti-pattern list naming the wrong reasoning paths the model was taking.
- Asymmetric default to `false` when uncertain.