### PR TITLE
Feat/niche topic tagging

### DIFF
--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -61,6 +61,10 @@ import {
   canUserAddGroupToMarket,
 } from 'shared/update-group-contracts-internal'
 import {
+  AUTO_TAG_API_MARKET_CREATIONS,
+  getNicheTopicMatchesForContract,
+} from 'shared/helpers/topic-matching'
+import {
   htmlToRichText,
   isProd,
   log,
@@ -112,10 +116,43 @@ export const createMarket: APIHandler<'market'> = onlyUsersWhoCanPerformAction(
           market.answers.forEach(broadcastNewAnswer)
         }
         await onCreateMarket(market, embedding)
+        await maybeAutoTagApiMarket(pg, market, groupIds)
       },
     }
   }
 )
+
+// API counterpart to the web UI's getSimilarGroupsToContract suggester,
+// for markets created without groupIds. Off by default — see flag.
+async function maybeAutoTagApiMarket(
+  pg: SupabaseDirectClient,
+  market: Contract,
+  groupIdsProvided: string[] | null | undefined
+) {
+  if (!AUTO_TAG_API_MARKET_CREATIONS) return
+  if (groupIdsProvided && groupIdsProvided.length > 0) return
+  if (market.visibility !== 'public') return
+  if (market.outcomeType === 'STONK' || market.outcomeType === 'POLL') return
+
+  try {
+    const matches = await getNicheTopicMatchesForContract(pg, market.id)
+    for (const match of matches) {
+      await addGroupToContract(pg, market, {
+        id: match.id,
+        slug: match.slug,
+      })
+    }
+    if (matches.length > 0) {
+      log(
+        `Auto-tagged API market ${market.id} with: ${matches
+          .map((m) => m.slug)
+          .join(', ')}`
+      )
+    }
+  } catch (err) {
+    log.error('Auto-tag failed for market ' + market.id, { err })
+  }
+}
 
 export async function createMarketHelper(body: Body, auth: AuthedUser) {
   const {

--- a/backend/api/src/get-feed.ts
+++ b/backend/api/src/get-feed.ts
@@ -23,7 +23,11 @@ import {
 } from 'shared/topic-interests'
 import { privateUserBlocksSql } from 'shared/supabase/search-contracts'
 import { getFollowedReposts, getTopicReposts } from 'shared/supabase/reposts'
-import { FeedContract, GROUP_SCORE_PRIOR } from 'common/feed'
+import {
+  FeedContract,
+  GROUP_SCORE_PRIOR,
+  NICHE_BLEND_TOPIC_SCORE_SQL,
+} from 'common/feed'
 
 const DEBUG_USER_ID = undefined
 const DEBUG_FEED = false //process.platform === 'darwin'
@@ -113,7 +117,7 @@ export const getFeed: APIHandler<'get-feed'> = async (props) => {
   const baseQueryArray = () =>
     buildArray(
       select('contracts.*'),
-      select(`avg(uti.topic_score) as topic_conversion_score`),
+      select(`${NICHE_BLEND_TOPIC_SCORE_SQL} as topic_conversion_score`),
       from(
         `(select
                unnest(array[$1]) as group_id,
@@ -151,8 +155,8 @@ export const getFeed: APIHandler<'get-feed'> = async (props) => {
     order(`contracts.conversion_score desc`)
   )
   const sorts = {
-    conversion: `avg(uti.topic_score  * contracts.conversion_score) desc`,
-    freshness: `avg(uti.topic_score  * contracts.freshness_score) desc`,
+    conversion: `${NICHE_BLEND_TOPIC_SCORE_SQL} * contracts.conversion_score desc`,
+    freshness: `${NICHE_BLEND_TOPIC_SCORE_SQL} * contracts.freshness_score desc`,
   }
   const sortQueries = Object.values(sorts).map((orderQ) =>
     renderSql(...baseQueryArray(), order(orderQ))

--- a/backend/api/src/get-unified-feed.ts
+++ b/backend/api/src/get-unified-feed.ts
@@ -25,7 +25,11 @@ import {
 } from 'shared/topic-interests'
 import { privateUserBlocksSql } from 'shared/supabase/search-contracts'
 import { getFollowedReposts, getTopicReposts } from 'shared/supabase/reposts'
-import { FeedContract, GROUP_SCORE_PRIOR } from 'common/feed'
+import {
+  FeedContract,
+  GROUP_SCORE_PRIOR,
+  NICHE_BLEND_TOPIC_SCORE_SQL,
+} from 'common/feed'
 import { CommentWithTotalReplies } from 'common/comment'
 import { JSONContent } from '@tiptap/core'
 import { contractColumnsToSelect } from 'shared/utils'
@@ -181,7 +185,7 @@ async function fetchPersonalizedFeed(
   const baseQueryArray = () =>
     buildArray(
       select('contracts.*'),
-      select(`avg(uti.topic_score) as topic_conversion_score`),
+      select(`${NICHE_BLEND_TOPIC_SCORE_SQL} as topic_conversion_score`),
       from(
         `(select unnest(array[$1]) as group_id, unnest(array[$2]) as topic_score) as uti`,
         [
@@ -219,7 +223,9 @@ async function fetchPersonalizedFeed(
   // Run optimized parallel queries - combine conversion and freshness into single query
   const combinedQuery = renderSql(
     ...baseQueryArray(),
-    order(`avg(uti.topic_score * contracts.conversion_score * contracts.freshness_score) desc`)
+    order(
+      `${NICHE_BLEND_TOPIC_SCORE_SQL} * contracts.conversion_score * contracts.freshness_score desc`
+    )
   )
 
   const [combinedContracts, followedContracts, followedRepostData, topicRepostData] =

--- a/backend/shared/src/helpers/topic-matching.ts
+++ b/backend/shared/src/helpers/topic-matching.ts
@@ -1,0 +1,63 @@
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+// Unsupervised tag attachment for API-created markets without groupIds.
+// Differs from get-similar-groups-to-contract.ts (the web-UI suggester):
+// pure-distance ranking, no importance-score floor, tighter threshold —
+// surfaces niche tags like Mining/Metals/Commodities rather than the
+// broad generics the importance-weighted formula favours.
+
+export const NICHE_TOPIC_SIMILARITY_THRESHOLD = 0.42
+export const NICHE_AUTOTAG_LIMIT = 3
+
+export const AUTO_TAG_API_MARKET_CREATIONS = false
+
+// Topics the embedding model over-triggers on for quantitative content
+// (crypto/bitcoin/numbers) or that are dev-only.
+const NICHE_TAG_BLOCKLIST = [
+  'olivia',
+  'nathans-dashboard',
+  'tomeks-specials',
+  'austin-less-wrong-2023-predictions',
+  'fantasy-football-stock-exchange',
+  'ancient-markets',
+  'spam',
+  'test',
+  'sf-bay-rationalists',
+  'conditional-markets',
+  'crypto-speculation',
+  'bitcoin',
+  'bitcoin-maxi',
+  'numbers',
+]
+
+export async function getNicheTopicMatchesForContract(
+  pg: SupabaseDirectClient,
+  contractId: string,
+  limit = NICHE_AUTOTAG_LIMIT,
+  threshold = NICHE_TOPIC_SIMILARITY_THRESHOLD
+): Promise<{ id: string; slug: string; distance: number }[]> {
+  return pg.map(
+    `with target as (
+       select embedding as emb from contract_embeddings where contract_id = $1
+     )
+     select g.id, g.slug, (ge.embedding <=> (select emb from target)) as distance
+     from groups g
+     join group_embeddings ge on g.id = ge.group_id
+     where (ge.embedding <=> (select emb from target)) < $2
+       and g.privacy_status = 'public'
+       and g.total_members >= 1
+       and g.slug not in ($3:list)
+       -- Block calendar buckets ('2026', 'august-2025', 'q1-2024') while
+       -- preserving event-year tags ('election-2024', 'world-cup-2026').
+       and g.slug !~ '^[0-9]{4}$'
+       and g.slug !~* '^(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec|january|february|march|april|june|july|august|september|october|november|december|q[1-4])-(19|20)[0-9]{2}$'
+     order by (ge.embedding <=> (select emb from target)) asc
+     limit $4`,
+    [contractId, threshold, NICHE_TAG_BLOCKLIST, limit],
+    (r: { id: string; slug: string; distance: string }) => ({
+      id: r.id,
+      slug: r.slug,
+      distance: Number(r.distance),
+    })
+  )
+}

--- a/backend/shared/src/update-group-contracts-internal.ts
+++ b/backend/shared/src/update-group-contracts-internal.ts
@@ -18,10 +18,15 @@ export async function addGroupToContract(
   group: { id: string; slug: string },
   userId?: string
 ) {
-  await pg.none(
-    `insert into group_contracts (contract_id, group_id) values ($1, $2)`,
+  // RETURNING 1 lets us skip the slug append on duplicates —
+  // FieldVal.arrayConcat would otherwise double-append.
+  const inserted = await pg.oneOrNone(
+    `insert into group_contracts (contract_id, group_id) values ($1, $2)
+     on conflict (contract_id, group_id) do nothing
+     returning 1`,
     [contract.id, group.id]
   )
+  if (!inserted) return
   await updateContract(pg, contract.id, {
     groupSlugs: FieldVal.arrayConcat(group.slug),
     lastUpdatedTime: Date.now(),

--- a/common/src/feed.ts
+++ b/common/src/feed.ts
@@ -22,3 +22,8 @@ export const GROUP_SCORE_PRIOR = 0.34698192227708463 // betaIncompleteInverse(1/
 export const FOLLOWED_TOPIC_CONVERSION_PRIOR = 1
 export const NEW_USER_FOLLOWED_TOPIC_SCORE_BOOST = 0.7
 export const OLD_USER_FOLLOWED_TOPIC_SCORE_BOOST = 0.3
+
+// 70/30 max/avg blend across a market's matching tags — keeps a strong
+// niche match from being diluted by broad parent tags also on the market.
+export const NICHE_BLEND_TOPIC_SCORE_SQL =
+  '(0.7 * max(uti.topic_score) + 0.3 * avg(uti.topic_score))'


### PR DESCRIPTION
- Topic tags on API created markets
- Increase niche-topic visibility (AVG -> 70/30 MAX+AVG blend). Stops the strongest-match tag being averaged down by broader parent tags they only loosely care about. A user with `Mining=0.8, Business=0.05, Economics=0.05` evaluating `[Mining, Business, Economics]` used to score it at `avg=0.3` (2.7x below the same market just tagged with `mining`) -- Now it scores `0.7*0.8+0.3*0.3 = 0.65`. Single niche still slightly outrank multi-niche, by design. 
- Structure still kinda sucks but will fix comprehensively later
- `addGroupToContract` idempotency: stopping duplicate slugs in the `groupSlugs` JSONB when I run backfill script for markets with no tags.
- Going to run a backfill script (not included in PR) once to add tags to mass-API-created markets. 