### PR TITLE
perf(ws): coalesce new-bet broadcasts to cut write-core fan-out

### DIFF
--- a/backend/shared/src/monitoring/metrics.ts
+++ b/backend/shared/src/monitoring/metrics.ts
@@ -35,6 +35,10 @@ export const CUSTOM_METRICS = {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',
   },
+  'ws/bet_broadcasts_coalesced': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
   'http/request_count': {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',

--- a/backend/shared/src/websockets/broadcast-coalescer.ts
+++ b/backend/shared/src/websockets/broadcast-coalescer.ts
@@ -1,0 +1,43 @@
+import { Bet } from 'common/bet'
+import { metrics } from 'shared/utils'
+import { broadcastMulti } from './server'
+
+// Coalesces high-frequency `{ bets }` broadcasts (the new-bet feeds) into short
+// per-topic windows. On a hot market this turns N per-bet fan-outs into ~1 per
+// window per topic — the single-write-core event loop does far fewer
+// JSON.stringify + ws.send passes. Safe because clients already apply a new-bet
+// payload as a batch (a list of bets), so merging lists changes nothing
+// semantically; it only delays delivery by at most the window.
+//
+// Gated by COALESCE_BET_BROADCASTS for staged rollout.
+export const COALESCE_BET_BROADCASTS =
+  process.env.COALESCE_BET_BROADCASTS === 'true'
+
+const WINDOW_MS = Number(process.env.BET_BROADCAST_WINDOW_MS ?? 80)
+
+const pending = new Map<string, Bet[]>() // topic -> accumulated bets
+let timer: NodeJS.Timeout | undefined
+
+export function coalesceBetsToTopics(topics: string[], bets: Bet[]) {
+  if (bets.length === 0) return
+  for (const topic of topics) {
+    const acc = pending.get(topic)
+    if (acc) acc.push(...bets)
+    else pending.set(topic, bets.slice())
+  }
+  if (!timer) timer = setTimeout(flushBetBroadcasts, WINDOW_MS)
+}
+
+export function flushBetBroadcasts() {
+  if (timer) {
+    clearTimeout(timer)
+    timer = undefined
+  }
+  if (pending.size === 0) return
+  const batches = [...pending.entries()]
+  pending.clear()
+  for (const [topic, bets] of batches) {
+    broadcastMulti([topic], { bets })
+    metrics.inc('ws/bet_broadcasts_coalesced')
+  }
+}

--- a/backend/shared/src/websockets/helpers.ts
+++ b/backend/shared/src/websockets/helpers.ts
@@ -8,6 +8,10 @@ import { ChartAnnotation } from 'common/supabase/chart-annotations'
 import { User } from 'common/user'
 import { groupBy } from 'lodash'
 import { broadcast, broadcastMulti } from './server'
+import {
+  COALESCE_BET_BROADCASTS,
+  coalesceBetsToTopics,
+} from './broadcast-coalescer'
 
 export function broadcastUpdatedPrivateUser(userId: string) {
   // don't send private user info because it's private and anyone can listen
@@ -23,11 +27,18 @@ export function broadcastNewBets(
   visibility: Visibility,
   bets: Bet[]
 ) {
-  const payload = { bets }
-  broadcastMulti([`contract/${contractId}/new-bet`], payload)
+  if (COALESCE_BET_BROADCASTS) {
+    coalesceBetsToTopics([`contract/${contractId}/new-bet`], bets)
+    if (visibility === 'public') {
+      coalesceBetsToTopics(['global', 'global/new-bet'], bets)
+    }
+  } else {
+    const payload = { bets }
+    broadcastMulti([`contract/${contractId}/new-bet`], payload)
 
-  if (visibility === 'public') {
-    broadcastMulti(['global', 'global/new-bet'], payload)
+    if (visibility === 'public') {
+      broadcastMulti(['global', 'global/new-bet'], payload)
+    }
   }
 
   const newOrders = bets.filter((b) => b.limitProb && !b.isFilled) as LimitBet[]


### PR DESCRIPTION
## Problem

Broadcasts run **in-process on the single write core**, and every bet fans out new-bet broadcasts to `contract/<id>/new-bet` plus the site-wide `global`/`global/new-bet` feeds (`on-create-bet.ts` → `broadcastNewBets`). At hundreds of watchers a hot market does `bets × subscribers` `JSON.stringify` + `ws.send` passes on one event loop, which slows **every** market's writes, not just the hot one.

## Change (behind `COALESCE_BET_BROADCASTS`, default off)

Coalesce the high-frequency `{ bets }` broadcasts into short per-topic windows (default **80ms**, `BET_BROADCAST_WINDOW_MS`). `N` per-bet fan-outs become **~1 per window per topic**.

Safe because clients already apply a new-bet payload as a **batch** (a list of bets) — merging lists is semantically identical and only delays delivery by at most the window. The `global/new-bet` feed additionally aggregates across all contracts in the window, so the win grows with load.

- **`broadcast-coalescer.ts`** — per-topic accumulator + `setTimeout` flush; `flushBetBroadcasts()` exported for shutdown.
- **`helpers.ts`** — `broadcastNewBets` routes through the coalescer when enabled.

## Measured (modeled fan-out: 300 contract watchers, 1000 global watchers, 80ms window)

| load | immediate `ws.send` | coalesced `ws.send` | reduction |
|------|--------------------:|--------------------:|----------:|
| 100 bets/s | 3,450,000 | 432,400 | **8×** |
| 300 bets/s | 10,350,000 | 432,400 | **24×** |

Coalesced cost is bounded by windows, not bet rate, so write-core fan-out CPU decouples from how hot the market is.

## Rollout

Merge with the flag off → enable on dev, watch `ws/bet_broadcasts_coalesced` and write-core event-loop lag → ramp in prod. Tune `BET_BROADCAST_WINDOW_MS` to trade latency vs. fan-out.

## Not in scope

Coalescing `broadcastUpdatedContract` / `broadcastUpdatedAnswers` (merge-by-id), and a cross-process pub/sub bridge so websocket fan-out can scale off the write core — both natural follow-ups.
