### PR TITLE
feat: shared PositionsHovercard component

### DIFF
--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -34,8 +34,9 @@ export function PositionsHovercard({
   limitOrders,
   numericSummary,
 }: PositionsData) {
-  const shownPositions = positions.slice(0, MAX_SHOWN)
-  const extraPositions = positions.length - shownPositions.length
+  const sorted = [...positions].sort((a, b) => b.amount - a.amount)
+  const shownPositions = sorted.slice(0, MAX_SHOWN)
+  const extraPositions = sorted.length - shownPositions.length
   const shownOrders = limitOrders.slice(0, MAX_SHOWN)
   const extraOrders = limitOrders.length - shownOrders.length
 

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -1,0 +1,136 @@
+import clsx from 'clsx'
+import { Row } from 'web/components/layout/row'
+
+export type UserPosition = {
+  name: string
+  color?: string
+  amount: number
+  profit: number
+}
+
+export type UserLimitOrder = {
+  name: string
+  prob: number
+  amount: number
+}
+
+export type UserNumericSummary = {
+  total: number
+  buckets: number
+  profit: number
+  orders?: { total: number; count: number }
+}
+
+export type PositionsData = {
+  positions: UserPosition[]
+  limitOrders: UserLimitOrder[]
+  numericSummary?: UserNumericSummary
+}
+
+const MAX_SHOWN = 4
+
+export function PositionsHovercard({ positions, limitOrders, numericSummary }: PositionsData) {
+  const shownPositions = positions.slice(0, MAX_SHOWN)
+  const extraPositions = positions.length - shownPositions.length
+  const shownOrders = limitOrders.slice(0, MAX_SHOWN)
+  const extraOrders = limitOrders.length - shownOrders.length
+
+  return (
+    <div className="min-w-[220px] text-left">
+      {positions.length > 0 && (
+        <>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Positions
+            </p>
+          </Row>
+          {shownPositions.map((p) => (
+            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
+              <Row className="min-w-0 items-center gap-1.5">
+                {p.color !== undefined && (
+                  <span
+                    className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
+                    style={{ backgroundColor: p.color }}
+                  />
+                )}
+                <span className="min-w-0 truncate text-sm">{p.name}</span>
+              </Row>
+              <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
+                <span>Ṁ{p.amount}</span>
+                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
+                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
+                </span>
+              </Row>
+            </Row>
+          ))}
+          {extraPositions > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">
+              +{extraPositions} more — view market
+            </p>
+          )}
+        </>
+      )}
+      {limitOrders.length > 0 && (
+        <div className={positions.length > 0 ? 'mt-3' : ''}>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Limit Orders
+            </p>
+          </Row>
+          {shownOrders.map((o, i) => (
+            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
+              <span className="min-w-0 truncate">{o.name}</span>
+              <span className="flex-shrink-0">
+                at {o.prob}% — Ṁ{o.amount}
+              </span>
+            </Row>
+          ))}
+          {extraOrders > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">
+              +{extraOrders} more — view market
+            </p>
+          )}
+        </div>
+      )}
+      {numericSummary && (
+        <>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Positions
+            </p>
+          </Row>
+          <Row className="items-center justify-between gap-4">
+            <span className="text-ink-400 text-sm">
+              Ṁ{numericSummary.total} across {numericSummary.buckets} buckets
+            </span>
+            <span
+              className={clsx(
+                'flex-shrink-0 text-sm font-semibold',
+                numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
+              )}
+            >
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{numericSummary.profit}
+            </span>
+          </Row>
+          {numericSummary.orders && (
+            <div className="mt-3">
+              <Row className="mb-2 items-center gap-1.5">
+                <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
+                <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+                  Limit Orders
+                </p>
+              </Row>
+              <span className="text-ink-400 text-sm">
+                Ṁ{numericSummary.orders.total} pending across{' '}
+                {numericSummary.orders.count} orders
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -57,9 +57,9 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 <span className="min-w-0 truncate text-sm">{p.name}</span>
               </Row>
               <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
-                <span>Ṁ{p.amount}</span>
+                <span>Ṁ{Math.round(p.amount)}</span>
                 <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
-                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
+                  {p.profit >= 0 ? '+' : ''}Ṁ{Math.round(p.profit)}
                 </span>
               </Row>
             </Row>
@@ -83,7 +83,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
               <span className="min-w-0 truncate">{o.name}</span>
               <span className="flex-shrink-0">
-                at {o.prob}% — Ṁ{o.amount}
+                at {o.prob}% — Ṁ{Math.round(o.amount)}
               </span>
             </Row>
           ))}
@@ -104,7 +104,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
           </Row>
           <Row className="items-center justify-between gap-4">
             <span className="text-ink-400 text-sm">
-              Ṁ{numericSummary.total} across {numericSummary.buckets} buckets
+              Ṁ{Math.round(numericSummary.total)} across {numericSummary.buckets} buckets
             </span>
             <span
               className={clsx(
@@ -112,7 +112,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
               )}
             >
-              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{numericSummary.profit}
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{Math.round(numericSummary.profit)}
             </span>
           </Row>
           {numericSummary.orders && (
@@ -124,7 +124,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 </p>
               </Row>
               <span className="text-ink-400 text-sm">
-                Ṁ{numericSummary.orders.total} pending across{' '}
+                Ṁ{Math.round(numericSummary.orders.total)} pending across{' '}
                 {numericSummary.orders.count} orders
               </span>
             </div>

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -29,7 +29,11 @@ export type PositionsData = {
 
 const MAX_SHOWN = 4
 
-export function PositionsHovercard({ positions, limitOrders, numericSummary }: PositionsData) {
+export function PositionsHovercard({
+  positions,
+  limitOrders,
+  numericSummary,
+}: PositionsData) {
   const shownPositions = positions.slice(0, MAX_SHOWN)
   const extraPositions = positions.length - shownPositions.length
   const shownOrders = limitOrders.slice(0, MAX_SHOWN)
@@ -46,7 +50,10 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             </p>
           </Row>
           {shownPositions.map((p) => (
-            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
+            <Row
+              key={p.name}
+              className="mb-1 items-center justify-between gap-4"
+            >
               <Row className="min-w-0 items-center gap-1.5">
                 {p.color !== undefined && (
                   <span
@@ -58,7 +65,9 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
               </Row>
               <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
                 <span>Ṁ{Math.round(p.amount)}</span>
-                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
+                <span
+                  className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}
+                >
                   {p.profit >= 0 ? '+' : ''}Ṁ{Math.round(p.profit)}
                 </span>
               </Row>
@@ -80,7 +89,10 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             </p>
           </Row>
           {shownOrders.map((o, i) => (
-            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
+            <Row
+              key={i}
+              className="text-ink-400 mb-0.5 items-center gap-1 text-sm"
+            >
               <span className="min-w-0 truncate">{o.name}</span>
               <span className="flex-shrink-0">
                 at {o.prob}% — Ṁ{Math.round(o.amount)}
@@ -104,7 +116,8 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
           </Row>
           <Row className="items-center justify-between gap-4">
             <span className="text-ink-400 text-sm">
-              Ṁ{Math.round(numericSummary.total)} across {numericSummary.buckets} buckets
+              Ṁ{Math.round(numericSummary.total)} across{' '}
+              {numericSummary.buckets} buckets
             </span>
             <span
               className={clsx(
@@ -112,7 +125,8 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
               )}
             >
-              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{Math.round(numericSummary.profit)}
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ
+              {Math.round(numericSummary.profit)}
             </span>
           </Row>
           {numericSummary.orders && (

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { formatMoney } from 'common/util/format'
 import { Row } from 'web/components/layout/row'
 
 export type UserPosition = {
@@ -65,11 +66,12 @@ export function PositionsHovercard({
                 <span className="min-w-0 truncate text-sm">{p.name}</span>
               </Row>
               <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
-                <span>Ṁ{Math.round(p.amount)}</span>
+                <span>{formatMoney(p.amount)}</span>
                 <span
                   className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}
                 >
-                  {p.profit >= 0 ? '+' : ''}Ṁ{Math.round(p.profit)}
+                  {p.profit >= 0 ? '+' : ''}
+                  {formatMoney(p.profit)}
                 </span>
               </Row>
             </Row>
@@ -96,7 +98,7 @@ export function PositionsHovercard({
             >
               <span className="min-w-0 truncate">{o.name}</span>
               <span className="flex-shrink-0">
-                at {o.prob}% — Ṁ{Math.round(o.amount)}
+                at {o.prob}% — {formatMoney(o.amount)}
               </span>
             </Row>
           ))}
@@ -117,7 +119,7 @@ export function PositionsHovercard({
           </Row>
           <Row className="items-center justify-between gap-4">
             <span className="text-ink-400 text-sm">
-              Ṁ{Math.round(numericSummary.total)} across{' '}
+              {formatMoney(numericSummary.total)} across{' '}
               {numericSummary.buckets} buckets
             </span>
             <span
@@ -126,8 +128,8 @@ export function PositionsHovercard({
                 numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
               )}
             >
-              {numericSummary.profit >= 0 ? '+' : ''}Ṁ
-              {Math.round(numericSummary.profit)}
+              {numericSummary.profit >= 0 ? '+' : ''}
+              {formatMoney(numericSummary.profit)}
             </span>
           </Row>
           {numericSummary.orders && (
@@ -139,7 +141,7 @@ export function PositionsHovercard({
                 </p>
               </Row>
               <span className="text-ink-400 text-sm">
-                Ṁ{Math.round(numericSummary.orders.total)} pending across{' '}
+                {formatMoney(numericSummary.orders.total)} pending across{' '}
                 {numericSummary.orders.count} orders
               </span>
             </div>


### PR DESCRIPTION
## Summary

Extracts position display into a shared component at `web/components/contract/positions-hovercard.tsx` for reuse across sports match cards and dashboard market cards.

Exports:
- `PositionsHovercard` — the hovercard content component
- `PositionsData`, `UserPosition`, `UserLimitOrder`, `UserNumericSummary` — types

Supports:
- Named positions with amount and P&L; optional `color` for a team/answer-colored pip (sports cards use this, other cards omit it)
- Limit orders with name, probability, and amount
- Numeric summary for bucket-style markets (total, bucket count, P&L, optional pending orders)
- Capped at 4 entries each with an overflow note

No card changes in this PR — follow-up PRs will import from this component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)