### PR TITLE
Fix UK home-nation flags on World Cup sports dashboard

### DIFF
--- a/common/src/sports.test.ts
+++ b/common/src/sports.test.ts
@@ -6,6 +6,7 @@ import {
   computeCloseTime,
   flagEmoji,
   flagEmojiToCode,
+  flagImageCode,
   FDMatch,
   TournamentConfig,
 } from './sports'
@@ -274,6 +275,30 @@ describe('flagEmojiToCode', () => {
     expect(flagEmojiToCode('')).toBe('')
     expect(flagEmojiToCode('KR')).toBe('') // plain letters, not the emoji
     expect(flagEmojiToCode('⚽')).toBe('')
+  })
+})
+
+describe('flagImageCode', () => {
+  it('overrides UK home nations by name to their subdivision flag images', () => {
+    // football-data gives all four the GB flag emoji; disambiguate by name.
+    const gb = flagEmoji('GB')
+    expect(flagImageCode(gb, 'Scotland')).toBe('gb-sct')
+    expect(flagImageCode(gb, 'England')).toBe('gb-eng')
+    expect(flagImageCode(gb, 'Wales')).toBe('gb-wls')
+    expect(flagImageCode(gb, 'Northern Ireland')).toBe('gb-nir')
+  })
+  it('is case- and whitespace-insensitive on the name', () => {
+    expect(flagImageCode(flagEmoji('GB'), '  scotland ')).toBe('gb-sct')
+  })
+  it('falls back to the emoji-derived ISO2 for other teams', () => {
+    expect(flagImageCode(flagEmoji('BR'), 'Brazil')).toBe('br')
+    expect(flagImageCode('🇯🇵', 'Japan')).toBe('jp')
+    // Great Britain proper (not a home nation) keeps the GB flag.
+    expect(flagImageCode(flagEmoji('GB'), 'Great Britain')).toBe('gb')
+  })
+  it('returns empty string when nothing is mappable', () => {
+    expect(flagImageCode(undefined, undefined)).toBe('')
+    expect(flagImageCode('', 'Club FC')).toBe('')
   })
 })
 

--- a/common/src/sports.ts
+++ b/common/src/sports.ts
@@ -333,6 +333,29 @@ export function flagEmojiToCode(flag: string): string {
   return cps.map((cp) => String.fromCharCode(cp - A + 97)).join('')
 }
 
+// The UK home nations share the GB flag emoji (football-data gives them area
+// code GB), so the emoji alone can't tell them apart. They have no usable single
+// emoji — the subdivision "tag sequence" emoji renders as a bare black flag on
+// Windows/older Android — but flagcdn serves their ISO 3166-2 flag IMAGES. Since
+// the team name is always alongside the flag, disambiguate by name for the image
+// while leaving the Union Jack emoji as the (recognizable) cross-platform
+// fallback.
+const SUBDIVISION_FLAG_CODE: Record<string, string> = {
+  england: 'gb-eng',
+  scotland: 'gb-sct',
+  wales: 'gb-wls',
+  'northern ireland': 'gb-nir',
+}
+
+// Resolve the flagcdn image code for a team, preferring a name-based subdivision
+// override (England/Scotland/Wales/N. Ireland) and otherwise falling back to the
+// ISO2 code derived from the flag emoji.
+export function flagImageCode(emoji?: string, name?: string): string {
+  const key = name?.trim().toLowerCase()
+  if (key && SUBDIVISION_FLAG_CODE[key]) return SUBDIVISION_FLAG_CODE[key]
+  return emoji ? flagEmojiToCode(emoji) : ''
+}
+
 function teamFlag(team: FDMatch['homeTeam']): string {
   return teamFlagFromArea(team.area?.code ?? team.tla ?? '')
 }

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -5,7 +5,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { useApiSubscription } from 'client-common/hooks/use-api-subscription'
 import { useUnfilledBets } from 'client-common/hooks/use-bets'
-import { flagEmojiToCode } from 'common/sports'
+import { flagImageCode } from 'common/sports'
 import { ContractMetric } from 'common/contract-metric'
 import { SportsBetPanel } from './sports-bet-panel'
 import { Tooltip } from 'web/components/widgets/tooltip'
@@ -21,9 +21,10 @@ import { db } from 'web/lib/supabase/db'
 // Renders a country flag as an image (works on every platform) rather than the
 // regional-indicator emoji, which Windows/Chrome draw as bare letters ("KR").
 // Falls back to the emoji for inputs we can't map (e.g. club tournaments, which
-// pass no flag).
-export function Flag({ emoji }: { emoji?: string }) {
-  const code = emoji ? flagEmojiToCode(emoji) : ''
+// pass no flag). The team name disambiguates UK home nations, which all share
+// the GB flag emoji but have distinct flag images.
+export function Flag({ emoji, name }: { emoji?: string; name?: string }) {
+  const code = flagImageCode(emoji, name)
   const [failed, setFailed] = useState(false)
   // No mappable code, or the image failed to load → fall back to the emoji.
   if (!code || failed)
@@ -101,7 +102,6 @@ function OutcomeRow({
   score,
   isWinner,
   isDraw,
-  isFirstTeam,
   resolved,
   teamColor,
   winnerColor,
@@ -114,24 +114,29 @@ function OutcomeRow({
   score?: number
   isWinner?: boolean
   isDraw?: boolean
-  isFirstTeam?: boolean
   resolved?: boolean
   teamColor?: string
   winnerColor?: string
   onClick?: () => void
   hasPosition?: boolean
 }) {
-  const barColor = isWinner
-    ? 'bg-green-400'
-    : isDraw
-    ? 'bg-ink-400'
-    : isFirstTeam
-    ? 'bg-yes-500'
-    : 'bg-no-500'
+  const clickable = !resolved && !!onClick
 
   return (
     <div
-      onClick={!resolved ? onClick : undefined}
+      onClick={clickable ? onClick : undefined}
+      onKeyDown={
+        clickable
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onClick?.()
+              }
+            }
+          : undefined
+      }
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
       className={clsx(
         'relative flex items-center gap-2 overflow-hidden rounded-lg border-2 px-2 py-1.5 transition-colors',
         !resolved && 'cursor-pointer',
@@ -179,7 +184,7 @@ function OutcomeRow({
             </span>
           </div>
         ) : (
-          <Flag emoji={flag} />
+          <Flag emoji={flag} name={name} />
         )}
 
         <span
@@ -526,7 +531,6 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
             prob={probs.teamA}
             score={homeScore}
             isWinner={resolved && match.winner === 'teamA'}
-            isFirstTeam
             resolved={resolved}
             teamColor={SPORTS_COLORS.teamA}
             winnerColor={match.winner === 'teamA' ? winnerColor : undefined}


### PR DESCRIPTION
England/Scotland/Wales/N. Ireland all rendered the Union Jack: football-data gives them area code GB, so they share the 🇬🇧 emoji.

flagcdn serves their distinct flag IMAGES and the team name always sits beside the flag, so disambiguate by name when picking the dashboard flag image (flagImageCode), leaving the GB emoji as the recognizable cross-platform fallback. Deliberately avoids the ISO 3166-2 subdivision tag-sequence emoji, which renders as a bare black flag on Windows / older Android. No change to baked market data — fixes existing and future markets on the dashboard.

Also resolves pre-existing lint debt in the touched OutcomeRow: makes the clickable betting row keyboard-operable (role/tabIndex/onKeyDown) and drops the dead barColor/isFirstTeam props.