### PR TITLE
Opt-in fine-resolution betting at the tails: 0.1pp increments, 0.1–99.9% bounds (binary)

### DIFF
--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -442,18 +442,6 @@ export const updateMakers = async (
   }
 }
 
-export const getRoundedLimitProb = (limitProb: number | undefined) => {
-  if (limitProb === undefined) return limitProb
-  const isRounded = floatingEqual(Math.round(limitProb * 100), limitProb * 100)
-  if (!isRounded)
-    throw new APIError(
-      400,
-      'limitProb must be in increments of 0.01 (i.e. whole percentage points)'
-    )
-
-  return Math.round(limitProb * 100) / 100
-}
-
 export const getMakerIdsFromBetResult = (result: NewBetResult) => {
   const { makers = [], otherBetResults = [], ordersToCancel = [] } = result
 

--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -1,7 +1,6 @@
 import {
   fetchContractBetDataAndValidate,
   getMakerIdsFromBetResult,
-  getRoundedLimitProb,
   getUniqueBettorBonusQuery,
   getUserBalancesAndMetrics,
   updateMakers,
@@ -23,6 +22,7 @@ import {
   CandidateBet,
   getBinaryCpmmBetInfo,
   getNewMultiCpmmBetInfo,
+  getRoundedLimitProb,
 } from 'common/new-bet'
 import { convertBet } from 'common/supabase/bets'
 import { convertContract } from 'common/supabase/contracts'
@@ -30,7 +30,7 @@ import { convertTxn } from 'common/supabase/txns'
 import { UniqueBettorBonusTxn } from 'common/txn'
 import { User } from 'common/user'
 import { filterDefined } from 'common/util/array'
-import { EPSILON, floatingEqual } from 'common/util/math'
+import { EPSILON } from 'common/util/math'
 import { removeUndefinedProps } from 'common/util/object'
 import { first, isEqual, maxBy, sumBy } from 'lodash'
 import { betsQueue, ordersQueue } from 'shared/helpers/fn-queue'
@@ -88,7 +88,7 @@ const queueDependenciesThenBet = async (
   const { dryRun, contractId } = props
   const minimalDeps = [auth.uid, contractId]
   return await ordersQueue.enqueueFn(async () => {
-    const { contract, answers, unfilledBets, balanceByUserId } =
+    const { user, contract, answers, unfilledBets, balanceByUserId } =
       await fetchContractBetDataAndValidate(
         createSupabaseDirectClient(),
         props,
@@ -98,6 +98,7 @@ const queueDependenciesThenBet = async (
     // Simulate bet to see whose limit orders you match.
     const simulatedResult = calculateBetResult(
       props,
+      user,
       contract,
       answers,
       unfilledBets,
@@ -144,6 +145,7 @@ export const placeBetMain = async (
   // Simulate bet to see whose limit orders you match.
   const simulatedResult = calculateBetResult(
     body,
+    user,
     contract,
     answers,
     unfilledBets,
@@ -173,6 +175,7 @@ export const placeBetMain = async (
     }
     const newBetResult = calculateBetResult(
       body,
+      user,
       contract,
       answers,
       unfilledBets,
@@ -181,7 +184,12 @@ export const placeBetMain = async (
     log(`Calculated new bet information for ${user.username} - auth ${uid}.`)
     const { newBet } = newBetResult
     if (!newBet.amount && !newBet.orderAmount && !newBet.shares) {
-      throw new APIError(400, 'Betting allowed only between 1-99%.')
+      throw new APIError(
+        400,
+        user.fineProbBetting && contract.outcomeType === 'BINARY'
+          ? 'Betting allowed only between 0.1-99.9%.'
+          : 'Betting allowed only between 1-99%.'
+      )
     }
     const actualMakerIds = getMakerIdsFromBetResult(newBetResult)
     log(
@@ -237,6 +245,7 @@ export const placeBetMain = async (
 
 export const calculateBetResult = (
   body: ValidatedAPIParams<'bet'>,
+  user: User,
   contract: MarketContract,
   answers: Answer[] | undefined,
   unfilledBets: LimitBet[],
@@ -246,24 +255,17 @@ export const calculateBetResult = (
   const { outcomeType, mechanism } = contract
 
   if (mechanism == 'cpmm-1') {
-    // eslint-disable-next-line prefer-const
-    let { outcome, limitProb, expiresAt } = body
+    const { outcome, expiresAt } = body
     if (expiresAt && expiresAt < Date.now())
       throw new APIError(400, 'Bet cannot expire in the past.')
 
-    if (limitProb !== undefined && outcomeType === 'BINARY') {
-      const isRounded = floatingEqual(
-        Math.round(limitProb * 100),
-        limitProb * 100
-      )
-      if (!isRounded)
-        throw new APIError(
-          400,
-          'limitProb must be in increments of 0.01 (i.e. whole percentage points)'
-        )
-
-      limitProb = Math.round(limitProb * 100) / 100
-    }
+    const fineProbBetting = !!user.fineProbBetting && outcomeType === 'BINARY'
+    // Pseudo-numeric and stonk limit probs come from value mapping and are
+    // not grid-constrained (matching legacy behavior).
+    const limitProb =
+      outcomeType === 'BINARY'
+        ? getRoundedLimitProb(body.limitProb, fineProbBetting)
+        : body.limitProb
 
     return getBinaryCpmmBetInfo(
       contract,
@@ -273,7 +275,8 @@ export const calculateBetResult = (
       unfilledBets,
       balanceByUserId,
       expiresAt,
-      expiresMillisAfter
+      expiresMillisAfter,
+      fineProbBetting
     )
   } else if (mechanism == 'cpmm-multi-1') {
     const { shouldAnswersSumToOne } = contract

--- a/backend/api/src/place-multi-bet.ts
+++ b/backend/api/src/place-multi-bet.ts
@@ -1,11 +1,8 @@
-import {
-  fetchContractBetDataAndValidate,
-  getRoundedLimitProb,
-} from 'api/helpers/bets'
+import { fetchContractBetDataAndValidate } from 'api/helpers/bets'
 import { onCreateBets } from 'api/on-create-bet'
 import { executeNewBetResult } from 'api/place-bet'
 import { ValidatedAPIParams } from 'common/api/schema'
-import { getNewMultiCpmmBetsInfo } from 'common/new-bet'
+import { getNewMultiCpmmBetsInfo, getRoundedLimitProb } from 'common/new-bet'
 import * as crypto from 'crypto'
 import { betsQueue } from 'shared/helpers/fn-queue'
 import { runTransactionWithRetries } from 'shared/transact-with-retries'

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -385,7 +385,10 @@ export const API = (_apiTypeCheck = {
         contractId: z.string(),
         amount: z.number().gte(SWEEPS_MIN_BET),
         replyToCommentId: z.string().optional(),
-        limitProb: z.number().gte(0.01).lte(0.99).optional(),
+        // Bounds for users with fineProbBetting; the per-user grid (whole
+        // percentage points, or 0.1pp at the tails when flagged) is enforced
+        // server-side in getRoundedLimitProb.
+        limitProb: z.number().gte(0.001).lte(0.999).optional(),
         expiresMillisAfter: z.number().lt(MAX_EXPIRES_AT).optional(),
         silent: z.boolean().optional(),
         expiresAt: z.number().lt(MAX_EXPIRES_AT).optional(),
@@ -1226,6 +1229,7 @@ export const API = (_apiTypeCheck = {
       // settings
       optOutBetWarnings: z.boolean().optional(),
       isAdvancedTrader: z.boolean().optional(),
+      fineProbBetting: z.boolean().optional(),
       //internal
       seenStreakModal: z.boolean().optional(),
       shouldShowWelcome: z.boolean().optional(),

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -220,12 +220,18 @@ export const computeFills = (
   const now = Date.now()
   const { max, min } = limitProbs ?? {}
   const limit = initialLimitProb ?? (outcome === 'YES' ? max : min)
+  // Clamp the taker's limit to the allowed range. Passed limitProbs may
+  // widen the range beyond the standard CPMM bounds (fine prob betting) but
+  // never narrow it, preserving legacy behavior for explicit limits on
+  // contract types with tighter default bounds (e.g. STONK).
+  const maxLimitProb = Math.max(max ?? MAX_CPMM_PROB, MAX_CPMM_PROB)
+  const minLimitProb = Math.min(min ?? MIN_CPMM_PROB, MIN_CPMM_PROB)
   const limitProb = !limit
     ? undefined
-    : limit > MAX_CPMM_PROB
-    ? MAX_CPMM_PROB
-    : limit < MIN_CPMM_PROB
-    ? MIN_CPMM_PROB
+    : limit > maxLimitProb
+    ? maxLimitProb
+    : limit < minLimitProb
+    ? minLimitProb
     : limit
 
   const sortedBets = sortBy(

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -503,6 +503,15 @@ export const MIN_CPMM_PROB = 0.01
 export const MAX_STONK_PROB = 0.95
 export const MIN_STONK_PROB = 0.2
 
+// Users with the `fineProbBetting` setting (settable via the me/update API)
+// can bet on binary markets in 0.1-percentage-point increments at the tails
+// of the prob range, out to these wider bounds. The tail threshold keeps the
+// grid honest in odds terms: a 0.1pp step at 97% is about as large a move in
+// log-odds as the 1pp step at 50% that everyone already has.
+export const MAX_FINE_CPMM_PROB = 0.999
+export const MIN_FINE_CPMM_PROB = 0.001
+export const FINE_PROB_TAIL = 0.03
+
 export const isMarketRanked = (contract: Contract) =>
   contract.isRanked != false &&
   contract.visibility === 'public' &&

--- a/common/src/fine-prob-betting.test.ts
+++ b/common/src/fine-prob-betting.test.ts
@@ -1,0 +1,244 @@
+import { APIError } from './api/utils'
+import { LimitBet } from './bet'
+import { computeFills, getCpmmProbability } from './calculate-cpmm'
+import {
+  MAX_CPMM_PROB,
+  MAX_FINE_CPMM_PROB,
+  MIN_CPMM_PROB,
+  MIN_FINE_CPMM_PROB,
+} from './contract'
+import { noFees } from './fees'
+import { getRoundedLimitProb } from './new-bet'
+
+const STANDARD_BOUNDS = { max: MAX_CPMM_PROB, min: MIN_CPMM_PROB }
+const FINE_BOUNDS = { max: MAX_FINE_CPMM_PROB, min: MIN_FINE_CPMM_PROB }
+
+const makeLimitBet = (props: {
+  id: string
+  userId: string
+  outcome: 'YES' | 'NO'
+  limitProb: number
+  orderAmount: number
+}): LimitBet =>
+  ({
+    ...props,
+    amount: 0,
+    shares: 0,
+    contractId: 'contract1',
+    createdTime: 1,
+    isFilled: false,
+    isCancelled: false,
+    fills: [],
+    probBefore: 0.5,
+    probAfter: 0.5,
+    fees: noFees,
+    isRedemption: false,
+    visibility: 'public',
+  } as unknown as LimitBet)
+
+// p = 0.5, so prob(YES) = NO / (YES + NO)
+const poolAtProb = (prob: number, liquidity = 1000) => ({
+  pool: { YES: liquidity * (1 - prob), NO: liquidity * prob },
+  p: 0.5,
+  collectedFees: noFees,
+})
+
+describe('getRoundedLimitProb', () => {
+  it('passes undefined through', () => {
+    expect(getRoundedLimitProb(undefined)).toBeUndefined()
+    expect(getRoundedLimitProb(undefined, true)).toBeUndefined()
+  })
+
+  describe('without fineProbBetting (legacy behavior)', () => {
+    it('accepts whole percentage points', () => {
+      expect(getRoundedLimitProb(0.97)).toBe(0.97)
+      expect(getRoundedLimitProb(0.99)).toBe(0.99)
+      expect(getRoundedLimitProb(0.01)).toBe(0.01)
+      expect(getRoundedLimitProb(0.5)).toBe(0.5)
+    })
+
+    it('rejects sub-percentage-point increments everywhere', () => {
+      expect(() => getRoundedLimitProb(0.975)).toThrow(APIError)
+      expect(() => getRoundedLimitProb(0.005)).toThrow(APIError)
+      expect(() => getRoundedLimitProb(0.999)).toThrow(APIError)
+      expect(() => getRoundedLimitProb(0.001)).toThrow(APIError)
+    })
+
+    it('rounds float noise to whole percentage points', () => {
+      expect(getRoundedLimitProb(0.9700000000001)).toBe(0.97)
+    })
+  })
+
+  describe('with fineProbBetting', () => {
+    it('accepts 0.1pp increments at the tails', () => {
+      expect(getRoundedLimitProb(0.975, true)).toBe(0.975)
+      expect(getRoundedLimitProb(0.999, true)).toBe(0.999)
+      expect(getRoundedLimitProb(0.001, true)).toBe(0.001)
+      expect(getRoundedLimitProb(0.029, true)).toBe(0.029)
+    })
+
+    it('still accepts whole percentage points everywhere', () => {
+      expect(getRoundedLimitProb(0.03, true)).toBe(0.03)
+      expect(getRoundedLimitProb(0.97, true)).toBe(0.97)
+      expect(getRoundedLimitProb(0.55, true)).toBe(0.55)
+    })
+
+    it('rejects 0.1pp increments between 3% and 97%', () => {
+      expect(() => getRoundedLimitProb(0.045, true)).toThrow(APIError)
+      expect(() => getRoundedLimitProb(0.505, true)).toThrow(APIError)
+      expect(() => getRoundedLimitProb(0.965, true)).toThrow(APIError)
+    })
+
+    it('rejects increments finer than 0.1pp even at the tails', () => {
+      expect(() => getRoundedLimitProb(0.9995, true)).toThrow(APIError)
+      expect(() => getRoundedLimitProb(0.0295, true)).toThrow(APIError)
+      expect(() => getRoundedLimitProb(0.9705, true)).toThrow(APIError)
+    })
+  })
+})
+
+describe('computeFills with fine prob bounds', () => {
+  it('lets a NO taker fill a resting YES maker at 99.5% without moving the pool', () => {
+    const state = poolAtProb(0.98)
+    const maker = makeLimitBet({
+      id: 'maker1',
+      userId: 'alice',
+      outcome: 'YES',
+      limitProb: 0.995,
+      orderAmount: 1000,
+    })
+
+    const { takers, makers, cpmmState } = computeFills(
+      state,
+      'NO',
+      1,
+      undefined,
+      [maker],
+      { alice: 10000 },
+      STANDARD_BOUNDS,
+      true // freeFees, for exact price assertions
+    )
+
+    expect(takers).toHaveLength(1)
+    expect(takers[0].matchedBetId).toBe('maker1')
+    // Taker buys NO at 1 - 0.995 = 0.005 per share.
+    expect(takers[0].amount / takers[0].shares).toBeCloseTo(0.005, 10)
+    expect(makers[0].amount / makers[0].shares).toBeCloseTo(0.995, 10)
+    // Direct match: the pool is untouched.
+    expect(cpmmState.pool).toEqual(state.pool)
+  })
+
+  it('still stops an unflagged market order at 99%', () => {
+    const state = poolAtProb(0.98)
+    const { cpmmState } = computeFills(
+      state,
+      'YES',
+      1e6,
+      undefined,
+      [],
+      {},
+      STANDARD_BOUNDS,
+      true
+    )
+    expect(getCpmmProbability(cpmmState.pool, cpmmState.p)).toBeCloseTo(
+      MAX_CPMM_PROB,
+      6
+    )
+  })
+
+  it('lets a flagged market order move the pool to 99.9%', () => {
+    const state = poolAtProb(0.98)
+    const { cpmmState } = computeFills(
+      state,
+      'YES',
+      1e6,
+      undefined,
+      [],
+      {},
+      FINE_BOUNDS,
+      true
+    )
+    expect(getCpmmProbability(cpmmState.pool, cpmmState.p)).toBeCloseTo(
+      MAX_FINE_CPMM_PROB,
+      6
+    )
+  })
+
+  it('still clamps an unflagged explicit limit to 99%', () => {
+    const state = poolAtProb(0.98)
+    const { cpmmState } = computeFills(
+      state,
+      'YES',
+      1e6,
+      0.995, // beyond standard bounds; clamped without the fine flag
+      [],
+      {},
+      STANDARD_BOUNDS,
+      true
+    )
+    expect(getCpmmProbability(cpmmState.pool, cpmmState.p)).toBeCloseTo(
+      MAX_CPMM_PROB,
+      6
+    )
+  })
+
+  it('lets an unflagged user at a >99% pool bet only toward 50%', () => {
+    const state = poolAtProb(0.995)
+
+    const yesBet = computeFills(
+      state,
+      'YES',
+      100,
+      undefined,
+      [],
+      {},
+      STANDARD_BOUNDS,
+      true
+    )
+    expect(yesBet.takers).toHaveLength(0)
+
+    const noBet = computeFills(
+      state,
+      'NO',
+      100,
+      undefined,
+      [],
+      {},
+      STANDARD_BOUNDS,
+      true
+    )
+    expect(noBet.takers.length).toBeGreaterThan(0)
+    expect(
+      getCpmmProbability(noBet.cpmmState.pool, noBet.cpmmState.p)
+    ).toBeLessThan(0.995)
+  })
+
+  it('lets a flagged YES limit at 99.5% cross a resting NO maker at 99.5%', () => {
+    const state = poolAtProb(0.98)
+    const maker = makeLimitBet({
+      id: 'maker2',
+      userId: 'bob',
+      outcome: 'NO',
+      limitProb: 0.995,
+      orderAmount: 5,
+    })
+
+    const { takers, cpmmState } = computeFills(
+      state,
+      'YES',
+      1e6,
+      0.995,
+      [maker],
+      { bob: 10000 },
+      FINE_BOUNDS,
+      true
+    )
+
+    // Fills from the pool up to 99.5%, then directly against the maker.
+    expect(takers.some((t) => t.matchedBetId === 'maker2')).toBe(true)
+    expect(getCpmmProbability(cpmmState.pool, cpmmState.p)).toBeCloseTo(
+      0.995,
+      6
+    )
+  })
+})

--- a/common/src/new-bet.ts
+++ b/common/src/new-bet.ts
@@ -5,9 +5,12 @@ import { computeFills, CpmmState, getCpmmProbability } from './calculate-cpmm'
 import {
   BinaryContract,
   CPMMMultiContract,
+  FINE_PROB_TAIL,
   MAX_CPMM_PROB,
+  MAX_FINE_CPMM_PROB,
   MAX_STONK_PROB,
   MIN_CPMM_PROB,
+  MIN_FINE_CPMM_PROB,
   MIN_STONK_PROB,
   MultiContract,
   PseudoNumericContract,
@@ -31,6 +34,33 @@ export type BetInfo = {
   newPool?: { [outcome: string]: number }
   newTotalLiquidity?: number
   newP?: number
+}
+
+export const getRoundedLimitProb = (
+  limitProb: number | undefined,
+  fineProbBetting = false
+) => {
+  if (limitProb === undefined) return limitProb
+  // Fine prob betting unlocks 0.1-percentage-point increments at the tails
+  // of the prob range, where a 0.1pp step is no finer a move in log-odds
+  // than the 1pp step at 50% that everyone already has.
+  const fine =
+    fineProbBetting &&
+    (limitProb <= FINE_PROB_TAIL || limitProb >= 1 - FINE_PROB_TAIL)
+  const step = fine ? 1000 : 100
+  const isRounded = floatingEqual(
+    Math.round(limitProb * step),
+    limitProb * step
+  )
+  if (!isRounded)
+    throw new APIError(
+      400,
+      fine
+        ? 'limitProb must be in increments of 0.001 (i.e. tenths of a percentage point) below 3% / above 97%'
+        : 'limitProb must be in increments of 0.01 (i.e. whole percentage points)'
+    )
+
+  return Math.round(limitProb * step) / step
 }
 
 export const computeCpmmBet = (
@@ -89,7 +119,8 @@ export const getBinaryCpmmBetInfo = (
   unfilledBets: LimitBet[],
   balanceByUserId: { [userId: string]: number },
   expiresAt?: number,
-  expiresMillisAfter?: number
+  expiresMillisAfter?: number,
+  fineProbBetting?: boolean
 ) => {
   const cpmmState = {
     pool: contract.pool,
@@ -118,6 +149,8 @@ export const getBinaryCpmmBetInfo = (
     balanceByUserId,
     contract.outcomeType === 'STONK'
       ? { max: MAX_STONK_PROB, min: MIN_STONK_PROB }
+      : fineProbBetting && contract.outcomeType === 'BINARY'
+      ? { max: MAX_FINE_CPMM_PROB, min: MIN_FINE_CPMM_PROB }
       : { max: MAX_CPMM_PROB, min: MIN_CPMM_PROB }
   )
   const now = Date.now()

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -113,13 +113,17 @@ export type User = {
   // When false, user cannot change their @username
   // Automatically set to false when any ban is applied (unless mod opts out)
   // Must be manually re-enabled by a mod
-  canChangeUsername?: boolean  // undefined = allowed, false = restricted
+  canChangeUsername?: boolean // undefined = allowed, false = restricted
 
   userDeleted?: boolean
   optOutBetWarnings?: boolean
   signupBonusPaid?: number
   isBot?: boolean
   isAdvancedTrader?: boolean
+  // Fine-resolution betting on binary markets: 0.1pp limit order increments
+  // and a 0.1%-99.9% range at the tails (<=3% / >=97%). Settable only via
+  // the me/update API on purpose — no web UI toggle.
+  fineProbBetting?: boolean
   purchasedMana?: boolean
   verifiedPhone?: boolean
 

--- a/common/src/util/format.ts
+++ b/common/src/util/format.ts
@@ -176,18 +176,20 @@ export function getPercent(zeroToOne: number) {
 }
 
 function getPercentDecimalPlaces(zeroToOne: number) {
-  return zeroToOne < 0.02 || zeroToOne > 0.98 ? 1 : 0
+  // Matches FINE_PROB_TAIL in common/contract: the region where fine prob
+  // betting allows 0.1pp limit orders, which must display honestly.
+  return zeroToOne < 0.03 || zeroToOne > 0.97 ? 1 : 0
 }
 
 export function formatPercent(zeroToOne: number) {
-  // Show 1 decimal place if <2% or >98%, giving more resolution on the tails
+  // Show 1 decimal place if <3% or >97%, giving more resolution on the tails
   const decimalPlaces = getPercentDecimalPlaces(zeroToOne)
   const percent = zeroToOne * 100
   return percent.toFixed(decimalPlaces) + '%'
 }
 
 export function formatPercentNumber(zeroToOne: number) {
-  // Show 1 decimal place if <2% or >98%, giving more resolution on the tails
+  // Show 1 decimal place if <3% or >97%, giving more resolution on the tails
   const decimalPlaces = getPercentDecimalPlaces(zeroToOne)
   return Number((zeroToOne * 100).toFixed(decimalPlaces))
 }

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -963,6 +963,8 @@ Parameters:
 - `outcome`: Optional. `YES` (default) or `NO`
 - `limitProb`: Optional. Makes this a limit order. `limitProb` is a number from `0.01` to `0.99` representing the probability price to set a limit order at (like 0.01 is 1%). Can only be two decimal digits - a whole precent.
 
+  Accounts with the `fineProbBetting` setting enabled (via the `me/update` API; binary markets only) may additionally use three decimal digits (0.1 percentage point increments) at the tails — `limitProb` at most `0.03` or at least `0.97` — and the allowed range widens to `0.001` to `0.999`.
+
   If the limit crosses the market price, the bet will execute immediately in the direction of `outcome` up to the limit. If not all the bet is filled, the rest will remain as an open limit order.
 
   - For example, if the current market probability is `50%`:


### PR DESCRIPTION
## What

An opt-in, per-account setting `fineProbBetting` that enables fine-resolution betting on **binary** markets:

- **0.1-percentage-point increments** for `limitProb` at the tails of the range — at most 3% or at least 97% (whole percentage points still required in between, and remain available everywhere)
- bounds widened from [1%, 99%] to **[0.1%, 99.9%]**, for both limit orders and market orders

The setting is enabled via the API only — deliberately no web UI toggle:

```bash
curl https://api.manifold.markets/v0/me/update \
  -X POST -H 'Authorization: Key ...' -H 'Content-Type: application/json' \
  -d '{"fineProbBetting": true}'
```

For everyone else, nothing changes (see "No behavior change" below).

## Why

For near-certain markets, whole-percentage-point pricing is extremely coarse *in odds terms*: 98% vs 99% is a 2x difference in return-from-certainty, so makers can't quote these markets honestly — the order book at the tails collapses to "99% or nothing". This blocks decent pricing on exactly the markets where prediction-market calibration at the tails is most interesting.

**Why 3%/97% and not finer everywhere:** a 0.1pp step at 97% is about as large a move in log-odds (~0.034) as the 1pp step at 50% (~0.040) that everyone already has. So this grid never offers meaningfully finer odds resolution than the platform always had — it just stops the resolution from collapsing at the tails. (By the same rule, a future PR could unlock another digit per decade of 1−p, e.g. 0.01pp beyond 99.75%.)

**Why API-only opt-in:** the feature adds resolution, not risk — an account can already bet its whole balance at 99% today — but keeping it off the web UI means only deliberate users (bots, market makers) encounter prices like 99.9%, where small probability differences are large odds differences.

## How it works

- `getRoundedLimitProb` (moved to `common/new-bet` and consolidated — the binary path in `place-bet.ts` had its own inline copy of the same validation) enforces the per-user grid server-side.
- Orders beyond 99%/1% can't fill from the pool when the taker is unflagged, but they don't need to: they rest in the book and fill through the existing **direct maker matching** at the maker's `limitProb` (`computeFill`'s matched-bet branch already prices fills this way, unclamped).
- Flagged users' bets pass wider pool bounds `[0.001, 0.999]` through the existing `limitProbs` parameter of `computeFills`. The internal clamp now honors passed bounds **only when wider** than the standard CPMM bounds — never narrower — so explicit limits on STONK etc. behave exactly as before.
- `formatPercent`'s one-decimal tail threshold moves from 2%/98% to 3%/97% so every placeable price displays honestly (this is the one user-visible change for everyone: probabilities in (97%, 98%] and [2%, 3%) now show one decimal).

## No behavior change without the flag

- Same grid, same bounds, same error messages (the bet schema bounds widen to [0.001, 0.999], but the unchanged 1pp grid check makes the effective unflagged bounds [0.01, 0.99] exactly as before — covered by tests).
- If a flagged user has moved a pool beyond 99%, unflagged users can still bet **toward** 50% with market orders, and can always **sell** — sells never had prob bounds (in fact pools above 99% are already reachable today by selling NO shares at 99%; this PR doesn't introduce that state, it just makes it quotable).
- Pseudo-numeric, stonk, and multi-choice markets are unchanged (multi-choice would interact with the answers-sum-to-one arbitrage and is left for a follow-up).

## Tests

`common/src/fine-prob-betting.test.ts` (14 tests): grid acceptance/rejection in both modes including region boundaries (rejects 2.95%, 97.05%, 99.95%; accepts 2.9%, 97.5%, 99.9%), and fill mechanics — direct match against a 99.5% maker with the pool untouched and the fill priced exactly at 0.995, unflagged market orders still stop at 99%, flagged market orders stop at 99.9%, unflagged explicit limits still clamp to 99%, toward-50-only at an extreme pool, and a flagged taker limit crossing a resting maker above 99%.

Also verified end-to-end against a local stack: flag set via `me/update`, unflagged rejection with the legacy error, a resting 99.5% maker order crossed at exactly 0.995, and `probAfter` capping at exactly 0.999 for a flagged market order.
