### PR TITLE
feat(browse): add shiny World Cup pill + dashboard back button

### DIFF
--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -8,6 +8,7 @@ import { LiteGroup } from 'common/group'
 import { CONTRACTS_PER_SEARCH_PAGE } from 'common/supabase/contracts'
 import { buildArray } from 'common/util/array'
 import { capitalize, groupBy, minBy, orderBy, sample, uniqBy } from 'lodash'
+import Link from 'next/link'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 import { Button } from 'web/components/buttons/button'
 import { AddContractToGroupButton } from 'web/components/topics/add-contract-to-group-modal'
@@ -570,6 +571,20 @@ export function Search(props: SearchProps) {
                     Followed
                   </button>
                 )}
+                <Link
+                  href="/sports/world-cup-2026"
+                  onClick={() =>
+                    track('select search topic', { topic: 'world-cup-2026' })
+                  }
+                  className={clsx(
+                    'shrink-0 self-center whitespace-nowrap rounded-full px-2.5 py-0.5 font-medium text-white',
+                    'bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500',
+                    'shadow-sm shadow-purple-500/30 ring-1 ring-white/20',
+                    'transition-all hover:brightness-110'
+                  )}
+                >
+                  ⚽ World Cup
+                </Link>
                 {ALL_PARENT_TOPICS.map((topic) => (
                   <button
                     key={topic}

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -49,6 +49,7 @@ import {
 import { JSONEmpty } from 'web/components/contract/contract-description'
 import { XCircleIcon } from '@heroicons/react/solid'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/outline'
+import { BackButton } from 'web/components/contract/back-button'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -920,7 +921,8 @@ export function SportsDashboardPage({
       </Head>
       <Col className="mx-auto w-full max-w-5xl gap-8 px-4 py-6 sm:px-6">
         <Row className="border-ink-200 bg-canvas-0 sticky top-0 z-20 -mt-6 items-center justify-between border-b pb-5 pt-6">
-          <Row className="items-center gap-3">
+          <Row className="items-center gap-2">
+            <BackButton className="-ml-2 shrink-0" />
             <span className="text-2xl">{emoji}</span>
             <h1 className="text-ink-1000 text-xl font-medium tracking-tight">
               {title}


### PR DESCRIPTION
Add a gradient World Cup pill to the browse topic sort row (after Followed) linking to /sports/world-cup-2026, and a back button to the sports dashboard sticky header.