### PR TITLE
fix: community guidelines content updates from mod feedback

### DIFF
--- a/web/pages/community-guidelines.tsx
+++ b/web/pages/community-guidelines.tsx
@@ -20,7 +20,7 @@ const GUIDELINES = [
   'Be excellent to each other.',
   "Don't exploit bonuses, bugs, or loopholes — especially on your own markets.",
   'Resolve honestly and promptly.',
-  'Report security issues privately to a dev.',
+  "Report bugs in #bugs on Discord. Report security issues or exploits privately to info@manifold.markets — don't act on them first.",
   'These are guidelines, not a contract. Act in good faith, not just within the letter of the rules.',
 ]
 

--- a/web/pages/community-guidelines/bots.tsx
+++ b/web/pages/community-guidelines/bots.tsx
@@ -75,14 +75,15 @@ export default function CommunityGuidelinesBotsPage() {
               A "Bot" badge appears next to your name everywhere on the site.
             </li>
             <li>
-              You're moved into the{' '}
+              You'll be placed in the{' '}
               <Link
                 href="/community-guidelines/leagues#silicon"
                 className="text-primary-500 underline"
               >
                 Silicon
               </Link>{' '}
-              division for leagues and compete only against other bots.
+              division at the start of the next season and compete only against
+              other bots.
             </li>
             <li>
               Your bets don't count toward unique trader bonuses for market
@@ -130,8 +131,15 @@ export default function CommunityGuidelinesBotsPage() {
           </h2>
           <p className="text-ink-700 mt-3">
             Bot accounts don't need to complete identity verification. If your
-            bot wins a Silicon league prize or earns mana you'd like to convert,
-            send it to your verified main account and participate in{' '}
+            bot wins a Silicon league prize or earns mana you'd like to use,
+            send it to your{' '}
+            <a
+              href="#verification-and-prizes"
+              className="text-primary-500 underline"
+            >
+              Verified
+            </a>{' '}
+            main account via Managram and participate in{' '}
             <Link
               href="/community-guidelines/prize-drawings-faq"
               className="text-primary-500 underline"
@@ -140,7 +148,21 @@ export default function CommunityGuidelinesBotsPage() {
             </Link>{' '}
             from there.
           </p>
-          <p className="text-ink-600 mt-3 text-sm">
+        </div>
+
+        <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
+          <h2
+            id="transferring-mana"
+            className="text-ink-1000 text-xl font-semibold"
+          >
+            Transferring mana to/from bot accounts
+          </h2>
+          <p className="text-ink-700 mt-3">
+            You can send profit/balance to/from your main account, but you
+            cannot exploit bonuses or manipulate markets or intentionally trade
+            against yourself to launder profit.
+          </p>
+          <p className="text-ink-700 mt-3">
             This is the one sanctioned exception to the rule that{' '}
             <Link
               href="/community-guidelines/accounts#alt-accounts"
@@ -150,7 +172,8 @@ export default function CommunityGuidelinesBotsPage() {
             </Link>
             . The rule against funneling targets bonus harvesting (signup
             bonuses, daily streaks, unique trader bonuses), not transferring a
-            bot's legitimately-earned mana for prize redemption.
+            bot's legitimately-earned mana for trading, prize drawings, or
+            charity giveaways.
           </p>
         </div>
 

--- a/web/pages/community-guidelines/comment-guidelines.tsx
+++ b/web/pages/community-guidelines/comment-guidelines.tsx
@@ -105,6 +105,17 @@ export default function CommunityGuidelinesCommentGuidelinesPage() {
             severity and history. Repeated violations are treated more harshly
             than first offenses.
           </p>
+          <p className="text-ink-700 mt-3">
+            To report a comment or user, use the three dots menu (…) on the
+            comment or their profile. See{' '}
+            <a
+              href="/community-guidelines/platform-conduct#reporting-and-feedback"
+              className="text-primary-500 underline"
+            >
+              Reporting & feedback
+            </a>{' '}
+            for full details.
+          </p>
         </div>
 
         <SectionNav currentHref="/community-guidelines/comment-guidelines" />

--- a/web/pages/community-guidelines/creator-guide.tsx
+++ b/web/pages/community-guidelines/creator-guide.tsx
@@ -163,25 +163,16 @@ export default function CommunityGuidelinesCreatorGuidePage() {
               unavailable, ambiguous outcome.
             </li>
             <li>
+              Avoid the word "by" with dates — it's ambiguous. Use "before
+              [date]" if you mean before that day begins, or "before the end of
+              [date]" if you mean by 11:59pm on that day.
+            </li>
+            <li>
               If you have to update criteria mid-market because new events
               happened, do it in the description and post a comment so traders
               see the change.
             </li>
           </ul>
-        </div>
-
-        <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
-          <h2
-            id="pick-a-reasonable-close-date"
-            className="text-ink-1000 text-xl font-semibold"
-          >
-            Pick a reasonable close date
-          </h2>
-          <p className="text-ink-700 mt-3">
-            Close shortly before the outcome is known, not after. Closing too
-            early kills late-information trading; closing too late lets people
-            pile in once the answer is obvious.
-          </p>
         </div>
 
         <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
@@ -221,31 +212,27 @@ export default function CommunityGuidelinesCreatorGuidePage() {
 
         <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
           <h2
-            id="when-all-else-fails-na"
+            id="trader-bonuses"
             className="text-ink-1000 text-xl font-semibold"
           >
-            When all else fails, N/A
+            Trader bonuses
           </h2>
           <p className="text-ink-700 mt-3">
-            N/A returns mana to traders at their cost basis and isn't a black
-            mark. It's the right move when:
+            You can offset market creation costs by earning unique trader
+            bonuses.
           </p>
-          <ul className="text-ink-700 mt-3 list-disc space-y-2 pl-5">
-            <li>The outcome is genuinely unknowable.</li>
-            <li>
-              An event was cancelled or the criteria are no longer achievable.
-            </li>
-            <li>
-              You realized the question was ambiguous and there's no fair way to
-              call it.
-            </li>
-          </ul>
           <p className="text-ink-700 mt-3">
-            Before reaching for N/A, it's worth checking in with Mods —
-            sometimes they can help you find a resolution path you hadn't
-            considered. N/A is a release valve for when that genuinely doesn't
-            exist. Use it without guilt when needed, but don't reach for it just
-            to dodge a hard call.
+            Every time a new unique trader bets on your market, you earn a mana
+            bonus. The amount scales with your market's liquidity — more
+            liquidity in the pool means more earned per trader. These bonuses
+            count toward your{' '}
+            <Link
+              href="/community-guidelines/leagues"
+              className="text-primary-500 underline"
+            >
+              Leagues
+            </Link>{' '}
+            score alongside your trading profit.
           </p>
         </div>
 

--- a/web/pages/community-guidelines/leagues.tsx
+++ b/web/pages/community-guidelines/leagues.tsx
@@ -94,9 +94,13 @@ export default function CommunityGuidelinesLeaguesPage() {
               status.
             </li>
             <li>
-              Bets on your own markets count only after a 1-hour delay — this
-              prevents creators from pump-and-dumping fresh markets for league
-              points.
+              Unique trader bonuses earned on ranked markets you've created also
+              count toward your score.
+            </li>
+            <li>
+              Bets on your own markets within the first hour of creation don't
+              count toward your league score — this prevents creators from
+              pump-and-dumping fresh markets for league points.
             </li>
           </ul>
         </div>
@@ -259,23 +263,6 @@ export default function CommunityGuidelinesLeaguesPage() {
               applied to league play.
             </li>
           </ul>
-        </div>
-
-        <div className="border-ink-200 bg-canvas-50 mt-6 rounded-xl border-2 p-5">
-          <p className="text-ink-700 text-sm">
-            Leagues are meant to reward being good at predicting, not at
-            extracting. If you're not sure whether a strategy crosses the line,
-            ask in{' '}
-            <a
-              className="text-primary-500 underline"
-              href="https://discord.gg/2sHu6z9WMQ"
-              target="_blank"
-              rel="noreferrer"
-            >
-              Discord
-            </a>{' '}
-            before running it.
-          </p>
         </div>
 
         <SectionNav currentHref="/community-guidelines/leagues" />

--- a/web/pages/community-guidelines/market-policies.tsx
+++ b/web/pages/community-guidelines/market-policies.tsx
@@ -111,42 +111,6 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
         </div>
 
         <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
-          <h2 id="subsidized" className="text-ink-1000 text-xl font-semibold">
-            Subsidized
-          </h2>
-          <p className="text-ink-700 mt-3">
-            Creators receive 5 mana per unique trader for the first 50 traders,
-            then 1 mana up to a cap of 10,000. Markets also receive a 20 mana
-            liquidity subsidy from the house for each of the first 50 traders,
-            then 5 mana to the same cap.
-          </p>
-          <p className="text-ink-700 mt-3">A market may be unsubsidized if:</p>
-          <ul className="text-ink-700 mt-2 list-disc space-y-2 pl-5">
-            <li>
-              It's unlisted — unlisted markets are never subsidized by default
-            </li>
-            <li>It's self-referential</li>
-            <li>It resolves to something purely random or gambling-like</li>
-            <li>
-              It's spam or extremely low quality (e.g. "will the sun explode
-              tomorrow?")
-            </li>
-            <li>It can never be resolved or could only ever resolve one way</li>
-            <li>It's an exact or near-exact duplicate of an existing market</li>
-            <li>
-              It falls under the unlisting criteria below but isn't severe
-              enough to act on
-            </li>
-          </ul>
-          <p className="text-ink-600 mt-3 text-sm">
-            Note: unsubsidization may be applied after some initial bonuses have
-            already been received and is not retroactive. Markets that
-            technically qualify but seem genuinely valuable may still be left
-            subsidized.
-          </p>
-        </div>
-
-        <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
           <h2
             id="unlisted-na-deleted"
             className="text-ink-1000 text-xl font-semibold"

--- a/web/pages/community-guidelines/moderation.tsx
+++ b/web/pages/community-guidelines/moderation.tsx
@@ -115,9 +115,11 @@ export default function CommunityGuidelinesModerationPage() {
             How to request mod help
           </h2>
           <p className="text-ink-700 mt-3">
-            If you need a Mod to resolve a market, post a comment on the market
-            with your desired resolution and a source or reasoning. This helps
-            Mods act quickly and accurately.
+            The easiest way to reach Mods is to post a comment on the relevant
+            market and tag <span className="font-medium">@mods</span> — this
+            sends an alert to all active Mods and adds the market to the mod
+            queue. Include your desired resolution and a source or reasoning to
+            help Mods act quickly and accurately.
           </p>
           <ul className="text-ink-700 mt-3 list-disc space-y-2 pl-5">
             <li>
@@ -130,7 +132,7 @@ export default function CommunityGuidelinesModerationPage() {
               request mod help directly without waiting.
             </li>
             <li>
-              Use the @mods tag on the market itself to flag it for the mod
+              Post a comment on the market tagging @mods to flag it for the mod
               queue.
             </li>
           </ul>

--- a/web/pages/community-guidelines/platform-conduct.tsx
+++ b/web/pages/community-guidelines/platform-conduct.tsx
@@ -84,8 +84,20 @@ export default function CommunityGuidelinesPlatformConductPage() {
             Reporting & feedback
           </h2>
           <p className="text-ink-700 mt-3">
-            If you believe a rule has been broken or want to flag something to
-            the team, reach out on{' '}
+            If you believe a rule has been broken, you can report directly on
+            the site using the three dots menu (…):
+          </p>
+          <ul className="text-ink-700 mt-2 list-disc space-y-2 pl-5">
+            <li>
+              To report a user, use the three dots menu on a comment they've
+              left, or on their profile page.
+            </li>
+            <li>
+              To report a market, use the three dots menu on the market page.
+            </li>
+          </ul>
+          <p className="text-ink-700 mt-3">
+            You can also reach the team on{' '}
             <a
               className="text-primary-500 underline"
               href="https://discord.gg/2sHu6z9WMQ"
@@ -94,7 +106,7 @@ export default function CommunityGuidelinesPlatformConductPage() {
             >
               Discord
             </a>{' '}
-            or email{' '}
+            or by emailing{' '}
             <a
               className="text-primary-500 underline"
               href="mailto:info@manifold.markets"
@@ -102,6 +114,35 @@ export default function CommunityGuidelinesPlatformConductPage() {
               info@manifold.markets
             </a>
             .
+          </p>
+        </div>
+
+        <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
+          <h2
+            id="reporting-bugs-and-exploits"
+            className="text-ink-1000 text-xl font-semibold"
+          >
+            Reporting bugs and exploits
+          </h2>
+          <p className="text-ink-700 mt-3">
+            Found a bug or a potential exploit? Please report it before acting
+            on it. For general bugs, use the{' '}
+            <a
+              className="text-primary-500 underline"
+              href="https://discord.gg/2sHu6z9WMQ"
+              target="_blank"
+              rel="noreferrer"
+            >
+              #bugs channel on Discord
+            </a>
+            . For security issues or exploits, email{' '}
+            <a
+              className="text-primary-500 underline"
+              href="mailto:info@manifold.markets"
+            >
+              info@manifold.markets
+            </a>{' '}
+            directly rather than posting publicly.
           </p>
         </div>
 

--- a/web/pages/community-guidelines/resolving-markets.tsx
+++ b/web/pages/community-guidelines/resolving-markets.tsx
@@ -53,8 +53,8 @@ export default function CommunityGuidelinesResolvingMarketsPage() {
               or ban.
             </li>
             <li>
-              If you made a mistake, tag @mods or an admin to request a
-              re-resolution.
+              If you made a mistake, post a comment on the market tagging @mods
+              to request a re-resolution.
             </li>
           </ul>
         </div>
@@ -85,9 +85,9 @@ export default function CommunityGuidelinesResolvingMarketsPage() {
               fraudulently — including markets created before this policy.
             </li>
             <li>
-              If resolution is genuinely ambiguous, we recommend resolving N/A,
-              especially if the ambiguity is the creator's fault. Please check
-              with Mods first for support in this decision.
+              If resolution is genuinely ambiguous or the outcome is proving
+              contentious, Mods are here to help. In the comments, tag @mods for
+              support in finding the best solution.
             </li>
           </ul>
         </div>

--- a/web/pages/community-guidelines/running-a-market.tsx
+++ b/web/pages/community-guidelines/running-a-market.tsx
@@ -72,11 +72,17 @@ export default function CommunityGuidelinesRunningAMarketPage() {
             Trade in good faith
           </h2>
           <p className="text-ink-700 mt-3">
-            Don't trade on insider knowledge in your own market, exploit
-            ambiguity in your own resolution criteria, or use loopholes for
-            personal gain. Traders are trusting you to call it straight. The
-            fact that you created the market doesn't give you an advantage over
-            the people betting on it.
+            Don't exploit ambiguity in your own resolution criteria or use
+            loopholes for personal gain. Traders are trusting you to call it
+            straight. The fact that you created the market doesn't give you an
+            advantage over the people betting on it.
+          </p>
+          <p className="text-ink-700 mt-3">
+            If you want to make that commitment public, you can permanently
+            block yourself from trading on your own market. The option is in the
+            market info card — once set, it's visible to all traders and can
+            only be undone by a Moderator or admin. Traders can and do request
+            this before placing bets on markets where creator bias is a concern.
           </p>
         </div>
 
@@ -87,7 +93,7 @@ export default function CommunityGuidelinesRunningAMarketPage() {
           <p className="text-ink-700 mt-3">
             If traders are asking questions in the comments, respond. If your
             market is being disputed, engage. An unresponsive creator is one of
-            the most common reasons mods have to step in. You don't have to be
+            the most common reasons Mods have to step in. You don't have to be
             glued to your market, but you should be checking in.
           </p>
         </div>
@@ -110,7 +116,7 @@ export default function CommunityGuidelinesRunningAMarketPage() {
             >
               Resolving Markets
             </Link>{' '}
-            page for detail on the resolution process and when mods can step in.
+            page for detail on the resolution process and when Mods can step in.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Content updates based on mod team feedback on the live community guidelines. Clean branch rebased off main.

- N/A language softened on Resolving Markets; N/A section removed from Creator Guide
- "Don't trade on insider knowledge" removed from Running a Market (contradicted Accounts page)
- Subsidized section removed from Market Policies (no active house subsidy)
- Bug/exploit reporting added to Platform Conduct and main page short version
- In-site reporting (three dots menu) added to Platform Conduct and Comment Guidelines
- @mods tag explained in Moderation; consistent phrasing across all pages
- Unique trader bonuses added to Leagues scoring section and Creator Guide
- "Block yourself from trading" added to Running a Market
- "before" vs "by" date guidance added to Creator Guide resolution criteria
- Bots: Silicon placed next season not immediately; new mana transfer section
- Leagues: 1-hour delay wording clarified; confusing closing note removed
- Lowercase Mods/Moderators fixed throughout

## Test plan

- [ ] Check all updated pages render correctly
- [ ] Verify @mods references are consistent across pages
- [ ] Confirm Leagues scoring section mentions unique trader bonuses
- [ ] Confirm Bots page mana transfer section reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)