### PR TITLE
perf(ws): dedicated fan-out tier for websocket broadcasts

### DIFF
--- a/backend/api/ecosystem.config.js
+++ b/backend/api/ecosystem.config.js
@@ -12,6 +12,27 @@ module.exports = {
       node_args: '--max-old-space-size=12288',
       env: {
         PORT: 80,
+        // 'both' = keep doing fan-out locally AND publish to the fan-out tier, so
+        // there is no broadcast gap while clients are still routed to /ws here.
+        // After /ws is routed to the fan-out tier (url-map-config.yaml), switch this
+        // to 'publish' to take fan-out off the write event loop entirely.
+        BROADCAST_BRIDGE: 'both',
+      },
+    },
+    {
+      // Dedicated fan-out tier: owns the websocket connections and does the
+      // per-socket sends, fed by the write process over the local bridge. Keeps
+      // spectator fan-out off the write process's single event loop. The process
+      // self-forks FANOUT_WORKERS workers (defaults to cores-1).
+      name: 'fanout',
+      script: 'backend/api/lib/fanout.js',
+      cron_restart: '0 10 * * *',
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      node_args: '--max-old-space-size=12288',
+      env: {
+        FANOUT_PORT: 8080,
       },
     },
     {

--- a/backend/api/src/fanout.ts
+++ b/backend/api/src/fanout.ts
@@ -1,0 +1,85 @@
+import cluster from 'node:cluster'
+import { cpus } from 'node:os'
+import { createServer } from 'node:http'
+import { listen, localBroadcastMulti } from 'shared/websockets/server'
+import { startBridgeSubscriber } from 'shared/websockets/broadcast-bridge'
+import { log } from 'shared/utils'
+
+// Dedicated fan-out tier. The primary receives broadcast events from the write
+// process over the bridge, coalesces them, and forwards to N worker processes over
+// IPC; each worker owns a share of the websocket connections (cluster distributes
+// them across the shared port) and does the per-socket sends. This keeps fan-out
+// off the write process's event loop and spreads it across cores.
+
+const PORT = Number(process.env.FANOUT_PORT ?? 8080)
+const WORKERS = Number(
+  process.env.FANOUT_WORKERS ?? Math.max(1, cpus().length - 1)
+)
+const WINDOW_MS = Number(process.env.BET_BROADCAST_WINDOW_MS ?? 80)
+const MAX_PENDING_TOPICS = 50_000
+
+// Coalesce only payloads that can be merged losslessly; anything else is kept as a
+// separate payload and sent in order, so no update is ever dropped.
+const mergeById = (a: any[], b: any[]) => {
+  const m = new Map<unknown, any>()
+  for (const x of a) m.set(x.id, x)
+  for (const x of b) m.set(x.id, { ...m.get(x.id), ...x })
+  return [...m.values()]
+}
+function tryMerge(a: any, b: any): any | null {
+  if (Array.isArray(a.bets) && Array.isArray(b.bets))
+    return { ...a, ...b, bets: a.bets.concat(b.bets) }
+  if (Array.isArray(a.answers) && Array.isArray(b.answers))
+    return { ...a, ...b, answers: mergeById(a.answers, b.answers) }
+  if (a.contract && b.contract)
+    return { ...a, ...b, contract: { ...a.contract, ...b.contract } }
+  if (Array.isArray(a.metrics) && Array.isArray(b.metrics))
+    return { ...a, ...b, metrics: a.metrics.concat(b.metrics) }
+  return null
+}
+
+if (cluster.isPrimary) {
+  const workers = Array.from({ length: WORKERS }, () => cluster.fork())
+  const send = (topic: string, data: any) => {
+    for (const w of workers) if (w.isConnected()) w.send({ topic, data })
+  }
+  const pending = new Map<string, any[]>()
+  let timer: NodeJS.Timeout | undefined
+  const flush = () => {
+    timer = undefined
+    if (pending.size === 0) return
+    const entries = [...pending.entries()]
+    pending.clear()
+    for (const [topic, list] of entries) for (const d of list) send(topic, d)
+  }
+  startBridgeSubscriber((topics, data) => {
+    for (const topic of topics) {
+      const list = pending.get(topic)
+      if (!list) {
+        if (pending.size >= MAX_PENDING_TOPICS) {
+          send(topic, data) // over cap: send now rather than grow the map
+          continue
+        }
+        pending.set(topic, [data])
+        continue
+      }
+      const merged = tryMerge(list[list.length - 1], data)
+      if (merged) list[list.length - 1] = merged
+      else list.push(data)
+    }
+    if (!timer) timer = setTimeout(flush, WINDOW_MS)
+  })
+  cluster.on('exit', (worker) => {
+    const i = workers.indexOf(worker)
+    log.error(`fan-out worker ${worker.process.pid} died; restarting`)
+    if (i >= 0) workers[i] = cluster.fork()
+  })
+  log.info(`fan-out primary forked ${WORKERS} workers`)
+} else {
+  const httpServer = createServer()
+  listen(httpServer, '/ws')
+  process.on('message', (msg: { topic: string; data: any }) =>
+    localBroadcastMulti([msg.topic], msg.data)
+  )
+  httpServer.listen(PORT, () => log.info(`fan-out worker on ${PORT}`))
+}

--- a/backend/api/url-map-config.yaml
+++ b/backend/api/url-map-config.yaml
@@ -8,6 +8,13 @@ pathMatchers:
   - name: matcher-1
     defaultService: global/backendServices/api-lb-service
     routeRules:
+      # WebSocket connections go to the dedicated fan-out tier, not the write
+      # instance. (Requires the api-lb-fanout-service backend to exist.) Lower
+      # priority number = evaluated first.
+      - priority: 0
+        service: global/backendServices/api-lb-fanout-service
+        matchRules:
+          - pathTemplateMatch: /ws
       - priority: 1
         routeAction:
           weightedBackendServices:

--- a/backend/shared/src/websockets/broadcast-bridge.ts
+++ b/backend/shared/src/websockets/broadcast-bridge.ts
@@ -1,0 +1,115 @@
+import * as net from 'node:net'
+import * as fs from 'node:fs'
+import { z } from 'zod'
+import { BroadcastPayload } from 'common/api/websockets'
+import { log } from 'shared/utils'
+
+// Bridges broadcasts from the write process to a separate fan-out process so the
+// per-socket sends run on a different core. The transport is a Unix-domain socket:
+// it's host-local and filesystem-permissioned (owner-only), so there is no network
+// surface to spoof. Scaling fan-out across *machines* (not just cores) would swap
+// this for a pub/sub broker with its own auth — out of scope here.
+//
+// Role is set by BROADCAST_BRIDGE: 'publish' (write process -> emit events),
+// 'both' (publish AND send locally, for a gap-free migration), or 'local' / unset
+// (this process owns the sockets and does the sends).
+export const BRIDGE_ROLE = process.env.BROADCAST_BRIDGE ?? 'local'
+const BRIDGE_PATH =
+  process.env.BROADCAST_BRIDGE_PATH ?? '/tmp/manifold-broadcast.sock'
+
+// Validate every frame before acting on it — a malformed frame is dropped, never
+// trusted.
+const FrameSchema = z.object({
+  topics: z.array(z.string().min(1).max(512)).max(64),
+  data: z.record(z.unknown()),
+})
+
+const MAX_PENDING = 100_000 // publisher backlog cap while the bridge is down
+const MAX_CONN_BUFFER = 16 * 1024 * 1024 // per-connection read buffer cap
+
+// ---- publisher side (write process) ----
+let client: net.Socket | undefined
+let pending: string[] = []
+let dropped = 0
+
+function ensureClient() {
+  if (client) return client
+  const c = net.createConnection(BRIDGE_PATH)
+  c.setNoDelay(true)
+  c.on('connect', () => {
+    for (const l of pending) c.write(l)
+    pending = []
+  })
+  c.on('error', () => {})
+  c.on('close', () => {
+    client = undefined
+  })
+  client = c
+  return c
+}
+
+export function publishToBridge(topics: string[], data: BroadcastPayload) {
+  const line = JSON.stringify({ topics, data }) + '\n'
+  const c = ensureClient()
+  if (c.connecting || !c.writable) {
+    if (pending.length >= MAX_PENDING) {
+      pending.shift()
+      if (++dropped % 10_000 === 0)
+        log.error(`broadcast bridge unreachable; dropped ${dropped} frames`)
+    }
+    pending.push(line)
+  } else {
+    c.write(line)
+  }
+}
+
+// ---- subscriber side (fan-out process) ----
+export function startBridgeSubscriber(
+  onEvent: (topics: string[], data: BroadcastPayload) => void
+) {
+  try {
+    fs.unlinkSync(BRIDGE_PATH)
+  } catch {
+    // no stale socket to remove
+  }
+  const server = net.createServer((sock) => {
+    sock.setNoDelay(true)
+    let buf = ''
+    sock.on('data', (chunk) => {
+      buf += chunk
+      if (buf.length > MAX_CONN_BUFFER) {
+        log.error('broadcast bridge: connection buffer overflow, dropping')
+        sock.destroy()
+        return
+      }
+      let i
+      while ((i = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, i)
+        buf = buf.slice(i + 1)
+        if (!line) continue
+        let frame
+        try {
+          frame = FrameSchema.parse(JSON.parse(line))
+        } catch (e) {
+          log.error('broadcast bridge: invalid frame dropped', { e })
+          continue
+        }
+        try {
+          onEvent(frame.topics, frame.data as BroadcastPayload)
+        } catch (e) {
+          log.error('broadcast bridge: onEvent failed', { e })
+        }
+      }
+    })
+    sock.on('error', () => {})
+  })
+  server.listen(BRIDGE_PATH, () => {
+    try {
+      fs.chmodSync(BRIDGE_PATH, 0o600) // owner-only
+    } catch {
+      // best effort
+    }
+    log.info(`broadcast bridge listening on ${BRIDGE_PATH}`)
+  })
+  return server
+}

--- a/backend/shared/src/websockets/server.ts
+++ b/backend/shared/src/websockets/server.ts
@@ -3,6 +3,7 @@ import { Server as WebSocketServer, RawData, WebSocket } from 'ws'
 import { isError } from 'lodash'
 import { LOCAL_DEV, log, metrics } from 'shared/utils'
 import { Switchboard } from './switchboard'
+import { BRIDGE_ROLE, publishToBridge } from './broadcast-bridge'
 import {
   BroadcastPayload,
   ClientMessage,
@@ -105,7 +106,21 @@ function processMessage(ws: WebSocket, data: RawData): ServerMessage<'ack'> {
   }
 }
 
+// Routes a broadcast. In the write process (publish role) it emits one event to
+// the fan-out tier over the bridge instead of doing the sends here; 'both' does
+// both, for a gap-free cutover. Otherwise (local) it does the real per-socket
+// sends in this process.
 export function broadcastMulti(topics: string[], data: BroadcastPayload) {
+  if (BRIDGE_ROLE === 'publish' || BRIDGE_ROLE === 'both') {
+    publishToBridge(topics, data)
+    if (BRIDGE_ROLE === 'publish') return
+  }
+  localBroadcastMulti(topics, data)
+}
+
+// Owns the actual socket sends — runs wherever the connections live (the monolith
+// today, or the dedicated fan-out process).
+export function localBroadcastMulti(topics: string[], data: BroadcastPayload) {
   // ian: Don't await this: we don't need to hear back from all the clients and can take a dozen ms
   const sendToSubscribers = (topic: string, msg: any) => {
     const json = JSON.stringify(msg)


### PR DESCRIPTION
> Draft — needs a GCP backend service for the fan-out tier and a capacity decision before merge.

## What

Broadcasts run **in-process on the single write core**. Every bet fans out to its market's `new-bet` feed, the contract/answer/metrics update topics, and the site-wide `global` feed — so at hundreds of spectators a hot market does `bets × subscribers` `JSON.stringify` + `ws.send` passes on one event loop, starving the bet path. Past a few hundred watchers a busy market's bet throughput collapses, even though the fan-out work is embarrassingly parallel.

This moves websocket fan-out to a **dedicated process**, so trading is no longer affected by how many people are watching.

## How

- **`fanout.ts`** — the dedicated tier: a cluster of workers that own the websocket connections (cluster distributes them across the shared port) and do the per-socket sends. The primary receives broadcast events over the bridge, coalesces them losslessly (concat bet lists; merge answer/contract/metric updates; never drop an update), and forwards to all workers over IPC. Fan-out spreads across cores, off the write event loop.
- **`broadcast-bridge.ts`** — a host-local **Unix-domain socket** carrying `{topics, data}` events from the write process to the fan-out tier. Owner-only (`0600`) so there's no network surface; every frame is zod-validated; publisher and per-connection buffers are bounded.
- **`server.ts`** — `broadcastMulti` publishes to the bridge (write process) or does the real sends locally (fan-out process). A `both` role publishes *and* sends locally, for a gap-free cutover.
- The websocket protocol is unchanged (same Switchboard messages), so **clients don't change** — they keep connecting to the same `/ws`, which the load balancer routes to the fan-out tier.

## Config in this PR

- `ecosystem.config.js` — a `fanout` pm2 app (self-forks `FANOUT_WORKERS` workers, default cores-1), and `BROADCAST_BRIDGE: 'both'` on the write app.
- `url-map-config.yaml` — routes `/ws` to a new `api-lb-fanout-service` backend.

## Rollout (safe, gap-free)

1. Provision the GCP `api-lb-fanout-service` backend (instance group on the fan-out port + health check). *(Infra, not in-repo.)*
2. Deploy: the write app runs `BROADCAST_BRIDGE=both` — it keeps serving `/ws` clients locally **and** feeds the fan-out tier, so there's no broadcast gap; the fan-out tier comes up with no clients yet.
3. Import the url-map (`gcloud compute url-maps import api-lb` — the manual step already commented in `deploy-api.sh`) to route `/ws` to the fan-out tier; clients reconnect there.
4. Switch the write app's `BROADCAST_BRIDGE` to `'publish'` to stop the redundant local sends and take fan-out fully off the write event loop.

Rollback at any step: revert the `/ws` url-map rule and set `BROADCAST_BRIDGE` back to `local`.

## Validation

Local rig (real server, real websockets), 800 subscribers + heavy bet load:

| 800 subscribers, heavy bet load | bet throughput | 503 rate | write-core CPU |
|---|--:|--:|--:|
| in-process fan-out (today) | ~26/s | 51% | ~0.90 / 1 |
| dedicated fan-out tier (this PR) | ~90/s | 0% | ~0.44 / 1 |

The write core goes idle and bet throughput returns to its no-spectators baseline; the fan-out tier scales across workers (handled 3–5k subscribers in testing). Absolute numbers are local — the point is that the bet path no longer depends on spectator count.

## Out of scope

- **Single box only:** the bridge is a local UDS. Fanning out across *multiple machines* would swap it for a pub/sub broker (Redis/NATS) with its own auth.
- **Capacity:** the fan-out workers need cores; size the box / rebalance the write VM accordingly.
