### PR TITLE
fix(checkout): expired-but-active offer no longer blanks /checkout

### DIFF
--- a/web/components/checkout/personalized-offer-card.tsx
+++ b/web/components/checkout/personalized-offer-card.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
 import { CurrencyDollarIcon, XIcon } from '@heroicons/react/solid'
 import { FaCreditCard } from 'react-icons/fa6'
 import { Col } from 'web/components/layout/col'
@@ -19,6 +18,11 @@ function formatHmsRemaining(ms: number) {
 }
 
 export function PersonalizedOfferCard(props: {
+  // Shared clock owned by the parent (checkout page). Passing it down instead
+  // of ticking our own keeps this card's expiry decision and the parent's
+  // showOfferCard gate on the exact same `now`, so they can't disagree and
+  // leave the page blank.
+  now: number
   activeCount: number
   nextExpiresAt: number | null
   manaAmount: number
@@ -38,6 +42,7 @@ export function PersonalizedOfferCard(props: {
   dismissDisabled?: boolean
 }) {
   const {
+    now,
     activeCount,
     nextExpiresAt,
     manaAmount,
@@ -51,13 +56,6 @@ export function PersonalizedOfferCard(props: {
     onDismiss,
     dismissDisabled,
   } = props
-
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    if (!nextExpiresAt) return
-    const id = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(id)
-  }, [nextExpiresAt])
 
   const remaining = nextExpiresAt != null ? nextExpiresAt - now : 0
   if (activeCount === 0) return null

--- a/web/pages/checkout.tsx
+++ b/web/pages/checkout.tsx
@@ -327,11 +327,36 @@ function CheckoutContent() {
     offers.refresh()
   }
 
+  // Ticking clock for the offer countdown. Keyed on the offer's expiry so it
+  // stays inert when there's no offer. This is the single source of truth for
+  // "now" — passed down to the card too — so the gate below and the card's own
+  // render decision read the same clock and can never disagree (which is what
+  // produced the blank "active but expired" dead zone).
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!effectiveNextExpiresAt) return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [effectiveNextExpiresAt])
+
+  const cryptoLoading =
+    sessionState.status === 'creating' || sessionState.status === 'ready'
+
   // The offer card and hidden-offer chip nest INSIDE the standard Buy mana
   // card body, above the mana image. They're only meaningful when we're
   // showing the normal payment state (success / error states swap the body
   // out entirely, naturally hiding the offer UI).
-  const showOfferCard = effectiveActiveCount > 0
+  //
+  // Gate on the card's exact render predicate (incl. the `: 0` null-expiry
+  // mapping): active AND (not expired OR a payment is in flight). The
+  // cryptoLoading exception keeps an in-flight session visible through the
+  // backend's redemption grace window, exactly as the card does — without it
+  // an expired-but-active offer hides the standard buy UI while the card
+  // renders nothing, leaving the page blank.
+  const offerRemaining =
+    effectiveNextExpiresAt != null ? effectiveNextExpiresAt - now : 0
+  const showOfferCard =
+    effectiveActiveCount > 0 && (offerRemaining > 0 || cryptoLoading)
   const showHiddenChip =
     !showOfferCard && offers.dismissedCount > 0 && offers.activeCount === 0
 
@@ -396,15 +421,13 @@ function CheckoutContent() {
                 chip takes its place when dismissed. */}
             {showOfferCard ? (
               <PersonalizedOfferCard
+                now={now}
                 activeCount={effectiveActiveCount}
                 nextExpiresAt={effectiveNextExpiresAt}
                 manaAmount={offers.manaAmount}
                 priceUsdStripe={offers.priceUsdStripe}
                 priceUsdCrypto={offers.priceUsdCrypto}
-                cryptoLoading={
-                  sessionState.status === 'creating' ||
-                  sessionState.status === 'ready'
-                }
+                cryptoLoading={cryptoLoading}
                 cryptoDisabled={!canPay}
                 creditCardDisabled={!canPay}
                 onBuyWithCrypto={() =>
@@ -494,10 +517,7 @@ function CheckoutContent() {
                     <>
                       <button
                         onClick={() => handleBuyManaClick()}
-                        disabled={
-                          sessionState.status === 'creating' ||
-                          sessionState.status === 'ready'
-                        }
+                        disabled={cryptoLoading}
                         className={clsx(
                           'group relative w-full overflow-hidden rounded-xl border-2 border-transparent',
                           'bg-gradient-to-r from-indigo-600 via-purple-600 to-indigo-600 bg-[length:200%_100%]',


### PR DESCRIPTION
An offer with status 'active' but a countdown past expiry (remaining <= 0) left the page body empty: the showOfferCard gate keyed only on effectiveActiveCount > 0 (hiding the standard buy UI) while the card itself returns null once remaining <= 0. Since the expiry cron only flips active -> expired after a 2h grace, every offer spent hours in this dead zone.

Single-source the render decision: lift the countdown clock into CheckoutContent and gate showOfferCard on the card's exact predicate — active AND (not expired OR a payment is in flight). The cryptoLoading exception preserves an in-flight session through the backend grace window. Pass the shared `now` down to the card and drop the card's own clock so the two sites read one clock and can't disagree. An expired-active offer now falls back to the standard buy UI instead of a blank page.