### PR TITLE
feat(dashboard): positions pill and whole-card navigation on DashboardMarketCard

### DIFF
--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -1,0 +1,136 @@
+import clsx from 'clsx'
+import { Row } from 'web/components/layout/row'
+
+export type UserPosition = {
+  name: string
+  color?: string
+  amount: number
+  profit: number
+}
+
+export type UserLimitOrder = {
+  name: string
+  prob: number
+  amount: number
+}
+
+export type UserNumericSummary = {
+  total: number
+  buckets: number
+  profit: number
+  orders?: { total: number; count: number }
+}
+
+export type PositionsData = {
+  positions: UserPosition[]
+  limitOrders: UserLimitOrder[]
+  numericSummary?: UserNumericSummary
+}
+
+const MAX_SHOWN = 4
+
+export function PositionsHovercard({ positions, limitOrders, numericSummary }: PositionsData) {
+  const shownPositions = positions.slice(0, MAX_SHOWN)
+  const extraPositions = positions.length - shownPositions.length
+  const shownOrders = limitOrders.slice(0, MAX_SHOWN)
+  const extraOrders = limitOrders.length - shownOrders.length
+
+  return (
+    <div className="min-w-[220px] text-left">
+      {positions.length > 0 && (
+        <>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Positions
+            </p>
+          </Row>
+          {shownPositions.map((p) => (
+            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
+              <Row className="min-w-0 items-center gap-1.5">
+                {p.color !== undefined && (
+                  <span
+                    className="h-1.5 w-1.5 flex-shrink-0 rounded-full"
+                    style={{ backgroundColor: p.color }}
+                  />
+                )}
+                <span className="min-w-0 truncate text-sm">{p.name}</span>
+              </Row>
+              <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
+                <span>Ṁ{p.amount}</span>
+                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
+                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
+                </span>
+              </Row>
+            </Row>
+          ))}
+          {extraPositions > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">
+              +{extraPositions} more — view market
+            </p>
+          )}
+        </>
+      )}
+      {limitOrders.length > 0 && (
+        <div className={positions.length > 0 ? 'mt-3' : ''}>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Limit Orders
+            </p>
+          </Row>
+          {shownOrders.map((o, i) => (
+            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
+              <span className="min-w-0 truncate">{o.name}</span>
+              <span className="flex-shrink-0">
+                at {o.prob}% — Ṁ{o.amount}
+              </span>
+            </Row>
+          ))}
+          {extraOrders > 0 && (
+            <p className="text-ink-400 mt-0.5 text-[11px]">
+              +{extraOrders} more — view market
+            </p>
+          )}
+        </div>
+      )}
+      {numericSummary && (
+        <>
+          <Row className="mb-2 items-center gap-1.5">
+            <span className="bg-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full" />
+            <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+              Positions
+            </p>
+          </Row>
+          <Row className="items-center justify-between gap-4">
+            <span className="text-ink-400 text-sm">
+              Ṁ{numericSummary.total} across {numericSummary.buckets} buckets
+            </span>
+            <span
+              className={clsx(
+                'flex-shrink-0 text-sm font-semibold',
+                numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
+              )}
+            >
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{numericSummary.profit}
+            </span>
+          </Row>
+          {numericSummary.orders && (
+            <div className="mt-3">
+              <Row className="mb-2 items-center gap-1.5">
+                <span className="border-ink-300 h-2.5 w-2.5 flex-shrink-0 rounded-full border" />
+                <p className="text-ink-300 text-xs font-bold uppercase tracking-wider">
+                  Limit Orders
+                </p>
+              </Row>
+              <span className="text-ink-400 text-sm">
+                Ṁ{numericSummary.orders.total} pending across{' '}
+                {numericSummary.orders.count} orders
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -57,9 +57,9 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 <span className="min-w-0 truncate text-sm">{p.name}</span>
               </Row>
               <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
-                <span>Ṁ{p.amount}</span>
+                <span>Ṁ{Math.round(p.amount)}</span>
                 <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
-                  {p.profit >= 0 ? '+' : ''}Ṁ{p.profit}
+                  {p.profit >= 0 ? '+' : ''}Ṁ{Math.round(p.profit)}
                 </span>
               </Row>
             </Row>
@@ -83,7 +83,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
               <span className="min-w-0 truncate">{o.name}</span>
               <span className="flex-shrink-0">
-                at {o.prob}% — Ṁ{o.amount}
+                at {o.prob}% — Ṁ{Math.round(o.amount)}
               </span>
             </Row>
           ))}
@@ -104,7 +104,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
           </Row>
           <Row className="items-center justify-between gap-4">
             <span className="text-ink-400 text-sm">
-              Ṁ{numericSummary.total} across {numericSummary.buckets} buckets
+              Ṁ{Math.round(numericSummary.total)} across {numericSummary.buckets} buckets
             </span>
             <span
               className={clsx(
@@ -112,7 +112,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
               )}
             >
-              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{numericSummary.profit}
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{Math.round(numericSummary.profit)}
             </span>
           </Row>
           {numericSummary.orders && (
@@ -124,7 +124,7 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 </p>
               </Row>
               <span className="text-ink-400 text-sm">
-                Ṁ{numericSummary.orders.total} pending across{' '}
+                Ṁ{Math.round(numericSummary.orders.total)} pending across{' '}
                 {numericSummary.orders.count} orders
               </span>
             </div>

--- a/web/components/contract/positions-hovercard.tsx
+++ b/web/components/contract/positions-hovercard.tsx
@@ -29,7 +29,11 @@ export type PositionsData = {
 
 const MAX_SHOWN = 4
 
-export function PositionsHovercard({ positions, limitOrders, numericSummary }: PositionsData) {
+export function PositionsHovercard({
+  positions,
+  limitOrders,
+  numericSummary,
+}: PositionsData) {
   const shownPositions = positions.slice(0, MAX_SHOWN)
   const extraPositions = positions.length - shownPositions.length
   const shownOrders = limitOrders.slice(0, MAX_SHOWN)
@@ -46,7 +50,10 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             </p>
           </Row>
           {shownPositions.map((p) => (
-            <Row key={p.name} className="mb-1 items-center justify-between gap-4">
+            <Row
+              key={p.name}
+              className="mb-1 items-center justify-between gap-4"
+            >
               <Row className="min-w-0 items-center gap-1.5">
                 {p.color !== undefined && (
                   <span
@@ -58,7 +65,9 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
               </Row>
               <Row className="flex-shrink-0 items-center gap-1.5 text-sm font-semibold">
                 <span>Ṁ{Math.round(p.amount)}</span>
-                <span className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}>
+                <span
+                  className={p.profit >= 0 ? 'text-green-600' : 'text-red-500'}
+                >
                   {p.profit >= 0 ? '+' : ''}Ṁ{Math.round(p.profit)}
                 </span>
               </Row>
@@ -80,7 +89,10 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
             </p>
           </Row>
           {shownOrders.map((o, i) => (
-            <Row key={i} className="mb-0.5 items-center gap-1 text-sm text-ink-400">
+            <Row
+              key={i}
+              className="text-ink-400 mb-0.5 items-center gap-1 text-sm"
+            >
               <span className="min-w-0 truncate">{o.name}</span>
               <span className="flex-shrink-0">
                 at {o.prob}% — Ṁ{Math.round(o.amount)}
@@ -104,7 +116,8 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
           </Row>
           <Row className="items-center justify-between gap-4">
             <span className="text-ink-400 text-sm">
-              Ṁ{Math.round(numericSummary.total)} across {numericSummary.buckets} buckets
+              Ṁ{Math.round(numericSummary.total)} across{' '}
+              {numericSummary.buckets} buckets
             </span>
             <span
               className={clsx(
@@ -112,7 +125,8 @@ export function PositionsHovercard({ positions, limitOrders, numericSummary }: P
                 numericSummary.profit >= 0 ? 'text-green-600' : 'text-red-500'
               )}
             >
-              {numericSummary.profit >= 0 ? '+' : ''}Ṁ{Math.round(numericSummary.profit)}
+              {numericSummary.profit >= 0 ? '+' : ''}Ṁ
+              {Math.round(numericSummary.profit)}
             </span>
           </Row>
           {numericSummary.orders && (

--- a/web/components/dashboard/dashboard-market-card.tsx
+++ b/web/components/dashboard/dashboard-market-card.tsx
@@ -96,7 +96,6 @@ function statusLabel(contract: Contract): string | null {
   return null
 }
 
-
 export function DashboardMarketCard({
   contract: initialContract,
   trackingLocation = 'dashboard',
@@ -150,28 +149,44 @@ export function DashboardMarketCard({
     if (isBinary || isPseudoNumeric) {
       const m = allMetrics.find((m) => m.answerId === null)
       if (m?.hasShares) {
-        positions = [{ name: m.maxSharesOutcome === 'NO' ? 'No' : 'Yes', amount: m.invested, profit: m.profit }]
+        positions = [
+          {
+            name: m.maxSharesOutcome === 'NO' ? 'No' : 'Yes',
+            amount: m.invested,
+            profit: m.profit,
+          },
+        ]
       }
       limitOrders = myLimitBets
         .filter((b) => b.answerId == null)
-        .map((b) => ({ name: b.outcome === 'NO' ? 'No' : 'Yes', prob: Math.round(b.limitProb * 100), amount: b.orderAmount - b.amount }))
+        .map((b) => ({
+          name: b.outcome === 'NO' ? 'No' : 'Yes',
+          prob: Math.round(b.limitProb * 100),
+          amount: b.orderAmount - b.amount,
+        }))
     } else if (isMulti) {
       positions = allMetrics
         .filter((m) => m.answerId !== null && m.hasShares)
         .map((m) => ({
-          name: multiContract?.answers.find((a) => a.id === m.answerId)?.text ?? 'Answer',
+          name:
+            multiContract?.answers.find((a) => a.id === m.answerId)?.text ??
+            'Answer',
           amount: m.invested,
           profit: m.profit,
         }))
       limitOrders = myLimitBets
         .filter((b) => b.answerId != null)
         .map((b) => ({
-          name: multiContract?.answers.find((a) => a.id === b.answerId)?.text ?? 'Answer',
+          name:
+            multiContract?.answers.find((a) => a.id === b.answerId)?.text ??
+            'Answer',
           prob: Math.round(b.limitProb * 100),
           amount: b.orderAmount - b.amount,
         }))
     } else if (isNumericBuckets) {
-      const bucketMetrics = allMetrics.filter((m) => m.answerId !== null && m.hasShares)
+      const bucketMetrics = allMetrics.filter(
+        (m) => m.answerId !== null && m.hasShares
+      )
       const numericOrders = myLimitBets.filter((b) => b.answerId != null)
       if (bucketMetrics.length > 0 || numericOrders.length > 0) {
         numericSummary = {
@@ -180,7 +195,10 @@ export function DashboardMarketCard({
           profit: bucketMetrics.reduce((sum, m) => sum + m.profit, 0),
           ...(numericOrders.length > 0 && {
             orders: {
-              total: numericOrders.reduce((sum, b) => sum + b.orderAmount - b.amount, 0),
+              total: numericOrders.reduce(
+                (sum, b) => sum + b.orderAmount - b.amount,
+                0
+              ),
               count: numericOrders.length,
             },
           }),
@@ -189,8 +207,10 @@ export function DashboardMarketCard({
     }
   }
   const userData: PositionsData = { positions, limitOrders, numericSummary }
-  const hasPositions = userData.positions.length > 0 || !!userData.numericSummary
-  const hasOrders = userData.limitOrders.length > 0 || !!userData.numericSummary?.orders
+  const hasPositions =
+    userData.positions.length > 0 || !!userData.numericSummary
+  const hasOrders =
+    userData.limitOrders.length > 0 || !!userData.numericSummary?.orders
   const hasAny = hasPositions || hasOrders
 
   return (
@@ -389,8 +409,12 @@ export function DashboardMarketCard({
             tooltipClassName="!bg-canvas-20 border-ink-200 border shadow-lg !text-left !max-w-none !px-3 !py-2.5 !rounded-lg"
           >
             <div className="border-ink-400 text-ink-500 hover:border-ink-600 hover:text-ink-700 flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] transition-colors">
-              {hasPositions && <span className="bg-ink-400 h-1.5 w-1.5 rounded-full" />}
-              {hasOrders && <span className="border-ink-500 h-1.5 w-1.5 rounded-full border" />}
+              {hasPositions && (
+                <span className="bg-ink-400 h-1.5 w-1.5 rounded-full" />
+              )}
+              {hasOrders && (
+                <span className="border-ink-500 h-1.5 w-1.5 rounded-full border" />
+              )}
               <span>Positions</span>
             </div>
           </Tooltip>

--- a/web/components/dashboard/dashboard-market-card.tsx
+++ b/web/components/dashboard/dashboard-market-card.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import Link from 'next/link'
+import Router from 'next/router'
 import {
   BinaryContract,
   CPMMContract,
@@ -29,6 +29,11 @@ import { useDisplayUserById } from 'web/hooks/use-user-supabase'
 import { Avatar } from 'web/components/widgets/avatar'
 import { UserLink } from 'web/components/widgets/user-link'
 import { UserHovercard } from 'web/components/user/user-hovercard'
+import { Tooltip } from 'web/components/widgets/tooltip'
+import {
+  PositionsHovercard,
+  PositionsData,
+} from 'web/components/contract/positions-hovercard'
 
 type MarketMeta = {
   label: string
@@ -87,6 +92,68 @@ function statusLabel(contract: Contract): string | null {
   return null
 }
 
+// ── DEV MOCK: cycles cards through position states ────────────────────────────
+function getMockUserData(contractId: string, outcomeType: string): PositionsData {
+  const hash = contractId.split('').reduce((a, c) => a + c.charCodeAt(0), 0)
+  if (outcomeType === 'BINARY' || outcomeType === 'PSEUDO_NUMERIC') {
+    switch (hash % 4) {
+      case 0: return { positions: [], limitOrders: [] }
+      case 1: return {
+        positions: [{ name: 'Yes', amount: 200, profit: 45 }],
+        limitOrders: [],
+      }
+      case 2: return {
+        positions: [{ name: 'No', amount: 150, profit: -20 }],
+        limitOrders: [{ name: 'Yes', prob: 40, amount: 100 }],
+      }
+      default: return {
+        positions: [{ name: 'Yes', amount: 300, profit: 67 }],
+        limitOrders: [{ name: 'No', prob: 60, amount: 200 }],
+      }
+    }
+  }
+  if (outcomeType === 'MULTIPLE_CHOICE') {
+    switch (hash % 4) {
+      case 0: return { positions: [], limitOrders: [] }
+      case 1: return {
+        positions: [{ name: 'Answer 1', amount: 150, profit: 23 }],
+        limitOrders: [],
+      }
+      case 2: return {
+        positions: [
+          { name: 'Answer 1', amount: 150, profit: 23 },
+          { name: 'Answer 2', amount: 80, profit: -12 },
+        ],
+        limitOrders: [],
+      }
+      default: return {
+        positions: [{ name: 'Answer 1', amount: 150, profit: 23 }],
+        limitOrders: [{ name: 'Answer 2', prob: 35, amount: 100 }],
+      }
+    }
+  }
+  if (
+    outcomeType === 'NUMBER' ||
+    outcomeType === 'MULTI_NUMERIC' ||
+    outcomeType === 'DATE'
+  ) {
+    switch (hash % 2) {
+      case 0: return {
+        positions: [],
+        limitOrders: [],
+        numericSummary: { total: 350, buckets: 8, profit: 67 },
+      }
+      default: return {
+        positions: [],
+        limitOrders: [],
+        numericSummary: { total: 120, buckets: 3, profit: -22, orders: { total: 200, count: 2 } },
+      }
+    }
+  }
+  return { positions: [], limitOrders: [] }
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function DashboardMarketCard({
   contract: initialContract,
   trackingLocation = 'dashboard',
@@ -125,12 +192,25 @@ export function DashboardMarketCard({
   const status = statusLabel(contract)
   const contractUrl = contractPath(contract)
 
+  const userData = resolved
+    ? { positions: [], limitOrders: [] }
+    : getMockUserData(contract.id, contract.outcomeType)
+  const hasPositions = userData.positions.length > 0 || !!userData.numericSummary
+  const hasOrders = userData.limitOrders.length > 0 || !!userData.numericSummary?.orders
+  const hasAny = hasPositions || hasOrders
+
   return (
-    <div className="bg-canvas-50 border-ink-200 hover:border-ink-300 flex h-[340px] flex-col rounded-xl border transition-colors">
+    <div
+      className="bg-canvas-50 border-ink-200 hover:border-primary-300 flex h-[340px] cursor-pointer flex-col rounded-xl border transition-colors"
+      onClick={() => Router.push(contractUrl)}
+    >
       {/* Creator row + type badge */}
       <Row className="items-center gap-2 px-5 pt-5">
         <UserHovercard userId={contract.creatorId} className="min-w-0 flex-1">
-          <Row className="text-ink-500 items-center gap-1.5">
+          <Row
+            className="text-ink-500 items-center gap-1.5"
+            onClick={(e) => e.stopPropagation()}
+          >
             <Avatar
               size="xs"
               avatarUrl={creator?.avatarUrl ?? contract.creatorAvatarUrl}
@@ -168,11 +248,11 @@ export function DashboardMarketCard({
       </Row>
 
       {/* Question title */}
-      <Link href={contractUrl} className="px-5 pt-3 hover:opacity-80">
+      <div className="px-5 pt-3">
         <p className="text-ink-900 line-clamp-2 text-lg font-semibold leading-snug">
           {contract.question}
         </p>
-      </Link>
+      </div>
 
       {/* Market-type content */}
       <div className="min-h-0 flex-1 overflow-hidden px-5 pb-2 pt-4">
@@ -193,7 +273,7 @@ export function DashboardMarketCard({
                     </span>
                     <span className="text-ink-400 text-[11px]">chance</span>
                   </Row>
-                  <div className="-mt-3">
+                  <div className="-mt-3" onClick={(e) => e.stopPropagation()}>
                     <BetButton
                       contract={binaryContract}
                       user={user}
@@ -218,7 +298,9 @@ export function DashboardMarketCard({
         )}
 
         {multiContract && (
-          <SimpleAnswerBars contract={multiContract} maxAnswers={3} />
+          <div onClick={(e) => e.stopPropagation()}>
+            <SimpleAnswerBars contract={multiContract} maxAnswers={3} />
+          </div>
         )}
 
         {isNumericBuckets && (
@@ -264,51 +346,61 @@ export function DashboardMarketCard({
               </Row>
             ))}
             {pollOptions.length > 5 && (
-              <Link
-                href={contractUrl}
-                className="text-ink-400 hover:text-ink-600 text-[11px] transition-colors"
-              >
-                +{pollOptions.length - 5} more →
-              </Link>
+              <span className="text-ink-400 text-[11px]">
+                +{pollOptions.length - 5} more
+              </span>
             )}
           </Col>
         )}
       </div>
 
       {/* Footer */}
-      <Row className="border-ink-200 items-center gap-3 border-t px-5 py-1.5">
-        <TradesButton contract={contract} size="sm" />
-        {liquidity > 0 && (
-          <Row className="text-ink-500 items-center gap-1">
-            <TbDroplet className="h-4 w-4 stroke-2" />
-            <span className="text-ink-600 text-[13px]">
-              {shortFormatNumber(liquidity)}
-            </span>
-          </Row>
+      <Row
+        className="border-ink-200 items-center justify-between border-t px-5 py-1.5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Row className="items-center gap-3">
+          <TradesButton contract={contract} size="sm" />
+          {liquidity > 0 && (
+            <Row className="text-ink-500 items-center gap-1">
+              <TbDroplet className="h-4 w-4 stroke-2" />
+              <span className="text-ink-600 text-[13px]">
+                {shortFormatNumber(liquidity)}
+              </span>
+            </Row>
+          )}
+          <RepostButton
+            playContract={contract}
+            size="2xs"
+            iconClassName="text-ink-500"
+          />
+          <ReactButton
+            contentId={contract.id}
+            contentCreatorId={contract.creatorId}
+            user={user}
+            contentType="contract"
+            contentText={contract.question}
+            size="2xs"
+            trackingLocation={trackingLocation}
+            placement="top"
+            contractId={contract.id}
+            heartClassName="stroke-ink-500"
+          />
+        </Row>
+        {hasAny && (
+          <Tooltip
+            text={<PositionsHovercard {...userData} />}
+            placement="top-end"
+            hasSafePolygon
+            tooltipClassName="!bg-canvas-20 border-ink-200 border shadow-lg !text-left !max-w-none !px-3 !py-2.5 !rounded-lg"
+          >
+            <div className="border-ink-400 text-ink-500 hover:border-ink-600 hover:text-ink-700 flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] transition-colors">
+              {hasPositions && <span className="bg-ink-400 h-1.5 w-1.5 rounded-full" />}
+              {hasOrders && <span className="border-ink-500 h-1.5 w-1.5 rounded-full border" />}
+              <span>Positions</span>
+            </div>
+          </Tooltip>
         )}
-        <RepostButton
-          playContract={contract}
-          size="2xs"
-          iconClassName="text-ink-500"
-        />
-        <ReactButton
-          contentId={contract.id}
-          contentCreatorId={contract.creatorId}
-          user={user}
-          contentType="contract"
-          contentText={contract.question}
-          size="2xs"
-          trackingLocation={trackingLocation}
-          placement="top"
-          contractId={contract.id}
-          heartClassName="stroke-ink-500"
-        />
-        <Link
-          href={contractUrl}
-          className="text-ink-400 hover:text-ink-600 ml-auto text-[11px] transition-colors"
-        >
-          View market →
-        </Link>
       </Row>
     </div>
   )

--- a/web/components/dashboard/dashboard-market-card.tsx
+++ b/web/components/dashboard/dashboard-market-card.tsx
@@ -34,6 +34,10 @@ import {
   PositionsHovercard,
   PositionsData,
 } from 'web/components/contract/positions-hovercard'
+import { useAllSavedContractMetrics } from 'web/hooks/use-saved-contract-metrics'
+import { useUnfilledBets } from 'client-common/hooks/use-bets'
+import { api } from 'web/lib/api/api'
+import { useIsPageVisible } from 'web/hooks/use-page-visible'
 
 type MarketMeta = {
   label: string
@@ -92,67 +96,6 @@ function statusLabel(contract: Contract): string | null {
   return null
 }
 
-// ── DEV MOCK: cycles cards through position states ────────────────────────────
-function getMockUserData(contractId: string, outcomeType: string): PositionsData {
-  const hash = contractId.split('').reduce((a, c) => a + c.charCodeAt(0), 0)
-  if (outcomeType === 'BINARY' || outcomeType === 'PSEUDO_NUMERIC') {
-    switch (hash % 4) {
-      case 0: return { positions: [], limitOrders: [] }
-      case 1: return {
-        positions: [{ name: 'Yes', amount: 200, profit: 45 }],
-        limitOrders: [],
-      }
-      case 2: return {
-        positions: [{ name: 'No', amount: 150, profit: -20 }],
-        limitOrders: [{ name: 'Yes', prob: 40, amount: 100 }],
-      }
-      default: return {
-        positions: [{ name: 'Yes', amount: 300, profit: 67 }],
-        limitOrders: [{ name: 'No', prob: 60, amount: 200 }],
-      }
-    }
-  }
-  if (outcomeType === 'MULTIPLE_CHOICE') {
-    switch (hash % 4) {
-      case 0: return { positions: [], limitOrders: [] }
-      case 1: return {
-        positions: [{ name: 'Answer 1', amount: 150, profit: 23 }],
-        limitOrders: [],
-      }
-      case 2: return {
-        positions: [
-          { name: 'Answer 1', amount: 150, profit: 23 },
-          { name: 'Answer 2', amount: 80, profit: -12 },
-        ],
-        limitOrders: [],
-      }
-      default: return {
-        positions: [{ name: 'Answer 1', amount: 150, profit: 23 }],
-        limitOrders: [{ name: 'Answer 2', prob: 35, amount: 100 }],
-      }
-    }
-  }
-  if (
-    outcomeType === 'NUMBER' ||
-    outcomeType === 'MULTI_NUMERIC' ||
-    outcomeType === 'DATE'
-  ) {
-    switch (hash % 2) {
-      case 0: return {
-        positions: [],
-        limitOrders: [],
-        numericSummary: { total: 350, buckets: 8, profit: 67 },
-      }
-      default: return {
-        positions: [],
-        limitOrders: [],
-        numericSummary: { total: 120, buckets: 3, profit: -22, orders: { total: 200, count: 2 } },
-      }
-    }
-  }
-  return { positions: [], limitOrders: [] }
-}
-// ─────────────────────────────────────────────────────────────────────────────
 
 export function DashboardMarketCard({
   contract: initialContract,
@@ -163,6 +106,13 @@ export function DashboardMarketCard({
 }) {
   const contract = useLiveContract(initialContract)
   const user = useUser()
+  const allMetrics = useAllSavedContractMetrics(contract)
+  const allLimitBets = useUnfilledBets(
+    contract.id,
+    (params) => api('bets', params),
+    useIsPageVisible,
+    { enabled: !contract.resolution && !!user }
+  )
   const creator = useDisplayUserById(contract.creatorId)
   const meta = marketMeta(contract.outcomeType)
   const isBinary = contract.outcomeType === 'BINARY'
@@ -192,9 +142,53 @@ export function DashboardMarketCard({
   const status = statusLabel(contract)
   const contractUrl = contractPath(contract)
 
-  const userData = resolved
-    ? { positions: [], limitOrders: [] }
-    : getMockUserData(contract.id, contract.outcomeType)
+  const myLimitBets = (allLimitBets ?? []).filter((b) => b.userId === user?.id)
+  let positions: PositionsData['positions'] = []
+  let limitOrders: PositionsData['limitOrders'] = []
+  let numericSummary: PositionsData['numericSummary']
+  if (!resolved && user && allMetrics) {
+    if (isBinary || isPseudoNumeric) {
+      const m = allMetrics.find((m) => m.answerId === null)
+      if (m?.hasShares) {
+        positions = [{ name: m.maxSharesOutcome === 'NO' ? 'No' : 'Yes', amount: m.invested, profit: m.profit }]
+      }
+      limitOrders = myLimitBets
+        .filter((b) => b.answerId == null)
+        .map((b) => ({ name: b.outcome === 'NO' ? 'No' : 'Yes', prob: Math.round(b.limitProb * 100), amount: b.orderAmount - b.amount }))
+    } else if (isMulti) {
+      positions = allMetrics
+        .filter((m) => m.answerId !== null && m.hasShares)
+        .map((m) => ({
+          name: multiContract?.answers.find((a) => a.id === m.answerId)?.text ?? 'Answer',
+          amount: m.invested,
+          profit: m.profit,
+        }))
+      limitOrders = myLimitBets
+        .filter((b) => b.answerId != null)
+        .map((b) => ({
+          name: multiContract?.answers.find((a) => a.id === b.answerId)?.text ?? 'Answer',
+          prob: Math.round(b.limitProb * 100),
+          amount: b.orderAmount - b.amount,
+        }))
+    } else if (isNumericBuckets) {
+      const bucketMetrics = allMetrics.filter((m) => m.answerId !== null && m.hasShares)
+      const numericOrders = myLimitBets.filter((b) => b.answerId != null)
+      if (bucketMetrics.length > 0 || numericOrders.length > 0) {
+        numericSummary = {
+          total: bucketMetrics.reduce((sum, m) => sum + m.invested, 0),
+          buckets: bucketMetrics.length,
+          profit: bucketMetrics.reduce((sum, m) => sum + m.profit, 0),
+          ...(numericOrders.length > 0 && {
+            orders: {
+              total: numericOrders.reduce((sum, b) => sum + b.orderAmount - b.amount, 0),
+              count: numericOrders.length,
+            },
+          }),
+        }
+      }
+    }
+  }
+  const userData: PositionsData = { positions, limitOrders, numericSummary }
   const hasPositions = userData.positions.length > 0 || !!userData.numericSummary
   const hasOrders = userData.limitOrders.length > 0 || !!userData.numericSummary?.orders
   const hasAny = hasPositions || hasOrders


### PR DESCRIPTION
## Summary

- Adds a **Positions** pill to the bottom-right of `DashboardMarketCard` footers showing the user's positions and open limit orders on that market (solid pip for positions, outlined pip for limit orders)
- Hovering the pill shows a breakdown: positions with amount and P&L, limit orders with name/probability/amount; numeric bucket markets show an aggregate summary
- Makes the whole card clickable (navigates to the market); stopPropagation on interactive elements so they still work independently
- Depends on PR #3883 — merge that first

🤖 Generated with [Claude Code](https://claude.com/claude-code)