### PR TITLE
fix: Lock the contract row FOR UPDATE on bet and sell

### DIFF
--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -47,21 +47,20 @@ import { getInsertQuery } from 'shared/supabase/utils'
 import { txnToRow } from 'shared/txn/run-txn'
 import { contractColumnsToSelect } from 'shared/utils'
 
-export const fetchContractBetDataAndValidate = async (
-  pgTrans: SupabaseTransaction | SupabaseDirectClient,
-  body: {
-    contractId: string
-    amount: number | undefined
-    answerId?: string
-    answerIds?: string[]
-    outcome: 'YES' | 'NO'
-  },
-  uid: string,
-  isApi: boolean,
-  isAdminTrade: boolean = false
-) => {
-  const startTime = Date.now()
-  const { amount, contractId, outcome } = body
+type BetDataBody = {
+  contractId: string
+  amount?: number | undefined
+  answerId?: string
+  answerIds?: string[]
+  outcome: 'YES' | 'NO'
+}
+
+// Shared SQL fragments for selecting a contract's open limit orders. These are
+// reused by both fetchContractBetDataAndValidate (pre-transaction read) and
+// lockContractAndGetBetData (in-transaction locked re-read) so the two paths
+// can't drift. The fragments assume the query is formatted with
+// [uid, contractId, answerIds, outcome] bound to $1..$4.
+const getLimitOrderQueryFragments = (body: BetDataBody) => {
   const answerIds =
     'answerIds' in body
       ? body.answerIds
@@ -87,6 +86,26 @@ export const fetchContractBetDataAndValidate = async (
       (not ${isSumsToOne} and ($3 is null or b.answer_id in ($3:list)) and b.outcome != $4)
     )
   `
+  return { answerIds, isSumsToOne, whereLimitOrderBets }
+}
+
+export const fetchContractBetDataAndValidate = async (
+  pgTrans: SupabaseTransaction | SupabaseDirectClient,
+  body: {
+    contractId: string
+    amount: number | undefined
+    answerId?: string
+    answerIds?: string[]
+    outcome: 'YES' | 'NO'
+  },
+  uid: string,
+  isApi: boolean,
+  isAdminTrade: boolean = false
+) => {
+  const startTime = Date.now()
+  const { amount, contractId, outcome } = body
+  const { answerIds, isSumsToOne, whereLimitOrderBets } =
+    getLimitOrderQueryFragments(body)
   const queries = pgp.as.format(
     `
     select * from users where id = $1;
@@ -133,7 +152,13 @@ export const fetchContractBetDataAndValidate = async (
         and enabled = true
         and (expires_time is null or expires_time > now());
   `,
-    [uid, contractId, answerIds ?? null, outcome, [...SUPPORTER_ENTITLEMENT_IDS]]
+    [
+      uid,
+      contractId,
+      answerIds ?? null,
+      outcome,
+      [...SUPPORTER_ENTITLEMENT_IDS],
+    ]
   )
   const results = await pgTrans.multi(queries)
   const user = convertUser(results[0][0])
@@ -258,6 +283,65 @@ export const fetchContractBetDataAndValidate = async (
     balanceByUserId,
     unfilledBetUserIds,
     contractMetrics,
+  }
+}
+
+// Lock the contract row FOR UPDATE and re-read its fresh pool/answers/open limit
+// orders, inside the transaction. fetchContractBetDataAndValidate runs *before*
+// the transaction (to keep the heavy validation/metric reads out of it), so the
+// pool it read can be stale by the time we write, and the in-process betsQueue
+// only serializes bets within a single API replica. Without this, two bets on the
+// same contract on different replicas could each compute against the same pool and
+// blind-write conflicting absolute values (a lost update).
+//
+// Because this read is inside the transaction callback it reruns on every
+// runTransactionWithRetries attempt, so each retry recomputes against current
+// state; the FOR UPDATE serializes same-contract bets/sells across replicas,
+// surfacing a concurrent write as a 40001 retry instead of a silent race.
+export const lockContractAndGetBetData = async (
+  pgTrans: SupabaseTransaction,
+  body: BetDataBody,
+  uid: string
+) => {
+  const { contractId, outcome } = body
+  const { answerIds, isSumsToOne, whereLimitOrderBets } =
+    getLimitOrderQueryFragments(body)
+  const queries = pgp.as.format(
+    `
+    select ${contractColumnsToSelect} from contracts where id = $2 for update;
+    select * from answers
+      where contract_id = $2 and (
+        $3 is null or id in ($3:list) or ${isSumsToOne}
+      ) order by index;
+    select b.*, u.balance from contract_bets b join users u on b.user_id = u.id
+      where ${whereLimitOrderBets};
+  `,
+    [uid, contractId, answerIds ?? null, outcome]
+  )
+  const results = await pgTrans.multi(queries)
+  const contract = convertContract(results[0][0]) as MarketContract
+  const answers = results[1].map(convertAnswer)
+  if (contract.mechanism === 'cpmm-multi-1')
+    contract.answers = sortBy(
+      uniqBy([...answers, ...contract.answers], 'id'),
+      'index'
+    )
+  const unfilledBets = results[2].map(convertBet) as (LimitBet & {
+    balance: number
+  })[]
+  const balanceByUserId = Object.fromEntries(
+    uniqBy(unfilledBets, (b) => b.userId).map((bet) => [
+      bet.userId,
+      bet.balance,
+    ])
+  )
+  const unfilledBetUserIds = Object.keys(balanceByUserId)
+  return {
+    contract,
+    answers,
+    unfilledBets,
+    balanceByUserId,
+    unfilledBetUserIds,
   }
 }
 

--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -4,6 +4,7 @@ import {
   getRoundedLimitProb,
   getUniqueBettorBonusQuery,
   getUserBalancesAndMetrics,
+  lockContractAndGetBetData,
   updateMakers,
 } from 'api/helpers/bets'
 import { onCreateBets } from 'api/on-create-bet'
@@ -127,20 +128,13 @@ export const placeBetMain = async (
   const startTime = Date.now()
   const { contractId, replyToCommentId, deterministic, answerId, silent } = body
   // Fetch data outside transaction first to avoid locking all limit orderers
-  const {
-    user,
-    contract,
-    creator,
-    answers,
-    unfilledBets,
-    balanceByUserId,
-    unfilledBetUserIds,
-  } = await fetchContractBetDataAndValidate(
-    createSupabaseDirectClient(),
-    body,
-    uid,
-    isApi
-  )
+  const { user, contract, creator, answers, unfilledBets, balanceByUserId } =
+    await fetchContractBetDataAndValidate(
+      createSupabaseDirectClient(),
+      body,
+      uid,
+      isApi
+    )
   // Simulate bet to see whose limit orders you match.
   const simulatedResult = calculateBetResult(
     body,
@@ -153,19 +147,28 @@ export const placeBetMain = async (
 
   const result = await runTransactionWithRetries(async (pgTrans) => {
     log(`Inside main transaction for ${uid} placing a bet on ${contractId}.`)
+    // Re-read pool/answers/open limit orders under a FOR UPDATE lock on the
+    // contract row, so each retry recomputes against current state rather than the
+    // possibly-stale pre-transaction read.
+    const {
+      contract: lockedContract,
+      answers: lockedAnswers,
+      unfilledBets: lockedUnfilledBets,
+      unfilledBetUserIds: lockedUnfilledBetUserIds,
+    } = await lockContractAndGetBetData(pgTrans, body, uid)
     // Refetch just user balance and metrics in transaction, since queue only enforces contract and bets not changing.
     const { balanceByUserId, contractMetrics } =
       await getUserBalancesAndMetrics(
         pgTrans,
         [uid, ...simulatedMakerIds], // Fetch just the makers that matched in the simulation.
-        contract,
+        lockedContract,
         answerId
       )
     user.balance = balanceByUserId[uid]
     if (user.balance < body.amount)
       throw new APIError(403, 'Insufficient balance.')
 
-    for (const userId of unfilledBetUserIds) {
+    for (const userId of lockedUnfilledBetUserIds) {
       if (!(userId in balanceByUserId)) {
         // Assume other makers have infinite balance since they are not involved in this bet.
         balanceByUserId[userId] = Number.MAX_SAFE_INTEGER
@@ -173,9 +176,9 @@ export const placeBetMain = async (
     }
     const newBetResult = calculateBetResult(
       body,
-      contract,
-      answers,
-      unfilledBets,
+      lockedContract,
+      lockedAnswers,
+      lockedUnfilledBets,
       balanceByUserId
     )
     log(`Calculated new bet information for ${user.username} - auth ${uid}.`)
@@ -196,14 +199,15 @@ export const placeBetMain = async (
     }
 
     const betGroupId =
-      contract.mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne
+      lockedContract.mechanism === 'cpmm-multi-1' &&
+      lockedContract.shouldAnswersSumToOne
         ? getNewBetId()
         : undefined
 
     return await executeNewBetResult(
       pgTrans,
       newBetResult,
-      contract,
+      lockedContract,
       user,
       creator,
       isApi,

--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -2,6 +2,7 @@ import {
   fetchContractBetDataAndValidate,
   getMakerIdsFromBetResult,
   getUserBalancesAndMetrics,
+  lockContractAndGetBetData,
 } from 'api/helpers/bets'
 import { onCreateBets } from 'api/on-create-bet'
 import { Answer } from 'common/answer'
@@ -152,7 +153,6 @@ const sellSharesMain: APIHandler<'market/:contractId/sell'> = async (
     balanceByUserId,
     unfilledBets,
     contractMetrics,
-    unfilledBetUserIds,
   } = await fetchContractBetDataAndValidate(
     pg,
     { ...props, amount: undefined, outcome: oppositeOutcome },
@@ -176,16 +176,29 @@ const sellSharesMain: APIHandler<'market/:contractId/sell'> = async (
     log(
       `Inside main transaction for user ${uid} selling ${shares} shares on contract id ${contractId}.`
     )
+    // Re-read pool/answers/open limit orders under a FOR UPDATE lock on the
+    // contract row, so each retry recomputes against current state rather than the
+    // possibly-stale pre-transaction read.
+    const {
+      contract: lockedContract,
+      answers: lockedAnswers,
+      unfilledBets: lockedUnfilledBets,
+      unfilledBetUserIds: lockedUnfilledBetUserIds,
+    } = await lockContractAndGetBetData(
+      pgTrans,
+      { ...props, outcome: oppositeOutcome },
+      uid
+    )
     const { balanceByUserId, contractMetrics } =
       await getUserBalancesAndMetrics(
         pgTrans,
         [uid, ...simulatedMakerIds], // Fetch just the makers that matched in the simulation.
-        contract,
+        lockedContract,
         answerId
       )
     user.balance = balanceByUserId[uid]
 
-    for (const userId of unfilledBetUserIds) {
+    for (const userId of lockedUnfilledBetUserIds) {
       if (!(userId in balanceByUserId)) {
         // Assume other makers have infinite balance since they are not involved in this bet.
         balanceByUserId[userId] = Number.MAX_SAFE_INTEGER
@@ -200,9 +213,9 @@ const sellSharesMain: APIHandler<'market/:contractId/sell'> = async (
     const marginLoanBefore = userMetric.marginLoan ?? 0
 
     const newBetResult = calculateSellResult(
-      contract,
-      answers,
-      unfilledBets,
+      lockedContract,
+      lockedAnswers,
+      lockedUnfilledBets,
       balanceByUserId,
       answerId,
       outcome,
@@ -225,7 +238,7 @@ const sellSharesMain: APIHandler<'market/:contractId/sell'> = async (
     const betResult = await executeNewBetResult(
       pgTrans,
       newBetResult,
-      contract,
+      lockedContract,
       user,
       undefined, // creator - not needed for sells (no unique bettor bonus)
       isApi,


### PR DESCRIPTION
With a single API instance we maintain a bet queue in memory and process them in order, but with multiple replicas there is a possible race condition. We have some guards with database-level locking but previously there was not one for betting or selling shares. This PR adds a database-level FOR UPDATE lock on the contract row inside the transaction so that all bets on a contract are effectively serialize, even when coming from different API replicas. 

This effectively restores the previous queuing behavior that was present with a single API instance. There's not much risk of a cascade stall, since bets stall out of the queue in 10 seconds. The bets that would have triggered this bug will now wait their turn, slightly increasing latency, or possibly return 503 in some cases.

This was [tested on dev](https://dev.manifold.markets/devsabipesto/mana-raisin) before and after deployment. With 10 bets submitted simultaneously about 30-40% of them triggered this bug prior to the fix, after the fix I ran about 600 bets in the same pattern and didn't see the bug trigger once.