### PR TITLE
fix: Add FREE_MARKET_USER_ID exception to frontend

### DIFF
--- a/web/components/new-contract/contextual-editor-panel.tsx
+++ b/web/components/new-contract/contextual-editor-panel.tsx
@@ -58,8 +58,11 @@ export function ContextualEditorPanel(props: {
   isGeneratingAnswers?: boolean
   balance?: number
   submitState?: 'EDITING' | 'LOADING' | 'DONE'
+  // Mirrors the backend FREE_MARKET_USER_ID waiver; suppresses the
+  // CostSection "Insufficient balance" banner for eligible free markets.
+  isFreeMarket?: boolean
 }) {
-  const { formState, onUpdate, balance, validationErrors } = props
+  const { formState, onUpdate, balance, validationErrors, isFreeMarket } = props
 
   const { outcomeType, answers, liquidityTier, addAnswersMode } = formState
   const isPoll = outcomeType === 'POLL'
@@ -104,6 +107,7 @@ export function ContextualEditorPanel(props: {
                 numAnswers={
                   numAnswersForCost > 0 ? numAnswersForCost : undefined
                 }
+                isFreeMarket={isFreeMarket}
               />
             </Col>
           )}

--- a/web/components/new-contract/cost-section.tsx
+++ b/web/components/new-contract/cost-section.tsx
@@ -19,9 +19,16 @@ export const CostSection = (props: {
   liquidityTier: number
   setLiquidityTier: (tier: number) => void
   numAnswers: number | undefined
+  isFreeMarket?: boolean
 }) => {
-  const { balance, outcomeType, liquidityTier, setLiquidityTier, numAnswers } =
-    props
+  const {
+    balance,
+    outcomeType,
+    liquidityTier,
+    setLiquidityTier,
+    numAnswers,
+    isFreeMarket,
+  } = props
   const ante = getAnte(outcomeType, numAnswers, liquidityTier)
 
   return (
@@ -34,7 +41,7 @@ export const CostSection = (props: {
           outcomeType={outcomeType}
         />
       )}
-      {ante > balance && (
+      {!isFreeMarket && ante > balance && (
         <div className="mb-2 mr-auto mt-2 self-center whitespace-nowrap text-xs font-medium tracking-wide">
           <span className="text-scarlet-500 mr-2">Insufficient balance</span>
           <Link

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -2,7 +2,7 @@ import { useEvent } from 'client-common/hooks/use-event'
 import clsx from 'clsx'
 import { Contract, CreateableOutcomeType } from 'common/contract'
 import { MarketDraft } from 'common/drafts'
-import { BOOST_COST_MANA, getAnte } from 'common/economy'
+import { BOOST_COST_MANA, FREE_MARKET_USER_ID, getAnte } from 'common/economy'
 import { User } from 'common/user'
 import { formatMoney } from 'common/util/format'
 import { richTextToString } from 'common/util/parse'
@@ -464,9 +464,11 @@ export function NewContractPanel(props: {
   // Avoids duplication between mobile and desktop action bars
   const getSubmitButtonText = () => {
     if (willBoost) {
-      return `Create + Boost for ${formatMoney(totalCost)}`
+      return `Create + Boost for ${formatMoney(
+        isFreeMarket ? boostCost : totalCost
+      )}`
     }
-    return `Create for ${formatMoney(cost)}`
+    return isFreeMarket ? `Create for free!` : `Create for ${formatMoney(cost)}`
   }
 
   // Auto-extract close date from question
@@ -738,11 +740,14 @@ export function NewContractPanel(props: {
   const boostCost = willBoost ? BOOST_COST_MANA : 0
   const totalCost = cost + boostCost
 
+  // Mirror the backend's FREE_MARKET_USER_ID exemption (create-market.ts):
+  const isFreeMarket = creator.id === FREE_MARKET_USER_ID && cost <= 100
+
   // Add balance validation
   // Distinguish market-cost vs boost-cost insufficiency so the boost-only case
   // doesn't trigger the panel-wide red ring (it surfaces inline in BoostSection).
-  const insufficientForMarket = cost > creator.balance
-  const hasInsufficientBalance = totalCost > creator.balance
+  const insufficientForMarket = !isFreeMarket && cost > creator.balance
+  const hasInsufficientBalance = !isFreeMarket && totalCost > creator.balance
   const insufficientForBoostOnly =
     hasInsufficientBalance && !insufficientForMarket
   const validationErrors = {
@@ -1429,6 +1434,7 @@ export function NewContractPanel(props: {
           onUpdate={updateField}
           validationErrors={validationErrors}
           balance={creator.balance}
+          isFreeMarket={isFreeMarket}
           submitState={isSubmitting ? 'LOADING' : 'EDITING'}
           onGenerateAnswers={generateAnswers}
           isGeneratingAnswers={isGeneratingAnswers}


### PR DESCRIPTION
Tumbles should be able to make his free markets now. The backend would have allowed it, but the frontend wasn't sending the request since it knew he didn't have enough balance. This adds the same checks to the `/create` page so it can pass through correctly.