### PR TITLE
fix: Update backend time zones and timeout

### DIFF
--- a/backend/api/ecosystem.config.js
+++ b/backend/api/ecosystem.config.js
@@ -3,8 +3,13 @@ module.exports = {
     {
       name: 'serve',
       script: 'backend/api/lib/serve.js',
-      // Restart every day at 2/3 AM LA time (UTC-7/8)
-      cron_restart: '0 10 * * *',
+      // Restart daily at 08:00 UTC (midnight/1 AM LA). pm2 crons use the VM's
+      // clock (UTC), unlike the scheduler's jobs which run in LA time. The
+      // restart kicks off initCaches' user-interests build, a heavy db read;
+      // keep it clear of the scheduler's 2:00-5:30 AM LA maintenance pile,
+      // which already pins db disk throughput at its cap around 09:30-11:30
+      // UTC each morning (this stack-up caused the June 2026 outages).
+      cron_restart: '0 8 * * *',
       instances: 1,
       autorestart: true,
       watch: false,
@@ -12,6 +17,10 @@ module.exports = {
       node_args: '--max-old-space-size=12288',
       env: {
         PORT: 80,
+        // Cap statement runtime server-side (incl. lock waits) for
+        // request-serving processes. The scheduler runs without a cap.
+        // See createSupabaseDirectClient in shared/src/supabase/init.ts.
+        PG_STATEMENT_TIMEOUT_MS: 60_000,
       },
     },
     {
@@ -26,6 +35,7 @@ module.exports = {
       env: {
         PORT: 8090,
         READ_ONLY: true,
+        PG_STATEMENT_TIMEOUT_MS: 60_000,
       },
     },
   ],

--- a/backend/api/ecosystem.config.js
+++ b/backend/api/ecosystem.config.js
@@ -20,7 +20,7 @@ module.exports = {
         // Cap statement runtime server-side (incl. lock waits) for
         // request-serving processes. The scheduler runs without a cap.
         // See createSupabaseDirectClient in shared/src/supabase/init.ts.
-        PG_STATEMENT_TIMEOUT_MS: 60_000,
+        PG_STATEMENT_TIMEOUT_MS: 60000,
       },
     },
     {
@@ -35,7 +35,7 @@ module.exports = {
       env: {
         PORT: 8090,
         READ_ONLY: true,
-        PG_STATEMENT_TIMEOUT_MS: 60_000,
+        PG_STATEMENT_TIMEOUT_MS: 60000,
       },
     },
   ],

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -63,6 +63,9 @@ import { createUpcomingSportsMarkets } from './sports-create-markets'
 import { pollSportsLiveScores } from './sports-live'
 
 export function createJobs() {
+  // Schedules are 6-field croner expressions (seconds first) evaluated in
+  // America/Los_Angeles (DEFAULT_OPTS in ./helpers.ts) — NOT UTC. A run that
+  // is still going when its next firing comes due is skipped ("protect").
   return [
     createJob(
       'auto-leagues-cycle',
@@ -77,22 +80,22 @@ export function createJobs() {
     ),
     createJob(
       'update-contract-metrics',
-      '0 */21 * * * *', // every 21 minutes - (on the 3rd minute of every hour)
+      '0 */21 * * * *', // at :00, :21, and :42 of every hour
       () => updateContractMetricsCore(false)
     ),
     createJob(
       'update-contract-metrics-full',
-      '0 30 5 * * *', // every day at 5:30am
+      '0 30 5 * * *', // daily at 5:30 AM LA
       () => updateContractMetricsCore(true)
     ),
     createJob(
       'update-creator-metrics',
-      `0 */${CREATOR_UPDATE_FREQUENCY} * * * *`, // every 57 minutes - (on the 57th minute of every hour)
+      `0 ${CREATOR_UPDATE_FREQUENCY} * * * *`, // hourly at :57
       updateCreatorMetricsCore
     ),
     createJob(
       'group-importance-score',
-      '0 6 * * * *', // on the 6th minute of every hour
+      '0 6 * * * *', // hourly at :06
       () => calculateGroupImportanceScore()
     ),
     createJob(
@@ -102,17 +105,17 @@ export function createJobs() {
     ),
     createJob(
       'check-push-receipts',
-      '0 15 * * * *', // on the 15th minute of every hour
+      '0 15 * * * *', // hourly at :15
       checkPushNotificationReceipts
     ),
     createJob(
       'send-contract-movement-notifications',
-      '0 12 * * * *', // on the 12th minute of every hour
+      '0 12 * * * *', // hourly at :12
       () => sendMarketMovementNotifications(false)
     ),
     createJob(
       'calculate-conversion-scores',
-      '0 46 * * * *', // on the 46th minute of every hour
+      '0 46 * * * *', // hourly at :46
       calculateConversionScore
     ),
     createJob(
@@ -122,7 +125,7 @@ export function createJobs() {
     ),
     createJob(
       'auto-award-bounty',
-      '0 55 * * * *', // on the 55th minute of every hour
+      '0 55 * * * *', // hourly at :55
       autoAwardBounty
     ),
     createJob(
@@ -132,12 +135,12 @@ export function createJobs() {
     ),
     createJob(
       'update-user-portfolio-histories',
-      '30 * * * * *', // every minute
+      '30 * * * * *', // every minute, at :30s
       () => updateUserPortfolioHistoriesCore()
     ),
     createJob(
       'drizzle-liquidity',
-      '0 */7 * * * *', // every 7th minute
+      '0 */7 * * * *', // at :00, :07, ... :56 of every hour
       drizzleLiquidity
     ),
     createJob(
@@ -152,7 +155,8 @@ export function createJobs() {
     ),
     createJob(
       'score-contracts',
-      `0 */${isProd() ? IMPORTANCE_MINUTE_INTERVAL : 60} * * * *`, // every 2 minutes
+      // every IMPORTANCE_MINUTE_INTERVAL (2) minutes in prod; hourly in dev
+      `0 */${isProd() ? IMPORTANCE_MINUTE_INTERVAL : 60} * * * *`,
       scoreContracts
     ),
     createJob(
@@ -173,12 +177,12 @@ export function createJobs() {
     // Daily jobs:
     createJob(
       'process-membership-renewals',
-      '0 0 8 * * *', // 8 AM UTC daily (midnight PT)
+      '0 0 8 * * *', // daily at 8:00 AM LA
       processMembershipRenewals
     ),
     createJob(
       'check-subscription-expiry',
-      '0 0 10 * * *', // 10 AM UTC daily (2 AM PT) - warns users 2-3 days before expiry
+      '0 0 10 * * *', // daily at 10:00 AM LA - warns users 2-3 days before expiry
       checkSubscriptionExpiry
     ),
     createJob(
@@ -194,12 +198,12 @@ export function createJobs() {
     ),
     createJob(
       'send-unseen-notifications',
-      '0 0 13 * * *', // 1 PM daily
+      '0 0 13 * * *', // daily at 1:00 PM LA
       sendUnseenMarketMovementNotifications
     ),
     createJob(
       'clean-old-notifications',
-      '0 30 2 * * *', // 230 AM daily
+      '0 30 1 * * *', // daily at 1:30 AM LA - heavy disk user
       cleanOldNotifications
     ),
     // Autoresolve temporarily disabled — uncomment to continue with $100/day.
@@ -216,119 +220,119 @@ export function createJobs() {
     // ),
     createJob(
       'refresh-ach-volume',
-      '0 30 2 * * *', // 2:30 AM
+      '0 30 2 * * *', // daily at 2:30 AM LA
       refreshAchVolume
     ),
     createJob(
       'refresh-ach-comments',
-      '0 40 2 * * *', // 2:40 AM
+      '0 40 2 * * *', // daily at 2:40 AM LA
       refreshAchComments
     ),
     createJob(
       'refresh-ach-creator-contracts',
-      '0 50 2 * * *', // 2:50 AM
+      '0 50 2 * * *', // daily at 2:50 AM LA
       refreshAchCreatorContracts
     ),
     createJob(
       'refresh-ach-referrals',
-      '0 0 3 * * *', // 3:00 AM
+      '0 0 3 * * *', // daily at 3:00 AM LA
       refreshAchReferrals
     ),
     createJob(
       'refresh-ach-creator-traders',
-      '0 10 3 * * *', // 3:10 AM
+      '0 10 3 * * *', // daily at 3:10 AM LA
       refreshAchCreatorTraders
     ),
     createJob(
       'refresh-ach-leagues',
-      '0 20 3 * * *', // 3:20 AM
+      '0 20 3 * * *', // daily at 3:20 AM LA
       refreshAchLeagues
     ),
     createJob(
       'refresh-ach-pnl',
-      '0 30 3 * * *', // 3:30 AM
+      '0 30 3 * * *', // daily at 3:30 AM LA
       refreshAchPnl
     ),
     createJob(
       'refresh-ach-txns',
-      '0 40 3 * * *', // 3:40 AM
+      '0 40 3 * * *', // daily at 3:40 AM LA
       refreshAchTxns
     ),
     createJob(
       'refresh-ach-account-age',
-      '0 50 3 * * *', // 3:50 AM
+      '0 50 3 * * *', // daily at 3:50 AM LA
       refreshAchAccountAge
     ),
     createJob(
       'update-user-metric-periods',
-      '0 0 2 * * *', // 2 AM daily
+      '0 0 2 * * *', // daily at 2:00 AM LA
       async () => {
         await updateUserMetricPeriods()
       }
     ),
     createJob(
       'reset-pg-stats',
-      '0 0 3 * * *', // 3 AM daily
+      '0 0 3 * * *', // daily at 3:00 AM LA
       resetPgStats
     ),
     createJob(
       'calculate-user-topic-interests',
-      '0 0 3 * * *', // 3 AM daily
+      '0 0 4 * * *', // daily at 4:00 AM LA
       () => calculateUserTopicInterests()
     ),
     createJob(
       'update-stats',
-      '0 20 4 * * *', // on 4:20am daily
+      '0 20 4 * * *', // daily at 4:20 AM LA
       () => updateStatsCore(7)
     ),
     createJob(
       'onboarding-notification',
-      '0 0 11 * * *', // 11 AM daily
+      '0 0 11 * * *', // daily at 11:00 AM LA
       sendOnboardingNotificationsInternal
     ),
     createJob(
       'weekly-portfolio-emails',
-      '0 * 12-14 * * 5', // every Friday from 12pm to 2pm
+      '0 * 12-14 * * 5', // every minute from 12:00 to 2:59 PM LA on Fridays
       sendPortfolioUpdateEmailsToAllUsers
     ),
     createJob(
       'weekly-markets-emails',
-      '0 */2 10-17 * * 1', // every Monday
+      '0 */2 10-17 * * 1', // every 2 minutes from 10 AM to 5:58 PM LA on Mondays
       sendWeeklyMarketsEmails
     ),
     createJob(
       'reset-weekly-email-flags',
-      '0 0 0 * * 6', // every Saturday at midnight
+      '0 0 0 * * 6', // Saturdays at midnight LA
       resetWeeklyEmailsFlags
     ),
     createJob(
       'send-streak-notifications',
-      '0 30 18 * * *', // 6:30pm PST daily ( 9:30pm EST )
+      '0 30 18 * * *', // daily at 6:30 PM LA
       sendStreakExpirationNotification
     ),
     createJob(
       'update-league-ranks',
-      '0 0 0 * * *', // every day at midnight
+      '0 0 0 * * *', // daily at midnight LA
       () => updateLeagueRanks()
     ),
     createJob(
       'reset-betting-streaks',
-      '0 0 0 * * *', // every day at midnight
+      '0 0 0 * * *', // daily at midnight LA
       resetBettingStreaksInternal
     ),
     createJob(
       'reset-quests-stats',
-      '0 0 0 * * *', // every day at midnight
+      '0 0 0 * * *', // daily at midnight LA
       resetDailyQuestStatsInternal
     ),
     createJob(
       'reset-weekly-quests-stats',
-      '0 0 0 * * 1', // every Monday at midnight
+      '0 0 0 * * 1', // Mondays at midnight LA
       resetWeeklyQuestStatsInternal
     ),
     createJob(
       'downsample-portfolio-history',
-      '0 50 4 * * *', // every day at 4:50am
+      '0 50 4 * * *', // daily at 4:50 AM LA
       downsamplePortfolioHistory
     ),
     // All football-data.org tournaments: check for finished matches and auto-resolve every 15 minutes
@@ -337,10 +341,10 @@ export function createJobs() {
       '0 */15 * * * *', // every 15 minutes
       resolveSportsMarkets
     ),
-    // Create markets for upcoming matches in the next 7 days (runs daily at 7 AM UTC)
+    // Create markets for upcoming matches in the next 7 days
     createJob(
       'sports-create-markets',
-      '0 0 7 * * *', // 7 AM UTC daily
+      '0 0 7 * * *', // daily at 7:00 AM LA
       createUpcomingSportsMarkets
     ),
     // Poll in-play scores every 10s and broadcast them over websockets. No-op

--- a/backend/shared/src/supabase/init.ts
+++ b/backend/shared/src/supabase/init.ts
@@ -145,6 +145,17 @@ export function createSupabaseDirectClient(opts?: {
       "Can't connect to Supabase; no process.env.SUPABASE_PASSWORD."
     )
   }
+
+  // Server-side cap on total statement runtime, including lock waits. Opt-in
+  // via env so only request-serving processes get it (set in
+  // backend/api/ecosystem.config.js); the scheduler and ad-hoc scripts
+  // legitimately run long statements and leave it unset. Without this cap,
+  // queries that are slow only because the db's disk throughput is saturated
+  // pile up for hundreds of seconds and amplify the saturation
+  const statementTimeout = process.env.PG_STATEMENT_TIMEOUT_MS
+    ? parseInt(process.env.PG_STATEMENT_TIMEOUT_MS)
+    : undefined
+
   log('Connecting to postgres at ' + dbHost + ':' + port)
   const client = pgp({
     host: dbHost,
@@ -165,6 +176,7 @@ export function createSupabaseDirectClient(opts?: {
     // Although we don't yet know the cause, setting this timeout will limit the damage
     // from these connections. We should figure out the cause ASAP.
     idle_in_transaction_session_timeout: opts?.idleInTxnTimeout ?? 60_000, // 1 minute
+    ...(statementTimeout ? { statement_timeout: statementTimeout } : {}),
     max: 40,
   })
   const pool = client.$pool


### PR DESCRIPTION
Sets a backend statement timeout for the API servers to avoid a locked row stalling all requests. Also updates time zones and shifts around some scheduled jobs to even out database load.