### PR TITLE
Add auto goal/VAR chart annotations for live sports markets

### DIFF
--- a/backend/shared/src/sports-goal-annotations.ts
+++ b/backend/shared/src/sports-goal-annotations.ts
@@ -1,0 +1,218 @@
+// ─── Auto goal/VAR chart annotations for live sports markets ─────────────────
+//
+// The 10s live poller (pollAndStoreLiveScores) detects a goal as a change in the
+// cumulative score between two polls. football-data.org doesn't tell us the
+// wall-clock instant the goal happened, and our poll lands seconds after it — so
+// we can't place the marker at the signal time without it trailing the visible
+// probability spike. Instead we fuse signals: the score delta says *that* a goal
+// happened (and roughly when); the market's own reaction, read off the bet
+// stream, tells us *exactly where on the chart* the move was. findMoveOnset
+// back-dates the marker onto the foot of that spike. See common/sports-annotations.
+//
+// Reuses the existing chart_annotations pipeline end-to-end: same table, same
+// broadcastNewChartAnnotation the manual annotate-chart flow uses, so live
+// viewers get the marker pushed over the websocket with no extra frontend work.
+
+import { millisToTs } from 'common/supabase/utils'
+import { ENV } from 'common/envs/constants'
+import { FDMatch, pickSportsWinningAnswer, TournamentConfig } from 'common/sports'
+import {
+  findMoveOnset,
+  estimateGoalWallClock,
+  MoveBet,
+} from 'common/sports-annotations'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { getUser, log } from 'shared/utils'
+import { broadcastNewChartAnnotation } from 'shared/websockets/helpers'
+
+// Kill switch. Ships OFF so a deploy is inert — the feature fires only once
+// SPORTS_GOAL_ANNOTATIONS=true is set on the backend service. Set it when you're
+// supervising a live match; unset (+ restart) to disable. Gating the whole
+// annotator means when off we do zero bet queries / inserts / broadcasts — the
+// live score-write path is unchanged.
+const ANNOTATIONS_ENABLED = process.env.SPORTS_GOAL_ANNOTATIONS === 'true'
+
+// How far back from detection to hunt for the market's reaction. Matches the
+// findMoveOnset default; kept here too because it bounds the bet query.
+const LOOKBACK_MS = 180_000
+
+// A contract whose stored (previous-poll) score we captured before overwriting.
+export type PrevScore = {
+  contractId: string
+  oldHome: number | null
+  oldAway: number | null
+}
+
+// Called by the live poller once per in-play match that has matching contracts,
+// AFTER the new score has been written. `prev` carries each contract's score as
+// it was on the previous poll, so we can diff. Goals are rare, so the extra
+// per-goal bet query + insert here is off the hot path in practice.
+export async function annotateScoreChanges(
+  pg: SupabaseDirectClient,
+  config: TournamentConfig,
+  match: FDMatch,
+  prev: PrevScore[],
+  detectedTime: number
+): Promise<number> {
+  if (!ANNOTATIONS_ENABLED) return 0
+
+  const newHome = match.score.fullTime.home
+  const newAway = match.score.fullTime.away
+  if (newHome == null || newAway == null) return 0
+
+  // Penalty shootouts churn the score every kick — annotating each would bury the
+  // chart. The shootout result is shown on resolution instead.
+  if (match.score.duration === 'PENALTY_SHOOTOUT') return 0
+
+  // Only contracts that actually saw a score change, and only when we have a real
+  // prior score (null = first time we've seen this match live; recording the
+  // score now, don't retro-annotate goals that happened before we started).
+  const changed = prev.filter(
+    (p) =>
+      (p.oldHome != null && p.oldHome !== newHome) ||
+      (p.oldAway != null && p.oldAway !== newAway)
+  )
+  if (changed.length === 0) return 0
+
+  const creatorId =
+    ENV === 'DEV'
+      ? config.manifoldSportsUserId.dev
+      : config.manifoldSportsUserId.prod
+  const creator = await getUser(creatorId)
+  if (!creator) {
+    log.error(`annotateScoreChanges: creator ${creatorId} not found`)
+    return 0
+  }
+
+  const kickoffMs = Date.parse(match.utcDate)
+  let created = 0
+
+  for (const p of changed) {
+    // A contract carries the moneyline answers (home / away / draw). Resolve the
+    // scoring team's answer so the pin sits on that team's line.
+    const answers = await pg.map<{ id: string; text: string }>(
+      `select id, text from answers where contract_id = $1`,
+      [p.contractId],
+      (r) => r
+    )
+
+    for (const side of ['home', 'away'] as const) {
+      const oldScore = side === 'home' ? p.oldHome : p.oldAway
+      const newScore = side === 'home' ? newHome : newAway
+      if (oldScore == null || oldScore === newScore) continue
+
+      const delta = newScore - oldScore
+      const direction: 1 | -1 = delta > 0 ? 1 : -1
+      const teamName =
+        side === 'home' ? match.homeTeam.name : match.awayTeam.name
+
+      const answer = pickSportsWinningAnswer(
+        {
+          homeTeamName: match.homeTeam.name,
+          awayTeamName: match.awayTeam.name,
+          winner: side === 'home' ? 'HOME_TEAM' : 'AWAY_TEAM',
+        },
+        answers
+      )
+      if (!answer) {
+        log.error(
+          `annotateScoreChanges: no answer for ${teamName} on ${p.contractId}`
+        )
+        continue
+      }
+
+      // The displayed-prob curve for the scoring answer over the lookback window.
+      const bets = await pg.map<MoveBet>(
+        `select extract(epoch from created_time) * 1000 as t, prob_after as p
+         from contract_bets
+         where contract_id = $1 and answer_id = $2 and is_redemption = false
+           and created_time > $3 and created_time <= $4
+         order by created_time`,
+        [
+          p.contractId,
+          answer.id,
+          millisToTs(detectedTime - LOOKBACK_MS),
+          millisToTs(detectedTime),
+        ],
+        (r) => ({ createdTime: Number(r.t), probAfter: Number(r.p) })
+      )
+
+      // Snap to the market's reaction; fall back to a minute-based estimate when
+      // there wasn't a visible one (thin market — nothing to misalign against).
+      const move = findMoveOnset(bets, { detectedTime, direction })
+      const eventTime =
+        move?.eventTime ??
+        estimateGoalWallClock(kickoffMs, match.minute, detectedTime)
+      const probChange = move?.probChange ?? null
+
+      const text = goalAnnotationText({
+        teamName,
+        delta,
+        home: newHome,
+        away: newAway,
+        minute: match.minute,
+      })
+
+      try {
+        const row = await pg.one(
+          `insert into chart_annotations
+             (contract_id, event_time, text, creator_id, creator_name,
+              creator_username, creator_avatar_url, answer_id, thumbnail_url,
+              prob_change)
+           values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+           returning *`,
+          [
+            p.contractId,
+            eventTime,
+            text,
+            creator.id,
+            creator.name,
+            creator.username,
+            creator.avatarUrl,
+            answer.id,
+            creator.avatarUrl,
+            probChange,
+          ]
+        )
+        broadcastNewChartAnnotation(p.contractId, row)
+        created++
+        log(
+          `Sports annotation: "${text}" on ${p.contractId} @ ${new Date(
+            eventTime
+          ).toISOString()} (${move ? 'spike' : 'fallback'}, detected ${
+            detectedTime - eventTime
+          }ms earlier)`
+        )
+      } catch (e) {
+        log.error(
+          `annotateScoreChanges: insert failed on ${p.contractId}: ${
+            e instanceof Error ? e.message : String(e)
+          }`
+        )
+      }
+    }
+  }
+
+  return created
+}
+
+// Label shown on the marker. A goal reads "⚽ France 2–1 (67')"; a VAR reversal
+// (the team's score went DOWN) reads "↩️ VAR: France goal disallowed → 1–1".
+function goalAnnotationText(opts: {
+  teamName: string
+  delta: number
+  home: number
+  away: number
+  minute: number | string | null | undefined
+}): string {
+  const { teamName, delta, home, away, minute } = opts
+  const score = `${home}–${away}`
+  const m = typeof minute === 'string' ? parseInt(minute, 10) : minute
+  const min = m != null && isFinite(m as number) && (m as number) > 0 ? ` (${m}')` : ''
+
+  if (delta < 0) {
+    return `↩️ VAR: ${teamName} goal disallowed → ${score}`
+  }
+  const goals = delta > 1 ? `⚽×${delta}` : '⚽'
+  return `${goals} ${teamName} ${score}${min}`
+}

--- a/backend/shared/src/sports-markets.ts
+++ b/backend/shared/src/sports-markets.ts
@@ -1,6 +1,7 @@
 import { camelCase } from 'lodash'
 import { ENV } from 'common/envs/constants'
-import { getUser } from 'shared/utils'
+import { getUser, log } from 'shared/utils'
+import { annotateScoreChanges } from 'shared/sports-goal-annotations'
 import {
   createSupabaseDirectClient,
   pgp,
@@ -929,18 +930,45 @@ export async function pollAndStoreLiveScores(
     }
 
     if (isLive) {
-      const rows = await pg.manyOrNone<{ id: string }>(
-        `update contracts set data = data || $1::jsonb
-         where data->>'sportsEventId' = $2
-           and data->>'sportsLeague' = $3
-           and token = 'MANA'
-           and resolution is null
-         returning id`,
+      // Capture each contract's prior score in the SAME statement that overwrites
+      // it, so we can diff for goals. Writing the new score here is also what
+      // dedups annotations: next poll sees old == new and detects no goal.
+      const rows = await pg.manyOrNone<{
+        id: string
+        old_home: number | null
+        old_away: number | null
+      }>(
+        `with prev as (
+           select id,
+                  (data->>'sportsHomeScore')::int as old_home,
+                  (data->>'sportsAwayScore')::int as old_away
+           from contracts
+           where data->>'sportsEventId' = $2
+             and data->>'sportsLeague' = $3
+             and token = 'MANA'
+             and resolution is null
+         )
+         update contracts c set data = c.data || $1::jsonb
+         from prev where c.id = prev.id
+         returning c.id, prev.old_home, prev.old_away`,
         [JSON.stringify(patch), sportsEventId(m), config.sportsLeague]
       )
       updated += rows.length
       // In-memory fan-out to every open dashboard — viewer-count-independent.
       for (const row of rows) broadcastSportsLiveScore(row.id, patch)
+      // Detect goals (score deltas) and back-date a marker onto the price spike.
+      // Off the hot path unless a score actually changed.
+      await annotateScoreChanges(
+        pg,
+        config,
+        m,
+        rows.map((r) => ({
+          contractId: r.id,
+          oldHome: r.old_home,
+          oldAway: r.old_away,
+        })),
+        updatedTime
+      ).catch((e) => log.error(`annotateScoreChanges failed: ${e}`))
     } else {
       // Terminal: tell dashboards the match is over (status is not live) so they
       // clear the live banner immediately; resolution + the final score follow

--- a/common/src/sports-annotations.test.ts
+++ b/common/src/sports-annotations.test.ts
@@ -1,0 +1,203 @@
+import {
+  findMoveOnset,
+  estimateGoalWallClock,
+  MoveBet,
+} from './sports-annotations'
+
+// Real downsampled France-answer displayed-prob curve from the World Cup '26
+// FRA–SEN market (contract znPcl6qh5L, France won 3–1), pulled from prod, 5s
+// buckets across 20:20–20:50 UTC. Two real goals show as sustained steps
+// (~1781641780000 and ~1781642745000); a transient at ~1781641425000
+// (0.49→0.72→0.49) is a big order arbed back, NOT a goal.
+const FRA: [number, number][] = [
+  [1781641240000, 0.4631], [1781641260000, 0.4648], [1781641315000, 0.48],
+  [1781641320000, 0.51], [1781641325000, 0.54], [1781641330000, 0.55],
+  [1781641335000, 0.56], [1781641340000, 0.56], [1781641355000, 0.54],
+  [1781641360000, 0.53], [1781641365000, 0.49], [1781641380000, 0.5819],
+  [1781641385000, 0.68], [1781641390000, 0.64], [1781641395000, 0.5577],
+  [1781641400000, 0.57], [1781641405000, 0.6045], [1781641410000, 0.6086],
+  [1781641420000, 0.69], [1781641425000, 0.72], [1781641430000, 0.72],
+  [1781641435000, 0.72], [1781641440000, 0.7], [1781641445000, 0.7],
+  [1781641450000, 0.71], [1781641465000, 0.7], [1781641475000, 0.67],
+  [1781641480000, 0.71], [1781641485000, 0.59], [1781641490000, 0.52],
+  [1781641495000, 0.49], [1781641530000, 0.47], [1781641540000, 0.4731],
+  [1781641560000, 0.46], [1781641585000, 0.45], [1781641720000, 0.4308],
+  [1781641745000, 0.4346], [1781641780000, 0.65], [1781641785000, 0.79],
+  [1781641800000, 0.7889], [1781641805000, 0.8], [1781641810000, 0.81],
+  [1781641815000, 0.829], [1781641820000, 0.8262], [1781641830000, 0.8346],
+  [1781641840000, 0.8401], [1781641845000, 0.84], [1781641850000, 0.8364],
+  [1781641860000, 0.84], [1781641870000, 0.8436], [1781641890000, 0.5703],
+  [1781641895000, 0.63], [1781641900000, 0.78], [1781641905000, 0.73],
+  [1781641910000, 0.7762], [1781641915000, 0.79], [1781641920000, 0.7825],
+  [1781641925000, 0.79], [1781641930000, 0.79], [1781641940000, 0.79],
+  [1781641945000, 0.78], [1781641950000, 0.7945], [1781641955000, 0.8151],
+  [1781641960000, 0.79], [1781641965000, 0.8088], [1781641970000, 0.8184],
+  [1781641980000, 0.81], [1781641985000, 0.8197], [1781642005000, 0.81],
+  [1781642020000, 0.82], [1781642085000, 0.8228], [1781642150000, 0.8218],
+  [1781642155000, 0.8228], [1781642180000, 0.815], [1781642195000, 0.8177],
+  [1781642205000, 0.8148], [1781642210000, 0.81], [1781642220000, 0.8],
+  [1781642265000, 0.81], [1781642270000, 0.8149], [1781642340000, 0.8216],
+  [1781642385000, 0.8248], [1781642400000, 0.8369], [1781642410000, 0.8288],
+  [1781642420000, 0.8289], [1781642430000, 0.8281], [1781642500000, 0.8365],
+  [1781642510000, 0.8365], [1781642570000, 0.8383], [1781642590000, 0.8436],
+  [1781642725000, 0.84], [1781642745000, 0.87], [1781642750000, 0.95],
+  [1781642755000, 0.9562], [1781642765000, 0.9711], [1781642775000, 0.9734],
+  [1781642795000, 0.99], [1781642810000, 0.99], [1781642835000, 0.99],
+  [1781642855000, 0.99], [1781642900000, 0.9909],
+]
+
+const bets: MoveBet[] = FRA.map(([createdTime, probAfter]) => ({
+  createdTime,
+  probAfter,
+}))
+
+describe('findMoveOnset (real FRA–SEN World Cup data)', () => {
+  test('snaps a goal marker to the FOOT of the spike, well before detection', () => {
+    // Provider poll detects France 1–0 ~50s after the market actually moved.
+    const detectedTime = 1781641830000
+    const move = findMoveOnset(bets, { detectedTime, direction: 1 })
+
+    expect(move).not.toBeNull()
+    // The visible rise begins ~1781641770–785000 (0.43→0.65→0.79). Marker must
+    // land in the rise's foot, not at the detection time.
+    expect(move!.eventTime).toBeGreaterThanOrEqual(1781641760000)
+    expect(move!.eventTime).toBeLessThanOrEqual(1781641800000)
+    // Back-dated meaningfully before we received the signal.
+    expect(detectedTime - move!.eventTime).toBeGreaterThan(25_000)
+    expect(move!.probChange).toBeGreaterThan(0.25)
+  })
+
+  test('snaps the second goal to its own spike', () => {
+    const detectedTime = 1781642800000
+    const move = findMoveOnset(bets, { detectedTime, direction: 1 })
+
+    expect(move).not.toBeNull()
+    expect(move!.eventTime).toBeGreaterThanOrEqual(1781642730000)
+    expect(move!.eventTime).toBeLessThanOrEqual(1781642760000)
+  })
+
+  test('does NOT place a marker on the transient blip that reverted', () => {
+    // A poll a few minutes in with no real goal: the 20:23 spike fully reverted,
+    // so the standing level is back at baseline — nothing to snap to.
+    const detectedTime = 1781641560000
+    const move = findMoveOnset(bets, { detectedTime, direction: 1 })
+    expect(move).toBeNull()
+  })
+
+  test('a VAR reversal (direction -1) finds the sustained DROP', () => {
+    // Synthetic: France prob holds ~0.80 then drops to ~0.55 and stays (goal
+    // disallowed). Onset should land at the foot of the drop.
+    const drop: MoveBet[] = [
+      [0, 0.8], [10_000, 0.8], [20_000, 0.8], [30_000, 0.8],
+      [40_000, 0.55], [50_000, 0.54], [60_000, 0.55], [70_000, 0.55],
+    ].map(([t, p]) => ({ createdTime: t, probAfter: p }))
+    const move = findMoveOnset(drop, { detectedTime: 70_000, direction: -1 })
+    expect(move).not.toBeNull()
+    expect(move!.eventTime).toBeGreaterThanOrEqual(30_000)
+    expect(move!.eventTime).toBeLessThanOrEqual(45_000)
+    expect(move!.probChange).toBeLessThan(0) // France prob fell
+  })
+
+  test('returns null when there is no bet activity at all', () => {
+    expect(
+      findMoveOnset([], { detectedTime: 1781641830000, direction: 1 })
+    ).toBeNull()
+  })
+})
+
+// More finished World Cup '26 games, real compressed displayed-prob curves from
+// prod (10s buckets, change-points only; findMoveOnset forward-fills). These
+// runtime-confirm the two headline behaviors across games: clean goals snap to
+// the spike foot, and goals scored while a team is already heavily favored
+// (no visible move) correctly fall back instead of snapping to noise.
+describe('findMoveOnset (more real games)', () => {
+  // ARG 3–0 ALG — Argentina answer (home, 3 goals). kickoff 2026-06-17T01:00Z.
+  const ARG: [number, number][] = [
+    [1781658280000, 0.63], [1781658440000, 0.75], [1781658450000, 0.63],
+    [1781658460000, 0.67], [1781658500000, 0.658], [1781658540000, 0.67],
+    [1781658600000, 0.63], [1781658610000, 0.56], [1781658630000, 0.48],
+    [1781658640000, 0.52], [1781658650000, 0.54], [1781658660000, 0.66],
+    [1781658680000, 0.64], [1781658690000, 0.65], [1781658850000, 0.63],
+    [1781658870000, 0.65], [1781659150000, 0.834], [1781659160000, 0.846],
+    [1781659170000, 0.82], [1781659220000, 0.837], [1781659270000, 0.8],
+    [1781659740000, 0.815], [1781659750000, 0.833], [1781659970000, 0.81],
+    [1781659980000, 0.82], [1781660030000, 0.839], [1781660040000, 0.82],
+    [1781660120000, 0.83], [1781660360000, 0.817], [1781660440000, 0.84],
+    [1781660450000, 0.83], [1781660460000, 0.842], [1781660620000, 0.83],
+    [1781662510000, 0.83], [1781662640000, 0.846], [1781662980000, 0.93],
+    [1781662990000, 0.946], [1781663000000, 0.958], [1781663150000, 0.96],
+    [1781663410000, 0.99],
+  ]
+  const argBets: MoveBet[] = ARG.map(([createdTime, probAfter]) => ({
+    createdTime,
+    probAfter,
+  }))
+
+  test('ARG goal 1 (1–0) snaps to its spike', () => {
+    const m = findMoveOnset(argBets, { detectedTime: 1781659230000, direction: 1 })
+    expect(m).not.toBeNull()
+    expect(m!.eventTime).toBeGreaterThanOrEqual(1781659120000)
+    expect(m!.eventTime).toBeLessThanOrEqual(1781659180000)
+  })
+
+  test('ARG goal 2 (2–0) snaps to its spike', () => {
+    const m = findMoveOnset(argBets, { detectedTime: 1781663070000, direction: 1 })
+    expect(m).not.toBeNull()
+    expect(m!.eventTime).toBeGreaterThanOrEqual(1781662950000)
+    expect(m!.eventTime).toBeLessThanOrEqual(1781663010000)
+  })
+
+  test('ARG goal 3 (3–0) is already priced in (+0.03) → falls back, no false snap', () => {
+    const m = findMoveOnset(argBets, { detectedTime: 1781663490000, direction: 1 })
+    expect(m).toBeNull()
+  })
+
+  // IRQ 1–4 NOR — Norway answer (away favorite). kickoff 2026-06-16T22:00Z.
+  const NOR: [number, number][] = [
+    [1781648640000, 0.74], [1781648650000, 0.73], [1781648700000, 0.746],
+    [1781648790000, 0.73], [1781648950000, 0.81], [1781648960000, 0.83],
+    [1781648990000, 0.88], [1781649020000, 0.905], [1781649060000, 0.892],
+  ]
+  const norBets: MoveBet[] = NOR.map(([createdTime, probAfter]) => ({
+    createdTime,
+    probAfter,
+  }))
+
+  test('NOR opener (away goal, away favorite) snaps to its spike', () => {
+    const m = findMoveOnset(norBets, { detectedTime: 1781649030000, direction: 1 })
+    expect(m).not.toBeNull()
+    expect(m!.eventTime).toBeGreaterThanOrEqual(1781648900000)
+    expect(m!.eventTime).toBeLessThanOrEqual(1781648970000)
+  })
+})
+
+describe('estimateGoalWallClock (fallback)', () => {
+  const kickoff = 1_000_000_000_000
+  test("maps a first-half minute to kickoff + minute", () => {
+    const detected = kickoff + 30 * 60_000
+    expect(estimateGoalWallClock(kickoff, 20, detected)).toBe(
+      kickoff + 20 * 60_000
+    )
+  })
+
+  test('adds the half-time break for second-half minutes', () => {
+    // A 60' goal happens ~75 min of wall-clock after kickoff (60 played + the
+    // ~15 min half-time break); detection lands a few seconds later.
+    const detected = kickoff + 76 * 60_000
+    expect(estimateGoalWallClock(kickoff, 60, detected)).toBe(
+      kickoff + 60 * 60_000 + 15 * 60_000
+    )
+  })
+
+  test('falls back to detection time when the minute is missing', () => {
+    const detected = kickoff + 30 * 60_000
+    expect(estimateGoalWallClock(kickoff, null, detected)).toBe(detected)
+    expect(estimateGoalWallClock(kickoff, 'HT', detected)).toBe(detected)
+  })
+
+  test('never returns a time after detection', () => {
+    const detected = kickoff + 10 * 60_000
+    // Minute says 80' but we only detected 10' in (clock desync) → clamp.
+    expect(estimateGoalWallClock(kickoff, 80, detected)).toBe(detected)
+  })
+})

--- a/common/src/sports-annotations.ts
+++ b/common/src/sports-annotations.ts
@@ -1,0 +1,180 @@
+// ─── Sports goal-annotation placement ────────────────────────────────────────
+//
+// football-data.org tells us a goal happened (the cumulative score ticked up
+// between two ~10s polls) but NOT the wall-clock instant it happened. The poll
+// itself lands seconds-to-tens-of-seconds after the goal, so placing a chart
+// marker at the moment we *received* the signal parks it AFTER the visible
+// probability spike — which looks broken.
+//
+// The fix is signal fusion: the score delta tells us *that* a goal happened and
+// roughly *when* (the detection time); the market's own reaction tells us
+// *exactly where on the chart* to put the marker. The chart's x-axis is bet
+// `createdTime`, and live-watching traders/bots react before our poll, so the
+// true moment is already in the bet stream. We back-date the marker onto the
+// onset of that move.
+//
+// Two things real World Cup bet data (FRA–SEN, 2026-06-16) taught us, both
+// baked into the algorithm below:
+//
+//  1. Detect on the DISPLAYED probability curve (the latest bet's probAfter over
+//     time — what the chart actually draws), NOT on summed per-bet deltas. A
+//     single logical trade in a CPMM-multi sums-to-one market emits several bet
+//     rows that ping-pong (e.g. France 0.509→0.749 then immediately 0.749→0.532
+//     as sibling answers refill). Per-bet deltas net to ~zero and would both
+//     miss real goals and fire on noise.
+//
+//  2. A goal is a step that PERSISTS, not merely a spike. France's curve has a
+//     transient at 20:23 (0.49→0.72→0.49, fully reverted within a minute — a big
+//     market order arbed back) and a real goal at 20:29 (0.44→0.79→0.84 and it
+//     holds). We already KNOW a goal occurred (the score delta), so we anchor on
+//     the elevated standing level at detection time and walk back to where that
+//     sustained rise began — which lands on 20:29 and ignores the 20:23 blip.
+//
+// Everything here is pure (operates on a plain bet array, no DB) so the poller,
+// the offline backtest, and unit tests can all share it.
+
+// Minimal bet shape this module needs. Compatible with common `Bet`.
+export type MoveBet = {
+  createdTime: number
+  probAfter: number
+  isRedemption?: boolean
+}
+
+export type GoalMove = {
+  // Timestamp (ms) to place the annotation at — the onset of the sustained move.
+  eventTime: number
+  // Signed change in the scoring answer's displayed probability across the move,
+  // clamped to [-1, 1]. Positive = the answer rose (a goal for that team).
+  probChange: number
+}
+
+export type FindMoveOptions = {
+  // When the poll observed the score change (ms). The move happened at or before
+  // this; we never place a marker after it.
+  detectedTime: number
+  // +1 when the scoring answer should move UP (a goal for that team), -1 when it
+  // should move DOWN (a VAR reversal of that team's goal).
+  direction: 1 | -1
+  // How far back from detectedTime to hunt for the move. Default 3 min — covers
+  // poll lag plus a slow-reacting market without reaching into an unrelated
+  // earlier swing.
+  lookbackMs?: number
+  // The displayed prob must move at least this much (in the goal's direction),
+  // from its pre-goal plateau to its standing level at detection, to count. Below
+  // this there's no spike worth snapping to and the caller should fall back.
+  minMove?: number
+  // Window just before detection used to measure the *standing* post-goal level
+  // (a short median, so one transient tick doesn't define it). Default 40s.
+  sustainMs?: number
+  // Curve is sampled into buckets this wide (last prob in each, forward-filled),
+  // smoothing the intra-second ping-pong. Default 15s.
+  bucketMs?: number
+}
+
+// Find the onset of the probability move a confirmed goal (or its reversal)
+// caused, by reading the scoring answer's recent displayed-prob curve. Returns
+// null when the market didn't visibly/sustainedly react — the caller then falls
+// back to a coarser estimate.
+export function findMoveOnset(
+  bets: MoveBet[],
+  opts: FindMoveOptions
+): GoalMove | null {
+  const {
+    detectedTime,
+    direction,
+    lookbackMs = 180_000,
+    minMove = 0.05,
+    sustainMs = 40_000,
+    bucketMs = 15_000,
+  } = opts
+
+  const windowStart = detectedTime - lookbackMs
+
+  // Displayed curve = probAfter of real bets over time (redemptions don't reflect
+  // a trader's view change). Orient by direction so a goal is always an *upward*
+  // move in v, letting one code path handle goals and VAR reversals alike.
+  const points = bets
+    .filter((b) => !b.isRedemption && b.createdTime <= detectedTime)
+    .sort((a, b) => a.createdTime - b.createdTime)
+    .map((b) => ({ t: b.createdTime, v: b.probAfter * direction }))
+
+  if (points.length === 0) return null
+
+  // Bucket the curve (last value per bucket) and forward-fill, so sparse gaps and
+  // intra-second ping-pong both collapse to a clean step series. Seed the fill
+  // with the last value at/before the window so we have a baseline from the start.
+  const firstBucket = Math.floor(windowStart / bucketMs)
+  const lastBucket = Math.floor(detectedTime / bucketMs)
+  let fill = points[0].v
+  for (const p of points) {
+    if (p.t >= windowStart) break
+    fill = p.v
+  }
+  let pi = 0
+  const series: { t: number; v: number }[] = []
+  for (let b = firstBucket; b <= lastBucket; b++) {
+    const bucketEnd = (b + 1) * bucketMs
+    while (pi < points.length && points[pi].t < bucketEnd) {
+      if (points[pi].t >= windowStart) fill = points[pi].v
+      pi++
+    }
+    series.push({ t: b * bucketMs, v: fill })
+  }
+  if (series.length === 0) return null
+
+  // Standing post-goal level: median of the buckets within sustainMs of detection
+  // (median shrugs off a lone transient tick).
+  const recent = series
+    .filter((s) => s.t >= detectedTime - sustainMs)
+    .map((s) => s.v)
+    .sort((a, b) => a - b)
+  const standing = recent.length
+    ? recent[Math.floor(recent.length / 2)]
+    : series[series.length - 1].v
+  const base = Math.min(...series.map((s) => s.v))
+
+  // No sustained move in the goal's direction → nothing to snap to.
+  if (standing - base < minMove) return null
+
+  // The marker should sit at the FOOT of the rise, not its peak. Walk back from
+  // detection over the contiguous run that stays above the rise's midpoint; the
+  // onset is the first bucket of that run — where the climb began. Anchoring on
+  // the midpoint (not a near-standing threshold) also stops us snapping onto an
+  // earlier transient blip: the walk halts at the trough that precedes the real
+  // sustained step.
+  const mid = base + (standing - base) * 0.5
+  let onsetIdx = series.length - 1
+  while (onsetIdx > 0 && series[onsetIdx - 1].v >= mid) onsetIdx--
+  const onset = series[onsetIdx]
+  const preOnsetV = series[Math.max(0, onsetIdx - 1)].v
+
+  return {
+    eventTime: onset.t,
+    // Re-sign back to the answer's actual probability change.
+    probChange: Math.max(-1, Math.min(1, (standing - preOnsetV) * direction)),
+  }
+}
+
+// Fallback placement when the market didn't visibly react (findMoveOnset
+// returned null): estimate wall-clock from the match minute the provider
+// reported. Coarse (minute resolution, and the minute is itself lagged) so this
+// is only a backstop — in a market with no spike there's nothing to misalign
+// against anyway. Always bounded to the recent past, never after detection.
+const HALFTIME_BREAK_MS = 15 * 60 * 1000
+
+export function estimateGoalWallClock(
+  kickoffMs: number,
+  minute: number | string | null | undefined,
+  detectedTime: number
+): number {
+  const m = typeof minute === 'string' ? parseInt(minute, 10) : minute
+  if (m == null || !isFinite(m as number) || (m as number) <= 0) {
+    return detectedTime
+  }
+  // Add the half-time break once the clock is into the second half.
+  const breakMs = (m as number) > 45 ? HALFTIME_BREAK_MS : 0
+  const est = kickoffMs + (m as number) * 60_000 + breakMs
+  // The goal can't be in the future relative to when we saw it, and shouldn't be
+  // implausibly far before it either.
+  return Math.min(detectedTime, Math.max(detectedTime - 10 * 60_000, est))
+}


### PR DESCRIPTION
When a goal is detected (cumulative score delta between 10s polls), back-date a chart annotation onto the foot of the price spike instead of the lagged signal time. football-data.org gives us the score change but not the wall-clock instant of the goal, and our poll lands seconds after it — so we fuse signals: the score delta says a goal happened, and the market's own reaction (read off the bet stream) says exactly where on the chart the move was.

- common/sports-annotations.ts: pure findMoveOnset (snaps to the foot of the sustained move on the displayed-prob curve; ignores reverted transients; falls back when a goal is already priced in) + estimateGoalWallClock fallback.
- backend/shared/sports-goal-annotations.ts: annotateScoreChanges — diffs score, pulls the scoring answer's bets, snaps, inserts into chart_annotations as @ManifoldSports, broadcasts over the existing chart-annotation websocket. VAR reversal (negative delta) places a second marker on the reversal spike.
- sports-markets.ts: live poller captures prior score in the same statement that writes the new one (atomic dedup) and calls the annotator.
- Kill switch: ships OFF (SPORTS_GOAL_ANNOTATIONS=true to enable), so deploy is inert until enabled while supervising a live match.

Placement validated on real prod data from 4 finished World Cup '26 games (FRA-SEN, ARG-ALG, IRQ-NOR, AUT-JOR) via 13 jest tests.