### PR TITLE
feat(sports): add share link button to sports dashboard header

### DIFF
--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -53,6 +53,7 @@ import { BackButton } from 'web/components/contract/back-button'
 import { CopyLinkOrShareButton } from 'web/components/buttons/copy-link-button'
 import { ENV_CONFIG } from 'common/envs/constants'
 import { referralQuery } from 'common/util/share'
+import { useSaveReferral } from 'web/hooks/use-save-referral'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -780,6 +781,7 @@ export function SportsDashboardPage({
 
   const isAdmin = useAdminOrMod() || useDev()
   const user = useUser()
+  useSaveReferral(user)
 
   async function fetchMarkets() {
     try {

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -50,6 +50,9 @@ import { JSONEmpty } from 'web/components/contract/contract-description'
 import { XCircleIcon } from '@heroicons/react/solid'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/outline'
 import { BackButton } from 'web/components/contract/back-button'
+import { CopyLinkOrShareButton } from 'web/components/buttons/copy-link-button'
+import { ENV_CONFIG } from 'common/envs/constants'
+import { referralQuery } from 'common/util/share'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -776,6 +779,7 @@ export function SportsDashboardPage({
   }
 
   const isAdmin = useAdminOrMod() || useDev()
+  const user = useUser()
 
   async function fetchMarkets() {
     try {
@@ -927,6 +931,13 @@ export function SportsDashboardPage({
             <h1 className="text-ink-1000 text-xl font-medium tracking-tight">
               {title}
             </h1>
+            <CopyLinkOrShareButton
+              url={`https://${ENV_CONFIG.domain}${router.pathname}${
+                user?.username ? referralQuery(user.username) : ''
+              }`}
+              eventTrackingName="copy sports dashboard link"
+              tooltip="Share"
+            />
           </Row>
           <Row className="items-center gap-2">
             <SportsDashboardTabButton


### PR DESCRIPTION
Adds a share/copy-link button to the World Cup dashboard sticky header, next to the title. Reuses CopyLinkOrShareButton (same as regular dashboard pages): copies the full URL with the user's referral query appended, shows the platform-appropriate share icon on iOS/Android. Quick discoverability follow-up to the browse-page World Cup pill.