### PR TITLE
Drop resolved Manifold Sports markets from the default feed after 15 min

### DIFF
--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -369,6 +369,14 @@ function getSearchContractWhereSQL(args: {
   const loveFilter = hideLove
     ? `group_slugs is null or not group_slugs && $1`
     : ''
+  // Drop Manifold Sports markets (identified by sportsEventId) from the default
+  // browse/home feed once they've been resolved for more than 15 minutes — they
+  // otherwise linger in the feed long after the match is decided. Gated on
+  // hideStonks, which marks the default feed (score sort, no search term, no
+  // topic), so explicit searches and the sports dashboard still surface them.
+  const resolvedSportsFilter = hideStonks
+    ? `contracts.data->>'sportsEventId' is null or resolution_time is null or resolution_time > now() - interval '15 minutes'`
+    : ''
   const sortFilter =
     sort === 'close-date'
       ? 'close_time > NOW()'
@@ -412,6 +420,7 @@ function getSearchContractWhereSQL(args: {
   return [
     where(filterSQL[filter]),
     where(stonkFilter),
+    where(resolvedSportsFilter),
     where(loveFilter, [[PROD_MANIFOLD_LOVE_GROUP_SLUG]]),
     where(sortFilter),
     where(contractTypeFilter),


### PR DESCRIPTION
World Cup / Manifold Sports per-match markets keep surfacing in the home and browse feed long after they resolve, cluttering it. Add a feed-level filter (mirroring the existing hideStonks/loveFilter pattern) that, on the default feed only (score sort, no search term, no topic), excludes markets with a sportsEventId that resolved more than 15 minutes ago.

Explicit searches, topic/group browsing, and the sports dashboard still surface them, so past results remain discoverable. Gated on hideStonks so it never affects term searches. Validated against prod: hides 24 resolved WC match markets, keeps the 42 open ones.