### PR TITLE
feat: Add backend health check endpoints

### DIFF
--- a/backend/api/add-backend-service.sh
+++ b/backend/api/add-backend-service.sh
@@ -54,12 +54,55 @@ gcloud compute instance-groups unmanaged set-named-ports \
 
 HEALTH_CHECK_NAME="${BACKEND_NAME}-health-check"
 
+# HTTP check against /healthz/ready (not TCP). A TCP check only proves the port
+# is open, so a process that's alive but wedged/saturated keeps passing and the
+# LB keeps routing to it. /healthz/ready reports 503 from local pool state (no
+# db query) when the instance is saturated, so the LB drains it. The endpoint
+# never hangs, and GCP fails open if every backend is unhealthy at once.
+#
+# unhealthy-threshold is deliberately > healthy-threshold: slow to pull an
+# instance out (avoid flapping on a brief burst), quick to put it back.
 echo "Creating health check"
-gcloud compute health-checks create tcp ${HEALTH_CHECK_NAME} \
+gcloud compute health-checks create http ${HEALTH_CHECK_NAME} \
     --project=${GCLOUD_PROJECT} \
     --port-name ${PORT_NAME} \
+    --request-path /healthz/ready \
+    --check-interval 5s \
+    --timeout 5s \
+    --healthy-threshold 2 \
+    --unhealthy-threshold 3 \
     --global
 
+
+# Health-check protocol note: a backend service can't switch an existing
+# check's protocol in place, so converting the existing prod read services from
+# the old TCP checks to the HTTP /healthz/ready checks means creating new HTTP
+# checks and re-pointing each service (one-time; the old TCP checks can be
+# deleted afterwards once nothing references them):
+#
+#   for i in 0 1 2; do
+#     gcloud compute health-checks create http api-lb-read-service-$i-http-health-check \
+#       --project mantic-markets --global \
+#       --port-name read-$i --request-path /healthz/ready \
+#       --check-interval 5s --timeout 5s \
+#       --healthy-threshold 2 --unhealthy-threshold 3
+#     gcloud compute backend-services update api-lb-read-service-$i \
+#       --project mantic-markets --global \
+#       --health-checks api-lb-read-service-$i-http-health-check
+#   done
+#
+# The default api-lb-service (write process + /ws websockets) can be converted
+# the same way and benefits equally — readiness is independent of the long
+# backend-service timeout that /ws needs, so this is safe:
+#
+#   gcloud compute health-checks create http api-lb-service-http-health-check \
+#     --project mantic-markets --global \
+#     --port-name http --request-path /healthz/ready \
+#     --check-interval 5s --timeout 5s \
+#     --healthy-threshold 2 --unhealthy-threshold 3
+#   gcloud compute backend-services update api-lb-service \
+#     --project mantic-markets --global \
+#     --health-checks api-lb-service-http-health-check
 
 # backend type instance group
 echo "Creating backend service ${BACKEND_NAME}"

--- a/backend/api/src/app.ts
+++ b/backend/api/src/app.ts
@@ -15,6 +15,7 @@ import { handleMcpRequest } from './mcp'
 import { MINUTE_MS } from 'common/util/time'
 import { addOldRoutes } from './old-routes'
 import { handlers } from './routes'
+import { healthzLive, healthzReady } from './healthz'
 
 export const allowCorsUnrestricted: RequestHandler = cors({
   origin: '*',
@@ -102,6 +103,13 @@ export const apiErrorHandler: ErrorRequestHandler = (
 }
 
 export const app = express()
+
+// Infra health checks, registered before requestMonitoring so the LB's
+// per-instance polling (every few seconds) doesn't spam request logs or inflate
+// http/request_count. These are unauthenticated and intentionally trivial.
+app.get('/healthz/live', healthzLive)
+app.get('/healthz/ready', healthzReady)
+
 app.use(compression())
 app.use(requestMonitoring)
 

--- a/backend/api/src/healthz.ts
+++ b/backend/api/src/healthz.ts
@@ -27,10 +27,9 @@ const READY_MAX_WAITING = 5
 // common case (one wedged instance) gets traffic pulled off it automatically.
 export const healthzReady: RequestHandler = (_req, res) => {
   const pool = createSupabaseDirectClient().$pool
-  const { idleCount, waitingCount, totalCount } = pool
+  const { idleCount, waitingCount } = pool
   const saturated = idleCount === 0 && waitingCount > READY_MAX_WAITING
   res.status(saturated ? 503 : 200).json({
     status: saturated ? 'saturated' : 'ok',
-    pool: { idle: idleCount, waiting: waitingCount, total: totalCount },
   })
 }

--- a/backend/api/src/healthz.ts
+++ b/backend/api/src/healthz.ts
@@ -1,0 +1,36 @@
+import { RequestHandler } from 'express'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+
+// Liveness: is this process up with a responsive event loop? Used for restart
+// decisions. Deliberately does NOT touch the db or the connection pool — a
+// live-but-saturated instance should be drained, not killed and restarted
+// (restart just throws away warm caches and stampedes the db again).
+export const healthzLive: RequestHandler = (_req, res) => {
+  res.status(200).json({ status: 'ok' })
+}
+
+// How saturated this process's pg pool must be before we ask the LB to stop
+// sending us new traffic: every pooled connection busy AND at least this many
+// requests already queued waiting for one. The small queue allowance avoids
+// flapping on a single in-flight burst.
+const READY_MAX_WAITING = 5
+
+// Readiness: should the load balancer route new requests to this instance right
+// now? We report not-ready purely from local pool state and run NO db query, so
+// a db-wide slowdown can never make the check itself hang. This is per-instance
+// backpressure: a hot instance sheds load onto cooler ones.
+//
+// On the failure mode this is meant to survive — every instance saturating at
+// once during a true db-wide pin — GCP health checking fails open: when all
+// backends in a service are unhealthy it routes to all of them anyway. So the
+// worst case degrades to today's behaviour rather than a full blackout, and the
+// common case (one wedged instance) gets traffic pulled off it automatically.
+export const healthzReady: RequestHandler = (_req, res) => {
+  const pool = createSupabaseDirectClient().$pool
+  const { idleCount, waitingCount, totalCount } = pool
+  const saturated = idleCount === 0 && waitingCount > READY_MAX_WAITING
+  res.status(saturated ? 503 : 200).json({
+    status: saturated ? 'saturated' : 'ok',
+    pool: { idle: idleCount, waiting: waitingCount, total: totalCount },
+  })
+}


### PR DESCRIPTION
- `/healthz/live` indicates that the server is alive and accepting any requests
- `/healthz/ready` indicates that the database connection pool has headroom for more queries, or `503 saturated` otherwise

These are used by the load balancer to determine when a server is ready for connections upon startup and when it needs to be de-prioritized due to high load.