### PR TITLE
feat: Add Redis intermediary for passing websocket messages between API instances

### DIFF
--- a/backend/api/deploy-api-windows.sh
+++ b/backend/api/deploy-api-windows.sh
@@ -23,6 +23,10 @@ REGION="us-east4" # Ashburn, Virginia
 ZONE="us-east4-a"
 ENV=${1:-dev}
 
+# Private Memorystore instance
+WEBSOCKET_REDIS_URL=redis://10.215.204.211:6379
+DISABLE_REDIS_WEBSOCKET_BROADCASTS=false
+
 case $ENV in
     dev)
         NEXT_PUBLIC_FIREBASE_ENV=DEV
@@ -100,7 +104,7 @@ gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --container-image ${IMAGE_URL} \
        --machine-type ${MACHINE_TYPE} \
        --boot-disk-size=100GB \
-       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT} \
+       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT},WEBSOCKET_REDIS_URL=${WEBSOCKET_REDIS_URL},DISABLE_REDIS_WEBSOCKET_BROADCASTS=${DISABLE_REDIS_WEBSOCKET_BROADCASTS} \
        --no-user-output-enabled \
        --scopes default,cloud-platform \
        --tags lb-health-check

--- a/backend/api/deploy-api.sh
+++ b/backend/api/deploy-api.sh
@@ -16,17 +16,17 @@ REGION="us-east4" # Ashburn, Virginia
 ZONE="us-east4-a"
 ENV=${1:-dev}
 
-# Private Memorystore instance
-WEBSOCKET_REDIS_URL=redis://10.215.204.211:6379
-DISABLE_REDIS_WEBSOCKET_BROADCASTS=false
-
 case $ENV in
     dev)
         NEXT_PUBLIC_FIREBASE_ENV=DEV
+        WEBSOCKET_REDIS_URL=
+        DISABLE_REDIS_WEBSOCKET_BROADCASTS=true
         GCLOUD_PROJECT=dev-mantic-markets
         MACHINE_TYPE=e2-small ;; # previously n2-standard-2
     prod)
         NEXT_PUBLIC_FIREBASE_ENV=PROD
+        WEBSOCKET_REDIS_URL=redis://10.215.204.211:6379
+        DISABLE_REDIS_WEBSOCKET_BROADCASTS=false
         GCLOUD_PROJECT=mantic-markets
         MACHINE_TYPE=c2-standard-4 ;;
     *)

--- a/backend/api/deploy-api.sh
+++ b/backend/api/deploy-api.sh
@@ -16,6 +16,10 @@ REGION="us-east4" # Ashburn, Virginia
 ZONE="us-east4-a"
 ENV=${1:-dev}
 
+# Private Memorystore instance
+WEBSOCKET_REDIS_URL=redis://10.215.204.211:6379
+DISABLE_REDIS_WEBSOCKET_BROADCASTS=false
+
 case $ENV in
     dev)
         NEXT_PUBLIC_FIREBASE_ENV=DEV
@@ -89,7 +93,7 @@ gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --container-image ${IMAGE_URL} \
        --machine-type ${MACHINE_TYPE} \
        --boot-disk-size=100GB \
-       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT} \
+       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT},WEBSOCKET_REDIS_URL=${WEBSOCKET_REDIS_URL},DISABLE_REDIS_WEBSOCKET_BROADCASTS=${DISABLE_REDIS_WEBSOCKET_BROADCASTS} \
        --no-user-output-enabled \
        --scopes default,cloud-platform \
        --tags lb-health-check

--- a/backend/api/deploy-dev-windows.ps1
+++ b/backend/api/deploy-dev-windows.ps1
@@ -7,6 +7,10 @@ $ErrorActionPreference = "Stop"
 Write-Host "=== Starting dev deployment ===" -ForegroundColor Cyan
 Write-Host "Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
 
+# Private Memorystore instance
+$WEBSOCKET_REDIS_URL = "redis://10.215.204.211:6379"
+$DISABLE_REDIS_WEBSOCKET_BROADCASTS = "false"
+
 # Check Docker is running
 $dockerStatus = docker info 2>&1
 if ($LASTEXITCODE -ne 0) {
@@ -83,7 +87,7 @@ gcloud compute instance-templates create-with-container $TEMPLATE_NAME `
     --container-image=$IMAGE_URL `
     --machine-type=e2-small `
     --boot-disk-size=100GB `
-    --container-env="NEXT_PUBLIC_FIREBASE_ENV=DEV,GOOGLE_CLOUD_PROJECT=dev-mantic-markets" `
+    --container-env="NEXT_PUBLIC_FIREBASE_ENV=DEV,GOOGLE_CLOUD_PROJECT=dev-mantic-markets,WEBSOCKET_REDIS_URL=$WEBSOCKET_REDIS_URL,DISABLE_REDIS_WEBSOCKET_BROADCASTS=$DISABLE_REDIS_WEBSOCKET_BROADCASTS" `
     --no-user-output-enabled `
     --scopes="default,cloud-platform" `
     --tags=lb-health-check

--- a/backend/api/package.json
+++ b/backend/api/package.json
@@ -56,6 +56,7 @@
     "marked": "4.1.1",
     "openai": "5.12.2",
     "pg-promise": "11.10.0",
+    "redis": "4.7.0",
     "sharp": "0.32.6",
     "string-similarity": "4.0.4",
     "stripe": "8.194.0",

--- a/backend/shared/package.json
+++ b/backend/shared/package.json
@@ -26,6 +26,7 @@
     "mailgun-js": "0.22.0",
     "openai": "4.92.1",
     "pg-promise": "11.4.1",
+    "redis": "4.7.0",
     "string-similarity": "4.0.4"
   },
   "devDependencies": {

--- a/backend/shared/src/monitoring/metrics.ts
+++ b/backend/shared/src/monitoring/metrics.ts
@@ -35,6 +35,34 @@ export const CUSTOM_METRICS = {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',
   },
+  'ws/redis_broadcasts_published': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'ws/redis_broadcasts_received': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'ws/redis_broadcast_publish_errors': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'ws/redis_broadcast_parse_errors': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'ws/redis_publisher_errors': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'ws/redis_subscriber_errors': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'ws/redis_subscriber_start_errors': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
   'http/request_count': {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',

--- a/backend/shared/src/websockets/server.ts
+++ b/backend/shared/src/websockets/server.ts
@@ -1,4 +1,5 @@
 import { Server as HttpServer } from 'node:http'
+import { createClient } from 'redis'
 import { Server as WebSocketServer, RawData, WebSocket } from 'ws'
 import { isError } from 'lodash'
 import { LOCAL_DEV, log, metrics } from 'shared/utils'
@@ -14,6 +15,19 @@ const SWITCHBOARD = new Switchboard()
 
 // if a connection doesn't ping for this long, we assume the other side is toast
 const CONNECTION_TIMEOUT_MS = 60 * 1000
+const DEFAULT_REDIS_BROADCAST_CHANNEL_PREFIX = 'api-websocket-broadcasts'
+
+type RedisBroadcast = {
+  topics: string[]
+  data: BroadcastPayload
+}
+
+type RedisClient = ReturnType<typeof createClient>
+
+let redisPublisher: RedisClient | undefined
+let redisPublisherConnect: Promise<RedisClient> | undefined
+let redisSubscriber: RedisClient | undefined
+let redisSubscriberConnect: Promise<void> | undefined
 
 // Categorize topics to avoid unbounded metric cardinality
 function getTopicCategory(topic: string): string {
@@ -22,7 +36,7 @@ function getTopicCategory(topic: string): string {
   } else if (topic.startsWith('contract/')) {
     return 'contract'
   } else if (topic.startsWith('user/')) {
-    return 'user'  
+    return 'user'
   } else if (topic.startsWith('private-user/')) {
     return 'private-user'
   } else if (topic === 'global' || topic.startsWith('global/')) {
@@ -105,37 +119,214 @@ function processMessage(ws: WebSocket, data: RawData): ServerMessage<'ack'> {
   }
 }
 
-export function broadcastMulti(topics: string[], data: BroadcastPayload) {
-  // ian: Don't await this: we don't need to hear back from all the clients and can take a dozen ms
-  const sendToSubscribers = (topic: string, msg: any) => {
-    const json = JSON.stringify(msg)
-    const subscribers = SWITCHBOARD.getSubscribers(topic)
-    return Promise.allSettled(
-      subscribers.map(
-        ([ws, _]) =>
-          new Promise<void>((resolve) =>
-            ws.send(json, (err) => {
-              if (err) log.error('Broadcast error', { error: err })
-              resolve()
-            })
-          )
-      )
-    ).catch((err) => log.error('Broadcast failed', { error: err }))
+function getRedisUrl() {
+  const url = process.env.WEBSOCKET_REDIS_URL ?? process.env.REDIS_URL
+  return url && url.trim().length > 0 ? url : undefined
+}
+
+function getRedisBroadcastEnvironment() {
+  const explicitEnv = process.env.WEBSOCKET_REDIS_ENV
+  if (explicitEnv != null && explicitEnv.trim().length > 0) {
+    return explicitEnv.trim().toLowerCase()
   }
+
+  const firebaseEnv = process.env.NEXT_PUBLIC_FIREBASE_ENV
+  if (firebaseEnv != null && firebaseEnv.trim().length > 0) {
+    return firebaseEnv.trim().toLowerCase()
+  }
+
+  return process.env.GOOGLE_CLOUD_PROJECT === 'mantic-markets' ? 'prod' : 'dev'
+}
+
+function getRedisBroadcastChannel() {
+  const explicitChannel = process.env.WEBSOCKET_REDIS_CHANNEL
+  if (explicitChannel != null && explicitChannel.trim().length > 0) {
+    return explicitChannel.trim()
+  }
+
+  return `${DEFAULT_REDIS_BROADCAST_CHANNEL_PREFIX}-${getRedisBroadcastEnvironment()}`
+}
+
+function redisBroadcastsEnabled() {
+  return (
+    getRedisUrl() != null &&
+    process.env.DISABLE_REDIS_WEBSOCKET_BROADCASTS !== 'true'
+  )
+}
+
+function recordBroadcastMetrics(topics: string[]) {
+  for (const topic of topics) {
+    const topicCategory = getTopicCategory(topic)
+    metrics.inc('ws/broadcasts_sent', { category: topicCategory })
+  }
+}
+
+function sendToLocalSubscribers(
+  topic: string,
+  msg: ServerMessage<'broadcast'> & { topics?: string[] }
+) {
+  const json = JSON.stringify(msg)
+  const subscribers = SWITCHBOARD.getSubscribers(topic)
+  return Promise.allSettled(
+    subscribers.map(
+      ([ws, _]) =>
+        new Promise<void>((resolve) =>
+          ws.send(json, (err) => {
+            if (err) log.error('Broadcast error', { error: err })
+            resolve()
+          })
+        )
+    )
+  ).catch((err) => log.error('Broadcast failed', { error: err }))
+}
+
+function sendToLocalSubscribersMulti(topics: string[], data: BroadcastPayload) {
+  // ian: Don't await this: we don't need to hear back from all the clients and can take a dozen ms
 
   // mqp: it isn't secure to do this in prod because we rely on security-through-
   // topic-id-obscurity for unlisted contracts. but it's super convenient for testing
   if (LOCAL_DEV) {
-    const msg = { type: 'broadcast', topic: '*', topics, data }
-    sendToSubscribers('*', msg)
+    sendToLocalSubscribers('*', { type: 'broadcast', topic: '*', topics, data })
   }
 
   for (const topic of topics) {
-    const msg = { type: 'broadcast', topic, data }
-    sendToSubscribers(topic, msg)
-    // Categorize topics to avoid unbounded cardinality
-    const topicCategory = getTopicCategory(topic)
-    metrics.inc('ws/broadcasts_sent', { category: topicCategory })
+    sendToLocalSubscribers(topic, { type: 'broadcast', topic, data })
+  }
+}
+
+function parseRedisBroadcast(message: string) {
+  const parsed = JSON.parse(message) as RedisBroadcast
+  if (!Array.isArray(parsed.topics)) {
+    throw new Error('Redis websocket broadcast has no topics array.')
+  }
+  for (const topic of parsed.topics) {
+    if (typeof topic !== 'string') {
+      throw new Error('Redis websocket broadcast topic is not a string.')
+    }
+  }
+  if (parsed.data == null || typeof parsed.data !== 'object') {
+    throw new Error('Redis websocket broadcast has invalid data.')
+  }
+  return parsed
+}
+
+function resetRedisPublisher() {
+  redisPublisher = undefined
+  redisPublisherConnect = undefined
+}
+
+async function getRedisPublisher() {
+  if (!redisBroadcastsEnabled()) return undefined
+  if (redisPublisherConnect != null) return await redisPublisherConnect
+
+  const url = getRedisUrl()
+  if (url == null) return undefined
+
+  redisPublisher = createClient({ url })
+  redisPublisher.on('error', (err: unknown) => {
+    log.error('Redis websocket publisher error.', { error: err })
+    metrics.inc('ws/redis_publisher_errors')
+  })
+  redisPublisher.on('reconnecting', () => {
+    log.warn('Redis websocket publisher reconnecting.')
+  })
+
+  redisPublisherConnect = redisPublisher
+    .connect()
+    .then(() => {
+      log.info('Redis websocket publisher connected.')
+      return redisPublisher!
+    })
+    .catch((err: unknown) => {
+      resetRedisPublisher()
+      throw err
+    })
+
+  return await redisPublisherConnect
+}
+
+async function publishRedisBroadcast(topics: string[], data: BroadcastPayload) {
+  const publisher = await getRedisPublisher()
+  if (publisher == null) {
+    sendToLocalSubscribersMulti(topics, data)
+    return
+  }
+
+  const broadcast: RedisBroadcast = { topics, data }
+  await publisher.publish(getRedisBroadcastChannel(), JSON.stringify(broadcast))
+  metrics.inc('ws/redis_broadcasts_published')
+}
+
+function handleRedisBroadcast(message: string) {
+  try {
+    const { topics, data } = parseRedisBroadcast(message)
+    metrics.inc('ws/redis_broadcasts_received')
+    sendToLocalSubscribersMulti(topics, data)
+  } catch (err: unknown) {
+    log.error('Error handling Redis websocket broadcast.', { error: err })
+    metrics.inc('ws/redis_broadcast_parse_errors')
+  }
+}
+
+function startRedisBroadcastSubscriber() {
+  if (!redisBroadcastsEnabled()) return
+  if (redisSubscriberConnect != null) return
+
+  const url = getRedisUrl()
+  if (url == null) return
+
+  redisSubscriber = createClient({ url })
+  redisSubscriber.on('error', (err: unknown) => {
+    log.error('Redis websocket subscriber error.', { error: err })
+    metrics.inc('ws/redis_subscriber_errors')
+  })
+  redisSubscriber.on('reconnecting', () => {
+    log.warn('Redis websocket subscriber reconnecting.')
+  })
+
+  redisSubscriberConnect = redisSubscriber
+    .connect()
+    .then(() =>
+      redisSubscriber!.subscribe(
+        getRedisBroadcastChannel(),
+        handleRedisBroadcast
+      )
+    )
+    .then(() => {
+      log.info(
+        `Redis websocket subscriber listening on ${getRedisBroadcastChannel()}.`
+      )
+    })
+    .catch((err: unknown) => {
+      redisSubscriberConnect = undefined
+      log.error('Failed to start Redis websocket subscriber.', { error: err })
+      metrics.inc('ws/redis_subscriber_start_errors')
+    })
+}
+
+function stopRedisBroadcastSubscriber() {
+  const subscriber = redisSubscriber
+  redisSubscriber = undefined
+  redisSubscriberConnect = undefined
+  subscriber?.quit().catch((err: unknown) => {
+    log.error('Failed to quit Redis websocket subscriber.', { error: err })
+  })
+}
+
+export function broadcastMulti(topics: string[], data: BroadcastPayload) {
+  recordBroadcastMetrics(topics)
+
+  if (redisBroadcastsEnabled()) {
+    publishRedisBroadcast(topics, data).catch((err: unknown) => {
+      log.error(
+        'Redis websocket broadcast failed; falling back to local-only broadcast.',
+        { error: err }
+      )
+      metrics.inc('ws/redis_broadcast_publish_errors')
+      sendToLocalSubscribersMulti(topics, data)
+    })
+  } else {
+    sendToLocalSubscribersMulti(topics, data)
   }
 }
 
@@ -144,6 +335,7 @@ export function broadcast(topic: string, data: BroadcastPayload) {
 }
 
 export function listen(server: HttpServer, path: string) {
+  startRedisBroadcastSubscriber()
   const wss = new WebSocketServer({ server, path })
   let deadConnectionCleaner: NodeJS.Timeout | undefined
   wss.on('listening', () => {
@@ -184,6 +376,7 @@ export function listen(server: HttpServer, path: string) {
   })
   wss.on('close', function close() {
     clearInterval(deadConnectionCleaner)
+    stopRedisBroadcastSubscriber()
   })
   return wss
 }

--- a/backend/shared/src/websockets/server.ts
+++ b/backend/shared/src/websockets/server.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { Server as HttpServer } from 'node:http'
 import { createClient } from 'redis'
 import { Server as WebSocketServer, RawData, WebSocket } from 'ws'
@@ -16,8 +17,12 @@ const SWITCHBOARD = new Switchboard()
 // if a connection doesn't ping for this long, we assume the other side is toast
 const CONNECTION_TIMEOUT_MS = 60 * 1000
 const DEFAULT_REDIS_BROADCAST_CHANNEL_PREFIX = 'api-websocket-broadcasts'
+const REDIS_SUBSCRIBER_INITIAL_RETRY_DELAY_MS = 1_000
+const REDIS_SUBSCRIBER_MAX_RETRY_DELAY_MS = 60_000
+const WEBSOCKET_INSTANCE_ID = randomUUID()
 
 type RedisBroadcast = {
+  originInstanceId?: string
   topics: string[]
   data: BroadcastPayload
 }
@@ -28,6 +33,9 @@ let redisPublisher: RedisClient | undefined
 let redisPublisherConnect: Promise<RedisClient> | undefined
 let redisSubscriber: RedisClient | undefined
 let redisSubscriberConnect: Promise<void> | undefined
+let redisSubscriberShouldRun = false
+let redisSubscriberRetryTimeout: NodeJS.Timeout | undefined
+let redisSubscriberRetryDelayMs = REDIS_SUBSCRIBER_INITIAL_RETRY_DELAY_MS
 
 // Categorize topics to avoid unbounded metric cardinality
 function getTopicCategory(topic: string): string {
@@ -207,6 +215,12 @@ function parseRedisBroadcast(message: string) {
   if (parsed.data == null || typeof parsed.data !== 'object') {
     throw new Error('Redis websocket broadcast has invalid data.')
   }
+  if (
+    parsed.originInstanceId != null &&
+    typeof parsed.originInstanceId !== 'string'
+  ) {
+    throw new Error('Redis websocket broadcast origin instance ID is invalid.')
+  }
   return parsed
 }
 
@@ -247,20 +261,22 @@ async function getRedisPublisher() {
 
 async function publishRedisBroadcast(topics: string[], data: BroadcastPayload) {
   const publisher = await getRedisPublisher()
-  if (publisher == null) {
-    sendToLocalSubscribersMulti(topics, data)
-    return
-  }
+  if (publisher == null) return
 
-  const broadcast: RedisBroadcast = { topics, data }
+  const broadcast: RedisBroadcast = {
+    originInstanceId: WEBSOCKET_INSTANCE_ID,
+    topics,
+    data,
+  }
   await publisher.publish(getRedisBroadcastChannel(), JSON.stringify(broadcast))
   metrics.inc('ws/redis_broadcasts_published')
 }
 
 function handleRedisBroadcast(message: string) {
   try {
-    const { topics, data } = parseRedisBroadcast(message)
+    const { originInstanceId, topics, data } = parseRedisBroadcast(message)
     metrics.inc('ws/redis_broadcasts_received')
+    if (originInstanceId === WEBSOCKET_INSTANCE_ID) return
     sendToLocalSubscribersMulti(topics, data)
   } catch (err: unknown) {
     log.error('Error handling Redis websocket broadcast.', { error: err })
@@ -268,43 +284,78 @@ function handleRedisBroadcast(message: string) {
   }
 }
 
+function clearRedisSubscriberRetry() {
+  if (redisSubscriberRetryTimeout != null) {
+    clearTimeout(redisSubscriberRetryTimeout)
+    redisSubscriberRetryTimeout = undefined
+  }
+}
+
+function resetRedisSubscriberRetryDelay() {
+  redisSubscriberRetryDelayMs = REDIS_SUBSCRIBER_INITIAL_RETRY_DELAY_MS
+}
+
+function scheduleRedisSubscriberRetry() {
+  if (!redisSubscriberShouldRun || !redisBroadcastsEnabled()) return
+  if (redisSubscriberRetryTimeout != null) return
+
+  const delayMs = redisSubscriberRetryDelayMs
+  redisSubscriberRetryDelayMs = Math.min(
+    redisSubscriberRetryDelayMs * 2,
+    REDIS_SUBSCRIBER_MAX_RETRY_DELAY_MS
+  )
+  log.warn(`Retrying Redis websocket subscriber in ${delayMs}ms.`)
+  redisSubscriberRetryTimeout = setTimeout(() => {
+    redisSubscriberRetryTimeout = undefined
+    startRedisBroadcastSubscriber()
+  }, delayMs)
+}
+
 function startRedisBroadcastSubscriber() {
   if (!redisBroadcastsEnabled()) return
-  if (redisSubscriberConnect != null) return
+  redisSubscriberShouldRun = true
+  if (redisSubscriberConnect != null || redisSubscriberRetryTimeout != null)
+    return
 
   const url = getRedisUrl()
   if (url == null) return
 
-  redisSubscriber = createClient({ url })
-  redisSubscriber.on('error', (err: unknown) => {
+  const channel = getRedisBroadcastChannel()
+  const subscriber = createClient({ url })
+  redisSubscriber = subscriber
+  subscriber.on('error', (err: unknown) => {
     log.error('Redis websocket subscriber error.', { error: err })
     metrics.inc('ws/redis_subscriber_errors')
   })
-  redisSubscriber.on('reconnecting', () => {
+  subscriber.on('reconnecting', () => {
     log.warn('Redis websocket subscriber reconnecting.')
   })
 
-  redisSubscriberConnect = redisSubscriber
+  redisSubscriberConnect = subscriber
     .connect()
-    .then(() =>
-      redisSubscriber!.subscribe(
-        getRedisBroadcastChannel(),
-        handleRedisBroadcast
-      )
-    )
+    .then(() => subscriber.subscribe(channel, handleRedisBroadcast))
     .then(() => {
-      log.info(
-        `Redis websocket subscriber listening on ${getRedisBroadcastChannel()}.`
-      )
+      resetRedisSubscriberRetryDelay()
+      log.info(`Redis websocket subscriber listening on ${channel}.`)
     })
     .catch((err: unknown) => {
+      if (redisSubscriber === subscriber) redisSubscriber = undefined
       redisSubscriberConnect = undefined
+      subscriber.quit().catch((quitErr: unknown) => {
+        log.error('Failed to quit Redis websocket subscriber.', {
+          error: quitErr,
+        })
+      })
       log.error('Failed to start Redis websocket subscriber.', { error: err })
       metrics.inc('ws/redis_subscriber_start_errors')
+      scheduleRedisSubscriberRetry()
     })
 }
 
 function stopRedisBroadcastSubscriber() {
+  redisSubscriberShouldRun = false
+  clearRedisSubscriberRetry()
+  resetRedisSubscriberRetryDelay()
   const subscriber = redisSubscriber
   redisSubscriber = undefined
   redisSubscriberConnect = undefined
@@ -315,18 +366,13 @@ function stopRedisBroadcastSubscriber() {
 
 export function broadcastMulti(topics: string[], data: BroadcastPayload) {
   recordBroadcastMetrics(topics)
+  sendToLocalSubscribersMulti(topics, data)
 
   if (redisBroadcastsEnabled()) {
     publishRedisBroadcast(topics, data).catch((err: unknown) => {
-      log.error(
-        'Redis websocket broadcast failed; falling back to local-only broadcast.',
-        { error: err }
-      )
+      log.error('Redis websocket broadcast failed.', { error: err })
       metrics.inc('ws/redis_broadcast_publish_errors')
-      sendToLocalSubscribersMulti(topics, data)
     })
-  } else {
-    sendToLocalSubscribersMulti(topics, data)
   }
 }
 

--- a/backend/shared/src/websockets/server.ts
+++ b/backend/shared/src/websockets/server.ts
@@ -132,6 +132,60 @@ function getRedisUrl() {
   return url && url.trim().length > 0 ? url : undefined
 }
 
+function getRedisUrlForLogging() {
+  const url = getRedisUrl()
+  if (url == null) return undefined
+
+  try {
+    const parsed = new URL(url)
+    const auth = parsed.username || parsed.password ? '<redacted>@' : ''
+    return `${parsed.protocol}//${auth}${parsed.hostname}:${
+      parsed.port || '6379'
+    }`
+  } catch {
+    return '<invalid redis url>'
+  }
+}
+
+function getRedisErrorDetails(err: unknown) {
+  if (err == null || typeof err !== 'object') return { error: err }
+  const e = err as {
+    name?: unknown
+    message?: unknown
+    code?: unknown
+    errno?: unknown
+    syscall?: unknown
+    address?: unknown
+    port?: unknown
+    command?: unknown
+    cause?: unknown
+  }
+  return {
+    name: e.name,
+    message: e.message,
+    code: e.code,
+    errno: e.errno,
+    syscall: e.syscall,
+    address: e.address,
+    port: e.port,
+    command: e.command,
+    cause: e.cause,
+  }
+}
+
+function getRedisLogContext() {
+  return {
+    enabled: redisBroadcastsEnabled(),
+    url: getRedisUrlForLogging(),
+    channel: getRedisBroadcastChannel(),
+    env: getRedisBroadcastEnvironment(),
+    project: process.env.GOOGLE_CLOUD_PROJECT,
+    firebaseEnv: process.env.NEXT_PUBLIC_FIREBASE_ENV,
+    disabled: process.env.DISABLE_REDIS_WEBSOCKET_BROADCASTS,
+    instanceId: WEBSOCKET_INSTANCE_ID,
+  }
+}
+
 function getRedisBroadcastEnvironment() {
   const explicitEnv = process.env.WEBSOCKET_REDIS_ENV
   if (explicitEnv != null && explicitEnv.trim().length > 0) {
@@ -236,9 +290,16 @@ async function getRedisPublisher() {
   const url = getRedisUrl()
   if (url == null) return undefined
 
+  log.info(
+    'Starting Redis websocket publisher connection.',
+    getRedisLogContext()
+  )
   redisPublisher = createClient({ url })
   redisPublisher.on('error', (err: unknown) => {
-    log.error('Redis websocket publisher error.', { error: err })
+    log.error('Redis websocket publisher error.', {
+      ...getRedisErrorDetails(err),
+      ...getRedisLogContext(),
+    })
     metrics.inc('ws/redis_publisher_errors')
   })
   redisPublisher.on('reconnecting', () => {
@@ -248,11 +309,15 @@ async function getRedisPublisher() {
   redisPublisherConnect = redisPublisher
     .connect()
     .then(() => {
-      log.info('Redis websocket publisher connected.')
+      log.info('Redis websocket publisher connected.', getRedisLogContext())
       return redisPublisher!
     })
     .catch((err: unknown) => {
       resetRedisPublisher()
+      log.error('Failed to start Redis websocket publisher.', {
+        ...getRedisErrorDetails(err),
+        ...getRedisLogContext(),
+      })
       throw err
     })
 
@@ -312,7 +377,10 @@ function scheduleRedisSubscriberRetry() {
 }
 
 function startRedisBroadcastSubscriber() {
-  if (!redisBroadcastsEnabled()) return
+  if (!redisBroadcastsEnabled()) {
+    log.info('Redis websocket broadcasts disabled.', getRedisLogContext())
+    return
+  }
   redisSubscriberShouldRun = true
   if (redisSubscriberConnect != null || redisSubscriberRetryTimeout != null)
     return
@@ -321,10 +389,17 @@ function startRedisBroadcastSubscriber() {
   if (url == null) return
 
   const channel = getRedisBroadcastChannel()
+  log.info(
+    'Starting Redis websocket subscriber connection.',
+    getRedisLogContext()
+  )
   const subscriber = createClient({ url })
   redisSubscriber = subscriber
   subscriber.on('error', (err: unknown) => {
-    log.error('Redis websocket subscriber error.', { error: err })
+    log.error('Redis websocket subscriber error.', {
+      ...getRedisErrorDetails(err),
+      ...getRedisLogContext(),
+    })
     metrics.inc('ws/redis_subscriber_errors')
   })
   subscriber.on('reconnecting', () => {
@@ -336,6 +411,7 @@ function startRedisBroadcastSubscriber() {
     .then(() => subscriber.subscribe(channel, handleRedisBroadcast))
     .then(() => {
       resetRedisSubscriberRetryDelay()
+      log.info('Redis websocket subscriber connected.', getRedisLogContext())
       log.info(`Redis websocket subscriber listening on ${channel}.`)
     })
     .catch((err: unknown) => {
@@ -343,10 +419,14 @@ function startRedisBroadcastSubscriber() {
       redisSubscriberConnect = undefined
       subscriber.quit().catch((quitErr: unknown) => {
         log.error('Failed to quit Redis websocket subscriber.', {
-          error: quitErr,
+          ...getRedisErrorDetails(quitErr),
+          ...getRedisLogContext(),
         })
       })
-      log.error('Failed to start Redis websocket subscriber.', { error: err })
+      log.error('Failed to start Redis websocket subscriber.', {
+        ...getRedisErrorDetails(err),
+        ...getRedisLogContext(),
+      })
       metrics.inc('ws/redis_subscriber_start_errors')
       scheduleRedisSubscriberRetry()
     })
@@ -360,7 +440,10 @@ function stopRedisBroadcastSubscriber() {
   redisSubscriber = undefined
   redisSubscriberConnect = undefined
   subscriber?.quit().catch((err: unknown) => {
-    log.error('Failed to quit Redis websocket subscriber.', { error: err })
+    log.error('Failed to quit Redis websocket subscriber.', {
+      ...getRedisErrorDetails(err),
+      ...getRedisLogContext(),
+    })
   })
 }
 
@@ -370,7 +453,10 @@ export function broadcastMulti(topics: string[], data: BroadcastPayload) {
 
   if (redisBroadcastsEnabled()) {
     publishRedisBroadcast(topics, data).catch((err: unknown) => {
-      log.error('Redis websocket broadcast failed.', { error: err })
+      log.error('Redis websocket broadcast failed.', {
+        ...getRedisErrorDetails(err),
+        ...getRedisLogContext(),
+      })
       metrics.inc('ws/redis_broadcast_publish_errors')
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4008,6 +4008,40 @@
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.33.1.tgz#2c0b97bef8f7c2f99d0a030eda083d32cf503629"
   integrity sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==
 
+"@redis/bloom@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.6.0.tgz#dcf4ae1319763db6fdddd6de7f0af68a352c30ea"
+  integrity sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.1.tgz#8c10df2df7f7d02741866751764031a957a170ea"
+  integrity sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==
+
+"@redis/json@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.7.tgz#016257fcd933c4cbcb9c49cde8a0961375c6893b"
+  integrity sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==
+
+"@redis/search@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.2.0.tgz#50976fd3f31168f585666f7922dde111c74567b8"
+  integrity sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==
+
+"@redis/time-series@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.1.0.tgz#cba454c05ec201bd5547aaf55286d44682ac8eb5"
+  integrity sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==
+
 "@reown/appkit-common@1.7.8":
   version "1.7.8"
   resolved "https://registry.yarnpkg.com/@reown/appkit-common/-/appkit-common-1.7.8.tgz#6fc29db977b7325e8170b1fd08176fe15ea0b39c"
@@ -9974,6 +10008,11 @@ clsx@^2.0.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 cmd-shim@^6.0.0:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-6.0.3.tgz#c491e9656594ba17ac83c4bd931590a9d6e26033"
@@ -12500,6 +12539,11 @@ generator-function@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"
   integrity sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==
+
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -16903,6 +16947,18 @@ real-require@^0.2.0:
   resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
   integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
+redis@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.7.0.tgz#b401787514d25dd0cfc22406d767937ba3be55d6"
+  integrity sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.6.0"
+    "@redis/graph" "1.1.1"
+    "@redis/json" "1.0.7"
+    "@redis/search" "1.2.0"
+    "@redis/time-series" "1.1.0"
+
 redux@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
@@ -19620,6 +19676,11 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@4.0.0, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -19629,11 +19690,6 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yallist@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
When we added a second API server, many comments and bets were not being properly broadcast to users. In about half of cases a user would not be able to see their own comments until the page was refreshed. This is caused by each API server having its own in-memory switchboard and their own set of client connections. When a user is connected to the socket of server A but their comment gets routed to server B, only users listening to server B will see the comment. A stopgap was added with GCP's session affinity based on client IP which helped somewhat.

This PR adds a connection from each API server to a small central Memorystore Redis instance. When a new broadcast would be sent, it is broadcast to all connected users plus also to Redis. All API servers are also listening to the Redis stream, when they see a new message (that they didn't send) they rebroadcast it to all of their connected users. This allows all users to see all bets, comments, etc. If the Redis instance breaks for some reason then the messages are still broadcast to locally connected users, regressing back to what we had yesterday (still with session affinity).

I tested this by running a small script that listens to all bets over websockets and then checks that none were missed against the typical API endpoints.