### PR TITLE
feat: favicon next to external links + harden link sanitization

### DIFF
--- a/web/components/contract/editable-question-title.tsx
+++ b/web/components/contract/editable-question-title.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { updateMarket } from 'web/lib/api/api'
 import { IconButton } from '../buttons/button'
 import { ExpandingInput } from '../widgets/expanding-input'
-import { Linkify } from '../widgets/linkify'
 
 export const EditableQuestionTitle = (props: {
   contract: Contract
@@ -61,7 +60,7 @@ export const EditableQuestionTitle = (props: {
     </div>
   ) : (
     <div className="group text-xl font-medium sm:text-2xl">
-      <Linkify text={contract.question} />
+      {contract.question}
       {canEdit && (
         <button
           type="button"

--- a/web/components/editor/link-extension.tsx
+++ b/web/components/editor/link-extension.tsx
@@ -2,10 +2,11 @@ import { mergeAttributes } from '@tiptap/core'
 import { Link as TiptapLink } from '@tiptap/extension-link'
 import NextLink from 'next/link'
 import { ReactNode } from 'react'
-import { linkClass } from 'web/components/widgets/site-link'
+import { linkClass, LinkFavicon } from 'web/components/widgets/site-link'
 
 const LinkComponent = (props: { href: string; children: ReactNode }) => {
-  const { href, children } = props
+  const { href: rawHref, children } = props
+  const href = safeHref(rawHref)
 
   if (isInternal(href)) {
     return (
@@ -17,23 +18,16 @@ const LinkComponent = (props: { href: string; children: ReactNode }) => {
 
   return (
     <a href={href} target="_blank" rel="noopener ugc" className={linkClass}>
+      <LinkFavicon href={href} />
       {children}
     </a>
   )
 }
 
+
 export const DisplayLink = TiptapLink.extend({
   renderHTML({ HTMLAttributes }) {
-    // Block dangerous protocols (javascript:, data:, vbscript:, etc.)
-    const href = HTMLAttributes.href
-    if (
-      href &&
-      !/^https?:\/\//i.test(href) &&
-      !href.startsWith('/') &&
-      !href.startsWith('#')
-    ) {
-      HTMLAttributes.href = '#'
-    }
+    HTMLAttributes.href = safeHref(HTMLAttributes.href)
 
     // This is used for SSR and copy/paste
     HTMLAttributes.target = isInternal(HTMLAttributes.href) ? '_self' : '_blank'
@@ -57,8 +51,32 @@ export const DisplayLink = TiptapLink.extend({
   },
 })
 
-const isInternal = (href: string) =>
-  href.startsWith('/') ||
-  href.startsWith('#') ||
-  href.includes('manifold.markets') ||
-  href.includes('localhost')
+// Allow http(s) absolute URLs, root-relative paths, and in-page anchors only.
+// Reject protocol-relative (`//host`, `/\host`) and everything else
+// (javascript:, data:, vbscript:, file:, etc.) → '#'.
+const isLocalPath = (href: string) =>
+  (href.startsWith('/') && !href.startsWith('//') && !href.startsWith('/\\')) ||
+  href.startsWith('#')
+
+const safeHref = (href: string | undefined | null): string => {
+  if (!href) return '#'
+  if (isLocalPath(href)) return href
+  if (/^https?:\/\//i.test(href)) return href
+  return '#'
+}
+
+const INTERNAL_HOSTS = new Set(['manifold.markets', 'manifold.love', 'localhost'])
+
+const isInternal = (href: string) => {
+  if (isLocalPath(href)) return true
+  try {
+    const { hostname } = new URL(href)
+    return (
+      INTERNAL_HOSTS.has(hostname) ||
+      hostname.endsWith('.manifold.markets') ||
+      hostname.endsWith('.manifold.love')
+    )
+  } catch {
+    return false
+  }
+}

--- a/web/components/tv/tv-display.tsx
+++ b/web/components/tv/tv-display.tsx
@@ -11,7 +11,6 @@ import { Col } from 'web/components/layout/col'
 import { Page } from 'web/components/layout/page'
 import { Row } from 'web/components/layout/row'
 import { useUser } from 'web/hooks/use-user'
-import { Linkify } from 'web/components/widgets/linkify'
 import { useAdminOrMod } from 'web/hooks/use-admin'
 import {
   BinaryBetPanel,
@@ -100,7 +99,7 @@ export function TVDisplay(props: {
                   target="_blank"
                   className="hover:underline"
                 >
-                  <Linkify text={contract.question} />
+                  {contract.question}
                 </Link>
               </Row>
               {isBinary && (

--- a/web/components/widgets/linkify.tsx
+++ b/web/components/widgets/linkify.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import Link from 'next/link'
 import { Fragment } from 'react'
 import { useNativeInfo } from '../native-message-provider'
-import { linkClass } from './site-link'
+import { linkClass, LinkFavicon } from './site-link'
 
 // Return a JSX span, linkifying @username, and https://...
 export function Linkify(props: { text: string; className?: string }) {
@@ -42,6 +42,7 @@ export function Linkify(props: { text: string; className?: string }) {
             className={className}
             href={href}
           >
+            <LinkFavicon href={href} />
             {symbol}
             {tag}
           </a>
@@ -63,12 +64,22 @@ export function Linkify(props: { text: string; className?: string }) {
 
 const isInternalHref = (href: string) => href.startsWith('/')
 
+const isManifoldHost = (href: string) => {
+  try {
+    const { hostname } = new URL(href)
+    return (
+      hostname === 'manifold.markets' ||
+      hostname === 'manifold.love' ||
+      hostname.endsWith('.manifold.markets') ||
+      hostname.endsWith('.manifold.love')
+    )
+  } catch {
+    return false
+  }
+}
+
 export const getLinkTarget = (href: string, newTab?: boolean) => {
-  if (
-    href.startsWith('http') &&
-    !href.startsWith(`https://manifold`) // covers manifold.markets and manifold.love
-  )
-    return '_blank'
+  if (href.startsWith('http') && !isManifoldHost(href)) return '_blank'
   const { isNative } = useNativeInfo()
   // Native will open 'a new tab' when target = '_blank' in the system browser rather than in the app
   if (isNative) return '_self'

--- a/web/components/widgets/site-link.tsx
+++ b/web/components/widgets/site-link.tsx
@@ -1,2 +1,26 @@
 export const linkClass =
   'break-anywhere hover:underline hover:decoration-primary-400 hover:decoration-2 active:underline active:decoration-primary-400'
+
+export const LinkFavicon = (props: { href: string }) => {
+  let hostname: string | null = null
+  try {
+    hostname = new URL(props.href).hostname
+  } catch {
+    return null
+  }
+  return (
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${hostname}&sz=32`}
+      alt=""
+      aria-hidden="true"
+      width={16}
+      height={16}
+      loading="lazy"
+      decoding="async"
+      className="mr-1 my-0 inline-block h-[1em] w-[1em] align-text-bottom"
+      onError={(e) => {
+        ;(e.currentTarget as HTMLImageElement).style.display = 'none'
+      }}
+    />
+  )
+}


### PR DESCRIPTION
- Add a small favicon (Google s2/favicons) before external link text in rendered comments, descriptions, posts, etc. Internal links unchanged.
- Apply favicon to both rich-text (TipTap) and plaintext (Linkify) paths.
- Drop Linkify wrapper from market question titles (and TV display) so URLs typed into titles render as plain text instead of auto-linked.

Hardening (closes pre-existing bugs surfaced during audit):
- Extract safeHref() and apply on every render path; previously the javascript:/data:/vbscript: blocklist only ran in renderHTML, not in renderReact (used by RichContent/generateReact).
- Rewrite isInternal()/isManifoldHost() to use URL.hostname allowlist instead of substring matching, so e.g. evil.com/?q=manifold.markets is no longer treated as internal.
- Reject protocol-relative hrefs (//evil.com, /\evil.com) which slipped past startsWith('/') in both safeHref and isInternal.