### PR TITLE
mark Manifest standard ticket as out of stock

### DIFF
--- a/common/src/shop/items.ts
+++ b/common/src/shop/items.ts
@@ -951,7 +951,7 @@ export const SHOP_ITEMS: ShopItem[] = [
     limit: 'one-time',
     category: 'ticket',
     slot: 'unique',
-    maxStock: 20,
+    maxStock: 0,
   },
 ]
 


### PR DESCRIPTION
Sets maxStock to 0 so the card shows "Sold out" via the existing available <= 0 check.