### PR TITLE
Update API configuration with minimum 2 instances and autoscaling

### DIFF
--- a/backend/api/deploy-api-windows.sh
+++ b/backend/api/deploy-api-windows.sh
@@ -92,38 +92,6 @@ fi
 TEMPLATE_NAME="${SERVICE_NAME}-${IMAGE_TAG}"
 GROUP_PAGE_URL="https://console.cloud.google.com/compute/instanceGroups/details/${ZONE}/${SERVICE_GROUP}?project=${GCLOUD_PROJECT}"
 
-# ian: GambleId requires a static IP address for the API
-STATIC_IP_NAME="${SERVICE_NAME}-static-ip"
-MAX_IPS=4  # Maximum number of static IPs to cycle through
-
-for i in $(seq 1 $MAX_IPS); do
-    CURRENT_IP_NAME="${STATIC_IP_NAME}-${i}"
-    STATIC_IP_ADDRESS=$(gcloud compute addresses describe ${CURRENT_IP_NAME} --region=${REGION} --project=${GCLOUD_PROJECT} --format='get(address)' 2>/dev/null || echo "")
-
-    if [ -z "${STATIC_IP_ADDRESS}" ]; then
-        echo "Creating new static IP address ${CURRENT_IP_NAME}..."
-        gcloud compute addresses create ${CURRENT_IP_NAME} --region=${REGION} --project=${GCLOUD_PROJECT}
-        STATIC_IP_ADDRESS=$(gcloud compute addresses describe ${CURRENT_IP_NAME} --region=${REGION} --project=${GCLOUD_PROJECT} --format='get(address)')
-    fi
-
-    # Check if any instance is using this IP
-    INSTANCE_USING_IP=$(gcloud compute instances list --project=${GCLOUD_PROJECT} --filter="networkInterfaces.accessConfigs.natIP:${STATIC_IP_ADDRESS}" --format="value(name)")
-
-    if [ -z "${INSTANCE_USING_IP}" ]; then
-        echo "Using available static IP address: ${STATIC_IP_ADDRESS}"
-        break
-    else
-        echo "IP ${STATIC_IP_ADDRESS} is currently in use by instance ${INSTANCE_USING_IP}. Trying next IP."
-    fi
-done
-
-if [ -z "${STATIC_IP_ADDRESS}" ]; then
-    echo "Error: No available static IPs found. Are there too many concurrent deploys? Check your GCP virtual machine dashboard."
-    exit 1
-fi
-
-echo "Using static IP address: ${STATIC_IP_ADDRESS}"
-echo
 echo "Creating new instance template ${TEMPLATE_NAME} using Docker image https://${IMAGE_URL}..."
 gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --project ${GCLOUD_PROJECT} \
@@ -135,8 +103,7 @@ gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT} \
        --no-user-output-enabled \
        --scopes default,cloud-platform \
-       --tags lb-health-check \
-       --address ${STATIC_IP_ADDRESS}
+       --tags lb-health-check
 
 echo "Updating ${SERVICE_GROUP} to ${TEMPLATE_NAME}. See status here: ${GROUP_PAGE_URL}"
 gcloud compute instance-groups managed rolling-action start-update ${SERVICE_GROUP} \
@@ -144,7 +111,8 @@ gcloud compute instance-groups managed rolling-action start-update ${SERVICE_GRO
        --zone ${ZONE} \
        --version template=${TEMPLATE_NAME} \
        --no-user-output-enabled \
-       --max-unavailable 0 # don't kill old one until new one is healthy
+       --max-unavailable 0 \
+       --max-surge 1 # don't kill old one until new one is healthy
 
 echo "Rollout underway. Waiting for update to finish rolling out"
 echo "Current time: $(date "+%Y-%m-%d %I:%M:%S %p")"

--- a/backend/api/deploy-api.sh
+++ b/backend/api/deploy-api.sh
@@ -20,8 +20,7 @@ case $ENV in
     dev)
         NEXT_PUBLIC_FIREBASE_ENV=DEV
         GCLOUD_PROJECT=dev-mantic-markets
-        # MACHINE_TYPE=n2-standard-2 ;;
-        MACHINE_TYPE=e2-small ;;
+        MACHINE_TYPE=e2-small ;; # previously n2-standard-2
     prod)
         NEXT_PUBLIC_FIREBASE_ENV=PROD
         GCLOUD_PROJECT=mantic-markets
@@ -82,38 +81,6 @@ GROUP_PAGE_URL="https://console.cloud.google.com/compute/instanceGroups/details/
 # to upgrading from iptables-legacy to iptables-nft
 # UPDATE 2025-10-02: cos-109-lts no longer exists, upgraded to cos-121-lts to test
 
-# ian: GambleId requires a static IP address for the API
-STATIC_IP_NAME="${SERVICE_NAME}-static-ip"
-MAX_IPS=4  # Maximum number of static IPs to cycle through
-
-for i in $(seq 1 $MAX_IPS); do
-    CURRENT_IP_NAME="${STATIC_IP_NAME}-${i}"
-    STATIC_IP_ADDRESS=$(gcloud compute addresses describe ${CURRENT_IP_NAME} --region=${REGION} --project=${GCLOUD_PROJECT} --format='get(address)' 2>/dev/null || echo "")
-
-    if [ -z "${STATIC_IP_ADDRESS}" ]; then
-        echo "Creating new static IP address ${CURRENT_IP_NAME}..."
-        gcloud compute addresses create ${CURRENT_IP_NAME} --region=${REGION} --project=${GCLOUD_PROJECT}
-        STATIC_IP_ADDRESS=$(gcloud compute addresses describe ${CURRENT_IP_NAME} --region=${REGION} --project=${GCLOUD_PROJECT} --format='get(address)')
-    fi
-
-    # Check if any instance is using this IP
-    INSTANCE_USING_IP=$(gcloud compute instances list --project=${GCLOUD_PROJECT} --filter="networkInterfaces.accessConfigs.natIP:${STATIC_IP_ADDRESS}" --format="value(name)")
-
-    if [ -z "${INSTANCE_USING_IP}" ]; then
-        echo "Using available static IP address: ${STATIC_IP_ADDRESS}"
-        break
-    else
-        echo "IP ${STATIC_IP_ADDRESS} is currently in use by instance ${INSTANCE_USING_IP}. Trying next IP."
-    fi
-done
-
-if [ -z "${STATIC_IP_ADDRESS}" ]; then
-    echo "Error: No available static IPs found. Are there too many concurrent deploys? Check your GCP virtual machine dashboard."
-    exit 1
-fi
-
-echo "Using static IP address: ${STATIC_IP_ADDRESS}"
-echo
 echo "Creating new instance template ${TEMPLATE_NAME} using Docker image https://${IMAGE_URL}..."
 gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --project ${GCLOUD_PROJECT} \
@@ -125,26 +92,26 @@ gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT} \
        --no-user-output-enabled \
        --scopes default,cloud-platform \
-       --tags lb-health-check \
-       --address ${STATIC_IP_ADDRESS}
+       --tags lb-health-check
 
 # ian: Uncomment this after you update the url-map config
 # echo "Importing url-map config"
 # gcloud compute url-maps import api-lb \
 #         --source=url-map-config.yaml \
 #         --project ${GCLOUD_PROJECT} \
-#         --global 
+#         --global
 
 echo "Updating ${SERVICE_GROUP} to ${TEMPLATE_NAME}. See status here: ${GROUP_PAGE_URL}"
 gcloud compute instance-groups managed rolling-action start-update ${SERVICE_GROUP} \
-       --project ${GCLOUD_PROJECT} \
-       --zone ${ZONE} \
-       --version template=${TEMPLATE_NAME} \
-       --no-user-output-enabled \
-       --max-unavailable 0 # don't kill old one until new one is healthy
+        --project ${GCLOUD_PROJECT} \
+        --zone ${ZONE} \
+        --version template=${TEMPLATE_NAME} \
+        --no-user-output-enabled \
+        --max-unavailable 0 \
+        --max-surge 1
 
 echo "Rollout underway. Waiting for update to finish rolling out"
 echo "Current time: $(date "+%Y-%m-%d %I:%M:%S %p")"
 gcloud compute instance-groups managed wait-until --stable ${SERVICE_GROUP} \
-       --project ${GCLOUD_PROJECT} \
-       --zone ${ZONE}
+        --project ${GCLOUD_PROJECT} \
+        --zone ${ZONE}

--- a/backend/api/deploy-dev-windows.ps1
+++ b/backend/api/deploy-dev-windows.ps1
@@ -70,31 +70,8 @@ Write-Host "`n=== Step 4: Pushing Docker image ===" -ForegroundColor Yellow
 docker push $IMAGE_URL
 if ($LASTEXITCODE -ne 0) { Write-Host "Docker push failed" -ForegroundColor Red; exit 1 }
 
-# Step 5: Find available static IP
-Write-Host "`n=== Step 5: Finding available static IP ===" -ForegroundColor Yellow
-
-$STATIC_IP_ADDRESS = $null
-foreach ($i in 1..4) {
-    $ip = gcloud compute addresses describe "api-static-ip-$i" --region=us-east4 --project=dev-mantic-markets --format="get(address)" 2>$null
-    if ($ip) {
-        $inUse = gcloud compute instances list --project=dev-mantic-markets --filter="networkInterfaces.accessConfigs.natIP:$ip" --format="value(name)" 2>$null
-        if (-not $inUse) {
-            $STATIC_IP_ADDRESS = $ip
-            Write-Host "Using available IP: $STATIC_IP_ADDRESS (api-static-ip-$i)"
-            break
-        } else {
-            Write-Host "IP api-static-ip-$i ($ip) is in use by $inUse, trying next..."
-        }
-    }
-}
-
-if (-not $STATIC_IP_ADDRESS) {
-    Write-Host "ERROR: No available static IPs found. Too many concurrent deploys?" -ForegroundColor Red
-    exit 1
-}
-
-# Step 6: Create instance template
-Write-Host "`n=== Step 6: Creating instance template ===" -ForegroundColor Yellow
+# Step 5: Create instance template
+Write-Host "`n=== Step 5: Creating instance template ===" -ForegroundColor Yellow
 
 $TEMPLATE_NAME = "api-$IMAGE_TAG"
 Write-Host "Creating template: $TEMPLATE_NAME"
@@ -107,25 +84,27 @@ gcloud compute instance-templates create-with-container $TEMPLATE_NAME `
     --machine-type=e2-small `
     --boot-disk-size=100GB `
     --container-env="NEXT_PUBLIC_FIREBASE_ENV=DEV,GOOGLE_CLOUD_PROJECT=dev-mantic-markets" `
+    --no-user-output-enabled `
     --scopes="default,cloud-platform" `
-    --tags=lb-health-check `
-    --address=$STATIC_IP_ADDRESS
+    --tags=lb-health-check
 
 if ($LASTEXITCODE -ne 0) { Write-Host "Template creation failed" -ForegroundColor Red; exit 1 }
 
-# Step 7: Start rollout
-Write-Host "`n=== Step 7: Starting rollout ===" -ForegroundColor Yellow
+# Step 6: Start rollout
+Write-Host "`n=== Step 6: Starting rollout ===" -ForegroundColor Yellow
 
 gcloud compute instance-groups managed rolling-action start-update api-group-east `
     --project=dev-mantic-markets `
     --zone=us-east4-a `
     --version=template=$TEMPLATE_NAME `
-    --max-unavailable=0
+    --no-user-output-enabled `
+    --max-unavailable=0 `
+    --max-surge=1
 
 if ($LASTEXITCODE -ne 0) { Write-Host "Rollout failed to start" -ForegroundColor Red; exit 1 }
 
-# Step 8: Wait for completion
-Write-Host "`n=== Step 8: Waiting for rollout to complete ===" -ForegroundColor Yellow
+# Step 7: Wait for completion
+Write-Host "`n=== Step 7: Waiting for rollout to complete ===" -ForegroundColor Yellow
 Write-Host "This usually takes 2-5 minutes..."
 
 gcloud compute instance-groups managed wait-until --stable api-group-east `

--- a/backend/api/update-scaling.sh
+++ b/backend/api/update-scaling.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# This script will update the API server to use autoscaling based on CPU utilization.
+# Update these values then run this script for the changes to take effect.
+# These actions should be idempotent, so running it multiple times is reasonably safe.
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: the first argument should be 'dev' or 'prod'"
+    exit 1
+fi
+
+# Make sure these are the same as deploy.sh
+SERVICE_NAME="api"
+SERVICE_GROUP="${SERVICE_NAME}-group-east"
+ZONE="us-east4-a"
+ENV=${1:-dev}
+
+case $ENV in
+    dev)
+        GCLOUD_PROJECT=dev-mantic-markets
+        MIN_REPLICAS=2
+        MAX_REPLICAS=3
+        TARGET_CPU_UTILIZATION=0.60
+        COOL_DOWN_PERIOD=180 ;;
+    prod)
+        GCLOUD_PROJECT=mantic-markets
+        MIN_REPLICAS=2
+        MAX_REPLICAS=3
+        TARGET_CPU_UTILIZATION=0.60
+        COOL_DOWN_PERIOD=180 ;;
+    *)
+        echo "Invalid environment; must be dev or prod."
+        exit 1
+esac
+
+echo "Updating scaling config for ${SERVICE_GROUP} in ${GCLOUD_PROJECT}/${ZONE}"
+echo "Autoscaling: min=${MIN_REPLICAS}, max=${MAX_REPLICAS}, target CPU=${TARGET_CPU_UTILIZATION}, cooldown=${COOL_DOWN_PERIOD}s"
+
+# Autoscaling requires the MIG to repair failed VMs. If this is set to DO_NOTHING,
+# gcloud returns: "Setting DO_NOTHING in default action on failure and using autoscaler is not supported".
+# (The old config was set to DO_NOTHING.)
+echo
+echo "Ensuring ${SERVICE_GROUP} repairs failed VMs before enabling autoscaling"
+gcloud compute instance-groups managed update ${SERVICE_GROUP} \
+        --project ${GCLOUD_PROJECT} \
+        --zone ${ZONE} \
+        --default-action-on-vm-failure repair
+
+echo
+echo "Ensuring autoscaling is enabled"
+gcloud compute instance-groups managed set-autoscaling ${SERVICE_GROUP} \
+        --project ${GCLOUD_PROJECT} \
+        --zone ${ZONE} \
+        --min-num-replicas ${MIN_REPLICAS} \
+        --max-num-replicas ${MAX_REPLICAS} \
+        --target-cpu-utilization ${TARGET_CPU_UTILIZATION} \
+        --cool-down-period ${COOL_DOWN_PERIOD}
+
+echo
+echo "Scaling config updated. Current MIG status:"
+gcloud compute instance-groups managed describe ${SERVICE_GROUP} \
+        --project ${GCLOUD_PROJECT} \
+        --zone ${ZONE} \
+        --format="yaml(targetSize,autoscaler,status)"


### PR DESCRIPTION
- Removed static IP configuration. It was only needed for GambleID which we no longer use. We may still be paying for the IPs but they aren't attached to any machines. 
- Added a script to update autoscale configuration. It should be idempotent, if you need to increase scaling or change some option just update the variables in that script and run it again.
- Added max surge count to ensure that new instances are created one at a time. Increase this if you want to deploy faster.
- Mirrored changes to windows scripts

The autoscaler trips at 60% CPU, adding a third instance if necessary. The cap and target CPU and other variables are all configurable. These changes are already deployed on dev and prod. I tested for a while on dev this afternoon and got good results. Prod seems to be healthy as well.