### PR TITLE
feat(ui): stack page title above header controls on mobile

### DIFF
--- a/web/components/contract/back-button.tsx
+++ b/web/components/contract/back-button.tsx
@@ -2,10 +2,10 @@ import { ArrowLeftIcon } from '@heroicons/react/solid'
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import clsx from 'clsx'
-import { Button } from 'web/components/buttons/button'
+import { Button, SizeType } from 'web/components/buttons/button'
 
-export function BackButton(props: { className?: string }) {
-  const { className } = props
+export function BackButton(props: { className?: string; size?: SizeType }) {
+  const { className, size } = props
   const router = useRouter()
   const [canGoBack, setCanGoBack] = useState(false)
 
@@ -21,6 +21,7 @@ export function BackButton(props: { className?: string }) {
       className={clsx('rounded', className)}
       onClick={router.back}
       color={'gray-white'}
+      size={size}
     >
       <ArrowLeftIcon className="h-5 w-5" aria-hidden />
       <div className="sr-only">Back</div>

--- a/web/components/dashboard/dashboard-page.tsx
+++ b/web/components/dashboard/dashboard-page.tsx
@@ -136,7 +136,8 @@ export function DashboardPage(props: {
               className="!w-full !text-lg"
             />
           ) : (
-            <Row className="items-center justify-between">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              {/* Mobile stacks the title above the controls; sm+ is one row. */}
               <Title className="!mb-0 ">{dashboard.title}</Title>
 
               <div className="flex items-center">
@@ -166,7 +167,7 @@ export function DashboardPage(props: {
                   </Button>
                 )}
               </div>
-            </Row>
+            </div>
           )}
         </div>
         {editMode ? (

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -98,6 +98,26 @@ function CommunityEmptyState() {
   )
 }
 
+// Placeholder cards matching DashboardMarketCard's shell (340px, 2-col grid),
+// shown while the community markets are loading.
+function MarketCardSkeletonGrid() {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Col
+          key={i}
+          className="bg-canvas-50 border-ink-200 h-[340px] animate-pulse gap-3 rounded-xl border p-5"
+        >
+          <div className="bg-ink-200 h-3 w-1/3 rounded" />
+          <div className="bg-ink-200 h-5 w-3/4 rounded" />
+          <div className="bg-ink-100 flex-1 rounded" />
+          <div className="bg-ink-200 h-8 w-full rounded" />
+        </Col>
+      ))}
+    </div>
+  )
+}
+
 function parseAnswerText(text: string): { flag: string; name: string } {
   const chars = [...text.trim()]
   const isRegionalIndicator = (c?: string) => {
@@ -269,6 +289,10 @@ function CommunityTab({
   const [contracts, setContracts] = useState<Contract[] | undefined>(undefined)
 
   useEffect(() => {
+    // Until the dashboard itself has loaded, the empty slug list just means
+    // "unknown" — don't mark contracts as loaded ([]), or the no-markets
+    // state flashes before the real fetch even starts.
+    if (dashboard === undefined) return
     if (questionSlugs.length === 0) {
       setContracts([])
       return
@@ -292,7 +316,7 @@ function CommunityTab({
     return () => {
       cancelled = true
     }
-  }, [questionSlugs.join(',')])
+  }, [questionSlugs.join(','), dashboard === undefined])
 
   // Returns resolution timestamp, or null if still open.
   // For cpmm-multi-1 sports markets, waits until all answers are resolved.
@@ -401,7 +425,7 @@ function CommunityTab({
     }
   }
 
-  if (dashboard === undefined) return <LoadingIndicator />
+  if (dashboard === undefined) return <MarketCardSkeletonGrid />
 
   if (dashboard === null && !isAdmin) {
     return <CommunityEmptyState />
@@ -464,9 +488,7 @@ function CommunityTab({
       )}
 
       {/* Markets still loading — don't flash the empty state */}
-      {dashboard !== null && contractsLoading && (
-        <LoadingIndicator className="py-20" />
-      )}
+      {dashboard !== null && contractsLoading && <MarketCardSkeletonGrid />}
 
       {/* Open markets */}
       {dashboard !== null &&

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -264,7 +264,9 @@ function CommunityTab({
     )
     .map((i) => i.slug)
 
-  const [contracts, setContracts] = useState<Contract[]>([])
+  // undefined = first fetch still in flight; later re-fetches (after
+  // add/remove/reorder) keep showing the previous contracts instead.
+  const [contracts, setContracts] = useState<Contract[] | undefined>(undefined)
 
   useEffect(() => {
     if (questionSlugs.length === 0) {
@@ -306,18 +308,21 @@ function CommunityTab({
     return null
   }
 
+  const contractsLoading = contracts === undefined
+  const loadedContracts = contracts ?? []
+
   const now = Date.now()
-  const polls = contracts.filter((c) => c.outcomeType === 'POLL')
-  const open = contracts.filter(
+  const polls = loadedContracts.filter((c) => c.outcomeType === 'POLL')
+  const open = loadedContracts.filter(
     (c) => contractResolvedAt(c) === null && c.outcomeType !== 'POLL'
   )
-  const recentResolved = contracts.filter((c) => {
+  const recentResolved = loadedContracts.filter((c) => {
     const t = contractResolvedAt(c)
     return (
       t !== null && now - t < RECENT_THRESHOLD_MS && c.outcomeType !== 'POLL'
     )
   })
-  const pastResolved = contracts.filter((c) => {
+  const pastResolved = loadedContracts.filter((c) => {
     const t = contractResolvedAt(c)
     return (
       t !== null && now - t >= RECENT_THRESHOLD_MS && c.outcomeType !== 'POLL'
@@ -326,9 +331,10 @@ function CommunityTab({
 
   // Report total items in this tab (open + resolved), matching the parent's
   // mount-time prefetch so the badge doesn't jump when the tab is first opened.
+  // Skip while loading so we don't overwrite the prefetched count with 0.
   useEffect(() => {
-    onCountChange?.(contracts.length)
-  }, [contracts.length])
+    if (contracts) onCountChange?.(contracts.length)
+  }, [contracts?.length])
 
   const sortedOpen = sortContracts(open, questionSlugs, sort)
   // Apply the same sort to the resolved sections so the toggle isn't silently
@@ -457,8 +463,14 @@ function CommunityTab({
         </p>
       )}
 
+      {/* Markets still loading — don't flash the empty state */}
+      {dashboard !== null && contractsLoading && (
+        <LoadingIndicator className="py-20" />
+      )}
+
       {/* Open markets */}
       {dashboard !== null &&
+        !contractsLoading &&
         polls.length === 0 &&
         sortedOpen.length === 0 &&
         recentResolved.length === 0 &&

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -935,7 +935,7 @@ export function SportsDashboardPage({
               {title}
             </h1>
           </Row>
-          <BackButton className="order-2 -ml-2 shrink-0 sm:order-1" />
+          <BackButton size="xs" className="order-2 -ml-2 shrink-0 sm:order-1" />
           {/* CopyLinkOrShareButton's className lands on the inner Button (it's
               wrapped in a Tooltip), so the order class needs its own wrapper. */}
           <div className="order-3">
@@ -945,6 +945,8 @@ export function SportsDashboardPage({
               }`}
               eventTrackingName="copy sports dashboard link"
               tooltip="Share"
+              size="xs"
+              className="text-ink-500 hover:text-ink-600"
             />
           </div>
           <Row className="order-4 ml-auto items-center gap-2">

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -936,14 +936,17 @@ export function SportsDashboardPage({
             </h1>
           </Row>
           <BackButton className="order-2 -ml-2 shrink-0 sm:order-1" />
-          <CopyLinkOrShareButton
-            className="order-3"
-            url={`https://${ENV_CONFIG.domain}${router.pathname}${
-              user?.username ? referralQuery(user.username) : ''
-            }`}
-            eventTrackingName="copy sports dashboard link"
-            tooltip="Share"
-          />
+          {/* CopyLinkOrShareButton's className lands on the inner Button (it's
+              wrapped in a Tooltip), so the order class needs its own wrapper. */}
+          <div className="order-3">
+            <CopyLinkOrShareButton
+              url={`https://${ENV_CONFIG.domain}${router.pathname}${
+                user?.username ? referralQuery(user.username) : ''
+              }`}
+              eventTrackingName="copy sports dashboard link"
+              tooltip="Share"
+            />
+          </div>
           <Row className="order-4 ml-auto items-center gap-2">
             <SportsDashboardTabButton
               active={activeTab === 'official'}

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -926,22 +926,25 @@ export function SportsDashboardPage({
         <title>{title} | Manifold</title>
       </Head>
       <Col className="mx-auto w-full max-w-5xl gap-8 px-4 py-6 sm:px-6">
-        <Row className="border-ink-200 bg-canvas-0 sticky top-0 z-20 -mt-6 items-center justify-between border-b pb-5 pt-6">
-          <Row className="items-center gap-2">
-            <BackButton className="-ml-2 shrink-0" />
+        {/* On mobile the title takes its own full-width line above the
+            buttons (back/share/tabs); on sm+ everything sits in one row. */}
+        <div className="border-ink-200 bg-canvas-0 sticky top-0 z-20 -mt-6 flex flex-wrap items-center gap-x-2 gap-y-3 border-b pb-5 pt-6">
+          <Row className="order-1 w-full items-center gap-2 sm:order-2 sm:w-auto">
             <span className="text-2xl">{emoji}</span>
             <h1 className="text-ink-1000 text-xl font-medium tracking-tight">
               {title}
             </h1>
-            <CopyLinkOrShareButton
-              url={`https://${ENV_CONFIG.domain}${router.pathname}${
-                user?.username ? referralQuery(user.username) : ''
-              }`}
-              eventTrackingName="copy sports dashboard link"
-              tooltip="Share"
-            />
           </Row>
-          <Row className="items-center gap-2">
+          <BackButton className="order-2 -ml-2 shrink-0 sm:order-1" />
+          <CopyLinkOrShareButton
+            className="order-3"
+            url={`https://${ENV_CONFIG.domain}${router.pathname}${
+              user?.username ? referralQuery(user.username) : ''
+            }`}
+            eventTrackingName="copy sports dashboard link"
+            tooltip="Share"
+          />
+          <Row className="order-4 ml-auto items-center gap-2">
             <SportsDashboardTabButton
               active={activeTab === 'official'}
               count={upcoming.length}
@@ -957,7 +960,7 @@ export function SportsDashboardPage({
               Community
             </SportsDashboardTabButton>
           </Row>
-        </Row>
+        </div>
 
         {activeTab === 'community' ? (
           hasCommunity ? (

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -658,7 +658,8 @@ export function SportsDashboardTabButton({
     <button
       onClick={onClick}
       className={clsx(
-        'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors',
+        // Compact on mobile so the header button row fits on one line.
+        'flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium transition-colors sm:gap-2 sm:px-3 sm:py-1.5 sm:text-sm',
         active
           ? 'border-ink-700 text-ink-1000 border-2'
           : 'border-ink-300 text-ink-500 hover:border-ink-400 hover:text-ink-700 border'
@@ -668,7 +669,7 @@ export function SportsDashboardTabButton({
       {count !== undefined && (
         <span
           className={clsx(
-            'rounded-full px-1.5 py-0.5 text-xs font-semibold',
+            'rounded-full px-1 py-0.5 text-[10px] font-semibold sm:px-1.5 sm:text-xs',
             active
               ? 'bg-primary-100 text-primary-600'
               : 'bg-ink-100 text-ink-500'

--- a/web/pages/charity.tsx
+++ b/web/pages/charity.tsx
@@ -426,12 +426,15 @@ export default function CharityGiveawayPage(props: { giveawayNum?: number }) {
       <Col className="mx-auto w-full max-w-3xl gap-8 px-4 py-8 sm:px-6">
         {/* Header */}
         <Col className="gap-4">
-          <Row className="items-center gap-3">
-            <FaHeart className="h-8 w-8 text-emerald-500" />
-            <h1 className="text-ink-900 text-3xl font-bold tracking-tight">
-              Manifold Charity Giveaway
-            </h1>
-            <div className="ml-auto flex items-center gap-2">
+          {/* Mobile stacks the title above the controls; sm+ is one row. */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Row className="items-center gap-3">
+              <FaHeart className="h-8 w-8 text-emerald-500" />
+              <h1 className="text-ink-900 text-3xl font-bold tracking-tight">
+                Manifold Charity Giveaway
+              </h1>
+            </Row>
+            <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
               {giveawayList.length > 1 && (
                 <SelectDropdown
                   aria-label="Select charity giveaway"
@@ -474,7 +477,7 @@ export default function CharityGiveawayPage(props: { giveawayNum?: number }) {
                   </Button>
                 )}
             </div>
-          </Row>
+          </div>
           <p className="text-ink-600 text-lg leading-relaxed">
             Manifold is giving ${giveaway.prizeAmountUsd.toLocaleString()} to
             charity—you decide which one. Convert mana into entries to boost a

--- a/web/pages/prize.tsx
+++ b/web/pages/prize.tsx
@@ -432,12 +432,15 @@ export default function SweepstakesPage() {
       <Col className="mx-auto w-full max-w-3xl gap-8 px-4 py-8 sm:px-6">
         {/* Header */}
         <Col className="gap-4">
-          <Row className="items-center gap-3">
-            <FaGift className="h-8 w-8 text-teal-500" />
-            <h1 className="text-ink-900 text-3xl font-bold tracking-tight">
-              Manifold Prize Drawing
-            </h1>
-            <div className="ml-auto flex items-center gap-2">
+          {/* Mobile stacks the title above the controls; sm+ is one row. */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Row className="items-center gap-3">
+              <FaGift className="h-8 w-8 text-teal-500" />
+              <h1 className="text-ink-900 text-3xl font-bold tracking-tight">
+                Manifold Prize Drawing
+              </h1>
+            </Row>
+            <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
               {sweepstakesList.length > 1 && (
                 <SelectDropdown
                   aria-label="Select prize drawing"
@@ -502,7 +505,7 @@ export default function SweepstakesPage() {
                   </Button>
                 )}
             </div>
-          </Row>
+          </div>
           <p className="text-ink-600 text-lg leading-relaxed">
             Enter the drawing for a chance to win USDC prizes! Winners receive
             real crypto payouts. No purchase necessary.


### PR DESCRIPTION
On mobile (<sm), page headers now render the title on its own full-width line above the buttons/dropdowns/tabs, with content below. Desktop layout is unchanged.

Pages updated:
- **Prize Drawings** (/prize): title row, then drawing selector + admin buttons below
- **Charity Giveaway** (/charity): title row, then giveaway selector + admin buttons below
- **World Cup / sports dashboards**: title (emoji + name) on its own line, then back button, share button, and Official/Community tabs on the second line — done with flex-wrap + order classes so there's no duplicated markup
- **Generic dashboards** (/dashboard/[slug]): title stacks above share/follow/edit controls