### PR TITLE
fix(feed): blocked topics leaking into home feed via sports markets

### DIFF
--- a/backend/api/src/admin-sports-create-markets.ts
+++ b/backend/api/src/admin-sports-create-markets.ts
@@ -214,8 +214,8 @@ export const adminSportsCreateMarkets: APIHandler<
       // Attach group tags (createMarketHelper doesn't do this — only the full handler does)
       await Promise.allSettled(
         params.groupIds.map((gId) =>
-          pg.oneOrNone(
-            `select id from groups where id = $1 limit 1`,
+          pg.oneOrNone<{ id: string; slug: string }>(
+            `select id, slug from groups where id = $1 limit 1`,
             [gId]
           ).then((g) => g ? addGroupToContract(pg, contract, g) : null)
         )

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -15,7 +15,7 @@ import {
   SearchTypes,
   sortFields,
 } from 'shared/supabase/search-contracts'
-import { log } from 'shared/utils'
+import { getPrivateUser, log } from 'shared/utils'
 import { z } from 'zod'
 import { APIError, type APIHandler } from './helpers/endpoint'
 
@@ -102,12 +102,18 @@ const search = async (
     (token === 'MANA' || token === 'ALL') &&
     !isRecent
   ) {
+    // Enforce blocked users/contracts/topics in the query itself — the
+    // client-side filter only patches holes in already-fetched pages.
+    const privateUser = userId
+      ? (await getPrivateUser(userId, pg)) ?? undefined
+      : undefined
     if (!isForYou || !userId) {
       return await pg.map(
         basicSearchSQL({
           ...props,
           uid: userId,
           isPrizeMarket,
+          privateUser,
         }),
         null,
         convertContract
@@ -118,6 +124,7 @@ const search = async (
         uid: userId,
         sort,
         isPrizeMarket,
+        privateUser,
       })
       return await pg.map(forYouSql, [term], (r) => convertContract(r))
     }

--- a/backend/scheduler/src/jobs/sports-create-markets.ts
+++ b/backend/scheduler/src/jobs/sports-create-markets.ts
@@ -22,7 +22,7 @@ export async function createUpcomingSportsMarkets() {
 
     try {
       const { created, skipped, errors } = await createTournamentMarkets(config, apiKey, {
-        daysAhead: 7,
+        daysAhead: 14,
         dashboardUrl: config.dashboardPath,
       })
       log(`[sports-create] ${config.footballDataCode}: created=${created} skipped=${skipped} errors=${errors}`)

--- a/backend/scripts/backfill-null-group-slugs.ts
+++ b/backend/scripts/backfill-null-group-slugs.ts
@@ -1,0 +1,69 @@
+// One-shot repair for contracts whose data->groupSlugs contains json nulls.
+// admin-sports-create-markets selected only `id` from groups before passing
+// the row to addGroupToContract, so each group add appended `undefined`
+// (serialized as json null) instead of the slug. That broke blocked-topic
+// filtering: the client hides feed markets via contract.groupSlugs, and
+// these markets matched no blocked slug despite being in blocked groups
+// (e.g. ManifoldSports soccer markets shown to users who blocked Soccer).
+//
+// Rebuilds groupSlugs from the group_contracts table (the source of truth).
+// The contracts_populate trigger re-derives the native group_slugs column
+// from the updated data, so a single data update fixes both.
+
+import { runScript } from 'run-script'
+
+const DRY_RUN = process.env.DRY_RUN !== 'false'
+
+if (require.main === module) {
+  runScript(async ({ pg }) => {
+    const affected = await pg.manyOrNone<{
+      id: string
+      question: string
+      group_slugs: string[] | null
+      correct_slugs: string[]
+    }>(
+      `select c.id,
+              c.data->>'question' as question,
+              c.group_slugs,
+              coalesce(
+                (select array_agg(distinct g.slug)
+                 from group_contracts gc
+                 join groups g on g.id = gc.group_id
+                 where gc.contract_id = c.id),
+                '{}'
+              ) as correct_slugs
+       from contracts c
+       where c.data->'groupSlugs' @> '[null]'::jsonb`
+    )
+    console.log(`Found ${affected.length} contracts with null groupSlugs`)
+    for (const c of affected) {
+      console.log(
+        `${c.id} | ${c.question} | ${JSON.stringify(
+          c.group_slugs
+        )} -> ${JSON.stringify(c.correct_slugs)}`
+      )
+    }
+
+    if (DRY_RUN) {
+      console.log('DRY_RUN=true — no updates written. Set DRY_RUN=false to apply.')
+      return
+    }
+
+    const updated = await pg.result(
+      `update contracts c
+       set data = jsonb_set(
+         c.data,
+         '{groupSlugs}',
+         coalesce(
+           (select jsonb_agg(distinct g.slug)
+            from group_contracts gc
+            join groups g on g.id = gc.group_id
+            where gc.contract_id = c.id),
+           '[]'::jsonb
+         )
+       )
+       where c.data->'groupSlugs' @> '[null]'::jsonb`
+    )
+    console.log(`Updated ${updated.rowCount} contracts`)
+  })
+}

--- a/backend/shared/src/sports-markets.ts
+++ b/backend/shared/src/sports-markets.ts
@@ -660,7 +660,7 @@ export async function createTournamentMarkets(
     notifyFollowers?: boolean
   } = {}
 ): Promise<{ created: number; skipped: number; errors: number; log: CreateLogEntry[] }> {
-  const { daysAhead = 7, dryRun = false, dashboardUrl } = opts
+  const { daysAhead = 14, dryRun = false, dashboardUrl } = opts
   const pg = createSupabaseDirectClient()
   const log: CreateLogEntry[] = []
 

--- a/backend/shared/src/supabase/utils.ts
+++ b/backend/shared/src/supabase/utils.ts
@@ -255,23 +255,40 @@ export const FieldVal = {
 
   delete: () => (fieldName: string) => `- '${fieldName}'`,
 
-  arrayConcat:
-    (...values: string[]) =>
-    (fieldName: string) => {
+  arrayConcat: (...values: string[]) => {
+    // Untyped query results can sneak undefined past the string[] signature,
+    // and :json would silently serialize it as a json null inside the array
+    // (e.g. groupSlugs [null, null, null], which broke blocked-topic filters).
+    if (values.some((v) => v == null)) {
+      throw new Error(
+        `FieldVal.arrayConcat: got null/undefined in values: ${JSON.stringify(
+          values
+        )}`
+      )
+    }
+    return (fieldName: string) => {
       return pgp.as.format(
         `|| jsonb_build_object($1, coalesce(data->$1, '[]'::jsonb) || $2:json)`,
         [fieldName, values]
       )
-    },
+    }
+  },
 
-  arrayRemove:
-    (...values: string[]) =>
-    (fieldName: string) => {
+  arrayRemove: (...values: string[]) => {
+    if (values.some((v) => v == null)) {
+      throw new Error(
+        `FieldVal.arrayRemove: got null/undefined in values: ${JSON.stringify(
+          values
+        )}`
+      )
+    }
+    return (fieldName: string) => {
       return pgp.as.format(
         `|| jsonb_build_object($1, coalesce(data->$1,'[]'::jsonb) - '{$2:raw}'::text[])`,
         [fieldName, values.join(',')]
       )
-    },
+    }
+  },
 }
 export type FieldValFunction = (fieldName: string) => string
 

--- a/backend/shared/src/update-group-contracts-internal.ts
+++ b/backend/shared/src/update-group-contracts-internal.ts
@@ -18,6 +18,17 @@ export async function addGroupToContract(
   group: { id: string; slug: string },
   userId?: string
 ) {
+  // Some callers build the group object from untyped queries — a missing
+  // slug would otherwise append a json null to the contract's groupSlugs,
+  // breaking blocked-topic filtering.
+  let slug = group.slug
+  if (!slug) {
+    slug = await pg.one(
+      `select slug from groups where id = $1`,
+      [group.id],
+      (r) => r.slug
+    )
+  }
   // RETURNING 1 lets us skip the slug append on duplicates —
   // FieldVal.arrayConcat would otherwise double-append.
   const inserted = await pg.oneOrNone(
@@ -28,7 +39,7 @@ export async function addGroupToContract(
   )
   if (!inserted) return
   await updateContract(pg, contract.id, {
-    groupSlugs: FieldVal.arrayConcat(group.slug),
+    groupSlugs: FieldVal.arrayConcat(slug),
     lastUpdatedTime: Date.now(),
   })
 


### PR DESCRIPTION
## Bug (reported by Egor)

ManifoldSports soccer markets appeared on the home feed for users who had blocked the Soccer topic.

**Root cause:** the 51 World Cup ''26 markets created 2026-06-09 via `admin-sports-create-markets` had `groupSlugs: [null, null, null]` in their contract data. The endpoint''s group lookup selected only `id` from groups, so `addGroupToContract` passed `undefined` to `FieldVal.arrayConcat`, which pg-promise''s `:json` silently serialized as a json `null`. The home feed''s blocked-topic filter is client-side and matches on `contract.groupSlugs`, so these markets matched no blocked slug and slipped through — even for users who also blocked `ms-official-wc2026`.

A second, latent gap: `search-markets-full` (which powers the home feed) never fetched the caller''s private user, so `privateUserBlocksSql` was never applied server-side at all.

## Changes

- **admin-sports-create-markets**: select `id, slug` in the group attach (the actual bug)
- **addGroupToContract**: resolves the slug from the DB if the caller''s group object lacks one
- **FieldVal.arrayConcat/arrayRemove**: throw on null/undefined values — fail loudly at the choke point instead of silently corrupting stored arrays
- **search-markets-full**: fetches the caller''s private user and passes it to `basicSearchSQL`/`getForYouSQL`, enforcing blocked users/contracts/topics in SQL (the filter joins `group_contracts`, so it works even if denormalized `groupSlugs` drifts again). Client-side page filter remains as a second layer.
- **backend/scripts/backfill-null-group-slugs.ts**: repairs affected contracts from `group_contracts`; the `contract_populate` trigger re-syncs the native `group_slugs` column. **Already run against prod** — all 51 affected contracts repaired, 0 remain.

## Also included

- `feat(sports)`: tournament market autogeneration now creates markets 14 days ahead instead of 7 (cron arg + `createTournamentMarkets` default). Safe with football-data.org: the per-competition matches endpoint has no 10-day date-window cap.

## Verification

- Dry-run of the backfill against prod listed exactly the 51 corrupted contracts, each mapping `[null,null,null]` → `[ms-official-wc2026,soccer,sports-default]`; post-run query confirms 0 contracts with null groupSlugs remain
- `yarn typecheck:api`, `yarn typecheck:scheduler`, `yarn build:shared` all pass