### PR TITLE
fix(sports): extend close time for knockout matches to cover ET and penalties

### DIFF
--- a/common/src/sports.ts
+++ b/common/src/sports.ts
@@ -374,8 +374,15 @@ export function stageLiquidityForMatch(
   )
 }
 
+// Knockout matches can run up to ~170 min (90' + halftime + 30' ET + ET break +
+// ~30' penalties). Use 3.5 h so betting stays open through the final whistle.
+const KNOCKOUT_CLOSE_OFFSET_MS = 3.5 * 60 * 60 * 1000
+
 export function computeCloseTime(match: FDMatch, config: TournamentConfig): number {
-  return new Date(match.utcDate).getTime() + config.closeTimeOffsetMs
+  const offsetMs = isKnockoutStage(match.stage)
+    ? Math.max(config.closeTimeOffsetMs, KNOCKOUT_CLOSE_OFFSET_MS)
+    : config.closeTimeOffsetMs
+  return new Date(match.utcDate).getTime() + offsetMs
 }
 
 function isKnockoutStage(stage: string): boolean {


### PR DESCRIPTION
## Summary
- Knockout matches can run up to ~170 min (90' regulation + halftime + 30' ET + ET break + ~30' penalty shootout)
- The existing flat 2.5 h close time offset could close betting mid-extra-time for deep knockout matches
- Adds a `KNOCKOUT_CLOSE_OFFSET_MS` constant (3.5 h) used for all knockout stages (R16, QF, SF, 3rd place, Final)
- Uses `Math.max` so if a config ever sets `closeTimeOffsetMs` higher than 3.5 h, that takes precedence

## Test plan
- [ ] Create a knockout stage market via admin panel and verify close time is kickoff + 3.5 h
- [ ] Verify group stage markets still use kickoff + 2.5 h

🤖 Generated with [Claude Code](https://claude.com/claude-code)