### PR TITLE
fix(sports): strip flag emoji from market card titles on Windows

### DIFF
--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -206,6 +206,10 @@ function OutcomeRow({
   )
 }
 
+function stripEmoji(str: string): string {
+  return str.replace(/\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu, '').trim()
+}
+
 export function SportsMatchCard({ match }: { match: SportsMatch }) {
   const resolved = match.status === 'resolved'
   const now = Date.now()
@@ -318,7 +322,7 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
             href={marketHref}
             className="text-ink-900 hover:text-primary-600 line-clamp-2 text-[15px] font-semibold leading-snug transition-colors"
           >
-            {match.question}
+            {stripEmoji(match.question)}
           </Link>
         )}
 


### PR DESCRIPTION
## Summary
- Windows/Chrome can't render regional-indicator flag emoji and shows bare letter pairs instead (e.g. "🇰🇷" → "KR"), making titles like "🇰🇷KOR vs 🇨🇿CZE — Group A" read as garbled text
- The `OutcomeRow` already handles this correctly via the `Flag` component (loads SVG images from flagcdn.com), but the market card title was rendering `match.question` as raw text
- Adds a `stripEmoji` helper and applies it to the title display — the 3-letter country codes remain so titles stay readable on all platforms

## Test plan
- [ ] On Windows/Chrome: market card titles should show "KOR vs CZE — Group A [World Cup '26]" instead of "KRKOR vs CZCZE..."
- [ ] On Mac/other platforms: titles still readable, flag images still appear in the outcome rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)