### PR TITLE
fix(sports): handle LAST_16 and LAST_32 stage names from football-data.org

### DIFF
--- a/common/src/sports.test.ts
+++ b/common/src/sports.test.ts
@@ -309,6 +309,8 @@ describe('stageLabel', () => {
   })
   it('abbreviates knockout stages', () => {
     expect(stageLabel(makeMatch({ stage: 'ROUND_OF_16' }))).toBe('R16')
+    expect(stageLabel(makeMatch({ stage: 'LAST_16' }))).toBe('R16')
+    expect(stageLabel(makeMatch({ stage: 'LAST_32' }))).toBe('R32')
     expect(stageLabel(makeMatch({ stage: 'FINAL' }))).toBe('Final')
   })
   it('uses matchday for regular season / league phase', () => {
@@ -365,6 +367,19 @@ describe('buildMarketParams', () => {
     expect(params.question).toBe("Arsenal vs Chelsea [Test '26]")
     expect(params.answers).toEqual(['Arsenal FC', 'Chelsea FC', 'Draw'])
     expect(params.answerShortTexts).toEqual(['Arsenal', 'Chelsea', 'Draw'])
+  })
+
+  it('treats football-data LAST_32 / LAST_16 as knockout, not group stage', () => {
+    for (const stage of ['LAST_32', 'LAST_16'] as const) {
+      const params = buildMarketParams(makeMatch({ stage, group: null }), makeConfig(), 'g')
+      expect(params.answers).toEqual([`${BR} Brazil`, `${AR} Argentina`])
+      expect(params.answers).not.toContain('Draw')
+      expect(params.answerImageUrls).toEqual(['https://x/bra.png', 'https://x/arg.png'])
+      expect(params.liquidityTier).toBe(10_000)
+      expect(params.closeTime).toBe(
+        new Date('2026-06-15T19:00:00Z').getTime() + 3.5 * 60 * 60 * 1000
+      )
+    }
   })
 
   it('omits images on a knockout when any crest is missing', () => {

--- a/common/src/sports.ts
+++ b/common/src/sports.ts
@@ -368,6 +368,9 @@ export function stageLabel(match: FDMatch): string {
       return (match.group ?? 'Group Stage').replace(/^GROUP_/, 'Group ')
     case 'LEAGUE_PHASE':
       return match.matchday != null ? `MD ${match.matchday}` : 'League Phase'
+    case 'LAST_32':
+      return 'R32'
+    case 'LAST_16':
     case 'ROUND_OF_16':
       return 'R16'
     case 'QUARTER_FINALS':
@@ -383,6 +386,13 @@ export function stageLabel(match: FDMatch): string {
   }
 }
 
+// football-data.org uses LAST_16 / LAST_32 for the World Cup knockout rounds;
+// map them to our canonical ROUND_OF_16 key so configs don't need extra entries.
+function normalizeStage(stage: string): string {
+  if (stage === 'LAST_16' || stage === 'LAST_32') return 'ROUND_OF_16'
+  return stage
+}
+
 export function stageLiquidityForMatch(
   match: FDMatch,
   config: TournamentConfig,
@@ -390,7 +400,7 @@ export function stageLiquidityForMatch(
 ): LiquidityTierValue {
   const tiers = { ...config.stageLiquidityTiers, ...overrides }
   return (
-    (tiers as Record<string, LiquidityTierValue | undefined>)[match.stage] ??
+    (tiers as Record<string, LiquidityTierValue | undefined>)[normalizeStage(match.stage)] ??
     tiers.LEAGUE_PHASE ??
     tiers.GROUP_STAGE ??
     1_000
@@ -409,7 +419,15 @@ export function computeCloseTime(match: FDMatch, config: TournamentConfig): numb
 }
 
 function isKnockoutStage(stage: string): boolean {
-  return ['ROUND_OF_16', 'QUARTER_FINALS', 'SEMI_FINALS', 'THIRD_PLACE', 'FINAL'].includes(stage)
+  return [
+    'LAST_32',
+    'LAST_16',
+    'ROUND_OF_16',
+    'QUARTER_FINALS',
+    'SEMI_FINALS',
+    'THIRD_PLACE',
+    'FINAL',
+  ].includes(stage)
 }
 
 export function sportsEventId(match: FDMatch): string {

--- a/web/pages/admin/sports.tsx
+++ b/web/pages/admin/sports.tsx
@@ -36,6 +36,8 @@ const STAGE_LABELS: Record<string, string> = {
   REGULAR_SEASON: 'Regular Season',
   GROUP_STAGE: 'Group Stage',
   LEAGUE_PHASE: 'League Phase',
+  LAST_32: 'Round of 32',
+  LAST_16: 'Round of 16',
   ROUND_OF_16: 'Round of 16',
   QUARTER_FINALS: 'Quarterfinal',
   SEMI_FINALS: 'Semifinal',


### PR DESCRIPTION
## Summary

Knockout markets for the World Cup 2026 were being created with a Draw option because `isKnockoutStage` didn't recognise the stage values the football-data.org API actually returns for the Round of 16 and Round of 32 (`LAST_16`, `LAST_32`) — it only checked for `ROUND_OF_16`.

- `isKnockoutStage` now includes `LAST_16` and `LAST_32`
- `stageLiquidityForMatch` normalises `LAST_16`/`LAST_32` → `ROUND_OF_16` before looking up the liquidity tier, so they get 10k instead of falling back to group-stage 1k
- `stageLabel` maps them to `R16`/`R32` for display

Only group stage matches should have three options (Team A / Team B / Draw). All other stages are two-option binary markets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)