### PR TITLE
feat(bets): pre-select a side in the versus bet modal with a persiste…

### DIFF
--- a/web/components/answers/binary-multi-answers-panel.tsx
+++ b/web/components/answers/binary-multi-answers-panel.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { PencilIcon } from '@heroicons/react/solid'
 import { Answer } from 'common/answer'
 import { CPMMMultiContract, getMainBinaryMCAnswer } from 'common/contract'
@@ -18,12 +19,19 @@ import {
 export function BinaryMultiAnswersPanel(props: {
   contract: CPMMMultiContract
   feedReason?: string
+  // When set (e.g. inside a bet modal), skip the two-step "pick a side first"
+  // picker: open pre-selected on a side with a persistent two-side selector so
+  // both options stay visible and switching sides updates the panel in place.
+  preselect?: boolean
+  onClose?: () => void
 }) {
-  const { feedReason, contract } = props
+  const { feedReason, contract, preselect, onClose } = props
   const answers = contract.answers
   const user = useUser()
 
-  const [outcome, setOutcome] = useState<'YES' | 'NO' | undefined>(undefined)
+  const [outcome, setOutcome] = useState<'YES' | 'NO' | undefined>(
+    preselect ? 'YES' : undefined
+  )
 
   if (contract.isResolved) {
     return (
@@ -40,6 +48,20 @@ export function BinaryMultiAnswersPanel(props: {
           />
         ))}
       </>
+    )
+  }
+
+  if (preselect) {
+    const selected = outcome ?? 'YES'
+    return (
+      <BinaryMultiChoiceBetPanel
+        answer={selected === 'YES' ? answers[0] : answers[1]}
+        contract={contract}
+        outcome={selected}
+        setOutcome={setOutcome}
+        closePanel={onClose ?? (() => setOutcome('YES'))}
+        showSelector
+      />
     )
   }
 
@@ -147,8 +169,12 @@ function BinaryMultiChoiceBetPanel(props: {
   closePanel: () => void
   outcome: 'YES' | 'NO' | undefined
   setOutcome: (outcome: 'YES' | 'NO') => void
+  // Render a persistent two-side selector (both options visible) at the top of
+  // the panel instead of the single selected-answer header.
+  showSelector?: boolean
 }) {
-  const { answer, contract, closePanel, outcome, setOutcome } = props
+  const { answer, contract, closePanel, outcome, setOutcome, showSelector } =
+    props
 
   const [editing, setEditing] = useState(false)
   const color = getAnswerColor(answer)
@@ -183,32 +209,60 @@ function BinaryMultiChoiceBetPanel(props: {
       location={'contract page answer'}
       className="bg-canvas-50"
     >
-      <Row className="items-baseline justify-between">
-        <div className={'group mr-6 text-2xl'}>
-          {answer.text}
-          {canEdit && user && (
-            <div>
-              <Button
-                color="gray-white"
-                aria-label={`Edit answer ${answer.text}`}
-                className="visible group-hover:visible sm:invisible"
-                size="xs"
-                onClick={() => setEditing(true)}
+      {showSelector ? (
+        <Row className="bg-canvas-100 mb-1 mt-1 w-full items-stretch gap-1 rounded-lg p-1">
+          {contract.answers.map((a, i) => {
+            const oc = i === 0 ? 'YES' : 'NO'
+            const isSelected = outcome === oc
+            return (
+              <button
+                key={a.id}
+                onClick={() => setOutcome(oc)}
+                aria-label={`Bet ${a.text}`}
+                className={clsx(
+                  'flex min-w-0 flex-1 items-center justify-between gap-1 truncate rounded-md px-3 py-2 text-base font-semibold transition-colors',
+                  isSelected ? 'text-white' : 'text-ink-600 hover:text-ink-900'
+                )}
+                style={
+                  isSelected
+                    ? { backgroundColor: getAnswerColor(a) }
+                    : undefined
+                }
               >
-                <PencilIcon className="text-primary-700 h-4 w-4" />
-              </Button>
-              <EditAnswerModal
-                open={editing}
-                setOpen={setEditing}
-                contract={contract}
-                answer={answer}
-                color={color}
-              />
-            </div>
-          )}
-        </div>
-        <span className="text-2xl">{formatPercent(answer.prob)}</span>
-      </Row>
+                <span className="truncate">{a.text}</span>
+                <span className="shrink-0">{formatPercent(a.prob)}</span>
+              </button>
+            )
+          })}
+        </Row>
+      ) : (
+        <Row className="items-baseline justify-between">
+          <div className={'group mr-6 text-2xl'}>
+            {answer.text}
+            {canEdit && user && (
+              <div>
+                <Button
+                  color="gray-white"
+                  aria-label={`Edit answer ${answer.text}`}
+                  className="visible group-hover:visible sm:invisible"
+                  size="xs"
+                  onClick={() => setEditing(true)}
+                >
+                  <PencilIcon className="text-primary-700 h-4 w-4" />
+                </Button>
+                <EditAnswerModal
+                  open={editing}
+                  setOpen={setEditing}
+                  contract={contract}
+                  answer={answer}
+                  color={color}
+                />
+              </div>
+            )}
+          </div>
+          <span className="text-2xl">{formatPercent(answer.prob)}</span>
+        </Row>
+      )}
     </BuyPanelBody>
   )
 }

--- a/web/components/bet/bet-dialog.tsx
+++ b/web/components/bet/bet-dialog.tsx
@@ -130,6 +130,8 @@ export function MultiBetDialog(props: {
             {isBinaryMC ? (
               <BinaryMultiAnswersPanel
                 contract={contract as CPMMMultiContract}
+                preselect
+                onClose={() => setOpen(false)}
               />
             ) : (
               <AnswersPanel

--- a/web/components/sports/sports-bet-panel.tsx
+++ b/web/components/sports/sports-bet-panel.tsx
@@ -21,10 +21,56 @@ import { Input } from 'web/components/widgets/input'
 import { ProbabilitySlider } from 'web/components/widgets/probability-input'
 import DropdownMenu from 'web/components/widgets/dropdown-menu'
 import { OrderBookPanel } from 'web/components/bet/order-book'
+import { MultiBetDialog } from 'web/components/bet/bet-dialog'
 import { getLimitBetReturns } from 'client-common/lib/bet'
 import { SportsMatch, MatchOutcome, SPORTS_COLORS } from './sports-match-card'
 
 const expirationOptions = EXPIRATION_OPTIONS.filter((o) => o.value !== -1)
+
+// Knockout markets have no Draw answer, so they're plain binary-multi "versus"
+// markets — bet on them with Manifold's standard versus modal (MultiBetDialog →
+// BinaryMultiAnswersPanel) instead of the custom three-way sports panel below.
+// Loads the contract by id the same way SportsBetPanel does.
+export function SportsVersusBetDialog({
+  contractId,
+  onClose,
+}: {
+  contractId: string | undefined
+  onClose: () => void
+}) {
+  const [contract, setContract] = useState<CPMMMultiContract | null>(null)
+
+  useEffect(() => {
+    if (!contractId) return
+    let cancelled = false
+    getContract(db, contractId)
+      .then(async (c) => {
+        if (cancelled || !c || c.mechanism !== 'cpmm-multi-1') return
+        const answerMap = await getAnswersForContracts(db, [c.id])
+        if (cancelled) return
+        const multi = c as CPMMMultiContract
+        setContract({
+          ...multi,
+          answers: answerMap[c.id] ?? multi.answers ?? [],
+        })
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [contractId])
+
+  if (!contract) return null
+  return (
+    <MultiBetDialog
+      contract={contract}
+      open
+      setOpen={(open) => {
+        if (!open) onClose()
+      }}
+    />
+  )
+}
 
 export function SportsBetPanel({
   match,

--- a/web/components/sports/sports-match-card.tsx
+++ b/web/components/sports/sports-match-card.tsx
@@ -7,7 +7,7 @@ import { useApiSubscription } from 'client-common/hooks/use-api-subscription'
 import { useUnfilledBets } from 'client-common/hooks/use-bets'
 import { flagImageCode } from 'common/sports'
 import { ContractMetric } from 'common/contract-metric'
-import { SportsBetPanel } from './sports-bet-panel'
+import { SportsBetPanel, SportsVersusBetDialog } from './sports-bet-panel'
 import { Tooltip } from 'web/components/widgets/tooltip'
 import {
   PositionsHovercard,
@@ -604,19 +604,26 @@ export function SportsMatchCard({ match }: { match: SportsMatch }) {
         </Row>
       </div>
 
-      {betOutcome && (
-        <SportsBetPanel
-          match={{
-            ...match,
-            teamA: { ...match.teamA, prob: probs.teamA },
-            teamB: { ...match.teamB, prob: probs.teamB },
-            draw: { prob: probs.draw },
-            liveScore,
-          }}
-          initialOutcome={betOutcome}
-          onClose={() => setBetOutcome(null)}
-        />
-      )}
+      {betOutcome &&
+        (match.hasDraw === false ? (
+          // Knockout (2-way) markets use the standard versus bet modal.
+          <SportsVersusBetDialog
+            contractId={match.contractId}
+            onClose={() => setBetOutcome(null)}
+          />
+        ) : (
+          <SportsBetPanel
+            match={{
+              ...match,
+              teamA: { ...match.teamA, prob: probs.teamA },
+              teamB: { ...match.teamB, prob: probs.teamB },
+              draw: { prob: probs.draw },
+              liveScore,
+            }}
+            initialOutcome={betOutcome}
+            onClose={() => setBetOutcome(null)}
+          />
+        ))}
     </>
   )
 }


### PR DESCRIPTION
…nt selector

The MultiBetDialog versus flow (binary-multi markets) opened on a two-button "pick a side" screen, then swapped the whole panel for a single-side buy form — a clunky two-step with a large layout jump. Add an opt-in `preselect` mode (passed by MultiBetDialog) that opens directly in bet mode with both sides shown as a persistent selector, defaulting to one side; switching sides updates the panel in place. The inline contract-page/feed usage is unchanged — `preselect` is only set by the modal, so non-modal BinaryMultiAnswersPanel renders as before.