### PR TITLE
feat: Add Redis cache as an L2

### DIFF
--- a/backend/api/deploy-api-windows.sh
+++ b/backend/api/deploy-api-windows.sh
@@ -23,17 +23,19 @@ REGION="us-east4" # Ashburn, Virginia
 ZONE="us-east4-a"
 ENV=${1:-dev}
 
-# Private Memorystore instance
-WEBSOCKET_REDIS_URL=redis://10.215.204.211:6379
-DISABLE_REDIS_WEBSOCKET_BROADCASTS=false
-
 case $ENV in
     dev)
         NEXT_PUBLIC_FIREBASE_ENV=DEV
+        REDIS_URL=
+        DISABLE_REDIS_CACHE=true
         GCLOUD_PROJECT=dev-mantic-markets
         MACHINE_TYPE=e2-small ;;
     prod)
         NEXT_PUBLIC_FIREBASE_ENV=PROD
+        # Private Memorystore instance. Passed at the container level so both
+        # the main API process and PM2 read replicas inherit it.
+        REDIS_URL=redis://10.215.204.211:6379
+        DISABLE_REDIS_CACHE=false
         GCLOUD_PROJECT=mantic-markets
         MACHINE_TYPE=c2-standard-4 ;;
     *)
@@ -104,7 +106,7 @@ gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --container-image ${IMAGE_URL} \
        --machine-type ${MACHINE_TYPE} \
        --boot-disk-size=100GB \
-       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT},WEBSOCKET_REDIS_URL=${WEBSOCKET_REDIS_URL},DISABLE_REDIS_WEBSOCKET_BROADCASTS=${DISABLE_REDIS_WEBSOCKET_BROADCASTS} \
+       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT},REDIS_URL=${REDIS_URL},DISABLE_REDIS_CACHE=${DISABLE_REDIS_CACHE} \
        --no-user-output-enabled \
        --scopes default,cloud-platform \
        --tags lb-health-check

--- a/backend/api/deploy-api.sh
+++ b/backend/api/deploy-api.sh
@@ -19,14 +19,16 @@ ENV=${1:-dev}
 case $ENV in
     dev)
         NEXT_PUBLIC_FIREBASE_ENV=DEV
-        WEBSOCKET_REDIS_URL=
-        DISABLE_REDIS_WEBSOCKET_BROADCASTS=true
+        REDIS_URL=
+        DISABLE_REDIS_CACHE=true
         GCLOUD_PROJECT=dev-mantic-markets
         MACHINE_TYPE=e2-small ;; # previously n2-standard-2
     prod)
         NEXT_PUBLIC_FIREBASE_ENV=PROD
-        WEBSOCKET_REDIS_URL=redis://10.215.204.211:6379
-        DISABLE_REDIS_WEBSOCKET_BROADCASTS=false
+        # Private Memorystore instance. Passed at the container level so both
+        # the main API process and PM2 read replicas inherit it.
+        REDIS_URL=redis://10.215.204.211:6379
+        DISABLE_REDIS_CACHE=false
         GCLOUD_PROJECT=mantic-markets
         MACHINE_TYPE=c2-standard-4 ;;
     *)
@@ -93,7 +95,7 @@ gcloud compute instance-templates create-with-container ${TEMPLATE_NAME} \
        --container-image ${IMAGE_URL} \
        --machine-type ${MACHINE_TYPE} \
        --boot-disk-size=100GB \
-       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT},WEBSOCKET_REDIS_URL=${WEBSOCKET_REDIS_URL},DISABLE_REDIS_WEBSOCKET_BROADCASTS=${DISABLE_REDIS_WEBSOCKET_BROADCASTS} \
+       --container-env NEXT_PUBLIC_FIREBASE_ENV=${NEXT_PUBLIC_FIREBASE_ENV},GOOGLE_CLOUD_PROJECT=${GCLOUD_PROJECT},REDIS_URL=${REDIS_URL},DISABLE_REDIS_CACHE=${DISABLE_REDIS_CACHE} \
        --no-user-output-enabled \
        --scopes default,cloud-platform \
        --tags lb-health-check

--- a/backend/api/deploy-dev-windows.ps1
+++ b/backend/api/deploy-dev-windows.ps1
@@ -7,9 +7,8 @@ $ErrorActionPreference = "Stop"
 Write-Host "=== Starting dev deployment ===" -ForegroundColor Cyan
 Write-Host "Time: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
 
-# Private Memorystore instance
-$WEBSOCKET_REDIS_URL = "redis://10.215.204.211:6379"
-$DISABLE_REDIS_WEBSOCKET_BROADCASTS = "false"
+$REDIS_URL = ""
+$DISABLE_REDIS_CACHE = "true"
 
 # Check Docker is running
 $dockerStatus = docker info 2>&1
@@ -87,7 +86,7 @@ gcloud compute instance-templates create-with-container $TEMPLATE_NAME `
     --container-image=$IMAGE_URL `
     --machine-type=e2-small `
     --boot-disk-size=100GB `
-    --container-env="NEXT_PUBLIC_FIREBASE_ENV=DEV,GOOGLE_CLOUD_PROJECT=dev-mantic-markets,WEBSOCKET_REDIS_URL=$WEBSOCKET_REDIS_URL,DISABLE_REDIS_WEBSOCKET_BROADCASTS=$DISABLE_REDIS_WEBSOCKET_BROADCASTS" `
+    --container-env="NEXT_PUBLIC_FIREBASE_ENV=DEV,GOOGLE_CLOUD_PROJECT=dev-mantic-markets,REDIS_URL=$REDIS_URL,DISABLE_REDIS_CACHE=$DISABLE_REDIS_CACHE" `
     --no-user-output-enabled `
     --scopes="default,cloud-platform" `
     --tags=lb-health-check

--- a/backend/api/src/get-related-markets.ts
+++ b/backend/api/src/get-related-markets.ts
@@ -5,7 +5,8 @@ import {
   createSupabaseDirectClient,
   SupabaseDirectClient,
 } from 'shared/supabase/init'
-import { log } from 'shared/utils'
+import { log, metrics } from 'shared/utils'
+import { cacheGetJson, cacheSetJson } from 'shared/redis/cache'
 
 import { APIHandler } from 'api/helpers/endpoint'
 import { orderBy } from 'lodash'
@@ -16,7 +17,13 @@ type cacheType = {
   marketIdsFromEmbeddings: string[]
   lastUpdated: number
 }
+// L1: per-process, avoids a Redis round-trip on hot contracts. L2 (Redis) is
+// shared across processes and survives redeploys; both store only the related
+// contract ids — the contracts themselves are refetched fresh on every hit.
 const cachedRelatedMarkets = new Map<string, cacheType>()
+const RELATED_MARKETS_CACHE_TTL_S = 6 * 60 * 60
+const relatedMarketsCacheKey = (contractId: string) =>
+  `related-markets:${contractId}`
 
 // We cache the state of the contracts every 10 minutes via the cache header,
 // and the actual contracts to include for an hour via the internal cachedRelatedMarkets.
@@ -29,6 +36,23 @@ export const getRelatedMarkets: APIHandler<'get-related-markets'> = async (
   if (cachedResults && cachedResults.lastUpdated > Date.now() - HOUR_MS) {
     return refreshedRelatedMarkets(contractId, cachedResults, pg)
   }
+
+  // L1 miss/stale: try the shared Redis cache before recomputing the (expensive)
+  // embeddings search + Gemini filter.
+  const cachedIds = await cacheGetJson<string[]>(
+    relatedMarketsCacheKey(contractId)
+  )
+  if (cachedIds && cachedIds.length > 0) {
+    metrics.inc('cache/hits', { cache: 'related-markets' })
+    const entry: cacheType = {
+      marketIdsFromEmbeddings: cachedIds,
+      lastUpdated: Date.now(),
+    }
+    cachedRelatedMarkets.set(contractId, entry)
+    return refreshedRelatedMarkets(contractId, entry, pg)
+  }
+  metrics.inc('cache/misses', { cache: 'related-markets' })
+
   const unfilteredMarketsFromEmbeddings = await pg.map(
     `
       select * from close_contract_embeddings(
@@ -90,10 +114,18 @@ Return a JSON array containing ONLY the IDs of markets to KEEP (those that are d
   }
   marketsFromEmbeddings = marketsFromEmbeddings.slice(0, limit)
 
+  const marketIds = marketsFromEmbeddings.map((c) => c.id)
   cachedRelatedMarkets.set(contractId, {
-    marketIdsFromEmbeddings: marketsFromEmbeddings.map((c) => c.id),
+    marketIdsFromEmbeddings: marketIds,
     lastUpdated: Date.now(),
   })
+  if (marketIds.length > 0) {
+    await cacheSetJson(
+      relatedMarketsCacheKey(contractId),
+      marketIds,
+      RELATED_MARKETS_CACHE_TTL_S
+    )
+  }
 
   return {
     marketsFromEmbeddings: orderBy(

--- a/backend/api/src/get-related-markets.ts
+++ b/backend/api/src/get-related-markets.ts
@@ -22,8 +22,11 @@ type cacheType = {
 // contract ids — the contracts themselves are refetched fresh on every hit.
 const cachedRelatedMarkets = new Map<string, cacheType>()
 const RELATED_MARKETS_CACHE_TTL_S = 6 * 60 * 60
-const relatedMarketsCacheKey = (contractId: string) =>
-  `related-markets:${contractId}`
+const relatedMarketsCacheKey = (contractId: string, limit: number) =>
+  `related-markets:${contractId}:limit:${limit}`
+
+const orderByNonStonks = (c: Contract) =>
+  c.outcomeType !== 'STONK' && !c.question.includes('stock') ? 1 : 0
 
 // We cache the state of the contracts every 10 minutes via the cache header,
 // and the actual contracts to include for an hour via the internal cachedRelatedMarkets.
@@ -32,23 +35,22 @@ export const getRelatedMarkets: APIHandler<'get-related-markets'> = async (
 ) => {
   const { contractId, limit, question, uniqueBettorCount } = body
   const pg = createSupabaseDirectClient()
-  const cachedResults = cachedRelatedMarkets.get(contractId)
+  const cacheKey = relatedMarketsCacheKey(contractId, limit)
+  const cachedResults = cachedRelatedMarkets.get(cacheKey)
   if (cachedResults && cachedResults.lastUpdated > Date.now() - HOUR_MS) {
     return refreshedRelatedMarkets(contractId, cachedResults, pg)
   }
 
   // L1 miss/stale: try the shared Redis cache before recomputing the (expensive)
   // embeddings search + Gemini filter.
-  const cachedIds = await cacheGetJson<string[]>(
-    relatedMarketsCacheKey(contractId)
-  )
-  if (cachedIds && cachedIds.length > 0) {
+  const cachedIds = await cacheGetJson<string[]>(cacheKey)
+  if (cachedIds !== undefined) {
     metrics.inc('cache/hits', { cache: 'related-markets' })
     const entry: cacheType = {
       marketIdsFromEmbeddings: cachedIds,
       lastUpdated: Date.now(),
     }
-    cachedRelatedMarkets.set(contractId, entry)
+    cachedRelatedMarkets.set(cacheKey, entry)
     return refreshedRelatedMarkets(contractId, entry, pg)
   }
   metrics.inc('cache/misses', { cache: 'related-markets' })
@@ -63,9 +65,6 @@ export const getRelatedMarkets: APIHandler<'get-related-markets'> = async (
     [contractId, limit * 2, TOPIC_SIMILARITY_THRESHOLD],
     (row) => row.data as Contract
   )
-
-  const orderByNonStonks = (c: Contract) =>
-    c.outcomeType !== 'STONK' && !c.question.includes('stock') ? 1 : 0
 
   let marketsFromEmbeddings = unfilteredMarketsFromEmbeddings
 
@@ -83,7 +82,7 @@ export const getRelatedMarkets: APIHandler<'get-related-markets'> = async (
 
       const prompt = `
 I have a prediction market with the question: "${question}".
-I also have a list of potentially related markets below. 
+I also have a list of potentially related markets below.
 Please identify which markets are semantically different enough to keep, and which are too similar in meaning and should be filtered out.
 
 For markets that ask essentially the same question with different wording, like "Who will win the 2024 election?" vs "2024 election winner?", filter them out.
@@ -115,17 +114,11 @@ Return a JSON array containing ONLY the IDs of markets to KEEP (those that are d
   marketsFromEmbeddings = marketsFromEmbeddings.slice(0, limit)
 
   const marketIds = marketsFromEmbeddings.map((c) => c.id)
-  cachedRelatedMarkets.set(contractId, {
+  cachedRelatedMarkets.set(cacheKey, {
     marketIdsFromEmbeddings: marketIds,
     lastUpdated: Date.now(),
   })
-  if (marketIds.length > 0) {
-    await cacheSetJson(
-      relatedMarketsCacheKey(contractId),
-      marketIds,
-      RELATED_MARKETS_CACHE_TTL_S
-    )
-  }
+  await cacheSetJson(cacheKey, marketIds, RELATED_MARKETS_CACHE_TTL_S)
 
   return {
     marketsFromEmbeddings: orderBy(
@@ -157,7 +150,16 @@ const refreshedRelatedMarkets = async (
     cachedResults.marketIdsFromEmbeddings,
     pg
   )
+  const contractsById = new Map(refreshedContracts.map((c) => [c.id, c]))
+  const orderedContracts = cachedResults.marketIdsFromEmbeddings
+    .map((id) => contractsById.get(id))
+    .filter((c): c is Contract => c != null)
+
   return {
-    marketsFromEmbeddings: refreshedContracts.map(cleanContractForStaticProps),
+    marketsFromEmbeddings: orderBy(
+      orderedContracts,
+      orderByNonStonks,
+      'desc'
+    ).map(cleanContractForStaticProps),
   }
 }

--- a/backend/shared/src/monitoring/metrics.ts
+++ b/backend/shared/src/monitoring/metrics.ts
@@ -127,6 +127,22 @@ export const CUSTOM_METRICS = {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',
   },
+  // Redis-backed shared cache (shared/redis/cache.ts). hits/misses are labelled
+  // by `cache` (e.g. user-interests, related-markets) so we can watch hit rate
+  // per consumer; redis_errors covers connect/get/set failures (which fall back
+  // to the db, so they degrade latency rather than break requests).
+  'cache/hits': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'cache/misses': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
+  'cache/redis_errors': {
+    metricKind: 'CUMULATIVE',
+    valueKind: 'int64Value',
+  },
 } as const satisfies { [k: string]: MetricDescriptor }
 
 // the typing for all this could be way fancier, but seems overkill

--- a/backend/shared/src/redis/cache.ts
+++ b/backend/shared/src/redis/cache.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'redis'
+import { createClient } from 'redis/dist/index'
 import { log, metrics } from 'shared/utils'
 
 // A small, shared Redis-backed cache for data that is expensive to compute from
@@ -21,6 +21,9 @@ type RedisClient = ReturnType<typeof createClient>
 const KEY_PREFIX = `cache:v1:${process.env.GOOGLE_CLOUD_PROJECT ?? 'local'}:`
 
 const RECONNECT_MAX_DELAY_MS = 30_000
+// Bound the initial connect so request paths fall back instead of waiting on
+// node-redis' reconnect loop while Redis is down.
+const INITIAL_CONNECT_TIMEOUT_MS = 1_000
 // After a failed initial connect, don't try again for this long — otherwise a
 // request storm while Redis is down would create a client per call.
 const CONNECT_COOLDOWN_MS = 10_000
@@ -43,6 +46,23 @@ function cacheEnabled() {
 function errDetails(err: unknown) {
   const e = (err ?? {}) as { name?: unknown; message?: unknown; code?: unknown }
   return { name: e.name, message: e.message, code: e.code }
+}
+
+async function connectWithTimeout(c: RedisClient) {
+  let timeout: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      c.connect(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error('Redis cache initial connect timed out.')),
+          INITIAL_CONNECT_TIMEOUT_MS
+        )
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
 }
 
 // Returns a *ready* client, or undefined if Redis is unavailable. Never throws.
@@ -68,8 +88,7 @@ async function getClient(): Promise<RedisClient | undefined> {
     log.error('Redis cache client error.', errDetails(err))
   })
 
-  connectPromise = c
-    .connect()
+  connectPromise = connectWithTimeout(c)
     .then(() => {
       client = c
       log.info('Redis cache client connected.')

--- a/backend/shared/src/redis/cache.ts
+++ b/backend/shared/src/redis/cache.ts
@@ -1,0 +1,173 @@
+import { createClient } from 'redis'
+import { log, metrics } from 'shared/utils'
+
+// A small, shared Redis-backed cache for data that is expensive to compute from
+// postgres and is otherwise held per-process in memory. The point is to share
+// it across the pm2 processes on a box and, crucially, to survive redeploys:
+// a freshly started process can read a warm value from Redis instead of
+// re-querying the db (which, multiplied across processes on every deploy, is a
+// meaningful db load spike).
+//
+// Every operation degrades gracefully: if Redis is unconfigured, disabled,
+// down, or slow-to-error, the helpers return "miss" and the caller falls back
+// to its existing db path.
+//
+// Redis must never be able to break a request!
+
+type RedisClient = ReturnType<typeof createClient>
+
+// Namespaced by project so dev and prod can't collide if they ever share an
+// instance, and so a key scheme change is a prefix bump rather than a flush.
+const KEY_PREFIX = `cache:v1:${process.env.GOOGLE_CLOUD_PROJECT ?? 'local'}:`
+
+const RECONNECT_MAX_DELAY_MS = 30_000
+// After a failed initial connect, don't try again for this long — otherwise a
+// request storm while Redis is down would create a client per call.
+const CONNECT_COOLDOWN_MS = 10_000
+
+let client: RedisClient | undefined
+let connectPromise: Promise<RedisClient | undefined> | undefined
+let cooldownUntil = 0
+
+function getCacheRedisUrl() {
+  const url = process.env.REDIS_URL
+  return url && url.trim().length > 0 ? url : undefined
+}
+
+function cacheEnabled() {
+  return (
+    process.env.DISABLE_REDIS_CACHE !== 'true' && getCacheRedisUrl() != null
+  )
+}
+
+function errDetails(err: unknown) {
+  const e = (err ?? {}) as { name?: unknown; message?: unknown; code?: unknown }
+  return { name: e.name, message: e.message, code: e.code }
+}
+
+// Returns a *ready* client, or undefined if Redis is unavailable. Never throws.
+// Only ever creates one client: while it's reconnecting (isReady === false) we
+// return undefined so callers fall back rather than spawning a second client.
+async function getClient(): Promise<RedisClient | undefined> {
+  if (!cacheEnabled()) return undefined
+  if (client) return client.isReady ? client : undefined
+  if (connectPromise) return connectPromise
+  if (Date.now() < cooldownUntil) return undefined
+
+  const url = getCacheRedisUrl()!
+  const c = createClient({
+    url,
+    socket: {
+      reconnectStrategy: (retries) =>
+        Math.min(1000 * 2 ** retries, RECONNECT_MAX_DELAY_MS),
+    },
+  })
+  // An 'error' listener is required, else the client throws on connection drops.
+  c.on('error', (err: unknown) => {
+    metrics.inc('cache/redis_errors')
+    log.error('Redis cache client error.', errDetails(err))
+  })
+
+  connectPromise = c
+    .connect()
+    .then(() => {
+      client = c
+      log.info('Redis cache client connected.')
+      return c
+    })
+    .catch((err: unknown) => {
+      cooldownUntil = Date.now() + CONNECT_COOLDOWN_MS
+      log.error(
+        'Redis cache client failed to connect; falling back to db.',
+        errDetails(err)
+      )
+      // Tear down the dead client so the next attempt (after the cooldown)
+      // starts a fresh one rather than leaking sockets/listeners.
+      void c.disconnect().catch(() => {})
+      return undefined
+    })
+    .finally(() => {
+      connectPromise = undefined
+    })
+
+  return connectPromise
+}
+
+export async function cacheGetJson<T>(key: string): Promise<T | undefined> {
+  const c = await getClient()
+  if (!c) return undefined
+  try {
+    const raw = await c.get(KEY_PREFIX + key)
+    return raw == null ? undefined : (JSON.parse(raw) as T)
+  } catch (err) {
+    metrics.inc('cache/redis_errors')
+    log.error('Redis cache get failed.', { key, ...errDetails(err) })
+    return undefined
+  }
+}
+
+// Batch get. Returns results positionally aligned with `keys`; misses (and any
+// Redis failure) come back as undefined for that slot.
+export async function cacheMGetJson<T>(
+  keys: string[]
+): Promise<(T | undefined)[]> {
+  if (keys.length === 0) return []
+  const c = await getClient()
+  if (!c) return keys.map(() => undefined)
+  try {
+    const raws = await c.mGet(keys.map((k) => KEY_PREFIX + k))
+    return raws.map((raw) => {
+      if (raw == null) return undefined
+      try {
+        return JSON.parse(raw) as T
+      } catch {
+        return undefined
+      }
+    })
+  } catch (err) {
+    metrics.inc('cache/redis_errors')
+    log.error('Redis cache mget failed.', {
+      count: keys.length,
+      ...errDetails(err),
+    })
+    return keys.map(() => undefined)
+  }
+}
+
+export async function cacheSetJson(
+  key: string,
+  value: unknown,
+  ttlSeconds: number
+): Promise<void> {
+  const c = await getClient()
+  if (!c) return
+  try {
+    await c.set(KEY_PREFIX + key, JSON.stringify(value), { EX: ttlSeconds })
+  } catch (err) {
+    metrics.inc('cache/redis_errors')
+    log.error('Redis cache set failed.', { key, ...errDetails(err) })
+  }
+}
+
+// Batch set, each entry with the same TTL. Best-effort and non-throwing.
+export async function cacheSetManyJson(
+  entries: { key: string; value: unknown }[],
+  ttlSeconds: number
+): Promise<void> {
+  if (entries.length === 0) return
+  const c = await getClient()
+  if (!c) return
+  try {
+    const multi = c.multi()
+    for (const { key, value } of entries) {
+      multi.set(KEY_PREFIX + key, JSON.stringify(value), { EX: ttlSeconds })
+    }
+    await multi.exec()
+  } catch (err) {
+    metrics.inc('cache/redis_errors')
+    log.error('Redis cache mset failed.', {
+      count: entries.length,
+      ...errDetails(err),
+    })
+  }
+}

--- a/backend/shared/src/redis/cache.ts
+++ b/backend/shared/src/redis/cache.ts
@@ -31,6 +31,7 @@ const CONNECT_COOLDOWN_MS = 10_000
 let client: RedisClient | undefined
 let connectPromise: Promise<RedisClient | undefined> | undefined
 let cooldownUntil = 0
+let loggedDisabled = false
 
 function getCacheRedisUrl() {
   const url = process.env.REDIS_URL
@@ -43,9 +44,67 @@ function cacheEnabled() {
   )
 }
 
+function getRedisUrlForLogging() {
+  const url = getCacheRedisUrl()
+  if (url == null) return undefined
+
+  try {
+    const parsed = new URL(url)
+    const auth = parsed.username || parsed.password ? '<redacted>@' : ''
+    return `${parsed.protocol}//${auth}${parsed.hostname}:${
+      parsed.port || '6379'
+    }`
+  } catch {
+    return '<invalid redis url>'
+  }
+}
+
+function getRedisLogContext() {
+  return {
+    component: 'cache',
+    enabled: cacheEnabled(),
+    url: getRedisUrlForLogging(),
+    project: process.env.GOOGLE_CLOUD_PROJECT,
+    firebaseEnv: process.env.NEXT_PUBLIC_FIREBASE_ENV,
+    disabled: process.env.DISABLE_REDIS_CACHE,
+    keyPrefix: KEY_PREFIX,
+  }
+}
+
+function logDisabledOnce() {
+  if (loggedDisabled) return
+  loggedDisabled = true
+  const message =
+    getCacheRedisUrl() == null
+      ? 'Redis cache disabled: REDIS_URL is not set.'
+      : 'Redis cache disabled by DISABLE_REDIS_CACHE.'
+  log.info(message, getRedisLogContext())
+}
+
 function errDetails(err: unknown) {
-  const e = (err ?? {}) as { name?: unknown; message?: unknown; code?: unknown }
-  return { name: e.name, message: e.message, code: e.code }
+  if (err == null || typeof err !== 'object') return { error: err }
+  const e = err as {
+    name?: unknown
+    message?: unknown
+    code?: unknown
+    errno?: unknown
+    syscall?: unknown
+    address?: unknown
+    port?: unknown
+    command?: unknown
+    cause?: unknown
+  }
+  return {
+    name: e.name,
+    message: e.message,
+    code: e.code,
+    errno: e.errno,
+    syscall: e.syscall,
+    address: e.address,
+    port: e.port,
+    command: e.command,
+    cause: e.cause,
+  }
 }
 
 async function connectWithTimeout(c: RedisClient) {
@@ -69,12 +128,16 @@ async function connectWithTimeout(c: RedisClient) {
 // Only ever creates one client: while it's reconnecting (isReady === false) we
 // return undefined so callers fall back rather than spawning a second client.
 async function getClient(): Promise<RedisClient | undefined> {
-  if (!cacheEnabled()) return undefined
+  if (!cacheEnabled()) {
+    logDisabledOnce()
+    return undefined
+  }
   if (client) return client.isReady ? client : undefined
   if (connectPromise) return connectPromise
   if (Date.now() < cooldownUntil) return undefined
 
   const url = getCacheRedisUrl()!
+  log.info('Starting Redis cache client connection.', getRedisLogContext())
   const c = createClient({
     url,
     socket: {
@@ -85,21 +148,28 @@ async function getClient(): Promise<RedisClient | undefined> {
   // An 'error' listener is required, else the client throws on connection drops.
   c.on('error', (err: unknown) => {
     metrics.inc('cache/redis_errors')
-    log.error('Redis cache client error.', errDetails(err))
+    log.error('Redis cache client error.', {
+      ...errDetails(err),
+      ...getRedisLogContext(),
+    })
+  })
+  c.on('reconnecting', () => {
+    log.warn('Redis cache client reconnecting.', getRedisLogContext())
   })
 
   connectPromise = connectWithTimeout(c)
     .then(() => {
       client = c
-      log.info('Redis cache client connected.')
+      log.info('Redis cache client connected.', getRedisLogContext())
       return c
     })
     .catch((err: unknown) => {
       cooldownUntil = Date.now() + CONNECT_COOLDOWN_MS
-      log.error(
-        'Redis cache client failed to connect; falling back to db.',
-        errDetails(err)
-      )
+      log.error('Redis cache client failed to connect; falling back to db.', {
+        ...errDetails(err),
+        cooldownMs: CONNECT_COOLDOWN_MS,
+        ...getRedisLogContext(),
+      })
       // Tear down the dead client so the next attempt (after the cooldown)
       // starts a fresh one rather than leaking sockets/listeners.
       void c.disconnect().catch(() => {})
@@ -120,7 +190,11 @@ export async function cacheGetJson<T>(key: string): Promise<T | undefined> {
     return raw == null ? undefined : (JSON.parse(raw) as T)
   } catch (err) {
     metrics.inc('cache/redis_errors')
-    log.error('Redis cache get failed.', { key, ...errDetails(err) })
+    log.error('Redis cache get failed.', {
+      key,
+      ...errDetails(err),
+      ...getRedisLogContext(),
+    })
     return undefined
   }
 }
@@ -148,6 +222,7 @@ export async function cacheMGetJson<T>(
     log.error('Redis cache mget failed.', {
       count: keys.length,
       ...errDetails(err),
+      ...getRedisLogContext(),
     })
     return keys.map(() => undefined)
   }
@@ -164,7 +239,12 @@ export async function cacheSetJson(
     await c.set(KEY_PREFIX + key, JSON.stringify(value), { EX: ttlSeconds })
   } catch (err) {
     metrics.inc('cache/redis_errors')
-    log.error('Redis cache set failed.', { key, ...errDetails(err) })
+    log.error('Redis cache set failed.', {
+      key,
+      ttlSeconds,
+      ...errDetails(err),
+      ...getRedisLogContext(),
+    })
   }
 }
 
@@ -186,7 +266,9 @@ export async function cacheSetManyJson(
     metrics.inc('cache/redis_errors')
     log.error('Redis cache mset failed.', {
       count: entries.length,
+      ttlSeconds,
       ...errDetails(err),
+      ...getRedisLogContext(),
     })
   }
 }

--- a/backend/shared/src/topic-interests.ts
+++ b/backend/shared/src/topic-interests.ts
@@ -1,4 +1,6 @@
 import { log } from 'shared/monitoring/log'
+import { metrics } from 'shared/monitoring/metrics'
+import { cacheMGetJson, cacheSetManyJson } from 'shared/redis/cache'
 import {
   createSupabaseDirectClient,
   SupabaseDirectClient,
@@ -29,28 +31,59 @@ export const userIdsToAverageTopicConversionScores: {
 export const activeTopics: { [topicId: string]: number } = {}
 let lastRefreshTime = 0
 
+// How long a user's topic-interest scores live in Redis. They change slowly, so
+// a long ttl maximises the chance a redeploy finds a warm value; the worst case
+// is slightly-stale feed ranking, which is low-risk.
+const USER_INTERESTS_CACHE_TTL_S = 6 * 60 * 60
+const userInterestsCacheKey = (userId: string) => `user-interests:${userId}`
+
 export const buildUserInterestsCache = async (userIds: string[]) => {
   log('Starting user topic interests cache build process')
   const pg = createSupabaseDirectClient()
-  if (
-    userIds.every(
-      (uid) =>
-        Object.keys(userIdsToAverageTopicConversionScores[uid] ?? {}).length > 0
-    )
-  ) {
-    return
-  }
 
-  log('building cache for users: ', userIds.length)
+  // Already warm in this process's memory (L1) — nothing to do for those.
+  const missingUserIds = userIds.filter(
+    (uid) =>
+      !Object.keys(userIdsToAverageTopicConversionScores[uid] ?? {}).length
+  )
+  if (missingUserIds.length === 0) return
+
+  // Keep activeTopics warm whenever there are users to (re)hydrate — even if
+  // Redis ends up serving all of them below. Several feed endpoints read
+  // activeTopics directly, and it used to be populated only as a side effect of
+  // the db build path; without this a fully cache-warm process would never load
+  // it. (refreshActiveTopics self-gates to ~hourly via lastRefreshTime.)
   if (Object.keys(activeTopics).length === 0) await refreshActiveTopics(pg)
-  const topicIdsMeetingMinimumBar = Object.keys(activeTopics)
   // Refresh the cache, and use the old one in the meantime
   if (lastRefreshTime < Date.now() - HOUR_MS) refreshActiveTopics(pg)
+  const topicIdsMeetingMinimumBar = Object.keys(activeTopics)
 
-  const chunks = chunk(userIds, 25)
-  for (const userIds of chunks) {
+  // L2: try the shared Redis cache before touching the db. On a redeploy this
+  // lets a freshly started process repopulate from a sibling/previous process's
+  // work instead of re-running the per-user topic-interest queries (the burst
+  // that 4 processes x every deploy would otherwise put on the db).
+  const cached = await cacheMGetJson<TopicToInterestWeights>(
+    missingUserIds.map(userInterestsCacheKey)
+  )
+  const userIdsToBuild: string[] = []
+  missingUserIds.forEach((userId, i) => {
+    const scores = cached[i]
+    if (scores && Object.keys(scores).length > 0) {
+      userIdsToAverageTopicConversionScores[userId] = scores
+      metrics.inc('cache/hits', { cache: 'user-interests' })
+    } else {
+      userIdsToBuild.push(userId)
+      metrics.inc('cache/misses', { cache: 'user-interests' })
+    }
+  })
+  if (userIdsToBuild.length === 0) return
+
+  log('building cache for users: ', userIdsToBuild.length)
+
+  const chunks = chunk(userIdsToBuild, 25)
+  for (const chunkUserIds of chunks) {
     await Promise.all(
-      userIds.map(async (userId) => {
+      chunkUserIds.map(async (userId) => {
         const results = await pg.multi(
           `
         select group_id from group_members where member_id = $1;
@@ -102,6 +135,17 @@ export const buildUserInterestsCache = async (userIds: string[]) => {
           userIdsToAverageTopicConversionScores[userId][groupId] = 0
         }
       })
+    )
+
+    // Write this chunk back to the shared cache so siblings and post-redeploy
+    // processes can skip the db. Done per-chunk so partial progress is cached
+    // even if a later chunk fails. Best-effort: never blocks on Redis errors.
+    await cacheSetManyJson(
+      chunkUserIds.map((userId) => ({
+        key: userInterestsCacheKey(userId),
+        value: userIdsToAverageTopicConversionScores[userId],
+      })),
+      USER_INTERESTS_CACHE_TTL_S
     )
 
     log(

--- a/backend/shared/src/topic-interests.ts
+++ b/backend/shared/src/topic-interests.ts
@@ -34,6 +34,7 @@ let lastRefreshTime = 0
 // How long a user's topic-interest scores live in Redis. They change slowly, so
 // a long ttl maximises the chance a redeploy finds a warm value; the worst case
 // is slightly-stale feed ranking, which is low-risk.
+// WP: We may consider invalidating this when a user blocks/follows a topic.
 const USER_INTERESTS_CACHE_TTL_S = 6 * 60 * 60
 const userInterestsCacheKey = (userId: string) => `user-interests:${userId}`
 

--- a/backend/shared/src/topic-interests.ts
+++ b/backend/shared/src/topic-interests.ts
@@ -43,8 +43,7 @@ export const buildUserInterestsCache = async (userIds: string[]) => {
 
   // Already warm in this process's memory (L1) — nothing to do for those.
   const missingUserIds = userIds.filter(
-    (uid) =>
-      !Object.keys(userIdsToAverageTopicConversionScores[uid] ?? {}).length
+    (uid) => userIdsToAverageTopicConversionScores[uid] == null
   )
   if (missingUserIds.length === 0) return
 
@@ -68,7 +67,7 @@ export const buildUserInterestsCache = async (userIds: string[]) => {
   const userIdsToBuild: string[] = []
   missingUserIds.forEach((userId, i) => {
     const scores = cached[i]
-    if (scores && Object.keys(scores).length > 0) {
+    if (scores !== undefined) {
       userIdsToAverageTopicConversionScores[userId] = scores
       metrics.inc('cache/hits', { cache: 'user-interests' })
     } else {

--- a/backend/shared/src/websockets/server.ts
+++ b/backend/shared/src/websockets/server.ts
@@ -175,6 +175,7 @@ function getRedisErrorDetails(err: unknown) {
 
 function getRedisLogContext() {
   return {
+    component: 'websocket-broadcast',
     enabled: redisBroadcastsEnabled(),
     url: getRedisUrlForLogging(),
     channel: getRedisBroadcastChannel(),
@@ -289,7 +290,7 @@ async function getRedisPublisher() {
     metrics.inc('ws/redis_publisher_errors')
   })
   redisPublisher.on('reconnecting', () => {
-    log.warn('Redis websocket publisher reconnecting.')
+    log.warn('Redis websocket publisher reconnecting.', getRedisLogContext())
   })
 
   redisPublisherConnect = redisPublisher
@@ -330,7 +331,10 @@ function handleRedisBroadcast(message: string) {
     if (originInstanceId === WEBSOCKET_INSTANCE_ID) return
     sendToLocalSubscribersMulti(topics, data)
   } catch (err: unknown) {
-    log.error('Error handling Redis websocket broadcast.', { error: err })
+    log.error('Error handling Redis websocket broadcast.', {
+      ...getRedisErrorDetails(err),
+      ...getRedisLogContext(),
+    })
     metrics.inc('ws/redis_broadcast_parse_errors')
   }
 }
@@ -355,7 +359,10 @@ function scheduleRedisSubscriberRetry() {
     redisSubscriberRetryDelayMs * 2,
     REDIS_SUBSCRIBER_MAX_RETRY_DELAY_MS
   )
-  log.warn(`Retrying Redis websocket subscriber in ${delayMs}ms.`)
+  log.warn('Retrying Redis websocket subscriber.', {
+    delayMs,
+    ...getRedisLogContext(),
+  })
   redisSubscriberRetryTimeout = setTimeout(() => {
     redisSubscriberRetryTimeout = undefined
     startRedisBroadcastSubscriber()
@@ -389,7 +396,7 @@ function startRedisBroadcastSubscriber() {
     metrics.inc('ws/redis_subscriber_errors')
   })
   subscriber.on('reconnecting', () => {
-    log.warn('Redis websocket subscriber reconnecting.')
+    log.warn('Redis websocket subscriber reconnecting.', getRedisLogContext())
   })
 
   redisSubscriberConnect = subscriber
@@ -398,7 +405,7 @@ function startRedisBroadcastSubscriber() {
     .then(() => {
       resetRedisSubscriberRetryDelay()
       log.info('Redis websocket subscriber connected.', getRedisLogContext())
-      log.info(`Redis websocket subscriber listening on ${channel}.`)
+      log.info('Redis websocket subscriber listening.', getRedisLogContext())
     })
     .catch((err: unknown) => {
       if (redisSubscriber === subscriber) redisSubscriber = undefined
@@ -419,6 +426,7 @@ function startRedisBroadcastSubscriber() {
 }
 
 function stopRedisBroadcastSubscriber() {
+  log.info('Stopping Redis websocket subscriber.', getRedisLogContext())
   redisSubscriberShouldRun = false
   clearRedisSubscriberRetry()
   resetRedisSubscriberRetryDelay()

--- a/backend/shared/src/websockets/server.ts
+++ b/backend/shared/src/websockets/server.ts
@@ -128,7 +128,7 @@ function processMessage(ws: WebSocket, data: RawData): ServerMessage<'ack'> {
 }
 
 function getRedisUrl() {
-  const url = process.env.WEBSOCKET_REDIS_URL ?? process.env.REDIS_URL
+  const url = process.env.REDIS_URL
   return url && url.trim().length > 0 ? url : undefined
 }
 
@@ -181,17 +181,11 @@ function getRedisLogContext() {
     env: getRedisBroadcastEnvironment(),
     project: process.env.GOOGLE_CLOUD_PROJECT,
     firebaseEnv: process.env.NEXT_PUBLIC_FIREBASE_ENV,
-    disabled: process.env.DISABLE_REDIS_WEBSOCKET_BROADCASTS,
     instanceId: WEBSOCKET_INSTANCE_ID,
   }
 }
 
 function getRedisBroadcastEnvironment() {
-  const explicitEnv = process.env.WEBSOCKET_REDIS_ENV
-  if (explicitEnv != null && explicitEnv.trim().length > 0) {
-    return explicitEnv.trim().toLowerCase()
-  }
-
   const firebaseEnv = process.env.NEXT_PUBLIC_FIREBASE_ENV
   if (firebaseEnv != null && firebaseEnv.trim().length > 0) {
     return firebaseEnv.trim().toLowerCase()
@@ -201,19 +195,11 @@ function getRedisBroadcastEnvironment() {
 }
 
 function getRedisBroadcastChannel() {
-  const explicitChannel = process.env.WEBSOCKET_REDIS_CHANNEL
-  if (explicitChannel != null && explicitChannel.trim().length > 0) {
-    return explicitChannel.trim()
-  }
-
   return `${DEFAULT_REDIS_BROADCAST_CHANNEL_PREFIX}-${getRedisBroadcastEnvironment()}`
 }
 
 function redisBroadcastsEnabled() {
-  return (
-    getRedisUrl() != null &&
-    process.env.DISABLE_REDIS_WEBSOCKET_BROADCASTS !== 'true'
-  )
+  return getRedisUrl() != null
 }
 
 function recordBroadcastMetrics(topics: string[]) {


### PR DESCRIPTION
Each API server holds some cache in memory, namely the related markets and user interests. Now that there are two of them, this is getting out of hand. The user interests cache is especially bad because it gets rebuilt on each server startup, and as we add more instances this will spike DB load every redeploy. We already have Redis set up for websocket re-broadcasts so this just uses the existing infrastructure to cache data for all instances to share. Now when a new instance is spun up it'll pull user interests from the warn Redis cache instead of from the database. If Redis is dead or unconfigured, it falls back to the existing local-only cache. 

There are some risks here since we're potentially caching data for longer, some stale entries could last up to 6 hours. In the future we should invalidate items when markets close, when users follow or block topics, etc.