### PR TITLE
Disable prize drawing autoresolve

### DIFF
--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -20,7 +20,8 @@ import { sendWeeklyMarketsEmails } from 'shared/weekly-markets-emails'
 import { sendPortfolioUpdateEmailsToAllUsers } from 'shared/weekly-portfolio-emails'
 import { applyPendingClarifications } from './apply-pending-clarifications'
 import { autoAwardBounty } from './auto-award-bounty'
-import { autoGenerateAndResolvePrizeDrawings } from './auto-generate-and-resolve-prize-drawings'
+// Auto-cycle disabled while we rework prize drawings — resolve/restart manually.
+// import { autoGenerateAndResolvePrizeDrawings } from './auto-generate-and-resolve-prize-drawings'
 import { autobanUsers } from './autoban-users'
 import { autoLeaguesCycle } from './auto-leagues-cycle'
 import { cleanOldNotifications } from './clean-old-notifications'
@@ -198,11 +199,12 @@ export function createJobs() {
       '0 30 2 * * *', // 230 AM daily
       cleanOldNotifications
     ),
-    createJob(
-      'auto-generate-and-resolve-prize-drawings',
-      '0 0 13 * * *', // 1 PM PT daily
-      autoGenerateAndResolvePrizeDrawings
-    ),
+    // Auto-cycle disabled while we rework prize drawings — resolve/restart manually.
+    // createJob(
+    //   'auto-generate-and-resolve-prize-drawings',
+    //   '0 0 13 * * *', // 1 PM PT daily
+    //   autoGenerateAndResolvePrizeDrawings
+    // ),
     // // Achievement MV refreshes (nightly, staggered ~10 mins apart)
     // createJob(
     //   'update-ach-trades',

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -20,7 +20,7 @@ import { sendWeeklyMarketsEmails } from 'shared/weekly-markets-emails'
 import { sendPortfolioUpdateEmailsToAllUsers } from 'shared/weekly-portfolio-emails'
 import { applyPendingClarifications } from './apply-pending-clarifications'
 import { autoAwardBounty } from './auto-award-bounty'
-// Auto-cycle disabled while we rework prize drawings — resolve/restart manually.
+// Autoresolve temporarily disabled — uncomment to continue with $100/day.
 // import { autoGenerateAndResolvePrizeDrawings } from './auto-generate-and-resolve-prize-drawings'
 import { autobanUsers } from './autoban-users'
 import { autoLeaguesCycle } from './auto-leagues-cycle'
@@ -199,7 +199,7 @@ export function createJobs() {
       '0 30 2 * * *', // 230 AM daily
       cleanOldNotifications
     ),
-    // Auto-cycle disabled while we rework prize drawings — resolve/restart manually.
+    // Autoresolve temporarily disabled — uncomment to continue with $100/day.
     // createJob(
     //   'auto-generate-and-resolve-prize-drawings',
     //   '0 0 13 * * *', // 1 PM PT daily


### PR DESCRIPTION
Comments out the daily autoresolve cron so we can manually resolve + restart drawings. Uncomment to restore $100/day