### PR TITLE
perf(bets): parallelize independent answers in the bet path

### DIFF
--- a/backend/api/src/helpers/answer-bet-parallelism.ts
+++ b/backend/api/src/helpers/answer-bet-parallelism.ts
@@ -1,0 +1,54 @@
+import { Contract } from 'common/contract'
+
+// Immutable per-contract metadata, used to choose the queue key *before* the
+// contract is fetched. `mechanism` and `shouldAnswersSumToOne` are fixed at
+// creation, so this cache never needs invalidation.
+type ContractMeta = { mechanism: string; shouldAnswersSumToOne: boolean }
+const metaCache = new Map<string, ContractMeta>()
+
+export const cacheContractMeta = (contract: Contract) => {
+  if (metaCache.has(contract.id)) return
+  metaCache.set(contract.id, {
+    mechanism: contract.mechanism,
+    shouldAnswersSumToOne:
+      'shouldAnswersSumToOne' in contract
+        ? !!contract.shouldAnswersSumToOne
+        : false,
+  })
+}
+
+// True when an independent answer of this contract may be keyed/persisted on its
+// own: a known (cached) multiple-choice market whose answers do not sum to one
+// (sum-to-one answers are arbitrage-coupled and must stay coupled). On a cache
+// miss we return false and fall back to the coarse contract key, which is always
+// safe; the cache warms from the first fetch of the contract.
+export const canParallelizeAnswer = (
+  contractId: string,
+  answerId: string | undefined
+) => {
+  if (!answerId) return false
+  const meta = metaCache.get(contractId)
+  return (
+    !!meta && meta.mechanism === 'cpmm-multi-1' && !meta.shouldAnswersSumToOne
+  )
+}
+
+// The queue dependency token for an answer's pool. Independent answers get their
+// own token so operations on different answers run in parallel; binary /
+// sum-to-one / unknown fall back to the coarse contract token. Falling back is
+// always safe — it can only serialize more operations together, never fewer.
+//
+// Invariant: every transaction that writes an answer's pool (bets, sells) must
+// enqueue with that answer's pool token. Pool exclusion comes from the queue, not
+// the database — single-answer ops on independent answers run at READ COMMITTED,
+// where a concurrent read-compute-write of the same pool would silently lose an
+// update. Ops that touch several answers (multi-bet, multi-sell) take one token
+// per touched answer plus the coarse contract token, which also keeps them
+// serialized among themselves.
+export const getPoolDepToken = (
+  contractId: string,
+  answerId: string | undefined
+) =>
+  canParallelizeAnswer(contractId, answerId)
+    ? `${contractId}:${answerId}`
+    : contractId

--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -1,4 +1,5 @@
 import { NewBetResult } from 'api/place-bet'
+import { cacheContractMeta } from 'api/helpers/answer-bet-parallelism'
 import { redeemShares } from 'api/redeem-shares'
 import { Answer } from 'common/answer'
 import { APIError } from 'common/api/utils'
@@ -230,6 +231,10 @@ export const fetchContractBetDataAndValidate = async (
     `Loaded user ${user.username} with id ${user.id} betting on slug ${contract.slug} with contract id: ${contract.id}.`
   )
   log(`Fetch bet data took ${Date.now() - startTime}ms`)
+
+  // Warm the immutable-metadata cache so the bets queue can pick a per-answer
+  // key on the next bet for this contract (see answer-bet-parallelism).
+  cacheContractMeta(contract)
 
   return {
     user,

--- a/backend/api/src/helpers/contract-aggregate-buffer.ts
+++ b/backend/api/src/helpers/contract-aggregate-buffer.ts
@@ -1,0 +1,80 @@
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { log, metrics } from 'shared/utils'
+import { debounce } from './debounce'
+
+// Deferred, debounced writer for a contract's display aggregates.
+//
+// For independent (non-sum-to-one) multiple-choice markets, the per-bet
+// transaction omits the shared contract row so concurrent answer-bets touch only
+// disjoint rows. The contract row holds eventually-consistent, recomputable
+// display state (volume, uniqueBettorCount, lastBetTime, and the denormalized
+// data.answers cache whose source of truth is the `answers` table), applied here
+// with atomic SQL so concurrent answers never collide on it.
+//
+// Drift on crash is bounded by the debounce window and self-heals via the
+// unique-bettor / volume backfills.
+
+type Agg = {
+  volume: number
+  uniqueBettors: number
+  lastBetTime: number
+  answersChanged: boolean
+}
+
+const buffers = new Map<string, Agg>()
+const FLUSH_MS = 150
+
+export const bufferContractAggregate = (
+  contractId: string,
+  delta: Agg
+) => {
+  const cur =
+    buffers.get(contractId) ??
+    { volume: 0, uniqueBettors: 0, lastBetTime: 0, answersChanged: false }
+  cur.volume += delta.volume
+  cur.uniqueBettors += delta.uniqueBettors
+  cur.lastBetTime = Math.max(cur.lastBetTime, delta.lastBetTime)
+  cur.answersChanged = cur.answersChanged || delta.answersChanged
+  buffers.set(contractId, cur)
+  debounce(`contract-agg-${contractId}`, () => flushContractAggregate(contractId), FLUSH_MS)
+}
+
+export const flushContractAggregate = async (contractId: string) => {
+  const agg = buffers.get(contractId)
+  if (!agg) return
+  buffers.delete(contractId)
+
+  const pg = createSupabaseDirectClient()
+  try {
+    await pg.tx(async (t) => {
+      // Recomputable display state -> skipping the fsync is safe and removes the
+      // aggregate write from the durability-critical path entirely.
+      await t.none('set local synchronous_commit = off')
+      await t.none(
+        `update contracts c set data = c.data
+           || jsonb_build_object(
+                'volume', coalesce((c.data->>'volume')::numeric, 0) + $2,
+                'uniqueBettorCount', coalesce((c.data->>'uniqueBettorCount')::int, 0) + $3,
+                'lastBetTime', greatest(coalesce((c.data->>'lastBetTime')::bigint, 0), $4),
+                'lastUpdatedTime', $4)
+           || case when $5 then jsonb_build_object('answers', (
+                select coalesce(jsonb_agg(a.data order by (a.data->>'index')::int), '[]'::jsonb)
+                from answers a where a.contract_id = $1
+              )) else '{}'::jsonb end
+         where c.id = $1`,
+        [contractId, agg.volume, agg.uniqueBettors, agg.lastBetTime, agg.answersChanged]
+      )
+    })
+    metrics.inc('bet/contract_agg_flush')
+  } catch (err) {
+    // Re-buffer so the deltas aren't lost; the debounce will retry.
+    bufferContractAggregate(contractId, agg)
+    log.error('contract aggregate flush failed', { err, contractId })
+  }
+}
+
+// Flush all pending buffers — call on graceful shutdown so a planned restart
+// (the daily pm2 cron_restart) cannot drop deltas inside the debounce window.
+export const flushAllContractAggregates = async () => {
+  await Promise.all([...buffers.keys()].map(flushContractAggregate))
+}

--- a/backend/api/src/multi-sell.ts
+++ b/backend/api/src/multi-sell.ts
@@ -7,6 +7,7 @@ import { getCpmmMultiSellSharesInfo } from 'common/sell-bet'
 import { convertBet } from 'common/supabase/bets'
 import * as crypto from 'crypto'
 import { groupBy, keyBy, mapValues, sumBy } from 'lodash'
+import { getPoolDepToken } from 'api/helpers/answer-bet-parallelism'
 import { betsQueue } from 'shared/helpers/fn-queue'
 import { getContractMetrics } from 'shared/helpers/user-contract-metrics'
 import {
@@ -19,10 +20,15 @@ import { getContract, getUser, log } from 'shared/utils'
 import { APIError, type APIHandler } from './helpers/endpoint'
 
 export const multiSell: APIHandler<'multi-sell'> = async (props, auth, req) => {
-  return await betsQueue.enqueueFn(
-    () => multiSellMain(props, auth, req),
-    [props.contractId, auth.uid]
-  )
+  // Pool tokens mutually exclude this sell from bets on any answer it touches
+  // (bets on independent answers run at READ COMMITTED, so exclusion must come
+  // from the queue — see getPoolDepToken). The coarse contractId token keeps
+  // multi-answer ops serialized among themselves.
+  return await betsQueue.enqueueFn(() => multiSellMain(props, auth, req), [
+    auth.uid,
+    props.contractId,
+    ...props.answerIds.map((id) => getPoolDepToken(props.contractId, id)),
+  ])
 }
 
 const multiSellMain: APIHandler<'multi-sell'> = async (props, auth) => {

--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -7,6 +7,11 @@ import {
   updateMakers,
 } from 'api/helpers/bets'
 import { onCreateBets } from 'api/on-create-bet'
+import {
+  canParallelizeAnswer,
+  getPoolDepToken,
+} from 'api/helpers/answer-bet-parallelism'
+import { bufferContractAggregate } from 'api/helpers/contract-aggregate-buffer'
 import { Answer } from 'common/answer'
 import { ValidatedAPIParams } from 'common/api/schema'
 import { Bet, getNewBetId, LimitBet, maker } from 'common/bet'
@@ -47,6 +52,8 @@ import {
 } from 'shared/supabase/bets'
 import {
   createSupabaseDirectClient,
+  READ_COMMITTED_MODE,
+  SERIAL_MODE,
   SupabaseTransaction,
 } from 'shared/supabase/init'
 import {
@@ -73,8 +80,14 @@ export const placeBet: APIHandler<'bet'> = async (props, auth) => {
     return queueDependenciesThenBet(props, auth, isApi)
   }
 
-  // Worst thing that could happen from wrong deps is contention
-  const fullDeps = [auth.uid, contractId, ...(deps ?? [])]
+  // These queue keys are the correctness mechanism for the READ COMMITTED
+  // parallel-answer path (see placeBetMain): the bettor uid + pool token are what
+  // keep same-user / same-pool bets from running concurrently — which READ
+  // COMMITTED will not catch. Keep them, and assume a single write process; a
+  // second writer or weaker keys could allow lost updates / double-spends.
+  // (Client-supplied `deps` are only hints; wrong ones merely cost contention.)
+  const poolToken = getPoolDepToken(contractId, props.answerId)
+  const fullDeps = [auth.uid, poolToken, ...(deps ?? [])]
   return await betsQueue.enqueueFn(() => {
     return placeBetMain(props, auth.uid, isApi)
   }, fullDeps)
@@ -86,7 +99,10 @@ const queueDependenciesThenBet = async (
   isApi: boolean
 ) => {
   const { dryRun, contractId } = props
-  const minimalDeps = [auth.uid, contractId]
+  // Correctness-critical under READ COMMITTED (see placeBet): the uid + pool token
+  // here, plus the matched maker ids appended below, are what serialize bets that
+  // touch the same balance / pool / maker.
+  const minimalDeps = [auth.uid, getPoolDepToken(contractId, props.answerId)]
   return await ordersQueue.enqueueFn(async () => {
     const { contract, answers, unfilledBets, balanceByUserId } =
       await fetchContractBetDataAndValidate(
@@ -215,7 +231,11 @@ export const placeBetMain = async (
       false,
       isApi ? undefined : silent
     )
-  })
+    // For independent answers (which run in parallel) the per-pool queue already
+    // serializes same-pool and same-user bets, so SERIALIZABLE's predicate locks
+    // are redundant and only cause 40001 storms — use READ COMMITTED there.
+    // Binary / sum-to-one bets are unaffected and stay SERIALIZABLE.
+  }, canParallelizeAnswer(contractId, answerId) ? READ_COMMITTED_MODE : SERIAL_MODE)
 
   const { newBet, betId, betGroupId } = result
 
@@ -605,7 +625,19 @@ export const executeNewBetResult = async (
   })
   const metricsQuery = bulkUpdateContractMetricsQuery(newMetrics)
   const streakIncrementedQuery = incrementStreakQuery(user, newBet.createdTime)
-  const contractUpdateQuery = updateDataQuery('contracts', 'id', contractUpdate)
+  // For independent (non-sum-to-one) multi answers, keep the shared contract row
+  // OUT of this transaction so concurrent answers touch only disjoint rows. This is
+  // load-bearing: that path runs at READ COMMITTED, so a read-modify-write of any
+  // row shared across answers or bettors (like contracts) would race here with no
+  // SSI to catch it. New writes added to this transaction must stay per-answer /
+  // per-user, or be atomic increments. The contract's eventually-consistent
+  // aggregates are applied via the deferred buffer below. Gated on !isMultiBet so
+  // the multi-answer-at-once path is never affected.
+  const deferContractAgg =
+    !isMultiBet && canParallelizeAnswer(contract.id, newBet.answerId)
+  const contractUpdateQuery = deferContractAgg
+    ? 'select 1 where false'
+    : updateDataQuery('contracts', 'id', contractUpdate)
   const answerUpdateQuery = bulkUpdateQuery(
     'answers',
     ['id'],
@@ -628,6 +660,15 @@ export const executeNewBetResult = async (
      `
   )
   log(`placeBet bulk insert/update took ${Date.now() - startTime}ms`)
+  if (deferContractAgg) {
+    // Apply the contract-row aggregates out of band (atomic, recomputable).
+    bufferContractAggregate(contract.id, {
+      volume: sumBy(betsToInsert, (b) => Math.abs(b.amount)),
+      uniqueBettors: isUniqueBettor ? 1 : 0,
+      lastBetTime,
+      answersChanged: answerUpdates.length > 0,
+    })
+  }
   const userUpdates = results[0] as UserUpdate[]
   if (userUpdates.length) {
     // if negative balances, make sure the balance is higher than when they started

--- a/backend/api/src/place-multi-bet.ts
+++ b/backend/api/src/place-multi-bet.ts
@@ -7,6 +7,7 @@ import { executeNewBetResult } from 'api/place-bet'
 import { ValidatedAPIParams } from 'common/api/schema'
 import { getNewMultiCpmmBetsInfo } from 'common/new-bet'
 import * as crypto from 'crypto'
+import { getPoolDepToken } from 'api/helpers/answer-bet-parallelism'
 import { betsQueue } from 'shared/helpers/fn-queue'
 import { runTransactionWithRetries } from 'shared/transact-with-retries'
 import { log } from 'shared/utils'
@@ -15,9 +16,17 @@ import { APIError, type APIHandler } from './helpers/endpoint'
 export const placeMultiBet: APIHandler<'multi-bet'> = async (props, auth) => {
   const isApi = auth.creds.kind === 'key'
 
+  // Pool tokens mutually exclude this bet from single bets on any answer it
+  // touches (those run at READ COMMITTED, so exclusion must come from the queue —
+  // see getPoolDepToken). The coarse contractId token keeps multi-answer ops
+  // serialized among themselves.
   return await betsQueue.enqueueFn(
     () => placeMultiBetMain(props, auth.uid, isApi),
-    [auth.uid, props.contractId]
+    [
+      auth.uid,
+      props.contractId,
+      ...props.answerIds.map((id) => getPoolDepToken(props.contractId, id)),
+    ]
   )
 }
 

--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -15,6 +15,7 @@ import { randomString } from 'common/util/random'
 import { isEqual, keyBy } from 'lodash'
 import { trackPublicAuditBetEvent } from 'shared/audit-events'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { getPoolDepToken } from 'api/helpers/answer-bet-parallelism'
 import { betsQueue } from 'shared/helpers/fn-queue'
 import {
   getLoanTrackingRows,
@@ -122,7 +123,17 @@ export const sellShares: APIHandler<'market/:contractId/sell'> = async (
     throwErrorIfNotAdmin(auth.uid)
   }
   const userId = sellForUserId || auth.uid
-  const fullDeps = [userId, contractId, ...(deps ?? [])]
+  // The pool token mutually excludes this sell from bets on the same answer:
+  // sells write the same pool rows, and bets on independent answers run at READ
+  // COMMITTED, so exclusion must come from the queue (see getPoolDepToken). The
+  // coarse contractId token keeps sells serialized with other sells and with
+  // multi-answer ops.
+  const fullDeps = [
+    userId,
+    contractId,
+    getPoolDepToken(contractId, props.answerId),
+    ...(deps ?? []),
+  ]
   return await betsQueue.enqueueFn(
     () => sellSharesMain(props, auth, req),
     fullDeps

--- a/backend/api/src/serve.ts
+++ b/backend/api/src/serve.ts
@@ -5,6 +5,7 @@ import { LOCAL_DEV, LOCAL_ONLY, log } from 'shared/utils'
 import { METRIC_WRITER } from 'shared/monitoring/metric-writer'
 import { initCaches } from 'shared/init-caches'
 import { listen as webSocketListen } from 'shared/websockets/server'
+import { flushAllContractAggregates } from './helpers/contract-aggregate-buffer'
 import { app } from './app'
 
 if (!LOCAL_ONLY) {
@@ -64,6 +65,18 @@ const startupProcess = async () => {
   if (!process.env.READ_ONLY) {
     webSocketListen(httpServer, '/ws')
     log.info('Web socket server listening on /ws')
+
+    // Flush any buffered contract aggregates before a planned restart so the
+    // debounce window can't drop deltas (see contract-aggregate-buffer).
+    const flushOnExit = (signal: string) => async () => {
+      log(`Received ${signal}; flushing contract aggregates before exit.`)
+      await flushAllContractAggregates().catch((err) =>
+        log.error('Failed flushing contract aggregates on exit', { err })
+      )
+      process.exit(0)
+    }
+    process.once('SIGTERM', flushOnExit('SIGTERM'))
+    process.once('SIGINT', flushOnExit('SIGINT'))
   }
 
   log('Server started successfully')

--- a/backend/shared/src/monitoring/metrics.ts
+++ b/backend/shared/src/monitoring/metrics.ts
@@ -51,6 +51,10 @@ export const CUSTOM_METRICS = {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',
   },
+  'bet/contract_agg_flush': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
   'app/contract_view_count': {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',

--- a/backend/shared/src/supabase/init.ts
+++ b/backend/shared/src/supabase/init.ts
@@ -188,3 +188,11 @@ export const SERIAL_MODE = new pgp.txMode.TransactionMode({
   readOnly: false,
   deferrable: false,
 })
+
+// READ COMMITTED isolation. Use where mutual exclusion between transactions is
+// already guaranteed elsewhere, so SERIALIZABLE's predicate-lock serialization
+// failures would be pure overhead.
+export const READ_COMMITTED_MODE = new pgp.txMode.TransactionMode({
+  tiLevel: pgp.txMode.isolationLevel.readCommitted,
+  readOnly: false,
+})

--- a/backend/shared/src/transact-with-retries.ts
+++ b/backend/shared/src/transact-with-retries.ts
@@ -7,23 +7,25 @@ import {
 import { log } from 'shared/monitoring/log'
 
 export const runTransactionWithRetries = async <T>(
-  callback: (trans: SupabaseTransaction) => Promise<T>
+  callback: (trans: SupabaseTransaction) => Promise<T>,
+  mode: typeof SERIAL_MODE = SERIAL_MODE
 ) => {
   const pg = createSupabaseDirectClient()
-  return transactWithRetries(pg, 3, callback)
+  return transactWithRetries(pg, 3, callback, mode)
 }
 
 async function transactWithRetries<T>(
   pg: SupabaseDirectClient,
   maxAttempts = 5,
-  fn: (t: SupabaseTransaction) => Promise<T>
+  fn: (t: SupabaseTransaction) => Promise<T>,
+  mode: typeof SERIAL_MODE = SERIAL_MODE
 ): Promise<T> {
   let attempt = 0
   while (true) {
     try {
       attempt++
       log(`Attempt ${attempt} of ${maxAttempts}`)
-      return await pg.tx({ mode: SERIAL_MODE }, fn)
+      return await pg.tx({ mode }, fn)
     } catch (error: any) {
       log.error(`Attempt ${attempt} of ${maxAttempts} failed: ${error.message}`)
       const isRetryable =


### PR DESCRIPTION
## What

On a multiple-choice market whose answers don't sum to one, each answer is an independent CPMM pool — but today every bet on the contract is processed single-file. The bets queue keys on `contractId`, and the bet transaction writes the shared `contracts` row, so two bets on *different* answers still block each other. A busy multi-answer market backs up and starts rejecting bets even though the answers are independent.

This makes independent answers run in parallel.

## How

- **Per-pool queue keys for every pool writer.** For non-sum-to-one multiple-choice markets, single-answer operations (bets and sells) key the bets queue on `contractId:answerId` instead of `contractId`, so different answers no longer serialize against each other. Multi-answer operations (`multi-bet`, `multi-sell`) take a token per touched answer plus the coarse contract token, which keeps them serialized among themselves. Since every transaction that writes an answer's pool participates, two transactions can never race on the same pool. A small immutable-metadata cache (`{mechanism, shouldAnswersSumToOne}`, fixed at creation) lets the queue pick keys before the contract is fetched; on a cache miss everything falls back to the coarse key, which is always safe.

- **Deferred contract aggregates.** The `contracts` row holds eventually-consistent, recomputable display state (volume, uniqueBettorCount, lastBetTime, and the denormalized `answers` cache whose source of truth is the `answers` table). For independent answers that write moves out of the bet transaction into a debounced, atomic per-contract writer, so concurrent answer-bets touch only disjoint rows. Aggregates flush on a short debounce and on graceful shutdown; drift is bounded and self-heals via the existing unique-bettor / volume backfills. (Adds a `bet/contract_agg_flush` metric.)

- **READ COMMITTED for the parallel path.** With the per-pool queue serializing same-pool and same-user bets, SERIALIZABLE's predicate locks are redundant for these transactions and only produce serialization-failure retries once answers run concurrently. The bet transaction for independent answers uses READ COMMITTED; binary and sum-to-one markets keep SERIALIZABLE and are otherwise untouched.

## Correctness

The bets queue serializes by pool token + bettor + matched maker ids, so no two concurrent transactions touch the same pool, the same balance, or the same maker; balance writes are atomic increments with an overdraft post-check. Verified under load with a mixed workload (80% bets / 20% sells): thousands of concurrent operations across answers produce **zero per-answer probability-chain discontinuities** (each pool move's `probAfter` equals the next move's `probBefore`), i.e. no lost or raced pool updates, and zero serialization-failure errors.

## Scope

- Only non-sum-to-one multiple-choice markets parallelize. Binary and sum-to-one markets are unchanged (sum-to-one answers are arbitrage-coupled and must stay coupled).
- This spreads a hot multi-answer market's load across its answers. A single hammered pool (one binary market, or everyone on one answer) is still one serial book.

## Validation

Local rig running the real bet path (`serve.js` in `LOCAL_ONLY` mode against Postgres loaded with the production schema), driven by concurrent HTTP clients placing bets across a hot 20-answer market, API on 4 cores, 3 runs each:

| | baseline | this change |
|---|--:|--:|
| throughput | ~94 bets/sec | ~294 bets/sec |
| p50 latency | ~4.1 s | ~1.3 s |
| serialization-failure errors | 0 | 0 |

That's ~3x single-market bet throughput. Absolute numbers are local (a remote DB's latency/fsync differ); what transfers is that independent answers no longer block each other. Correctness was checked under the same load: across thousands of concurrent bets, **zero per-answer probability-chain discontinuities** (each bet's `probAfter` equals the next bet's `probBefore`) — i.e. no lost or raced pool updates.
