### PR TITLE
feat: allow unverified users to buy mana with a credit card

### DIFF
--- a/backend/api/src/stripe-endpoints.ts
+++ b/backend/api/src/stripe-endpoints.ts
@@ -18,7 +18,6 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { updateUser } from 'shared/supabase/users'
 import { STRIPE_PAYMENTS_ENABLED } from 'common/envs/constants'
 import { WEB_PRICES } from 'common/economy'
-import { canReceiveBonuses } from 'common/user'
 import { isUserBanned } from 'common/ban-utils'
 import { getActiveUserBans } from './helpers/rate-limit'
 import { getContract } from 'shared/utils'
@@ -92,14 +91,6 @@ export const createcheckoutsession = async (req: Request, res: Response) => {
   const user = await getUser(userId)
   if (!user) {
     res.status(404).send('User not found')
-    return
-  }
-  if (!canReceiveBonuses(user)) {
-    res
-      .status(403)
-      .send(
-        'Identity verification is required to purchase mana with a credit card.'
-      )
     return
   }
   const bans = await getActiveUserBans(userId)

--- a/web/components/modals/verification-required-modal.tsx
+++ b/web/components/modals/verification-required-modal.tsx
@@ -21,7 +21,6 @@ type VerificationRequiredModalProps = {
     | 'claim free loan'
     | 'earn full bonuses'
     | 'enter prize drawings'
-    | 'buy mana with a credit card'
 }
 
 export function VerificationRequiredModal({

--- a/web/pages/checkout.tsx
+++ b/web/pages/checkout.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx'
 import { useRouter } from 'next/router'
 
 import { isUserBanned } from 'common/ban-utils'
-import { canReceiveBonuses } from 'common/user'
 import { Col } from 'web/components/layout/col'
 import { Page } from 'web/components/layout/page'
 import { DaimoProviders } from 'web/components/crypto/crypto-providers'
@@ -21,9 +20,7 @@ import { Row } from 'web/components/layout/row'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
 import { Button } from 'web/components/buttons/button'
 import { Modal, MODAL_CLASS } from 'web/components/layout/modal'
-import { Tooltip } from 'web/components/widgets/tooltip'
 import { PriceTile } from 'web/components/add-funds-modal'
-import { VerificationRequiredModal } from 'web/components/modals/verification-required-modal'
 import { usePrices } from 'web/hooks/use-prices'
 import {
   CurrencyDollarIcon,
@@ -188,7 +185,6 @@ function CheckoutContent() {
     status: 'idle',
   })
   const [creditCardModalOpen, setCreditCardModalOpen] = useState(false)
-  const [verificationModalOpen, setVerificationModalOpen] = useState(false)
 
   // Check if user has made a crypto purchase before
   const { data: cryptoStatus } = useAPIGetter('get-crypto-purchase-status', {})
@@ -205,8 +201,6 @@ function CheckoutContent() {
     ? isUserBanned(userBansData.bans as any, 'purchase')
     : false
   const canPay = !!user?.id && !isPurchaseBanned
-  const isBonusEligible = !!user && canReceiveBonuses(user)
-  const canUseCreditCard = canPay && isBonusEligible
 
   const offers = usePersonalizedManaOffers()
   const router = useRouter()
@@ -276,11 +270,7 @@ function CheckoutContent() {
   }
 
   const handleOfferStripe = () => {
-    if (!user?.id || !effectiveOfferId) return
-    if (!canUseCreditCard) {
-      setVerificationModalOpen(true)
-      return
-    }
+    if (!user?.id || !effectiveOfferId || !canPay) return
     // /createcheckoutsession is POST-only on the backend; navigate via a
     // programmatic form submission (matches AddFundsModal's pattern).
     const action = checkoutURL(
@@ -535,38 +525,20 @@ function CheckoutContent() {
                         </Row>
                       </button>
 
-                      <Tooltip
-                        text={
-                          canUseCreditCard
-                            ? null
-                            : 'Verify your identity to enable credit card purchases.'
-                        }
-                        placement="bottom"
-                        className="block w-full"
+                      <button
+                        onClick={() => setCreditCardModalOpen(true)}
+                        className={clsx(
+                          'group relative w-full overflow-hidden rounded-xl border-2',
+                          'px-8 py-4 text-lg font-semibold shadow-sm transition-all duration-200',
+                          'active:scale-[0.98]',
+                          'bg-canvas-0 border-indigo-600 text-indigo-700 hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-950/30'
+                        )}
                       >
-                        <button
-                          onClick={() => {
-                            if (canUseCreditCard) {
-                              setCreditCardModalOpen(true)
-                            } else {
-                              setVerificationModalOpen(true)
-                            }
-                          }}
-                          className={clsx(
-                            'group relative w-full overflow-hidden rounded-xl border-2',
-                            'px-8 py-4 text-lg font-semibold shadow-sm transition-all duration-200',
-                            'active:scale-[0.98]',
-                            canUseCreditCard
-                              ? 'bg-canvas-0 border-indigo-600 text-indigo-700 hover:bg-indigo-50 dark:border-indigo-400 dark:text-indigo-300 dark:hover:bg-indigo-950/30'
-                              : 'border-ink-300 bg-canvas-50 text-ink-500 dark:bg-canvas-100'
-                          )}
-                        >
-                          <Row className="items-center justify-center gap-3">
-                            <FaCreditCard className="h-5 w-5 transition-transform group-hover:scale-110" />
-                            <span>Buy with credit card</span>
-                          </Row>
-                        </button>
-                      </Tooltip>
+                        <Row className="items-center justify-center gap-3">
+                          <FaCreditCard className="h-5 w-5 transition-transform group-hover:scale-110" />
+                          <span>Buy with credit card</span>
+                        </Row>
+                      </button>
                     </>
                   )}
                 </Col>
@@ -664,16 +636,6 @@ function CheckoutContent() {
           <CreditCardPurchaseGrid />
         </Col>
       </Modal>
-
-      {/* Verification Required Modal */}
-      {user && verificationModalOpen && (
-        <VerificationRequiredModal
-          open={verificationModalOpen}
-          setOpen={setVerificationModalOpen}
-          user={user}
-          action="buy mana with a credit card"
-        />
-      )}
     </Col>
   )
 }


### PR DESCRIPTION
Remove the iDenfy identity-verification gate from credit-card (Stripe) purchases. Previously createcheckoutsession returned 403 unless canReceiveBonuses(user) was true, and the /checkout UI routed unverified users to the VerificationRequiredModal instead of the purchase grid.

- backend: drop the canReceiveBonuses check in createcheckoutsession; the purchase-ban check is retained.
- web/checkout: card button always opens the purchase grid; remove the verify-gate tooltip, modal routing, and now-unused state/imports.
- verification-required-modal: drop the orphaned 'buy mana with a credit card' action.