### PR TITLE
log: Downgrade simple validation errors to warnings

### DIFF
--- a/backend/api/src/helpers/endpoint.ts
+++ b/backend/api/src/helpers/endpoint.ts
@@ -94,7 +94,10 @@ export const lookupUser = async (creds: Credentials): Promise<AuthedUser> => {
       const key = creds.data
       const privateUser = await getUnbannedPrivateUserByKey(key)
       if (!privateUser) {
-        throw new APIError(401, 'No private user exists with the provided API key.')
+        throw new APIError(
+          401,
+          'No private user exists with the provided API key.'
+        )
       }
       return { uid: privateUser.id, creds: { privateUser, ...creds } }
     }
@@ -113,7 +116,11 @@ export const validate = <T extends z.ZodTypeAny>(schema: T, val: unknown) => {
       }
     })
     if (issues.length > 0) {
-      log.error(issues.map((i) => `${i.field}: ${i.error}`).join('\n'))
+      log.warn(
+        `Validation issues: ${issues
+          .map((i) => `${i.field}: ${i.error}`)
+          .join(', ')}`
+      )
     }
     throw new APIError(400, 'Error validating request.', issues)
   } else {


### PR DESCRIPTION
We get a *lot* of errors in the logs from simple validation isues, mostly from old MCP servers that hallucinated options that we never supported. I tried to fix this by clarifying options on our own instance in #3875 but it did not have much effect, probably since most requests go through servers we don't control. This PR just downgrades the log level from error to warning so we can actually instrument the error lines without having to filter out a flood of these silly ones. 

Eventually I'd like to check request origin so we can tell when our own frontend is producing these errors, but that's for another day.