### PR TITLE
fix: show 'verification temporarily unavailable' when iDenfy quota is…

### DIFF
--- a/backend/api/src/idenfy/create-session.ts
+++ b/backend/api/src/idenfy/create-session.ts
@@ -68,6 +68,18 @@ export const createIdenfySession: APIHandler<'create-idenfy-session'> = async (
       status: response.status,
       body: errorText,
     })
+    let identifier: string | undefined
+    try {
+      identifier = JSON.parse(errorText)?.identifier
+    } catch {
+      // body wasn't JSON; identifier stays undefined
+    }
+    if (identifier === 'PERMISSIONS_ERROR') {
+      throw new APIError(
+        503,
+        'Identity verification is temporarily unavailable. Please try again later or contact support.'
+      )
+    }
     throw new APIError(500, 'Failed to create verification session')
   }
 

--- a/web/components/comments/comment-input.tsx
+++ b/web/components/comments/comment-input.tsx
@@ -18,7 +18,7 @@ import { Tooltip } from 'web/components/widgets/tooltip'
 import { useAnswer } from 'web/hooks/use-answers'
 import { isBlocked, usePrivateUser, useUser } from 'web/hooks/use-user'
 import { useDisplayUserById } from 'web/hooks/use-user-supabase'
-import { api } from 'web/lib/api/api'
+import { api, APIError } from 'web/lib/api/api'
 import { firebaseLogin } from 'web/lib/firebase/users'
 import { track } from 'web/lib/service/analytics'
 import { safeLocalStorage } from 'web/lib/util/local'
@@ -292,7 +292,11 @@ function VerifyToCommentPrompt(props: { className?: string }) {
       window.location.href = response.redirectUrl
     } catch (e) {
       console.error('Failed to start verification:', e)
-      setError('Failed to start verification. Please try again.')
+      setError(
+        e instanceof APIError && e.code === 503
+          ? e.message
+          : 'Failed to start verification. Please try again.'
+      )
     } finally {
       setLoading(false)
     }

--- a/web/components/modals/verification-required-modal.tsx
+++ b/web/components/modals/verification-required-modal.tsx
@@ -5,7 +5,7 @@ import { Modal, MODAL_CLASS } from 'web/components/layout/modal'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Button } from 'web/components/buttons/button'
-import { api } from 'web/lib/api/api'
+import { api, APIError } from 'web/lib/api/api'
 import { track } from 'web/lib/service/analytics'
 import { User } from 'common/user'
 
@@ -44,7 +44,11 @@ export function VerificationRequiredModal({
       window.location.href = response.redirectUrl
     } catch (e) {
       console.error('Failed to start verification:', e)
-      setError('Failed to start verification. Please try again.')
+      setError(
+        e instanceof APIError && e.code === 503
+          ? e.message
+          : 'Failed to start verification. Please try again.'
+      )
       track('bonus verification: error', {
         action,
         error: e instanceof Error ? e.message : 'Unknown error',

--- a/web/components/onboarding/identity-verification-page.tsx
+++ b/web/components/onboarding/identity-verification-page.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 
 import { canReceiveBonuses, User } from 'common/user'
-import { api } from 'web/lib/api/api'
+import { api, APIError } from 'web/lib/api/api'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
@@ -56,7 +56,11 @@ export function IdentityVerificationPage(props: {
       window.location.href = response.redirectUrl
     } catch (e) {
       console.error('Failed to start verification:', e)
-      setError('Failed to start verification. Please try again.')
+      setError(
+        e instanceof APIError && e.code === 503
+          ? e.message
+          : 'Failed to start verification. Please try again.'
+      )
       track('identity verification: error', {
         error: e instanceof Error ? e.message : 'Unknown error',
       })

--- a/web/components/onboarding/verification-result-modal.tsx
+++ b/web/components/onboarding/verification-result-modal.tsx
@@ -6,7 +6,7 @@ import { Modal, MODAL_CLASS } from 'web/components/layout/modal'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Button } from 'web/components/buttons/button'
-import { api } from 'web/lib/api/api'
+import { api, APIError } from 'web/lib/api/api'
 import { track } from 'web/lib/service/analytics'
 
 type VerificationResult = 'approved' | 'denied' | 'unverified' | null
@@ -94,7 +94,11 @@ function DeniedContent({ onClose }: { onClose: () => void }) {
       window.location.href = response.redirectUrl
     } catch (e) {
       console.error('Failed to start verification:', e)
-      setError('Failed to start verification. Please try again.')
+      setError(
+        e instanceof APIError && e.code === 503
+          ? e.message
+          : 'Failed to start verification. Please try again.'
+      )
     } finally {
       setLoading(false)
     }

--- a/web/components/profile/settings.tsx
+++ b/web/components/profile/settings.tsx
@@ -15,7 +15,7 @@ import { Title } from '../widgets/title'
 import { canReceiveBonuses, PrivateUser, User } from 'common/user'
 import { useEffect, useState } from 'react'
 import { generateNewApiKey } from 'web/lib/api/api-key'
-import { api } from 'web/lib/api/api'
+import { api, APIError } from 'web/lib/api/api'
 import { track } from 'web/lib/service/analytics'
 import { DeleteYourselfButton } from './delete-yourself'
 import { capitalize } from 'lodash'
@@ -155,7 +155,11 @@ function IdentityVerificationSetting() {
       window.location.href = response.redirectUrl
     } catch (e) {
       console.error('Failed to start verification:', e)
-      setError('Failed to start verification. Please try again.')
+      setError(
+        e instanceof APIError && e.code === 503
+          ? e.message
+          : 'Failed to start verification. Please try again.'
+      )
     } finally {
       setLoading(false)
     }

--- a/web/components/user/verify-phone-number-banner.tsx
+++ b/web/components/user/verify-phone-number-banner.tsx
@@ -8,7 +8,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Button } from 'web/components/buttons/button'
 import { useUser } from 'web/hooks/use-user'
-import { api } from 'web/lib/api/api'
+import { api, APIError } from 'web/lib/api/api'
 import { track } from 'web/lib/service/analytics'
 import { usePersistentLocalState } from 'web/hooks/use-persistent-local-state'
 
@@ -47,7 +47,11 @@ export const VerifyPhoneNumberBanner = (props: {
       window.location.href = response.redirectUrl
     } catch (e) {
       console.error('Failed to start verification:', e)
-      setError('Failed to start verification. Please try again.')
+      setError(
+        e instanceof APIError && e.code === 503
+          ? e.message
+          : 'Failed to start verification. Please try again.'
+      )
     } finally {
       setLoading(false)
     }

--- a/web/pages/create-post.tsx
+++ b/web/pages/create-post.tsx
@@ -214,7 +214,11 @@ function VerifyToCreatePost() {
       window.location.href = response.redirectUrl
     } catch (e) {
       console.error('Failed to start verification:', e)
-      setError('Failed to start verification. Please try again.')
+      setError(
+        e instanceof APIError && e.code === 503
+          ? e.message
+          : 'Failed to start verification. Please try again.'
+      )
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
… hit

iDenfy returns PERMISSIONS_ERROR (HTTP 400) when the plan's verification quota is exhausted. Previously this surfaced as a generic 'Failed to start verification. Please try again', so users with no remedy would retry indefinitely while the platform stayed silent (the last outage went ~70h before a user reported it).

- Backend: parse the iDenfy error body and throw APIError(503, ...) with a user-facing message when identifier === 'PERMISSIONS_ERROR'.
- Frontend: each of the 7 create-idenfy-session call sites now passes the server message through when the error is a 503; other failures keep the existing generic message.