### PR TITLE
feat(sports): position indicator stripe and hovercard on match cards

### DIFF
--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -1,0 +1,136 @@
+import clsx from 'clsx'
+import { Row } from 'web/components/layout/row'
+
+export type UserPosition = {
+  name: string
+  color?: string
+  amount: number
+  profit: number
+}
+
+export type UserLimitOrder = {
+  name: string
+  prob: number
+  amount: number
+}
+
+export type UserNumericSummary = {
+  total: number
+  buckets: number
+  profit: number
+  orders?: { total: number; count: number }
+}
+
+export type PositionsData = {
+  positions: UserPosition[]
+  limitOrders: UserLimitOrder[]
+  numericSummary?: UserNumericSummary
+}
+
+const MAX_SHOWN = 4
+
+export function PositionsHovercard({ positions, limitOrders, numericSummary }: PositionsData) {
+  const shownPositions = positions.slice(0, MAX_SHOWN)
+  const extraPositions = positions.length - shownPositions.length
+  const shownOrders = limitOrders.slice(0, MAX_SHOWN)
+  const extraOrders = limitOrders.length - shownOrders.length
+
+  return (
+    <div className="min-w-[220px] text-left">
+      {positions.length > 0 && (
+        <>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Positions
+            </p>
+          </Row>
+          {shownPositions.map((p) => (
+            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
+              <Row className="min-w-0 items-center gap-1.5">
+                {p.color !== undefined && (
+                  <span
+                    className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
+                    style={{ backgroundColor: p.color }}
+                  />
+                )}
+                <span className="min-w-0 truncate text-sm">{p.name}</span>
+              </Row>
+              <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
+                <span>Ṁ{p.amount}</span>
+                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
+                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
+                </span>
+              </Row>
+            </Row>
+          ))}
+          {extraPositions > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">
+              +{extraPositions} more — view market
+            </p>
+          )}
+        </>
+      )}
+      {limitOrders.length > 0 && (
+        <div className={positions.length > 0 ? 'mt-3' : ''}>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Limit Orders
+            </p>
+          </Row>
+          {shownOrders.map((o, i) => (
+            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
+              <span className="min-w-0 truncate">{o.name}</span>
+              <span className="flex-shrink-0">
+                at {o.prob}% — Ṁ{o.amount}
+              </span>
+            </Row>
+          ))}
+          {extraOrders > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">
+              +{extraOrders} more — view market
+            </p>
+          )}
+        </div>
+      )}
+      {numericSummary && (
+        <>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Positions
+            </p>
+          </Row>
+          <Row className="items-center justify-between gap-4">
+            <span className="text-ink-400 text-sm">
+              Ṁ{numericSummary.total} across {numericSummary.buckets} buckets
+            </span>
+            <span
+              className={clsx(
+                'flex-shrink-0 text-sm font-semibold',
+                numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
+              )}
+            >
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{numericSummary.profit}
+            </span>
+          </Row>
+          {numericSummary.orders && (
+            <div className="mt-3">
+              <Row className="mb-2 items-center gap-1.5">
+                <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
+                <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+                  Limit Orders
+                </p>
+              </Row>
+              <span className="text-ink-400 text-sm">
+                Ṁ{numericSummary.orders.total} pending across{' '}
+                {numericSummary.orders.count} orders
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -57,9 +57,9 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 <span className="min-w-0 truncate text-sm">{p.name}</span>
               </Row>
               <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
-                <span>Ṁ{p.amount}</span>
+                <span>Ṁ{Math.round(p.amount)}</span>
                 <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
-                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
+                  {p.profit >= 0 ? '+' : ''}Ṁ{Math.round(p.profit)}
                 </span>
               </Row>
             </Row>
@@ -83,7 +83,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
               <span className="min-w-0 truncate">{o.name}</span>
               <span className="flex-shrink-0">
-                at {o.prob}% — Ṁ{o.amount}
+                at {o.prob}% — Ṁ{Math.round(o.amount)}
               </span>
             </Row>
           ))}
@@ -104,7 +104,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
           </Row>
           <Row className="items-center justify-between gap-4">
             <span className="text-ink-400 text-sm">
-              Ṁ{numericSummary.total} across {numericSummary.buckets} buckets
+              Ṁ{Math.round(numericSummary.total)} across {numericSummary.buckets} buckets
             </span>
             <span
               className={clsx(
@@ -112,7 +112,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
               )}
             >
-              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{numericSummary.profit}
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{Math.round(numericSummary.profit)}
             </span>
           </Row>
           {numericSummary.orders && (
@@ -124,7 +124,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 </p>
               </Row>
               <span className="text-ink-400 text-sm">
-                Ṁ{numericSummary.orders.total} pending across{' '}
+                Ṁ{Math.round(numericSummary.orders.total)} pending across{' '}
                 {numericSummary.orders.count} orders
               </span>
             </div>

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -29,7 +29,11 @@ export type PositionsData = {
 
 const MAX_SHOWN = 4
 
-export function PositionsHovercard({ positions, limitOrders, numericSummary }: PositionsData) {
+export function PositionsHovercard({
+  positions,
+  limitOrders,
+  numericSummary,
+}: PositionsData) {
   const shownPositions = positions.slice(0, MAX_SHOWN)
   const extraPositions = positions.length - shownPositions.length
   const shownOrders = limitOrders.slice(0, MAX_SHOWN)
@@ -46,7 +50,10 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             </p>
           </Row>
           {shownPositions.map((p) => (
-            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
+            <Row
+              key={p.name}
+              className="mb-1 items-center justify-between gap-4"
+            >
               <Row className="min-w-0 items-center gap-1.5">
                 {p.color !== undefined && (
                   <span
@@ -58,7 +65,9 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
               </Row>
               <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
                 <span>Ṁ{Math.round(p.amount)}</span>
-                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
+                <span
+                  className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}
+                >
                   {p.profit >= 0 ? '+' : ''}Ṁ{Math.round(p.profit)}
                 </span>
               </Row>
@@ -80,7 +89,10 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             </p>
           </Row>
           {shownOrders.map((o, i) => (
-            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
+            <Row
+              key={i}
+              className="text-ink-400 mb-0.5 items-center gap-1 text-sm"
+            >
               <span className="min-w-0 truncate">{o.name}</span>
               <span className="flex-shrink-0">
                 at {o.prob}% — Ṁ{Math.round(o.amount)}
@@ -104,7 +116,8 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
           </Row>
           <Row className="items-center justify-between gap-4">
             <span className="text-ink-400 text-sm">
-              Ṁ{Math.round(numericSummary.total)} across {numericSummary.buckets} buckets
+              Ṁ{Math.round(numericSummary.total)} across{' '}
+              {numericSummary.buckets} buckets
             </span>
             <span
               className={clsx(
@@ -112,7 +125,8 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
               )}
             >
-              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{Math.round(numericSummary.profit)}
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ
+              {Math.round(numericSummary.profit)}
             </span>
           </Row>
           {numericSummary.orders && (

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -7,6 +7,10 @@ import { useApiSubscription } from 'client-common/hooks/use-api-subscription'
 import { flagEmojiToCode } from 'common/sports'
 import { SportsBetPanel } from './sports-bet-panel'
 import { Tooltip } from 'web/components/widgets/tooltip'
+import {
+  PositionsHovercard,
+  PositionsData,
+} from 'web/components/contract/positions-hovercard'
 
 // Renders a country flag as an image (works on every platform) rather than the
 // regional-indicator emoji, which Windows/Chrome draw as bare letters ("KR").
@@ -221,11 +225,7 @@ function OutcomeRow({
 }
 
 // ── DEV MOCK: cycles cards through position states for visual preview ──────────
-type MockPosition = { name: string; color: string; amount: number; profit: number }
-type MockOrder = { name: string; prob: number; amount: number }
-type MockUserData = { positions: MockPosition[]; limitOrders: MockOrder[] }
-
-function getMockUserData(matchId: string, match: SportsMatch): MockUserData {
+function getMockUserData(matchId: string, match: SportsMatch): PositionsData {
   const hash = matchId.split('').reduce((a, c) => a + c.charCodeAt(0), 0)
   const teamAName = match.teamA.name
   const teamBName = match.teamB.name
@@ -269,66 +269,6 @@ function getMockUserData(matchId: string, match: SportsMatch): MockUserData {
       ],
     }
   }
-}
-
-const MAX_SHOWN = 4
-
-function PositionsHoverContent({ positions, limitOrders }: MockUserData) {
-  const shownPositions = positions.slice(0, MAX_SHOWN)
-  const extraPositions = positions.length - shownPositions.length
-  const shownOrders = limitOrders.slice(0, MAX_SHOWN)
-  const extraOrders = limitOrders.length - shownOrders.length
-
-  return (
-    <div className="min-w-[220px] text-left">
-      {positions.length > 0 && (
-        <>
-          <Row className="mb-2 items-center gap-1.5">
-            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
-            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
-              Positions
-            </p>
-          </Row>
-          {shownPositions.map((p) => (
-            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
-              <Row className="min-w-0 items-center gap-1.5">
-                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full" style={{ backgroundColor: p.color }} />
-                <span className="min-w-0 truncate text-sm">{p.name}</span>
-              </Row>
-              <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
-                <span>Ṁ{p.amount}</span>
-                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
-                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
-                </span>
-              </Row>
-            </Row>
-          ))}
-          {extraPositions > 0 && (
-            <p className="text-ink-400 mt-0.5 text-[11px]">+{extraPositions} more — view market</p>
-          )}
-        </>
-      )}
-      {limitOrders.length > 0 && (
-        <div className={positions.length > 0 ? 'mt-3' : ''}>
-          <Row className="mb-2 items-center gap-1.5">
-            <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
-            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
-              Limit Orders
-            </p>
-          </Row>
-          {shownOrders.map((o, i) => (
-            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
-              <span className="min-w-0 truncate">{o.name}</span>
-              <span className="flex-shrink-0">at {o.prob}% — Ṁ{o.amount}</span>
-            </Row>
-          ))}
-          {extraOrders > 0 && (
-            <p className="text-ink-400 mt-0.5 text-[11px]">+{extraOrders} more — view market</p>
-          )}
-        </div>
-      )}
-    </div>
-  )
 }
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -548,7 +488,7 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
             <Tooltip
               text={
                 <Link href={marketHref} className="block">
-                  <PositionsHoverContent {...userData} />
+                  <PositionsHovercard {...userData} />
                 </Link>
               }
               placement="top"

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -6,6 +6,7 @@ import { Row } from 'web/components/layout/row'
 import { useApiSubscription } from 'client-common/hooks/use-api-subscription'
 import { flagEmojiToCode } from 'common/sports'
 import { SportsBetPanel } from './sports-bet-panel'
+import { Tooltip } from 'web/components/widgets/tooltip'
 
 // Renders a country flag as an image (works on every platform) rather than the
 // regional-indicator emoji, which Windows/Chrome draw as bare letters ("KR").
@@ -95,6 +96,7 @@ function OutcomeRow({
   teamColor,
   winnerColor,
   onClick,
+  hasPosition,
 }: {
   flag?: string
   name: string
@@ -107,6 +109,7 @@ function OutcomeRow({
   teamColor?: string
   winnerColor?: string
   onClick?: () => void
+  hasPosition?: boolean
 }) {
   const barColor = isWinner
     ? 'bg-green-400'
@@ -139,6 +142,17 @@ function OutcomeRow({
           opacity: 0.5,
         }}
       />
+      {hasPosition && (
+        <div
+          className="pointer-events-none absolute inset-y-0 left-0 w-[5px]"
+          style={{ backgroundColor: teamColor ?? undefined }}
+        >
+          <div
+            className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2"
+            style={{ backgroundColor: 'rgba(255,255,255,0.35)' }}
+          />
+        </div>
+      )}
       <div className="relative z-10 flex w-full items-center gap-2">
         {isDraw ? (
           <div className="border-ink-300 bg-canvas-100 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border">
@@ -206,6 +220,118 @@ function OutcomeRow({
   )
 }
 
+// ── DEV MOCK: cycles cards through position states for visual preview ──────────
+type MockPosition = { name: string; color: string; amount: number; profit: number }
+type MockOrder = { name: string; prob: number; amount: number }
+type MockUserData = { positions: MockPosition[]; limitOrders: MockOrder[] }
+
+function getMockUserData(matchId: string, match: SportsMatch): MockUserData {
+  const hash = matchId.split('').reduce((a, c) => a + c.charCodeAt(0), 0)
+  const teamAName = match.teamA.name
+  const teamBName = match.teamB.name
+  switch (hash % 5) {
+    case 0: return { positions: [], limitOrders: [] }
+    case 1: return {
+      positions: [{ name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 }],
+      limitOrders: [],
+    }
+    case 2: return {
+      positions: [
+        { name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 },
+        { name: 'Draw', color: SPORTS_COLORS.draw, amount: 50, profit: -8 },
+      ],
+      limitOrders: [],
+    }
+    case 3: return {
+      positions: [{ name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 }],
+      limitOrders: [
+        { name: teamAName, prob: 70, amount: 100 },
+        { name: teamAName, prob: 65, amount: 75 },
+        { name: teamAName, prob: 60, amount: 50 },
+        { name: teamBName, prob: 25, amount: 200 },
+        { name: teamBName, prob: 20, amount: 150 },
+        { name: teamBName, prob: 15, amount: 100 },
+        { name: 'Draw', prob: 30, amount: 80 },
+        { name: 'Draw', prob: 25, amount: 60 },
+      ],
+    }
+    default: return {
+      positions: [
+        { name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 },
+        { name: teamBName, color: SPORTS_COLORS.teamB, amount: 80, profit: -12 },
+        { name: 'Draw', color: SPORTS_COLORS.draw, amount: 50, profit: -8 },
+      ],
+      limitOrders: [
+        { name: teamAName, prob: 70, amount: 100 },
+        { name: teamAName, prob: 60, amount: 75 },
+        { name: teamBName, prob: 25, amount: 200 },
+        { name: 'Draw', prob: 30, amount: 80 },
+      ],
+    }
+  }
+}
+
+const MAX_SHOWN = 4
+
+function PositionsHoverContent({ positions, limitOrders }: MockUserData) {
+  const shownPositions = positions.slice(0, MAX_SHOWN)
+  const extraPositions = positions.length - shownPositions.length
+  const shownOrders = limitOrders.slice(0, MAX_SHOWN)
+  const extraOrders = limitOrders.length - shownOrders.length
+
+  return (
+    <div className="min-w-[220px] text-left">
+      {positions.length > 0 && (
+        <>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Positions
+            </p>
+          </Row>
+          {shownPositions.map((p) => (
+            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
+              <Row className="min-w-0 items-center gap-1.5">
+                <span className="h-1.5 w-1.5 flex-shrink-0 rounded-full" style={{ backgroundColor: p.color }} />
+                <span className="min-w-0 truncate text-sm">{p.name}</span>
+              </Row>
+              <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
+                <span>Ṁ{p.amount}</span>
+                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
+                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
+                </span>
+              </Row>
+            </Row>
+          ))}
+          {extraPositions > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">+{extraPositions} more — view market</p>
+          )}
+        </>
+      )}
+      {limitOrders.length > 0 && (
+        <div className={positions.length > 0 ? 'mt-3' : ''}>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Limit Orders
+            </p>
+          </Row>
+          {shownOrders.map((o, i) => (
+            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
+              <span className="min-w-0 truncate">{o.name}</span>
+              <span className="flex-shrink-0">at {o.prob}% — Ṁ{o.amount}</span>
+            </Row>
+          ))}
+          {extraOrders > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">+{extraOrders} more — view market</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function SportsMatchCard({ match }: { match: SportsMatch }) {
   const resolved = match.status === 'resolved'
   const now = Date.now()
@@ -248,6 +374,10 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
   const awayScore = resolved ? match.finalScore?.away : undefined
   const winnerColor = resolved ? vibrantForOutcome(match.winner) : undefined
   const marketHref = match.marketUrl ?? '#'
+  const userData = resolved ? { positions: [], limitOrders: [] } : getMockUserData(match.id, match)
+  const hasPositions = userData.positions.length > 0
+  const hasOrders = userData.limitOrders.length > 0
+  const hasAny = hasPositions || hasOrders
   const LIVE_COLOR = '#16a34a'
 
   // Annotate how a knockout was decided so the fullTime score (which can be a
@@ -383,6 +513,7 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
             teamColor={SPORTS_COLORS.teamA}
             winnerColor={match.winner === 'teamA' ? winnerColor : undefined}
             onClick={!resolved ? () => setBetOutcome('teamA') : undefined}
+            hasPosition={userData.positions.some((p) => p.name === match.teamA.name)}
           />
           <OutcomeRow
             flag={match.teamB.flag}
@@ -394,6 +525,7 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
             teamColor={SPORTS_COLORS.teamB}
             winnerColor={match.winner === 'teamB' ? winnerColor : undefined}
             onClick={!resolved ? () => setBetOutcome('teamB') : undefined}
+            hasPosition={userData.positions.some((p) => p.name === match.teamB.name)}
           />
           {(match.hasDraw ?? true) && (
             <OutcomeRow
@@ -405,12 +537,34 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
               teamColor={SPORTS_COLORS.draw}
               winnerColor={match.winner === 'draw' ? winnerColor : undefined}
               onClick={!resolved ? () => setBetOutcome('draw') : undefined}
+              hasPosition={userData.positions.some((p) => p.name === 'Draw')}
             />
           )}
         </Col>
 
-        <Row className="border-ink-200 justify-between border-t pt-2">
+        <Row className="border-ink-200 items-center justify-between border-t pt-2">
           <span className="text-ink-500 text-[11px]">Ṁ {match.volume} vol</span>
+          {hasAny && (
+            <Tooltip
+              text={
+                <Link href={marketHref} className="block">
+                  <PositionsHoverContent {...userData} />
+                </Link>
+              }
+              placement="top"
+              hasSafePolygon
+              tooltipClassName="!bg-canvas-20 border-ink-200 border shadow-lg !text-left !max-w-none !px-3 !py-2.5 !rounded-lg"
+            >
+              <Link
+                href={marketHref}
+                className="text-ink-500 hover:text-ink-700 flex items-center gap-1.5 text-[11px] transition-colors"
+              >
+                {hasPositions && <span className="bg-ink-400 h-2 w-2 rounded-full" />}
+                {hasOrders && <span className="border-ink-600 h-2 w-2 rounded-full border" />}
+                <span>Positions</span>
+              </Link>
+            </Tooltip>
+          )}
           <Link
             href={marketHref}
             className="text-ink-500 hover:text-yes-500 text-[11px] transition-colors"

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -232,7 +232,9 @@ function OutcomeRow({
 
 function useMyMatchMetrics(contractId: string | undefined) {
   const user = useUser()
-  const [metrics, setMetrics] = useState<ContractMetric[] | undefined>(undefined)
+  const [metrics, setMetrics] = useState<ContractMetric[] | undefined>(
+    undefined
+  )
 
   useEffect(() => {
     if (!user?.id || !contractId) {
@@ -320,30 +322,70 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
   const winnerColor = resolved ? vibrantForOutcome(match.winner) : undefined
   const marketHref = match.marketUrl ?? '#'
   const myLimitBets = (allLimitBets ?? []).filter((b) => b.userId === user?.id)
-  const teamAPos = !resolved && myMetrics?.find((m) => m.answerId === match.teamAAnswerId && m.hasShares)
-  const teamBPos = !resolved && myMetrics?.find((m) => m.answerId === match.teamBAnswerId && m.hasShares)
-  const drawPos = !resolved && myMetrics?.find((m) => m.answerId === match.drawAnswerId && m.hasShares)
+  const teamAPos =
+    !resolved &&
+    myMetrics?.find((m) => m.answerId === match.teamAAnswerId && m.hasShares)
+  const teamBPos =
+    !resolved &&
+    myMetrics?.find((m) => m.answerId === match.teamBAnswerId && m.hasShares)
+  const drawPos =
+    !resolved &&
+    myMetrics?.find((m) => m.answerId === match.drawAnswerId && m.hasShares)
   const positions: PositionsData['positions'] = [
-    ...(teamAPos ? [{ name: match.teamA.name, color: SPORTS_COLORS.teamA, amount: teamAPos.invested, profit: teamAPos.profit }] : []),
-    ...(teamBPos ? [{ name: match.teamB.name, color: SPORTS_COLORS.teamB, amount: teamBPos.invested, profit: teamBPos.profit }] : []),
-    ...(drawPos ? [{ name: 'Draw', color: SPORTS_COLORS.draw, amount: drawPos.invested, profit: drawPos.profit }] : []),
+    ...(teamAPos
+      ? [
+          {
+            name: match.teamA.name,
+            color: SPORTS_COLORS.teamA,
+            amount: teamAPos.invested,
+            profit: teamAPos.profit,
+          },
+        ]
+      : []),
+    ...(teamBPos
+      ? [
+          {
+            name: match.teamB.name,
+            color: SPORTS_COLORS.teamB,
+            amount: teamBPos.invested,
+            profit: teamBPos.profit,
+          },
+        ]
+      : []),
+    ...(drawPos
+      ? [
+          {
+            name: 'Draw',
+            color: SPORTS_COLORS.draw,
+            amount: drawPos.invested,
+            profit: drawPos.profit,
+          },
+        ]
+      : []),
   ]
-  const limitOrders: PositionsData['limitOrders'] = !resolved && user
-    ? myLimitBets
-        .filter((b) => !!b.answerId)
-        .map((b) => {
-          const name =
-            b.answerId === match.teamAAnswerId
-              ? match.teamA.name
-              : b.answerId === match.teamBAnswerId
-              ? match.teamB.name
-              : b.answerId === match.drawAnswerId
-              ? 'Draw'
+  const limitOrders: PositionsData['limitOrders'] =
+    !resolved && user
+      ? myLimitBets
+          .filter((b) => !!b.answerId)
+          .map((b) => {
+            const name =
+              b.answerId === match.teamAAnswerId
+                ? match.teamA.name
+                : b.answerId === match.teamBAnswerId
+                ? match.teamB.name
+                : b.answerId === match.drawAnswerId
+                ? 'Draw'
+                : null
+            return name
+              ? {
+                  name,
+                  prob: Math.round(b.limitProb * 100),
+                  amount: b.orderAmount - b.amount,
+                }
               : null
-          return name ? { name, prob: Math.round(b.limitProb * 100), amount: b.orderAmount - b.amount } : null
-        })
-        .filter((o): o is NonNullable<typeof o> => o !== null)
-    : []
+          })
+          .filter((o): o is NonNullable<typeof o> => o !== null)
+      : []
   const userData: PositionsData = { positions, limitOrders }
   const hasPositions = userData.positions.length > 0
   const hasOrders = userData.limitOrders.length > 0
@@ -483,7 +525,9 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
             teamColor={SPORTS_COLORS.teamA}
             winnerColor={match.winner === 'teamA' ? winnerColor : undefined}
             onClick={!resolved ? () => setBetOutcome('teamA') : undefined}
-            hasPosition={userData.positions.some((p) => p.name === match.teamA.name)}
+            hasPosition={userData.positions.some(
+              (p) => p.name === match.teamA.name
+            )}
           />
           <OutcomeRow
             flag={match.teamB.flag}
@@ -495,7 +539,9 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
             teamColor={SPORTS_COLORS.teamB}
             winnerColor={match.winner === 'teamB' ? winnerColor : undefined}
             onClick={!resolved ? () => setBetOutcome('teamB') : undefined}
-            hasPosition={userData.positions.some((p) => p.name === match.teamB.name)}
+            hasPosition={userData.positions.some(
+              (p) => p.name === match.teamB.name
+            )}
           />
           {(match.hasDraw ?? true) && (
             <OutcomeRow
@@ -529,8 +575,12 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
                 href={marketHref}
                 className="text-ink-500 hover:text-ink-700 flex items-center gap-1.5 text-[11px] transition-colors"
               >
-                {hasPositions && <span className="bg-ink-400 h-2 w-2 rounded-full" />}
-                {hasOrders && <span className="border-ink-600 h-2 w-2 rounded-full border" />}
+                {hasPositions && (
+                  <span className="bg-ink-400 h-2 w-2 rounded-full" />
+                )}
+                {hasOrders && (
+                  <span className="border-ink-600 h-2 w-2 rounded-full border" />
+                )}
                 <span>Positions</span>
               </Link>
             </Tooltip>

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -4,13 +4,19 @@ import clsx from 'clsx'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { useApiSubscription } from 'client-common/hooks/use-api-subscription'
+import { useUnfilledBets } from 'client-common/hooks/use-bets'
 import { flagEmojiToCode } from 'common/sports'
+import { ContractMetric } from 'common/contract-metric'
 import { SportsBetPanel } from './sports-bet-panel'
 import { Tooltip } from 'web/components/widgets/tooltip'
 import {
   PositionsHovercard,
   PositionsData,
 } from 'web/components/contract/positions-hovercard'
+import { useUser } from 'web/hooks/use-user'
+import { useIsPageVisible } from 'web/hooks/use-page-visible'
+import { api } from 'web/lib/api/api'
+import { db } from 'web/lib/supabase/db'
 
 // Renders a country flag as an image (works on every platform) rather than the
 // regional-indicator emoji, which Windows/Chrome draw as bare letters ("KR").
@@ -224,57 +230,56 @@ function OutcomeRow({
   )
 }
 
-// ── DEV MOCK: cycles cards through position states for visual preview ──────────
-function getMockUserData(matchId: string, match: SportsMatch): PositionsData {
-  const hash = matchId.split('').reduce((a, c) => a + c.charCodeAt(0), 0)
-  const teamAName = match.teamA.name
-  const teamBName = match.teamB.name
-  switch (hash % 5) {
-    case 0: return { positions: [], limitOrders: [] }
-    case 1: return {
-      positions: [{ name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 }],
-      limitOrders: [],
+function useMyMatchMetrics(contractId: string | undefined) {
+  const user = useUser()
+  const [metrics, setMetrics] = useState<ContractMetric[] | undefined>(undefined)
+
+  useEffect(() => {
+    if (!user?.id || !contractId) {
+      setMetrics(undefined)
+      return
     }
-    case 2: return {
-      positions: [
-        { name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 },
-        { name: 'Draw', color: SPORTS_COLORS.draw, amount: 50, profit: -8 },
-      ],
-      limitOrders: [],
-    }
-    case 3: return {
-      positions: [{ name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 }],
-      limitOrders: [
-        { name: teamAName, prob: 70, amount: 100 },
-        { name: teamAName, prob: 65, amount: 75 },
-        { name: teamAName, prob: 60, amount: 50 },
-        { name: teamBName, prob: 25, amount: 200 },
-        { name: teamBName, prob: 20, amount: 150 },
-        { name: teamBName, prob: 15, amount: 100 },
-        { name: 'Draw', prob: 30, amount: 80 },
-        { name: 'Draw', prob: 25, amount: 60 },
-      ],
-    }
-    default: return {
-      positions: [
-        { name: teamAName, color: SPORTS_COLORS.teamA, amount: 150, profit: 23 },
-        { name: teamBName, color: SPORTS_COLORS.teamB, amount: 80, profit: -12 },
-        { name: 'Draw', color: SPORTS_COLORS.draw, amount: 50, profit: -8 },
-      ],
-      limitOrders: [
-        { name: teamAName, prob: 70, amount: 100 },
-        { name: teamAName, prob: 60, amount: 75 },
-        { name: teamBName, prob: 25, amount: 200 },
-        { name: 'Draw', prob: 30, amount: 80 },
-      ],
-    }
-  }
+    db.from('user_contract_metrics')
+      .select('data')
+      .eq('contract_id', contractId)
+      .eq('user_id', user.id)
+      .then(({ data }) => {
+        setMetrics((data ?? []).map((row) => row.data as ContractMetric))
+      })
+  }, [user?.id, contractId])
+
+  useApiSubscription({
+    topics:
+      contractId && user?.id
+        ? [`contract/${contractId}/user-metrics/${user.id}`]
+        : [],
+    enabled: !!user?.id && !!contractId,
+    onBroadcast: ({ data }) => {
+      const updated = data.metrics as ContractMetric[]
+      if (updated?.length) {
+        setMetrics((prev) => {
+          const map = new Map((prev ?? []).map((m) => [m.answerId, m]))
+          updated.forEach((m) => map.set(m.answerId, m))
+          return Array.from(map.values())
+        })
+      }
+    },
+  })
+
+  return metrics
 }
-// ─────────────────────────────────────────────────────────────────────────────
 
 export function SportsMatchCard({ match }: { match: SportsMatch }) {
   const resolved = match.status === 'resolved'
   const now = Date.now()
+  const user = useUser()
+  const myMetrics = useMyMatchMetrics(!resolved ? match.contractId : undefined)
+  const allLimitBets = useUnfilledBets(
+    match.contractId ?? '',
+    (params) => api('bets', params),
+    useIsPageVisible,
+    { enabled: !resolved && !!user && !!match.contractId }
+  )
   // Live state is data-driven (a fresh in-play score), not a fixed time window —
   // so a long match never falsely reverts to "Upcoming". Seeded from the initial
   // fetch, then updated live over the websocket below.
@@ -314,7 +319,32 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
   const awayScore = resolved ? match.finalScore?.away : undefined
   const winnerColor = resolved ? vibrantForOutcome(match.winner) : undefined
   const marketHref = match.marketUrl ?? '#'
-  const userData = resolved ? { positions: [], limitOrders: [] } : getMockUserData(match.id, match)
+  const myLimitBets = (allLimitBets ?? []).filter((b) => b.userId === user?.id)
+  const teamAPos = !resolved && myMetrics?.find((m) => m.answerId === match.teamAAnswerId && m.hasShares)
+  const teamBPos = !resolved && myMetrics?.find((m) => m.answerId === match.teamBAnswerId && m.hasShares)
+  const drawPos = !resolved && myMetrics?.find((m) => m.answerId === match.drawAnswerId && m.hasShares)
+  const positions: PositionsData['positions'] = [
+    ...(teamAPos ? [{ name: match.teamA.name, color: SPORTS_COLORS.teamA, amount: teamAPos.invested, profit: teamAPos.profit }] : []),
+    ...(teamBPos ? [{ name: match.teamB.name, color: SPORTS_COLORS.teamB, amount: teamBPos.invested, profit: teamBPos.profit }] : []),
+    ...(drawPos ? [{ name: 'Draw', color: SPORTS_COLORS.draw, amount: drawPos.invested, profit: drawPos.profit }] : []),
+  ]
+  const limitOrders: PositionsData['limitOrders'] = !resolved && user
+    ? myLimitBets
+        .filter((b) => !!b.answerId)
+        .map((b) => {
+          const name =
+            b.answerId === match.teamAAnswerId
+              ? match.teamA.name
+              : b.answerId === match.teamBAnswerId
+              ? match.teamB.name
+              : b.answerId === match.drawAnswerId
+              ? 'Draw'
+              : null
+          return name ? { name, prob: Math.round(b.limitProb * 100), amount: b.orderAmount - b.amount } : null
+        })
+        .filter((o): o is NonNullable<typeof o> => o !== null)
+    : []
+  const userData: PositionsData = { positions, limitOrders }
   const hasPositions = userData.positions.length > 0
   const hasOrders = userData.limitOrders.length > 0
   const hasAny = hasPositions || hasOrders


### PR DESCRIPTION
## Summary

- Adds a position indicator to `SportsMatchCard`: a 5px left-edge colored stripe on outcome rows where the user holds a position, and a **Positions** pill in the card footer (solid pip for positions, outlined pip for limit orders)
- Hovering the pill shows a breakdown of the user's positions (amount + P&L) and open limit orders for that match
- Clicking the indicator navigates to the market page
- Depends on PR #3883 — merge that first

🤖 Generated with [Claude Code](https://claude.com/claude-code)