### PR TITLE
fix(sports): raise sticky header z-index to prevent card content bleed

### DIFF
--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -919,7 +919,7 @@ export function SportsDashboardPage({
         <title>{title} | Manifold</title>
       </Head>
       <Col className="mx-auto w-full max-w-5xl gap-8 px-4 py-6 sm:px-6">
-        <Row className="border-ink-200 bg-canvas-0 sticky top-0 z-10 -mt-6 items-center justify-between border-b pb-5 pt-6">
+        <Row className="border-ink-200 bg-canvas-0 sticky top-0 z-20 -mt-6 items-center justify-between border-b pb-5 pt-6">
           <Row className="items-center gap-3">
             <span className="text-2xl">{emoji}</span>
             <h1 className="text-ink-1000 text-xl font-medium tracking-tight">


### PR DESCRIPTION
## Summary
- Raises the sports dashboard sticky header from `z-10` to `z-20`
- `OutcomeRow` content wrappers inside match cards use `z-10`; when cards scroll behind the sticky header, their `z-10` elements rendered above the header (later DOM order wins ties). `z-20` restores correct layering.

## Test plan
- [ ] Scroll down on the World Cup dashboard official tab — team name/% text should no longer bleed into the sticky header

🤖 Generated with [Claude Code](https://claude.com/claude-code)