### PR TITLE
feat: cpmm-multi-2 — per-answer p for multi-choice markets (opt-in, gated, v1 frozen)

### DIFF
--- a/backend/api/src/add-liquidity.ts
+++ b/backend/api/src/add-liquidity.ts
@@ -42,11 +42,14 @@ export const addContractLiquidity = async (
       )
     }
 
-    if (
-      contract.mechanism !== 'cpmm-1' &&
-      !isMultiCpmm(contract)
-    )
-      throw new APIError(403, 'Only cpmm-1 and cpmm-multi-1 are supported')
+    // isMultiCpmm covers both cpmm-multi-1 and cpmm-multi-2; the subsidy lands in
+    // subsidyPool + an LP-provision row, and the drizzle job injects it into the
+    // pools (losslessly via the V2 float-p add for cpmm-multi-2; see 2b.6).
+    if (contract.mechanism !== 'cpmm-1' && !isMultiCpmm(contract))
+      throw new APIError(
+        403,
+        'Only cpmm-1 and multiple-choice CPMM markets are supported'
+      )
 
     const { closeTime } = contract
     if (closeTime && Date.now() > closeTime)

--- a/backend/api/src/add-liquidity.ts
+++ b/backend/api/src/add-liquidity.ts
@@ -8,6 +8,7 @@ import { getContract, getUser } from 'shared/utils'
 import { onCreateLiquidityProvision } from './on-update-liquidity-provision'
 import { insertLiquidity } from 'shared/supabase/liquidity'
 import { convertLiquidity } from 'common/supabase/liquidity'
+import { isMultiCpmm } from 'common/contract'
 import { FieldVal } from 'shared/supabase/utils'
 import { updateContract } from 'shared/supabase/contracts'
 
@@ -43,7 +44,7 @@ export const addContractLiquidity = async (
 
     if (
       contract.mechanism !== 'cpmm-1' &&
-      contract.mechanism !== 'cpmm-multi-1'
+      !isMultiCpmm(contract)
     )
       throw new APIError(403, 'Only cpmm-1 and cpmm-multi-1 are supported')
 

--- a/backend/api/src/add-liquidity.ts
+++ b/backend/api/src/add-liquidity.ts
@@ -11,7 +11,11 @@ import { convertLiquidity } from 'common/supabase/liquidity'
 import { CPMM_MULTI_2_CREATION_ENABLED, isMultiCpmm } from 'common/contract'
 import { FieldVal } from 'shared/supabase/utils'
 import { updateContract } from 'shared/supabase/contracts'
-import { getAnswer, updateAnswer } from 'shared/supabase/answers'
+import {
+  getAnswer,
+  getAnswerForUpdate,
+  updateAnswer,
+} from 'shared/supabase/answers'
 
 export const addLiquidity: APIHandler<'market/:contractId/add-liquidity'> =
   onlyUsersWhoCanPerformAction(
@@ -115,8 +119,11 @@ export const addContractLiquidity = async (
 
     if (answerId !== undefined) {
       // Per-answer: the subsidy lands in THAT answer's subsidyPool (drizzleAnswer deepens it
-      // losslessly). updateAnswer takes a concrete value, so read-then-add within this tx.
-      const answer = await getAnswer(tx, answerId)
+      // losslessly). updateAnswer takes a concrete value, so the read-then-add must hold a
+      // row lock — the scheduler's drizzleAnswer (separate process; betsQueue is per-process
+      // only) also read-modify-writes subsidyPool, and either interleaving would create or
+      // destroy subsidy mana.
+      const answer = await getAnswerForUpdate(tx, answerId)
       await updateAnswer(tx, answerId, {
         subsidyPool: (answer?.subsidyPool ?? 0) + subsidyAmount,
       })

--- a/backend/api/src/add-liquidity.ts
+++ b/backend/api/src/add-liquidity.ts
@@ -8,7 +8,7 @@ import { getContract, getUser } from 'shared/utils'
 import { onCreateLiquidityProvision } from './on-update-liquidity-provision'
 import { insertLiquidity } from 'shared/supabase/liquidity'
 import { convertLiquidity } from 'common/supabase/liquidity'
-import { isMultiCpmm } from 'common/contract'
+import { CPMM_MULTI_2_CREATION_ENABLED, isMultiCpmm } from 'common/contract'
 import { FieldVal } from 'shared/supabase/utils'
 import { updateContract } from 'shared/supabase/contracts'
 
@@ -85,9 +85,21 @@ export const addContractLiquidity = async (
     const liquidityRow = await insertLiquidity(tx, newLiquidityProvision)
     const liquidity = convertLiquidity(liquidityRow)
 
+    // Lazy v1 -> v2 conversion: an explicit user addLiquidity is THE conversion trigger for a
+    // cpmm-multi-1 market (the scheduler drizzle never converts — it must not flip fill semantics
+    // under resting orders; see migration policy). Conversion is lossless in state: a cpmm-multi-1
+    // market IS a cpmm-multi-2 market with every answer p = 0.5, so flipping the mechanism string is
+    // the whole migration. p is nullable-defaulting-0.5 on read, and the first v2 drizzle deepen
+    // persists each answer's concrete floated p. The mechanism flip is the API-visible version event
+    // that switches reads/bets/drizzle to the v2 (lossless + reversible-fill) path. Gated behind the
+    // same staged-rollout kill-switch as v2 creation, so it stays inert until deliberately enabled.
+    const shouldConvertToV2 =
+      CPMM_MULTI_2_CREATION_ENABLED && contract.mechanism === 'cpmm-multi-1'
+
     await updateContract(tx, contractId, {
       subsidyPool: FieldVal.increment(subsidyAmount),
       totalLiquidity: FieldVal.increment(subsidyAmount),
+      ...(shouldConvertToV2 ? { mechanism: 'cpmm-multi-2' as const } : {}),
     })
 
     return {

--- a/backend/api/src/add-liquidity.ts
+++ b/backend/api/src/add-liquidity.ts
@@ -11,19 +11,22 @@ import { convertLiquidity } from 'common/supabase/liquidity'
 import { CPMM_MULTI_2_CREATION_ENABLED, isMultiCpmm } from 'common/contract'
 import { FieldVal } from 'shared/supabase/utils'
 import { updateContract } from 'shared/supabase/contracts'
+import { getAnswer, updateAnswer } from 'shared/supabase/answers'
 
 export const addLiquidity: APIHandler<'market/:contractId/add-liquidity'> =
   onlyUsersWhoCanPerformAction(
     'addLiquidity',
-    async ({ contractId, amount }, auth) => {
-      return addContractLiquidity(contractId, amount, auth.uid)
+    async ({ contractId, amount, answerId }, auth) => {
+      return addContractLiquidity(contractId, amount, auth.uid, answerId)
     }
   )
 
 export const addContractLiquidity = async (
   contractId: string,
   amount: number,
-  userId: string
+  userId: string,
+  // When set, subsidize a single answer (its own binary CPMM) rather than the whole market.
+  answerId?: string
 ) => {
   // Run as transaction to prevent race conditions
   return await createSupabaseDirectClient().tx(async (tx) => {
@@ -50,6 +53,19 @@ export const addContractLiquidity = async (
         403,
         'Only cpmm-1 and multiple-choice CPMM markets are supported'
       )
+
+    // Per-answer subsidy: only meaningful for multi-choice CPMM (each answer is its own binary
+    // pool). Validate the answer belongs to this contract before we move any mana.
+    if (answerId !== undefined) {
+      if (!isMultiCpmm(contract))
+        throw new APIError(
+          403,
+          'answerId is only supported for multiple-choice CPMM markets'
+        )
+      const answer = await getAnswer(tx, answerId)
+      if (!answer || answer.contractId !== contractId)
+        throw new APIError(404, 'Answer not found on this contract')
+    }
 
     const { closeTime } = contract
     if (closeTime && Date.now() > closeTime)
@@ -79,7 +95,8 @@ export const addContractLiquidity = async (
     const newLiquidityProvision = getNewLiquidityProvision(
       userId,
       subsidyAmount,
-      contract
+      contract,
+      answerId
     )
 
     const liquidityRow = await insertLiquidity(tx, newLiquidityProvision)
@@ -96,11 +113,26 @@ export const addContractLiquidity = async (
     const shouldConvertToV2 =
       CPMM_MULTI_2_CREATION_ENABLED && contract.mechanism === 'cpmm-multi-1'
 
-    await updateContract(tx, contractId, {
-      subsidyPool: FieldVal.increment(subsidyAmount),
-      totalLiquidity: FieldVal.increment(subsidyAmount),
-      ...(shouldConvertToV2 ? { mechanism: 'cpmm-multi-2' as const } : {}),
-    })
+    if (answerId !== undefined) {
+      // Per-answer: the subsidy lands in THAT answer's subsidyPool (drizzleAnswer deepens it
+      // losslessly). updateAnswer takes a concrete value, so read-then-add within this tx.
+      const answer = await getAnswer(tx, answerId)
+      await updateAnswer(tx, answerId, {
+        subsidyPool: (answer?.subsidyPool ?? 0) + subsidyAmount,
+      })
+      // contract-level totalLiquidity still tracks the whole market's subsidy; the conversion
+      // trigger applies just as for a whole-market add.
+      await updateContract(tx, contractId, {
+        totalLiquidity: FieldVal.increment(subsidyAmount),
+        ...(shouldConvertToV2 ? { mechanism: 'cpmm-multi-2' as const } : {}),
+      })
+    } else {
+      await updateContract(tx, contractId, {
+        subsidyPool: FieldVal.increment(subsidyAmount),
+        totalLiquidity: FieldVal.increment(subsidyAmount),
+        ...(shouldConvertToV2 ? { mechanism: 'cpmm-multi-2' as const } : {}),
+      })
+    }
 
     return {
       result: liquidity,

--- a/backend/api/src/claim-free-loan.ts
+++ b/backend/api/src/claim-free-loan.ts
@@ -2,6 +2,7 @@ import { APIError, type APIHandler } from './helpers/endpoint'
 import { createSupabaseDirectClient, pgp } from 'shared/supabase/init'
 import { getUser, log } from 'shared/utils'
 import { hasFullBonusAccess } from 'common/user'
+import { isMultiCpmm } from 'common/contract'
 import {
   calculateMaxGeneralLoanAmount,
   calculateDailyLoanLimit,
@@ -165,7 +166,7 @@ export const claimFreeLoan: APIHandler<'claim-free-loan'> = async (_, auth) => {
     const contractMetrics = metricsGroupedByContract[contractId]
     const contract = contractsById[contractId]
     const isIndependent =
-      contract?.mechanism === 'cpmm-multi-1' && !contract?.shouldAnswersSumToOne
+      contract && isMultiCpmm(contract) && !contract.shouldAnswersSumToOne
 
     if (isIndependent) {
       // For independent markets, calculate limits per answer
@@ -208,7 +209,7 @@ export const claimFreeLoan: APIHandler<'claim-free-loan'> = async (_, auth) => {
 
     const contract = contractsById[m.contractId]
     const isIndependent =
-      contract?.mechanism === 'cpmm-multi-1' && !contract?.shouldAnswersSumToOne
+      contract && isMultiCpmm(contract) && !contract.shouldAnswersSumToOne
 
     if (isIndependent) {
       // For independent markets, use per-answer limit

--- a/backend/api/src/create-answer-cpmm.ts
+++ b/backend/api/src/create-answer-cpmm.ts
@@ -162,6 +162,7 @@ const createAnswerCpmmMain = async (
         isOther: false,
         poolYes,
         poolNo,
+        p: 0.5, // balanced pool at p=0.5; v2 lossless split sets per-answer p (PR2 late add-on)
         prob,
         totalLiquidity,
         subsidyPool: 0,

--- a/backend/api/src/create-answer-cpmm.ts
+++ b/backend/api/src/create-answer-cpmm.ts
@@ -7,7 +7,7 @@ import {
   addCpmmMultiLiquidityAnswersSumToOne,
   getCpmmProbability,
 } from 'common/calculate-cpmm'
-import { CPMMMultiContract } from 'common/contract'
+import { CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
 import { isAdminId } from 'common/envs/constants'
 import { noFees } from 'common/fees'
@@ -82,7 +82,7 @@ const verifyContract = async (contractId: string, creatorId: string) => {
   if (contract.token !== 'MANA') {
     throw new APIError(403, 'Cannot add answers to sweepstakes question')
   }
-  if (contract.mechanism !== 'cpmm-multi-1')
+  if (!isMultiCpmm(contract))
     throw new APIError(403, 'Requires a cpmm multiple choice contract')
   if (contract.outcomeType === 'NUMBER')
     throw new APIError(403, 'Cannot create new answers for numeric contracts')

--- a/backend/api/src/create-answer-cpmm.ts
+++ b/backend/api/src/create-answer-cpmm.ts
@@ -8,7 +8,11 @@ import {
   getCpmmLiquidity,
   getCpmmProbability,
 } from 'common/calculate-cpmm'
-import { CPMMMultiContract, isMultiCpmm } from 'common/contract'
+import {
+  CPMMMultiContract,
+  isMultiCpmm,
+  MIN_CPMM_PROB,
+} from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
 import { isAdminId } from 'common/envs/constants'
 import { noFees } from 'common/fees'
@@ -493,6 +497,20 @@ async function createAnswerAndSumAnswersToOneV2(
   const No = otherAnswer.poolNo
   const pOther = otherAnswer.p ?? 0.5
   const probOther = getCpmmProbability({ YES: Yo, NO: No }, pOther)
+  // GP19d split floor: each split halves Other's prob mass geometrically, and both
+  // children land at probOther/2 — below MIN_CPMM_PROB they'd sit under the
+  // market-order clamp (untradeable-downward zombie answers). The split itself never
+  // breaks strict sanity (GP19d), so this is the ONLY guard the operation needs.
+  if (probOther < 2 * MIN_CPMM_PROB) {
+    throw new APIError(
+      403,
+      `Cannot add an answer: the "Other" answer's probability (${Math.round(
+        probOther * 1000
+      ) / 10}%) is too low to split — both halves would fall below the ${
+        MIN_CPMM_PROB * 100
+      }% minimum. Trade "Other" up or resolve the market instead.`
+    )
+  }
   const targetProb = probOther / 2 // A and Other' each take half of Other's prob mass
   const a = answerCost / 2 // symmetric: split the added mana 50/50 (GP18e: the 1 free DOF)
 

--- a/backend/api/src/create-answer-cpmm.ts
+++ b/backend/api/src/create-answer-cpmm.ts
@@ -1,5 +1,9 @@
 import { followContractInternal } from 'api/follow-contract'
-import { getUnfilledBetsAndUserBalances, updateMakers } from 'api/helpers/bets'
+import {
+  getUnfilledBets,
+  getUnfilledBetsAndUserBalances,
+  updateMakers,
+} from 'api/helpers/bets'
 import { Answer, getMaximumAnswers } from 'common/answer'
 import { getCpmmInitialLiquidity } from 'common/antes'
 import { Bet, getNewBetId, LimitBet, maker } from 'common/bet'
@@ -7,6 +11,7 @@ import {
   addCpmmMultiLiquidityAnswersSumToOne,
   getCpmmLiquidity,
   getCpmmProbability,
+  pForProbability,
 } from 'common/calculate-cpmm'
 import {
   CPMMMultiContract,
@@ -63,6 +68,8 @@ import { broadcastUpdatedMetrics } from 'shared/websockets/helpers'
 import { APIError, APIHandler } from './helpers/endpoint'
 import { onlyUsersWhoCanPerformAction } from './helpers/rate-limit'
 import { redeemShares } from './redeem-shares'
+
+// (GPnn labels cite machine-checked proofs: https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/proofs)
 export const createAnswerCPMM: APIHandler<'market/:contractId/answer'> =
   onlyUsersWhoCanPerformAction('createAnswer', async (props, auth) => {
     const { contractId, text } = props
@@ -514,14 +521,10 @@ async function createAnswerAndSumAnswersToOneV2(
   const targetProb = probOther / 2 // A and Other' each take half of Other's prob mass
   const a = answerCost / 2 // symmetric: split the added mana 50/50 (GP18e: the 1 free DOF)
 
-  // p that makes pool (Y,N) display probability q (GP6a).
-  const weightFor = (pool: { YES: number; NO: number }, q: number) =>
-    (q * pool.YES) / (q * pool.YES + (1 - q) * pool.NO)
-
   const newAnswerPool = { YES: Yo + a, NO: a }
   const newOtherPool = { YES: Yo + a, NO: a }
-  const newAnswerP = weightFor(newAnswerPool, targetProb)
-  const newOtherP = weightFor(newOtherPool, targetProb)
+  const newAnswerP = pForProbability(newAnswerPool, targetProb)
+  const newOtherP = pForProbability(newOtherPool, targetProb)
 
   const n = answers.length
   newAnswer = {
@@ -579,14 +582,13 @@ async function createAnswerAndSumAnswersToOneV2(
     await bulkInsertBets(pgTrans, poolNoBets, metrics)
   }
 
-  // Cancel Other's resting limit orders (priced at the old probability).
-  const { unfilledBets } = await getUnfilledBetsAndUserBalances(
+  // Cancel Other's resting limit orders (priced at the old probability). Fetch just
+  // that answer's unfilled bets — the v2 split doesn't move any listed price, so the
+  // whole-contract balances/metrics load the v1 path needs is pure overhead here.
+  const ordersToCancel = await getUnfilledBets(
     pgTrans,
-    contract,
-    user.id
-  )
-  const ordersToCancel = unfilledBets.filter(
-    (b) => b.answerId === otherAnswer.id
+    contract.id,
+    otherAnswer.id
   )
   await cancelLimitOrders(pgTrans, ordersToCancel)
 }

--- a/backend/api/src/create-answer-cpmm.ts
+++ b/backend/api/src/create-answer-cpmm.ts
@@ -5,6 +5,7 @@ import { getCpmmInitialLiquidity } from 'common/antes'
 import { Bet, getNewBetId, LimitBet, maker } from 'common/bet'
 import {
   addCpmmMultiLiquidityAnswersSumToOne,
+  getCpmmLiquidity,
   getCpmmProbability,
 } from 'common/calculate-cpmm'
 import { CPMMMultiContract, isMultiCpmm } from 'common/contract'
@@ -172,14 +173,26 @@ const createAnswerCpmmMain = async (
 
       const updatedAnswers: Answer[] = []
       if (shouldAnswersSumToOne) {
-        await createAnswerAndSumAnswersToOne(
-          pgTrans,
-          user,
-          contract,
-          answers,
-          newAnswer,
-          answerCost
-        )
+        // cpmm-multi-2: lossless refinement split (GP18). v1 path stays frozen.
+        if (contract.mechanism === 'cpmm-multi-2') {
+          await createAnswerAndSumAnswersToOneV2(
+            pgTrans,
+            user,
+            contract,
+            answers,
+            newAnswer,
+            answerCost
+          )
+        } else {
+          await createAnswerAndSumAnswersToOne(
+            pgTrans,
+            user,
+            contract,
+            answers,
+            newAnswer,
+            answerCost
+          )
+        }
         const updatedAnswers = await getAnswersForContract(pgTrans, contract.id)
         await convertOtherAnswerShares(
           pgTrans,
@@ -442,6 +455,122 @@ async function createAnswerAndSumAnswersToOne(
 
   allOrdersToCancel.push(...unfilledBetsOnOther)
   await cancelLimitOrders(pgTrans, allOrdersToCancel)
+}
+
+// cpmm-multi-2: lossless "Other" split as a REFINEMENT (GP18, tasks/cpmm_multi_2/
+// proofs/other_split_refinement.py + findings-other-split-refinement-2026-06-28.md).
+// Treat Other as the event (A or Other'); adding A refines it, so it must be invariant w.r.t.
+// anything that can't distinguish A from Other':
+//   - copy Other's YES inventory into BOTH new pools and fund their NO with a balanced
+//     answerCost/2 add (D-preserving), repriced via per-answer p to q_A = q_Other' = p_o/2;
+//   - listed pools are UNTOUCHED (prices fixed) — no excess-NO dump, no bet-down;
+//   - the pool's NO inventory relabels to YES in each listed answer (redemption identity:
+//     NO-Other ≡ Σ YES-listed), held OFF the listed pools (so prices stay) — conserves mana
+//     exactly (GP18f: keeping NO in the pools would create `No` mana);
+//   - user positions are handled by convertOtherAnswerShares (the same refinement on bets).
+// The v1 path (createAnswerAndSumAnswersToOne, p=0.5 surgery + overshoot + bet-down) is frozen.
+async function createAnswerAndSumAnswersToOneV2(
+  pgTrans: SupabaseTransaction,
+  user: User,
+  contract: CPMMMultiContract,
+  answers: Answer[],
+  newAnswer: Answer,
+  answerCost: number
+) {
+  const [otherAnswers, answersWithoutOther] = partition(
+    answers,
+    (a) => a.isOther
+  )
+  const otherAnswer = otherAnswers[0]
+  if (!otherAnswer) {
+    throw new APIError(
+      500,
+      '"Other" answer not found, and is required for adding new answers.'
+    )
+  }
+
+  const Yo = otherAnswer.poolYes
+  const No = otherAnswer.poolNo
+  const pOther = otherAnswer.p ?? 0.5
+  const probOther = getCpmmProbability({ YES: Yo, NO: No }, pOther)
+  const targetProb = probOther / 2 // A and Other' each take half of Other's prob mass
+  const a = answerCost / 2 // symmetric: split the added mana 50/50 (GP18e: the 1 free DOF)
+
+  // p that makes pool (Y,N) display probability q (GP6a).
+  const weightFor = (pool: { YES: number; NO: number }, q: number) =>
+    (q * pool.YES) / (q * pool.YES + (1 - q) * pool.NO)
+
+  const newAnswerPool = { YES: Yo + a, NO: a }
+  const newOtherPool = { YES: Yo + a, NO: a }
+  const newAnswerP = weightFor(newAnswerPool, targetProb)
+  const newOtherP = weightFor(newOtherPool, targetProb)
+
+  const n = answers.length
+  newAnswer = {
+    ...newAnswer,
+    index: n - 1,
+    poolYes: newAnswerPool.YES,
+    poolNo: newAnswerPool.NO,
+    p: newAnswerP,
+    prob: targetProb,
+    totalLiquidity: getCpmmLiquidity(newAnswerPool, newAnswerP),
+  }
+  const updatedOtherAnswerProps = {
+    poolYes: newOtherPool.YES,
+    poolNo: newOtherPool.NO,
+    p: newOtherP,
+    prob: targetProb,
+    index: n,
+    totalLiquidity: getCpmmLiquidity(newOtherPool, newOtherP),
+  }
+
+  await insertAnswer(pgTrans, newAnswer)
+  await updateAnswer(pgTrans, otherAnswer.id, updatedOtherAnswerProps)
+
+  // Relabel the POOL's NO inventory: `No` NO-Other shares ≡ `No` YES in each listed answer
+  // (redemption identity GP18a). Credit them to the LP (contract creator) as redemption bets, OFF
+  // the listed pools so listed prices stay fixed. Single-LP attribution is fine for conservation;
+  // multi-LP proportional attribution is a follow-up refinement.
+  const now = Date.now()
+  const poolNoBets: Bet[] = answersWithoutOther.map((listed) => ({
+    id: getNewBetId(),
+    contractId: contract.id,
+    userId: contract.creatorId,
+    answerId: listed.id,
+    outcome: 'YES',
+    shares: No,
+    amount: 0,
+    isCancelled: false,
+    isFilled: true,
+    loanAmount: 0,
+    probBefore: listed.prob,
+    probAfter: listed.prob,
+    createdTime: now,
+    fees: noFees,
+    isRedemption: true,
+    isApi: false,
+  }))
+  if (poolNoBets.length > 0) {
+    const metrics = await getContractMetrics(
+      pgTrans,
+      [contract.creatorId],
+      contract.id,
+      filterDefined(poolNoBets.map((b) => b.answerId)),
+      true
+    )
+    await bulkInsertBets(pgTrans, poolNoBets, metrics)
+  }
+
+  // Cancel Other's resting limit orders (priced at the old probability).
+  const { unfilledBets } = await getUnfilledBetsAndUserBalances(
+    pgTrans,
+    contract,
+    user.id
+  )
+  const ordersToCancel = unfilledBets.filter(
+    (b) => b.answerId === otherAnswer.id
+  )
+  await cancelLimitOrders(pgTrans, ordersToCancel)
 }
 
 async function convertOtherAnswerShares(

--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -41,7 +41,8 @@ import { Row } from 'common/supabase/utils'
 import { removeUndefinedProps } from 'common/util/object'
 import { randomString } from 'common/util/random'
 import { slugify } from 'common/util/slugify'
-import { camelCase, first } from 'lodash'
+import { camelCase, first, sum } from 'lodash'
+import { cpmmMulti2SumToOneFeasible } from 'common/calculate-cpmm'
 import { generateAntes } from 'shared/create-contract-helpers'
 import { getCloseDate } from 'shared/helpers/ai-close-date'
 import { betsQueue } from 'shared/helpers/fn-queue'
@@ -573,6 +574,20 @@ function validateMarketBody(body: Body) {
           400,
           'initialProbs must have exactly one probability per answer.'
         )
+      // GP19a feasibility: the sum-to-one √variance construction is not total — a
+      // skewed many-answer vector (possible from n = 21 up; e.g. 30 answers with a 90%
+      // favorite) has no sane pool realization (poolYes < 0, p ∉ (0,1)). Reject with a
+      // clear 400 here; the construction in new-contract.ts also throws as a backstop.
+      if (shouldAnswersSumToOne) {
+        const total = sum(initialProbs)
+        if (!cpmmMulti2SumToOneFeasible(initialProbs.map((x) => x / total)))
+          throw new APIError(
+            400,
+            'initialProbs are too extreme for this many answers: no valid sum-to-one ' +
+              'pool exists for this probability vector. Moderate the most extreme ' +
+              'probabilities (or use fewer answers) and try again.'
+          )
+      }
     }
     // Unfortunately this is a requirement because if we don't add an answer,
     // then the market creation cost will just be lost. If we just set totalLiquidity to 0,

--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -25,6 +25,7 @@ import {
   PollVoterVisibility,
   add_answers_mode,
   contractUrl,
+  isMultiCpmm,
   nativeContractColumnsArray,
 } from 'common/contract'
 import { FREE_MARKET_USER_ID, getAnte } from 'common/economy'
@@ -323,7 +324,7 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
         Object.entries(contract).filter(([key]) => !nativeKeys.includes(key))
       )
       const insertAnswersQuery =
-        contract.mechanism === 'cpmm-multi-1'
+        isMultiCpmm(contract)
           ? bulkInsertQuery('answers', contract.answers.map(answerToRow), true)
           : 'select 1 where false'
       const contractQuery = pgp.as.format(
@@ -337,7 +338,7 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
        ${insertAnswersQuery};`
       )
 
-      if (result[1].length > 0 && contract.mechanism === 'cpmm-multi-1') {
+      if (result[1].length > 0 && isMultiCpmm(contract)) {
         contract.answers = result[1].map(convertAnswer)
       }
       const house = isProd()

--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -21,6 +21,7 @@ import {
   NO_CLOSE_TIME_TYPES,
   NUMBER_CREATION_ENABLED,
   CPMM_MULTI_2_CREATION_ENABLED,
+  MIN_CPMM_PROB,
   OutcomeType,
   PollType,
   PollVoterVisibility,
@@ -580,7 +581,16 @@ function validateMarketBody(body: Body) {
       // clear 400 here; the construction in new-contract.ts also throws as a backstop.
       if (shouldAnswersSumToOne) {
         const total = sum(initialProbs)
-        if (!cpmmMulti2SumToOneFeasible(initialProbs.map((x) => x / total)))
+        const normalized = initialProbs.map((x) => x / total)
+        // The [1,99] schema bound is pre-normalization; a direct API call with a sum
+        // far from 100 could still normalize an answer below the market-order floor.
+        // Keep every created prob inside [MIN, MAX]_CPMM_PROB, like binary creation.
+        if (normalized.some((q) => q < MIN_CPMM_PROB - 1e-12))
+          throw new APIError(
+            400,
+            'initialProbs must normalize to at least 1% per answer for sum-to-one markets.'
+          )
+        if (!cpmmMulti2SumToOneFeasible(normalized))
           throw new APIError(
             400,
             'initialProbs are too extreme for this many answers: no valid sum-to-one ' +

--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -76,6 +76,8 @@ import {
 import { z } from 'zod'
 import { APIError, AuthedUser, type APIHandler } from './helpers/endpoint'
 import { onlyUsersWhoCanPerformAction } from './helpers/rate-limit'
+
+// (GPnn labels cite machine-checked proofs: https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/proofs)
 type Body = ValidatedAPIParams<'market'>
 
 export const createMarket: APIHandler<'market'> = onlyUsersWhoCanPerformAction(

--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -549,20 +549,19 @@ function validateMarketBody(body: Body) {
       addAnswersMode !== 'DISABLED' && shouldAnswersSumToOne
     const numAnswers = answers.length + (hasOtherAnswer ? 1 : 0)
 
-    // cpmm-multi-2 (PR2c): per-answer initial probabilities. First cut supports
-    // only fixed, sum-to-one markets with no "Other" answer — so each provided
-    // prob maps 1:1 to a created answer and Σp = 1 is well-defined. (Non-uniform
-    // "Other" splitting is a later add-on; see pr2-plan.md "Other split".)
+    // cpmm-multi-2 (PR2c): per-answer initial probabilities. Supports both
+    // fixed sum-to-one ("Multiple Choice", Σp normalized to 1) and independent
+    // ("Set", each prob absolute, no Σ constraint) markets — in both, each prob
+    // maps 1:1 to a created answer. No "Other"/addable answers (their probs
+    // aren't covered by initialProbs); "Other" splitting is a later add-on, see
+    // pr2-plan.md "Other split". Both representations are balanced-pool + per-
+    // answer p (lossless): a skewed start is carried by p, never by discarding
+    // shares or oversizing one reserve past the funded ante.
     if (initialProbs !== undefined) {
       if (!CPMM_MULTI_2_CREATION_ENABLED)
         throw new APIError(
           403,
           'Creating cpmm-multi-2 (custom initial probabilities) markets is not currently enabled.'
-        )
-      if (shouldAnswersSumToOne === false)
-        throw new APIError(
-          400,
-          'initialProbs requires shouldAnswersSumToOne markets.'
         )
       if (addAnswersMode !== 'DISABLED')
         throw new APIError(

--- a/backend/api/src/create-market.ts
+++ b/backend/api/src/create-market.ts
@@ -20,6 +20,7 @@ import {
   Contract,
   NO_CLOSE_TIME_TYPES,
   NUMBER_CREATION_ENABLED,
+  CPMM_MULTI_2_CREATION_ENABLED,
   OutcomeType,
   PollType,
   PollVoterVisibility,
@@ -179,6 +180,7 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
     sportsLeague,
     answerShortTexts,
     answerImageUrls,
+    initialProbs,
     takerAPIOrdersDisabled,
     liquidityTier,
     unit,
@@ -295,6 +297,7 @@ export async function createMarketHelper(body: Body, auth: AuthedUser) {
           answers: answers ?? [],
           answerShortTexts,
           answerImageUrls,
+          initialProbs,
           addAnswersMode,
           shouldAnswersSumToOne,
           isAutoBounty,
@@ -438,6 +441,7 @@ function validateMarketBody(body: Body) {
     answers: string[] | undefined,
     answerShortTexts: string[] | undefined,
     answerImageUrls: string[] | undefined,
+    initialProbs: number[] | undefined,
     addAnswersMode: add_answers_mode | undefined,
     shouldAnswersSumToOne: boolean | undefined,
     totalBounty: number | undefined,
@@ -537,12 +541,40 @@ function validateMarketBody(body: Body) {
       answers,
       answerShortTexts,
       answerImageUrls,
+      initialProbs,
       addAnswersMode,
       shouldAnswersSumToOne,
     } = validateMarketType(outcomeType, createMultiSchema, body))
     const hasOtherAnswer =
       addAnswersMode !== 'DISABLED' && shouldAnswersSumToOne
     const numAnswers = answers.length + (hasOtherAnswer ? 1 : 0)
+
+    // cpmm-multi-2 (PR2c): per-answer initial probabilities. First cut supports
+    // only fixed, sum-to-one markets with no "Other" answer — so each provided
+    // prob maps 1:1 to a created answer and Σp = 1 is well-defined. (Non-uniform
+    // "Other" splitting is a later add-on; see pr2-plan.md "Other split".)
+    if (initialProbs !== undefined) {
+      if (!CPMM_MULTI_2_CREATION_ENABLED)
+        throw new APIError(
+          403,
+          'Creating cpmm-multi-2 (custom initial probabilities) markets is not currently enabled.'
+        )
+      if (shouldAnswersSumToOne === false)
+        throw new APIError(
+          400,
+          'initialProbs requires shouldAnswersSumToOne markets.'
+        )
+      if (addAnswersMode !== 'DISABLED')
+        throw new APIError(
+          400,
+          'initialProbs is not supported with addable answers (no "Other" answer).'
+        )
+      if (initialProbs.length !== answers.length)
+        throw new APIError(
+          400,
+          'initialProbs must have exactly one probability per answer.'
+        )
+    }
     // Unfortunately this is a requirement because if we don't add an answer,
     // then the market creation cost will just be lost. If we just set totalLiquidity to 0,
     // then the answer costs will be calculated based on 0, which is not what we want.
@@ -611,6 +643,7 @@ function validateMarketBody(body: Body) {
     sportsLeague,
     answerShortTexts,
     answerImageUrls,
+    initialProbs,
     takerAPIOrdersDisabled,
     unit,
     midpoints,

--- a/backend/api/src/edit-answer.ts
+++ b/backend/api/src/edit-answer.ts
@@ -1,5 +1,6 @@
 import { MAX_ANSWER_LENGTH } from 'common/answer'
 import { isUserBanned } from 'common/ban-utils'
+import { isMultiCpmm } from 'common/contract'
 import { isAdminId, isModId } from 'common/envs/constants'
 import { removeUndefinedProps } from 'common/util/object'
 import { HOUR_MS } from 'common/util/time'
@@ -38,7 +39,7 @@ export const editanswercpmm = authEndpoint(async (req, auth) => {
   const contract = await getContract(pg, contractId)
   if (!contract) throw new APIError(404, 'Contract not found')
 
-  if (contract.mechanism !== 'cpmm-multi-1')
+  if (!isMultiCpmm(contract))
     throw new APIError(403, 'Requires a cpmm multiple choice contract')
 
   const { closeTime } = contract

--- a/backend/api/src/get-balance-changes.ts
+++ b/backend/api/src/get-balance-changes.ts
@@ -12,6 +12,7 @@ import { filterDefined } from 'common/util/array'
 import { charities } from 'common/charity'
 import { convertTxn } from 'common/supabase/txns'
 import { LiquidityProvision } from 'common/liquidity-provision'
+import { isMultiCpmm } from 'common/contract'
 import { getContractsDirect } from 'shared/supabase/contracts'
 
 // market creation fees
@@ -169,7 +170,7 @@ const getLiquidityBalanceChanges = async (
       answerText:
         doc.answerId &&
         contract.visibility === 'public' &&
-        contract.mechanism === 'cpmm-multi-1'
+        isMultiCpmm(contract)
           ? contract.answers.find((a) => a.id === doc.answerId)?.text
           : undefined,
     }

--- a/backend/api/src/get-free-loan-available.ts
+++ b/backend/api/src/get-free-loan-available.ts
@@ -15,6 +15,7 @@ import {
   getUnresolvedStatsForToken,
 } from 'shared/update-user-portfolio-histories-core'
 import { keyBy, sumBy } from 'lodash'
+import { isMultiCpmm } from 'common/contract'
 import {
   getFreeLoanRate,
   getMaxLoanNetWorthPercent,
@@ -147,7 +148,7 @@ export const getFreeLoanAvailable: APIHandler<
     const contractMetrics = metricsGroupedByContract[contractId]
     const contract = contractsById[contractId]
     const isIndependent =
-      contract?.mechanism === 'cpmm-multi-1' && !contract?.shouldAnswersSumToOne
+      contract && isMultiCpmm(contract) && !contract.shouldAnswersSumToOne
 
     if (isIndependent) {
       // For independent markets, calculate limits per answer
@@ -190,7 +191,7 @@ export const getFreeLoanAvailable: APIHandler<
 
     const contract = contractsById[m.contractId]
     const isIndependent =
-      contract?.mechanism === 'cpmm-multi-1' && !contract?.shouldAnswersSumToOne
+      contract && isMultiCpmm(contract) && !contract.shouldAnswersSumToOne
 
     let freeLoanContribution = baseFreeLoan
 

--- a/backend/api/src/get-markets.ts
+++ b/backend/api/src/get-markets.ts
@@ -1,7 +1,7 @@
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { convertAnswer, convertContract } from 'common/supabase/contracts'
 import { contractColumnsToSelect } from 'shared/utils'
-import { CPMMMultiContract } from 'common/contract'
+import { CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { APIHandler } from './helpers/endpoint'
 import { sortBy } from 'lodash'
 
@@ -16,7 +16,7 @@ export const getMarketsByIds: APIHandler<'markets-by-ids'> = async (props) => {
   )
   const contracts = results[0].map(convertContract)
   const answers = results[1].map(convertAnswer)
-  const multiContracts = contracts.filter((c) => c.mechanism === 'cpmm-multi-1')
+  const multiContracts = contracts.filter((c) => isMultiCpmm(c))
   for (const contract of multiContracts) {
     ;(contract as CPMMMultiContract).answers = sortBy(
       answers.filter((a) => a.contractId === contract.id),

--- a/backend/api/src/get-user-contract-metrics-with-contracts.ts
+++ b/backend/api/src/get-user-contract-metrics-with-contracts.ts
@@ -14,7 +14,7 @@ export const getUserContractMetricsWithContracts: APIHandler<
   const { userId, limit, offset = 0, perAnswer = false, order } = props
   const visibilitySQL = getContractPrivacyWhereSQLFilter(auth?.uid, 'c.id')
   const pg = createSupabaseDirectClient()
-  const metricFilterSQL = `(c.mechanism <> 'cpmm-multi-1' OR ucm.answer_id is not null)`
+  const metricFilterSQL = `(c.mechanism not in ('cpmm-multi-1', 'cpmm-multi-2') OR ucm.answer_id is not null)`
   const rankedOrderBySQL =
     order === 'profit'
       ? `total_profit DESC`

--- a/backend/api/src/get-user-contract-metrics-with-contracts.ts
+++ b/backend/api/src/get-user-contract-metrics-with-contracts.ts
@@ -7,6 +7,7 @@ import { getContractPrivacyWhereSQLFilter } from 'shared/supabase/contracts'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { prefixedContractColumnsToSelect } from 'shared/utils'
 import { APIHandler } from './helpers/endpoint'
+import { MULTI_CPMM_MECHANISMS_SQL } from 'common/contract'
 
 export const getUserContractMetricsWithContracts: APIHandler<
   'get-user-contract-metrics-with-contracts'
@@ -14,7 +15,7 @@ export const getUserContractMetricsWithContracts: APIHandler<
   const { userId, limit, offset = 0, perAnswer = false, order } = props
   const visibilitySQL = getContractPrivacyWhereSQLFilter(auth?.uid, 'c.id')
   const pg = createSupabaseDirectClient()
-  const metricFilterSQL = `(c.mechanism not in ('cpmm-multi-1', 'cpmm-multi-2') OR ucm.answer_id is not null)`
+  const metricFilterSQL = `(c.mechanism not in ${MULTI_CPMM_MECHANISMS_SQL} OR ucm.answer_id is not null)`
   const rankedOrderBySQL =
     order === 'profit'
       ? `total_profit DESC`

--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -5,7 +5,7 @@ import { APIError } from 'common/api/utils'
 import { isUserBanned, getUserBanMessage } from 'common/ban-utils'
 import { LimitBet, maker } from 'common/bet'
 import { MarginalBet } from 'common/calculate-metrics'
-import { Contract, MarketContract } from 'common/contract'
+import { Contract, MarketContract, isMultiCpmm } from 'common/contract'
 import { ContractMetric, isSummary } from 'common/contract-metric'
 import { getUniqueBettorBonusAmount } from 'common/economy'
 import {
@@ -219,7 +219,7 @@ export const fetchContractBetDataAndValidate = async (
   if (contract.mechanism === 'none' || contract.mechanism === 'qf')
     throw new APIError(400, 'This is not a market')
 
-  if (contract.mechanism === 'cpmm-multi-1')
+  if (isMultiCpmm(contract))
     contract.answers = sortBy(
       uniqBy([...answers, ...contract.answers], 'id'),
       'index'
@@ -370,7 +370,7 @@ export const getUserBalancesAndMetrics = async (
   const { id: contractId, mechanism } = contract
   // TODO: if we pass the makers' answerIds, we don't need to fetch the metrics for all answers
   const sumsToOne =
-    mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne
+    isMultiCpmm(contract) && contract.shouldAnswersSumToOne
   const results = await pgTrans.multi(
     `
       SELECT balance, id FROM users WHERE id = ANY($1);

--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -326,7 +326,10 @@ export const lockContractAndGetBetData = async (
   const results = await pgTrans.multi(queries)
   const contract = convertContract(results[0][0]) as MarketContract
   const answers = results[1].map(convertAnswer)
-  if (contract.mechanism === 'cpmm-multi-1')
+  // isMultiCpmm, matching the pre-transaction read above — the in-transaction locked
+  // re-read must merge the fresh SQL answers for BOTH multi mechanisms, or a
+  // cpmm-multi-2 bet executes against the stale denormalized blob answers.
+  if (isMultiCpmm(contract))
     contract.answers = sortBy(
       uniqBy([...answers, ...contract.answers], 'id'),
       'index'

--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -60,6 +60,11 @@ type BetDataBody = {
 // lockContractAndGetBetData (in-transaction locked re-read) so the two paths
 // can't drift. The fragments assume the query is formatted with
 // [uid, contractId, answerIds, outcome] bound to $1..$4.
+// NOTE: `isSumsToOne` makes both answer-load queries below fetch ALL of a linked contract's
+// answers, including resolved ones — safe today because linked answers cannot be individually
+// resolved. If cpmm-multi-2 early per-answer NO resolution ships (reserved; see the CPMMMulti
+// doc comment in common/src/contract.ts), the sum-to-one arb must receive only the unresolved
+// subset — these loads are the natural filter site.
 const getLimitOrderQueryFragments = (body: BetDataBody) => {
   const answerIds =
     'answerIds' in body

--- a/backend/api/src/helpers/bets.ts
+++ b/backend/api/src/helpers/bets.ts
@@ -375,7 +375,7 @@ export const getUserBalancesAndMetrics = async (
   answerId?: string
 ) => {
   const startTime = Date.now()
-  const { id: contractId, mechanism } = contract
+  const { id: contractId } = contract
   // TODO: if we pass the makers' answerIds, we don't need to fetch the metrics for all answers
   const sumsToOne =
     isMultiCpmm(contract) && contract.shouldAnswersSumToOne

--- a/backend/api/src/multi-sell.ts
+++ b/backend/api/src/multi-sell.ts
@@ -2,6 +2,7 @@ import { getUnfilledBetsAndUserBalances } from 'api/helpers/bets'
 import { onCreateBets } from 'api/on-create-bet'
 import { executeNewBetResult } from 'api/place-bet'
 import { isSummary } from 'common/contract-metric'
+import { isMultiCpmm } from 'common/contract'
 import { MS_PER_DAY } from 'common/loans'
 import { getCpmmMultiSellSharesInfo } from 'common/sell-bet'
 import { convertBet } from 'common/supabase/bets'
@@ -36,7 +37,7 @@ const multiSellMain: APIHandler<'multi-sell'> = async (props, auth) => {
   const results = await runTransactionWithRetries(async (pgTrans) => {
     const contract = await getContract(pgTrans, contractId)
     if (!contract) throw new APIError(404, 'Contract not found')
-    const { closeTime, isResolved, mechanism } = contract
+    const { closeTime, isResolved } = contract
     if (closeTime && Date.now() > closeTime)
       throw new APIError(403, 'Trading is closed.')
     if (isResolved) throw new APIError(403, 'Market is resolved.')
@@ -46,7 +47,7 @@ const multiSellMain: APIHandler<'multi-sell'> = async (props, auth) => {
         'You have blocked yourself from betting on this market. Contact a moderator if you need this reversed.'
       )
     }
-    if (mechanism != 'cpmm-multi-1' || !('shouldAnswersSumToOne' in contract))
+    if (!isMultiCpmm(contract) || !('shouldAnswersSumToOne' in contract))
       throw new APIError(400, 'Contract type/mechanism not supported')
 
     const answersToSell = contract.answers.filter((a) =>

--- a/backend/api/src/on-create-bet.ts
+++ b/backend/api/src/on-create-bet.ts
@@ -6,7 +6,7 @@ import {
   getUsers,
 } from 'shared/utils'
 import { Bet, LimitBet } from 'common/bet'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import { User } from 'common/user'
 import { groupBy, sortBy, sumBy } from 'lodash'
 import { filterDefined } from 'common/util/array'
@@ -489,7 +489,7 @@ export const injectLiquidityBonus = async (
 
   if (contract.mechanism === 'cpmm-1') {
     await addHouseSubsidy(contract.id, subsidy)
-  } else if (contract.mechanism === 'cpmm-multi-1' && bet.answerId) {
+  } else if (isMultiCpmm(contract) && bet.answerId) {
     if (
       contract.shouldAnswersSumToOne &&
       (bet.probAfter < 0.15 || bet.probAfter > 0.95)

--- a/backend/api/src/on-update-liquidity-provision.ts
+++ b/backend/api/src/on-update-liquidity-provision.ts
@@ -11,7 +11,7 @@ export const onCreateLiquidityProvision = async (
 ) => {
   const pg = createSupabaseDirectClient()
   const contract = (await getContract(pg, liquidity.contractId)) as Contract & {
-    mechanism: 'cpmm-1' | 'cpmm-multi-1'
+    mechanism: 'cpmm-1' | 'cpmm-multi-1' | 'cpmm-multi-2'
   }
 
   if (!contract)

--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -16,6 +16,7 @@ import {
   CPMM_MIN_POOL_QTY,
   MarketContract,
   MultiContract,
+  isMultiCpmm,
 } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
 import { FLAT_TRADE_FEE } from 'common/fees'
@@ -199,8 +200,7 @@ export const placeBetMain = async (
     }
 
     const betGroupId =
-      lockedContract.mechanism === 'cpmm-multi-1' &&
-      lockedContract.shouldAnswersSumToOne
+      isMultiCpmm(lockedContract) && lockedContract.shouldAnswersSumToOne
         ? getNewBetId()
         : undefined
 
@@ -279,7 +279,7 @@ export const calculateBetResult = (
       expiresAt,
       expiresMillisAfter
     )
-  } else if (mechanism == 'cpmm-multi-1') {
+  } else if (isMultiCpmm(contract)) {
     const { shouldAnswersSumToOne } = contract
     if (!body.answerId || !answers) {
       throw new APIError(400, 'answerId must be specified for multi bets')
@@ -430,7 +430,7 @@ export const executeNewBetResult = async (
   }[] = []
 
   const sumsToOne =
-    contract.mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne
+    isMultiCpmm(contract) && contract.shouldAnswersSumToOne
   let bonusTxnQuery = 'select 1 where false'
   if (
     (!isMultiBet || firstBetInMultiBet) &&
@@ -529,7 +529,7 @@ export const executeNewBetResult = async (
             prob:
               newPool && newP ? getCpmmProbability(newPool, newP) : undefined,
           }
-        : contract.mechanism === 'cpmm-multi-1' &&
+        : isMultiCpmm(contract) &&
           answerUpdates.length > 0 &&
           contract.answers.length > 0
         ? {

--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -472,7 +472,9 @@ export const executeNewBetResult = async (
         })
 
         const { YES: poolYes, NO: poolNo } = cpmmState.pool
-        const prob = getCpmmProbability(cpmmState.pool, 0.5)
+        // Use the answer's own p (cpmm-multi-2) so the denormalized `prob`
+        // matches the read-path `probability`; p=0.5 ⇒ byte-identical for v1.
+        const prob = getCpmmProbability(cpmmState.pool, cpmmState.p)
         answerUpdates.push({
           id: answer.id,
           poolYes,
@@ -495,11 +497,14 @@ export const executeNewBetResult = async (
   // Multi-cpmm-1 contract: add main bet's answer update
   if (newBet.answerId && newPool) {
     const { YES: poolYes, NO: poolNo } = newPool
-    const prob = getCpmmProbability(newPool, 0.5)
     const answer = (contract as MultiContract).answers.find(
       (a) => a.id === newBet.answerId
     )
     if (!answer) throw new APIError(404, 'Answer not found')
+    // newP is only set for cpmm-1; for multi the per-answer p is unchanged by a
+    // buy/sell, so use answer.p (= 0.5 for cpmm-multi-1 ⇒ byte-identical). This
+    // keeps the denormalized `prob` consistent with the read-path `probability`.
+    const prob = getCpmmProbability(newPool, answer.p)
     answerUpdates.push({
       id: newBet.answerId,
       poolYes,

--- a/backend/api/src/place-multi-bet.ts
+++ b/backend/api/src/place-multi-bet.ts
@@ -6,6 +6,7 @@ import { onCreateBets } from 'api/on-create-bet'
 import { executeNewBetResult } from 'api/place-bet'
 import { ValidatedAPIParams } from 'common/api/schema'
 import { getNewMultiCpmmBetsInfo } from 'common/new-bet'
+import { isMultiCpmm } from 'common/contract'
 import * as crypto from 'crypto'
 import { betsQueue } from 'shared/helpers/fn-queue'
 import { runTransactionWithRetries } from 'shared/transact-with-retries'
@@ -47,9 +48,7 @@ export const placeMultiBetMain = async (
       isApi
     )
 
-    const { mechanism } = contract
-
-    if (mechanism != 'cpmm-multi-1' || !('shouldAnswersSumToOne' in contract)) {
+    if (!isMultiCpmm(contract) || !('shouldAnswersSumToOne' in contract)) {
       throw new APIError(400, 'Contract type/mechanism not supported')
     }
     if (!answers) throw new APIError(404, 'Answers not found')

--- a/backend/api/src/rebalance-position.ts
+++ b/backend/api/src/rebalance-position.ts
@@ -2,7 +2,7 @@ import { APIError, type APIHandler } from './helpers/endpoint'
 import { Bet, getNewBetId } from 'common/bet'
 import { computeRebalance } from 'common/rebalance'
 import { ContractMetric } from 'common/contract-metric'
-import { MarketContract } from 'common/contract'
+import { MarketContract, isMultiCpmm } from 'common/contract'
 import { noFees } from 'common/fees'
 import { MS_PER_DAY } from 'common/loans'
 import { EPSILON } from 'common/util/math'
@@ -43,7 +43,7 @@ export const rebalancePosition: APIHandler<
   const contract = await getContract(pg, contractId)
   if (!contract) throw new APIError(404, 'Contract not found.')
   if (
-    contract.mechanism !== 'cpmm-multi-1' ||
+    !isMultiCpmm(contract) ||
     !contract.shouldAnswersSumToOne
   ) {
     throw new APIError(

--- a/backend/api/src/resolve-market.ts
+++ b/backend/api/src/resolve-market.ts
@@ -104,6 +104,13 @@ function getResolutionParams(
   const { outcomeType } = contract
   const isMultiChoice = isMultiCpmm(contract)
 
+  // Routing: independent multi (shouldAnswersSumToOne = false) resolves PER ANSWER (binary
+  // schema + answerId); linked multi resolves WHOLE MARKET only (multi schema below — even
+  // CHOOSE_ONE becomes a full resolutions map, never a per-answer resolve). This branch is
+  // the single enforcement point of "linked answers are never individually resolved".
+  // cpmm-multi-2 reserves relaxing this to allow early per-answer NO resolution of linked
+  // answers (see the CPMMMulti doc comment in common/src/contract.ts) — don't add new code
+  // that bakes the whole-market-only assumption into cpmm-multi-2 handling.
   if (
     outcomeType === 'BINARY' ||
     (isMultiChoice && !contract.shouldAnswersSumToOne)

--- a/backend/api/src/resolve-market.ts
+++ b/backend/api/src/resolve-market.ts
@@ -1,6 +1,11 @@
 import { sumBy } from 'lodash'
 import { HOUSE_LIQUIDITY_PROVIDER_ID } from 'common/antes'
-import { Contract, MarketContract, MultiContract } from 'common/contract'
+import {
+  Contract,
+  MarketContract,
+  MultiContract,
+  isMultiCpmm,
+} from 'common/contract'
 import { getContract, getUser, isProd, log } from 'shared/utils'
 import { APIError, type APIHandler, validate } from './helpers/endpoint'
 import { onlyUsersWhoCanPerformAction } from './helpers/rate-limit'
@@ -97,7 +102,7 @@ function getResolutionParams(
   props: ValidatedAPIParams<'market/:contractId/resolve'>
 ) {
   const { outcomeType } = contract
-  const isMultiChoice = contract.mechanism === 'cpmm-multi-1'
+  const isMultiChoice = isMultiCpmm(contract)
 
   if (
     outcomeType === 'BINARY' ||

--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -8,7 +8,7 @@ import { onCreateBets } from 'api/on-create-bet'
 import { Answer } from 'common/answer'
 import { LimitBet } from 'common/bet'
 import { MS_PER_DAY } from 'common/loans'
-import { MarketContract } from 'common/contract'
+import { MarketContract, isMultiCpmm } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
 import { getCpmmMultiSellBetInfo, getCpmmSellBetInfo } from 'common/sell-bet'
 import { floatingLesserEqual } from 'common/util/math'
@@ -61,7 +61,7 @@ const calculateSellResult = (
   let answer
   if (
     mechanism === 'cpmm-1' ||
-    (mechanism === 'cpmm-multi-1' && !contract.shouldAnswersSumToOne)
+    (isMultiCpmm(contract) && !contract.shouldAnswersSumToOne)
   ) {
     if (answerId) {
       answer = answers?.find((a) => a.id === answerId)

--- a/backend/api/src/unresolve.ts
+++ b/backend/api/src/unresolve.ts
@@ -3,7 +3,11 @@ import { onlyUsersWhoCanPerformAction } from 'api/helpers/rate-limit'
 import { HOUSE_LIQUIDITY_PROVIDER_ID } from 'common/antes'
 import { Answer } from 'common/answer'
 import { getCpmmProbability } from 'common/calculate-cpmm'
-import { Contract, MINUTES_ALLOWED_TO_UNRESOLVE } from 'common/contract'
+import {
+  Contract,
+  MINUTES_ALLOWED_TO_UNRESOLVE,
+  isMultiCpmm,
+} from 'common/contract'
 import { isAdminId, isModId } from 'common/envs/constants'
 import { convertAnswer } from 'common/supabase/contracts'
 import { convertTxn } from 'common/supabase/txns'
@@ -114,7 +118,7 @@ const verifyUserCanUnresolve = async (
   let resolutionTime: number
   if (
     mechanism === 'cpmm-1' ||
-    (mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne)
+    (isMultiCpmm(contract) && contract.shouldAnswersSumToOne)
   ) {
     if (answerId !== undefined) {
       throw new APIError(
@@ -129,7 +133,7 @@ const verifyUserCanUnresolve = async (
   } else {
     // Is independent multi.
     assert(
-      mechanism === 'cpmm-multi-1' && !contract.shouldAnswersSumToOne,
+      isMultiCpmm(contract) && !contract.shouldAnswersSumToOne,
       'Invalid contract mechanism'
     )
 
@@ -327,7 +331,7 @@ const undoResolution = async (
     }))
     await bulkUpdateContractMetrics(updateMetrics, pg)
   }
-  if (contract.mechanism === 'cpmm-multi-1' && !answerId) {
+  if (isMultiCpmm(contract) && !answerId) {
     // remove resolutionTime and resolverId from all answers in the contract, restore subsidyPool
     const newAnswers = await pg.map(
       `

--- a/backend/api/src/unresolve.ts
+++ b/backend/api/src/unresolve.ts
@@ -116,6 +116,9 @@ const verifyUserCanUnresolve = async (
   }
 
   let resolutionTime: number
+  // Whole-market-only unresolve for binary and LINKED multi — the mirror of the routing gate
+  // in resolve-market.ts. If cpmm-multi-2 per-answer NO resolution of linked answers ships
+  // (reserved — see the CPMMMulti doc comment in common/src/contract.ts), this relaxes too.
   if (
     mechanism === 'cpmm-1' ||
     (isMultiCpmm(contract) && contract.shouldAnswersSumToOne)

--- a/backend/scheduler/src/jobs/denormalize-answers.ts
+++ b/backend/scheduler/src/jobs/denormalize-answers.ts
@@ -7,6 +7,7 @@ import {
 import { getAnswersForContracts } from 'common/supabase/contracts'
 import { SupabaseClient } from 'common/supabase/utils'
 import { updateContract } from 'shared/supabase/contracts'
+import { MULTI_CPMM_MECHANISMS_SQL } from 'common/contract'
 
 export async function denormalizeAnswers() {
   const pg = createSupabaseDirectClient()
@@ -17,7 +18,7 @@ export async function denormalizeAnswers() {
     `
         select id from contracts
         where last_updated_time > $1
-        and mechanism in ('cpmm-multi-1', 'cpmm-multi-2')
+        and mechanism in ${MULTI_CPMM_MECHANISMS_SQL}
         `,
     [oneMinuteAgo.toISOString()],
     (r) => r.id as string

--- a/backend/scheduler/src/jobs/denormalize-answers.ts
+++ b/backend/scheduler/src/jobs/denormalize-answers.ts
@@ -17,7 +17,7 @@ export async function denormalizeAnswers() {
     `
         select id from contracts
         where last_updated_time > $1
-        and mechanism = 'cpmm-multi-1'
+        and mechanism in ('cpmm-multi-1', 'cpmm-multi-2')
         `,
     [oneMinuteAgo.toISOString()],
     (r) => r.id as string

--- a/backend/scheduler/src/jobs/drizzle-liquidity.ts
+++ b/backend/scheduler/src/jobs/drizzle-liquidity.ts
@@ -42,6 +42,16 @@ export const drizzleLiquidity = async () => {
 
   log('found', answers.length, 'answers to drizzle')
 
+  // Per-answer subsidies (from a per-answer addLiquidity) drizzle here, independently of the
+  // whole-market subsidy above. NOTE (cpmm-multi-2, observed on the dev instance): when a market
+  // has BOTH a contract-level subsidy and a per-answer subsidy, drizzleMarket rewrites every
+  // answer's pool and so contends on the same rows as drizzleAnswer; drizzleMarket retries
+  // (runTransactionWithRetries) while drizzleAnswer uses a plain tx, so the per-answer side tends
+  // to lose and only drains once the contract-level subsidy is exhausted. This merely DELAYS
+  // distribution — it never loses mana: any undrizzled subsidy (contract or per-answer) is still
+  // paid out at resolution (getMultiLiquidityPoolPayouts sums answer.subsidyPool). Deemed
+  // acceptable; not adding retry parity here. The only cost is the per-answer subsidy deepens the
+  // live market later than a lone subsidy would.
   await mapAsync(answers, (answer) => drizzleAnswer(pg, answer.id), 10)
 }
 

--- a/backend/scheduler/src/jobs/drizzle-liquidity.ts
+++ b/backend/scheduler/src/jobs/drizzle-liquidity.ts
@@ -18,7 +18,11 @@ import {
   createSupabaseDirectClient,
 } from 'shared/supabase/init'
 import { convertAnswer } from 'common/supabase/contracts'
-import { getAnswer, updateAnswer, updateAnswers } from 'shared/supabase/answers'
+import {
+  getAnswerForUpdate,
+  updateAnswer,
+  updateAnswers,
+} from 'shared/supabase/answers'
 import { runTransactionWithRetries } from 'shared/transact-with-retries'
 import { getContract, log } from 'shared/utils'
 import { updateContract } from 'shared/supabase/contracts'
@@ -159,7 +163,9 @@ const drizzleMarket = async (contractId: string) => {
 
 const drizzleAnswer = async (pg: SupabaseDirectClient, answerId: string) => {
   await pg.tx(async (tx) => {
-    const answer = await getAnswer(tx, answerId)
+    // Row-locked read: this tx read-modify-writes subsidyPool (and pools) with concrete
+    // values, racing the per-answer addLiquidity API path in another process.
+    const answer = await getAnswerForUpdate(tx, answerId)
     if (!answer) return
 
     const { subsidyPool, poolYes, poolNo } = answer

--- a/backend/scheduler/src/jobs/drizzle-liquidity.ts
+++ b/backend/scheduler/src/jobs/drizzle-liquidity.ts
@@ -1,4 +1,4 @@
-import { CPMMContract, CPMMMultiContract } from 'common/contract'
+import { CPMMContract, CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { mapAsync } from 'common/util/promise'
 import { APIError } from 'common/api/utils'
 import {
@@ -55,7 +55,7 @@ const drizzleMarket = async (contractId: string) => {
     const v = (uniqueBettorCount ?? 0) < 50 ? 0.3 : 0.6
     const amount = subsidyPool <= 1 ? subsidyPool : r * v * subsidyPool
 
-    if (contract.mechanism === 'cpmm-multi-1') {
+    if (isMultiCpmm(contract)) {
       const answers = contract.answers
       if (!answers.length) {
         return

--- a/backend/scheduler/src/jobs/drizzle-liquidity.ts
+++ b/backend/scheduler/src/jobs/drizzle-liquidity.ts
@@ -5,9 +5,11 @@ import {
   addCpmmLiquidity,
   addCpmmLiquidityFixedP,
   addCpmmMultiLiquidityAnswersSumToOne,
+  addCpmmMultiLiquidityAnswersSumToOneV2,
   addCpmmMultiLiquidityToAnswersIndependently,
   getCpmmProbability,
 } from 'common/calculate-cpmm'
+import { Answer } from 'common/answer'
 import { formatMoneyWithDecimals } from 'common/util/format'
 import { shuffle } from 'lodash'
 import {
@@ -61,21 +63,52 @@ const drizzleMarket = async (contractId: string) => {
         return
       }
 
-      const poolsByAnswer = Object.fromEntries(
-        answers.map((a) => [a.id, { YES: a.poolYes, NO: a.poolNo }])
-      )
-      const newPools = contract.shouldAnswersSumToOne
-        ? addCpmmMultiLiquidityAnswersSumToOne(poolsByAnswer, amount)
-        : addCpmmMultiLiquidityToAnswersIndependently(poolsByAnswer, amount)
+      // cpmm-multi-2 sum-to-one markets take the lossless float-p subsidy: inject into both
+      // reserves and let each answer's p absorb the mana, so probability is preserved with no
+      // discarded shares. This only DEEPENS an already-converted v2 market — drizzle never
+      // converts a v1 market (conversion is gated to an explicit user addLiquidity, so the
+      // scheduler can't flip fill semantics under resting orders; see migration policy).
+      const isV2SumToOne =
+        contract.mechanism === 'cpmm-multi-2' && contract.shouldAnswersSumToOne
 
-      const poolEntries = Object.entries(newPools).slice(0, 50_000)
+      let answerUpdates: (Partial<Answer> & { id: string })[]
+      if (isV2SumToOne) {
+        const poolsByAnswer = Object.fromEntries(
+          answers.map((a) => [
+            a.id,
+            { pool: { YES: a.poolYes, NO: a.poolNo }, p: a.p },
+          ])
+        )
+        const newByAnswer = addCpmmMultiLiquidityAnswersSumToOneV2(
+          poolsByAnswer,
+          amount
+        )
+        answerUpdates = Object.entries(newByAnswer)
+          .slice(0, 50_000)
+          .map(([answerId, { pool, p }]) => ({
+            id: answerId,
+            poolYes: pool.YES,
+            poolNo: pool.NO,
+            p,
+            prob: getCpmmProbability(pool, p),
+          }))
+      } else {
+        const poolsByAnswer = Object.fromEntries(
+          answers.map((a) => [a.id, { YES: a.poolYes, NO: a.poolNo }])
+        )
+        const newPools = contract.shouldAnswersSumToOne
+          ? addCpmmMultiLiquidityAnswersSumToOne(poolsByAnswer, amount)
+          : addCpmmMultiLiquidityToAnswersIndependently(poolsByAnswer, amount)
 
-      const answerUpdates = poolEntries.map(([answerId, newPool]) => ({
-        id: answerId,
-        poolYes: newPool.YES,
-        poolNo: newPool.NO,
-        prob: getCpmmProbability(newPool, 0.5),
-      }))
+        answerUpdates = Object.entries(newPools)
+          .slice(0, 50_000)
+          .map(([answerId, newPool]) => ({
+            id: answerId,
+            poolYes: newPool.YES,
+            poolNo: newPool.NO,
+            prob: getCpmmProbability(newPool, 0.5),
+          }))
+      }
 
       await updateAnswers(pgTrans, contractId, answerUpdates)
 

--- a/backend/scheduler/src/jobs/drizzle-liquidity.ts
+++ b/backend/scheduler/src/jobs/drizzle-liquidity.ts
@@ -7,6 +7,7 @@ import {
   addCpmmMultiLiquidityAnswersSumToOne,
   addCpmmMultiLiquidityAnswersSumToOneV2,
   addCpmmMultiLiquidityToAnswersIndependently,
+  addCpmmMultiLiquidityToAnswersIndependentlyV2,
   getCpmmProbability,
 } from 'common/calculate-cpmm'
 import { Answer } from 'common/answer'
@@ -63,26 +64,27 @@ const drizzleMarket = async (contractId: string) => {
         return
       }
 
-      // cpmm-multi-2 sum-to-one markets take the lossless float-p subsidy: inject into both
-      // reserves and let each answer's p absorb the mana, so probability is preserved with no
-      // discarded shares. This only DEEPENS an already-converted v2 market — drizzle never
-      // converts a v1 market (conversion is gated to an explicit user addLiquidity, so the
-      // scheduler can't flip fill semantics under resting orders; see migration policy).
-      const isV2SumToOne =
-        contract.mechanism === 'cpmm-multi-2' && contract.shouldAnswersSumToOne
+      // cpmm-multi-2 markets take the lossless float-p subsidy: inject the mana into BOTH reserves
+      // of each answer and let that answer's p absorb it, so each probability is preserved with no
+      // discarded shares (the same move the binary CPMM makes in addCpmmLiquidity). Sum-to-one
+      // keeps Σ prob = 1 as a consequence (GP6a); independent answers are each their own binary
+      // market. This only DEEPENS an already-converted v2 market — drizzle NEVER converts a v1
+      // market (conversion is gated to an explicit user addLiquidity, so the scheduler can't flip
+      // fill semantics under resting orders; see migration policy). So any in-flight v1 subsidy
+      // keeps draining through the frozen v1 fixed-p path below, unchanged.
+      const isV2 = contract.mechanism === 'cpmm-multi-2'
 
       let answerUpdates: (Partial<Answer> & { id: string })[]
-      if (isV2SumToOne) {
+      if (isV2) {
         const poolsByAnswer = Object.fromEntries(
           answers.map((a) => [
             a.id,
             { pool: { YES: a.poolYes, NO: a.poolNo }, p: a.p },
           ])
         )
-        const newByAnswer = addCpmmMultiLiquidityAnswersSumToOneV2(
-          poolsByAnswer,
-          amount
-        )
+        const newByAnswer = contract.shouldAnswersSumToOne
+          ? addCpmmMultiLiquidityAnswersSumToOneV2(poolsByAnswer, amount)
+          : addCpmmMultiLiquidityToAnswersIndependentlyV2(poolsByAnswer, amount)
         answerUpdates = Object.entries(newByAnswer)
           .slice(0, 50_000)
           .map(([answerId, { pool, p }]) => ({
@@ -93,6 +95,7 @@ const drizzleMarket = async (contractId: string) => {
             prob: getCpmmProbability(pool, p),
           }))
       } else {
+        // cpmm-multi-1 (frozen v1): lossy fixed-p add, p pinned at 0.5.
         const poolsByAnswer = Object.fromEntries(
           answers.map((a) => [a.id, { YES: a.poolYes, NO: a.poolNo }])
         )
@@ -156,9 +159,19 @@ const drizzleAnswer = async (pg: SupabaseDirectClient, answerId: string) => {
     const amount = subsidyPool <= 1 ? subsidyPool : r * 0.4 * subsidyPool
 
     const pool = { YES: poolYes, NO: poolNo }
-    const { newPool } = addCpmmLiquidityFixedP(pool, amount)
 
-    if (!isFinite(newPool.YES) || !isFinite(newPool.NO)) {
+    // A cpmm-multi-2 answer is its own binary CPMM, so it takes the lossless float-p add (inject
+    // into both reserves, float p to hold its probability — no discarded shares, prob preserved).
+    // cpmm-multi-1 stays on the frozen lossy fixed-p add (which pins p = 0.5 and clobbers prob to
+    // N/(Y+N)). Drizzle only deepens — it never converts (that's the explicit user addLiquidity).
+    const contract = await getContract(tx, answer.contractId)
+    const isV2 = contract?.mechanism === 'cpmm-multi-2'
+
+    const { newPool, newP } = isV2
+      ? addCpmmLiquidity(pool, answer.p, amount)
+      : { ...addCpmmLiquidityFixedP(pool, amount), newP: 0.5 }
+
+    if (!isFinite(newPool.YES) || !isFinite(newPool.NO) || !isFinite(newP)) {
       throw new APIError(
         500,
         'Liquidity injection rejected due to overflow error.'
@@ -168,7 +181,8 @@ const drizzleAnswer = async (pg: SupabaseDirectClient, answerId: string) => {
     await updateAnswer(tx, answerId, {
       poolYes: newPool.YES,
       poolNo: newPool.NO,
-      prob: getCpmmProbability(newPool, 0.5),
+      ...(isV2 ? { p: newP } : {}),
+      prob: getCpmmProbability(newPool, newP),
       subsidyPool: subsidyPool - amount,
     })
 

--- a/backend/scheduler/src/jobs/drizzle-liquidity.ts
+++ b/backend/scheduler/src/jobs/drizzle-liquidity.ts
@@ -27,6 +27,8 @@ import { runTransactionWithRetries } from 'shared/transact-with-retries'
 import { getContract, log } from 'shared/utils'
 import { updateContract } from 'shared/supabase/contracts'
 
+// (GPnn labels cite machine-checked proofs: https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/proofs)
+
 export const drizzleLiquidity = async () => {
   const pg = createSupabaseDirectClient()
 
@@ -180,8 +182,14 @@ const drizzleAnswer = async (pg: SupabaseDirectClient, answerId: string) => {
     // into both reserves, float p to hold its probability — no discarded shares, prob preserved).
     // cpmm-multi-1 stays on the frozen lossy fixed-p add (which pins p = 0.5 and clobbers prob to
     // N/(Y+N)). Drizzle only deepens — it never converts (that's the explicit user addLiquidity).
-    const contract = await getContract(tx, answer.contractId)
-    const isV2 = contract?.mechanism === 'cpmm-multi-2'
+    // Read just the mechanism column, but INSIDE the tx (a v1->v2 conversion can flip it; a
+    // stale pre-job read could apply the lossy v1 add to a converted market) — the win over
+    // getContract is skipping the whole data-blob fetch+convert once per subsidized answer.
+    const row = await tx.oneOrNone<{ mechanism: string }>(
+      `select mechanism from contracts where id = $1`,
+      [answer.contractId]
+    )
+    const isV2 = row?.mechanism === 'cpmm-multi-2'
 
     const { newPool, newP } = isV2
       ? addCpmmLiquidity(pool, answer.p, amount)

--- a/backend/scripts/delete-private-groups.ts
+++ b/backend/scripts/delete-private-groups.ts
@@ -39,7 +39,7 @@ runScript(async ({ pg }) => {
   console.log(`redacting all answers`)
   await pg.none(
     `with private_contracts as (
-      select id from contracts where visibility = 'private' and mechanism = 'cpmm-multi-1'
+      select id from contracts where visibility = 'private' and mechanism in ('cpmm-multi-1', 'cpmm-multi-2')
     )
     update answers
     set data = data || jsonb_build_object('text', '[deleted answer ' || index || ']')

--- a/backend/scripts/delete-private-groups.ts
+++ b/backend/scripts/delete-private-groups.ts
@@ -3,6 +3,7 @@ import { runScript } from 'run-script'
 import { setAdjustProfitFromResolvedMarkets } from 'shared/helpers/user-contract-metrics'
 import { resolveMarketHelper } from 'shared/resolve-market-helpers'
 import { getUser } from 'shared/utils'
+import { MULTI_CPMM_MECHANISMS_SQL } from 'common/contract'
 
 runScript(async ({ pg }) => {
   console.log(`deleting all private comments`)
@@ -39,7 +40,7 @@ runScript(async ({ pg }) => {
   console.log(`redacting all answers`)
   await pg.none(
     `with private_contracts as (
-      select id from contracts where visibility = 'private' and mechanism in ('cpmm-multi-1', 'cpmm-multi-2')
+      select id from contracts where visibility = 'private' and mechanism in ${MULTI_CPMM_MECHANISMS_SQL}
     )
     update answers
     set data = data || jsonb_build_object('text', '[deleted answer ' || index || ']')

--- a/backend/shared/src/create-contract-helpers.ts
+++ b/backend/shared/src/create-contract-helpers.ts
@@ -1,6 +1,11 @@
 import { getNewLiquidityProvision } from 'common/add-liquidity'
 import { getCpmmInitialLiquidity } from 'common/antes'
-import { BinaryContract, Contract, CPMMMultiContract } from 'common/contract'
+import {
+  BinaryContract,
+  Contract,
+  CPMMMultiContract,
+  isMultiCpmm,
+} from 'common/contract'
 import { updateContract } from './supabase/contracts'
 import { SupabaseDirectClient } from './supabase/init'
 import { insertLiquidity } from './supabase/liquidity'
@@ -14,10 +19,11 @@ export async function generateAntes(
   ante: number,
   totalMarketCost: number
 ) {
-  if (
-    contract.mechanism === 'cpmm-multi-1' &&
-    !contract.shouldAnswersSumToOne
-  ) {
+  // NOTE: these branches must cover cpmm-multi-2 as well as cpmm-multi-1 — the
+  // ante LiquidityProvision row is what records the creator as the pool's LP, so
+  // that resolution returns the pools' resolved value to them (without it the
+  // ante is stranded). `isMultiCpmm` covers both mechanisms.
+  if (isMultiCpmm(contract) && !contract.shouldAnswersSumToOne) {
     const { answers } = contract
     for (const answer of answers) {
       const ante = Math.sqrt(answer.poolYes * answer.poolNo)
@@ -32,10 +38,7 @@ export async function generateAntes(
 
       await insertLiquidity(pg, lp)
     }
-  } else if (
-    contract.mechanism === 'cpmm-multi-1' ||
-    contract.mechanism === 'cpmm-1'
-  ) {
+  } else if (isMultiCpmm(contract) || contract.mechanism === 'cpmm-1') {
     const lp = getCpmmInitialLiquidity(
       providerId,
       contract as BinaryContract | CPMMMultiContract,
@@ -48,7 +51,7 @@ export async function generateAntes(
   const drizzledAmount = totalMarketCost - ante
   if (
     drizzledAmount > 0 &&
-    (contract.mechanism === 'cpmm-1' || contract.mechanism === 'cpmm-multi-1')
+    (contract.mechanism === 'cpmm-1' || isMultiCpmm(contract))
   ) {
     return await pg.txIf(async (tx) => {
       await runTxnOutsideBetQueue(tx, {

--- a/backend/shared/src/helpers/super-ban.ts
+++ b/backend/shared/src/helpers/super-ban.ts
@@ -1,5 +1,5 @@
 import { APIError } from 'common/api/utils'
-import { MarketContract } from 'common/contract'
+import { isMultiCpmm, MarketContract } from 'common/contract'
 import { isAdminId } from 'common/envs/constants'
 import { convertContract } from 'common/supabase/contracts'
 import { convertPost, TopLevelPost } from 'common/top-level-post'
@@ -145,7 +145,7 @@ export async function superBanUserCore(
     try {
       for (const contract of contracts.filter(
         (c) =>
-          (c.mechanism === 'cpmm-1' || c.mechanism === 'cpmm-multi-1') &&
+          (c.mechanism === 'cpmm-1' || isMultiCpmm(c)) &&
           !c.isResolved
       )) {
         await resolveMarketHelper(

--- a/backend/shared/src/resolve-market-helpers.ts
+++ b/backend/shared/src/resolve-market-helpers.ts
@@ -10,6 +10,7 @@ import {
   contractPath,
   ContractToken,
   CPMMMultiContract,
+  isMultiCpmm,
   MarketContract,
 } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
@@ -86,7 +87,7 @@ export const resolveMarketHelper = async (
       unresolvedContract,
       answerId
     )
-    const isIndieMC = c.mechanism === 'cpmm-multi-1' && !c.shouldAnswersSumToOne
+    const isIndieMC = isMultiCpmm(c) && !c.shouldAnswersSumToOne
 
     unresolvedContract = c as MarketContract
     if (unresolvedContract.isResolved) {
@@ -148,7 +149,7 @@ export const resolveMarketHelper = async (
       })
     let updateAnswerAttrs: Partial<Answer> | undefined
 
-    if (unresolvedContract.mechanism === 'cpmm-multi-1' && answerId) {
+    if (isMultiCpmm(unresolvedContract) && answerId) {
       // Only resolve the contract if all other answers are resolved.
       const allOtherAnswers = unresolvedContract.answers.filter(
         (a) => a.id !== answerId
@@ -200,7 +201,7 @@ export const resolveMarketHelper = async (
         ),
       } as Partial<CPMMMultiContract> & { id: string }
     } else if (
-      unresolvedContract.mechanism === 'cpmm-multi-1' &&
+      isMultiCpmm(unresolvedContract) &&
       updatedContractAttrs.isResolved
     ) {
       updateAnswerAttrs = removeUndefinedProps({
@@ -245,7 +246,7 @@ export const resolveMarketHelper = async (
       await updateAnswer(tx, answerId, props)
     } else if (
       updateAnswerAttrs &&
-      resolvedContract.mechanism === 'cpmm-multi-1'
+      isMultiCpmm(resolvedContract)
     ) {
       const answerUpdates = resolvedContract.answers.map((a) =>
         removeUndefinedProps({

--- a/backend/shared/src/resolve-sports-markets.ts
+++ b/backend/shared/src/resolve-sports-markets.ts
@@ -1,6 +1,6 @@
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { log } from 'shared/utils'
-import { SportsContract } from 'common/contract'
+import { isMultiCpmm, SportsContract } from 'common/contract'
 import {
   HOUSE_LIQUIDITY_PROVIDER_ID,
   DEV_HOUSE_LIQUIDITY_PROVIDER_ID,
@@ -84,7 +84,7 @@ export async function resolveSportsMarkets() {
 
       for (const contract of matchingContracts) {
         try {
-          if (contract.mechanism !== 'cpmm-multi-1') continue
+          if (!isMultiCpmm(contract)) continue
           const multiContract = contract
           const { answers, sportsLeague } = multiContract
           const isEPL = sportsLeague === 'English Premier League'

--- a/backend/shared/src/send-market-movement-notifications.ts
+++ b/backend/shared/src/send-market-movement-notifications.ts
@@ -1,5 +1,5 @@
 import { Answer } from 'common/answer'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import { Notification } from 'common/notification'
 import { convertAnswer, convertContract } from 'common/supabase/contracts'
 import { Row } from 'common/supabase/utils'
@@ -53,7 +53,7 @@ export async function sendMarketMovementNotifications(debug = false) {
   )
   const allContracts = results[0].map(convertContract)
   const sumToOneContractIds = allContracts
-    .filter((c) => c.mechanism === 'cpmm-multi-1' && c.shouldAnswersSumToOne)
+    .filter((c) => isMultiCpmm(c) && c.shouldAnswersSumToOne)
     .map((c) => c.id)
   const answers = results[1].map(convertAnswer)
   for (const contract of allContracts) {
@@ -109,10 +109,7 @@ export async function sendMarketMovementNotifications(debug = false) {
           currentProb: prob,
         })
       }
-    } else if (
-      contract.mechanism === 'cpmm-multi-1' &&
-      contract.shouldAnswersSumToOne
-    ) {
+    } else if (isMultiCpmm(contract) && contract.shouldAnswersSumToOne) {
       const { answers: contractAnswers } = contract
       let maxChange = probThreshold
       let maxChangedAnswer = null
@@ -293,7 +290,6 @@ async function createMarketMovementNotifications(
     avgAfter,
     currentProb,
   } of probChanges) {
-    const { mechanism } = contract
     // Get users who are watching this market or have shares in it
     const usersInterestedInContract = allInterestedUsers
       .filter((u) => u.contractId === contract.id)
@@ -317,8 +313,7 @@ async function createMarketMovementNotifications(
       const { sendToBrowser, sendToMobile } =
         getNotificationDestinationsForUser(user, 'market_movements')
 
-      const sumsToOne =
-        mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne
+      const sumsToOne = isMultiCpmm(contract) && contract.shouldAnswersSumToOne
 
       // Check if a similar notification has already been sent recently for the relevant destination
       const existingNotificationsForUserAndContract =

--- a/backend/shared/src/supabase/answers.ts
+++ b/backend/shared/src/supabase/answers.ts
@@ -15,6 +15,22 @@ export const getAnswer = async (pg: SupabaseDirectClient, id: string) => {
   return row ? convertAnswer(row) : null
 }
 
+// Like getAnswer, but takes a row lock (SELECT ... FOR UPDATE). Required whenever a
+// transaction read-modify-writes answer fields with concrete values (e.g. subsidyPool):
+// the betsQueue serializes only within one process, so the per-answer addLiquidity API
+// path and the scheduler's drizzleAnswer would otherwise interleave read-then-write and
+// create or destroy subsidy mana. Both of those writers must use this locking read.
+export const getAnswerForUpdate = async (
+  pg: SupabaseDirectClient,
+  id: string
+) => {
+  const row = await pg.oneOrNone(
+    `select * from answers where id = $1 for update`,
+    [id]
+  )
+  return row ? convertAnswer(row) : null
+}
+
 export const getAnswersForContractsDirect = async (
   pg: SupabaseDirectClient,
   contractIds: string[]

--- a/backend/shared/src/supabase/answers.ts
+++ b/backend/shared/src/supabase/answers.ts
@@ -97,6 +97,7 @@ export const answerToRow = (answer: Omit<Answer, 'id'> & { id?: string }) => ({
   color: answer.color,
   pool_yes: answer.poolYes,
   pool_no: answer.poolNo,
+  p: answer.p,
   prob: answer.prob,
   total_liquidity: answer.totalLiquidity,
   subsidy_pool: answer.subsidyPool,

--- a/backend/shared/src/supabase/contracts.ts
+++ b/backend/shared/src/supabase/contracts.ts
@@ -2,6 +2,7 @@ import { APIError } from 'common/api/utils'
 import {
   Contract,
   CPMMMultiContract,
+  isMultiCpmm,
   nativeContractColumnsArray,
 } from 'common/contract'
 import { isAdminId } from 'common/envs/constants'
@@ -73,7 +74,7 @@ export const getContractsDirect = async (
   )
   const contracts = results[0].map(convertContract)
   const answers = results[1].map(convertAnswer)
-  const multiContracts = contracts.filter((c) => c.mechanism === 'cpmm-multi-1')
+  const multiContracts = contracts.filter((c) => isMultiCpmm(c))
   for (const contract of multiContracts) {
     // eslint-disable-next-line no-extra-semi
     ;(contract as CPMMMultiContract).answers = sortBy(

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -26,6 +26,7 @@ import {
   userIdsToAverageTopicConversionScores,
 } from 'shared/topic-interests'
 import { contractColumnsToSelectWithPrefix, log } from 'shared/utils'
+import { MULTI_CPMM_MECHANISMS_SQL } from 'common/contract'
 
 const DEFAULT_THRESHOLD = 1000
 type TokenInputType = 'CASH' | 'MANA' | 'ALL' | 'CASH_AND_MANA'
@@ -396,11 +397,11 @@ function getSearchContractWhereSQL(args: {
   const liquidityFilter = liquidity
     ? `(
     CASE
-        WHEN mechanism in ('cpmm-multi-1', 'cpmm-multi-2') AND jsonb_typeof(contracts.data->'answers') = 'array' AND jsonb_array_length(contracts.data->'answers') > 0
+        WHEN mechanism in ${MULTI_CPMM_MECHANISMS_SQL} AND jsonb_typeof(contracts.data->'answers') = 'array' AND jsonb_array_length(contracts.data->'answers') > 0
         THEN (coalesce((contracts.data->>'totalLiquidity')::numeric, 0) / jsonb_array_length(contracts.data->'answers'))
         ELSE coalesce((contracts.data->>'totalLiquidity')::numeric, 0)
     END
-  ) >= case when mechanism in ('cpmm-multi-1', 'cpmm-multi-2') then ${answerLiquidity} else ${liquidity} end`
+  ) >= case when mechanism in ${MULTI_CPMM_MECHANISMS_SQL} then ${answerLiquidity} else ${liquidity} end`
     : ''
   const deletedFilter = `deleted = false`
 

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -1,4 +1,4 @@
-import { Contract, isSportsContract } from 'common/contract'
+import { Contract, isMultiCpmm, isSportsContract } from 'common/contract'
 import { PROD_MANIFOLD_LOVE_GROUP_SLUG } from 'common/envs/constants'
 import { GROUP_SCORE_PRIOR } from 'common/feed'
 import { tsToMillis } from 'common/supabase/utils'
@@ -396,11 +396,11 @@ function getSearchContractWhereSQL(args: {
   const liquidityFilter = liquidity
     ? `(
     CASE
-        WHEN mechanism = 'cpmm-multi-1' AND jsonb_typeof(contracts.data->'answers') = 'array' AND jsonb_array_length(contracts.data->'answers') > 0
+        WHEN mechanism in ('cpmm-multi-1', 'cpmm-multi-2') AND jsonb_typeof(contracts.data->'answers') = 'array' AND jsonb_array_length(contracts.data->'answers') > 0
         THEN (coalesce((contracts.data->>'totalLiquidity')::numeric, 0) / jsonb_array_length(contracts.data->'answers'))
         ELSE coalesce((contracts.data->>'totalLiquidity')::numeric, 0)
     END
-  ) >= case when mechanism = 'cpmm-multi-1' then ${answerLiquidity} else ${liquidity} end`
+  ) >= case when mechanism in ('cpmm-multi-1', 'cpmm-multi-2') then ${answerLiquidity} else ${liquidity} end`
     : ''
   const deletedFilter = `deleted = false`
 
@@ -472,7 +472,7 @@ export const sortFields: SortFields = {
   subsidy: {
     sql: "COALESCE((contracts.data->>'totalLiquidity')::numeric, 0)",
     sortCallback: (c: Contract) =>
-      c.mechanism === 'cpmm-1' || c.mechanism === 'cpmm-multi-1'
+      c.mechanism === 'cpmm-1' || isMultiCpmm(c)
         ? c.totalLiquidity
         : 0,
     order: 'DESC',

--- a/backend/shared/src/update-contract-metrics-core.ts
+++ b/backend/shared/src/update-contract-metrics-core.ts
@@ -1,6 +1,6 @@
 import { LimitBet } from 'common/bet'
 import { computeElasticity } from 'common/calculate-metrics'
-import { Contract, CPMM } from 'common/contract'
+import { Contract, CPMM, isMultiCpmm } from 'common/contract'
 import { convertAnswer, convertContract } from 'common/supabase/contracts'
 import { hasChanges } from 'common/util/object'
 import { DAY_MS, MONTH_MS, WEEK_MS } from 'common/util/time'
@@ -34,7 +34,7 @@ export async function updateContractMetricsCore(wholeMonth: boolean = false) {
   )
   const allContracts = results[0].map(convertContract)
   const sumToOneContractIds = allContracts
-    .filter((c) => c.mechanism === 'cpmm-multi-1' && c.shouldAnswersSumToOne)
+    .filter((c) => isMultiCpmm(c) && c.shouldAnswersSumToOne)
     .map((c) => c.id)
   const answers = results[1].map(convertAnswer)
   log(`Loaded ${allContracts.length} contracts.`)
@@ -109,7 +109,7 @@ export async function updateContractMetricsCore(wholeMonth: boolean = false) {
             month: resTime && resTime <= monthAgo ? 0 : prob - monthAgoProb,
           },
         }
-      } else if (contract.mechanism === 'cpmm-multi-1') {
+      } else if (isMultiCpmm(contract)) {
         const contractAnswers = answers.filter(
           (a) => a.contractId === contract.id
         )

--- a/backend/shared/src/update-user-metric-periods.ts
+++ b/backend/shared/src/update-user-metric-periods.ts
@@ -3,7 +3,7 @@ import {
   calculateMetricsFromProbabilityChanges,
   isEmptyMetric,
 } from 'common/calculate-metrics'
-import { Contract, CPMMMultiContract } from 'common/contract'
+import { Contract, CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
 import { convertBet } from 'common/supabase/bets'
 import { convertAnswer, convertContract } from 'common/supabase/contracts'
@@ -160,7 +160,7 @@ export async function updateUserMetricPeriods(
     const contracts = results[0].map(convertContract)
     const answers = results[1].map(convertAnswer)
     contracts.forEach((c) => {
-      if (c.mechanism === 'cpmm-multi-1')
+      if (isMultiCpmm(c))
         contractsById[c.id] = {
           ...c,
           answers: answers.filter((a) => a.contractId === c.id),
@@ -374,7 +374,7 @@ const getUnresolvedOrRecentlyResolvedBets = async (
     where
       cb.user_id in ($1:list)
       and cb.contract_id in ($3:list)
-      and (c.mechanism != 'cpmm-multi-1' or not cb.is_redemption)
+      and (c.mechanism not in ('cpmm-multi-1', 'cpmm-multi-2') or not cb.is_redemption)
       and (c.resolution_time is null or c.resolution_time > $2)
       and (a is null or a.resolution_time is null or a.resolution_time > $2)
     `,

--- a/backend/shared/src/update-user-metric-periods.ts
+++ b/backend/shared/src/update-user-metric-periods.ts
@@ -17,6 +17,7 @@ import {
 } from 'shared/supabase/init'
 import { contractColumnsToSelect, isProd, log } from 'shared/utils'
 import { bulkUpdateDataQuery, bulkUpdateQuery } from './supabase/utils'
+import { MULTI_CPMM_MECHANISMS_SQL } from 'common/contract'
 
 const CHUNK_SIZE = isProd() ? 400 : 10
 export async function updateUserMetricPeriods(
@@ -374,7 +375,7 @@ const getUnresolvedOrRecentlyResolvedBets = async (
     where
       cb.user_id in ($1:list)
       and cb.contract_id in ($3:list)
-      and (c.mechanism not in ('cpmm-multi-1', 'cpmm-multi-2') or not cb.is_redemption)
+      and (c.mechanism not in ${MULTI_CPMM_MECHANISMS_SQL} or not cb.is_redemption)
       and (c.resolution_time is null or c.resolution_time > $2)
       and (a is null or a.resolution_time is null or a.resolution_time > $2)
     `,

--- a/backend/shared/src/update-user-portfolio-histories-core.ts
+++ b/backend/shared/src/update-user-portfolio-histories-core.ts
@@ -13,6 +13,7 @@ import {
   Contract,
   ContractToken,
   CPMMMultiContract,
+  isMultiCpmm,
   MarketContract,
 } from 'common/contract'
 import {
@@ -241,7 +242,7 @@ export const getUnresolvedContractMetricsContractsAnswers = async (
     where('c.resolution_time is null'),
     where('(a is null or a.resolution_time is null)'),
     where(
-      `case when c.mechanism = 'cpmm-multi-1' then ucm.answer_id is not null else true end`
+      `case when c.mechanism in ('cpmm-multi-1', 'cpmm-multi-2') then ucm.answer_id is not null else true end`
     ),
   ]
   const metricsSql = renderSql(
@@ -350,7 +351,7 @@ export const getUnresolvedStatsForToken = (
     }
 
     // ignore summary metrics
-    if (contract.mechanism === 'cpmm-multi-1') {
+    if (isMultiCpmm(contract)) {
       if (!cm.answerId)
         return { value: 0, invested: 0, dailyProfit: 0, loan: 0 }
       const answer = contract.answers.find((a) => a.id === cm.answerId)

--- a/backend/shared/src/update-user-portfolio-histories-core.ts
+++ b/backend/shared/src/update-user-portfolio-histories-core.ts
@@ -38,6 +38,7 @@ import {
   leftJoin,
   where,
 } from './supabase/sql-builder'
+import { MULTI_CPMM_MECHANISMS_SQL } from 'common/contract'
 
 const userToPortfolioMetrics: {
   [userId: string]: {
@@ -242,7 +243,7 @@ export const getUnresolvedContractMetricsContractsAnswers = async (
     where('c.resolution_time is null'),
     where('(a is null or a.resolution_time is null)'),
     where(
-      `case when c.mechanism in ('cpmm-multi-1', 'cpmm-multi-2') then ucm.answer_id is not null else true end`
+      `case when c.mechanism in ${MULTI_CPMM_MECHANISMS_SQL} then ucm.answer_id is not null else true end`
     ),
   ]
   const metricsSql = renderSql(

--- a/backend/shared/src/utils.ts
+++ b/backend/shared/src/utils.ts
@@ -3,6 +3,7 @@ import { APIError, getCloudRunServiceUrl } from 'common/api/utils'
 import {
   Contract,
   contractPath,
+  isMultiCpmm,
   MarketContract,
   nativeContractColumnsArray,
 } from 'common/contract'
@@ -203,8 +204,8 @@ export const getContractAndMetricsAndLiquidities = async (
   unresolvedContract: MarketContract,
   answerId: string | undefined
 ) => {
-  const { id: contractId, mechanism } = unresolvedContract
-  const isMulti = mechanism === 'cpmm-multi-1'
+  const { id: contractId } = unresolvedContract
+  const isMulti = isMultiCpmm(unresolvedContract)
   const sumsToOne = isMulti && unresolvedContract.shouldAnswersSumToOne
   const metricsQuery = sumsToOne
     ? `

--- a/backend/shared/src/weekly-portfolio-emails.ts
+++ b/backend/shared/src/weekly-portfolio-emails.ts
@@ -1,4 +1,4 @@
-import { CPMMContract, CPMMMultiContract } from 'common/contract'
+import { CPMMContract, CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { getPrivateUsersNotSent, isProd, log } from 'shared/utils'
 import { filterDefined } from 'common/util/array'
 import { DAY_MS } from 'common/util/time'
@@ -167,7 +167,7 @@ export async function sendPortfolioUpdateEmailsToAllUsers() {
           const currentValue = cm.payout
           const { resolution, mechanism } = cpmmContract
           const resolutionTitle =
-            mechanism === 'cpmm-multi-1' &&
+            isMultiCpmm(cpmmContract) &&
             resolution &&
             cpmmContract.shouldAnswersSumToOne
               ? cpmmContract.answers.find((a) => a.id === resolution)?.text

--- a/backend/supabase/answers.sql
+++ b/backend/supabase/answers.sql
@@ -25,7 +25,8 @@ create table if not exists
     total_liquidity numeric default 0,
     user_id text,
     midpoint numeric,
-    volume numeric default 0
+    volume numeric default 0,
+    p numeric default 0.5 not null
   );
 
 -- Row Level Security

--- a/backend/supabase/migrations/2026062701_add_answers_p.sql
+++ b/backend/supabase/migrations/2026062701_add_answers_p.sql
@@ -1,0 +1,12 @@
+-- cpmm-multi-2: add per-answer CPMM parameter `p` to answers.
+--
+-- Binary cpmm-1 markets carry a `p` on the contract (CPMM.p) so a non-50% market can be
+-- represented by a balanced, deep pool. Multi-choice answers have no such field, pinning
+-- every answer to p = 0.5 (uniform 1/n init, lossy liquidity adds). cpmm-multi-2 gives each
+-- answer its own `p`.
+--
+-- Additive and backwards-compatible: `not null default 0.5` means every existing row reads
+-- p = 0.5 with no backfill, and a cpmm-multi-1 answer is exactly a cpmm-multi-2 answer with
+-- p = 0.5. Probability reads stay byte-identical (getCpmmProbability(pool, 0.5) == N/(Y+N)).
+alter table answers
+  add column if not exists p numeric not null default 0.5;

--- a/client-common/src/hooks/use-contract-updates.ts
+++ b/client-common/src/hooks/use-contract-updates.ts
@@ -1,6 +1,6 @@
 import { SetStateAction } from 'react'
 import { useApiSubscription } from './use-api-subscription'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmmMechanism } from 'common/contract'
 import { Answer } from 'common/answer'
 import { uniqBy } from 'lodash'
 export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
@@ -9,7 +9,7 @@ export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
 ) => {
   useApiSubscription({
     topics: [`contract/${initial.id}/new-answer`],
-    enabled: 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
+    enabled: 'mechanism' in initial && isMultiCpmmMechanism(initial.mechanism),
     onBroadcast: ({ data }) => {
       setContract((contract) => {
         return {
@@ -28,7 +28,7 @@ export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
 
   useApiSubscription({
     topics: [`contract/${initial.id}/updated-answers`],
-    enabled: 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
+    enabled: 'mechanism' in initial && isMultiCpmmMechanism(initial.mechanism),
     onBroadcast: ({ data }) => {
       const newAnswerUpdates = data.answers as (Partial<Answer> & {
         id: string

--- a/client-common/src/lib/bet.ts
+++ b/client-common/src/lib/bet.ts
@@ -3,7 +3,7 @@ import {
   getCpmmProbability,
 } from 'common/calculate-cpmm'
 import { LimitBet } from 'common/bet'
-import { Answer } from 'common/answer'
+import { Answer, answerP } from 'common/answer'
 import { noFees } from 'common/fees'
 import { calculateCpmmMultiArbitrageBet } from 'common/calculate-cpmm-arbitrage'
 import { sumBy } from 'lodash'
@@ -43,7 +43,7 @@ export const getLimitBetReturns = (
           YES: multiProps!.answerToBuy.poolYes,
           NO: multiProps!.answerToBuy.poolNo,
         },
-        p: multiProps!.answerToBuy.p,
+        p: answerP(multiProps!.answerToBuy),
         collectedFees: contract.collectedFees,
       }
     : {

--- a/client-common/src/lib/bet.ts
+++ b/client-common/src/lib/bet.ts
@@ -43,7 +43,7 @@ export const getLimitBetReturns = (
           YES: multiProps!.answerToBuy.poolYes,
           NO: multiProps!.answerToBuy.poolNo,
         },
-        p: 0.5,
+        p: multiProps!.answerToBuy.p,
         collectedFees: contract.collectedFees,
       }
     : {

--- a/client-common/src/lib/bet.ts
+++ b/client-common/src/lib/bet.ts
@@ -12,7 +12,7 @@ import { computeCpmmBet } from 'common/new-bet'
 import { MAX_CPMM_PROB, MIN_CPMM_PROB } from 'common/contract'
 import { TRADE_TERM } from 'common/envs/constants'
 import { MarketContract } from 'common/contract'
-import { isBinaryMulti } from 'common/contract'
+import { isBinaryMulti, isMultiCpmm } from 'common/contract'
 const DEFAULT_SLIPPAGE = 0.1
 
 export const getLimitBetReturns = (
@@ -36,7 +36,7 @@ export const getLimitBetReturns = (
         : 'NO'
       : undefined) ?? binaryOutcome
 
-  const isCpmmMulti = contract.mechanism === 'cpmm-multi-1'
+  const isCpmmMulti = isMultiCpmm(contract)
   const cpmmState = isCpmmMulti
     ? {
         pool: {

--- a/common/src/answer-p-default.test.ts
+++ b/common/src/answer-p-default.test.ts
@@ -1,0 +1,60 @@
+import { Answer, answerP } from './answer'
+import { getAnswerProbability } from './calculate'
+import { MultiContract } from './contract'
+
+// Regression: answers deserialized from the denormalized contract data blob
+// (data->'answers' — SSR/SEO/embeds, search "lite" answers) bypass convertAnswer's
+// `row.p ?? 0.5` default, so any answer written before cpmm-multi-2 added `p` reads
+// p === undefined at runtime despite Answer typing it as non-optional. A bare
+// `answer.p` then poisons getCpmmProbability with NaN. answerP is the choke-point
+// default; getAnswerProbability (and the client bet-preview paths) must use it.
+
+const blobAnswer = (overrides: Partial<Answer> = {}): Answer =>
+  // Cast through unknown: we are deliberately building the type-violating shape
+  // (p missing) that real pre-p blob answers have at runtime.
+  ({
+    id: 'a1',
+    index: 0,
+    contractId: 'c1',
+    userId: 'u1',
+    text: 'answer one',
+    createdTime: 0,
+    poolYes: 100,
+    poolNo: 300,
+    prob: 0.75,
+    totalLiquidity: 100,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    ...overrides,
+  } as unknown as Answer)
+
+describe('answerP', () => {
+  it('defaults a missing p to 0.5', () => {
+    expect(answerP(blobAnswer())).toBe(0.5)
+  })
+
+  it('passes through a stored p', () => {
+    expect(answerP(blobAnswer({ p: 0.3 }))).toBe(0.3)
+  })
+})
+
+describe('getAnswerProbability on a blob-sourced (p-less) answer', () => {
+  const withAnswers = (...answers: Answer[]) =>
+    ({ mechanism: 'cpmm-multi-1', answers } as MultiContract)
+
+  it('returns the p=0.5 pool probability, not NaN', () => {
+    const prob = getAnswerProbability(withAnswers(blobAnswer()), 'a1')
+    expect(Number.isFinite(prob)).toBe(true)
+    // p = 0.5: prob = NO / (YES + NO) = 300 / 400
+    expect(prob).toBeCloseTo(0.75, 12)
+  })
+
+  it('still honors per-answer resolution fields', () => {
+    expect(
+      getAnswerProbability(withAnswers(blobAnswer({ resolution: 'NO' })), 'a1')
+    ).toBe(0)
+    expect(
+      getAnswerProbability(withAnswers(blobAnswer({ resolution: 'YES' })), 'a1')
+    ).toBe(1)
+  })
+})

--- a/common/src/answer.ts
+++ b/common/src/answer.ts
@@ -72,6 +72,14 @@ export const getDefaultSort = (contract: MultiContract) => {
   return 'old'
 }
 
+// Read an answer's CPMM p with the storage default applied. Answer.p is typed
+// non-optional and convertAnswer defaults it (row.p ?? 0.5), but answers deserialized
+// from the denormalized contract data blob (data->'answers' — SSR/SEO/embeds, search
+// "lite" answers) bypass convertAnswer, so any answer written before p existed reads
+// p === undefined at runtime and a bare `answer.p` poisons downstream math with NaN.
+// Use this accessor anywhere the answer may have come from the blob.
+export const answerP = (answer: Answer) => answer.p ?? 0.5
+
 export const sortAnswers = <T extends Answer>(
   contract: MultiContract,
   answers: T[],

--- a/common/src/answer.ts
+++ b/common/src/answer.ts
@@ -13,7 +13,8 @@ export type Answer = {
   // Mechanism props
   poolYes: number // YES shares
   poolNo: number // NO shares
-  prob: number // Computed from poolYes and poolNo.
+  p: number // CPMM parameter; prob = p*poolNo / ((1-p)*poolYes + p*poolNo). 0.5 for cpmm-multi-1.
+  prob: number // Computed from poolYes, poolNo and p.
   totalLiquidity: number // for historical reasons, this the total subsidy amount added in M
   subsidyPool: number // current value of subsidy pool in M
   volume: number // current volume of the answer in M

--- a/common/src/answer.ts
+++ b/common/src/answer.ts
@@ -22,6 +22,11 @@ export type Answer = {
   // Is this 'Other', the answer that represents all other answers, including answers added in the future.
   isOther?: boolean
 
+  // Per-answer resolution. Set today only for independent (shouldAnswersSumToOne = false)
+  // markets, where each answer resolves on its own. Reserved cpmm-multi-2 behavior: linked
+  // answers MAY also be individually resolved NO in the future (market stays open, probs
+  // sum to 1 over the unresolved answers) — see the CPMMMulti doc comment in contract.ts.
+  // Consumers should not assume linked answers are never individually resolved.
   resolution?: resolution
   resolutionTime?: number
   resolutionProbability?: number

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -402,6 +402,11 @@ export const createMultiSchema = z.object({
     .enum(['DISABLED', 'ONLY_CREATOR', 'ANYONE'])
     .default('DISABLED'),
   shouldAnswersSumToOne: z.boolean().optional(),
+  // cpmm-multi-2 (PR2c): per-answer initial probabilities, as percentages in
+  // (0, 100). When provided, the market is created as `cpmm-multi-2` with each
+  // answer's `p` set so its displayed prob matches (normalized to sum to 1).
+  // Length must match `answers`. Absent ⇒ uniform 1/n `cpmm-multi-1` (unchanged).
+  initialProbs: z.array(z.number().gt(0).lt(100)).max(MAX_ANSWERS).optional(),
 })
 
 export const createNumberSchema = z.object({

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -403,12 +403,15 @@ export const createMultiSchema = z.object({
     .default('DISABLED'),
   shouldAnswersSumToOne: z.boolean().optional(),
   // cpmm-multi-2 (PR2c): per-answer initial probabilities, as percentages in
-  // (0, 100). When provided, the market is created as `cpmm-multi-2` with each
-  // answer's `p` set so its displayed prob matches. Sum-to-one ("Multiple
-  // Choice") markets normalize the percentages to Σ = 1; independent ("Set")
-  // markets treat each as an absolute prob (no Σ constraint). Length must match
-  // `answers`. Absent ⇒ uniform 1/n `cpmm-multi-1` (unchanged).
-  initialProbs: z.array(z.number().gt(0).lt(100)).max(MAX_ANSWERS).optional(),
+  // [1, 99] — the same bounds as binary `initialProb`, keeping every created
+  // answer inside the market-order clamp [MIN, MAX]_CPMM_PROB (an open (0,100)
+  // bound admitted sub-floor answers that trades could never reach). When
+  // provided, the market is created as `cpmm-multi-2` with each answer's `p`
+  // set so its displayed prob matches. Sum-to-one ("Multiple Choice") markets
+  // normalize the percentages to Σ = 1; independent ("Set") markets treat each
+  // as an absolute prob (no Σ constraint). Length must match `answers`.
+  // Absent ⇒ uniform 1/n `cpmm-multi-1` (unchanged).
+  initialProbs: z.array(z.number().min(1).max(99)).max(MAX_ANSWERS).optional(),
 })
 
 export const createNumberSchema = z.object({

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -404,8 +404,10 @@ export const createMultiSchema = z.object({
   shouldAnswersSumToOne: z.boolean().optional(),
   // cpmm-multi-2 (PR2c): per-answer initial probabilities, as percentages in
   // (0, 100). When provided, the market is created as `cpmm-multi-2` with each
-  // answer's `p` set so its displayed prob matches (normalized to sum to 1).
-  // Length must match `answers`. Absent ⇒ uniform 1/n `cpmm-multi-1` (unchanged).
+  // answer's `p` set so its displayed prob matches. Sum-to-one ("Multiple
+  // Choice") markets normalize the percentages to Σ = 1; independent ("Set")
+  // markets treat each as an absolute prob (no Σ constraint). Length must match
+  // `answers`. Absent ⇒ uniform 1/n `cpmm-multi-1` (unchanged).
   initialProbs: z.array(z.number().gt(0).lt(100)).max(MAX_ANSWERS).optional(),
 })
 

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -3,6 +3,7 @@ import { Answer, MAX_ANSWERS } from 'common/answer'
 import { getAnswerProbability, getProbability } from 'common/calculate'
 import {
   Contract,
+  isMultiCpmm,
   MAX_QUESTION_LENGTH,
   MultiContract,
   RESOLUTIONS,
@@ -151,7 +152,7 @@ export function toLiteMarket(
     numericValues = { value, min, max, isLogScale }
   }
   const answers =
-    includeLiteAnswers && contract.mechanism === 'cpmm-multi-1'
+    includeLiteAnswers && isMultiCpmm(contract)
       ? contract.answers?.map((answer) => ({
           id: answer.id,
           text: answer.text,
@@ -212,14 +213,14 @@ export function toFullMarket(contract: Contract): FullMarket {
   const liteMarket = toLiteMarket(contract)
   const { outcomeType } = contract
   const answers =
-    contract.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(contract)
       ? contract.answers.map((answer) =>
           augmentAnswerWithProbability(contract, answer)
         )
       : undefined
 
   let multiValues = {}
-  if (contract.mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     multiValues = {
       shouldAnswersSumToOne: contract.shouldAnswersSumToOne,
       addAnswersMode: contract.addAnswersMode,

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -936,6 +936,10 @@ export const API = (_apiTypeCheck = {
       .object({
         contractId: z.string(),
         amount: z.number().gt(0).finite(),
+        // Subsidize a SINGLE answer (its own binary CPMM) instead of the whole market. Omit for
+        // the whole-market add. The subsidy lands in that answer's subsidyPool and the per-answer
+        // drizzle deepens it losslessly (float-p for cpmm-multi-2) — see add-liquidity.ts.
+        answerId: z.string().optional(),
       })
       .strict(),
   },

--- a/common/src/bets.ts
+++ b/common/src/bets.ts
@@ -4,7 +4,7 @@ import { groupBy, minBy, sortBy, uniqBy } from 'lodash'
 import { buildArray } from 'common/util/array'
 import { HOUR_MS } from 'common/util/time'
 import { getInitialAnswerProbability } from './calculate'
-import { MarketContract } from './contract'
+import { isMultiCpmm, MarketContract } from './contract'
 
 export async function getTotalBetCount(contractId: string) {
   const res = (await unauthedApi('bets', {
@@ -61,7 +61,7 @@ export const getBetPointsBetween = async (
   const sorted = sortBy(data, 'createdTime')
 
   const startingProbs = []
-  if (contract.mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     const { answers } = contract
     const rawPointsByAns = groupBy(data, 'answerId')
 

--- a/common/src/boost.ts
+++ b/common/src/boost.ts
@@ -1,4 +1,4 @@
-import { type Contract } from './contract'
+import { type Contract, isMultiCpmmMechanism } from './contract'
 
 export const BOOST_CONTENT_TYPES = ['contract', 'post'] as const
 export type BoostContentType = (typeof BOOST_CONTENT_TYPES)[number]
@@ -27,4 +27,4 @@ export const BOOST_CONTRACT_SUBSIDY_MANA = 5000
 export const contractBoostAddsSubsidy = (
   contract: Pick<Contract, 'mechanism'>
 ) =>
-  contract.mechanism === 'cpmm-1' || contract.mechanism === 'cpmm-multi-1'
+  contract.mechanism === 'cpmm-1' || isMultiCpmmMechanism(contract.mechanism)

--- a/common/src/calculate-cpmm-arbitrage.test.ts
+++ b/common/src/calculate-cpmm-arbitrage.test.ts
@@ -302,7 +302,8 @@ describe('calculateCpmmMultiArbitrageYesBets', () => {
       undefined,
       [],
       {},
-      noFees
+      noFees,
+      'cpmm-multi-1' // pinned: frozen-v1 behavior test
     )
     const { newBetResults, otherBetResults } = result
     const pools = [
@@ -324,7 +325,8 @@ describe('calculateCpmmMultiArbitrageYesBets', () => {
       undefined,
       [],
       {},
-      noFees
+      noFees,
+      'cpmm-multi-1' // pinned: frozen-v1 behavior test
     )
     const { newBetResults, otherBetResults, updatedAnswers } = result
 
@@ -389,7 +391,8 @@ describe('calculateCpmmMultiArbitrageYesBets', () => {
       undefined,
       [],
       {},
-      noFees
+      noFees,
+      'cpmm-multi-1' // pinned: frozen-v1 behavior test
     )
     const totalUserAmount = sumBy(
       newBetResults.flatMap((r) => r.takers),
@@ -442,7 +445,8 @@ describe('calculateCpmmMultiArbitrageYesBets', () => {
         undefined,
         unfilledBets,
         balanceByUserId,
-        noFees
+        noFees,
+        'cpmm-multi-1' // pinned: frozen-v1 behavior test
       )
 
     const allMakers = [

--- a/common/src/calculate-cpmm-arbitrage.test.ts
+++ b/common/src/calculate-cpmm-arbitrage.test.ts
@@ -831,3 +831,85 @@ describe('calculateCpmmMultiArbitrageBet — per-answer p (cpmm-multi-2)', () =>
     }
   })
 })
+
+// --- cpmm-multi-2: direct (Approach C) multi-buy removes transient-overshoot fills ----------
+// The v1 YES-basket auto-arb drives basket answers UP PAST their settled price, then back down,
+// consuming and KEEPING resting makers crossed only in the transient band (the bug). The v2 solve
+// (gated on the 'cpmm-multi-2' arg) buys each basket answer once, straight to final — every maker
+// is crossed at most once, in one direction. Fixture mirrors the multibuy-limit-cases spec
+// (5 answers @ 0.2, k=1000, YES basket {a0,a1}, bet 60; a0 settles ~0.399 with peak ~0.677 in v1).
+const getAnswerK = (index: number, prob: number, k: number): Answer =>
+  ({
+    id: `answer${index}`,
+    contractId: 'c',
+    userId: `user${index}`,
+    text: `Answer ${index}`,
+    createdTime: 0,
+    index,
+    prob,
+    poolYes: Math.sqrt((k * (1 - prob)) / prob),
+    poolNo: k / Math.sqrt((k * (1 - prob)) / prob),
+    p: 0.5,
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer)
+
+describe('calculateCpmmMultiArbitrageYesBets — cpmm-multi-2 no transient-overshoot fills', () => {
+  const mkMarket = () => [0, 1, 2, 3, 4].map((i) => getAnswerK(i, 0.2, 1000))
+  const BASKET = [0, 1]
+  const BET = 60
+  const runV2 = (orders: LimitBet[]) => {
+    const answers = mkMarket()
+    const res = calculateCpmmMultiArbitrageYesBets(
+      answers,
+      BASKET.map((i) => answers[i]),
+      BET,
+      undefined,
+      orders,
+      { mk: 1e9 },
+      noFees,
+      'cpmm-multi-2'
+    )
+    const finalById: Record<string, number> = {}
+    for (const a of res.updatedAnswers)
+      finalById[a.id] = getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+    const makers = [
+      ...res.newBetResults.flatMap((r) => r.makers),
+      ...res.otherBetResults.flatMap((r) => r.makers),
+    ]
+    const filledById = groupBy(makers, (mk) => mk.bet.id)
+    const filled = (id: string) => sumBy(filledById[id] ?? [], (mk) => mk.amount)
+    const cost =
+      sumBy(res.newBetResults, (r) => sumBy(r.takers, 'amount')) +
+      sumBy(res.otherBetResults, (r) => sumBy(r.takers, 'amount'))
+    return { res, finalById, filled, cost }
+  }
+
+  // No-limit settle price of the traded answer a0 (used by the past-final case).
+  const a0Final = runV2([]).finalById['answer0']
+
+  it('no-limit: Σp = 1, cost = betAmount, traded answer rises (~0.399)', () => {
+    const r = runV2([])
+    expect(sumBy(r.res.updatedAnswers, (a) => r.finalById[a.id])).toBeCloseTo(1, 6)
+    expect(r.cost).toBeCloseTo(BET, 3)
+    expect(a0Final).toBeGreaterThan(0.2)
+    expect(a0Final).toBeCloseTo(0.39942, 2)
+  })
+
+  it('in-path LARGE NO-ask on a basket answer -> price PINS at the limit (v1 mis-settles)', () => {
+    const o = getLimitBet('L1', mkMarket()[0], 'NO', 'mk', 600, 0.3)
+    const r = runV2([o])
+    expect(r.finalById['answer0']).toBeCloseTo(0.3, 2) // rests AT the limit, not past it
+    expect(r.filled('L1')).toBeGreaterThan(0)
+  })
+
+  it('past-final NO-ask (rho in the v1 overshoot band) -> UNFILLED (v1 keeps a phantom fill)', () => {
+    // 0.5 is above the no-limit settle (~0.399) but below v1's transient peak (~0.677).
+    const o = getLimitBet('L2', mkMarket()[0], 'NO', 'mk', 600, 0.5)
+    const r = runV2([o])
+    expect(r.filled('L2')).toBeLessThanOrEqual(1e-9) // never net-crossed
+    expect(r.finalById['answer0']).toBeCloseTo(a0Final, 2) // order has no effect
+  })
+})

--- a/common/src/calculate-cpmm-arbitrage.test.ts
+++ b/common/src/calculate-cpmm-arbitrage.test.ts
@@ -9,6 +9,8 @@ import {
   calculateCpmmMultiArbitrageBet,
   calculateCpmmMultiArbitrageSellYesEqually,
   calculateCpmmMultiArbitrageYesBets,
+  CpmmMulti2InvariantError,
+  verifyCpmmMulti2BetResult,
 } from './calculate-cpmm-arbitrage'
 import { getFeeTotal, getTakerFee, noFees } from './fees'
 import { getMultiNumericAnswerBucketRanges } from './number'
@@ -991,5 +993,120 @@ describe('calculateCpmmMultiArbitrageYesBets — cpmm-multi-2 m>1 basket conserv
   it('m=1 (single-answer via basket path) still conserves (byte-identical eta credit)', () => {
     const payouts = payoutByWinner(runBasket([0.5, 0.3, 0.2], [0], 25))
     expect(Math.max(...payouts) - Math.min(...payouts)).toBeLessThan(0.01)
+  })
+})
+
+// --- cpmm-multi-2: post-hoc solve verification (verifyCpmmMulti2BetResult) --------------------
+// The v2 solve's outer bisection is sound only if net(g) is strictly increasing, and GP12a proves
+// that only at p = 1/2 with no resting limits — production runs general p against a limit book.
+// The verifier re-checks the RETURNED result (cost/sum-to-one/positivity/maker-fill/equal-shares)
+// so a monotonicity failure fails the bet instead of silently mis-charging the taker. These tests
+// pin (1) that healthy solves pass, (2) that corrupted results are actually rejected (a verifier
+// that never fires is dead weight), and (3) that solve-level invariant failures surface as the
+// typed error (new-bet.ts maps it to a 503), not a stack-leaking plain Error.
+describe('verifyCpmmMulti2BetResult — cpmm-multi-2 post-hoc verification', () => {
+  // deep clone so tampering can't leak between assertions (results share object references)
+  const clone = <T>(x: T): T => JSON.parse(JSON.stringify(x))
+
+  const runV2 = (
+    answers: Answer[],
+    basketIdx: number[],
+    bet: number,
+    orders: LimitBet[] = [],
+    balances: { [userId: string]: number } = { mk: 1e9 }
+  ) =>
+    calculateCpmmMultiArbitrageYesBets(
+      answers,
+      basketIdx.map((i) => answers[i]),
+      bet,
+      undefined,
+      orders,
+      balances,
+      noFees,
+      'cpmm-multi-2'
+    )
+
+  const verify = (
+    bet: number,
+    res: ReturnType<typeof runV2>,
+    orders: LimitBet[] = []
+  ) =>
+    verifyCpmmMulti2BetResult(
+      bet,
+      res.newBetResults,
+      res.otherBetResults,
+      res.updatedAnswers as Answer[],
+      orders
+    )
+
+  it('passes on representative solves: no limits, maker fills, general p', () => {
+    // p = 1/2, no limits (the GP12a-proven regime)
+    const a1 = [0, 1, 2, 3, 4].map((i) => getAnswerK(i, 0.2, 1000))
+    expect(() => verify(60, runV2(a1, [0, 1], 60))).not.toThrow()
+
+    // maker fills: an in-path NO ask pins a basket answer (limit book engaged)
+    const a2 = [0, 1, 2, 3, 4].map((i) => getAnswerK(i, 0.2, 1000))
+    const orders = [getLimitBet('L1', a2[0], 'NO', 'mk', 600, 0.3)]
+    const res2 = runV2(a2, [0, 1], 60, orders)
+    // positive control: the maker actually filled, so check (d) is exercised, not vacuous
+    expect(res2.newBetResults.flatMap((r) => r.makers).length).toBeGreaterThan(0)
+    expect(() => verify(60, res2, orders)).not.toThrow()
+
+    // general p (outside GP12a's proven scope — exactly why the verifier exists)
+    const a3 = [0.55, 0.25, 0.12, 0.08].map((p, i) => getAnswerWithP(i, p))
+    expect(() => verify(150, runV2(a3, [1, 2], 150))).not.toThrow()
+  })
+
+  it('accepts the balance-bound maker case (legitimate Sum q deviation, shared with v1)', () => {
+    // A maker with YES bids on TWO non-basket answers but balance covering only ~one leg: the
+    // inner eta solve previews the NO legs with per-leg balance copies yet realizes them against
+    // a shared decremented balance, so final Sum q lands short of 1 by up to ~2e-3. Frozen v1
+    // shows the same deviation on this shape and the taker charge stays exact, so the verifier's
+    // Sum q tolerance must NOT reject it — else v2 refuses bets v1 accepts.
+    const answers = [0, 1, 2, 3, 4].map((i) => getAnswerK(i, 0.2, 1000))
+    const orders = [
+      getLimitBet('Y2', answers[2], 'YES', 'poorMk', 100, 0.15),
+      getLimitBet('Y3', answers[3], 'YES', 'poorMk', 100, 0.15),
+    ]
+    const res = runV2(answers, [0, 1], 500, orders, { poorMk: 5 })
+    // positive control: the maker actually engaged (otherwise this exercises nothing)
+    const makerFills = res.otherBetResults.flatMap((r) => r.makers)
+    expect(makerFills.length).toBeGreaterThan(0)
+    expect(() => verify(500, res, orders)).not.toThrow()
+  })
+
+  it('rejects a tampered taker amount (the mis-charge a wrong g would produce)', () => {
+    const answers = [0, 1, 2, 3, 4].map((i) => getAnswerK(i, 0.2, 1000))
+    const res = clone(runV2(answers, [0, 1], 60))
+    res.newBetResults[0].takers[0].amount += 1
+    expect(() => verify(60, res)).toThrow(CpmmMulti2InvariantError)
+  })
+
+  it('rejects a negative pool reserve', () => {
+    const answers = [0, 1, 2, 3, 4].map((i) => getAnswerK(i, 0.2, 1000))
+    const res = clone(runV2(answers, [0, 1], 60))
+    res.updatedAnswers[0].poolYes = -1
+    expect(() => verify(60, res)).toThrow(CpmmMulti2InvariantError)
+  })
+
+  it('rejects unequal basket shares (broken multi-bet equal-shares contract)', () => {
+    const answers = [0, 1, 2, 3, 4].map((i) => getAnswerK(i, 0.2, 1000))
+    const res = clone(runV2(answers, [0, 1], 60))
+    res.newBetResults[0].takers[0].shares += 0.5
+    expect(() => verify(60, res)).toThrow(CpmmMulti2InvariantError)
+  })
+
+  it('m = n (all-answers basket) surfaces as the typed error, not a plain Error', () => {
+    // Every g is infeasible when the basket is all answers (no "others" to arb against), so the
+    // solve's feasibility invariant fires. Regression: this used to throw a bare Error, which
+    // leaked to API callers as a 500 with a stack.
+    const answers = [0.5, 0.3, 0.2].map((p, i) => getAnswerWithP(i, p))
+    let caught: unknown
+    try {
+      runV2(answers, [0, 1, 2], 50)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(CpmmMulti2InvariantError)
   })
 })

--- a/common/src/calculate-cpmm-arbitrage.test.ts
+++ b/common/src/calculate-cpmm-arbitrage.test.ts
@@ -731,3 +731,103 @@ const getNumericAnswers = (min: number, max: number, step: number) => {
   const prob = 1 / bucketRanges.length
   return bucketRanges.map((_, i) => getAnswer(i, prob))
 }
+
+// --- cpmm-multi-2: per-answer p (general-p auto-arb) -------------------------
+// Balanced pools (Y = N = L) give prob_i = p_i exactly, so a valid sum-to-one
+// v2 market is just per-answer p that sums to 1. There is NO external p != 0.5
+// oracle (vendor v1 throws on p != 0.5), so internal-consistency invariants and a
+// cross-language anchor against the independent Python reference oracle
+// (manifold/market_simulator.MarketSimulator.simulate_buy, per-answer p threaded
+// in Slice 1b) do the validation. At p = 0.5 every path reduces to v1 (the suite
+// staying byte-identical is the regression lock).
+const getAnswerWithP = (index: number, p: number, L = 100): Answer =>
+  ({
+    id: `answer${index}`,
+    contractId: `contract${index}`,
+    userId: `user${index}`,
+    text: `Answer ${index}`,
+    createdTime: 0,
+    index,
+    prob: p, // balanced pool (Y = N = L) => prob = p
+    poolYes: L,
+    poolNo: L,
+    p,
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer)
+
+// Final per-answer prob, matched to each answer by identity (id) — never by
+// array position — and priced with that answer's own p.
+const probsAfterBet = (
+  result: ReturnType<typeof calculateCpmmMultiArbitrageBet>,
+  answers: Answer[]
+) => {
+  const byId = new Map<string, number>()
+  for (const r of [result.newBetResult, ...result.otherBetResults]) {
+    byId.set(r.answer.id, getCpmmProbability(r.cpmmState.pool, r.cpmmState.p))
+  }
+  return answers.map((a) => byId.get(a.id)!)
+}
+
+describe('calculateCpmmMultiArbitrageBet — per-answer p (cpmm-multi-2)', () => {
+  it('restores Σp = 1 (and is monotone) after a YES buy at non-uniform p', () => {
+    for (const ps of [
+      [0.5, 0.3, 0.2],
+      [0.7, 0.2, 0.1],
+      [0.6, 0.15, 0.15, 0.1],
+      [0.9, 0.05, 0.05],
+    ]) {
+      const answers = ps.map((p, i) => getAnswerWithP(i, p))
+      const result = calculateCpmmMultiArbitrageBet(
+        answers,
+        answers[0],
+        'YES',
+        25,
+        undefined,
+        [],
+        {},
+        noFees
+      )
+      const probs = probsAfterBet(result, answers)
+      expect(sumBy(probs, (p) => p)).toBeCloseTo(1, 6)
+      expect(probs[0]).toBeGreaterThan(ps[0]) // bought answer rises
+      for (let i = 1; i < ps.length; i++) {
+        expect(probs[i]).toBeLessThan(ps[i]) // every other answer falls
+      }
+    }
+  })
+
+  it('matches the Python reference oracle at p != 0.5 (cross-language anchor)', () => {
+    const cases = [
+      {
+        ps: [0.5, 0.3, 0.2],
+        sharesAns0: 46.82123779918318,
+        probs: [0.5668062275, 0.261508744769, 0.171685027732],
+      },
+      {
+        ps: [0.7, 0.2, 0.1],
+        sharesAns0: 34.78445693634237,
+        probs: [0.736335611567, 0.176510366064, 0.08715402237],
+      },
+    ]
+    for (const { ps, sharesAns0, probs: expected } of cases) {
+      const answers = ps.map((p, i) => getAnswerWithP(i, p))
+      const result = calculateCpmmMultiArbitrageBet(
+        answers,
+        answers[0],
+        'YES',
+        25,
+        undefined,
+        [],
+        {},
+        noFees
+      )
+      const probs = probsAfterBet(result, answers)
+      expected.forEach((e, i) => expect(probs[i]).toBeCloseTo(e, 6))
+      const shares = sumBy(result.newBetResult.takers, 'shares')
+      expect(shares).toBeCloseTo(sharesAns0, 4)
+    }
+  })
+})

--- a/common/src/calculate-cpmm-arbitrage.test.ts
+++ b/common/src/calculate-cpmm-arbitrage.test.ts
@@ -913,3 +913,83 @@ describe('calculateCpmmMultiArbitrageYesBets — cpmm-multi-2 no transient-overs
     expect(r.finalById['answer0']).toBeCloseTo(a0Final, 2) // order has no effect
   })
 })
+
+// --- cpmm-multi-2: m>1 basket multi-bet must conserve at resolution ----------------------------
+// Regression for the m>1 redemption share-split bug (tasks/cpmm_multi_2/
+// findings-m1-basket-conservation-bug-2026-06-28.md, GP16). A multi-answer YES basket buy
+// (m>=2) used to credit each basket answer eta/m redemption YES shares; the residual
+// "pays eta iff ANY basket answer wins" requires eta YES shares in EACH basket answer, so a
+// winning basket answer paid only eta/m and resolution to a basket answer DESTROYED mana
+// (found on the dev instance: a sole participant's payout came up ~10% short). The defect was
+// invisible to jest because no test checked cross-answer resolution conservation.
+//
+// Resolution payout for sum-to-one CHOOSE_ONE to winner W is (payouts-fixed.ts
+// getMultiLiquidityPoolPayouts + getMultiFixedPayouts): poolYes_W + traderYES_W +
+// Sum_{j!=W} (poolNo_j + traderNO_j). Conservation <=> that total is constant across W
+// <=> T_i^YES - T_i^NO is constant across answers, where T_i^YES = poolYes_i + traderYES_i,
+// T_i^NO = poolNo_i + traderNO_i. This holds for ANY p (general-p), not just p=0.5.
+describe('calculateCpmmMultiArbitrageYesBets — cpmm-multi-2 m>1 basket conserves at resolution', () => {
+  // For each candidate winner W, the total resolution payout (traders + LP) given the
+  // post-bet pools + recorded trader shares. Must be equal for every W.
+  const payoutByWinner = (
+    res: ReturnType<typeof calculateCpmmMultiArbitrageYesBets>
+  ) => {
+    const yesShares: Record<string, number> = {}
+    const noShares: Record<string, number> = {}
+    for (const r of res.newBetResults)
+      yesShares[r.answer.id] =
+        (yesShares[r.answer.id] ?? 0) + sumBy(r.takers, (t) => t.shares)
+    for (const r of res.otherBetResults)
+      noShares[r.answer.id] =
+        (noShares[r.answer.id] ?? 0) + sumBy(r.takers, (t) => t.shares)
+    const tYes = (a: Answer) => a.poolYes + (yesShares[a.id] ?? 0)
+    const tNo = (a: Answer) => a.poolNo + (noShares[a.id] ?? 0)
+    return res.updatedAnswers.map(
+      (w) =>
+        tYes(w) +
+        sumBy(
+          res.updatedAnswers.filter((a) => a.id !== w.id),
+          (a) => tNo(a)
+        )
+    )
+  }
+
+  const runBasket = (ps: number[], basketIdx: number[], bet: number) => {
+    const answers = ps.map((p, i) => getAnswerWithP(i, p))
+    return calculateCpmmMultiArbitrageYesBets(
+      answers,
+      basketIdx.map((i) => answers[i]),
+      bet,
+      undefined,
+      [],
+      {},
+      noFees,
+      'cpmm-multi-2'
+    )
+  }
+
+  it('m=2 basket: resolution payout identical for every winner (no mana destroyed)', () => {
+    // skewed 4-answer market, basket of the 2nd and 3rd answers (the exact dev-instance repro)
+    const res = runBasket([0.55, 0.25, 0.12, 0.08], [1, 2], 150)
+    const payouts = payoutByWinner(res)
+    const mn = Math.min(...payouts)
+    const mx = Math.max(...payouts)
+    // before the eta/m -> eta fix this spread was ~127 (basket winners short)
+    expect(mx - mn).toBeLessThan(0.01)
+  })
+
+  it('m=3 basket and uniform pools both conserve across all winners', () => {
+    for (const cfg of [
+      { ps: [0.4, 0.25, 0.2, 0.15], basket: [0, 1, 2], bet: 90 },
+      { ps: [0.25, 0.25, 0.25, 0.25], basket: [0, 1], bet: 200 }, // uniform still leaked pre-fix
+    ]) {
+      const payouts = payoutByWinner(runBasket(cfg.ps, cfg.basket, cfg.bet))
+      expect(Math.max(...payouts) - Math.min(...payouts)).toBeLessThan(0.01)
+    }
+  })
+
+  it('m=1 (single-answer via basket path) still conserves (byte-identical eta credit)', () => {
+    const payouts = payoutByWinner(runBasket([0.5, 0.3, 0.2], [0], 25))
+    expect(Math.max(...payouts) - Math.min(...payouts)).toBeLessThan(0.01)
+  })
+})

--- a/common/src/calculate-cpmm-arbitrage.test.ts
+++ b/common/src/calculate-cpmm-arbitrage.test.ts
@@ -678,6 +678,7 @@ const getAnswer = (index: number, prob: number) => {
     prob,
     poolYes,
     poolNo,
+    p: 0.5,
     totalLiquidity: 0,
     subsidyPool: 0,
     probChanges: { day: 0, week: 0, month: 0 },

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -504,13 +504,20 @@ function calculateCpmmMultiArbitrageBetsYesV2(
       fees: noFees,
     })
   }
-  // Split the redemption credit equally across the basket (eta/m shares, netOthers/m mana each);
-  // for m = 1 this reduces exactly to the single-answer redemption fill (eta shares, netOthers mana).
+  // Redemption credit to the basket YES legs. The eta NO shares held in each of the (n-m)
+  // other answers pay eta*(n-m) iff a basket answer wins and eta*(n-m-1) iff an other wins;
+  // the guaranteed floor eta*(n-m-1) is redeemed above, leaving a residual worth eta iff ANY
+  // basket answer wins. That residual is eta YES shares in EACH basket answer (whichever basket
+  // answer wins pays eta), NOT eta/m: with eta/m a winning basket answer would pay only eta/m,
+  // breaking sum-to-one conservation (T_i^YES - T_i^NO must be constant across answers) and
+  // destroying mana at resolution to a basket answer. The net mana (netOthers) still splits
+  // equally across the m basket legs so summed taker amount == betAmount. For m = 1 this is
+  // identical to the single-answer redemption fill (eta shares, netOthers mana).
   for (const yesBetResult of yesBetResults) {
     yesBetResult.takers.push({
       matchedBetId: null,
       amount: netOthers / m,
-      shares: eta / m,
+      shares: eta,
       timestamp: Date.now(),
       fees: noFees,
     })

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -342,6 +342,18 @@ function calculateCpmmMultiArbitrageBetsYesV2(
   const n = initialAnswers.length
   const m = initialAnswersToBuy.length
 
+  // m = n is the one structurally infeasible basket: with no other answers to arb down, any
+  // g > 0 pushes Sum p past 1, so every evalG is undefined and the bisection collapses to a
+  // denormal g where calculateAmountToBuySharesFixedP degenerates to NaN — surfacing as a
+  // stack-leaking 'Invalid bet amount' deep in computeFills. Reject up front with the typed
+  // error instead (new-bet.ts maps it to a 503).
+  if (others.length === 0) {
+    throw new CpmmMulti2InvariantError(
+      'cpmm-multi-2 YES basket cannot include every answer (m = n is infeasible)',
+      { n, m }
+    )
+  }
+
   // Evaluate one g: realize the basket YES legs + the arbed OTHER NO legs at the eta that pins
   // Sum prob == 1. Returns undefined when g is infeasible (basket alone already sums >= 1).
   const evalG = (g: number) => {
@@ -486,7 +498,12 @@ function calculateCpmmMultiArbitrageBetsYesV2(
   })
   const solved = evalG(g)
   if (!solved) {
-    throw new Error('Invariant failed in cpmm-multi-2 YES basket solve')
+    // Reachable e.g. when the basket is ALL answers (m = n: every g is infeasible, target <= 0).
+    // Typed so new-bet.ts maps it to a 503 instead of leaking a 500 stack to the API caller.
+    throw new CpmmMulti2InvariantError(
+      'Invariant failed in cpmm-multi-2 YES basket solve',
+      { g, betAmount, n, m }
+    )
   }
   const { yesBetResults, noBetResults, eta, net } = solved
 
@@ -551,7 +568,186 @@ function calculateCpmmMultiArbitrageBetsYesV2(
     collectedFees
   )
 
+  // Always-on post-hoc verification (cost is one pass over the result vs. ~100 evalG bisection
+  // probes to produce it). Throws CpmmMulti2InvariantError; new-bet.ts maps it to a retryable
+  // 503, so a wrong solve fails the bet instead of committing a mis-priced fill.
+  verifyCpmmMulti2BetResult(
+    betAmount,
+    newBetResults,
+    otherBetResults,
+    updatedAnswers,
+    unfilledBets
+  )
+
   return { newBetResults, otherBetResults, updatedAnswers }
+}
+
+// --- cpmm-multi-2 post-hoc solve verification -------------------------------------------------
+// The v2 solve above bisects on the premise that net(g) is strictly increasing. That premise is
+// proven only at p = 1/2 with no resting limits (GP12a); production runs general p against a live
+// limit book. If the premise ever fails, binarySearch returns a wrong g SILENTLY — the taker is
+// mis-charged with no error anywhere. But verifying a claimed equilibrium is trivial even where
+// finding it is hard, so we check the returned result and fail the bet (which the client can
+// retry) rather than commit a wrong fill. This demotes monotonicity from a correctness assumption
+// to a performance assumption.
+//
+// Deliberately a typed error rather than common/api/utils APIError: importing api/utils here
+// would close the module cycle api/utils -> api/schema -> new-bet -> this file. new-bet.ts
+// (which already imports APIError) maps it to APIError(503, ...), so API callers see a retryable
+// error instead of a stack-leaking 500.
+export class CpmmMulti2InvariantError extends Error {
+  details?: unknown
+  constructor(message: string, details?: unknown) {
+    super(message)
+    this.name = 'CpmmMulti2InvariantError'
+    this.details = details
+  }
+}
+
+// Tolerances calibrated 2026-07-01 against the 50-iteration bisection's observed residuals on
+// this repo's v2 jest fixtures plus the net(g) monotonicity probe's 152-call sweep (p = 1/2 and
+// general-p pools, m = 1..4 baskets, balanced/skewed/extreme creation pools, resting makers,
+// bets M$1..M$100k). Worst observed: cost 1.5e-9 absolute (M$100k whale; <= 1.1e-11 for bets
+// <= 500), basket share spread 2.2e-13 (relative), maker price / order overfill exactly 0.
+// Cost and shares are relative with an absolute floor (residuals scale with bet size).
+//
+// PROB-SUM CAVEAT — why its tolerance is loose (1e-2) while cost is tight: when a maker holds
+// YES bids on TWO+ non-basket answers but has balance for only one leg, the inner eta solve
+// previews the NO legs with per-leg balance copies yet realizes them against a shared decremented
+// balance, so realized Sum_others prob lands short of target — final Sum q deviates from 1 by up
+// to ~2e-3 (observed 1.73e-3 at bet 500). This is PRE-EXISTING behavior shared with frozen v1
+// (same config shows -1.03e-3 on v1) and the taker charge stays exact (cost residual 2.3e-12);
+// the market is merely left with a small open arb. A tight Sum q check would make v2 refuse bets
+// v1 accepts — a functional regression — so the tolerance sits above the balance-binding
+// deviation. In every non-balance-bound config |Sum q - 1| <= 8.9e-16.
+// TODO: recalibrate against the whale-bet probe (cpmm-perf-bench) before raising bet-size caps.
+const V2_VERIFY_COST_EPS = 1e-8 // relative to betAmount, floored at V2_VERIFY_COST_EPS_ABS
+const V2_VERIFY_COST_EPS_ABS = 1e-6 // absolute floor (observed worst 1.5e-9 at M$100k)
+const V2_VERIFY_PROB_SUM_EPS = 1e-2 // absolute on Sum_i prob_i — loose, see caveat above
+const V2_VERIFY_SHARES_EPS = 1e-9 // relative, basket equal-shares spread & other-leg net shares
+const V2_VERIFY_MAKER_EPS = 1e-9 // maker fill bookkeeping (exact identities up to roundoff)
+
+// Checks the v2 result exactly as downstream consumes it (executeNewBetResult / the conservation
+// grid): taker fills = `takers`, maker fills = `makers`, final pools = per-answer cpmmState.
+// NOT checkable post-hoc: the no-overshoot path property (a maker strictly outside an answer's
+// [initial, final] excursion must not be crossed) — the result carries no price path, so the
+// conservation grid's falsification sweep owns that invariant, not this verifier.
+export const verifyCpmmMulti2BetResult = (
+  betAmount: number,
+  newBetResults: ArbitrageBetArray,
+  otherBetResults: ArbitrageBetArray,
+  updatedAnswers: Answer[],
+  unfilledBets: LimitBet[]
+) => {
+  const fail = (check: string, details: unknown): never => {
+    throw new CpmmMulti2InvariantError(
+      `cpmm-multi-2 solve verification failed: ${check}`,
+      details
+    )
+  }
+
+  // (a) Cost conservation. The taker's whole spend lives on the basket YES legs: each other-
+  // answer NO leg carries an appended redemption fill that nets it to exactly zero mana AND zero
+  // shares (the eta*(n-m-1) credit plus the residual eta YES/leg flow to the basket legs). So
+  // Sum_basket takers.amount == betAmount — the same identity new-bet.ts uses for isFilled and
+  // the conservation grid's `Sum(balance deltas) + fees == 0` closure. A wrong g from a
+  // non-monotone net(g) surfaces HERE: the inner eta solve re-pins Sum p == 1 for any g, so
+  // mis-solves mis-charge rather than mis-price.
+  const spend = sumBy(
+    newBetResults.flatMap((r) => r.takers),
+    'amount'
+  )
+  const costTol = Math.max(
+    V2_VERIFY_COST_EPS_ABS,
+    V2_VERIFY_COST_EPS * betAmount
+  )
+  if (Math.abs(spend - betAmount) > costTol) {
+    fail('taker spend != betAmount (wrong g?)', { spend, betAmount })
+  }
+  for (const r of otherBetResults) {
+    const netAmount = sumBy(r.takers, 'amount')
+    const netShares = sumBy(r.takers, 'shares')
+    const grossShares = sumBy(r.takers, (t) => Math.abs(t.shares))
+    if (
+      Math.abs(netAmount) > costTol ||
+      Math.abs(netShares) > V2_VERIFY_SHARES_EPS * Math.max(1, grossShares)
+    ) {
+      fail('other-answer NO leg does not net to zero', {
+        answerId: r.answer.id,
+        netAmount,
+        netShares,
+      })
+    }
+  }
+
+  // (b) Sum-to-one + (c) positivity on the final state of EVERY answer. updatedAnswers is the
+  // solve's own final state (basket + others both realized), the same pools executeNewBetResult
+  // persists. The Sum q tolerance is deliberately loose — see the balance-bound-maker caveat at
+  // the EPS definitions above (legitimate ~2e-3 deviation shared with v1).
+  let probSum = 0
+  for (const a of updatedAnswers) {
+    if (!(a.poolYes > 0) || !(a.poolNo > 0) || !(a.p > 0 && a.p < 1)) {
+      fail('final pool not positive / p outside (0,1)', {
+        answerId: a.id,
+        poolYes: a.poolYes,
+        poolNo: a.poolNo,
+        p: a.p,
+      })
+    }
+    probSum += getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+  }
+  if (Math.abs(probSum - 1) > V2_VERIFY_PROB_SUM_EPS) {
+    fail('final probabilities do not sum to 1', { probSum })
+  }
+
+  // (d) Maker-fill sanity. A limit fill is priced AT the maker's limitProb (computeFill:
+  // maker.amount = shares * makerPrice), and the fills against one order cannot exceed what was
+  // left unfilled on the book when the solve started. Each answer's book is touched by exactly
+  // one leg in v2, but group by order id anyway so the check doesn't depend on that.
+  const bookById = new Map(unfilledBets.map((b) => [b.id, b]))
+  const allMakers = [...newBetResults, ...otherBetResults].flatMap(
+    (r) => r.makers
+  )
+  for (const m of allMakers) {
+    const price =
+      m.bet.outcome === 'YES' ? m.bet.limitProb : 1 - m.bet.limitProb
+    if (
+      m.shares < -V2_VERIFY_MAKER_EPS ||
+      m.amount < -V2_VERIFY_MAKER_EPS ||
+      Math.abs(m.amount - m.shares * price) >
+        V2_VERIFY_MAKER_EPS * Math.max(1, m.amount)
+    ) {
+      fail('maker fill not priced at its limitProb / negative fill', {
+        orderId: m.bet.id,
+        amount: m.amount,
+        shares: m.shares,
+        limitProb: m.bet.limitProb,
+      })
+    }
+  }
+  for (const [orderId, fills] of Object.entries(
+    groupBy(allMakers, (m) => m.bet.id)
+  )) {
+    const order = bookById.get(orderId) ?? fills[0].bet
+    const remaining = order.orderAmount - order.amount
+    const filled = sumBy(fills, 'amount')
+    if (filled > remaining + V2_VERIFY_MAKER_EPS * Math.max(1, remaining)) {
+      fail('maker order filled beyond its remaining size', {
+        orderId,
+        filled,
+        remaining,
+      })
+    }
+  }
+
+  // (e) Equal shares — the multi-bet contract: every basket answer acquires the same YES shares
+  // (g from the sweep + eta from the redemption residual).
+  const basketShares = newBetResults.map((r) => sumBy(r.takers, 'shares'))
+  const maxShares = Math.max(...basketShares)
+  const spread = maxShares - Math.min(...basketShares)
+  if (spread > V2_VERIFY_SHARES_EPS * Math.max(1, maxShares)) {
+    fail('basket YES shares not equal across answers', { basketShares })
+  }
 }
 
 export const getBetResultsAndUpdatedAnswers = (

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -327,6 +327,12 @@ function calculateCpmmMultiArbitrageBetsYes(
 //
 // net is strictly increasing in g (GP12a: dt/dg = Sum_basket prob > 0) and Sum_others prob is
 // strictly decreasing in eta (GP5a) — so both bisections are on monotone objectives.
+//
+// Precondition: `initialAnswers` is the FULL LIVE answer set — every answer participating in
+// the sum-to-one constraint. Today that is all of the contract's answers by construction
+// (linked answers cannot be individually resolved). If cpmm-multi-2 per-answer NO resolution
+// ships (reserved — see the CPMMMulti doc comment in contract.ts), callers must pass the
+// unresolved subset; every identity here (n, m, eta*(n - m - 1)) is relative to this array.
 function calculateCpmmMultiArbitrageBetsYesV2(
   initialAnswers: Answer[],
   initialAnswersToBuy: Answer[],

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -117,6 +117,8 @@ export function calculateCpmmMultiArbitrageYesBets(
       sumBy(
         result.newBetResults.map((r) => r.takers),
         'amount'
+
+// (GPnn labels cite machine-checked proofs: https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/proofs)
       ),
       0
     )
@@ -512,7 +514,7 @@ function calculateCpmmMultiArbitrageBetsYesV2(
       { g, betAmount, n, m }
     )
   }
-  const { yesBetResults, noBetResults, eta, net } = solved
+  const { yesBetResults, noBetResults, eta } = solved
 
   // Redemption fills (mirrors the single-answer path): the NO-in-others legs are internal
   // arbitrage that nets to zero mana/shares; the redemption credit flows to the basket YES legs.
@@ -546,7 +548,6 @@ function calculateCpmmMultiArbitrageBetsYesV2(
       fees: noFees,
     })
   }
-  void net
 
   const updatedAnswers = initialAnswers.map((answer) => {
     const r =

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -94,7 +94,12 @@ export function calculateCpmmMultiArbitrageYesBets(
   limitProb: number | undefined,
   unfilledBets: LimitBet[],
   balanceByUserId: { [userId: string]: number },
-  collectedFees: Fees
+  collectedFees: Fees,
+  // cpmm-multi-2 (per-answer p + reversible-limit auto-arb) routes the basket buy through the
+  // direct, non-overshooting "Approach C" solve. Defaults to the frozen v1 path so every
+  // existing cpmm-multi-1 caller is byte-identical. Gate at the call site on
+  // contract.mechanism === 'cpmm-multi-2'.
+  arbVersion: 'cpmm-multi-1' | 'cpmm-multi-2' = 'cpmm-multi-1'
 ) {
   const result = calculateCpmmMultiArbitrageBetsYes(
     answers,
@@ -103,7 +108,8 @@ export function calculateCpmmMultiArbitrageYesBets(
     limitProb,
     unfilledBets,
     balanceByUserId,
-    collectedFees
+    collectedFees,
+    arbVersion
   )
   if (
     floatingEqual(
@@ -189,8 +195,20 @@ function calculateCpmmMultiArbitrageBetsYes(
   limitProb: number | undefined,
   unfilledBets: LimitBet[],
   balanceByUserId: { [userId: string]: number },
-  collectedFees: Fees
+  collectedFees: Fees,
+  arbVersion: 'cpmm-multi-1' | 'cpmm-multi-2' = 'cpmm-multi-1'
 ) {
+  if (arbVersion === 'cpmm-multi-2') {
+    return calculateCpmmMultiArbitrageBetsYesV2(
+      initialAnswers,
+      initialAnswersToBuy,
+      initialBetAmount,
+      limitProb,
+      unfilledBets,
+      balanceByUserId,
+      collectedFees
+    )
+  }
   // Maintain mutable snapshots of unfilled orders and maker balances across the whole multi-buy
   let workingUnfilledBetsByAnswer = groupBy(unfilledBets, (bet) => bet.answerId)
   let workingBalanceByUserId = { ...balanceByUserId }
@@ -281,6 +299,248 @@ function calculateCpmmMultiArbitrageBetsYes(
     updatedAnswers.filter(
       (r) => !initialAnswersToBuy.map((a) => a.id).includes(r.id)
     ),
+    collectedFees
+  )
+
+  return { newBetResults, otherBetResults, updatedAnswers }
+}
+
+// cpmm-multi-2 multi-buy: the direct, non-overshooting "Approach C" solve (GP12 / reference
+// `tasks/cpmm_multi_2/proofs/reference_solve_c.py`). The DOLLAR-CENTRIC decomposition makes it
+// correct-by-construction under resting limits:
+//   * each basket answer is bought ONCE, straight up start -> final  (a single rising YES sweep)
+//   * each non-basket answer moves ONCE, straight down start -> final (a single falling NO sweep)
+// No answer is ever pushed past its settled price, so every resting maker is crossed exactly once,
+// in one direction (pinning included). This eliminates v1's transient-overshoot fills: the
+// iterate-buy-arb-reinvest loop in calculateCpmmMultiArbitrageBetsYes drives basket answers UP PAST
+// their final price and back down, consuming and keeping makers in the transient band (the bug).
+//
+// Because each answer is touched by exactly one leg (basket = YES, others = NO) and a resting order
+// lives on a single answerId, the per-answer maker books are disjoint — there is no cross-leg
+// working-state maker mutation to reason about (unlike the v1 share-centric "NO in all" loop).
+//
+//   solve g (equal YES shares per basket answer) s.t. net spend == budget        [outer bisection]
+//     buy g YES shares in each basket answer (limit-aware single rising sweep)
+//     solve eta (NO shares in each non-basket answer) s.t. Sum prob == 1          [inner bisection]
+//       buy eta NO shares in each non-basket answer (limit-aware single falling sweep)
+//     net = basketCost + othersCost - eta*(n - m - 1)   (dollar-centric redemption; m = |basket|)
+//
+// net is strictly increasing in g (GP12a: dt/dg = Sum_basket prob > 0) and Sum_others prob is
+// strictly decreasing in eta (GP5a) — so both bisections are on monotone objectives.
+function calculateCpmmMultiArbitrageBetsYesV2(
+  initialAnswers: Answer[],
+  initialAnswersToBuy: Answer[],
+  betAmount: number,
+  limitProb: number | undefined,
+  unfilledBets: LimitBet[],
+  balanceByUserId: { [userId: string]: number },
+  collectedFees: Fees
+) {
+  const unfilledBetsByAnswer = groupBy(unfilledBets, (b) => b.answerId)
+  const basketIds = new Set(initialAnswersToBuy.map((a) => a.id))
+  const others = initialAnswers.filter((a) => !basketIds.has(a.id))
+  const n = initialAnswers.length
+  const m = initialAnswersToBuy.length
+
+  // Evaluate one g: realize the basket YES legs + the arbed OTHER NO legs at the eta that pins
+  // Sum prob == 1. Returns undefined when g is infeasible (basket alone already sums >= 1).
+  const evalG = (g: number) => {
+    // Fresh working snapshots so each g-probe is independent (no maker capacity bleed across probes).
+    const workingUnfilledBetsByAnswer = mapValues(unfilledBetsByAnswer, (bets) => [
+      ...bets,
+    ])
+    const workingBalanceByUserId = { ...balanceByUserId }
+
+    // --- basket: buy g YES shares in each basket answer (single rising sweep, limit-aware) ---
+    let basketCost = 0
+    const yesBetResults = initialAnswersToBuy.map((answer) => {
+      const pool = { YES: answer.poolYes, NO: answer.poolNo }
+      const state = { pool, p: answer.p, collectedFees }
+      const yesAmount = calculateAmountToBuySharesFixedP(
+        state,
+        g,
+        'YES',
+        workingUnfilledBetsByAnswer[answer.id] ?? [],
+        workingBalanceByUserId
+      )
+      const result = {
+        ...computeFills(
+          state,
+          'YES',
+          yesAmount,
+          limitProb,
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId
+        ),
+        answer,
+      }
+      applyMakersToWorkingState(
+        result.makers,
+        result.ordersToCancel,
+        workingUnfilledBetsByAnswer,
+        workingBalanceByUserId
+      )
+      basketCost += sumBy(result.takers, 'amount')
+      return result
+    })
+    const basketSum = sumBy(yesBetResults, (r) =>
+      getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+    )
+    const target = 1 - basketSum // required Sum over the non-basket answers
+    if (target <= 1e-9) {
+      return undefined // basket alone sums to >= 1: this g is infeasible
+    }
+
+    // --- inner: eta NO shares in each OTHER answer so their prob-sum == target. Read-only preview
+    // (never applies makers) — Sum_others prob is strictly decreasing in eta => unique eta. ---
+    const othersSumAtEta = (eta: number) =>
+      sumBy(others, (answer) => {
+        const pool = { YES: answer.poolYes, NO: answer.poolNo }
+        const state = { pool, p: answer.p, collectedFees }
+        const noAmount = calculateAmountToBuySharesFixedP(
+          state,
+          eta,
+          'NO',
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId,
+          true
+        )
+        const { cpmmState } = computeFills(
+          state,
+          'NO',
+          noAmount,
+          undefined,
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId,
+          undefined,
+          true
+        )
+        return getCpmmProbability(cpmmState.pool, cpmmState.p)
+      })
+
+    let eta = 0
+    if (othersSumAtEta(0) > target) {
+      let hi = 1
+      while (othersSumAtEta(hi) > target && hi < 1e12) hi *= 2
+      // othersSum decreasing in eta => comparator (target - othersSum) increasing in eta.
+      eta = binarySearch(0, hi, (e) => target - othersSumAtEta(e))
+    }
+
+    // --- realize the OTHER NO legs at eta, this time applying maker fills to working state ---
+    let othersCost = 0
+    const noBetResults = others.map((answer) => {
+      const pool = { YES: answer.poolYes, NO: answer.poolNo }
+      const state = { pool, p: answer.p, collectedFees }
+      const noAmount = calculateAmountToBuySharesFixedP(
+        state,
+        eta,
+        'NO',
+        workingUnfilledBetsByAnswer[answer.id] ?? [],
+        workingBalanceByUserId,
+        true
+      )
+      const result = {
+        ...computeFills(
+          state,
+          'NO',
+          noAmount,
+          undefined,
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId,
+          undefined,
+          true
+        ),
+        answer,
+      }
+      applyMakersToWorkingState(
+        result.makers,
+        result.ordersToCancel,
+        workingUnfilledBetsByAnswer,
+        workingBalanceByUserId
+      )
+      othersCost += sumBy(result.takers, 'amount')
+      return result
+    })
+
+    // Dollar-centric redemption credit: eta NO shares in each of the (n - m) other answers, with g
+    // YES shares in each of the m basket answers, forms complete sets worth eta*(n - m - 1) mana.
+    // (For m = 1 this is eta*(n - 2), matching the single-answer calculateCpmmMultiArbitrageBetYes.)
+    const net = basketCost + othersCost - eta * (n - m - 1)
+    return { yesBetResults, noBetResults, eta, net }
+  }
+
+  // outer: net strictly increasing in g (and undefined past the feasibility boundary, which is an
+  // upper bound) => bracket by doubling, then bisect on net == betAmount.
+  let gHi = 1
+  while (true) {
+    const r = evalG(gHi)
+    if (!r || r.net >= betAmount) break
+    gHi *= 2
+    if (gHi > 1e9) {
+      throw new Error('budget unreachable in cpmm-multi-2 YES basket solve')
+    }
+  }
+  const g = binarySearch(0, gHi, (gg) => {
+    const r = evalG(gg)
+    return r ? r.net - betAmount : 1 // infeasible g overshoots Sum p => push g lower
+  })
+  const solved = evalG(g)
+  if (!solved) {
+    throw new Error('Invariant failed in cpmm-multi-2 YES basket solve')
+  }
+  const { yesBetResults, noBetResults, eta, net } = solved
+
+  // Redemption fills (mirrors the single-answer path): the NO-in-others legs are internal
+  // arbitrage that nets to zero mana/shares; the redemption credit flows to the basket YES legs.
+  // netOthers = othersCost - eta*(n - m - 1); summed taker amount across all legs == betAmount.
+  const othersCost = sumBy(noBetResults, (r) => sumBy(r.takers, 'amount'))
+  const netOthers = othersCost - eta * (n - m - 1)
+  for (const noBetResult of noBetResults) {
+    noBetResult.takers.push({
+      matchedBetId: null,
+      amount: -sumBy(noBetResult.takers, 'amount'),
+      shares: -sumBy(noBetResult.takers, 'shares'),
+      timestamp: Date.now(),
+      fees: noFees,
+    })
+  }
+  // Split the redemption credit equally across the basket (eta/m shares, netOthers/m mana each);
+  // for m = 1 this reduces exactly to the single-answer redemption fill (eta shares, netOthers mana).
+  for (const yesBetResult of yesBetResults) {
+    yesBetResult.takers.push({
+      matchedBetId: null,
+      amount: netOthers / m,
+      shares: eta / m,
+      timestamp: Date.now(),
+      fees: noFees,
+    })
+  }
+  void net
+
+  const updatedAnswers = initialAnswers.map((answer) => {
+    const r =
+      yesBetResults.find((b) => b.answer.id === answer.id) ??
+      noBetResults.find((b) => b.answer.id === answer.id)
+    if (!r) return answer
+    const { pool, p } = r.cpmmState
+    return {
+      ...answer,
+      poolYes: pool.YES,
+      poolNo: pool.NO,
+      prob: getCpmmProbability(pool, p),
+    }
+  })
+
+  const newBetResults = combineBetsOnSameAnswers(
+    yesBetResults,
+    'YES',
+    updatedAnswers.filter((a) => basketIds.has(a.id)),
+    collectedFees
+  )
+  const otherBetResults = combineBetsOnSameAnswers(
+    noBetResults,
+    'NO',
+    updatedAnswers.filter((a) => !basketIds.has(a.id)),
     collectedFees
   )
 

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -27,7 +27,7 @@ const noFillsReturn = (
     ordersToCancel: [] as LimitBet[],
     cpmmState: {
       pool: { YES: answer.poolYes, NO: answer.poolNo },
-      p: 0.5,
+      p: answer.p,
       collectedFees,
     },
     totalFees: { creatorFee: 0, liquidityFee: 0, platformFee: 0 },
@@ -125,7 +125,7 @@ export function calculateCpmmMultiArbitrageYesBets(
           ordersToCancel: [],
           cpmmState: {
             pool: { YES: r.answer.poolYes, NO: r.answer.poolNo },
-            p: 0.5,
+            p: r.answer.p,
             collectedFees,
           },
           totalFees: noFees,
@@ -209,9 +209,9 @@ function calculateCpmmMultiArbitrageBetsYes(
     const maxYesShares = amountToBet / yesSharePriceSum
     let yesAmounts: number[] = []
     binarySearch(0, maxYesShares, (yesShares) => {
-      yesAmounts = answersToBuy.map(({ id, poolYes, poolNo }) =>
+      yesAmounts = answersToBuy.map(({ id, poolYes, poolNo, p }) =>
         calculateAmountToBuySharesFixedP(
-          { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
+          { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
           yesShares,
           'YES',
           workingUnfilledBetsByAnswer[id] ?? [],
@@ -308,7 +308,7 @@ export const getBetResultsAndUpdatedAnswers = (
     const pool = { YES: answerToBuy.poolYes, NO: answerToBuy.poolNo }
     const yesBetResult = {
       ...computeFills(
-        { pool, p: 0.5, collectedFees },
+        { pool, p: answerToBuy.p, collectedFees },
         'YES',
         yesAmounts[i],
         limitProb,
@@ -435,7 +435,11 @@ export const combineBetsOnSameAnswers = (
       makers: betsForAnswer.flatMap((r) => r.makers),
       ordersToCancel: betsForAnswer.flatMap((r) => r.ordersToCancel),
       outcome,
-      cpmmState: { p: 0.5, pool: { YES: poolYes, NO: poolNo }, collectedFees },
+      cpmmState: {
+        p: answer.p,
+        pool: { YES: poolYes, NO: poolNo },
+        collectedFees,
+      },
       answer,
       totalFees,
     }
@@ -474,11 +478,12 @@ function calculateCpmmMultiArbitrageBetYes(
     if (!result) {
       return 1
     }
-    const newPools = [
-      ...result.noBetResults.map((r) => r.cpmmState.pool),
-      result.yesBetResult.cpmmState.pool,
-    ]
-    const diff = 1 - sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5))
+    const newStates = [...result.noBetResults, result.yesBetResult]
+    const diff =
+      1 -
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      )
     return diff
   })
 
@@ -502,10 +507,8 @@ function calculateCpmmMultiArbitrageBetYes(
   if (DEBUG) {
     const endTime = Date.now()
 
-    const newPools = [
-      ...noBetResults.map((r) => r.cpmmState.pool),
-      yesBetResult.cpmmState.pool,
-    ]
+    const newStates = [...noBetResults, yesBetResult]
+    const newPools = newStates.map((r) => r.cpmmState.pool)
 
     console.log('time', endTime - startTime, 'ms')
 
@@ -528,9 +531,11 @@ function calculateCpmmMultiArbitrageBetYes(
     console.log(
       'getBinaryBuyYes after',
       newPools,
-      newPools.map((pool) => getCpmmProbability(pool, 0.5)),
+      newStates.map((r) => getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)),
       'prob total',
-      sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5)),
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      ),
       'pool shares',
       newPools.map((pool) => `${pool.YES}, ${pool.NO}`),
       'no shares',
@@ -556,9 +561,9 @@ const buyNoSharesInOtherAnswersThenYesInAnswer = (
   collectedFees: Fees
 ) => {
   const otherAnswers = answers.filter((a) => a.id !== answerToBuy.id)
-  const noAmounts = otherAnswers.map(({ id, poolYes, poolNo }) =>
+  const noAmounts = otherAnswers.map(({ id, poolYes, poolNo, p }) =>
     calculateAmountToBuySharesFixedP(
-      { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
+      { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
       noShares,
       'NO',
       unfilledBetsByAnswer[id] ?? [],
@@ -578,7 +583,7 @@ const buyNoSharesInOtherAnswersThenYesInAnswer = (
     const pool = { YES: answer.poolYes, NO: answer.poolNo }
     const result = {
       ...computeFills(
-        { pool, p: 0.5, collectedFees },
+        { pool, p: answer.p, collectedFees },
         'NO',
         noAmount,
         undefined,
@@ -623,7 +628,7 @@ const buyNoSharesInOtherAnswersThenYesInAnswer = (
   const pool = { YES: answerToBuy.poolYes, NO: answerToBuy.poolNo }
   const yesBetResult = {
     ...computeFills(
-      { pool, p: 0.5, collectedFees },
+      { pool, p: answerToBuy.p, collectedFees },
       'YES',
       yesBetAmount,
       limitProb,
@@ -677,11 +682,11 @@ function calculateCpmmMultiArbitrageBetNo(
     )
     if (!result) return 1
     const { yesBetResults, noBetResult } = result
-    const newPools = [
-      ...yesBetResults.map((r) => r.cpmmState.pool),
-      noBetResult.cpmmState.pool,
-    ]
-    const diff = sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5)) - 1
+    const newStates = [...yesBetResults, noBetResult]
+    const diff =
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      ) - 1
     return diff
   })
 
@@ -703,10 +708,8 @@ function calculateCpmmMultiArbitrageBetNo(
   if (DEBUG) {
     const endTime = Date.now()
 
-    const newPools = [
-      ...yesBetResults.map((r) => r.cpmmState.pool),
-      noBetResult.cpmmState.pool,
-    ]
+    const newStates = [...yesBetResults, noBetResult]
+    const newPools = newStates.map((r) => r.cpmmState.pool)
 
     console.log('time', endTime - startTime, 'ms')
 
@@ -729,9 +732,11 @@ function calculateCpmmMultiArbitrageBetNo(
     console.log(
       'getBinaryBuyNo after',
       newPools,
-      newPools.map((pool) => getCpmmProbability(pool, 0.5)),
+      newStates.map((r) => getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)),
       'prob total',
-      sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5)),
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      ),
       'pool shares',
       newPools.map((pool) => `${pool.YES}, ${pool.NO}`),
       'yes shares',
@@ -757,9 +762,9 @@ const buyYesSharesInOtherAnswersThenNoInAnswer = (
   collectedFees: Fees
 ) => {
   const otherAnswers = answers.filter((a) => a.id !== answerToBuy.id)
-  const yesAmounts = otherAnswers.map(({ id, poolYes, poolNo }) =>
+  const yesAmounts = otherAnswers.map(({ id, poolYes, poolNo, p }) =>
     calculateAmountToBuySharesFixedP(
-      { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
+      { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
       yesShares,
       'YES',
       unfilledBetsByAnswer[id] ?? [],
@@ -779,7 +784,7 @@ const buyYesSharesInOtherAnswersThenNoInAnswer = (
     const { poolYes, poolNo } = answer
     const result = {
       ...computeFills(
-        { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
+        { pool: { YES: poolYes, NO: poolNo }, p: answer.p, collectedFees },
         'YES',
         yesAmount,
         undefined,
@@ -821,7 +826,7 @@ const buyYesSharesInOtherAnswersThenNoInAnswer = (
   const pool = { YES: answerToBuy.poolYes, NO: answerToBuy.poolNo }
   const noBetResult = {
     ...computeFills(
-      { pool, p: 0.5, collectedFees },
+      { pool, p: answerToBuy.p, collectedFees },
       'NO',
       noBetAmount,
       limitProb,
@@ -863,8 +868,9 @@ export const buyNoSharesUntilAnswersSumToOne = (
       answerIdsWithFees,
       false // don't mutate orders during binary search
     )
-    const newPools = result.noBetResults.map((r) => r.cpmmState.pool)
-    const probSum = sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5))
+    const probSum = sumBy(result.noBetResults, (r) =>
+      getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+    )
     if (probSum < 1) break
     maxNoShares *= 10
   } while (true)
@@ -879,8 +885,11 @@ export const buyNoSharesUntilAnswersSumToOne = (
       answerIdsWithFees,
       false // don't mutate orders during binary search
     )
-    const newPools = result.noBetResults.map((r) => r.cpmmState.pool)
-    const diff = 1 - sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5))
+    const diff =
+      1 -
+      sumBy(result.noBetResults, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      )
     return diff
   })
 
@@ -911,7 +920,7 @@ const buyNoSharesInAnswers = (
     const { id, poolYes, poolNo } = answer
     const pool = { YES: poolYes, NO: poolNo }
     const noAmount = calculateAmountToBuySharesFixedP(
-      { pool, p: 0.5, collectedFees },
+      { pool, p: answer.p, collectedFees },
       noShares,
       'NO',
       unfilledBetsByAnswer[id] ?? [],
@@ -922,7 +931,7 @@ const buyNoSharesInAnswers = (
 
     const res = {
       ...computeFills(
-        { pool, p: 0.5, collectedFees },
+        { pool, p: answer.p, collectedFees },
         'NO',
         noAmount,
         undefined,
@@ -990,16 +999,16 @@ export function calculateCpmmMultiArbitrageSellNo(
   const yesShares = binarySearch(0, noShares, (yesShares) => {
     const noSharesInOtherAnswers = noShares - yesShares
     const yesAmount = calculateAmountToBuySharesFixedP(
-      { pool, p: 0.5, collectedFees },
+      { pool, p: answerToSell.p, collectedFees },
       yesShares,
       'YES',
       unfilledBetsByAnswer[id] ?? [],
       balanceByUserId
     )
     const noAmounts = answersWithoutAnswerToSell.map(
-      ({ id, poolYes, poolNo }) =>
+      ({ id, poolYes, poolNo, p }) =>
         calculateAmountToBuySharesFixedP(
-          { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
+          { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
           noSharesInOtherAnswers,
           'NO',
           unfilledBetsByAnswer[id] ?? [],
@@ -1009,7 +1018,7 @@ export function calculateCpmmMultiArbitrageSellNo(
     )
 
     const yesResult = computeFills(
-      { pool, p: 0.5, collectedFees },
+      { pool, p: answerToSell.p, collectedFees },
       'YES',
       yesAmount,
       limitProb,
@@ -1021,7 +1030,7 @@ export function calculateCpmmMultiArbitrageSellNo(
       const pool = { YES: answer.poolYes, NO: answer.poolNo }
       return {
         ...computeFills(
-          { pool, p: 0.5, collectedFees },
+          { pool, p: answer.p, collectedFees },
           'NO',
           noAmount,
           undefined,
@@ -1034,34 +1043,35 @@ export function calculateCpmmMultiArbitrageSellNo(
       }
     })
 
-    const newPools = [
-      yesResult.cpmmState.pool,
-      ...noResults.map((r) => r.cpmmState.pool),
-    ]
-    const diff = sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5)) - 1
+    const newStates = [yesResult, ...noResults]
+    const diff =
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      ) - 1
     return diff
   })
 
   const noSharesInOtherAnswers = noShares - yesShares
   const yesAmount = calculateAmountToBuySharesFixedP(
-    { pool, p: 0.5, collectedFees },
+    { pool, p: answerToSell.p, collectedFees },
     yesShares,
     'YES',
     unfilledBetsByAnswer[id] ?? [],
     balanceByUserId
   )
-  const noAmounts = answersWithoutAnswerToSell.map(({ id, poolYes, poolNo }) =>
-    calculateAmountToBuySharesFixedP(
-      { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
-      noSharesInOtherAnswers,
-      'NO',
-      unfilledBetsByAnswer[id] ?? [],
-      balanceByUserId,
-      true
-    )
+  const noAmounts = answersWithoutAnswerToSell.map(
+    ({ id, poolYes, poolNo, p }) =>
+      calculateAmountToBuySharesFixedP(
+        { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
+        noSharesInOtherAnswers,
+        'NO',
+        unfilledBetsByAnswer[id] ?? [],
+        balanceByUserId,
+        true
+      )
   )
   const yesBetResult = computeFills(
-    { pool, p: 0.5, collectedFees },
+    { pool, p: answerToSell.p, collectedFees },
     'YES',
     yesAmount,
     limitProb,
@@ -1073,7 +1083,7 @@ export function calculateCpmmMultiArbitrageSellNo(
     const pool = { YES: answer.poolYes, NO: answer.poolNo }
     return {
       ...computeFills(
-        { pool, p: 0.5, collectedFees },
+        { pool, p: answer.p, collectedFees },
         'NO',
         noAmount,
         undefined,
@@ -1121,10 +1131,8 @@ export function calculateCpmmMultiArbitrageSellNo(
   if (DEBUG) {
     const endTime = Date.now()
 
-    const newPools = [
-      ...noBetResults.map((r) => r.cpmmState.pool),
-      yesBetResult.cpmmState.pool,
-    ]
+    const newStates = [...noBetResults, yesBetResult]
+    const newPools = newStates.map((r) => r.cpmmState.pool)
 
     console.log('time', endTime - startTime, 'ms')
 
@@ -1147,9 +1155,11 @@ export function calculateCpmmMultiArbitrageSellNo(
     console.log(
       'getBinaryBuyYes after',
       newPools,
-      newPools.map((pool) => getCpmmProbability(pool, 0.5)),
+      newStates.map((r) => getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)),
       'prob total',
-      sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5)),
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      ),
       'pool shares',
       newPools.map((pool) => `${pool.YES}, ${pool.NO}`),
       'no shares',
@@ -1185,16 +1195,16 @@ export function calculateCpmmMultiArbitrageSellYes(
   const noShares = binarySearch(0, yesShares, (noShares) => {
     const yesSharesInOtherAnswers = yesShares - noShares
     const noAmount = calculateAmountToBuySharesFixedP(
-      { pool, p: 0.5, collectedFees },
+      { pool, p: answerToSell.p, collectedFees },
       noShares,
       'NO',
       unfilledBetsByAnswer[id] ?? [],
       balanceByUserId
     )
     const yesAmounts = answersWithoutAnswerToSell.map(
-      ({ id, poolYes, poolNo }) =>
+      ({ id, poolYes, poolNo, p }) =>
         calculateAmountToBuySharesFixedP(
-          { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
+          { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
           yesSharesInOtherAnswers,
           'YES',
           unfilledBetsByAnswer[id] ?? [],
@@ -1204,7 +1214,7 @@ export function calculateCpmmMultiArbitrageSellYes(
     )
 
     const noResult = computeFills(
-      { pool, p: 0.5, collectedFees },
+      { pool, p: answerToSell.p, collectedFees },
       'NO',
       noAmount,
       limitProb,
@@ -1216,7 +1226,7 @@ export function calculateCpmmMultiArbitrageSellYes(
       const pool = { YES: answer.poolYes, NO: answer.poolNo }
       return {
         ...computeFills(
-          { pool, p: 0.5, collectedFees },
+          { pool, p: answer.p, collectedFees },
           'YES',
           yesAmount,
           undefined,
@@ -1229,34 +1239,36 @@ export function calculateCpmmMultiArbitrageSellYes(
       }
     })
 
-    const newPools = [
-      noResult.cpmmState.pool,
-      ...yesResults.map((r) => r.cpmmState.pool),
-    ]
-    const diff = 1 - sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5))
+    const newStates = [noResult, ...yesResults]
+    const diff =
+      1 -
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      )
     return diff
   })
 
   const yesSharesInOtherAnswers = yesShares - noShares
   const noAmount = calculateAmountToBuySharesFixedP(
-    { pool, p: 0.5, collectedFees },
+    { pool, p: answerToSell.p, collectedFees },
     noShares,
     'NO',
     unfilledBetsByAnswer[id] ?? [],
     balanceByUserId
   )
-  const yesAmounts = answersWithoutAnswerToSell.map(({ id, poolYes, poolNo }) =>
-    calculateAmountToBuySharesFixedP(
-      { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
-      yesSharesInOtherAnswers,
-      'YES',
-      unfilledBetsByAnswer[id] ?? [],
-      balanceByUserId,
-      true
-    )
+  const yesAmounts = answersWithoutAnswerToSell.map(
+    ({ id, poolYes, poolNo, p }) =>
+      calculateAmountToBuySharesFixedP(
+        { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
+        yesSharesInOtherAnswers,
+        'YES',
+        unfilledBetsByAnswer[id] ?? [],
+        balanceByUserId,
+        true
+      )
   )
   const noBetResult = computeFills(
-    { pool, p: 0.5, collectedFees },
+    { pool, p: answerToSell.p, collectedFees },
     'NO',
     noAmount,
     limitProb,
@@ -1268,7 +1280,7 @@ export function calculateCpmmMultiArbitrageSellYes(
     const pool = { YES: answer.poolYes, NO: answer.poolNo }
     return {
       ...computeFills(
-        { pool, p: 0.5, collectedFees },
+        { pool, p: answer.p, collectedFees },
         'YES',
         yesAmount,
         undefined,
@@ -1315,10 +1327,8 @@ export function calculateCpmmMultiArbitrageSellYes(
   if (DEBUG) {
     const endTime = Date.now()
 
-    const newPools = [
-      ...yesBetResults.map((r) => r.cpmmState.pool),
-      noBetResult.cpmmState.pool,
-    ]
+    const newStates = [...yesBetResults, noBetResult]
+    const newPools = newStates.map((r) => r.cpmmState.pool)
 
     console.log('time', endTime - startTime, 'ms')
 
@@ -1341,9 +1351,11 @@ export function calculateCpmmMultiArbitrageSellYes(
     console.log(
       'getBinaryBuyYes after',
       newPools,
-      newPools.map((pool) => getCpmmProbability(pool, 0.5)),
+      newStates.map((r) => getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)),
       'prob total',
-      sumBy(newPools, (pool) => getCpmmProbability(pool, 0.5)),
+      sumBy(newStates, (r) =>
+        getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+      ),
       'pool shares',
       newPools.map((pool) => `${pool.YES}, ${pool.NO}`),
       'no shares',
@@ -1394,9 +1406,9 @@ export const calculateCpmmMultiArbitrageSellYesEqually = (
     let saleBets: PreliminaryBetResults[]
     if (answersToSellNow.length !== initialAnswers.length) {
       const yesAmounts = oppositeAnswersFromSaleToBuyYesShares.map(
-        ({ id, poolYes, poolNo }) => {
+        ({ id, poolYes, poolNo, p }) => {
           return calculateAmountToBuySharesFixedP(
-            { pool: { YES: poolYes, NO: poolNo }, p: 0.5, collectedFees },
+            { pool: { YES: poolYes, NO: poolNo }, p, collectedFees },
             sharesToSell,
             'YES',
             unfilledBetsByAnswer[id] ?? [],
@@ -1456,7 +1468,7 @@ export const calculateCpmmMultiArbitrageSellYesEqually = (
               //...betResult.takers, these are takers in the opposite outcome, not sure where to put them
             ],
             cpmmState: {
-              p: 0.5,
+              p: answer.p,
               pool: { YES: poolYes, NO: poolNo },
               collectedFees,
             },
@@ -1529,7 +1541,11 @@ export const getSellAllRedemptionPreliminaryBets = (
       ],
       makers: [],
       totalFees: noFees,
-      cpmmState: { p: 0.5, pool: { YES: poolYes, NO: poolNo }, collectedFees },
+      cpmmState: {
+        p: answer.p,
+        pool: { YES: poolYes, NO: poolNo },
+        collectedFees,
+      },
       ordersToCancel: [],
       answer,
     }

--- a/common/src/calculate-cpmm-arbitrage.ts
+++ b/common/src/calculate-cpmm-arbitrage.ts
@@ -96,10 +96,11 @@ export function calculateCpmmMultiArbitrageYesBets(
   balanceByUserId: { [userId: string]: number },
   collectedFees: Fees,
   // cpmm-multi-2 (per-answer p + reversible-limit auto-arb) routes the basket buy through the
-  // direct, non-overshooting "Approach C" solve. Defaults to the frozen v1 path so every
-  // existing cpmm-multi-1 caller is byte-identical. Gate at the call site on
-  // contract.mechanism === 'cpmm-multi-2'.
-  arbVersion: 'cpmm-multi-1' | 'cpmm-multi-2' = 'cpmm-multi-1'
+  // direct, non-overshooting "Approach C" solve; cpmm-multi-1 keeps the frozen v1 nested
+  // search byte-identically. REQUIRED — pass contract.mechanism. Deliberately no default:
+  // a silent v1 default let a preview path (numeric-bet-panel) show v1 fills for a v2
+  // market; the compiler now forces every caller to say which market it is pricing.
+  arbVersion: 'cpmm-multi-1' | 'cpmm-multi-2'
 ) {
   const result = calculateCpmmMultiArbitrageBetsYes(
     answers,
@@ -196,7 +197,7 @@ function calculateCpmmMultiArbitrageBetsYes(
   unfilledBets: LimitBet[],
   balanceByUserId: { [userId: string]: number },
   collectedFees: Fees,
-  arbVersion: 'cpmm-multi-1' | 'cpmm-multi-2' = 'cpmm-multi-1'
+  arbVersion: 'cpmm-multi-1' | 'cpmm-multi-2'
 ) {
   if (arbVersion === 'cpmm-multi-2') {
     return calculateCpmmMultiArbitrageBetsYesV2(

--- a/common/src/calculate-cpmm.test.ts
+++ b/common/src/calculate-cpmm.test.ts
@@ -1,5 +1,8 @@
+import { mapValues, sum } from 'lodash'
 import {
   addCpmmLiquidity,
+  addCpmmLiquidityFixedP,
+  addCpmmMultiLiquidityAnswersSumToOneV2,
   calculateCpmmAmountToBuySharesFixedP,
   calculateCpmmPurchase,
   calculateCpmmShares,
@@ -248,5 +251,75 @@ describe('CPMM Calculations', () => {
         calculateCpmmAmountToBuySharesFixedP(state, shares, 'YES')
       ).toBeCloseTo(closed, 10)
     })
+  })
+})
+
+// --- cpmm-multi-2: lossless whole-market liquidity add (2b.5) ------------------------------
+// A valid v2 sum-to-one market is per-answer (pool, p) with Σ prob_i = 1. Balanced pools
+// (Y = N = L) give prob_i = p_i, so any {p_i} that sums to 1 is a valid market. There is NO
+// external p != 0.5 oracle (vendor v1 throws), so losslessness is validated by the invariants:
+// each answer's probability is preserved exactly, Σ prob stays 1, k strictly increases, and
+// nothing is discarded — versus v1's addCpmmLiquidityFixedP, which throws shares away on a
+// skewed pool. At p = 0.5 v2 reduces to the v1 fixed-p add (the regression anchor).
+describe('cpmm-multi-2 lossless liquidity add (addCpmmMultiLiquidityAnswersSumToOneV2)', () => {
+  const market = (ps: number[], L = 100) =>
+    Object.fromEntries(ps.map((p, i) => [`a${i}`, { pool: { YES: L, NO: L }, p }]))
+
+  const probsOf = (byId: {
+    [id: string]: { pool: { YES: number; NO: number }; p: number }
+  }) => mapValues(byId, ({ pool, p }) => getCpmmProbability(pool, p))
+
+  it('preserves every answer probability and Σ prob = 1 (lossless), deepening each pool', () => {
+    for (const ps of [
+      [0.5, 0.3, 0.2],
+      [0.7, 0.2, 0.1],
+      [0.9, 0.05, 0.05],
+      [0.4, 0.3, 0.2, 0.1],
+    ]) {
+      const before = market(ps)
+      const probsBefore = probsOf(before)
+      const after = addCpmmMultiLiquidityAnswersSumToOneV2(before, 50)
+      const probsAfter = probsOf(after)
+      for (const id of Object.keys(before)) {
+        // probability preserved exactly (the invariant), p floated to absorb the mana
+        expect(probsAfter[id]).toBeCloseTo(probsBefore[id], 10)
+        // pool deepened in BOTH reserves; positive k added; nothing discarded
+        expect(after[id].liquidity).toBeGreaterThan(0)
+        expect(after[id].pool.YES).toBeGreaterThan(before[id].pool.YES)
+        expect(after[id].pool.NO).toBeGreaterThan(before[id].pool.NO)
+      }
+      expect(sum(Object.values(probsAfter))).toBeCloseTo(1, 10)
+    }
+  })
+
+  it('at p = 0.5 reduces to the v1 fixed-p add (both reserves +amount, p stays 0.5, no discard)', () => {
+    const before = market([0.5, 0.5]) // uniform 2-answer market, Σ prob = 1
+    const after = addCpmmMultiLiquidityAnswersSumToOneV2(before, 50) // 25 per answer
+    for (const id of Object.keys(before)) {
+      const v1 = addCpmmLiquidityFixedP(before[id].pool, 25)
+      expect(after[id].p).toBeCloseTo(0.5, 10)
+      expect(after[id].pool.YES).toBeCloseTo(v1.newPool.YES, 8)
+      expect(after[id].pool.NO).toBeCloseTo(v1.newPool.NO, 8)
+      expect(v1.sharesThrownAway.YES).toBeCloseTo(0, 10)
+      expect(v1.sharesThrownAway.NO).toBeCloseTo(0, 10)
+    }
+  })
+
+  it('on a SKEWED pool v1 discards shares to hold prob; v2 keeps both reserves whole', () => {
+    const skewed = { YES: 30, NO: 270 } // prob = 0.9
+    const v1 = addCpmmLiquidityFixedP(skewed, 50)
+    // v1 holds prob by topping up the deep side and DISCARDING the shallow side's excess
+    expect(v1.sharesThrownAway.YES).toBeGreaterThan(0)
+    // v2 injects the full amount into both reserves and floats p instead — nothing thrown away
+    const v2 = addCpmmMultiLiquidityAnswersSumToOneV2(
+      { only: { pool: skewed, p: 0.5 } },
+      50
+    ).only
+    expect(v2.pool.YES).toBeCloseTo(skewed.YES + 50, 8)
+    expect(v2.pool.NO).toBeCloseTo(skewed.NO + 50, 8)
+    expect(getCpmmProbability(v2.pool, v2.p)).toBeCloseTo(
+      getCpmmProbability(skewed, 0.5),
+      10
+    )
   })
 })

--- a/common/src/calculate-cpmm.test.ts
+++ b/common/src/calculate-cpmm.test.ts
@@ -7,6 +7,7 @@ import {
   calculateCpmmAmountToBuySharesFixedP,
   calculateCpmmPurchase,
   calculateCpmmShares,
+  cpmmMulti2SumToOnePools,
   CpmmState,
   getCpmmOutcomeProbabilityAfterBet,
   getCpmmProbability,
@@ -322,6 +323,50 @@ describe('cpmm-multi-2 lossless liquidity add (addCpmmMultiLiquidityAnswersSumTo
       getCpmmProbability(skewed, 0.5),
       10
     )
+  })
+
+  // GP17 — the whole-market add follows the √variance CREATION shape (not a flat equal-split):
+  // it MERGES a Δ-ante √variance creation computed at the current probs, then re-prices each p.
+  // proofs/liquidity_add_split.py is the reference; these lock the key consequences in jest.
+  it('GP17: concentrates added depth in uncertain answers (NOT a flat equal-split)', () => {
+    // Skewed 4-answer market at q = [.55,.25,.12,.08], created on the √variance manifold, then a
+    // whole-market add. The added geometric depth Δk should be far from flat (uncertain answers get
+    // much more) — the deliberate departure from the old amount/n equal-split.
+    const q = [0.55, 0.25, 0.12, 0.08]
+    const created = cpmmMulti2SumToOnePools(q, 1000)
+    const before = Object.fromEntries(
+      created.map((c, i) => [
+        `a${i}`,
+        { pool: { YES: c.poolYes, NO: c.poolNo }, p: c.p },
+      ])
+    )
+    const after = addCpmmMultiLiquidityAnswersSumToOneV2(before, 500)
+    const dk = Object.keys(before).map((id) => after[id].liquidity)
+    // ratio of most-uncertain to least-uncertain added depth ≫ 1 (≈5; equal-split would be ≈1.17)
+    expect(Math.max(...dk) / Math.min(...dk)).toBeGreaterThan(4)
+    // every prob preserved + Σ = 1 still holds under the new shape
+    const probsAfter = Object.keys(before).map((id) =>
+      getCpmmProbability(after[id].pool, after[id].p)
+    )
+    q.forEach((qi, i) => expect(probsAfter[i]).toBeCloseTo(qi, 10))
+    expect(sum(probsAfter)).toBeCloseTo(1, 10)
+  })
+
+  it('GP17: on an untraded market, add(Δ) == create(A+Δ) (homogeneity / scale)', () => {
+    const q = [0.55, 0.25, 0.12, 0.08]
+    const A = 1000
+    const D = 500
+    const base = cpmmMulti2SumToOnePools(q, A)
+    const before = Object.fromEntries(
+      base.map((c, i) => [`a${i}`, { pool: { YES: c.poolYes, NO: c.poolNo }, p: c.p }])
+    )
+    const after = addCpmmMultiLiquidityAnswersSumToOneV2(before, D)
+    const created = cpmmMulti2SumToOnePools(q, A + D)
+    created.forEach((c, i) => {
+      expect(after[`a${i}`].pool.YES).toBeCloseTo(c.poolYes, 6)
+      expect(after[`a${i}`].pool.NO).toBeCloseTo(c.poolNo, 6)
+      expect(after[`a${i}`].p).toBeCloseTo(c.p, 8)
+    })
   })
 })
 

--- a/common/src/calculate-cpmm.test.ts
+++ b/common/src/calculate-cpmm.test.ts
@@ -3,6 +3,7 @@ import {
   addCpmmLiquidity,
   addCpmmLiquidityFixedP,
   addCpmmMultiLiquidityAnswersSumToOneV2,
+  addCpmmMultiLiquidityToAnswersIndependentlyV2,
   calculateCpmmAmountToBuySharesFixedP,
   calculateCpmmPurchase,
   calculateCpmmShares,
@@ -321,5 +322,56 @@ describe('cpmm-multi-2 lossless liquidity add (addCpmmMultiLiquidityAnswersSumTo
       getCpmmProbability(skewed, 0.5),
       10
     )
+  })
+})
+
+describe('cpmm-multi-2 lossless liquidity add — INDEPENDENT / "Set" (addCpmmMultiLiquidityToAnswersIndependentlyV2)', () => {
+  const market = (ps: number[], L = 100) =>
+    Object.fromEntries(ps.map((p, i) => [`a${i}`, { pool: { YES: L, NO: L }, p }]))
+
+  const probsOf = (byId: {
+    [id: string]: { pool: { YES: number; NO: number }; p: number }
+  }) => mapValues(byId, ({ pool, p }) => getCpmmProbability(pool, p))
+
+  it('REGRESSION: a balanced Set answer with p != 0.5 keeps prob == p (NOT clobbered to 0.5)', () => {
+    // The bug: the lossy fixed-p path recomputed prob as getCpmmProbability(newPool, 0.5) on the
+    // balanced (Y=N) Set pool, writing 0.5 and overwriting the real probability p. The float-p add
+    // must preserve prob == p exactly.
+    for (const p of [0.6, 0.75, 0.9, 0.1, 0.5]) {
+      const before = { only: { pool: { YES: 100, NO: 100 }, p } }
+      const after = addCpmmMultiLiquidityToAnswersIndependentlyV2(before, 40).only
+      expect(getCpmmProbability(after.pool, after.p)).toBeCloseTo(p, 10)
+      // both reserves deepened, k added, nothing discarded
+      expect(after.pool.YES).toBeGreaterThan(100)
+      expect(after.pool.NO).toBeGreaterThan(100)
+      expect(after.liquidity).toBeGreaterThan(0)
+    }
+  })
+
+  it('preserves each independent answer probability — and they need NOT sum to 1', () => {
+    // Independent answers are each their own binary CPMM: no Σ prob = 1 coupling.
+    const before = market([0.8, 0.65, 0.3]) // Σ prob = 1.75, deliberately != 1
+    const probsBefore = probsOf(before)
+    const after = addCpmmMultiLiquidityToAnswersIndependentlyV2(before, 60)
+    const probsAfter = probsOf(after)
+    for (const id of Object.keys(before)) {
+      expect(probsAfter[id]).toBeCloseTo(probsBefore[id], 10)
+      expect(after[id].pool.YES).toBeGreaterThan(before[id].pool.YES)
+      expect(after[id].pool.NO).toBeGreaterThan(before[id].pool.NO)
+    }
+    expect(sum(Object.values(probsAfter))).toBeCloseTo(1.75, 10)
+  })
+
+  it('at p = 0.5 on a balanced pool reduces to the v1 fixed-p add (no discard)', () => {
+    const before = market([0.5, 0.5])
+    const after = addCpmmMultiLiquidityToAnswersIndependentlyV2(before, 50) // 25 per answer
+    for (const id of Object.keys(before)) {
+      const v1 = addCpmmLiquidityFixedP(before[id].pool, 25)
+      expect(after[id].p).toBeCloseTo(0.5, 10)
+      expect(after[id].pool.YES).toBeCloseTo(v1.newPool.YES, 8)
+      expect(after[id].pool.NO).toBeCloseTo(v1.newPool.NO, 8)
+      expect(v1.sharesThrownAway.YES).toBeCloseTo(0, 10)
+      expect(v1.sharesThrownAway.NO).toBeCloseTo(0, 10)
+    }
   })
 })

--- a/common/src/calculate-cpmm.test.ts
+++ b/common/src/calculate-cpmm.test.ts
@@ -1,5 +1,6 @@
 import {
   addCpmmLiquidity,
+  calculateCpmmAmountToBuySharesFixedP,
   calculateCpmmPurchase,
   calculateCpmmShares,
   CpmmState,
@@ -189,6 +190,63 @@ describe('CPMM Calculations', () => {
       expect(finalPool.YES).toBeCloseTo(initialPool.YES, 5)
       expect(finalPool.NO).toBeCloseTo(initialPool.NO, 5)
       expect(finalP).toBeCloseTo(initialP, 5)
+    })
+  })
+
+  describe('calculateCpmmAmountToBuySharesFixedP (general p, cpmm-multi-2)', () => {
+    // The shares -> cost direction is transcendental for p != 0.5; the function
+    // inverts the (general-p) forward map calculateCpmmShares by bisection. These
+    // tests pin that inverse: cross-language anchors from the Python oracle
+    // (manifold/amm_core.cost_for_shares, GP3), a self-validating round-trip against
+    // calculateCpmmShares, and a check that the p=0.5 closed form is unchanged.
+    it('matches the general-p Python oracle (amm_core.cost_for_shares)', () => {
+      const cases = [
+        { pool: { YES: 100, NO: 50 }, p: 0.7, shares: 20, outcome: 'YES' as const, cost: 11.5061941179877 },
+        { pool: { YES: 100, NO: 50 }, p: 0.7, shares: 20, outcome: 'NO' as const, cost: 10.016299628032943 },
+        { pool: { YES: 80, NO: 120 }, p: 0.3, shares: 35, outcome: 'YES' as const, cost: 15.379495592014415 },
+        { pool: { YES: 200, NO: 100 }, p: 0.9, shares: 10, outcome: 'NO' as const, cost: 1.8886896107765505 },
+      ]
+      for (const { pool, p, shares, outcome, cost } of cases) {
+        const state: CpmmState = { pool, p, collectedFees: noFees }
+        expect(
+          calculateCpmmAmountToBuySharesFixedP(state, shares, outcome)
+        ).toBeCloseTo(cost, 6)
+      }
+    })
+
+    it('round-trips against calculateCpmmShares for general p (invert ∘ forward = id)', () => {
+      const ps = [0.3, 0.5, 0.7, 0.9]
+      const pools = [
+        { YES: 100, NO: 100 },
+        { YES: 100, NO: 50 },
+        { YES: 30, NO: 200 },
+      ]
+      const amounts = [1, 10, 50, 200]
+      for (const p of ps)
+        for (const pool of pools)
+          for (const outcome of ['YES', 'NO'] as const)
+            for (const amount of amounts) {
+              const shares = calculateCpmmShares(pool, p, amount, outcome)
+              const state: CpmmState = { pool, p, collectedFees: noFees }
+              const recovered = calculateCpmmAmountToBuySharesFixedP(
+                state,
+                shares,
+                outcome
+              )
+              expect(recovered).toBeCloseTo(amount, 4)
+            }
+    })
+
+    it('leaves the p = 0.5 closed form unchanged', () => {
+      const pool = { YES: 120, NO: 80 }
+      const shares = 25
+      const state: CpmmState = { pool, p: 0.5, collectedFees: noFees }
+      const closed =
+        (shares - 120 - 80 + Math.sqrt(4 * 80 * shares + (120 + 80 - shares) ** 2)) /
+        2
+      expect(
+        calculateCpmmAmountToBuySharesFixedP(state, shares, 'YES')
+      ).toBeCloseTo(closed, 10)
     })
   })
 })

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -16,6 +16,8 @@ import {
 import { Answer } from './answer'
 import { MarketContract, MAX_CPMM_PROB, MIN_CPMM_PROB } from 'common/contract'
 import { addObjects } from 'common/util/object'
+
+// (GPnn labels cite machine-checked proofs: https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/proofs)
 export const CPMM_ARBITRAGE_ERROR_PREFIX =
   'calculateAmountToBuySharesFixedP only works for p = 0.5, got '
 export type CpmmState = {
@@ -216,17 +218,11 @@ export function calculateCpmmAmountToBuySharesFixedP(
     low = -otherPool * (1 - 1e-9)
     high = 0
   }
-  for (let i = 0; i < 50; i++) {
-    const mid = (low + high) / 2
-    if (mid === low || mid === high) break
-    const sharesForMid = calculateCpmmShares(state.pool, state.p, mid, outcome)
-    if (sharesForMid < shares) {
-      low = mid
-    } else {
-      high = mid
-    }
-  }
-  return (low + high) / 2
+  // calculateCpmmShares is monotone increasing in the amount, so the signed shares
+  // error is a monotone comparator (binarySearch also fail-fasts on NaN).
+  return binarySearch(low, high, (mid) =>
+    calculateCpmmShares(state.pool, state.p, mid, outcome) - shares
+  )
 }
 
 export const computeFills = (
@@ -878,7 +874,7 @@ export function cpmmMulti2SumToOnePools(
   return q.map((qi, i) => {
     const poolNo = N[i]
     const poolYes = poolNo + D
-    const p = (qi * poolYes) / (qi * poolYes + (1 - qi) * poolNo)
+    const p = pForProbability({ YES: poolYes, NO: poolNo }, qi)
     return { poolYes, poolNo, p, prob: qi }
   })
 }
@@ -892,6 +888,18 @@ export function cpmmMulti2SumToOnePools(
 // sanity directly (no duplicated algebra to drift). The small margin keeps p (and via
 // re-pricing, reserves) representably far from {0,1} — float64 underflows exact-boundary
 // states (GP19b caveat).
+// The p that makes pool (Y, N) display probability q — the GP6a weight
+// p(q) = qY / (qY + (1 - q)N), the inverse of getCpmmProbability in p. Used by v2
+// creation, the whole-market add re-price, and the "Other" split. If p ever needs
+// clamping away from {0,1} (float64 representability, GP19b caveat), this is the
+// single home for it.
+export function pForProbability(
+  pool: { YES: number; NO: number },
+  q: number
+) {
+  return (q * pool.YES) / (q * pool.YES + (1 - q) * pool.NO)
+}
+
 const CPMM_MULTI_2_SANITY_EPS = 1e-9
 const isSanePool = (x: { poolYes: number; poolNo: number; p: number }) =>
   x.poolYes > 0 &&
@@ -954,8 +962,7 @@ export function addCpmmMultiLiquidityAnswersSumToOneV2(
       NO: pool.NO + delta[i].poolNo,
     }
     // Re-price p so prob(newPool, newP) == prob (unique; same form as creation's p).
-    const newP =
-      (prob * newPool.YES) / (prob * newPool.YES + (1 - prob) * newPool.NO)
+    const newP = pForProbability(newPool, prob)
     const liquidity =
       getCpmmLiquidity(newPool, newP) - getCpmmLiquidity(pool, newP)
     result[id] = { pool: newPool, p: newP, liquidity }

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -185,20 +185,48 @@ export function calculateCpmmAmountToBuySharesFixedP(
   shares: number,
   outcome: 'YES' | 'NO'
 ) {
-  if (!floatingEqual(state.p, 0.5)) {
-    throw new Error(CPMM_ARBITRAGE_ERROR_PREFIX + state.p)
-  }
-
   const { YES: y, NO: n } = state.pool
-  if (outcome === 'YES') {
-    // https://www.wolframalpha.com/input?i=%28y%2Bb-s%29%5E0.5+*+%28n%2Bb%29%5E0.5+%3D+y+%5E+0.5+*+n+%5E+0.5%2C+solve+b
+
+  if (floatingEqual(state.p, 0.5)) {
+    if (outcome === 'YES') {
+      // https://www.wolframalpha.com/input?i=%28y%2Bb-s%29%5E0.5+*+%28n%2Bb%29%5E0.5+%3D+y+%5E+0.5+*+n+%5E+0.5%2C+solve+b
+      return (
+        (shares - y - n + Math.sqrt(4 * n * shares + (y + n - shares) ** 2)) / 2
+      )
+    }
     return (
-      (shares - y - n + Math.sqrt(4 * n * shares + (y + n - shares) ** 2)) / 2
+      (shares - y - n + Math.sqrt(4 * y * shares + (y + n - shares) ** 2)) / 2
     )
   }
-  return (
-    (shares - y - n + Math.sqrt(4 * y * shares + (y + n - shares) ** 2)) / 2
-  )
+
+  // General p (cpmm-multi-2): shares -> cost has no closed form, so invert the
+  // general-p forward map calculateCpmmShares by bisection. calculateCpmmShares is
+  // monotone increasing in the bet amount, and a buy of `shares` costs < `shares`
+  // mana, so [0, shares*10] brackets a buy; a sell (shares < 0) is bounded below by
+  // draining the opposite pool side. Mirrors the proven Python oracle
+  // amm_core.cost_for_shares (GP3); 50 iterations reach double precision.
+  if (shares === 0) return 0
+  let low: number
+  let high: number
+  if (shares > 0) {
+    low = 0
+    high = shares * 10
+  } else {
+    const otherPool = outcome === 'YES' ? n : y
+    low = -otherPool * (1 - 1e-9)
+    high = 0
+  }
+  for (let i = 0; i < 50; i++) {
+    const mid = (low + high) / 2
+    if (mid === low || mid === high) break
+    const sharesForMid = calculateCpmmShares(state.pool, state.p, mid, outcome)
+    if (sharesForMid < shares) {
+      low = mid
+    } else {
+      high = mid
+    }
+  }
+  return (low + high) / 2
 }
 
 export const computeFills = (

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -832,6 +832,34 @@ export function addCpmmMultiLiquidityAnswersSumToOne(
   return newPools
 }
 
+// cpmm-multi-2: lossless whole-market liquidity add.
+//
+// v1 (addCpmmMultiLiquidityAnswersSumToOne, above) pins p = 0.5 and DISCARDS shares to hold each
+// answer's probability on a skewed pool, then iterates a while-loop redistributing the thrown-away
+// shares (the `sharesThrownAway` inefficiency). With per-answer p we don't have to: inject the
+// subsidy into BOTH reserves of each answer and float that answer's p to hold its probability (the
+// same lossless move the binary CPMM already makes in addCpmmLiquidity — GP6a). Because every
+// answer's probability is individually unchanged, Σ prob_i stays 1 with NO cross-answer
+// rebalancing and NO discarded shares — so there is no while-loop and no leftover to chase.
+//
+// p is the degree of freedom that MOVES to absorb the mana losslessly (probability is the invariant
+// that is preserved, not p). Returns the new pool, the floated p, and the liquidity (k) added per
+// answer for LP-provision accounting. At p = 0.5 on a balanced pool this reduces exactly to the v1
+// path (both reserves get +amount, p stays 0.5, sharesThrownAway = 0).
+export function addCpmmMultiLiquidityAnswersSumToOneV2(
+  poolsByAnswer: {
+    [answerId: string]: { pool: { YES: number; NO: number }; p: number }
+  },
+  amount: number
+) {
+  const answerIds = Object.keys(poolsByAnswer)
+  const amountPerAnswer = amount / answerIds.length
+  return mapValues(poolsByAnswer, ({ pool, p }) => {
+    const { newPool, liquidity, newP } = addCpmmLiquidity(pool, p, amountPerAnswer)
+    return { pool: newPool, p: newP, liquidity }
+  })
+}
+
 // Must be at least this many yes and no shares
 export const MINIMUM_LIQUIDITY = 100
 

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -626,7 +626,7 @@ export function calculateCpmmAmountToBuyShares(
       ? contract
       : {
           pool: { YES: answer!.poolYes, NO: answer!.poolNo },
-          p: 0.5,
+          p: answer!.p,
           collectedFees: contract.collectedFees,
         }
 

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -835,20 +835,65 @@ export function addCpmmMultiLiquidityAnswersSumToOne(
   return newPools
 }
 
-// cpmm-multi-2: lossless whole-market liquidity add.
+// cpmm-multi-2: the √variance sum-to-one CREATION pool rule (also used by new-contract.ts
+// createAnswers). Given target probabilities q (Σ q = 1) and an `ante`, build per-answer pools whose
+// effective depth W_i = (1−p_i)Y_i + p_iN_i ∝ √(q_i(1−q_i)) — the max-total-liquidity shape under
+// the no-house-risk basket budget (every winning scenario pays exactly the ante). Structure: all
+// answers share Y_i − N_i = D (all-winners-tight funding), p_i set so prob_i = q_i. Reduces to v1's
+// asymmetric pool at uniform q and to a balanced pool at n = 2. See
+// tasks/cpmm_multi_2/creation-liquidity-findings.md (GP13–GP15). It is HOMOGENEOUS degree-1 in ante
+// (reserves ∝ ante, p invariant — GP17a), which is what makes the whole-market liquidity-add merge
+// below well-defined.
+export function cpmmMulti2SumToOnePools(
+  q: number[],
+  ante: number
+): { poolYes: number; poolNo: number; p: number; prob: number }[] {
+  const n = q.length
+  if (n < 2) {
+    return q.map((qi) => ({ poolYes: ante, poolNo: ante, p: qi, prob: qi }))
+  }
+  const sqrtC = q.map((qi) => Math.sqrt(qi * (1 - qi)))
+  const meanSqrtC = sqrtC.reduce((s, x) => s + x, 0) / n
+  const D0 = (ante * (n - 2)) / (2 * (n - 1)) // uniform-optimum D (closed form)
+  const Wbar = (ante * n) / (4 * (n - 1)) // uniform-optimum depth
+  // Realize the depth profile W_i at the assumed D0:
+  //   W_i = N_i(N_i + D0)/(N_i + q_i D0)  ⇒  N_i² + N_i(D0 − W_i) − W_i q_i D0 = 0.
+  const N = q.map((qi, i) => {
+    const Wi = (Wbar * sqrtC[i]) / meanSqrtC
+    const b = D0 - Wi
+    return (-b + Math.sqrt(b * b + 4 * Wi * qi * D0)) / 2
+  })
+  // Force exact funding: Y_i = N_i + D with D = ante − ΣN_j makes every winning
+  // scenario pay exactly the ante (all-winners-tight). p_i set so prob_i = q_i.
+  const D = ante - N.reduce((s, x) => s + x, 0)
+  return q.map((qi, i) => {
+    const poolNo = N[i]
+    const poolYes = poolNo + D
+    const p = (qi * poolYes) / (qi * poolYes + (1 - qi) * poolNo)
+    return { poolYes, poolNo, p, prob: qi }
+  })
+}
+
+// cpmm-multi-2: lossless whole-market liquidity add — √variance MERGE rule (GP17).
 //
 // v1 (addCpmmMultiLiquidityAnswersSumToOne, above) pins p = 0.5 and DISCARDS shares to hold each
-// answer's probability on a skewed pool, then iterates a while-loop redistributing the thrown-away
-// shares (the `sharesThrownAway` inefficiency). With per-answer p we don't have to: inject the
-// subsidy into BOTH reserves of each answer and float that answer's p to hold its probability (the
-// same lossless move the binary CPMM already makes in addCpmmLiquidity — GP6a). Because every
-// answer's probability is individually unchanged, Σ prob_i stays 1 with NO cross-answer
-// rebalancing and NO discarded shares — so there is no while-loop and no leftover to chase.
+// answer's probability on a skewed pool. v2 is lossless: probability is the invariant we preserve,
+// p is the degree of freedom that floats to absorb the mana. The QUESTION is how to split the
+// subsidy across answers. The old implementation EQUAL-split (amount/n into each), which is
+// LMSR/balanced-shaped at the margin — inconsistent with the √variance CREATION rule above.
 //
-// p is the degree of freedom that MOVES to absorb the mana losslessly (probability is the invariant
-// that is preserved, not p). Returns the new pool, the floated p, and the liquidity (k) added per
-// answer for LP-provision accounting. At p = 0.5 on a balanced pool this reduces exactly to the v1
-// path (both reserves get +amount, p stays 0.5, sharesThrownAway = 0).
+// The creation-consistent rule (Evan: "apply creation's allocation to the *added* mana at current
+// probs; don't rearrange existing depth") is to MERGE a Δ = amount ante √variance creation computed
+// at the CURRENT probabilities into the existing reserves, then re-price each answer's p to hold its
+// probability. Properties (proofs/liquidity_add_split.py, GP17): each prob is preserved (unique
+// re-pricing, GP17b) so Σ prob = 1 is inherited; conservation holds because the Δ-creation is
+// all-winners-tight (locks exactly Δ) and resolution payout is linear in reserves, so the merge
+// superposes two conservative markets (GP17c); on an untraded market it equals create(A+Δ) and at
+// n = 2 it reduces EXACTLY to the old equal-split (GP17a/d). It concentrates the added depth in the
+// uncertain answers instead of spreading it flat. drizzleMarket inherits this (it calls this fn),
+// keeping the market on the √variance manifold rather than drifting toward balanced.
+//
+// Returns the new pool, the floated p, and the liquidity (k) added per answer for LP accounting.
 export function addCpmmMultiLiquidityAnswersSumToOneV2(
   poolsByAnswer: {
     [answerId: string]: { pool: { YES: number; NO: number }; p: number }
@@ -856,11 +901,34 @@ export function addCpmmMultiLiquidityAnswersSumToOneV2(
   amount: number
 ) {
   const answerIds = Object.keys(poolsByAnswer)
-  const amountPerAnswer = amount / answerIds.length
-  return mapValues(poolsByAnswer, ({ pool, p }) => {
-    const { newPool, liquidity, newP } = addCpmmLiquidity(pool, p, amountPerAnswer)
-    return { pool: newPool, p: newP, liquidity }
+  // Current probabilities (Σ = 1 for a sum-to-one market).
+  const probs = answerIds.map((id) =>
+    getCpmmProbability(poolsByAnswer[id].pool, poolsByAnswer[id].p)
+  )
+  // Allocate the ADDED mana exactly as creation would, at the current probs (√variance shape).
+  const delta = cpmmMulti2SumToOnePools(probs, amount)
+  const result: {
+    [answerId: string]: {
+      pool: { YES: number; NO: number }
+      p: number
+      liquidity: number
+    }
+  } = {}
+  answerIds.forEach((id, i) => {
+    const { pool } = poolsByAnswer[id]
+    const prob = probs[i]
+    const newPool = {
+      YES: pool.YES + delta[i].poolYes,
+      NO: pool.NO + delta[i].poolNo,
+    }
+    // Re-price p so prob(newPool, newP) == prob (unique; same form as creation's p).
+    const newP =
+      (prob * newPool.YES) / (prob * newPool.YES + (1 - prob) * newPool.NO)
+    const liquidity =
+      getCpmmLiquidity(newPool, newP) - getCpmmLiquidity(pool, newP)
+    result[id] = { pool: newPool, p: newP, liquidity }
   })
+  return result
 }
 
 // cpmm-multi-2: lossless whole-market liquidity add for INDEPENDENT (non-sum-to-one / "Set")

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -860,6 +860,36 @@ export function addCpmmMultiLiquidityAnswersSumToOneV2(
   })
 }
 
+// cpmm-multi-2: lossless whole-market liquidity add for INDEPENDENT (non-sum-to-one / "Set")
+// markets.
+//
+// An independent answer is literally its own standalone binary CPMM, so each answer takes the
+// exact binary lossless add (addCpmmLiquidity — inject the subsidy into BOTH reserves and float
+// that answer's p to hold its probability, discarding no shares). There is no Σ prob = 1 coupling
+// between answers — each is independent — so unlike the v1 fixed-p path
+// (addCpmmMultiLiquidityToAnswersIndependently → addCpmmLiquidityFixedP, which DISCARDS shares to
+// pin p = 0.5 on a skewed pool and clobbers prob to N/(Y+N)) nothing is thrown away and each
+// answer's true probability is preserved.
+//
+// Mathematically this is the same per-answer operation as addCpmmMultiLiquidityAnswersSumToOneV2
+// (sum-to-one preserves Σ = 1 only as a *consequence* of each prob being individually preserved —
+// GP6a); the two are kept as separate named functions to mirror the v1 sum-to-one / independent
+// split and keep the drizzle call sites self-documenting. At p = 0.5 on a balanced pool both
+// reserves get +amountPerAnswer, p stays 0.5, and prob is unchanged — i.e. it reduces to the v1
+// fixed-p add with sharesThrownAway = 0.
+export function addCpmmMultiLiquidityToAnswersIndependentlyV2(
+  poolsByAnswer: {
+    [answerId: string]: { pool: { YES: number; NO: number }; p: number }
+  },
+  amount: number
+) {
+  const amountPerAnswer = amount / Object.keys(poolsByAnswer).length
+  return mapValues(poolsByAnswer, ({ pool, p }) => {
+    const { newPool, liquidity, newP } = addCpmmLiquidity(pool, p, amountPerAnswer)
+    return { pool: newPool, p: newP, liquidity }
+  })
+}
+
 // Must be at least this many yes and no shares
 export const MINIMUM_LIQUIDITY = 100
 

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -634,7 +634,10 @@ export function calculateCpmmAmountToBuyShares(
     ? allUnfilledBets.filter((b) => b.answerId === answer.id)
     : allUnfilledBets
 
-  if (contract.mechanism === 'cpmm-1') {
+  // cpmm-multi-2 answers carry a general (non-0.5) p, so they take the same
+  // general-p inverse as cpmm-1 (the startCpmmState above already supplies
+  // answer.p). cpmm-multi-1 stays on the p=0.5 FixedP path (byte-identical).
+  if (contract.mechanism === 'cpmm-1' || contract.mechanism === 'cpmm-multi-2') {
     return calculateAmountToBuyShares(
       startCpmmState,
       shares,
@@ -651,7 +654,7 @@ export function calculateCpmmAmountToBuyShares(
       balanceByUserId
     )
   } else {
-    throw new Error('Only works for cpmm-1 and cpmm-multi-1')
+    throw new Error('Only works for cpmm-1, cpmm-multi-1, and cpmm-multi-2')
   }
 }
 

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -874,6 +874,29 @@ export function cpmmMulti2SumToOnePools(
   })
 }
 
+// GP19a creation-feasibility guard. The √variance construction above is NOT total: for
+// skewed many-answer prob vectors (first possible at n = 21; e.g. n = 30 with a 0.90
+// dominant answer) the funding term D goes negative enough that some poolYes < 0 and
+// p ∉ (0,1). Exact characterization (GP19a, proofs/sanity_closure.py): sane ⟺
+// Σⱼ Nⱼ(q,1) − minᵢ Nᵢ(q,1) < 1. The construction is homogeneous degree-1 in ante, so
+// feasibility depends only on q — we test by constructing at ante = 1 and checking
+// sanity directly (no duplicated algebra to drift). The small margin keeps p (and via
+// re-pricing, reserves) representably far from {0,1} — float64 underflows exact-boundary
+// states (GP19b caveat).
+const CPMM_MULTI_2_SANITY_EPS = 1e-9
+const isSanePool = (x: { poolYes: number; poolNo: number; p: number }) =>
+  x.poolYes > 0 &&
+  x.poolNo > 0 &&
+  x.p > CPMM_MULTI_2_SANITY_EPS &&
+  x.p < 1 - CPMM_MULTI_2_SANITY_EPS
+
+export function cpmmMulti2SumToOneFeasible(q: number[]) {
+  return cpmmMulti2SumToOnePools(q, 1).every(isSanePool)
+}
+
+const isSanePoolYesNo = (pool: { YES: number; NO: number }, p: number) =>
+  isSanePool({ poolYes: pool.YES, poolNo: pool.NO, p })
+
 // cpmm-multi-2: lossless whole-market liquidity add — √variance MERGE rule (GP17).
 //
 // v1 (addCpmmMultiLiquidityAnswersSumToOne, above) pins p = 0.5 and DISCARDS shares to hold each
@@ -928,6 +951,29 @@ export function addCpmmMultiLiquidityAnswersSumToOneV2(
       getCpmmLiquidity(newPool, newP) - getCpmmLiquidity(pool, newP)
     result[id] = { pool: newPool, p: newP, liquidity }
   })
+
+  // GP19c guard: a sane TRADED market can sit at creation-infeasible probs, where the
+  // √variance delta has dY_i < 0 on some answers and a large enough add drives a merged
+  // poolYes < 0 (p ∉ (0,1)) — the critical total is A*(state) = min_{i: dY_i<0}
+  // Y_i/|dY_i(q,1)|, and drizzle accumulates to the same bound (homogeneity — dripping
+  // does not evade it). Rather than cap or reject (drizzle must never brick), fall back
+  // to the unconditionally-sane allocation: split the amount equally as per-answer
+  // lossless adds (GP19e: floated p is the GP6a weight — sane and prob-preserving for
+  // ANY positive reserves; this is exactly the shipped per-answer addLiquidity op, so
+  // conservation is inherited). The √variance shape is an optimization, not an
+  // invariant; on the GP19a-feasible set the merge is unconditionally sane (A* = ∞) and
+  // this fallback never engages.
+  const merged = answerIds.map((id) => result[id])
+  if (!merged.every((x) => isSanePoolYesNo(x.pool, x.p))) {
+    const equalAmount = amount / answerIds.length
+    answerIds.forEach((id) => {
+      const { pool, p } = poolsByAnswer[id]
+      const { newPool, newP } = addCpmmLiquidity(pool, p, equalAmount)
+      const liquidity =
+        getCpmmLiquidity(newPool, newP) - getCpmmLiquidity(pool, newP)
+      result[id] = { pool: newPool, p: newP, liquidity }
+    })
+  }
   return result
 }
 

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -752,7 +752,16 @@ export function addCpmmLiquidity(
   const { YES: y, NO: n } = pool
   const numerator = prob * (amount + y)
   const denominator = amount - n * (prob - 1) + prob * y
-  const newP = numerator / denominator
+  let newP = numerator / denominator
+  // 0/0 rescue: at general p an extreme buy can underflow a pool side to EXACTLY 0
+  // (residual k^{1/(1-p)}/(pool+b)^{p/(1-p)} below one ulp — possible at p far from
+  // 0.5, never at v1's p = 0.5), making prob and hence both terms 0 when this is
+  // called with amount = 0 (calculateCpmmPurchase's post-bet re-price). A zero add
+  // leaves p unchanged. Guarded on non-finiteness so every well-conditioned call —
+  // in particular every v1 call — keeps the formula bit-for-bit.
+  if (amount === 0 && !isFinite(newP)) {
+    newP = p
+  }
 
   const newPool = { YES: y + amount, NO: n + amount }
 

--- a/common/src/calculate-metrics.ts
+++ b/common/src/calculate-metrics.ts
@@ -167,7 +167,7 @@ const computeMultiCpmmElasticity = (
   const elasticities = contract.answers.map((a) => {
     const cpmmState = {
       pool: { YES: a.poolYes, NO: a.poolNo },
-      p: 0.5,
+      p: a.p,
       collectedFees: noFees,
     }
     const unfilledBetsForAnswer = unfilledBets.filter(

--- a/common/src/calculate-metrics.ts
+++ b/common/src/calculate-metrics.ts
@@ -16,7 +16,7 @@ import {
   getContractBetMetricsPerAnswerWithoutLoans,
 } from './calculate'
 import { computeFills, CpmmState, getCpmmProbability } from './calculate-cpmm'
-import { Contract, MultiContract } from './contract'
+import { Contract, isMultiCpmm, MultiContract } from './contract'
 import { noFees } from './fees'
 import { floatingEqual, logit } from './util/math'
 import { removeUndefinedProps } from './util/object'
@@ -71,6 +71,7 @@ export const computeElasticity = (
         contract,
         betAmount
       )
+    case 'cpmm-multi-2':
     case 'cpmm-multi-1':
       return computeMultiCpmmElasticity(
         isResolved ? [] : unfilledBets, // only consider limit orders for open markets
@@ -560,7 +561,7 @@ export const calculateUpdatedMetricsForContracts = (
           return metric
             ? [calculateProfitMetricsAtProbOrCancel(state, metric)]
             : []
-        } else if (contract.mechanism === 'cpmm-multi-1') {
+        } else if (isMultiCpmm(contract)) {
           const oldSummary = useIncludedSummaryMetric
             ? userMetrics.find(isSummary)
             : undefined
@@ -618,7 +619,7 @@ export const calculateMetricsFromProbabilityChanges = (
     if (!contract) return metric
 
     let newProb: number
-    if (contract.mechanism === 'cpmm-multi-1' && metric.answerId) {
+    if (isMultiCpmm(contract) && metric.answerId) {
       const answer = contract.answers.find((a) => a.id === metric.answerId)
       if (!answer) return metric
       newProb = answer.prob
@@ -634,7 +635,7 @@ export const calculateMetricsFromProbabilityChanges = (
     // Calculate period profit changes (from calculatePeriodProfit logic)
     const calculatePeriodChange = (period: 'day' | 'week' | 'month') => {
       let probChange: number
-      if (contract.mechanism === 'cpmm-multi-1' && metric.answerId) {
+      if (isMultiCpmm(contract) && metric.answerId) {
         const answer = contract.answers.find((a) => a.id === metric.answerId)
         probChange = answer?.probChanges[period] ?? 0
       } else if (contract.mechanism === 'cpmm-1') {

--- a/common/src/calculate.ts
+++ b/common/src/calculate.ts
@@ -88,7 +88,7 @@ export function getAnswerProbability(
     if (resolution === 'NO') return 0
   }
   const pool = { YES: poolYes, NO: poolNo }
-  return getCpmmProbability(pool, 0.5)
+  return getCpmmProbability(pool, answer.p)
 }
 
 export function getInitialAnswerProbability(
@@ -389,10 +389,7 @@ export const getContractBetMetricsPerAnswerWithoutLoans = (
       const answerId = bets[0].answerId
       const baseMetrics = getContractBetMetrics(contract, bets, answerId)
       let periodMetrics
-      if (
-        contract.mechanism === 'cpmm-1' ||
-        isMultiCpmm(contract)
-      ) {
+      if (contract.mechanism === 'cpmm-1' || isMultiCpmm(contract)) {
         const answer = answers?.find((a) => a.id === answerId)
         const passedAnswer = !!answer
         if (isMultiCpmm(contract) && !passedAnswer) {

--- a/common/src/calculate.ts
+++ b/common/src/calculate.ts
@@ -100,6 +100,18 @@ export function getInitialAnswerProbability(
     return 0.5
   } else {
     if (contract.addAnswersMode === 'DISABLED') {
+      // cpmm-multi-2: creation probs can be custom (not uniform) and are not
+      // stored. Best available baseline is the pool-implied prob — exact for an
+      // untraded answer (pool untouched since creation); for a traded answer it
+      // only anchors the short pre-first-trade chart segment. (A converted v1
+      // market that traded before converting gets its current rather than 1/n
+      // here — same cosmetic class.) v1 keeps the exact uniform baseline.
+      if (contract.mechanism === 'cpmm-multi-2') {
+        return getCpmmProbability(
+          { YES: answer.poolYes, NO: answer.poolNo },
+          answerP(answer)
+        )
+      }
       return 1 / contract.answers.length
     } else {
       const answers = contract.answers

--- a/common/src/calculate.ts
+++ b/common/src/calculate.ts
@@ -16,7 +16,7 @@ import {
   sum,
   sumBy,
 } from 'lodash'
-import { Answer } from './answer'
+import { Answer, answerP } from './answer'
 import { Bet } from './bet'
 import {
   calculateCpmmPurchase,
@@ -88,7 +88,8 @@ export function getAnswerProbability(
     if (resolution === 'NO') return 0
   }
   const pool = { YES: poolYes, NO: poolNo }
-  return getCpmmProbability(pool, answer.p)
+  // answerP, not answer.p: this is called on blob-sourced answers (SSR/embeds/lite).
+  return getCpmmProbability(pool, answerP(answer))
 }
 
 export function getInitialAnswerProbability(

--- a/common/src/calculate.ts
+++ b/common/src/calculate.ts
@@ -31,6 +31,7 @@ import {
   BinaryContract,
   Contract,
   CPMMContract,
+  isMultiCpmm,
   MarketContract,
   MultiContract,
   PseudoNumericContract,
@@ -65,6 +66,7 @@ export function getOutcomeProbability(contract: Contract, outcome: string) {
       return outcome === 'YES'
         ? getCpmmProbability(contract.pool, contract.p)
         : 1 - getCpmmProbability(contract.pool, contract.p)
+    case 'cpmm-multi-2':
     case 'cpmm-multi-1':
       return 0
     default:
@@ -122,6 +124,7 @@ export function getOutcomeProbabilityAfterBet(
   switch (mechanism) {
     case 'cpmm-1':
       return getCpmmOutcomeProbabilityAfterBet(contract, outcome, bet)
+    case 'cpmm-multi-2':
     case 'cpmm-multi-1':
       return 0
     default:
@@ -147,7 +150,7 @@ export function calculatePayout(contract: Contract, bet: Bet, outcome: string) {
   const { mechanism } = contract
   return mechanism === 'cpmm-1'
     ? calculateFixedPayout(contract, bet, outcome)
-    : mechanism === 'cpmm-multi-1'
+    : isMultiCpmm(contract)
     ? calculateFixedPayoutMulti(contract, bet, outcome)
     : bet?.amount ?? 0
 }
@@ -158,7 +161,7 @@ export function resolvedPayout(contract: Contract, bet: Bet) {
 
   return mechanism === 'cpmm-1'
     ? calculateFixedPayout(contract, bet, resolution)
-    : mechanism === 'cpmm-multi-1'
+    : isMultiCpmm(contract)
     ? calculateFixedPayoutMulti(contract, bet, resolution)
     : bet?.amount ?? 0
 }
@@ -210,7 +213,7 @@ export function getSimpleCpmmInvested(yourBets: Bet[]) {
 export function getInvested(contract: Contract, yourBets: Bet[]) {
   const { mechanism } = contract
   if (mechanism === 'cpmm-1') return getCpmmInvested(yourBets)
-  if (mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     const betsByAnswerId = groupBy(yourBets, 'answerId')
     const investedByAnswerId = mapValues(betsByAnswerId, getCpmmInvested)
     return sum(Object.values(investedByAnswerId))
@@ -260,8 +263,7 @@ function getCpmmOrDpmProfit(
 }
 
 export function getProfitMetrics(contract: Contract, yourBets: Bet[]) {
-  const { mechanism } = contract
-  if (mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     const betsByAnswerId = groupBy(yourBets, 'answerId')
     const profitMetricsPerAnswer = Object.entries(betsByAnswerId).map(
       ([answerId, bets]) => {
@@ -336,8 +338,7 @@ export const getContractBetMetrics = (
   yourBets: Bet[],
   answerId?: string
 ): Omit<ContractMetric, 'id' | 'from' | 'userId' | 'loan' | 'marginLoan'> => {
-  const { mechanism } = contract
-  const isCpmmMulti = mechanism === 'cpmm-multi-1'
+  const isCpmmMulti = isMultiCpmm(contract)
   const {
     profit,
     profitPercent,
@@ -390,11 +391,11 @@ export const getContractBetMetricsPerAnswerWithoutLoans = (
       let periodMetrics
       if (
         contract.mechanism === 'cpmm-1' ||
-        contract.mechanism === 'cpmm-multi-1'
+        isMultiCpmm(contract)
       ) {
         const answer = answers?.find((a) => a.id === answerId)
         const passedAnswer = !!answer
-        if (contract.mechanism === 'cpmm-multi-1' && !passedAnswer) {
+        if (isMultiCpmm(contract) && !passedAnswer) {
           console.log(
             `answer with id ${bets[0].answerId} not found, but is required for cpmm-multi-1 contract: ${contract.id}`
           )
@@ -415,7 +416,7 @@ export const getContractBetMetricsPerAnswerWithoutLoans = (
   )
 
   // Calculate overall contract metrics with answerId:null bc it's nice to have
-  if (contract.mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     const baseFrom = metricsPerAnswer[0].from
     const calculateProfitPercent = (
       metrics: ContractMetric[],

--- a/common/src/calculate.ts
+++ b/common/src/calculate.ts
@@ -407,7 +407,7 @@ export const getContractBetMetricsPerAnswerWithoutLoans = (
         const passedAnswer = !!answer
         if (isMultiCpmm(contract) && !passedAnswer) {
           console.log(
-            `answer with id ${bets[0].answerId} not found, but is required for cpmm-multi-1 contract: ${contract.id}`
+            `answer with id ${bets[0].answerId} not found, but is required for multi-choice cpmm contract: ${contract.id}`
           )
         } else {
           periodMetrics = Object.fromEntries(

--- a/common/src/conservation-grid.test.ts
+++ b/common/src/conservation-grid.test.ts
@@ -20,7 +20,9 @@ import { Answer } from './answer'
 import {
   addCpmmMultiLiquidityAnswersSumToOneV2,
   addCpmmMultiLiquidityToAnswersIndependentlyV2,
+  calculateCpmmMultiSumsToOneSale,
   calculateCpmmPurchase,
+  calculateCpmmSale,
   getCpmmProbability,
 } from './calculate-cpmm'
 import {
@@ -203,6 +205,81 @@ class Sim {
     this.check(`multibet {${basketIdx}} M$${amount} by ${user}`)
   }
 
+  // Sell `shares` of `outcome` that `user` holds on answer `answerIndex`.
+  // Drives the REAL vendor sale calc (calculateCpmmSale for Set, the sum-to-one arb sale
+  // otherwise). Conservation model, verified against vendor (calculate-cpmm-arbitrage.ts
+  // calculateCpmmMultiArbitrageSellYes/No):
+  //   - the seller's position in the sold answer drops by `shares`;
+  //   - the seller's balance rises by `saleValue`;
+  //   - every answer's pool moves to the calc's final state.
+  // The cross-answer arb legs (otherBetResults) each get a redemption fill that EXACTLY
+  // cancels their arb buy (net amount 0, net shares 0), so they move pools only — the seller
+  // gains no other-answer position, and the cost of moving those pools is already folded into
+  // `saleValue` via the sold answer's arb taker. (Self-checked: dropping any of the three
+  // updates, or the otherBetResults pool moves, breaks the conservation oracle below.)
+  sell(user: string, answerIndex: number, outcome: 'YES' | 'NO', shares: number) {
+    const answerToSell = this.answers[answerIndex]
+    if (this.type === 'set_indep') {
+      const { cpmmState, saleValue, fees } = calculateCpmmSale(
+        {
+          pool: { YES: answerToSell.poolYes, NO: answerToSell.poolNo },
+          p: answerToSell.p,
+          collectedFees: noFees,
+        },
+        shares,
+        outcome,
+        [],
+        {}
+      )
+      this.answers = this.answers.map((x, i) =>
+        i === answerIndex
+          ? { ...x, poolYes: cpmmState.pool.YES, poolNo: cpmmState.pool.NO, p: cpmmState.p,
+              prob: getCpmmProbability(cpmmState.pool, cpmmState.p) }
+          : x
+      )
+      const p = this.posOf(user, answerToSell.id)
+      p[outcome] -= shares
+      p.sold += saleValue
+      this.credit(user, saleValue)
+      this.fees += getFeeTotal(fees)
+      this.check(`set sell ${outcome} ${shares}sh a${answerIndex} by ${user}`)
+      return
+    }
+    const { saleValue, newBetResult, otherBetResults } = calculateCpmmMultiSumsToOneSale(
+      this.answers,
+      answerToSell,
+      shares,
+      outcome,
+      undefined,
+      [],
+      {},
+      noFees
+    )
+    // sold answer pool by known id (newBetResult carries no `answer`); arb legs by their id.
+    const poolById = new Map<string, { [o: string]: number }>()
+    poolById.set(answerToSell.id, newBetResult.cpmmState.pool)
+    for (const o of otherBetResults) poolById.set(o.answer.id, o.cpmmState.pool)
+    this.answers = this.answers.map((a) => {
+      const pl = poolById.get(a.id)
+      return pl
+        ? { ...a, poolYes: pl.YES, poolNo: pl.NO, prob: getCpmmProbability(pl as any, a.p) }
+        : a
+    })
+    const pos = this.posOf(user, answerToSell.id)
+    pos[outcome] -= shares
+    pos.sold += saleValue
+    this.credit(user, saleValue)
+    this.fees +=
+      getFeeTotal(newBetResult.totalFees) +
+      sumBy(otherBetResults, (r) => getFeeTotal(r.totalFees))
+    this.check(`sell ${outcome} ${shares}sh a${answerIndex} by ${user}`)
+  }
+
+  // current YES/NO shares a user holds on an answer (for "sell what you bought").
+  sharesOf(user: string, answerIndex: number, outcome: 'YES' | 'NO') {
+    return this.posOf(user, this.answers[answerIndex].id)[outcome]
+  }
+
   addLiquidity(user: string, amount: number) {
     // model whole-market add as the lossless v2 deepen (what drizzle realizes), so the added
     // mana sits in pools and is read by getMultiLiquidityPoolPayouts at resolution.
@@ -363,6 +440,74 @@ describe('cpmm-multi-2 conservation grid (calc-layer rows)', () => {
     s.buy('bob', 1, 'NO', 40)
     s.addLiquidity('carol', 100)
     s.resolve('cancel')
+  })
+
+  // --- sell rows (covering array: trade=sell — rows 4,10,11,16,21; limits/single-outcome
+  //     liquidity aspects deferred to their own increments) -----------------------------------
+  it('sum-to-one: buy then sell-all round-trips pools to creation (+ conservation on resolve)', () => {
+    for (const probs of ['balanced', 'skewed', 'extreme'] as const)
+      for (const n of [2, 3, 5]) {
+        const s = new Sim({ n, probs, type: 'mc_sumone' })
+        const before = s.answers.map((a) => ({ y: a.poolYes, no: a.poolNo }))
+        s.buy('alice', 0, 'YES', 60)
+        const held = s.sharesOf('alice', 0, 'YES')
+        s.sell('alice', 0, 'YES', held) // sell everything back
+        // round-trip: pools return to creation (the AMM is path-reversible for a lone trader)
+        s.answers.forEach((a, i) => {
+          expect(a.poolYes).toBeCloseTo(before[i].y, 4)
+          expect(a.poolNo).toBeCloseTo(before[i].no, 4)
+        })
+        s.resolve('one', { winner: 0 })
+      }
+  })
+
+  it('sum-to-one: buy then PARTIAL sell -> resolve (traded / untouched / multiple)', () => {
+    for (const probs of ['balanced', 'skewed', 'extreme'] as const)
+      for (const n of [2, 3, 5]) {
+        const a = new Sim({ n, probs, type: 'mc_sumone' })
+        a.buy('alice', 0, 'YES', 80)
+        a.sell('alice', 0, 'YES', a.sharesOf('alice', 0, 'YES') / 2)
+        a.resolve('one', { winner: 0 }) // resolve to the (still partly-held) traded answer
+
+        const b = new Sim({ n, probs, type: 'mc_sumone' })
+        b.buy('alice', 0, 'YES', 80)
+        b.sell('alice', 0, 'YES', b.sharesOf('alice', 0, 'YES') / 2)
+        b.resolve('one', { winner: n - 1 }) // resolve to an untouched answer
+
+        const c = new Sim({ n, probs, type: 'mc_sumone' })
+        c.buy('alice', 1 % n, 'YES', 70)
+        c.sell('alice', 1 % n, 'YES', c.sharesOf('alice', 1 % n, 'YES') * 0.4)
+        c.resolve('multiple', { split: [0.6, 0.4] })
+      }
+  })
+
+  it('sum-to-one: multi-user sell + add-liquidity -> CHOOSE_ONE conservation (row 16 shape)', () => {
+    const s = new Sim({ n: 5, probs: 'balanced', type: 'mc_sumone' })
+    s.buy('alice', 0, 'YES', 60)
+    s.buy('bob', 2, 'NO', 40)
+    s.sell('alice', 0, 'YES', s.sharesOf('alice', 0, 'YES') * 0.5)
+    s.addLiquidity('carol', 200)
+    s.resolve('one', { winner: 0 })
+  })
+
+  it('Set (independent): buy then sell (full + partial) -> per-answer resolution', () => {
+    for (const probs of ['skewed', 'extreme'] as const)
+      for (const n of [2, 3]) {
+        const s = new Sim({ n, probs, type: 'set_indep' })
+        const before = s.answers.map((a) => ({ y: a.poolYes, no: a.poolNo }))
+        s.buy('alice', 0, 'YES', 40)
+        s.sell('alice', 0, 'YES', s.sharesOf('alice', 0, 'YES')) // round-trip answer 0
+        expect(s.answers[0].poolYes).toBeCloseTo(before[0].y, 4)
+        expect(s.answers[0].poolNo).toBeCloseTo(before[0].no, 4)
+        if (n > 2) {
+          s.buy('bob', 1, 'NO', 25)
+          s.sell('bob', 1, 'NO', s.sharesOf('bob', 1, 'NO') * 0.5) // partial
+        }
+        const outs = Array.from({ length: n }, (_, i) =>
+          i % 2 === 0 ? 'YES' : 'NO'
+        ) as ('YES' | 'NO')[]
+        s.resolve('set_yesno', { setOutcomes: outs })
+      }
   })
 
   it('Set (independent): create -> buys -> add-liquidity -> per-answer resolution', () => {

--- a/common/src/conservation-grid.test.ts
+++ b/common/src/conservation-grid.test.ts
@@ -19,6 +19,7 @@ import { sumBy } from 'lodash'
 import { Answer } from './answer'
 import { LimitBet } from './bet'
 import {
+  addCpmmLiquidity,
   addCpmmMultiLiquidityAnswersSumToOneV2,
   addCpmmMultiLiquidityToAnswersIndependentlyV2,
   calculateCpmmMultiSumsToOneSale,
@@ -360,9 +361,33 @@ class Sim {
     return this.posOf(user, this.answers[answerIndex].id)[outcome]
   }
 
-  addLiquidity(user: string, amount: number) {
-    // model whole-market add as the lossless v2 deepen (what drizzle realizes), so the added
-    // mana sits in pools and is read by getMultiLiquidityPoolPayouts at resolution.
+  // Add liquidity. With `answerIndex` set, subsidize a SINGLE answer (its own binary CPMM) via
+  // the same lossless float-p deepen the per-answer drizzle (drizzleAnswer) realizes — this is
+  // the `liq_target=single_outcome` covering-array case. Without it, whole-market (every answer).
+  // Both model the add as the deepen the drizzle eventually applies, so the mana sits in pools and
+  // is read by getMultiLiquidityPoolPayouts at resolution.
+  addLiquidity(user: string, amount: number, answerIndex?: number) {
+    if (answerIndex !== undefined) {
+      const a = this.answers[answerIndex]
+      const { newPool, newP } = addCpmmLiquidity({ YES: a.poolYes, NO: a.poolNo }, a.p, amount)
+      this.answers = this.answers.map((x, i) =>
+        i === answerIndex
+          ? { ...x, poolYes: newPool.YES, poolNo: newPool.NO, p: newP,
+              prob: getCpmmProbability(newPool, newP) }
+          : x
+      )
+      this.spend(user, amount)
+      this.liquidities.push({
+        id: `lp${this.lpId++}`,
+        userId: user,
+        contractId: 'c',
+        createdTime: this.lpId,
+        amount,
+        answerId: a.id,
+      })
+      this.check(`per-answer addLiquidity a${answerIndex} M$${amount} by ${user}`)
+      return
+    }
     const map = Object.fromEntries(
       this.answers.map((a) => [a.id, { pool: { YES: a.poolYes, NO: a.poolNo }, p: a.p }])
     )
@@ -602,6 +627,48 @@ describe('cpmm-multi-2 conservation grid (calc-layer rows)', () => {
         ) as ('YES' | 'NO')[]
         s.resolve('set_yesno', { setOutcomes: outs })
       }
+  })
+
+  // --- per-answer add-liquidity (covering array: liq_target=single_outcome) -------------------
+  it('sum-to-one: per-answer add-liquidity -> trade -> resolve (traded / subsidized answer)', () => {
+    for (const probs of ['balanced', 'skewed', 'extreme'] as const)
+      for (const n of [2, 3, 5]) {
+        const s = new Sim({ n, probs, type: 'mc_sumone' })
+        s.buy('alice', 0, 'YES', 50)
+        s.addLiquidity('bob', 150, 1 % n) // subsidize a SINGLE answer
+        s.buy('alice', 1 % n, 'NO', 30)
+        s.resolve('one', { winner: 0 })
+
+        const s2 = new Sim({ n, probs, type: 'mc_sumone' })
+        s2.addLiquidity('carol', 120, n - 1) // subsidize the last answer...
+        s2.resolve('one', { winner: n - 1 }) // ...and resolve to it
+      }
+  })
+
+  it('sum-to-one: per-answer add on multiple answers + MULTIPLE / CANCEL resolve', () => {
+    const s = new Sim({ n: 5, probs: 'skewed', type: 'mc_sumone' })
+    s.addLiquidity('bob', 100, 0)
+    s.addLiquidity('carol', 80, 2)
+    s.multibet('alice', [0, 1], 120)
+    s.resolve('multiple', { split: [0.6, 0.4] })
+
+    const s2 = new Sim({ n: 3, probs: 'skewed', type: 'mc_sumone' })
+    s2.addLiquidity('bob', 90, 1)
+    s2.buy('alice', 0, 'YES', 40)
+    s2.resolve('cancel')
+  })
+
+  it('Set (independent): per-answer add-liquidity -> per-answer resolution', () => {
+    for (const n of [2, 3]) {
+      const s = new Sim({ n, probs: 'extreme', type: 'set_indep' })
+      s.buy('alice', 0, 'YES', 40)
+      s.addLiquidity('bob', 100, 0)
+      if (n > 2) s.addLiquidity('carol', 60, 2)
+      const outs = Array.from({ length: n }, (_, i) =>
+        i % 2 === 0 ? 'YES' : 'NO'
+      ) as ('YES' | 'NO')[]
+      s.resolve('set_yesno', { setOutcomes: outs })
+    }
   })
 })
 

--- a/common/src/conservation-grid.test.ts
+++ b/common/src/conservation-grid.test.ts
@@ -449,7 +449,8 @@ class Sim {
     expect(netSum + this.fees).toBeCloseTo(0, 4)
   }
 
-  private check(step: string) {
+  // The param is a call-site label only (readable invariant-check tags); keep it named.
+  private check(_step: string) {
     for (const a of this.answers) {
       const pr = getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
       expect(pr).toBeGreaterThan(0)

--- a/common/src/conservation-grid.test.ts
+++ b/common/src/conservation-grid.test.ts
@@ -11,10 +11,11 @@
 // basket leak (calc-layer); it would have caught it (self-verified below).
 //
 // Scenario shapes are drawn from the pairwise covering array
-// (tasks/cpmm_multi_2/covering-array.txt). This file covers the rows whose ops are calc-layer
-// (create, single/multibet buy, whole-market add-liquidity, resolve). DEFERRED to the next
-// increment / the instance harness: trade=sell, limits!=none, liq_target=single_outcome
-// (per-answer addLiquidity not yet built for v2).
+// (tasks/cpmm_multi_2/covering-array.txt). Coverage now spans the calc layer end to end:
+// create (sum-to-one + independent Set), single/multibet buy, resting limit makers, sells
+// (partial / sell-all round-trip), whole-market AND per-answer add-liquidity, resolve.
+// Remaining gaps live in the instance harness (validate_lifecycle.py), not here: real
+// API/DB plumbing, drizzle scheduling, and the v1->v2 conversion lifecycle.
 import { sumBy } from 'lodash'
 import { Answer } from './answer'
 import { LimitBet } from './bet'
@@ -25,6 +26,7 @@ import {
   calculateCpmmMultiSumsToOneSale,
   calculateCpmmPurchase,
   calculateCpmmSale,
+  cpmmMulti2SumToOnePools,
   getCpmmProbability,
 } from './calculate-cpmm'
 import {
@@ -40,27 +42,9 @@ import {
 import { ContractMetric } from './contract-metric'
 import { LiquidityProvision } from './liquidity-provision'
 
-// --- creation pools (replicated from new-contract.ts so the test is self-contained) --------
-function sumToOnePools(q: number[], ante: number) {
-  const n = q.length
-  if (n < 2) return q.map((qi) => ({ poolYes: ante, poolNo: ante, p: qi }))
-  const sqrtC = q.map((qi) => Math.sqrt(qi * (1 - qi)))
-  const meanSqrtC = sqrtC.reduce((s, x) => s + x, 0) / n
-  const D0 = (ante * (n - 2)) / (2 * (n - 1))
-  const Wbar = (ante * n) / (4 * (n - 1))
-  const N = q.map((qi, i) => {
-    const Wi = (Wbar * sqrtC[i]) / meanSqrtC
-    const b = D0 - Wi
-    return (-b + Math.sqrt(b * b + 4 * Wi * qi * D0)) / 2
-  })
-  const D = ante - N.reduce((s, x) => s + x, 0)
-  return q.map((qi, i) => {
-    const poolNo = N[i]
-    const poolYes = poolNo + D
-    const p = (qi * poolYes) / (qi * poolYes + (1 - qi) * poolNo)
-    return { poolYes, poolNo, p }
-  })
-}
+// --- creation pools: the REAL production construction (was a local replica; a drifted
+// copy would validate the copy, not the shipping code) ------------------------------
+const sumToOnePools = cpmmMulti2SumToOnePools
 
 function setPools(q: number[], ante: number) {
   const L = ante / q.length

--- a/common/src/conservation-grid.test.ts
+++ b/common/src/conservation-grid.test.ts
@@ -1,0 +1,381 @@
+// cpmm-multi-2 conservation grid (Level-1, jest).
+//
+// Drives the REAL vendor calc + payout functions through create -> trades -> add-liquidity
+// -> resolve scenarios and asserts the master conservation law:
+//
+//     Sum over all users (final balance - initial balance) + fees collected == 0
+//
+// (the market neither creates nor destroys mana; fees are the only sink — currently 0).
+// Plus per-step invariants: Sum p == 1 (sum-to-one), prob in (0,1), and the GP16 conservation
+// locus T_i^YES - T_i^NO constant across answers. This is the bug class that hid the m>1
+// basket leak (calc-layer); it would have caught it (self-verified below).
+//
+// Scenario shapes are drawn from the pairwise covering array
+// (tasks/cpmm_multi_2/covering-array.txt). This file covers the rows whose ops are calc-layer
+// (create, single/multibet buy, whole-market add-liquidity, resolve). DEFERRED to the next
+// increment / the instance harness: trade=sell, limits!=none, liq_target=single_outcome
+// (per-answer addLiquidity not yet built for v2).
+import { sumBy } from 'lodash'
+import { Answer } from './answer'
+import {
+  addCpmmMultiLiquidityAnswersSumToOneV2,
+  addCpmmMultiLiquidityToAnswersIndependentlyV2,
+  calculateCpmmPurchase,
+  getCpmmProbability,
+} from './calculate-cpmm'
+import {
+  calculateCpmmMultiArbitrageBet,
+  calculateCpmmMultiArbitrageYesBets,
+} from './calculate-cpmm-arbitrage'
+import { noFees, getFeeTotal } from './fees'
+import {
+  getFixedCancelPayouts,
+  getIndependentMultiYesNoPayouts,
+  getMultiFixedPayouts,
+} from './payouts-fixed'
+import { ContractMetric } from './contract-metric'
+import { LiquidityProvision } from './liquidity-provision'
+
+// --- creation pools (replicated from new-contract.ts so the test is self-contained) --------
+function sumToOnePools(q: number[], ante: number) {
+  const n = q.length
+  if (n < 2) return q.map((qi) => ({ poolYes: ante, poolNo: ante, p: qi }))
+  const sqrtC = q.map((qi) => Math.sqrt(qi * (1 - qi)))
+  const meanSqrtC = sqrtC.reduce((s, x) => s + x, 0) / n
+  const D0 = (ante * (n - 2)) / (2 * (n - 1))
+  const Wbar = (ante * n) / (4 * (n - 1))
+  const N = q.map((qi, i) => {
+    const Wi = (Wbar * sqrtC[i]) / meanSqrtC
+    const b = D0 - Wi
+    return (-b + Math.sqrt(b * b + 4 * Wi * qi * D0)) / 2
+  })
+  const D = ante - N.reduce((s, x) => s + x, 0)
+  return q.map((qi, i) => {
+    const poolNo = N[i]
+    const poolYes = poolNo + D
+    const p = (qi * poolYes) / (qi * poolYes + (1 - qi) * poolNo)
+    return { poolYes, poolNo, p }
+  })
+}
+
+function setPools(q: number[], ante: number) {
+  const L = ante / q.length
+  return q.map((qi) => ({ poolYes: L, poolNo: L, p: qi })) // balanced => prob = p = q
+}
+
+type Cfg = {
+  n: number
+  probs: 'balanced' | 'skewed' | 'extreme'
+  type: 'mc_sumone' | 'set_indep'
+}
+
+const PROB_SETS: Record<string, Record<number, number[]>> = {
+  balanced: { 2: [0.5, 0.5], 3: [1 / 3, 1 / 3, 1 / 3], 5: Array(5).fill(0.2) },
+  skewed: { 2: [0.7, 0.3], 3: [0.55, 0.3, 0.15], 5: [0.4, 0.25, 0.18, 0.1, 0.07] },
+  extreme: { 2: [0.92, 0.08], 3: [0.85, 0.1, 0.05], 5: [0.8, 0.1, 0.05, 0.03, 0.02] },
+}
+
+// --- the conservation harness ---------------------------------------------------------------
+class Sim {
+  answers: Answer[]
+  type: Cfg['type']
+  ante: number
+  balances: Record<string, number> = {}
+  fees = 0
+  liquidities: LiquidityProvision[] = []
+  // trader positions: key `${user}|${answerId}` -> {YES, NO, invested, sold}
+  pos = new Map<string, { YES: number; NO: number; invested: number; sold: number }>()
+  private lpId = 0
+
+  constructor(cfg: Cfg, creator = 'creator', ante = 1000) {
+    this.type = cfg.type
+    this.ante = ante
+    const q =
+      cfg.type === 'mc_sumone'
+        ? normalize(PROB_SETS[cfg.probs][cfg.n])
+        : PROB_SETS[cfg.probs][cfg.n]
+    const pools = cfg.type === 'mc_sumone' ? sumToOnePools(q, ante) : setPools(q, ante)
+    this.answers = pools.map((pl, i) => mkAnswer(i, pl.poolYes, pl.poolNo, pl.p))
+    this.spend(creator, ante)
+    this.liquidities.push({
+      id: `lp${this.lpId++}`,
+      userId: creator,
+      contractId: 'c',
+      createdTime: 0,
+      isAnte: true,
+      amount: ante,
+    })
+    this.check('create')
+  }
+
+  private spend(user: string, amount: number) {
+    this.balances[user] = (this.balances[user] ?? 0) - amount
+  }
+  private credit(user: string, amount: number) {
+    this.balances[user] = (this.balances[user] ?? 0) + amount
+  }
+  private posOf(user: string, answerId: string) {
+    const k = `${user}|${answerId}`
+    if (!this.pos.has(k)) this.pos.set(k, { YES: 0, NO: 0, invested: 0, sold: 0 })
+    return this.pos.get(k)!
+  }
+
+  // apply a bet result (newBetResult-style: {answer, takers}) for `outcome` to user state
+  private applyResult(
+    user: string,
+    r: { answer: Answer; takers: { amount: number; shares: number }[] },
+    outcome: 'YES' | 'NO'
+  ) {
+    const p = this.posOf(user, r.answer.id)
+    const amt = sumBy(r.takers, (t) => t.amount)
+    const sh = sumBy(r.takers, (t) => t.shares)
+    p[outcome] += sh
+    if (amt >= 0) p.invested += amt
+    else p.sold += -amt
+    this.spend(user, amt) // negative amt (redemption/sell) credits back
+  }
+
+  buy(user: string, answerIndex: number, outcome: 'YES' | 'NO', amount: number) {
+    if (this.type === 'set_indep') {
+      // an independent answer is its own binary CPMM — single trade, NO cross-answer arb.
+      const a = this.answers[answerIndex]
+      const { shares, newPool, newP } = calculateCpmmPurchase(
+        { pool: { YES: a.poolYes, NO: a.poolNo }, p: a.p, collectedFees: noFees },
+        amount,
+        outcome,
+        true
+      )
+      this.answers = this.answers.map((x, i) =>
+        i === answerIndex
+          ? { ...x, poolYes: newPool.YES, poolNo: newPool.NO, p: newP,
+              prob: getCpmmProbability(newPool, newP) }
+          : x
+      )
+      const p = this.posOf(user, a.id)
+      p[outcome] += shares
+      p.invested += amount
+      this.spend(user, amount)
+      this.check(`set buy ${outcome} a${answerIndex} M$${amount} by ${user}`)
+      return
+    }
+    const res = calculateCpmmMultiArbitrageBet(
+      this.answers,
+      this.answers[answerIndex],
+      outcome,
+      amount,
+      undefined,
+      [],
+      {},
+      noFees
+    )
+    // single-bet path returns no updatedAnswers — rebuild pools from each leg's cpmmState.
+    const poolById = new Map<string, { [o: string]: number }>()
+    poolById.set(res.newBetResult.answer.id, res.newBetResult.cpmmState.pool)
+    for (const o of res.otherBetResults) poolById.set(o.answer.id, o.cpmmState.pool)
+    this.answers = this.answers.map((a) => {
+      const pl = poolById.get(a.id)
+      return pl
+        ? { ...a, poolYes: pl.YES, poolNo: pl.NO, prob: getCpmmProbability(pl as any, a.p) }
+        : a
+    })
+    // newBetResult is the traded answer (`outcome`); otherBetResults are the arbed legs.
+    this.applyResult(user, res.newBetResult as any, outcome)
+    for (const o of res.otherBetResults)
+      this.applyResult(user, o as any, outcome === 'YES' ? 'NO' : 'YES')
+    this.fees += getFeeTotal(res.newBetResult.totalFees)
+    this.check(`buy ${outcome} a${answerIndex} M$${amount} by ${user}`)
+  }
+
+  multibet(user: string, basketIdx: number[], amount: number) {
+    const res = calculateCpmmMultiArbitrageYesBets(
+      this.answers,
+      basketIdx.map((i) => this.answers[i]),
+      amount,
+      undefined,
+      [],
+      {},
+      noFees,
+      'cpmm-multi-2'
+    )
+    this.answers = res.updatedAnswers as Answer[]
+    for (const r of res.newBetResults) this.applyResult(user, r as any, 'YES')
+    for (const r of res.otherBetResults) this.applyResult(user, r as any, 'NO')
+    this.check(`multibet {${basketIdx}} M$${amount} by ${user}`)
+  }
+
+  addLiquidity(user: string, amount: number) {
+    // model whole-market add as the lossless v2 deepen (what drizzle realizes), so the added
+    // mana sits in pools and is read by getMultiLiquidityPoolPayouts at resolution.
+    const map = Object.fromEntries(
+      this.answers.map((a) => [a.id, { pool: { YES: a.poolYes, NO: a.poolNo }, p: a.p }])
+    )
+    const updated =
+      this.type === 'mc_sumone'
+        ? addCpmmMultiLiquidityAnswersSumToOneV2(map, amount)
+        : addCpmmMultiLiquidityToAnswersIndependentlyV2(map, amount)
+    this.answers = this.answers.map((a) => {
+      const u = updated[a.id]
+      return { ...a, poolYes: u.pool.YES, poolNo: u.pool.NO, p: u.p, prob: getCpmmProbability(u.pool, u.p) }
+    })
+    this.spend(user, amount)
+    this.liquidities.push({
+      id: `lp${this.lpId++}`,
+      userId: user,
+      contractId: 'c',
+      createdTime: this.lpId,
+      amount,
+    })
+    this.check(`addLiquidity M$${amount} by ${user}`)
+  }
+
+  private metrics(): ContractMetric[] {
+    const out: ContractMetric[] = []
+    for (const [k, v] of this.pos) {
+      const [userId, answerId] = k.split('|')
+      out.push({
+        userId,
+        answerId,
+        totalShares: { YES: v.YES, NO: v.NO },
+        totalAmountInvested: v.invested,
+        totalAmountSold: v.sold,
+      } as any)
+    }
+    return out
+  }
+
+  // resolve and assert global conservation
+  resolve(
+    mode: 'one' | 'multiple' | 'cancel' | 'set_yesno',
+    arg?: { winner?: number; split?: [number, number]; setOutcomes?: ('YES' | 'NO')[] }
+  ) {
+    const ms = this.metrics()
+    let traderPayouts: { userId: string; payout: number }[] = []
+    let liquidityPayouts: { userId: string; payout: number }[] = []
+    if (mode === 'cancel') {
+      ;({ traderPayouts, liquidityPayouts } = getFixedCancelPayouts(ms, this.liquidities))
+    } else if (mode === 'set_yesno') {
+      const outs = arg!.setOutcomes!
+      this.answers.forEach((a, i) => {
+        const r = getIndependentMultiYesNoPayouts(a, outs[i], ms, this.liquidities, 0)
+        traderPayouts.push(...r.traderPayouts)
+        liquidityPayouts.push(...r.liquidityPayouts)
+      })
+    } else {
+      const resolutions: Record<string, number> =
+        mode === 'one'
+          ? { [this.answers[arg!.winner!].id]: 1 }
+          : {
+              [this.answers[0].id]: arg!.split![0],
+              [this.answers[1].id]: arg!.split![1],
+            }
+      ;({ traderPayouts, liquidityPayouts } = getMultiFixedPayouts(
+        this.answers,
+        resolutions,
+        ms,
+        this.liquidities,
+        0
+      ))
+    }
+    for (const { userId, payout } of [...traderPayouts, ...liquidityPayouts])
+      this.credit(userId, payout)
+    const netSum = Object.values(this.balances).reduce((s, x) => s + x, 0)
+    // Sum of all user balance deltas + fees must be exactly 0.
+    expect(netSum + this.fees).toBeCloseTo(0, 4)
+  }
+
+  private check(step: string) {
+    for (const a of this.answers) {
+      const pr = getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+      expect(pr).toBeGreaterThan(0)
+      expect(pr).toBeLessThan(1)
+    }
+    if (this.type === 'mc_sumone') {
+      const s = sumBy(this.answers, (a) =>
+        getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+      )
+      expect(s).toBeCloseTo(1, 4)
+    }
+  }
+}
+
+function normalize(q: number[]) {
+  const s = q.reduce((a, b) => a + b, 0)
+  return q.map((x) => x / s)
+}
+function mkAnswer(i: number, poolYes: number, poolNo: number, p: number): Answer {
+  return {
+    id: `a${i}`,
+    contractId: 'c',
+    userId: 'creator',
+    text: `A${i}`,
+    createdTime: 0,
+    index: i,
+    poolYes,
+    poolNo,
+    p,
+    prob: getCpmmProbability({ YES: poolYes, NO: poolNo }, p),
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer
+}
+
+// --- the grid ------------------------------------------------------------------------------
+describe('cpmm-multi-2 conservation grid (calc-layer rows)', () => {
+  it('sum-to-one: create -> single buy -> resolve CHOOSE_ONE (winner classes)', () => {
+    for (const probs of ['balanced', 'skewed', 'extreme'] as const)
+      for (const n of [2, 3, 5]) {
+        const s = new Sim({ n, probs, type: 'mc_sumone' })
+        s.buy('alice', 1 % n, 'YES', 50)
+        s.resolve('one', { winner: 1 % n }) // resolve to the traded answer
+        const s2 = new Sim({ n, probs, type: 'mc_sumone' })
+        s2.buy('alice', 0, 'YES', 40)
+        s2.resolve('one', { winner: n - 1 }) // resolve to an untouched answer
+      }
+  })
+
+  it('sum-to-one: multibet basket (m>=2) -> resolve to a basket answer (the m>1 bug locus)', () => {
+    for (const probs of ['balanced', 'skewed', 'extreme'] as const)
+      for (const n of [3, 5]) {
+        const s = new Sim({ n, probs, type: 'mc_sumone' })
+        s.multibet('alice', [1, 2], 150)
+        s.resolve('one', { winner: 1 }) // basket member wins
+      }
+  })
+
+  it('sum-to-one: multi-user (creator/alice/bob) + add-liquidity -> CHOOSE_ONE / MULTIPLE', () => {
+    const s = new Sim({ n: 5, probs: 'skewed', type: 'mc_sumone' })
+    s.buy('alice', 0, 'YES', 60)
+    s.addLiquidity('bob', 300)
+    s.buy('alice', 2, 'NO', 30)
+    s.resolve('one', { winner: 0 })
+
+    const s2 = new Sim({ n: 5, probs: 'skewed', type: 'mc_sumone' })
+    s2.multibet('alice', [0, 1, 2], 90)
+    s2.addLiquidity('bob', 200)
+    s2.resolve('multiple', { split: [0.6, 0.4] })
+  })
+
+  it('sum-to-one: CANCEL after trades + add-liquidity refunds exactly', () => {
+    const s = new Sim({ n: 3, probs: 'skewed', type: 'mc_sumone' })
+    s.buy('alice', 0, 'YES', 50)
+    s.buy('bob', 1, 'NO', 40)
+    s.addLiquidity('carol', 100)
+    s.resolve('cancel')
+  })
+
+  it('Set (independent): create -> buys -> add-liquidity -> per-answer resolution', () => {
+    for (const probs of ['skewed', 'extreme'] as const)
+      for (const n of [2, 3]) {
+        const s = new Sim({ n, probs, type: 'set_indep' })
+        s.buy('alice', 0, 'YES', 40)
+        if (n > 2) s.buy('bob', 1, 'NO', 25)
+        s.addLiquidity('carol', 150)
+        const outs = Array.from({ length: n }, (_, i) =>
+          i % 2 === 0 ? 'YES' : 'NO'
+        ) as ('YES' | 'NO')[]
+        s.resolve('set_yesno', { setOutcomes: outs })
+      }
+  })
+})

--- a/common/src/conservation-grid.test.ts
+++ b/common/src/conservation-grid.test.ts
@@ -17,6 +17,7 @@
 // (per-answer addLiquidity not yet built for v2).
 import { sumBy } from 'lodash'
 import { Answer } from './answer'
+import { LimitBet } from './bet'
 import {
   addCpmmMultiLiquidityAnswersSumToOneV2,
   addCpmmMultiLiquidityToAnswersIndependentlyV2,
@@ -87,7 +88,14 @@ class Sim {
   liquidities: LiquidityProvision[] = []
   // trader positions: key `${user}|${answerId}` -> {YES, NO, invested, sold}
   pos = new Map<string, { YES: number; NO: number; invested: number; sold: number }>()
+  // resting limit orders (makers). Threaded into every calc; the `makers` the calc returns
+  // are applied to maker users here. Makers are NOT balance-capped — vendor's own multi-bet/
+  // sell simulation assumes infinite maker balance (sell-shares.ts), and computeFills skips
+  // the cap when balanceByUserId lacks the user, so we pass {} for balances and the real
+  // unfilled book here.
+  unfilled: LimitBet[] = []
   private lpId = 0
+  private limitId = 0
 
   constructor(cfg: Cfg, creator = 'creator', ante = 1000) {
     this.type = cfg.type
@@ -120,6 +128,65 @@ class Sim {
     const k = `${user}|${answerId}`
     if (!this.pos.has(k)) this.pos.set(k, { YES: 0, NO: 0, invested: 0, sold: 0 })
     return this.pos.get(k)!
+  }
+
+  // Place a resting limit order (maker). Returns the LimitBet so tests can inspect whether it
+  // interacted (bet.amount stays 0 and !isCancelled => untouched).
+  placeLimit(
+    user: string,
+    answerIndex: number,
+    outcome: 'YES' | 'NO',
+    limitProb: number,
+    orderAmount: number
+  ): LimitBet {
+    const a = this.answers[answerIndex]
+    const bet: LimitBet = {
+      id: `L${this.limitId++}`,
+      userId: user,
+      contractId: 'c',
+      answerId: a.id,
+      createdTime: this.limitId,
+      amount: 0,
+      loanAmount: 0,
+      outcome,
+      shares: 0,
+      probBefore: a.prob,
+      probAfter: a.prob,
+      fees: noFees,
+      isRedemption: false,
+      orderAmount,
+      limitProb,
+      isFilled: false,
+      isCancelled: false,
+      fills: [],
+    } as LimitBet
+    this.unfilled.push(bet)
+    return bet
+  }
+
+  // Apply the maker fills a calc produced: the maker pays `amount`, gains `shares` of their
+  // outcome, and the resting order's filled amount accumulates on the book. This is the maker
+  // side of conservation — it MUST be counted or `Sum deltas + fees` will not close.
+  private applyMakers(
+    makers: { bet: LimitBet; amount: number; shares: number }[],
+    ordersToCancel: LimitBet[] = []
+  ) {
+    for (const m of makers) {
+      const book = this.unfilled.find((b) => b.id === m.bet.id)
+      if (!book) continue
+      this.spend(m.bet.userId, m.amount) // maker pays mana
+      this.posOf(m.bet.userId, m.bet.answerId!)[m.bet.outcome as 'YES' | 'NO'] += m.shares
+      book.amount += m.amount
+      book.shares += m.shares
+      book.fills.push({ matchedBetId: null, amount: m.amount, shares: m.shares, timestamp: 0 })
+      if (Math.abs(book.amount) >= book.orderAmount - 1e-6) book.isFilled = true
+    }
+    for (const o of ordersToCancel) {
+      const book = this.unfilled.find((b) => b.id === o.id)
+      if (book) book.isCancelled = true
+    }
+    // a filled / cancelled order leaves the book (no further fills).
+    this.unfilled = this.unfilled.filter((b) => !b.isFilled && !b.isCancelled)
   }
 
   // apply a bet result (newBetResult-style: {answer, takers}) for `outcome` to user state
@@ -166,7 +233,7 @@ class Sim {
       outcome,
       amount,
       undefined,
-      [],
+      this.unfilled,
       {},
       noFees
     )
@@ -184,6 +251,10 @@ class Sim {
     this.applyResult(user, res.newBetResult as any, outcome)
     for (const o of res.otherBetResults)
       this.applyResult(user, o as any, outcome === 'YES' ? 'NO' : 'YES')
+    this.applyMakers(
+      [res.newBetResult, ...res.otherBetResults].flatMap((r: any) => r.makers ?? []),
+      [res.newBetResult, ...res.otherBetResults].flatMap((r: any) => r.ordersToCancel ?? [])
+    )
     this.fees += getFeeTotal(res.newBetResult.totalFees)
     this.check(`buy ${outcome} a${answerIndex} M$${amount} by ${user}`)
   }
@@ -194,7 +265,7 @@ class Sim {
       basketIdx.map((i) => this.answers[i]),
       amount,
       undefined,
-      [],
+      this.unfilled,
       {},
       noFees,
       'cpmm-multi-2'
@@ -202,6 +273,10 @@ class Sim {
     this.answers = res.updatedAnswers as Answer[]
     for (const r of res.newBetResults) this.applyResult(user, r as any, 'YES')
     for (const r of res.otherBetResults) this.applyResult(user, r as any, 'NO')
+    this.applyMakers(
+      [...res.newBetResults, ...res.otherBetResults].flatMap((r: any) => r.makers ?? []),
+      [...res.newBetResults, ...res.otherBetResults].flatMap((r: any) => r.ordersToCancel ?? [])
+    )
     this.check(`multibet {${basketIdx}} M$${amount} by ${user}`)
   }
 
@@ -220,7 +295,7 @@ class Sim {
   sell(user: string, answerIndex: number, outcome: 'YES' | 'NO', shares: number) {
     const answerToSell = this.answers[answerIndex]
     if (this.type === 'set_indep') {
-      const { cpmmState, saleValue, fees } = calculateCpmmSale(
+      const { cpmmState, saleValue, fees, makers } = calculateCpmmSale(
         {
           pool: { YES: answerToSell.poolYes, NO: answerToSell.poolNo },
           p: answerToSell.p,
@@ -228,7 +303,7 @@ class Sim {
         },
         shares,
         outcome,
-        [],
+        this.unfilled.filter((b) => b.answerId === answerToSell.id),
         {}
       )
       this.answers = this.answers.map((x, i) =>
@@ -241,6 +316,7 @@ class Sim {
       p[outcome] -= shares
       p.sold += saleValue
       this.credit(user, saleValue)
+      this.applyMakers((makers as any) ?? [])
       this.fees += getFeeTotal(fees)
       this.check(`set sell ${outcome} ${shares}sh a${answerIndex} by ${user}`)
       return
@@ -251,7 +327,7 @@ class Sim {
       shares,
       outcome,
       undefined,
-      [],
+      this.unfilled,
       {},
       noFees
     )
@@ -269,6 +345,10 @@ class Sim {
     pos[outcome] -= shares
     pos.sold += saleValue
     this.credit(user, saleValue)
+    this.applyMakers(
+      [newBetResult, ...otherBetResults].flatMap((r: any) => r.makers ?? []),
+      [newBetResult, ...otherBetResults].flatMap((r: any) => r.ordersToCancel ?? [])
+    )
     this.fees +=
       getFeeTotal(newBetResult.totalFees) +
       sumBy(otherBetResults, (r) => getFeeTotal(r.totalFees))
@@ -522,5 +602,162 @@ describe('cpmm-multi-2 conservation grid (calc-layer rows)', () => {
         ) as ('YES' | 'NO')[]
         s.resolve('set_yesno', { setOutcomes: outs })
       }
+  })
+})
+
+// --- LIMIT ORDERS (covering array: limits != none) -------------------------------------------
+// Master invariant (Evan, 2026-06-28): with resting limit orders, a limit STRICTLY outside
+// (initial, final) on its answer must NOT interact — the maker gets no shares and the order's
+// size on the book is unchanged. Resting orders are always on their far side (a NO maker rests
+// ABOVE current prob and fills only when price rises to it; a YES maker rests BELOW), so
+// "strictly outside (initial, final)" means the price excursion never reached it.
+//
+// This is also the acceptance test for v2's NON-OVERSHOOTING auto-arb vs. the §8 reversibility
+// caveat (docs/amm-invariants.md): v1 multibet could overshoot a limit at the peak and not
+// unwind it, so a limit past `final` still got consumed. If v2's "Approach C" solve leaves
+// just-past-final limits untouched even on a basket multibet, v2 killed that bug at the calc
+// layer. The grid adjudicates — it is NOT assumed.
+//
+// `Sum(all balance deltas) + fees == 0` must still close across taker + ALL makers + creator.
+const CAP_HI = 0.97
+const CAP_LO = 0.03
+// a validly-resting maker is strictly outside its answer's band iff price never reached it.
+const strictlyOutside = (
+  bet: { outcome: string; limitProb: number },
+  lo: number,
+  hi: number
+) =>
+  bet.outcome === 'NO' ? bet.limitProb > hi + 1e-9 : bet.limitProb < lo - 1e-9
+
+const assertOutsideUntouched = (
+  s: Sim,
+  placed: { bet: LimitBet; ai: number }[],
+  init: number[]
+) => {
+  const final = s.answers.map((a) => a.prob)
+  let checked = 0
+  for (const { bet, ai } of placed) {
+    const lo = Math.min(init[ai], final[ai])
+    const hi = Math.max(init[ai], final[ai])
+    if (strictlyOutside(bet, lo, hi)) {
+      expect(bet.amount).toBeCloseTo(0, 6) // no fill => shares & book size unchanged
+      expect(bet.isCancelled).toBe(false)
+      checked++
+    }
+  }
+  return checked
+}
+
+describe('cpmm-multi-2 conservation grid — limit orders', () => {
+  it('a crossed maker IS filled and IS counted in conservation (buy & sell)', () => {
+    for (const n of [2, 3, 5]) {
+      // buy crosses a NO maker resting just above answer-0's current prob
+      const s = new Sim({ n, probs: 'skewed', type: 'mc_sumone' })
+      const mkBuy = s.placeLimit('mk', 0, 'NO', Math.min(s.answers[0].prob + 0.02, CAP_HI), 300)
+      s.buy('alice', 0, 'YES', 200)
+      expect(mkBuy.amount).toBeGreaterThan(0) // positive control: it interacted
+      s.resolve('one', { winner: 0 }) // conservation across alice + mk + creator
+
+      // sell crosses a YES maker resting just below answer-0's current prob
+      const s2 = new Sim({ n, probs: 'skewed', type: 'mc_sumone' })
+      s2.buy('alice', 0, 'YES', 250) // give alice a position to sell
+      const mkSell = s2.placeLimit('mk', 0, 'YES', Math.max(s2.answers[0].prob - 0.02, CAP_LO), 300)
+      s2.sell('alice', 0, 'YES', s2.sharesOf('alice', 0, 'YES'))
+      expect(mkSell.amount).toBeGreaterThan(0)
+      s2.resolve('one', { winner: 0 })
+    }
+  })
+
+  it('INVARIANT: out-of-band resting limits never interact — buy (+ in-band positive control)', () => {
+    for (const probs of ['balanced', 'skewed'] as const)
+      for (const n of [2, 3, 5]) {
+        const s = new Sim({ n, probs, type: 'mc_sumone' })
+        const init = s.answers.map((a) => a.prob)
+        // far-out NO makers on every answer (above hi) + far-out YES makers (below lo): a single
+        // bounded buy on answer 0 reaches none of them.
+        const placed = s.answers.flatMap((_, ai) => [
+          { bet: s.placeLimit('mk', ai, 'NO', CAP_HI, 100), ai },
+          { bet: s.placeLimit('mk', ai, 'YES', CAP_LO, 100), ai },
+        ])
+        // in-band positive control on answer 0 (just above init0): must be touched.
+        const control = s.placeLimit('mk', 0, 'NO', Math.min(init[0] + 0.02, CAP_HI), 80)
+        s.buy('alice', 0, 'YES', 120)
+        const checked = assertOutsideUntouched(s, placed, init)
+        expect(checked).toBeGreaterThan(0) // not vacuous
+        expect(control.amount).toBeGreaterThan(0) // the matcher DOES fire in-band
+        s.resolve('one', { winner: 0 })
+      }
+  })
+
+  it('INVARIANT: out-of-band resting limits never interact — sell', () => {
+    for (const probs of ['balanced', 'skewed'] as const)
+      for (const n of [2, 3, 5]) {
+        const s = new Sim({ n, probs, type: 'mc_sumone' })
+        s.buy('alice', 0, 'YES', 200) // position to sell
+        const init = s.answers.map((a) => a.prob)
+        const placed = s.answers.flatMap((_, ai) => [
+          { bet: s.placeLimit('mk', ai, 'NO', CAP_HI, 100), ai },
+          { bet: s.placeLimit('mk', ai, 'YES', CAP_LO, 100), ai },
+        ])
+        s.sell('alice', 0, 'YES', s.sharesOf('alice', 0, 'YES') * 0.6)
+        const checked = assertOutsideUntouched(s, placed, init)
+        expect(checked).toBeGreaterThan(0)
+        s.resolve('multiple', { split: [0.6, 0.4] })
+      }
+  })
+
+  it('INVARIANT/§8 prize: v2 basket multibet does NOT overshoot a limit just past final', () => {
+    for (const n of [3, 5]) {
+      // baseline: where does the basket buy on [0,1] land each answer (no makers present)?
+      const base = new Sim({ n, probs: 'skewed', type: 'mc_sumone' })
+      base.multibet('alice', [0, 1], 160)
+      const finals = base.answers.map((a) => a.prob)
+      // re-run with a NO maker just past final on each UP-moved (bought) answer, and a YES maker
+      // just past final on each DOWN-moved (arbed) answer — each strictly outside its own band.
+      const s = new Sim({ n, probs: 'skewed', type: 'mc_sumone' })
+      const init = s.answers.map((a) => a.prob)
+      const placed = s.answers.map((_, ai) => {
+        const up = finals[ai] >= init[ai]
+        return up
+          ? { bet: s.placeLimit('mk', ai, 'NO', Math.min(finals[ai] + 0.01, CAP_HI), 200), ai }
+          : { bet: s.placeLimit('mk', ai, 'YES', Math.max(finals[ai] - 0.01, CAP_LO), 200), ai }
+      })
+      s.multibet('alice', [0, 1], 160)
+      // every just-past-final maker must be untouched => v2 did not overshoot.
+      for (const { bet } of placed) {
+        expect(bet.amount).toBeCloseTo(0, 6)
+        expect(bet.isCancelled).toBe(false)
+      }
+      s.resolve('one', { winner: 0 })
+
+      // independent positive control (own sim, so it can't perturb the run above): a maker
+      // mid-band on answer 0 MUST be crossed by the same multibet — proves the trade reaches
+      // into the band, so the untouched just-past-final result is a genuine no-overshoot.
+      const pc = new Sim({ n, probs: 'skewed', type: 'mc_sumone' })
+      const control = pc.placeLimit('mk', 0, 'NO', (init[0] + finals[0]) / 2, 50)
+      pc.multibet('alice', [0, 1], 160)
+      expect(control.amount).toBeGreaterThan(0)
+      pc.resolve('one', { winner: 0 })
+    }
+  })
+
+  it('NON-REVERSIBILITY: a buy that crosses a maker, then sell-all, does NOT return to creation', () => {
+    for (const n of [2, 3]) {
+      const s = new Sim({ n, probs: 'skewed', type: 'mc_sumone' })
+      const before = s.answers.map((a) => ({ y: a.poolYes, no: a.poolNo }))
+      const maker = s.placeLimit('mk', 0, 'NO', Math.min(s.answers[0].prob + 0.02, CAP_HI), 150)
+      s.buy('alice', 0, 'YES', 200)
+      expect(maker.amount).toBeGreaterThan(0) // a maker was permanently engaged
+      s.sell('alice', 0, 'YES', s.sharesOf('alice', 0, 'YES')) // alice unwinds fully
+      // pools do NOT return to creation: the maker now holds NO shares the AMM can't unwind.
+      const moved = s.answers.some(
+        (a, i) =>
+          Math.abs(a.poolYes - before[i].y) > 1e-3 ||
+          Math.abs(a.poolNo - before[i].no) > 1e-3
+      )
+      expect(moved).toBe(true)
+      // but global conservation STILL closes across alice + maker + creator.
+      s.resolve('one', { winner: 0 })
+    }
   })
 })

--- a/common/src/conservation-grid.test.ts
+++ b/common/src/conservation-grid.test.ts
@@ -741,6 +741,81 @@ describe('cpmm-multi-2 conservation grid — limit orders', () => {
     }
   })
 
+  // FALSIFICATION SWEEP: try hard to make a v2 trade touch an out-of-range limit. Place a maker
+  // just past `final` (on the far, unreached side) at progressively TIGHTER margins, per answer,
+  // one at a time (so an out-of-range maker can't perturb the run), across configs and across
+  // buy / sell / basket-multibet. ANY fill is a v2 invariant violation. Margins go to 1e-4 to
+  // catch numerical overshoot, not just the gross v1 transient band.
+  const MARGINS = [0.02, 0.0001] // one gross (v1 transient band), one tight (numerical overshoot)
+  // The invariant is per ATOMIC op: a limit outside THAT op's own (init,final) excursion must
+  // not interact. So each measured op is a single monotonic call; any position the op needs is
+  // built in a `setup` phase that runs BEFORE the maker is placed (and is not part of the range).
+  // ANY fill at any margin (down to 1e-4, to catch numerical overshoot) is a v2 violation.
+  it('FALSIFY: no v2 op (buy/sell/multibet) touches a limit outside its own range, any margin', () => {
+    let probes = 0
+    for (const probs of ['balanced', 'skewed', 'extreme'] as const)
+      for (const n of [2, 3, 5]) {
+        const cases: {
+          label: string
+          setup: (s: Sim) => void
+          op: (s: Sim) => void
+        }[] = [
+          { label: 'buy', setup: () => {}, op: (s) => s.buy('alice', 0, 'YES', 90) },
+          {
+            label: 'sell',
+            setup: (s) => s.buy('alice', 0, 'YES', 200), // build position FIRST, no maker yet
+            op: (s) => s.sell('alice', 0, 'YES', s.sharesOf('alice', 0, 'YES') * 0.5),
+          },
+          // n=5 multibet overshoot is covered by the dedicated §8 prize test; keep the broad
+          // sweep's multibet at n=3 to bound cost.
+          ...(n === 3
+            ? [{ label: 'multibet', setup: () => {}, op: (s: Sim) => s.multibet('alice', [0, 1], 140) }]
+            : []),
+        ]
+        for (const c of cases) {
+          // baseline: range of the measured op alone (after setup, before any maker).
+          const base = new Sim({ n, probs, type: 'mc_sumone' })
+          c.setup(base)
+          const init = base.answers.map((a) => a.prob)
+          c.op(base)
+          const finals = base.answers.map((a) => a.prob)
+          for (let ai = 0; ai < n; ai++) {
+            const lo = Math.min(init[ai], finals[ai])
+            const hi = Math.max(init[ai], finals[ai])
+            for (const m of MARGINS) {
+              // A valid resting maker outside the op's [lo,hi] excursion, BOTH sides:
+              //   NO  maker above hi  (rests above current prob; price never rose to it)
+              //   YES maker below lo  (rests below current prob; price never fell to it)
+              const placements: { outcome: 'YES' | 'NO'; L: number }[] = []
+              const noL = Math.min(hi + m, CAP_HI)
+              if (noL > hi + 1e-9) placements.push({ outcome: 'NO', L: noL })
+              const yesL = Math.max(lo - m, 0.011) // floor just above MIN_CPMM_PROB
+              if (yesL < lo - 1e-9) placements.push({ outcome: 'YES', L: yesL })
+              for (const pl of placements) {
+                const s = new Sim({ n, probs, type: 'mc_sumone' })
+                c.setup(s) // identical position build, still no maker
+                const bet = s.placeLimit('mk', ai, pl.outcome, pl.L, 300)
+                c.op(s)
+                if (Math.abs(bet.amount) > 1e-6 || bet.isCancelled) {
+                  // eslint-disable-next-line no-console
+                  console.log('VIOLATION', JSON.stringify({
+                    probs, n, op: c.label, ai, m, outcome: pl.outcome,
+                    init: +init[ai].toFixed(5), final: +finals[ai].toFixed(5),
+                    lo: +lo.toFixed(5), hi: +hi.toFixed(5), L: +pl.L.toFixed(5),
+                    fill: +bet.amount.toFixed(5), finalNow: +s.answers[ai].prob.toFixed(5),
+                  }))
+                }
+                expect(bet.amount).toBeCloseTo(0, 6)
+                expect(bet.isCancelled).toBe(false)
+                probes++
+              }
+            }
+          }
+        }
+      }
+    expect(probes).toBeGreaterThan(50) // the sweep actually exercised many placements
+  })
+
   it('NON-REVERSIBILITY: a buy that crosses a maker, then sell-all, does NOT return to creation', () => {
     for (const n of [2, 3]) {
       const s = new Sim({ n, probs: 'skewed', type: 'mc_sumone' })

--- a/common/src/contract-params.ts
+++ b/common/src/contract-params.ts
@@ -4,7 +4,12 @@ import {
   getInitialProbability,
 } from 'common/calculate'
 import { binAvg, maxMinBin, serializeMultiPoints } from 'common/chart'
-import { Contract, ContractParams, MultiContract } from 'common/contract'
+import {
+  Contract,
+  ContractParams,
+  isMultiCpmm,
+  MultiContract,
+} from 'common/contract'
 import { getChartAnnotations } from 'common/supabase/chart-annotations'
 import {
   getPinnedComments,
@@ -71,7 +76,7 @@ export async function getContractParams(
   const contractSlug = contract.slug
   const isCpmm1 = contract.mechanism === 'cpmm-1'
   const hasMechanism = contract.mechanism !== 'none'
-  const isMulti = contract.mechanism === 'cpmm-multi-1'
+  const isMulti = isMultiCpmm(contract)
   const isNumber = contract.outcomeType === 'NUMBER'
   const numberContractBetCount = async () =>
     retryUnAuthedApi(contractSlug, 'unique-bet-group-count', async () =>
@@ -80,7 +85,7 @@ export async function getContractParams(
       }).then((res) => res.count)
     )
   const includeRedemptions =
-    contract.mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne
+    isMultiCpmm(contract) && contract.shouldAnswersSumToOne
   const [
     totalBets,
     lastBetArray,
@@ -149,7 +154,7 @@ export async function getContractParams(
 
   if (
     contract.outcomeType === 'MULTIPLE_CHOICE' &&
-    contract.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(contract)
   ) {
     contract.answers = sortAnswers(contract, contract.answers)
       .slice(0, 20)
@@ -280,7 +285,7 @@ export const getAnswerProbAtEveryBetTime = (
 }
 
 export const shouldHideGraph = (contract: Contract) => {
-  if (contract.mechanism !== 'cpmm-multi-1') return false
+  if (!isMultiCpmm(contract)) return false
   if (
     contract.outcomeType == 'NUMBER' ||
     contract.outcomeType == 'MULTI_NUMERIC' ||

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -185,6 +185,18 @@ export const NO_CLOSE_TIME_TYPES: OutcomeType[] = NON_BETTING_OUTCOMES.concat([
  * Implemented as a set of cpmm-1 binary contracts, one for each answer.
  * The mechanism is stored among the contract's answers, which each
  * reference this contract id.
+ *
+ * Reserved cpmm-multi-2 semantics (declared now, not yet reachable): a
+ * shouldAnswersSumToOne=true answer MAY in the future be individually
+ * resolved NO while the market stays open (that answer's
+ * `Answer.resolution` set, siblings still unresolved), with probabilities
+ * summing to 1 over the *unresolved* answers. No code path creates this
+ * state today — resolution of linked markets remains whole-market-only —
+ * but integrators adding cpmm-multi-2 support should not assume
+ * "shouldAnswersSumToOne ⇒ answers are never individually resolved".
+ * (`Answer.resolution` already exists and is populated today for
+ * independent markets.) cpmm-multi-1 keeps the whole-market-only
+ * guarantee unchanged.
  */
 export type CPMMMulti = {
   mechanism: 'cpmm-multi-1' | 'cpmm-multi-2'

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -187,7 +187,7 @@ export const NO_CLOSE_TIME_TYPES: OutcomeType[] = NON_BETTING_OUTCOMES.concat([
  * reference this contract id.
  */
 export type CPMMMulti = {
-  mechanism: 'cpmm-multi-1'
+  mechanism: 'cpmm-multi-1' | 'cpmm-multi-2'
   outcomeType: 'MULTIPLE_CHOICE'
   shouldAnswersSumToOne: boolean
   addAnswersMode?: add_answers_mode
@@ -206,7 +206,7 @@ export type CPMMMulti = {
 }
 
 export type CPMMNumber = {
-  mechanism: 'cpmm-multi-1'
+  mechanism: 'cpmm-multi-1' | 'cpmm-multi-2'
   outcomeType: 'NUMBER'
   shouldAnswersSumToOne: true
   addAnswersMode: 'DISABLED'
@@ -269,7 +269,7 @@ export type Number = {
 }
 
 export type MultiNumeric = {
-  mechanism: 'cpmm-multi-1'
+  mechanism: 'cpmm-multi-1' | 'cpmm-multi-2'
   outcomeType: 'MULTI_NUMERIC'
   unit: string
   answers: Answer[]
@@ -387,7 +387,7 @@ export function contractUrl(contract: Contract) {
 export function contractPool(contract: Contract) {
   return contract.mechanism === 'cpmm-1'
     ? formatMoney(contract.totalLiquidity)
-    : contract.mechanism === 'cpmm-multi-1'
+    : isMultiCpmm(contract)
     ? formatMoney(
         sum(
           contract.answers.map((a) =>
@@ -398,8 +398,21 @@ export function contractPool(contract: Contract) {
     : 'Empty pool'
 }
 
+// True for any multi-answer CPMM market, v1 or v2. The mechanism is the AMM engine and is
+// orthogonal to outcomeType, so this covers MULTIPLE_CHOICE / NUMBER / MULTI_NUMERIC / DATE
+// alike (they are all cpmm-multi markets). Type guard → MultiContract.
+export const isMultiCpmm = (contract: Contract): contract is MultiContract =>
+  contract.mechanism === 'cpmm-multi-1' || contract.mechanism === 'cpmm-multi-2'
+
+// For sites that only have the mechanism string (destructured, raw, or compound `|| 'cpmm-1'`).
+export const isMultiCpmmMechanism = (mechanism: string): boolean =>
+  mechanism === 'cpmm-multi-1' || mechanism === 'cpmm-multi-2'
+
+// Raw-SQL fragment for the same predicate (the TS helpers can't reach SQL string literals).
+export const MULTI_CPMM_MECHANISMS_SQL = `('cpmm-multi-1', 'cpmm-multi-2')`
+
 export const isBinaryMulti = (contract: Contract) =>
-  contract.mechanism === 'cpmm-multi-1' &&
+  isMultiCpmm(contract) &&
   contract.outcomeType !== 'NUMBER' &&
   contract.outcomeType !== 'MULTI_NUMERIC' &&
   contract.outcomeType !== 'DATE' &&
@@ -413,7 +426,7 @@ export const isSportsContract = (
 ): contract is SportsContract => 'sportsEventId' in contract
 
 export const getMainBinaryMCAnswer = (contract: Contract) =>
-  isBinaryMulti(contract) && contract.mechanism === 'cpmm-multi-1'
+  isBinaryMulti(contract) && isMultiCpmm(contract)
     ? contract.answers[0]
     : undefined
 
@@ -516,7 +529,7 @@ export const getAdjustedProfit = (
   answers: Answer[] | undefined,
   answerId: string | null
 ) => {
-  if (contract.mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     // Null answerId stands for the summary of all answer metrics
     if (!answerId) {
       return isMarketRanked(contract) &&

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -452,6 +452,10 @@ export const MAX_DESCRIPTION_LENGTH = 16000
 export const CPMM_MIN_POOL_QTY = 0.01
 export const NUMBER_BUCKETS_MAX = 50
 export const NUMBER_CREATION_ENABLED = false
+// cpmm-multi-2 (PR2c) kill-switch: gates creating multiple-choice markets with
+// per-answer initial probabilities. Reads are always safe (p ?? 0.5), so only
+// the creation path is flagged. Flip last, for staged rollout.
+export const CPMM_MULTI_2_CREATION_ENABLED = false
 
 export type Visibility = 'public' | 'unlisted'
 export const VISIBILITIES = ['public', 'unlisted'] as const

--- a/common/src/cpmm-multi-2-creation.test.ts
+++ b/common/src/cpmm-multi-2-creation.test.ts
@@ -25,7 +25,8 @@ const creator = {
 const makeMC = (
   answers: string[],
   initialProbs: number[] | undefined,
-  ante = 1000
+  ante = 1000,
+  shouldAnswersSumToOne = true
 ): CPMMMulti =>
   getNewContract({
     id: 'contract1',
@@ -44,7 +45,7 @@ const makeMC = (
     isLogScale: false,
     answers,
     addAnswersMode: 'DISABLED',
-    shouldAnswersSumToOne: true,
+    shouldAnswersSumToOne,
     initialProbs,
     token: 'MANA',
     coverImageUrl: undefined,
@@ -125,6 +126,84 @@ describe('cpmm-multi-2 creation — per-answer initialProbs', () => {
       // v1 ante-maximizing pools
       expect(a.poolYes).toBeCloseTo(ante / 2, 8)
       expect(a.poolNo).toBeCloseTo(ante / (2 * n - 2), 8)
+    })
+  })
+})
+
+// cpmm-multi-2 (Set / INDEPENDENT_MULTIPLE_CHOICE): each answer is its own CPMM,
+// so per-answer initialProbs are ABSOLUTE (no Σ=1 normalization). Same balanced
+// deep pool + per-answer p representation as sum-to-one — required so the LP's
+// max loss = max(Y, N) = ante/n stays funded for any target prob (an asymmetric
+// p=0.5 pool would blow up max(Y,N) at the extremes ⇒ discard shares or house
+// risk; see tasks/cpmm_multi_2 math TODO).
+describe('cpmm-multi-2 creation — independent ("Set") absolute probs', () => {
+  const independent = (
+    answers: string[],
+    initialProbs: number[],
+    ante = 1000
+  ) => makeMC(answers, initialProbs, ante, false).answers
+
+  it('sets per-answer p = absolute prob, NOT normalized', () => {
+    const ante = 900
+    const probs = [80, 30, 10] // sum 120 — must NOT be rescaled
+    const ans = independent(['A', 'B', 'C'], probs, ante)
+    const n = ans.length
+    const targets = [0.8, 0.3, 0.1]
+    ans.forEach((a, i) => {
+      expect(a.p).toBeCloseTo(targets[i], 10)
+      expect(a.prob).toBeCloseTo(targets[i], 10)
+      expect(a.poolYes).toBeCloseTo(ante / n, 8)
+      expect(a.poolNo).toBeCloseTo(ante / n, 8)
+    })
+    // Independent ⇒ probs need not (and here do not) sum to 1.
+    expect(sumProbs(ans)).toBeCloseTo(1.2, 8)
+  })
+
+  it('mechanism is cpmm-multi-2', () => {
+    const contract = makeMC(['A', 'B'], [40, 90], 1000, false)
+    expect(contract.mechanism).toBe('cpmm-multi-2')
+  })
+
+  it('Set absolute differs from the sum-to-one normalization for the same input', () => {
+    const input = [40, 20, 10]
+    const set = independent(['A', 'B', 'C'], input)
+    const s2o = makeMC(['A', 'B', 'C'], input, 1000, true).answers
+    // Set: absolute 0.40 / 0.20 / 0.10
+    expect(set.map((a) => a.p)).toEqual([
+      expect.closeTo(0.4, 10),
+      expect.closeTo(0.2, 10),
+      expect.closeTo(0.1, 10),
+    ])
+    // sum-to-one: normalized 4/7 / 2/7 / 1/7
+    expect(s2o.map((a) => a.p)).toEqual([
+      expect.closeTo(4 / 7, 10),
+      expect.closeTo(2 / 7, 10),
+      expect.closeTo(1 / 7, 10),
+    ])
+  })
+
+  it('funding invariant: max(Y, N) = ante/n even at extreme probs (no house risk, no discard)', () => {
+    const ante = 1000
+    const ans = independent(['Long', 'Mid', 'Fav'], [1, 50, 99], ante)
+    const n = ans.length
+    ans.forEach((a) => {
+      // balanced ⇒ max(Y, N) = ante/n regardless of how extreme the prob is
+      expect(Math.max(a.poolYes, a.poolNo)).toBeCloseTo(ante / n, 8)
+      // all of the funded ante lands as liquidity — nothing discarded
+      expect(a.totalLiquidity).toBeCloseTo(ante / n, 8)
+    })
+  })
+
+  it('regression: Set with no initialProbs ⇒ v1 cpmm-multi-1, each answer 50%', () => {
+    const ante = 1000
+    const contract = makeMC(['A', 'B', 'C'], undefined, ante, false)
+    expect(contract.mechanism).toBe('cpmm-multi-1')
+    const n = contract.answers.length
+    contract.answers.forEach((a) => {
+      expect(a.prob).toBeCloseTo(0.5, 10)
+      expect(a.p).toBe(0.5)
+      expect(a.poolYes).toBeCloseTo(ante / n, 8)
+      expect(a.poolNo).toBeCloseTo(ante / n, 8)
     })
   })
 })

--- a/common/src/cpmm-multi-2-creation.test.ts
+++ b/common/src/cpmm-multi-2-creation.test.ts
@@ -1,0 +1,176 @@
+import { sumBy } from 'lodash'
+import { Answer } from './answer'
+import { getCpmmProbability } from './calculate-cpmm'
+import { calculateCpmmMultiArbitrageYesBets } from './calculate-cpmm-arbitrage'
+import { CPMMMulti } from './contract'
+import { noFees } from './fees'
+import { getNewContract } from './new-contract'
+import { User } from './user'
+
+// cpmm-multi-2 (PR2c) — creation path: per-answer `initialProbs` produce a
+// `cpmm-multi-2` market whose every answer's `p` is its (normalized) target
+// prob, on balanced deep pools (Y = N), with the same ante budget v1 uses.
+// Verified at jest level (no running dev instance): the created answers are
+// then fed straight into the v2 multi-buy arb to confirm they trade and hold
+// Σp = 1.
+
+const creator = {
+  id: 'creator1',
+  name: 'Creator',
+  username: 'creator',
+  avatarUrl: '',
+  createdTime: 0,
+} as User
+
+const makeMC = (
+  answers: string[],
+  initialProbs: number[] | undefined,
+  ante = 1000
+): CPMMMulti =>
+  getNewContract({
+    id: 'contract1',
+    slug: 'contract1',
+    creator,
+    question: 'Q?',
+    outcomeType: 'MULTIPLE_CHOICE',
+    description: '' as any,
+    initialProb: 50,
+    ante,
+    closeTime: Date.now() + 1e9,
+    visibility: 'public',
+    isTwitchContract: undefined,
+    min: 0,
+    max: 0,
+    isLogScale: false,
+    answers,
+    addAnswersMode: 'DISABLED',
+    shouldAnswersSumToOne: true,
+    initialProbs,
+    token: 'MANA',
+    coverImageUrl: undefined,
+    siblingContractId: undefined,
+    takerAPIOrdersDisabled: undefined,
+    isAutoBounty: undefined,
+    unit: '',
+    midpoints: undefined,
+    timezone: undefined,
+    voterVisibility: undefined,
+    pollType: undefined,
+    maxSelections: undefined,
+  } as any) as CPMMMulti
+
+const sumProbs = (answers: Answer[]) =>
+  sumBy(answers, (a) => getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p))
+
+describe('cpmm-multi-2 creation — per-answer initialProbs', () => {
+  it('sets mechanism cpmm-multi-2 and per-answer p = normalized target prob', () => {
+    const ante = 1200
+    const contract = makeMC(['A', 'B', 'C'], [60, 30, 10], ante)
+    expect(contract.mechanism).toBe('cpmm-multi-2')
+
+    const targets = [0.6, 0.3, 0.1]
+    const n = contract.answers.length
+    contract.answers.forEach((a, i) => {
+      // balanced deep pools: Y = N = ante / n
+      expect(a.poolYes).toBeCloseTo(ante / n, 8)
+      expect(a.poolNo).toBeCloseTo(ante / n, 8)
+      // p_i = target, and (because Y = N) displayed prob = p_i exactly (GP6a)
+      expect(a.p).toBeCloseTo(targets[i], 10)
+      expect(a.prob).toBeCloseTo(targets[i], 10)
+      expect(getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)).toBeCloseTo(
+        targets[i],
+        10
+      )
+    })
+
+    // Σ prob = 1 exactly.
+    expect(sumProbs(contract.answers)).toBeCloseTo(1, 10)
+
+    // Ante budget: when any answer wins, payout = poolYes_i + Σ_{j≠i} poolNo_j,
+    // which equals the ante for every i (the same budget v1 uses).
+    contract.answers.forEach((a, i) => {
+      const payout =
+        a.poolYes +
+        sumBy(
+          contract.answers.filter((_, j) => j !== i),
+          (o) => o.poolNo
+        )
+      expect(payout).toBeCloseTo(ante, 6)
+    })
+  })
+
+  it('normalizes initialProbs that do not sum to 100', () => {
+    const a = makeMC(['A', 'B', 'C'], [6, 3, 1]).answers
+    const b = makeMC(['A', 'B', 'C'], [60, 30, 10]).answers
+    a.forEach((ans, i) => expect(ans.p).toBeCloseTo(b[i].p, 12))
+    expect(sumProbs(a)).toBeCloseTo(1, 10)
+  })
+
+  it('supports two-answer (versus-style) custom probs', () => {
+    const contract = makeMC(['Yes', 'No'], [70, 30])
+    expect(contract.mechanism).toBe('cpmm-multi-2')
+    expect(contract.answers[0].p).toBeCloseTo(0.7, 10)
+    expect(contract.answers[1].p).toBeCloseTo(0.3, 10)
+    expect(sumProbs(contract.answers)).toBeCloseTo(1, 10)
+  })
+
+  it('regression: no initialProbs ⇒ frozen v1 cpmm-multi-1, uniform 1/n', () => {
+    const ante = 1000
+    const contract = makeMC(['A', 'B', 'C', 'D'], undefined, ante)
+    expect(contract.mechanism).toBe('cpmm-multi-1')
+    const n = contract.answers.length
+    contract.answers.forEach((a) => {
+      expect(a.prob).toBeCloseTo(1 / n, 10)
+      expect(a.p).toBe(0.5)
+      // v1 ante-maximizing pools
+      expect(a.poolYes).toBeCloseTo(ante / 2, 8)
+      expect(a.poolNo).toBeCloseTo(ante / (2 * n - 2), 8)
+    })
+  })
+})
+
+describe('cpmm-multi-2 created market — trades under the v2 arb (Σp = 1 held)', () => {
+  const finalProbs = (
+    res: ReturnType<typeof calculateCpmmMultiArbitrageYesBets>
+  ) => {
+    const all = [...res.newBetResults, ...res.otherBetResults]
+    return sumBy(all, (r) => getCpmmProbability(r.cpmmState.pool, r.cpmmState.p))
+  }
+
+  it('single-answer YES buy on a v2 market keeps Σp = 1', () => {
+    const answers = makeMC(['A', 'B', 'C'], [60, 30, 10]).answers
+    const res = calculateCpmmMultiArbitrageYesBets(
+      answers,
+      [answers[0]],
+      50,
+      undefined,
+      [],
+      { creator1: 100000 },
+      noFees,
+      'cpmm-multi-2'
+    )
+    expect(finalProbs(res)).toBeCloseTo(1, 8)
+    // YES buy on answer A moves its price up.
+    const a = res.newBetResults.find((r) => r.answer.id === answers[0].id)!
+    expect(getCpmmProbability(a.cpmmState.pool, a.cpmmState.p)).toBeGreaterThan(0.6)
+  })
+
+  it('multi-answer basket YES buy on a v2 market keeps Σp = 1 and spends the budget', () => {
+    const answers = makeMC(['A', 'B', 'C', 'D'], [40, 30, 20, 10]).answers
+    const bet = 80
+    const res = calculateCpmmMultiArbitrageYesBets(
+      answers,
+      [answers[0], answers[1]],
+      bet,
+      undefined,
+      [],
+      { creator1: 100000 },
+      noFees,
+      'cpmm-multi-2'
+    )
+    expect(finalProbs(res)).toBeCloseTo(1, 6)
+    // net taker spend across the basket equals the budget (no overshoot churn).
+    const spent = sumBy(res.newBetResults, (r) => sumBy(r.takers, 'amount'))
+    expect(spent).toBeCloseTo(bet, 4)
+  })
+})

--- a/common/src/cpmm-multi-2-creation.test.ts
+++ b/common/src/cpmm-multi-2-creation.test.ts
@@ -8,11 +8,13 @@ import { getNewContract } from './new-contract'
 import { User } from './user'
 
 // cpmm-multi-2 (PR2c) — creation path: per-answer `initialProbs` produce a
-// `cpmm-multi-2` market whose every answer's `p` is its (normalized) target
-// prob, on balanced deep pools (Y = N), with the same ante budget v1 uses.
-// Verified at jest level (no running dev instance): the created answers are
-// then fed straight into the v2 multi-buy arb to confirm they trade and hold
-// Σp = 1.
+// `cpmm-multi-2` market at the requested probabilities, with the same ante budget
+// v1 uses (no house risk). Sum-to-one markets use the √variance creation rule
+// (pool depth W_i ∝ √(q_i(1-q_i)); reduces to v1 exactly at uniform, balanced only
+// at n=2; see tasks/cpmm_multi_2/creation-liquidity-findings.md, GP13-GP15).
+// Independent ("Set") markets stay balanced (= binary CPMM, optimal per-answer).
+// Verified at jest level (no running dev instance): the created answers are then
+// fed straight into the v2 multi-buy arb to confirm they trade and hold Σp = 1.
 
 const creator = {
   id: 'creator1',
@@ -63,37 +65,94 @@ const makeMC = (
 const sumProbs = (answers: Answer[]) =>
   sumBy(answers, (a) => getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p))
 
+// Point liquidity a = dprob/dshares = q(1-q)/W, W = (1-p)Y + pN (GP13). Lower =
+// more liquid. W is the per-answer depth the √variance rule allocates.
+const depthW = (a: Answer) => (1 - a.p) * a.poolYes + a.p * a.poolNo
+const pointLiq = (a: Answer) => {
+  const q = getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+  return (q * (1 - q)) / depthW(a)
+}
+
 describe('cpmm-multi-2 creation — per-answer initialProbs', () => {
-  it('sets mechanism cpmm-multi-2 and per-answer p = normalized target prob', () => {
+  it('cpmm-multi-2 mechanism; prob_i = normalized target; funds exactly (no house risk)', () => {
     const ante = 1200
     const contract = makeMC(['A', 'B', 'C'], [60, 30, 10], ante)
     expect(contract.mechanism).toBe('cpmm-multi-2')
 
     const targets = [0.6, 0.3, 0.1]
-    const n = contract.answers.length
     contract.answers.forEach((a, i) => {
-      // balanced deep pools: Y = N = ante / n
-      expect(a.poolYes).toBeCloseTo(ante / n, 8)
-      expect(a.poolNo).toBeCloseTo(ante / n, 8)
-      // p_i = target, and (because Y = N) displayed prob = p_i exactly (GP6a)
-      expect(a.p).toBeCloseTo(targets[i], 10)
-      expect(a.prob).toBeCloseTo(targets[i], 10)
+      // The displayed prob is exact regardless of pool shape: p carries the
+      // target, so getCpmmProbability(pool, p) == target even when Y != N.
       expect(getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)).toBeCloseTo(
         targets[i],
         10
       )
+      expect(a.prob).toBeCloseTo(targets[i], 10)
     })
 
     // Σ prob = 1 exactly.
     expect(sumProbs(contract.answers)).toBeCloseTo(1, 10)
 
-    // Ante budget: when any answer wins, payout = poolYes_i + Σ_{j≠i} poolNo_j,
-    // which equals the ante for every i (the same budget v1 uses).
+    // No house risk: when any answer wins, payout = poolYes_i + Σ_{j≠i} poolNo_j,
+    // which equals the ante for every i (all-winners-tight; the same budget v1 uses).
     contract.answers.forEach((a, i) => {
       const payout =
         a.poolYes +
         sumBy(
           contract.answers.filter((_, j) => j !== i),
+          (o) => o.poolNo
+        )
+      expect(payout).toBeCloseTo(ante, 6)
+    })
+  })
+
+  it('uniform sum-to-one initialProbs reduce to v1 pools exactly', () => {
+    // Equal targets ⇒ the √variance rule coincides with v1's construction.
+    const ante = 1000
+    const contract = makeMC(['A', 'B', 'C'], [1, 1, 1], ante)
+    expect(contract.mechanism).toBe('cpmm-multi-2')
+    const n = contract.answers.length
+    contract.answers.forEach((a) => {
+      expect(a.poolYes).toBeCloseTo(ante / 2, 6)
+      expect(a.poolNo).toBeCloseTo(ante / (2 * n - 2), 6)
+      expect(a.p).toBeCloseTo(0.5, 8)
+      expect(getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)).toBeCloseTo(
+        1 / n,
+        10
+      )
+    })
+  })
+
+  it('skewed sum-to-one is asymmetric and more liquid than balanced', () => {
+    const ante = 1000
+    const contract = makeMC(['A', 'B', 'C'], [60, 25, 15], ante)
+    const ans = contract.answers
+    const n = ans.length
+
+    // Not the balanced pool: the √variance shape is asymmetric for n>=3 skew.
+    expect(Math.abs(ans[0].poolYes - ans[0].poolNo)).toBeGreaterThan(1)
+
+    // More liquid: total point-liquidity beats the balanced construction (W=ante/n)
+    // at the same probabilities (lower Σ a_i = more liquid).
+    const L = ante / n
+    const sqrtVarSum = sumBy(ans, pointLiq)
+    const balancedSum = sumBy(ans, (a) => {
+      const q = getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+      return (q * (1 - q)) / L
+    })
+    expect(sqrtVarSum).toBeLessThan(balancedSum)
+
+    // Depth follows √variance: higher-variance (mid-prob) answers are deeper.
+    // q = [0.6, 0.25, 0.15] ⇒ variance order A > B > C.
+    expect(depthW(ans[0])).toBeGreaterThan(depthW(ans[1]))
+    expect(depthW(ans[1])).toBeGreaterThan(depthW(ans[2]))
+
+    // Still funds exactly (no house risk).
+    ans.forEach((a, i) => {
+      const payout =
+        a.poolYes +
+        sumBy(
+          ans.filter((_, j) => j !== i),
           (o) => o.poolNo
         )
       expect(payout).toBeCloseTo(ante, 6)
@@ -168,14 +227,18 @@ describe('cpmm-multi-2 creation — independent ("Set") absolute probs', () => {
     const input = [40, 20, 10]
     const set = independent(['A', 'B', 'C'], input)
     const s2o = makeMC(['A', 'B', 'C'], input, 1000, true).answers
-    // Set: absolute 0.40 / 0.20 / 0.10
-    expect(set.map((a) => a.p)).toEqual([
+    // Compare the displayed probs: under √variance the sum-to-one `p` field
+    // carries the skew (p ≠ prob), so compare getCpmmProbability, not raw `p`.
+    const probOf = (a: Answer) =>
+      getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+    // Set: absolute 0.40 / 0.20 / 0.10 (balanced ⇒ prob = p).
+    expect(set.map(probOf)).toEqual([
       expect.closeTo(0.4, 10),
       expect.closeTo(0.2, 10),
       expect.closeTo(0.1, 10),
     ])
-    // sum-to-one: normalized 4/7 / 2/7 / 1/7
-    expect(s2o.map((a) => a.p)).toEqual([
+    // sum-to-one: normalized 4/7 / 2/7 / 1/7 (carried by the √variance pools).
+    expect(s2o.map(probOf)).toEqual([
       expect.closeTo(4 / 7, 10),
       expect.closeTo(2 / 7, 10),
       expect.closeTo(1 / 7, 10),

--- a/common/src/cpmm-multi-2-sanity-guards.test.ts
+++ b/common/src/cpmm-multi-2-sanity-guards.test.ts
@@ -1,0 +1,175 @@
+import { range } from 'lodash'
+import {
+  addCpmmMultiLiquidityAnswersSumToOneV2,
+  cpmmMulti2SumToOneFeasible,
+  cpmmMulti2SumToOnePools,
+  getCpmmProbability,
+} from './calculate-cpmm'
+
+// GP19a/GP19c runtime guards (proofs/sanity_closure.py; found by external review of
+// PR #3934: the √variance creation construction is not total — skewed many-answer
+// prob vectors produce poolYes < 0 and p ∉ (0,1)).
+//
+// Boundary calibration (GP19a, rest-uniform dominant family):
+//   n ≤ 20  feasible for ALL q; boundary first appears at n = 21
+//   n = 30  q_max ≈ 0.586;  n = 50  q_max ≈ 0.323;  n = 100  q_max ≈ 0.157
+// Two-big-answers family breaks at combined mass ≈ 0.851 (n=10), 0.445 (n=30).
+// Geometric decay breaks at n = 10 already for ratio r < 0.563.
+
+const dominant = (n: number, qMax: number) => [
+  qMax,
+  ...range(n - 1).map(() => (1 - qMax) / (n - 1)),
+]
+
+const twoBig = (n: number, combined: number) => [
+  combined / 2,
+  combined / 2,
+  ...range(n - 2).map(() => (1 - combined) / (n - 2)),
+]
+
+const geometric = (n: number, r: number) => {
+  const raw = range(n).map((i) => Math.pow(r, i))
+  const total = raw.reduce((s, x) => s + x, 0)
+  return raw.map((x) => x / total)
+}
+
+const sane = (x: { poolYes: number; poolNo: number; p: number }) =>
+  x.poolYes > 0 && x.poolNo > 0 && x.p > 0 && x.p < 1
+
+describe('cpmmMulti2SumToOneFeasible (GP19a)', () => {
+  it('accepts every dominant-prob vector for n ≤ 20', () => {
+    for (const n of [3, 5, 10, 15, 20]) {
+      for (const qMax of [0.05, 0.3, 0.5, 0.7, 0.9, 0.97]) {
+        expect(cpmmMulti2SumToOneFeasible(dominant(n, qMax))).toBe(true)
+      }
+    }
+  })
+
+  it('rejects the review repro: n = 30, 0.90 dominant', () => {
+    expect(cpmmMulti2SumToOneFeasible(dominant(30, 0.9))).toBe(false)
+  })
+
+  it('tracks the n = 30 boundary (q_max ≈ 0.586)', () => {
+    expect(cpmmMulti2SumToOneFeasible(dominant(30, 0.55))).toBe(true)
+    expect(cpmmMulti2SumToOneFeasible(dominant(30, 0.62))).toBe(false)
+  })
+
+  it('tracks the n = 100 boundary (q_max ≈ 0.157)', () => {
+    expect(cpmmMulti2SumToOneFeasible(dominant(100, 0.13))).toBe(true)
+    expect(cpmmMulti2SumToOneFeasible(dominant(100, 0.19))).toBe(false)
+  })
+
+  it('tracks the two-big-answers family (n = 10 breaks near combined 0.851)', () => {
+    expect(cpmmMulti2SumToOneFeasible(twoBig(10, 0.8))).toBe(true)
+    expect(cpmmMulti2SumToOneFeasible(twoBig(10, 0.9))).toBe(false)
+  })
+
+  it('tracks geometric decay (n = 10 breaks for r < 0.563)', () => {
+    expect(cpmmMulti2SumToOneFeasible(geometric(10, 0.6))).toBe(true)
+    expect(cpmmMulti2SumToOneFeasible(geometric(10, 0.5))).toBe(false)
+  })
+
+  it('agrees with direct construction sanity across a grid (the exact test)', () => {
+    // The helper IS "construct at ante 1 and check" — this pins the equivalence at
+    // production ante and asserts feasible vectors construct sane at scale.
+    for (const n of [21, 30, 50]) {
+      for (const qMax of [0.1, 0.3, 0.5, 0.7, 0.9]) {
+        const q = dominant(n, qMax)
+        const feasible = cpmmMulti2SumToOneFeasible(q)
+        const pools = cpmmMulti2SumToOnePools(q, 1000)
+        expect(pools.every(sane)).toBe(feasible)
+      }
+    }
+  })
+})
+
+describe('addCpmmMultiLiquidityAnswersSumToOneV2 guard (GP19c)', () => {
+  // A sane TRADED market sitting at creation-infeasible probs: build it directly
+  // (balanced pools at p = q read prob = q for any q — sane for every vector).
+  const stateAt = (q: number[], scale = 100) =>
+    Object.fromEntries(
+      q.map((qi, i) => [
+        `a${i}`,
+        { pool: { YES: scale, NO: scale }, p: qi },
+      ])
+    )
+
+  const checkSaneAndProbPreserving = (
+    q: number[],
+    amount: number
+  ) => {
+    const pools = stateAt(q)
+    const result = addCpmmMultiLiquidityAnswersSumToOneV2(pools, amount)
+    const ids = Object.keys(pools)
+    let probSum = 0
+    for (const [i, id] of ids.entries()) {
+      const { pool, p } = result[id]
+      expect(pool.YES).toBeGreaterThan(0)
+      expect(pool.NO).toBeGreaterThan(0)
+      expect(p).toBeGreaterThan(0)
+      expect(p).toBeLessThan(1)
+      const prob = getCpmmProbability(pool, p)
+      expect(prob).toBeCloseTo(q[i], 9) // lossless: every prob preserved
+      probSum += prob
+      expect(result[id].liquidity).toBeGreaterThan(0)
+    }
+    expect(probSum).toBeCloseTo(1, 9)
+  }
+
+  it('merge path (feasible q): sane, prob-preserving, √variance-shaped', () => {
+    const q = dominant(10, 0.5)
+    checkSaneAndProbPreserving(q, 500)
+    // Deltas match the creation shape at current probs (the un-guarded merge).
+    const pools = stateAt(q)
+    const result = addCpmmMultiLiquidityAnswersSumToOneV2(pools, 500)
+    const delta = cpmmMulti2SumToOnePools(q, 500)
+    Object.keys(pools).forEach((id, i) => {
+      expect(result[id].pool.YES).toBeCloseTo(100 + delta[i].poolYes, 9)
+      expect(result[id].pool.NO).toBeCloseTo(100 + delta[i].poolNo, 9)
+    })
+  })
+
+  it('infeasible q + large add stays sane and prob-preserving (fallback engages)', () => {
+    // n = 30, 0.90 dominant: creation-infeasible, so a large enough merge would drive
+    // merged poolYes < 0. The guard must keep every pool sane with probs preserved.
+    checkSaneAndProbPreserving(dominant(30, 0.9), 100_000)
+  })
+
+  it('infeasible q survives an accumulating drizzle (many small adds)', () => {
+    // GP19c(iii): dripping does not evade the A* bound — each tick re-guards.
+    const q = dominant(30, 0.9)
+    let pools = stateAt(q)
+    for (let tick = 0; tick < 50; tick++) {
+      const result = addCpmmMultiLiquidityAnswersSumToOneV2(pools, 1000)
+      pools = Object.fromEntries(
+        Object.keys(pools).map((id) => [
+          id,
+          { pool: result[id].pool, p: result[id].p },
+        ])
+      )
+    }
+    Object.values(pools).forEach(({ pool, p }) => {
+      expect(pool.YES).toBeGreaterThan(0)
+      expect(pool.NO).toBeGreaterThan(0)
+      expect(p).toBeGreaterThan(0)
+      expect(p).toBeLessThan(1)
+    })
+    const probSum = Object.keys(pools)
+      .map((id) => getCpmmProbability(pools[id].pool, pools[id].p))
+      .reduce((s, x) => s + x, 0)
+    expect(probSum).toBeCloseTo(1, 9)
+  })
+
+  it('small add below A* on infeasible q still uses the merge (no premature fallback)', () => {
+    // At infeasible q the merge is still sane for small totals (A* > 0); the guard
+    // must not fall back until the merge itself would go insane.
+    const q = dominant(30, 0.9)
+    const pools = stateAt(q, 10_000) // deep pools => large A*
+    const result = addCpmmMultiLiquidityAnswersSumToOneV2(pools, 10)
+    const delta = cpmmMulti2SumToOnePools(q, 10)
+    Object.keys(pools).forEach((id, i) => {
+      expect(result[id].pool.YES).toBeCloseTo(10_000 + delta[i].poolYes, 6)
+      expect(result[id].pool.NO).toBeCloseTo(10_000 + delta[i].poolNo, 6)
+    })
+  })
+})

--- a/common/src/cpmm-perf-bench.test.ts
+++ b/common/src/cpmm-perf-bench.test.ts
@@ -1,0 +1,274 @@
+// Performance benchmark for cpmm-multi-2 reviewer question:
+//   "Did you do any performance testing with this yet?"
+//
+// Measures:
+//   1. calculateCpmmAmountToBuySharesFixedP: p=0.5 closed form vs general-p 50-iter bisection
+//   2. Full multi-buy solve: v1 (calculateCpmmMultiArbitrageBetsYes, via public
+//      calculateCpmmMultiArbitrageYesBets) vs v2 (Approach C), n=10 answers,
+//      2-answer basket, M$100, with and without resting limit orders
+//   3. Scaling spot-check at n=50 answers
+//
+// Run with:  cd common && BENCH=1 npx jest cpmm-perf-bench --silent=false
+// Skipped (describe.skip) in normal test runs so it doesn't slow the suite.
+
+import { Answer } from './answer'
+import { LimitBet } from './bet'
+import { calculateCpmmAmountToBuySharesFixedP, CpmmState } from './calculate-cpmm'
+import { calculateCpmmMultiArbitrageYesBets } from './calculate-cpmm-arbitrage'
+import { noFees } from './fees'
+
+// ---------------------------------------------------------------- fixtures
+
+// p = 0.5 answer with pool product k = 100 at the given prob (mirrors
+// getAnswer in calculate-cpmm-arbitrage.test.ts)
+const getAnswer = (index: number, prob: number): Answer => {
+  const k = 100
+  const poolYes = Math.sqrt((k * (1 - prob)) / prob)
+  const poolNo = k / poolYes
+  return {
+    id: `answer${index}`,
+    contractId: `contract`,
+    userId: `user${index}`,
+    text: `Answer ${index}`,
+    createdTime: 0,
+    index,
+    prob,
+    poolYes,
+    poolNo,
+    p: 0.5,
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer
+}
+
+// general-p answer: balanced pools (Y = N = L) so prob = p (mirrors
+// getAnswerWithP in calculate-cpmm-arbitrage.test.ts)
+const getAnswerWithP = (index: number, p: number, L = 100): Answer =>
+  ({
+    id: `answer${index}`,
+    contractId: `contract`,
+    userId: `user${index}`,
+    text: `Answer ${index}`,
+    createdTime: 0,
+    index,
+    prob: p,
+    poolYes: L,
+    poolNo: L,
+    p,
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer)
+
+const getLimitBet = (
+  id: string,
+  answer: Answer,
+  outcome: 'YES' | 'NO',
+  userId: string,
+  orderAmount: number,
+  limitProb: number
+): LimitBet => ({
+  id,
+  userId,
+  contractId: answer.contractId,
+  answerId: answer.id,
+  createdTime: 0,
+  amount: 0,
+  loanAmount: 0,
+  outcome,
+  shares: 0,
+  probBefore: answer.prob,
+  probAfter: answer.prob,
+  fees: noFees,
+  isRedemption: false,
+  orderAmount,
+  limitProb,
+  isFilled: false,
+  isCancelled: false,
+  fills: [],
+})
+
+// ---------------------------------------------------------------- harness
+
+const quantile = (sorted: number[], q: number) =>
+  sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]
+
+/**
+ * Time fn with auto-calibrated batch size: aim for ~30ms per sample and a
+ * ~8s total budget per row (the multi-buy solves range from µs to 100s of ms
+ * per call, so fixed iteration counts don't work).
+ * Returns per-call median and p95 (across samples) in nanoseconds.
+ */
+function bench(fn: () => unknown) {
+  // warmup (JIT) + calibration
+  fn()
+  fn()
+  const c0 = process.hrtime.bigint()
+  fn()
+  const perCallEst = Math.max(1, Number(process.hrtime.bigint() - c0))
+  const targetSampleNs = 30e6 // ~30ms per sample
+  const budgetNs = 8e9 // ~8s per row
+  const batch = Math.max(1, Math.round(targetSampleNs / perCallEst))
+  const samples = Math.min(
+    30,
+    Math.max(5, Math.floor(budgetNs / (batch * perCallEst)))
+  )
+  const perCall: number[] = []
+  let sink: unknown
+  for (let s = 0; s < samples; s++) {
+    const t0 = process.hrtime.bigint()
+    for (let i = 0; i < batch; i++) sink = fn()
+    const t1 = process.hrtime.bigint()
+    perCall.push(Number(t1 - t0) / batch)
+  }
+  void sink
+  perCall.sort((a, b) => a - b)
+  return { median: quantile(perCall, 0.5), p95: quantile(perCall, 0.95) }
+}
+
+const fmt = (ns: number) =>
+  ns < 10_000
+    ? `${ns.toFixed(0)} ns`
+    : ns < 10_000_000
+    ? `${(ns / 1000).toFixed(1)} µs`
+    : `${(ns / 1e6).toFixed(2)} ms`
+
+const row = (label: string, r: { median: number; p95: number }) =>
+  console.log(
+    `${label.padEnd(58)} median ${fmt(r.median).padStart(10)}   p95 ${fmt(
+      r.p95
+    ).padStart(10)}`
+  )
+
+// ---------------------------------------------------------------- benches
+
+const d = process.env.BENCH ? describe : describe.skip
+
+d('cpmm perf bench', () => {
+  jest.setTimeout(600_000)
+
+  it('1. single-leg calculateCpmmAmountToBuySharesFixedP', () => {
+    const closedForm: CpmmState = {
+      pool: { YES: 120, NO: 90 },
+      p: 0.5,
+      collectedFees: noFees,
+    }
+    const generalP: CpmmState = {
+      pool: { YES: 120, NO: 90 },
+      p: 0.3,
+      collectedFees: noFees,
+    }
+    console.log('\n--- 1. single-leg shares->cost inversion ---')
+    row(
+      'p=0.5 closed form, buy 50 shares',
+      bench(() => calculateCpmmAmountToBuySharesFixedP(closedForm, 50, 'YES'))
+    )
+    row(
+      'p=0.3 bisection (50 iter), buy 50 shares',
+      bench(() => calculateCpmmAmountToBuySharesFixedP(generalP, 50, 'YES'))
+    )
+    row(
+      'p=0.3 bisection (50 iter), sell 50 shares',
+      bench(() => calculateCpmmAmountToBuySharesFixedP(generalP, -50, 'YES'))
+    )
+  })
+
+  const runMulti = (
+    answers: Answer[],
+    basketSize: number,
+    unfilled: LimitBet[],
+    version: 'cpmm-multi-1' | 'cpmm-multi-2'
+  ) => {
+    // clone mutables per call so every iteration sees fresh state
+    const bets = unfilled.map((b) => ({ ...b, fills: [] }))
+    return calculateCpmmMultiArbitrageYesBets(
+      answers,
+      answers.slice(0, basketSize),
+      100, // M$100
+      undefined,
+      bets,
+      { maker: 100_000 },
+      noFees,
+      version
+    )
+  }
+
+  it('2. multi-buy solve, n=10, 2-answer basket, M$100', () => {
+    const n = 10
+    const answersHalf = Array.from({ length: n }, (_, i) => getAnswer(i, 1 / n))
+    const answersGenP = Array.from({ length: n }, (_, i) =>
+      getAnswerWithP(i, 1 / n)
+    )
+    // ~5 resting limit orders on various answers: 2 YES just above current prob
+    // on basket answers (crossed as basket prices rise), 3 YES just below
+    // current prob on non-basket answers (crossed as arb pushes them down)
+    const mkLimits = (answers: Answer[]) => [
+      getLimitBet('l1', answers[0], 'YES', 'maker', 20, 0.13),
+      getLimitBet('l2', answers[1], 'YES', 'maker', 20, 0.14),
+      getLimitBet('l3', answers[3], 'YES', 'maker', 15, 0.09),
+      getLimitBet('l4', answers[5], 'YES', 'maker', 15, 0.085),
+      getLimitBet('l5', answers[7], 'YES', 'maker', 15, 0.095),
+    ]
+
+    // sanity: confirm the limit orders actually get consulted/filled
+    for (const version of ['cpmm-multi-1', 'cpmm-multi-2'] as const) {
+      const r = runMulti(answersHalf, 2, mkLimits(answersHalf), version)
+      const makers =
+        r.newBetResults.flatMap((b) => b.makers).length +
+        r.otherBetResults.flatMap((b) => b.makers).length
+      console.log(`sanity ${version}: maker fills with limits = ${makers}`)
+      expect(makers).toBeGreaterThan(0)
+    }
+
+    console.log('\n--- 2. multi-buy solve, n=10, basket=2, M$100 ---')
+    row(
+      'v1, p=0.5, no limit orders',
+      bench(() => runMulti(answersHalf, 2, [], 'cpmm-multi-1'))
+    )
+    row(
+      'v2, p=0.5, no limit orders',
+      bench(() => runMulti(answersHalf, 2, [], 'cpmm-multi-2'))
+    )
+    row(
+      'v2, general per-answer p, no limit orders',
+      bench(() => runMulti(answersGenP, 2, [], 'cpmm-multi-2'))
+    )
+    row(
+      'v1, p=0.5, 5 resting limit orders',
+      bench(() => runMulti(answersHalf, 2, mkLimits(answersHalf), 'cpmm-multi-1'))
+    )
+    row(
+      'v2, p=0.5, 5 resting limit orders',
+      bench(() => runMulti(answersHalf, 2, mkLimits(answersHalf), 'cpmm-multi-2'))
+    )
+    row(
+      'v2, general per-answer p, 5 resting limit orders',
+      bench(() => runMulti(answersGenP, 2, mkLimits(answersGenP), 'cpmm-multi-2'))
+    )
+  })
+
+  it('3. scaling spot-check, n=50, 2-answer basket, M$100, no limits', () => {
+    const n = 50
+    const answersHalf = Array.from({ length: n }, (_, i) => getAnswer(i, 1 / n))
+    const answersGenP = Array.from({ length: n }, (_, i) =>
+      getAnswerWithP(i, 1 / n)
+    )
+    console.log('\n--- 3. multi-buy solve, n=50, basket=2, M$100, no limits ---')
+    row(
+      'v1, p=0.5',
+      bench(() => runMulti(answersHalf, 2, [], 'cpmm-multi-1'))
+    )
+    row(
+      'v2, p=0.5',
+      bench(() => runMulti(answersHalf, 2, [], 'cpmm-multi-2'))
+    )
+    row(
+      'v2, general per-answer p',
+      bench(() => runMulti(answersGenP, 2, [], 'cpmm-multi-2'))
+    )
+    console.log(`\nnode ${process.version}`)
+  })
+})

--- a/common/src/cpmm-perf-bench.test.ts
+++ b/common/src/cpmm-perf-bench.test.ts
@@ -10,6 +10,13 @@
 //
 // Run with:  cd common && BENCH=1 npx jest cpmm-perf-bench --silent=false
 // Skipped (describe.skip) in normal test runs so it doesn't slow the suite.
+//
+// Headline (shallow-pool fixtures, single core): the v2 bisection itself is
+// negligible (~µs), but the full v2 multi-buy solve is ~7-10x v1 wall-clock
+// (~160ms at n=10, ~1-1.7s at n=50) — the cost is the per-probe computeFills
+// sweeps, not the outer search. A perf pass gates the creation flag flip, not
+// this PR (creation is kill-switched off). Kept in-tree (not in the evidence
+// repo) so the numbers stay reproducible against the code they measure.
 
 import { Answer } from './answer'
 import { LimitBet } from './bet'

--- a/common/src/net-g-monotonicity-probe.test.ts
+++ b/common/src/net-g-monotonicity-probe.test.ts
@@ -1,0 +1,855 @@
+// Adversarial probe of the cpmm-multi-2 v2 basket solve's bisection premise.
+//
+// calculateCpmmMultiArbitrageBetsYesV2 (calculate-cpmm-arbitrage.ts ~330-555) bisects on g
+// (equal YES shares per basket answer) assuming net(g) is strictly increasing. That is PROVEN
+// only at p = 1/2 with no limit orders (GP12a). Production runs general per-answer p WITH
+// resting limit orders. If net(g) plateaus or dips, binarySearch silently returns a wrong g
+// and the taker is mis-charged (realized cost != betAmount) with no error.
+//
+// Probes:
+//   0. Transcription validation: the internal evalG is transcribed here (with cited line
+//      numbers); we re-run the outer solve on the transcription and require it to reproduce
+//      the public calculateCpmmMultiArbitrageYesBets(arbVersion='cpmm-multi-2') output.
+//   1. Dense net(g) sampling at general p with resting limits, across a config grid.
+//   2. cost == betAmount invariant + sum-prob == 1 + pools > 0 via the public API,
+//      including whale bets on an ante-1000-scale market.
+//   3. Whale / feasibility-boundary behavior: residuals, bracket doublings, guard trips.
+//   x. Adversarial extra: a maker whose balance binds ACROSS two non-basket answers
+//      (the inner eta solve previews legs with per-leg balance copies but realizes them
+//      with a shared decremented balance -> preview != realization is a candidate bug).
+//
+// Run:
+//   cd /home/evand/predictions/vendor/manifold/common && \
+//     PROBE=1 npx jest net-g-monotonicity-probe --silent=false
+// Skipped (describe.skip) in normal test runs.
+
+import { Dictionary, groupBy, mapValues, sumBy } from 'lodash'
+import { Answer } from './answer'
+import { LimitBet, maker } from './bet'
+import {
+  calculateAmountToBuySharesFixedP,
+  computeFills,
+  getCpmmProbability,
+} from './calculate-cpmm'
+import { calculateCpmmMultiArbitrageYesBets } from './calculate-cpmm-arbitrage'
+import { Fees, noFees } from './fees'
+import { binarySearch } from './util/algos'
+
+// ---------------------------------------------------------------- fixtures
+// (copied from calculate-cpmm-arbitrage.test.ts / cpmm-perf-bench.test.ts)
+
+// p = 0.5 answer with pool product k = L^2 at the given prob
+const getAnswer = (index: number, prob: number, L = 10): Answer => {
+  const k = L * L
+  const poolYes = Math.sqrt((k * (1 - prob)) / prob)
+  const poolNo = k / poolYes
+  return {
+    id: `answer${index}`,
+    contractId: `contract`,
+    userId: `user${index}`,
+    text: `Answer ${index}`,
+    createdTime: 0,
+    index,
+    prob,
+    poolYes,
+    poolNo,
+    p: 0.5,
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer
+}
+
+// general-p answer: balanced pools (Y = N = L) so prob = p
+const getAnswerWithP = (index: number, p: number, L = 100): Answer =>
+  ({
+    id: `answer${index}`,
+    contractId: `contract`,
+    userId: `user${index}`,
+    text: `Answer ${index}`,
+    createdTime: 0,
+    index,
+    prob: p,
+    poolYes: L,
+    poolNo: L,
+    p,
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer)
+
+const getLimitBet = (
+  id: string,
+  answer: Answer,
+  outcome: 'YES' | 'NO',
+  userId: string,
+  orderAmount: number,
+  limitProb: number
+): LimitBet => ({
+  id,
+  userId,
+  contractId: answer.contractId,
+  answerId: answer.id,
+  createdTime: 0,
+  amount: 0,
+  loanAmount: 0,
+  outcome,
+  shares: 0,
+  probBefore: answer.prob,
+  probAfter: answer.prob,
+  fees: noFees,
+  isRedemption: false,
+  orderAmount,
+  limitProb,
+  isFilled: false,
+  isCancelled: false,
+  fills: [],
+})
+
+// clone mutables so repeated calls see fresh state
+const cloneBets = (bets: LimitBet[]) => bets.map((b) => ({ ...b, fills: [] }))
+
+// ------------------------------------------------- transcribed internals
+// applyMakersToWorkingState: transcribed from calculate-cpmm-arbitrage.ts lines 155-189
+// (not exported from production; transcribed rather than modifying production code).
+const applyMakersToWorkingStateT = (
+  makers: maker[],
+  ordersToCancel: LimitBet[],
+  workingUnfilledBetsByAnswer: Dictionary<LimitBet[]>,
+  workingBalanceByUserId: { [userId: string]: number }
+) => {
+  for (const maker of makers) {
+    const { bet, amount, shares } = maker
+    if (!bet.answerId) {
+      throw new Error('Multi-bet has no answerId')
+    }
+    if (amount > 0) {
+      const prev = workingBalanceByUserId[bet.userId]
+      if (prev !== undefined) workingBalanceByUserId[bet.userId] = prev - amount
+    }
+    const arr = workingUnfilledBetsByAnswer[bet.answerId] ?? []
+    const idx = arr.findIndex((b) => b.id === bet.id)
+    if (idx >= 0) {
+      const updated = { ...arr[idx] }
+      updated.amount = (updated.amount ?? 0) + amount
+      updated.shares = (updated.shares ?? 0) + shares
+      arr[idx] = updated
+      workingUnfilledBetsByAnswer[bet.answerId] = arr
+    }
+  }
+  if (ordersToCancel.length) {
+    const cancelIds = new Set(ordersToCancel.map((b) => b.id))
+    for (const [answerId, arr] of Object.entries(workingUnfilledBetsByAnswer)) {
+      workingUnfilledBetsByAnswer[answerId] = arr.filter(
+        (b) => !cancelIds.has(b.id)
+      )
+    }
+  }
+}
+
+// evalG + outer solve: transcribed from calculateCpmmMultiArbitrageBetsYesV2,
+// calculate-cpmm-arbitrage.ts lines 339-491 (evalG body: lines 347-470; outer bracket
+// doubling + bisection: lines 474-487). Verbatim logic; only instrumentation added.
+const makeSolver = (
+  initialAnswers: Answer[],
+  initialAnswersToBuy: Answer[],
+  limitProb: number | undefined,
+  unfilledBets: LimitBet[],
+  balanceByUserId: { [userId: string]: number },
+  collectedFees: Fees = noFees
+) => {
+  const unfilledBetsByAnswer = groupBy(unfilledBets, (b) => b.answerId)
+  const basketIds = new Set(initialAnswersToBuy.map((a) => a.id))
+  const others = initialAnswers.filter((a) => !basketIds.has(a.id))
+  const n = initialAnswers.length
+  const m = initialAnswersToBuy.length
+
+  // lines 347-470
+  const evalG = (g: number) => {
+    // line 349-352: fresh working snapshots per probe
+    const workingUnfilledBetsByAnswer = mapValues(
+      unfilledBetsByAnswer,
+      (bets) => [...bets]
+    )
+    const workingBalanceByUserId = { ...balanceByUserId }
+
+    // lines 354-385: basket YES legs, single rising sweep, limit-aware
+    let basketCost = 0
+    const yesBetResults = initialAnswersToBuy.map((answer) => {
+      const pool = { YES: answer.poolYes, NO: answer.poolNo }
+      const state = { pool, p: answer.p, collectedFees }
+      const yesAmount = calculateAmountToBuySharesFixedP(
+        state,
+        g,
+        'YES',
+        workingUnfilledBetsByAnswer[answer.id] ?? [],
+        workingBalanceByUserId
+      )
+      const result = {
+        ...computeFills(
+          state,
+          'YES',
+          yesAmount,
+          limitProb,
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId
+        ),
+        answer,
+      }
+      applyMakersToWorkingStateT(
+        result.makers,
+        result.ordersToCancel,
+        workingUnfilledBetsByAnswer,
+        workingBalanceByUserId
+      )
+      basketCost += sumBy(result.takers, 'amount')
+      return result
+    })
+    // lines 386-392
+    const basketSum = sumBy(yesBetResults, (r) =>
+      getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+    )
+    const target = 1 - basketSum
+    if (target <= 1e-9) {
+      return undefined
+    }
+
+    // lines 394-427: inner eta solve (read-only preview per eta)
+    const othersSumAtEta = (eta: number) =>
+      sumBy(others, (answer) => {
+        const pool = { YES: answer.poolYes, NO: answer.poolNo }
+        const state = { pool, p: answer.p, collectedFees }
+        const noAmount = calculateAmountToBuySharesFixedP(
+          state,
+          eta,
+          'NO',
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId,
+          true
+        )
+        const { cpmmState } = computeFills(
+          state,
+          'NO',
+          noAmount,
+          undefined,
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId,
+          undefined,
+          true
+        )
+        return getCpmmProbability(cpmmState.pool, cpmmState.p)
+      })
+
+    let eta = 0
+    let etaHi = 0
+    if (othersSumAtEta(0) > target) {
+      let hi = 1
+      while (othersSumAtEta(hi) > target && hi < 1e12) hi *= 2
+      etaHi = hi
+      eta = binarySearch(0, hi, (e) => target - othersSumAtEta(e))
+    }
+
+    // lines 429-463: realize the OTHER NO legs, applying maker fills
+    let othersCost = 0
+    const noBetResults = others.map((answer) => {
+      const pool = { YES: answer.poolYes, NO: answer.poolNo }
+      const state = { pool, p: answer.p, collectedFees }
+      const noAmount = calculateAmountToBuySharesFixedP(
+        state,
+        eta,
+        'NO',
+        workingUnfilledBetsByAnswer[answer.id] ?? [],
+        workingBalanceByUserId,
+        true
+      )
+      const result = {
+        ...computeFills(
+          state,
+          'NO',
+          noAmount,
+          undefined,
+          workingUnfilledBetsByAnswer[answer.id] ?? [],
+          workingBalanceByUserId,
+          undefined,
+          true
+        ),
+        answer,
+      }
+      applyMakersToWorkingStateT(
+        result.makers,
+        result.ordersToCancel,
+        workingUnfilledBetsByAnswer,
+        workingBalanceByUserId
+      )
+      othersCost += sumBy(result.takers, 'amount')
+      return result
+    })
+
+    // lines 465-469
+    const net = basketCost + othersCost - eta * (n - m - 1)
+    const realizedOthersSum = sumBy(noBetResults, (r) =>
+      getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+    )
+    return {
+      yesBetResults,
+      noBetResults,
+      eta,
+      etaHi,
+      net,
+      basketCost,
+      othersCost,
+      basketSum,
+      target,
+      realizedOthersSum,
+      finalSumProb: basketSum + realizedOthersSum,
+    }
+  }
+
+  // lines 474-487: outer bracket doubling + bisection (instrumented)
+  const solve = (betAmount: number) => {
+    let gHi = 1
+    let doublings = 0
+    while (true) {
+      const r = evalG(gHi)
+      if (!r || r.net >= betAmount) break
+      gHi *= 2
+      doublings++
+      if (gHi > 1e9) {
+        throw new Error('budget unreachable in cpmm-multi-2 YES basket solve')
+      }
+    }
+    const g = binarySearch(0, gHi, (gg) => {
+      const r = evalG(gg)
+      return r ? r.net - betAmount : 1
+    })
+    return { g, gHi, doublings, solved: evalG(g) }
+  }
+
+  return { evalG, solve, n, m, others }
+}
+
+// ---------------------------------------------------------------- helpers
+
+const publicV2 = (
+  answers: Answer[],
+  basket: Answer[],
+  betAmount: number,
+  unfilled: LimitBet[],
+  balances: { [userId: string]: number }
+) =>
+  calculateCpmmMultiArbitrageYesBets(
+    answers,
+    basket,
+    betAmount,
+    undefined,
+    cloneBets(unfilled),
+    { ...balances },
+    noFees,
+    'cpmm-multi-2'
+  )
+
+type PublicResult = ReturnType<typeof publicV2>
+
+const totalTakerAmount = (r: PublicResult) =>
+  sumBy(r.newBetResults, (b) => sumBy(b.takers, 'amount')) +
+  sumBy(r.otherBetResults, (b) => sumBy(b.takers, 'amount'))
+
+const sumProbAfter = (r: PublicResult) => sumBy(r.updatedAnswers, 'prob')
+
+const minPoolAfter = (r: PublicResult) =>
+  Math.min(
+    ...r.updatedAnswers.flatMap((a) => [a.poolYes, a.poolNo])
+  )
+
+const fmt = (x: number, d = 12) => x.toExponential(3).padStart(d)
+
+// ---------------------------------------------------------------- config grid
+
+type MakerCfg = 'none' | 'basket-pin' | 'other-side' | 'both'
+type Shape = 'extreme' | 'moderate' | 'p05-control'
+
+const PS: Record<Exclude<Shape, 'p05-control'>, number[]> = {
+  extreme: [0.9, 0.05, 0.03, 0.02],
+  moderate: [0.6, 0.2, 0.1, 0.1],
+}
+
+const mkAnswers = (shape: Shape, L = 100): Answer[] =>
+  shape === 'p05-control'
+    ? // p = 0.5 control with the same prob vector as 'extreme' (pools shaped, k = L^2)
+      PS.extreme.map((prob, i) => getAnswer(i, prob, L))
+    : PS[shape].map((p, i) => getAnswerWithP(i, p, L))
+
+// (a) large NO limit ask ~0.02 above the (first) basket answer's initial prob: pins
+//     the basket answer's price during the taker's rising YES sweep.
+// (b) YES bid on the first non-basket answer ~0.02 below its prob: crossed as the
+//     auto-arb NO sweep pushes that answer down.
+// Order sizes chosen so both the pinned segment AND the order-exhaustion kink land
+// inside probe 1's operational sweep (net <= ~1500): the pin (60 mana at ~0.92)
+// exhausts around g ~ 750; the bid (20 mana at ~0.03) exhausts around eta ~ 650.
+const mkMakers = (
+  answers: Answer[],
+  basketSize: number,
+  cfg: MakerCfg,
+  scale = 1
+): LimitBet[] => {
+  const bets: LimitBet[] = []
+  if (cfg === 'basket-pin' || cfg === 'both') {
+    const a = answers[0]
+    bets.push(
+      getLimitBet(
+        'pinNO',
+        a,
+        'NO',
+        'maker',
+        60 * scale,
+        Math.min(a.prob + 0.02, 0.98)
+      )
+    )
+  }
+  if (cfg === 'other-side' || cfg === 'both') {
+    const a = answers[basketSize] // first non-basket answer
+    bets.push(
+      getLimitBet(
+        'bidYES',
+        a,
+        'YES',
+        'maker',
+        20 * scale,
+        Math.max(a.prob - 0.02, 0.011)
+      )
+    )
+  }
+  return bets
+}
+
+const RICH = { maker: 1e9 }
+
+// ---------------------------------------------------------------- the probes
+
+const d = process.env.PROBE ? describe : describe.skip
+
+d('cpmm-multi-2 net(g) monotonicity probe', () => {
+  jest.setTimeout(600_000)
+
+  // ------------------------------------------------------------ probe 0
+  it('0. transcribed evalG/solve reproduces the public API', () => {
+    const configs: {
+      label: string
+      answers: Answer[]
+      basketSize: number
+      makers: MakerCfg
+      bet: number
+    }[] = [
+      {
+        label: 'extreme p, basket={0}, both makers, bet 60',
+        answers: mkAnswers('extreme'),
+        basketSize: 1,
+        makers: 'both',
+        bet: 60,
+      },
+      {
+        label: 'moderate p, basket={0,1}, no makers, bet 500',
+        answers: mkAnswers('moderate'),
+        basketSize: 2,
+        makers: 'none',
+        bet: 500,
+      },
+      {
+        label: 'p=0.5 control, basket={0}, basket-pin, bet 5',
+        answers: mkAnswers('p05-control'),
+        basketSize: 1,
+        makers: 'basket-pin',
+        bet: 5,
+      },
+    ]
+    console.log('\n--- 0. transcription validation ---')
+    for (const c of configs) {
+      const basket = c.answers.slice(0, c.basketSize)
+      const unfilled = mkMakers(c.answers, c.basketSize, c.makers)
+      const solver = makeSolver(
+        c.answers,
+        basket,
+        undefined,
+        cloneBets(unfilled),
+        { ...RICH }
+      )
+      const mine = solver.solve(c.bet)
+      const pub = publicV2(c.answers, basket, c.bet, unfilled, RICH)
+
+      // The public result's total taker amount equals net(g_solved) by construction
+      // (redemption fills zero the NO legs and credit netOthers/m to the YES legs).
+      const pubTotal = totalTakerAmount(pub)
+      const netDiff = Math.abs((mine.solved?.net ?? NaN) - pubTotal)
+
+      // Final pool state must match answer-by-answer.
+      let maxProbDiff = 0
+      for (const ua of pub.updatedAnswers) {
+        const r =
+          mine.solved?.yesBetResults.find((b) => b.answer.id === ua.id) ??
+          mine.solved?.noBetResults.find((b) => b.answer.id === ua.id)
+        if (!r) continue
+        const myProb = getCpmmProbability(r.cpmmState.pool, r.cpmmState.p)
+        maxProbDiff = Math.max(maxProbDiff, Math.abs(myProb - ua.prob))
+      }
+      console.log(
+        `${c.label.padEnd(52)} |net-pubTotal|=${fmt(netDiff)}  maxProbDiff=${fmt(
+          maxProbDiff
+        )}`
+      )
+      expect(netDiff).toBeLessThan(1e-9)
+      expect(maxProbDiff).toBeLessThan(1e-12)
+    }
+  })
+
+  // ------------------------------------------------------------ probe 1
+  it('1. dense net(g) sampling: strict monotonicity at general p with limits', () => {
+    const NPTS = 800
+    const shapes: Shape[] = ['extreme', 'moderate', 'p05-control']
+    const makerCfgs: MakerCfg[] = ['none', 'basket-pin', 'other-side', 'both']
+    const basketSizes = [1, 2]
+
+    type Violation = {
+      config: string
+      g0: number
+      g1: number
+      drop: number
+      relDrop: number
+      net0: number
+      net1: number
+    }
+    let worst: Violation | undefined
+    let plateauCount = 0
+    let worstPlateau: { config: string; g0: number; g1: number } | undefined
+    console.log(
+      '\n--- 1. dense net(g) sampling: 800 pts operational sweep (net <= ~1500,' +
+        ' covers all probe-2 bets + maker pin/exhaustion kinks) + 800 pts boundary' +
+        ' sweep (up to the Sum-prob->1 feasibility cutoff) ---'
+    )
+
+    for (const shape of shapes) {
+      for (const basketSize of basketSizes) {
+        for (const makerCfg of makerCfgs) {
+          const answers = mkAnswers(shape)
+          const basket = answers.slice(0, basketSize)
+          const unfilled = mkMakers(answers, basketSize, makerCfg)
+          const solver = makeSolver(answers, basket, undefined, unfilled, {
+            ...RICH,
+          })
+          const label = `${shape}/m=${basketSize}/${makerCfg}`
+
+          // Boundary of feasibility: for m >= 2 the basket prob-sum reaches 1 at
+          // finite g; for m = 1 it reaches the target <= 1e-9 numeric cutoff at
+          // large-but-finite g (~1.6e9 at this pool scale). Locate it by doubling
+          // + bisection on evalG === undefined.
+          let gBoundary = Infinity
+          {
+            let lo = 1
+            let hi = 1
+            let found = false
+            while (hi < 2 ** 40) {
+              if (solver.evalG(hi) === undefined) {
+                found = true
+                break
+              }
+              lo = hi
+              hi *= 2
+            }
+            if (found) {
+              for (let i = 0; i < 80; i++) {
+                const mid = (lo + hi) / 2
+                if (solver.evalG(mid) === undefined) hi = mid
+                else lo = mid
+                if (mid === lo || mid === hi) break
+              }
+              gBoundary = lo
+            }
+          }
+          // Operational cap: the g at which net ~ 1500 (3x the largest probe-2
+          // standard bet; also past the maker-order exhaustion kinks).
+          let gNetCap: number
+          {
+            let hi = 1
+            while ((solver.evalG(hi)?.net ?? Infinity) < 1500) hi *= 2
+            gNetCap = binarySearch(0, hi, (gg) => {
+              const r = solver.evalG(gg)
+              return r ? r.net - 1500 : 1
+            })
+          }
+
+          const sweeps: { name: string; gTop: number }[] = [
+            { name: 'op', gTop: Math.min(gNetCap, gBoundary * 0.999) },
+          ]
+          if (isFinite(gBoundary) && gBoundary * 0.999 > gNetCap * 1.01) {
+            sweeps.push({ name: 'bd', gTop: gBoundary * 0.999 })
+          }
+
+          for (const { name, gTop } of sweeps) {
+            // Sample net(g) at NPTS uniform points on (0, gTop].
+            let prevG = 0
+            let prevNet = 0 // net(0) = 0 (empty basket, eta = 0)
+            let localWorst: Violation | undefined
+            let localPlateaus = 0
+            let undefinedHoles = 0
+            for (let i = 1; i <= NPTS; i++) {
+              const g = (i / NPTS) * gTop
+              const r = solver.evalG(g)
+              if (!r) {
+                undefinedHoles++
+                continue
+              }
+              const dnet = r.net - prevNet
+              if (dnet < 0) {
+                const v = {
+                  config: `${label}[${name}]`,
+                  g0: prevG,
+                  g1: g,
+                  drop: -dnet,
+                  relDrop: -dnet / Math.max(1, Math.abs(prevNet)),
+                  net0: prevNet,
+                  net1: r.net,
+                }
+                if (!localWorst || v.relDrop > localWorst.relDrop) localWorst = v
+                if (!worst || v.relDrop > worst.relDrop) worst = v
+              } else if (dnet === 0) {
+                localPlateaus++
+                plateauCount++
+                if (!worstPlateau)
+                  worstPlateau = { config: `${label}[${name}]`, g0: prevG, g1: g }
+              }
+              prevG = g
+              prevNet = r.net
+            }
+            console.log(
+              `${label.padEnd(30)} [${name}] gTop=${gTop.toExponential(3)} ` +
+                `worstDrop=${localWorst ? fmt(localWorst.drop) : '        none'} ` +
+                `plateaus=${localPlateaus} undefHoles=${undefinedHoles}`
+            )
+            expect(undefinedHoles).toBe(0)
+          }
+        }
+      }
+    }
+
+    if (worst) {
+      console.log(
+        `\nWORST MONOTONICITY VIOLATION: ${worst.config} ` +
+          `net(${worst.g0}) = ${worst.net0} -> net(${worst.g1}) = ${worst.net1} ` +
+          `(drop ${worst.drop.toExponential(6)}, rel ${worst.relDrop.toExponential(6)})`
+      )
+    } else {
+      console.log(
+        `\nno local decrease found; plateaus (exact equal consecutive nets): ${plateauCount}` +
+          (worstPlateau
+            ? ` (first at ${worstPlateau.config} g in [${worstPlateau.g0}, ${worstPlateau.g1}])`
+            : '')
+      )
+    }
+    // Strict-increase premise: any measurable dip is a finding. Tolerance is
+    // relative to |net| (inner eta bisection resolves to ~etaHi/2^50, so net
+    // carries O(1e-10) absolute noise at operational scale, proportionally more
+    // in the boundary sweep where net ~ 1e9).
+    expect(worst?.relDrop ?? 0).toBeLessThan(1e-9)
+  })
+
+  // ------------------------------------------------------------ probe 2
+  it('2. cost == betAmount, sum prob == 1, pools > 0 via the public API', () => {
+    type Row = {
+      config: string
+      bet: number
+      residual: number
+      sumProbErr: number
+      minPool: number
+    }
+    const rows: Row[] = []
+    const run = (
+      label: string,
+      answers: Answer[],
+      basketSize: number,
+      unfilled: LimitBet[],
+      bet: number
+    ) => {
+      const basket = answers.slice(0, basketSize)
+      const r = publicV2(answers, basket, bet, unfilled, RICH)
+      rows.push({
+        config: label,
+        bet,
+        residual: totalTakerAmount(r) - bet,
+        sumProbErr: sumProbAfter(r) - 1,
+        minPool: minPoolAfter(r),
+      })
+    }
+
+    const shapes: Shape[] = ['extreme', 'moderate', 'p05-control']
+    const makerCfgs: MakerCfg[] = ['none', 'basket-pin', 'other-side', 'both']
+    for (const shape of shapes) {
+      for (const basketSize of [1, 2]) {
+        for (const makerCfg of makerCfgs) {
+          for (const bet of [5, 60, 500]) {
+            const answers = mkAnswers(shape)
+            run(
+              `${shape}/m=${basketSize}/${makerCfg}`,
+              answers,
+              basketSize,
+              mkMakers(answers, basketSize, makerCfg),
+              bet
+            )
+          }
+        }
+      }
+    }
+    // whale bets on an ante-1000-scale market (L = 1000 balanced pools)
+    for (const shape of ['extreme', 'moderate'] as const) {
+      for (const makerCfg of ['none', 'both'] as const) {
+        for (const bet of [1e4, 1e5]) {
+          const answers = mkAnswers(shape, 1000)
+          run(
+            `whale L=1000 ${shape}/m=1/${makerCfg}`,
+            answers,
+            1,
+            mkMakers(answers, 1, makerCfg, 10),
+            bet
+          )
+        }
+      }
+    }
+
+    rows.sort((a, b) => Math.abs(b.residual) - Math.abs(a.residual))
+    console.log('\n--- 2. cost==betAmount invariant (worst 15 by |residual|) ---')
+    console.log(
+      'config'.padEnd(36) +
+        'bet'.padStart(9) +
+        '  residual'.padStart(14) +
+        '  sumProb-1'.padStart(14) +
+        '  minPool'.padStart(12)
+    )
+    for (const r of rows.slice(0, 15)) {
+      console.log(
+        r.config.padEnd(36) +
+          String(r.bet).padStart(9) +
+          fmt(r.residual, 14) +
+          fmt(r.sumProbErr, 14) +
+          r.minPool.toExponential(2).padStart(12)
+      )
+    }
+    const worstResidual = Math.max(...rows.map((r) => Math.abs(r.residual)))
+    const worstSumProb = Math.max(...rows.map((r) => Math.abs(r.sumProbErr)))
+    const minPool = Math.min(...rows.map((r) => r.minPool))
+    console.log(
+      `\nworst |residual| = ${worstResidual.toExponential(6)}, ` +
+        `worst |sumProb-1| = ${worstSumProb.toExponential(6)}, ` +
+        `min pool = ${minPool.toExponential(6)}`
+    )
+    expect(worstResidual).toBeLessThan(1e-6)
+    expect(worstSumProb).toBeLessThan(1e-6)
+    expect(minPool).toBeGreaterThan(0)
+  })
+
+  // ------------------------------------------------------------ probe 3
+  it('3. whale / feasibility-boundary behavior, n=3, basket={0}', () => {
+    console.log('\n--- 3. whale/boundary: n=3, ps=[0.5,0.3,0.2], basket={0} ---')
+    console.log(
+      'L'.padStart(6) +
+        'bet'.padStart(10) +
+        'g'.padStart(16) +
+        'eta'.padStart(16) +
+        'residual'.padStart(14) +
+        'sumProb-1'.padStart(14) +
+        'maxProb'.padStart(12) +
+        'dbl'.padStart(5) +
+        '  guard'
+    )
+    for (const L of [100, 1000]) {
+      for (const bet of [1e3, 1e4, 1e5]) {
+        const answers = [0.5, 0.3, 0.2].map((p, i) => getAnswerWithP(i, p, L))
+        const basket = [answers[0]]
+        const solver = makeSolver(answers, basket, undefined, [], {})
+        let guard = ''
+        let out = ''
+        try {
+          const { g, doublings, solved } = solver.solve(bet)
+          const pub = publicV2(answers, basket, bet, [], {})
+          const residual = totalTakerAmount(pub) - bet
+          const sumProbErr = sumProbAfter(pub) - 1
+          const maxProb = Math.max(...pub.updatedAnswers.map((a) => a.prob))
+          // g-resolution amplification: local slope x bisection step (gHi / 2^50)
+          const gStep = solver.solve(bet).gHi / 2 ** 50
+          const rUp = solver.evalG(g + Math.max(gStep, g * 1e-9))
+          const slope = rUp
+            ? (rUp.net - (solved?.net ?? 0)) / Math.max(gStep, g * 1e-9)
+            : NaN
+          out =
+            String(L).padStart(6) +
+            bet.toExponential(0).padStart(10) +
+            g.toExponential(6).padStart(16) +
+            (solved?.eta ?? 0).toExponential(6).padStart(16) +
+            fmt(residual, 14) +
+            fmt(sumProbErr, 14) +
+            maxProb.toFixed(6).padStart(12) +
+            String(doublings).padStart(5) +
+            `  slope~${isNaN(slope) ? '?' : slope.toFixed(3)}`
+          expect(Math.abs(residual)).toBeLessThan(1e-6)
+          expect(Math.abs(sumProbErr)).toBeLessThan(1e-6)
+        } catch (e) {
+          guard = ` THREW: ${(e as Error).message}`
+          out =
+            String(L).padStart(6) +
+            bet.toExponential(0).padStart(10) +
+            guard
+        }
+        console.log(out + guard)
+      }
+    }
+  })
+
+  // ------------------------------------------------------------ probe x
+  it('x. adversarial: maker balance binding ACROSS two non-basket answers', () => {
+    // The inner eta solve previews each NO leg with a per-leg COPY of the working
+    // balances (othersSumAtEta never applies makers), but the realization pass
+    // decrements the shared balance between legs. A maker with YES bids on TWO
+    // non-basket answers and a balance that covers only one of them makes
+    // preview != realization: the realized sum-prob undershoots the target.
+    const answers = mkAnswers('extreme') // [0.9, 0.05, 0.03, 0.02]
+    const basket = [answers[0]]
+    const unfilled = [
+      getLimitBet('poor1', answers[1], 'YES', 'poorMaker', 100, 0.03),
+      getLimitBet('poor2', answers[2], 'YES', 'poorMaker', 100, 0.011),
+    ]
+    const balances = { poorMaker: 0.75 } // covers ~one leg's fill, not both
+
+    console.log('\n--- x. cross-answer maker balance binding ---')
+    for (const bet of [60, 500]) {
+      const solver = makeSolver(answers, basket, undefined, cloneBets(unfilled), {
+        ...balances,
+      })
+      const { solved } = solver.solve(bet)
+      const pub = publicV2(answers, basket, bet, unfilled, balances)
+      // v1 comparison on the identical config (same taker-charge/sum-prob checks)
+      const pubV1 = calculateCpmmMultiArbitrageYesBets(
+        answers,
+        basket,
+        bet,
+        undefined,
+        cloneBets(unfilled),
+        { ...balances },
+        noFees,
+        'cpmm-multi-1'
+      )
+      const residual = totalTakerAmount(pub) - bet
+      const sumProbErr = sumProbAfter(pub) - 1
+      const sumProbErrV1 = sumProbAfter(pubV1) - 1
+      const previewVsRealized =
+        (solved?.target ?? NaN) - (solved?.realizedOthersSum ?? NaN)
+      console.log(
+        `bet ${String(bet).padStart(4)}: residual=${fmt(residual)} ` +
+          `sumProb-1=${fmt(sumProbErr)} target-realizedOthersSum=${fmt(
+            previewVsRealized
+          )} v1 sumProb-1=${fmt(sumProbErrV1)}`
+      )
+      // Report-only softly; hard-assert the taker charge invariant, which is the
+      // money artifact if it breaks.
+      expect(Math.abs(residual)).toBeLessThan(1e-6)
+    }
+  })
+})

--- a/common/src/new-bet.ts
+++ b/common/src/new-bet.ts
@@ -297,8 +297,6 @@ const getNewMultiCpmmBetsInfoSumsToOne = (
     // NOTE: only accepts YES bets atm
     // cpmm-multi-2 routes through the direct non-overshooting solve (Approach C);
     // cpmm-multi-1 keeps the v1 nested search byte-identically.
-    const arbVersion =
-      contract.mechanism === 'cpmm-multi-2' ? 'cpmm-multi-2' : 'cpmm-multi-1'
     try {
       const multiRes = calculateCpmmMultiArbitrageYesBets(
         answers,
@@ -308,7 +306,7 @@ const getNewMultiCpmmBetsInfoSumsToOne = (
         unfilledBets,
         balanceByUserId,
         contract.collectedFees,
-        arbVersion
+        contract.mechanism
       )
       newBetResults.push(...multiRes.newBetResults)
       otherBetsResults.push(...multiRes.otherBetResults)

--- a/common/src/new-bet.ts
+++ b/common/src/new-bet.ts
@@ -294,6 +294,10 @@ const getNewMultiCpmmBetsInfoSumsToOne = (
       otherBetsResults.push(...(otherBetResults as ArbitrageBetArray))
   } else {
     // NOTE: only accepts YES bets atm
+    // cpmm-multi-2 routes through the direct non-overshooting solve (Approach C);
+    // cpmm-multi-1 keeps the v1 nested search byte-identically.
+    const arbVersion =
+      contract.mechanism === 'cpmm-multi-2' ? 'cpmm-multi-2' : 'cpmm-multi-1'
     const multiRes = calculateCpmmMultiArbitrageYesBets(
       answers,
       answersToBuy,
@@ -301,7 +305,8 @@ const getNewMultiCpmmBetsInfoSumsToOne = (
       limitProb,
       unfilledBets,
       balanceByUserId,
-      contract.collectedFees
+      contract.collectedFees,
+      arbVersion
     )
     newBetResults.push(...multiRes.newBetResults)
     otherBetsResults.push(...multiRes.otherBetResults)

--- a/common/src/new-bet.ts
+++ b/common/src/new-bet.ts
@@ -180,7 +180,7 @@ export const getNewMultiCpmmBetInfo = (
 
   const { poolYes, poolNo } = answer
   const pool = { YES: poolYes, NO: poolNo }
-  const cpmmState = { pool, p: 0.5, collectedFees: contract.collectedFees }
+  const cpmmState = { pool, p: answer.p, collectedFees: contract.collectedFees }
 
   const answerUnfilledBets = unfilledBets.filter(
     (b) => b.answerId === answer.id

--- a/common/src/new-bet.ts
+++ b/common/src/new-bet.ts
@@ -21,6 +21,7 @@ import {
   buyNoSharesUntilAnswersSumToOne,
   calculateCpmmMultiArbitrageBet,
   calculateCpmmMultiArbitrageYesBets,
+  CpmmMulti2InvariantError,
 } from './calculate-cpmm-arbitrage'
 import { APIError } from 'common/api/utils'
 
@@ -298,18 +299,35 @@ const getNewMultiCpmmBetsInfoSumsToOne = (
     // cpmm-multi-1 keeps the v1 nested search byte-identically.
     const arbVersion =
       contract.mechanism === 'cpmm-multi-2' ? 'cpmm-multi-2' : 'cpmm-multi-1'
-    const multiRes = calculateCpmmMultiArbitrageYesBets(
-      answers,
-      answersToBuy,
-      initialBetAmount,
-      limitProb,
-      unfilledBets,
-      balanceByUserId,
-      contract.collectedFees,
-      arbVersion
-    )
-    newBetResults.push(...multiRes.newBetResults)
-    otherBetsResults.push(...multiRes.otherBetResults)
+    try {
+      const multiRes = calculateCpmmMultiArbitrageYesBets(
+        answers,
+        answersToBuy,
+        initialBetAmount,
+        limitProb,
+        unfilledBets,
+        balanceByUserId,
+        contract.collectedFees,
+        arbVersion
+      )
+      newBetResults.push(...multiRes.newBetResults)
+      otherBetsResults.push(...multiRes.otherBetResults)
+    } catch (e) {
+      // v2 post-hoc verification (or the solve's own feasibility invariant) failed. Nothing has
+      // been committed yet, so surface a retryable 503 rather than a stack-leaking 500 — the
+      // safe outcome is "bet didn't execute", never "bet executed at a mis-solved price".
+      if (e instanceof CpmmMulti2InvariantError) {
+        throw new APIError(
+          503,
+          'Bet solve verification failed, please try again.',
+          {
+            reason: e.message,
+            details: e.details,
+          }
+        )
+      }
+      throw e
+    }
   }
   const now = Date.now()
   return newBetResults.map((newBetResult, i) => {

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -9,6 +9,7 @@ import {
   CPMMNumber,
   CREATEABLE_OUTCOME_TYPES,
   Contract,
+  isMultiCpmmMechanism,
   MultiDate,
   MultiNumeric,
   NonBet,
@@ -188,7 +189,7 @@ export function getNewContract(
     elasticity:
       propsByOutcomeType.mechanism === 'cpmm-1'
         ? computeBinaryCpmmElasticityFromAnte(ante)
-        : propsByOutcomeType.mechanism === 'cpmm-multi-1'
+        : isMultiCpmmMechanism(propsByOutcomeType.mechanism)
         ? 4.99 // TODO: calculate
         : 1_000_000,
 

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -476,6 +476,7 @@ function createAnswers(
 
       poolYes,
       poolNo,
+      p: 0.5, // cpmm-multi-1 / cpmm-multi-2-at-uniform-init; per-answer p set on v2 creation (PR2c)
       prob,
       totalLiquidity: getMultiCpmmLiquidity({ YES: poolYes, NO: poolNo }),
       subsidyPool: 0,

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -1,5 +1,5 @@
 import { Answer } from './answer'
-import { getMultiCpmmLiquidity } from './calculate-cpmm'
+import { getCpmmLiquidity, getMultiCpmmLiquidity } from './calculate-cpmm'
 import { computeBinaryCpmmElasticityFromAnte } from './calculate-metrics'
 import {
   Binary,
@@ -534,7 +534,10 @@ function createAnswers(
         poolNo,
         p,
         prob,
-        totalLiquidity: getMultiCpmmLiquidity({ YES: poolYes, NO: poolNo }),
+        // True general-p CPMM liquidity invariant k = Y^p · N^(1-p). getMultiCpmmLiquidity is the
+        // p=0.5 special case √(Y·N), which understates depth on the √variance asymmetric v2 pools
+        // (Y_i≠N_i, p_i≠0.5). Balanced Set pools (Y=N) give the same value either way.
+        totalLiquidity: getCpmmLiquidity({ YES: poolYes, NO: poolNo }, p),
         subsidyPool: 0,
         isOther: false,
         probChanges: { day: 0, week: 0, month: 0 },

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -36,6 +36,8 @@ export function getNewContract(
   props: Pick<
     Contract,
     | 'id'
+
+// (GPnn labels cite machine-checked proofs: https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/proofs)
     | 'slug'
     | 'question'
     | 'description'
@@ -463,6 +465,25 @@ function createAnswers(
 ) {
   const { colors, shortTexts, imageUrls, midpoints, initialProbs } = options
   const ids = answers.map(() => randomString())
+  const now = Date.now()
+
+  // Mechanism-independent Answer fields; each branch below supplies only the
+  // pool shape (poolYes/poolNo/p/prob/totalLiquidity) and isOther.
+  const baseAnswer = (i: number, text: string) => ({
+    id: ids[i],
+    index: i,
+    contractId,
+    userId,
+    text,
+    createdTime: now,
+    color: colors?.[i],
+    shortText: shortTexts?.[i],
+    imageUrl: imageUrls?.[i],
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    midpoint: midpoints?.[i],
+    volume: 0,
+  })
 
   // cpmm-multi-2: per-answer initial probs, dialed to target via each answer's
   // own `p`. Two regimes (see tasks/cpmm_multi_2/creation-liquidity-findings.md,
@@ -482,7 +503,6 @@ function createAnswers(
   if (initialProbs && initialProbs.length > 0) {
     const n = answers.length
     const sum = initialProbs.reduce((s, x) => s + x, 0)
-    const now = Date.now()
     const normalized = initialProbs.map((x) => x / sum)
     // GP19a backstop (API layer already 400s): the √variance construction is not
     // total; never persist an insane pool.
@@ -501,15 +521,7 @@ function createAnswers(
     return answers.map((text, i) => {
       const { poolYes, poolNo, p, prob } = pools[i]
       const answer: Answer = removeUndefinedProps({
-        id: ids[i],
-        index: i,
-        contractId,
-        userId,
-        text,
-        createdTime: now,
-        color: colors?.[i],
-        shortText: shortTexts?.[i],
-        imageUrl: imageUrls?.[i],
+        ...baseAnswer(i, text),
         poolYes,
         poolNo,
         p,
@@ -518,11 +530,7 @@ function createAnswers(
         // p=0.5 special case √(Y·N), which understates depth on the √variance asymmetric v2 pools
         // (Y_i≠N_i, p_i≠0.5). Balanced Set pools (Y=N) give the same value either way.
         totalLiquidity: getCpmmLiquidity({ YES: poolYes, NO: poolNo }, p),
-        subsidyPool: 0,
         isOther: false,
-        probChanges: { day: 0, week: 0, month: 0 },
-        midpoint: midpoints?.[i],
-        volume: 0,
       })
       return answer
     })
@@ -550,34 +558,18 @@ function createAnswers(
     // poolNo = ante * (prob ** 2 / (1 - prob))
   }
 
-  const now = Date.now()
-
   return answers.map((text, i) => {
-    const id = ids[i]
     const answer: Answer = removeUndefinedProps({
-      id,
-      index: i,
-      contractId,
-      userId,
-      text,
-      createdTime: now,
-      color: colors?.[i],
-      shortText: shortTexts?.[i],
-      imageUrl: imageUrls?.[i],
-
+      ...baseAnswer(i, text),
       poolYes,
       poolNo,
       p: 0.5, // cpmm-multi-1 / cpmm-multi-2-at-uniform-init; per-answer p set on v2 creation (PR2c)
       prob,
       totalLiquidity: getMultiCpmmLiquidity({ YES: poolYes, NO: poolNo }),
-      subsidyPool: 0,
       isOther:
         shouldAnswersSumToOne &&
         addAnswersMode !== 'DISABLED' &&
         i === answers.length - 1,
-      probChanges: { day: 0, week: 0, month: 0 },
-      midpoint: midpoints?.[i],
-      volume: 0,
     })
     return answer
   })

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -434,6 +434,43 @@ const getDateProps = (
   return system
 }
 
+// The √variance creation rule for cpmm-multi-2 sum-to-one markets. Given the
+// normalized target probs q_i (Σ = 1) and the ante, allocate pool depth
+// W_i = (1−p_i)Y_i + p_iN_i ∝ √(q_i(1−q_i)) — the variance-weighted depth that
+// maximizes effective liquidity under the no-house-risk basket budget (closed
+// form; derivation + benchmarks in tasks/cpmm_multi_2, GP13–GP15). Properties:
+// reduces to v1's pools exactly at uniform, to a balanced pool at n=2; funds
+// exactly (every winning scenario pays the ante) and reads back prob_i = q_i.
+function cpmmMulti2SumToOnePools(
+  q: number[],
+  ante: number
+): { poolYes: number; poolNo: number; p: number; prob: number }[] {
+  const n = q.length
+  if (n < 2) {
+    return q.map((qi) => ({ poolYes: ante, poolNo: ante, p: qi, prob: qi }))
+  }
+  const sqrtC = q.map((qi) => Math.sqrt(qi * (1 - qi)))
+  const meanSqrtC = sqrtC.reduce((s, x) => s + x, 0) / n
+  const D0 = (ante * (n - 2)) / (2 * (n - 1)) // uniform-optimum D (closed form)
+  const Wbar = (ante * n) / (4 * (n - 1)) // uniform-optimum depth
+  // Realize the depth profile W_i at the assumed D0:
+  //   W_i = N_i(N_i + D0)/(N_i + q_i D0)  ⇒  N_i² + N_i(D0 − W_i) − W_i q_i D0 = 0.
+  const N = q.map((qi, i) => {
+    const Wi = (Wbar * sqrtC[i]) / meanSqrtC
+    const b = D0 - Wi
+    return (-b + Math.sqrt(b * b + 4 * Wi * qi * D0)) / 2
+  })
+  // Force exact funding: Y_i = N_i + D with D = ante − ΣN_j makes every winning
+  // scenario pay exactly the ante (all-winners-tight). p_i set so prob_i = q_i.
+  const D = ante - N.reduce((s, x) => s + x, 0)
+  return q.map((qi, i) => {
+    const poolNo = N[i]
+    const poolYes = poolNo + D
+    const p = (qi * poolYes) / (qi * poolYes + (1 - qi) * poolNo)
+    return { poolYes, poolNo, p, prob: qi }
+  })
+}
+
 function createAnswers(
   contractId: string,
   userId: string,
@@ -452,28 +489,37 @@ function createAnswers(
   const { colors, shortTexts, imageUrls, midpoints, initialProbs } = options
   const ids = answers.map(() => randomString())
 
-  // cpmm-multi-2: per-answer initial probs ⇒ balanced deep pools dialed to
-  // target via each answer's own `p`. For balanced reserves (Y = N), the
-  // probability formula prob = p·N / ((1−p)·Y + p·N) collapses to prob = p
-  // (GP6a), so we set p_i = target prob and Y_i = N_i = ante/n. The balanced
-  // (lossless) representation is required so later liquidity adds don't discard
-  // shares (an asymmetric pool + p=0.5 would).
+  // cpmm-multi-2: per-answer initial probs, dialed to target via each answer's
+  // own `p`. Two regimes (see tasks/cpmm_multi_2/creation-liquidity-findings.md,
+  // GP13–GP15):
   //
   // Sum-to-one ("Multiple Choice"): exactly one answer resolves YES, so the raw
-  // percentages are normalized to Σ targetProb = 1. Worst-case payout when any
-  // answer wins is poolYes_i + Σ_{j≠i} poolNo_j = ante/n + (n−1)·ante/n = ante —
-  // the same mana budget v1 uses.
-  // Independent ("Set"): each answer is its own CPMM with no Σ=1 constraint, so
-  // each percentage is its own absolute prob (pct/100, no normalization).
+  // percentages are normalized to Σ q_i = 1. Pools use the √variance creation
+  // rule — depth W_i = (1−p_i)Y_i + p_iN_i ∝ √(q_i(1−q_i)) — which maximizes
+  // effective liquidity under the no-house-risk basket budget (every winning
+  // scenario pays exactly the ante). It reduces to v1's pools exactly at uniform
+  // and to a balanced pool at n=2; for n≥3 skew it is asymmetric with p_i≠q_i.
+  //
+  // Independent ("Set"): each answer is its own CPMM with no Σ=1 constraint and
+  // its own max-loss budget max(Y,N); at fixed risk the liquidity optimum is the
+  // balanced pool Y_i=N_i with p_i=q_i — exactly the binary-CPMM construction.
+  // Absolute probs (pct/100, no normalization).
   if (initialProbs && initialProbs.length > 0) {
     const n = answers.length
     const sum = initialProbs.reduce((s, x) => s + x, 0)
-    const L = ante / n
     const now = Date.now()
+    const pools = shouldAnswersSumToOne
+      ? cpmmMulti2SumToOnePools(
+          initialProbs.map((x) => x / sum),
+          ante
+        )
+      : initialProbs.map((x) => {
+          const L = ante / n
+          const prob = x / 100
+          return { poolYes: L, poolNo: L, p: prob, prob }
+        })
     return answers.map((text, i) => {
-      const targetProb = shouldAnswersSumToOne
-        ? initialProbs[i] / sum
-        : initialProbs[i] / 100
+      const { poolYes, poolNo, p, prob } = pools[i]
       const answer: Answer = removeUndefinedProps({
         id: ids[i],
         index: i,
@@ -484,11 +530,11 @@ function createAnswers(
         color: colors?.[i],
         shortText: shortTexts?.[i],
         imageUrl: imageUrls?.[i],
-        poolYes: L,
-        poolNo: L,
-        p: targetProb,
-        prob: targetProb,
-        totalLiquidity: getMultiCpmmLiquidity({ YES: L, NO: L }),
+        poolYes,
+        poolNo,
+        p,
+        prob,
+        totalLiquidity: getMultiCpmmLiquidity({ YES: poolYes, NO: poolNo }),
         subsidyPool: 0,
         isOther: false,
         probChanges: { day: 0, week: 0, month: 0 },

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -1,5 +1,6 @@
 import { Answer } from './answer'
 import {
+  cpmmMulti2SumToOneFeasible,
   cpmmMulti2SumToOnePools,
   getCpmmLiquidity,
   getMultiCpmmLiquidity,
@@ -482,11 +483,16 @@ function createAnswers(
     const n = answers.length
     const sum = initialProbs.reduce((s, x) => s + x, 0)
     const now = Date.now()
+    const normalized = initialProbs.map((x) => x / sum)
+    // GP19a backstop (API layer already 400s): the √variance construction is not
+    // total; never persist an insane pool.
+    if (shouldAnswersSumToOne && !cpmmMulti2SumToOneFeasible(normalized)) {
+      throw new Error(
+        'Infeasible sum-to-one initialProbs (GP19a): no sane pool realization exists.'
+      )
+    }
     const pools = shouldAnswersSumToOne
-      ? cpmmMulti2SumToOnePools(
-          initialProbs.map((x) => x / sum),
-          ante
-        )
+      ? cpmmMulti2SumToOnePools(normalized, ante)
       : initialProbs.map((x) => {
           const L = ante / n
           const prob = x / 100

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -58,6 +58,10 @@ export function getNewContract(
     shouldAnswersSumToOne?: boolean | undefined
     answerShortTexts?: string[]
     answerImageUrls?: string[]
+    // cpmm-multi-2: per-answer initial probabilities (percentages in (0,100)).
+    // Present ⇒ create a cpmm-multi-2 market with each answer's p set to its
+    // (normalized) target prob. Absent ⇒ uniform 1/n cpmm-multi-1 (unchanged).
+    initialProbs?: number[] | undefined
 
     // Bountied
     isAutoBounty?: boolean | undefined
@@ -104,6 +108,7 @@ export function getNewContract(
     sportsLeague,
     answerShortTexts,
     answerImageUrls,
+    initialProbs,
     takerAPIOrdersDisabled,
     siblingContractId,
     unit,
@@ -128,7 +133,8 @@ export function getNewContract(
         shouldAnswersSumToOne ?? true,
         ante,
         answerShortTexts,
-        answerImageUrls
+        answerImageUrls,
+        initialProbs
       ),
     STONK: () => getStonkCpmmProps(initialProb, ante),
     BOUNTIED_QUESTION: () => getBountiedQuestionProps(ante, isAutoBounty),
@@ -292,12 +298,18 @@ const getMultipleChoiceProps = (
   shouldAnswersSumToOne: boolean,
   ante: number,
   shortTexts?: string[],
-  imageUrls?: string[]
+  imageUrls?: string[],
+  initialProbs?: number[]
 ) => {
   const isBinaryMulti =
     addAnswersMode === 'DISABLED' &&
     answers.length === 2 &&
     shouldAnswersSumToOne
+
+  // cpmm-multi-2: per-answer initial probs ⇒ the v2 mechanism. The caller
+  // (create-market.ts) has already validated that initialProbs (when present)
+  // has one entry per answer, sums-to-one is on, and there is no "Other" answer.
+  const isV2 = !!initialProbs && initialProbs.length > 0
 
   const answersWithOther = answers.concat(
     !shouldAnswersSumToOne || addAnswersMode === 'DISABLED' ? [] : ['Other']
@@ -313,10 +325,11 @@ const getMultipleChoiceProps = (
       colors: isBinaryMulti ? VERSUS_COLORS : undefined,
       shortTexts,
       imageUrls,
+      initialProbs,
     })
   )
   const system: CPMMMulti = {
-    mechanism: 'cpmm-multi-1',
+    mechanism: isV2 ? 'cpmm-multi-2' : 'cpmm-multi-1',
     outcomeType: 'MULTIPLE_CHOICE',
     addAnswersMode: addAnswersMode ?? 'DISABLED',
     shouldAnswersSumToOne: shouldAnswersSumToOne ?? true,
@@ -433,10 +446,49 @@ function createAnswers(
     shortTexts?: string[]
     imageUrls?: string[]
     midpoints?: number[]
+    initialProbs?: number[]
   } = {}
 ) {
-  const { colors, shortTexts, imageUrls, midpoints } = options
+  const { colors, shortTexts, imageUrls, midpoints, initialProbs } = options
   const ids = answers.map(() => randomString())
+
+  // cpmm-multi-2: per-answer initial probs ⇒ balanced deep pools dialed to
+  // target via each answer's own `p`. For balanced reserves (Y = N), the
+  // probability formula prob = p·N / ((1−p)·Y + p·N) collapses to prob = p
+  // (GP6a), so we set p_i = (normalized) target prob and Y_i = N_i = ante/n.
+  // Worst-case payout when any answer wins is poolYes_i + Σ_{j≠i} poolNo_j =
+  // ante/n + (n−1)·ante/n = ante — i.e. the exact same mana budget v1 uses.
+  if (initialProbs && initialProbs.length > 0) {
+    const n = answers.length
+    const sum = initialProbs.reduce((s, x) => s + x, 0)
+    const L = ante / n
+    const now = Date.now()
+    return answers.map((text, i) => {
+      const targetProb = initialProbs[i] / sum
+      const answer: Answer = removeUndefinedProps({
+        id: ids[i],
+        index: i,
+        contractId,
+        userId,
+        text,
+        createdTime: now,
+        color: colors?.[i],
+        shortText: shortTexts?.[i],
+        imageUrl: imageUrls?.[i],
+        poolYes: L,
+        poolNo: L,
+        p: targetProb,
+        prob: targetProb,
+        totalLiquidity: getMultiCpmmLiquidity({ YES: L, NO: L }),
+        subsidyPool: 0,
+        isOther: false,
+        probChanges: { day: 0, week: 0, month: 0 },
+        midpoint: midpoints?.[i],
+        volume: 0,
+      })
+      return answer
+    })
+  }
 
   let prob = 0.5
   let poolYes = ante / answers.length

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -1,5 +1,9 @@
 import { Answer } from './answer'
-import { getCpmmLiquidity, getMultiCpmmLiquidity } from './calculate-cpmm'
+import {
+  cpmmMulti2SumToOnePools,
+  getCpmmLiquidity,
+  getMultiCpmmLiquidity,
+} from './calculate-cpmm'
 import { computeBinaryCpmmElasticityFromAnte } from './calculate-metrics'
 import {
   Binary,
@@ -441,36 +445,6 @@ const getDateProps = (
 // form; derivation + benchmarks in tasks/cpmm_multi_2, GP13–GP15). Properties:
 // reduces to v1's pools exactly at uniform, to a balanced pool at n=2; funds
 // exactly (every winning scenario pays the ante) and reads back prob_i = q_i.
-function cpmmMulti2SumToOnePools(
-  q: number[],
-  ante: number
-): { poolYes: number; poolNo: number; p: number; prob: number }[] {
-  const n = q.length
-  if (n < 2) {
-    return q.map((qi) => ({ poolYes: ante, poolNo: ante, p: qi, prob: qi }))
-  }
-  const sqrtC = q.map((qi) => Math.sqrt(qi * (1 - qi)))
-  const meanSqrtC = sqrtC.reduce((s, x) => s + x, 0) / n
-  const D0 = (ante * (n - 2)) / (2 * (n - 1)) // uniform-optimum D (closed form)
-  const Wbar = (ante * n) / (4 * (n - 1)) // uniform-optimum depth
-  // Realize the depth profile W_i at the assumed D0:
-  //   W_i = N_i(N_i + D0)/(N_i + q_i D0)  ⇒  N_i² + N_i(D0 − W_i) − W_i q_i D0 = 0.
-  const N = q.map((qi, i) => {
-    const Wi = (Wbar * sqrtC[i]) / meanSqrtC
-    const b = D0 - Wi
-    return (-b + Math.sqrt(b * b + 4 * Wi * qi * D0)) / 2
-  })
-  // Force exact funding: Y_i = N_i + D with D = ante − ΣN_j makes every winning
-  // scenario pay exactly the ante (all-winners-tight). p_i set so prob_i = q_i.
-  const D = ante - N.reduce((s, x) => s + x, 0)
-  return q.map((qi, i) => {
-    const poolNo = N[i]
-    const poolYes = poolNo + D
-    const p = (qi * poolYes) / (qi * poolYes + (1 - qi) * poolNo)
-    return { poolYes, poolNo, p, prob: qi }
-  })
-}
-
 function createAnswers(
   contractId: string,
   userId: string,

--- a/common/src/new-contract.ts
+++ b/common/src/new-contract.ts
@@ -455,16 +455,25 @@ function createAnswers(
   // cpmm-multi-2: per-answer initial probs ⇒ balanced deep pools dialed to
   // target via each answer's own `p`. For balanced reserves (Y = N), the
   // probability formula prob = p·N / ((1−p)·Y + p·N) collapses to prob = p
-  // (GP6a), so we set p_i = (normalized) target prob and Y_i = N_i = ante/n.
-  // Worst-case payout when any answer wins is poolYes_i + Σ_{j≠i} poolNo_j =
-  // ante/n + (n−1)·ante/n = ante — i.e. the exact same mana budget v1 uses.
+  // (GP6a), so we set p_i = target prob and Y_i = N_i = ante/n. The balanced
+  // (lossless) representation is required so later liquidity adds don't discard
+  // shares (an asymmetric pool + p=0.5 would).
+  //
+  // Sum-to-one ("Multiple Choice"): exactly one answer resolves YES, so the raw
+  // percentages are normalized to Σ targetProb = 1. Worst-case payout when any
+  // answer wins is poolYes_i + Σ_{j≠i} poolNo_j = ante/n + (n−1)·ante/n = ante —
+  // the same mana budget v1 uses.
+  // Independent ("Set"): each answer is its own CPMM with no Σ=1 constraint, so
+  // each percentage is its own absolute prob (pct/100, no normalization).
   if (initialProbs && initialProbs.length > 0) {
     const n = answers.length
     const sum = initialProbs.reduce((s, x) => s + x, 0)
     const L = ante / n
     const now = Date.now()
     return answers.map((text, i) => {
-      const targetProb = initialProbs[i] / sum
+      const targetProb = shouldAnswersSumToOne
+        ? initialProbs[i] / sum
+        : initialProbs[i] / 100
       const answer: Answer = removeUndefinedProps({
         id: ids[i],
         index: i,

--- a/common/src/notification.ts
+++ b/common/src/notification.ts
@@ -426,7 +426,7 @@ export type BetFillData = {
   limitOrderTotal?: number
   limitOrderRemaining?: number
   limitAt?: string
-  mechanism: 'cpmm-1' | 'cpmm-multi-1'
+  mechanism: 'cpmm-1' | 'cpmm-multi-1' | 'cpmm-multi-2'
   outcomeType: OutcomeType
   betAnswerId?: string
   expiresAt?: number

--- a/common/src/other-split-domain-probe.test.ts
+++ b/common/src/other-split-domain-probe.test.ts
@@ -302,14 +302,15 @@ d('other-split domain probe (cpmm-multi-2 v2)', () => {
   })
 
   // ------------------------------------------------------------------ edge 5
-  it('5. no guard: math happily splits an Other already at/below 0.02', () => {
-    // Static finding (see report): verifyContract (create-answer-cpmm.ts
-    // lines 80-110) checks token/mechanism/closeTime/addAnswersMode only;
-    // createAnswerCpmmMain checks balance (line 129) and maxAnswers
-    // (line 141). No probOther / MIN_CPMM_PROB check exists on the v2 path.
-    // Here: confirm the math itself raises no error and emits valid-looking
-    // (finite, tradeable) sub-floor answers — i.e. nothing downstream of the
-    // handler would stop it either.
+  it('5. math below the floor: splits stay finite/tradeable (guard is policy, upstream)', () => {
+    // HISTORY: this test originally documented a MISSING guard — nothing on the
+    // v2 path blocked splitting an Other already below MIN_CPMM_PROB. The GP19d
+    // guard now exists at the handler (create-answer-cpmm.ts: reject when
+    // probOther < 2*MIN_CPMM_PROB), so sub-floor splits are unreachable via the
+    // API. This test remains as defense-in-depth documentation: the MATH itself
+    // is total (GP19d — split sanity never breaks strictly), so if the policy
+    // guard were ever bypassed the failure mode is zombie sub-floor answers,
+    // not NaN/corruption.
     const rows: any[] = []
     for (const q of [0.02, 0.011, 0.0101, 0.005, 0.002]) {
       const pool = poolAtProb(q, 0.5, 100)
@@ -323,7 +324,7 @@ d('other-split domain probe (cpmm-multi-2 v2)', () => {
         p: f(r.newAnswer.p, 8),
         tradeMathOk: t.ok,
       })
-      expect(t.ok).toBe(true) // no throw, no NaN — GUARD MISSING upstream
+      expect(t.ok).toBe(true) // no throw, no NaN — the math is total below the floor
     }
     console.table(rows)
     expect(rows.every((r) => r.tradeMathOk)).toBe(true)

--- a/common/src/other-split-domain-probe.test.ts
+++ b/common/src/other-split-domain-probe.test.ts
@@ -1,0 +1,340 @@
+// Adversarial domain probe for the cpmm-multi-2 "Other split" math in
+// backend/api/src/create-answer-cpmm.ts :: createAnswerAndSumAnswersToOneV2
+// (lines 472-574 on branch feat/cpmm-multi-2).
+//
+// The DB handler is inseparable from the transaction plumbing, so the pure
+// pool/p construction (create-answer-cpmm.ts lines 492-506, plus the answer
+// fields set at lines 509-525) is TRANSCRIBED below as `splitOther`. Line
+// numbers cited inline. Production files are NOT modified.
+//
+// Probes:
+//   1. Tiny Other: probOther in {0.05, 0.021, 0.02, 0.015, 0.011}
+//   2. Repeated splits: Other from 0.5, split 8x
+//   3. Small pools: Yo/No in 1..10 mana vs answerCost 25 (min tier) and 100
+//   4. pOther != 0.5 (post-drizzle drift): lossless claim at general p
+//   5. Guard check is static (see report); here we confirm the math itself
+//      never throws/NaNs below the floor, i.e. nothing in the math stops it.
+//
+// Run with:
+//   cd common && PROBE=1 npx jest other-split-domain-probe --silent=false
+// Skipped (describe.skip) in normal test runs / CI.
+
+import {
+  calculateCpmmAmountToBuySharesFixedP,
+  calculateCpmmShares,
+  getCpmmLiquidity,
+  getCpmmProbability,
+  CpmmState,
+} from './calculate-cpmm'
+import { MIN_CPMM_PROB, MAX_CPMM_PROB } from './contract'
+import { noFees } from './fees'
+
+// ---------------------------------------------------------------------------
+// Transcription of createAnswerAndSumAnswersToOneV2's pure math.
+// Source: backend/api/src/create-answer-cpmm.ts
+//   line 492: const Yo = otherAnswer.poolYes
+//   line 493: const No = otherAnswer.poolNo
+//   line 494: const pOther = otherAnswer.p ?? 0.5
+//   line 495: const probOther = getCpmmProbability({ YES: Yo, NO: No }, pOther)
+//   line 496: const targetProb = probOther / 2
+//   line 497: const a = answerCost / 2
+//   lines 500-501: weightFor = (pool, q) => q*Y / (q*Y + (1-q)*N)
+//   line 503: newAnswerPool = { YES: Yo + a, NO: a }
+//   line 504: newOtherPool  = { YES: Yo + a, NO: a }
+//   lines 505-506: newAnswerP / newOtherP = weightFor(pool, targetProb)
+//   lines 509-525: prob = targetProb, totalLiquidity = getCpmmLiquidity(pool, p)
+// ---------------------------------------------------------------------------
+type Pool = { YES: number; NO: number }
+
+const weightFor = (pool: Pool, q: number) =>
+  (q * pool.YES) / (q * pool.YES + (1 - q) * pool.NO)
+
+const splitOther = (
+  Yo: number,
+  No: number,
+  pOther: number,
+  answerCost: number
+) => {
+  const probOther = getCpmmProbability({ YES: Yo, NO: No }, pOther)
+  const targetProb = probOther / 2
+  const a = answerCost / 2
+
+  const newAnswerPool: Pool = { YES: Yo + a, NO: a }
+  const newOtherPool: Pool = { YES: Yo + a, NO: a }
+  const newAnswerP = weightFor(newAnswerPool, targetProb)
+  const newOtherP = weightFor(newOtherPool, targetProb)
+
+  return {
+    probOther,
+    targetProb,
+    newAnswer: {
+      pool: newAnswerPool,
+      p: newAnswerP,
+      prob: targetProb,
+      totalLiquidity: getCpmmLiquidity(newAnswerPool, newAnswerP),
+    },
+    newOther: {
+      pool: newOtherPool,
+      p: newOtherP,
+      prob: targetProb,
+      totalLiquidity: getCpmmLiquidity(newOtherPool, newOtherP),
+    },
+  }
+}
+
+// Pool at a given displayed prob for given p and liquidity L = Y^p * N^(1-p).
+// From prob = pN / ((1-p)Y + pN): N/Y = (1-p)q / (p(1-q)).
+const poolAtProb = (q: number, p: number, L: number): Pool => {
+  const ratio = ((1 - p) * q) / (p * (1 - q)) // N/Y
+  const Y = L / ratio ** (1 - p)
+  const N = Y * ratio
+  return { YES: Y, NO: N }
+}
+
+const fin = (x: number) => Number.isFinite(x)
+
+// Exercise a follow-up trade on a freshly split answer: displayed prob, a
+// M$10 YES and NO buy via the forward map, and cost-for-10-shares via the
+// general-p bisection inverse (calculateCpmmAmountToBuySharesFixedP).
+const tradeCheck = (pool: Pool, p: number) => {
+  const state: CpmmState = { pool, p, collectedFees: noFees }
+  const prob = getCpmmProbability(pool, p)
+  const yesShares10 = calculateCpmmShares(pool, p, 10, 'YES')
+  const noShares10 = calculateCpmmShares(pool, p, 10, 'NO')
+  const costYes10 = calculateCpmmAmountToBuySharesFixedP(state, 10, 'YES')
+  const costNo10 = calculateCpmmAmountToBuySharesFixedP(state, 10, 'NO')
+  const probAfterYes10 = getCpmmProbability(
+    { YES: pool.YES + 10 - yesShares10, NO: pool.NO + 10 },
+    p
+  )
+  const ok =
+    fin(prob) &&
+    fin(yesShares10) &&
+    fin(noShares10) &&
+    fin(costYes10) &&
+    fin(costNo10) &&
+    fin(probAfterYes10) &&
+    yesShares10 > 0 &&
+    noShares10 > 0 &&
+    costYes10 > 0 &&
+    costNo10 > 0
+  return { prob, yesShares10, noShares10, costYes10, costNo10, probAfterYes10, ok }
+}
+
+const f = (x: number, d = 6) => Number(x.toFixed(d))
+
+const d = process.env.PROBE ? describe : describe.skip
+
+d('other-split domain probe (cpmm-multi-2 v2)', () => {
+  // ------------------------------------------------------------------ edge 1
+  it('1. tiny Other: probOther in {0.05, 0.021, 0.02, 0.015, 0.011}', () => {
+    const answerCost = 25 // min tier, common/src/tier.ts:2
+    const rows: any[] = []
+    for (const q of [0.05, 0.021, 0.02, 0.015, 0.011]) {
+      const pool = poolAtProb(q, 0.5, 100) // liquidity-100 Other at p=0.5
+      const r = splitOther(pool.YES, pool.NO, 0.5, answerCost)
+      const t = tradeCheck(r.newAnswer.pool, r.newAnswer.p)
+      rows.push({
+        probOther: q,
+        childProb: f(r.targetProb),
+        belowFloor: r.targetProb < MIN_CPMM_PROB,
+        poolYES: f(r.newAnswer.pool.YES, 3),
+        poolNO: f(r.newAnswer.pool.NO, 3),
+        p: f(r.newAnswer.p),
+        liq: f(r.newAnswer.totalLiquidity, 3),
+        probRoundTrip: f(t.prob),
+        cost10YES: f(t.costYes10, 4),
+        cost10NO: f(t.costNo10, 4),
+        probAfterYes10: f(t.probAfterYes10),
+        tradeMathOk: t.ok,
+      })
+      // The math itself never guards or degrades: everything finite,
+      // pools positive, p in (0,1), displayed prob == targetProb.
+      expect(t.ok).toBe(true)
+      expect(r.newAnswer.p).toBeGreaterThan(0)
+      expect(r.newAnswer.p).toBeLessThan(1)
+      expect(t.prob).toBeCloseTo(r.targetProb, 12)
+      // Both children identical by construction (lines 503-506).
+      expect(r.newOther.p).toBe(r.newAnswer.p)
+    }
+    console.table(rows)
+    // The floor violations we are demonstrating:
+    expect(rows.filter((r) => r.belowFloor).map((r) => r.probOther)).toEqual([
+      0.015, 0.011,
+    ])
+    // probOther = 0.02 lands exactly ON the floor (0.01), not below.
+    expect(rows.find((r) => r.probOther === 0.02)!.childProb).toBeCloseTo(
+      MIN_CPMM_PROB,
+      12
+    )
+  })
+
+  // ------------------------------------------------------------------ edge 2
+  it('2. repeated splits: Other from 0.5, 8 splits, find degeneracy point', () => {
+    const answerCost = 25
+    // Fresh v2 Other: balanced answerCost pool at p=0.5 (create-answer-cpmm.ts
+    // lines 148-151 use poolYes = poolNo = answerCost for new answers).
+    let Yo = 25
+    let No = 25
+    let p = 0.5
+    const rows: any[] = []
+    let firstSubFloor: number | null = null
+    for (let i = 1; i <= 8; i++) {
+      const r = splitOther(Yo, No, p, answerCost)
+      const t = tradeCheck(r.newOther.pool, r.newOther.p)
+      rows.push({
+        split: i,
+        probBefore: f(r.probOther),
+        childProb: f(r.targetProb, 8),
+        belowFloor: r.targetProb < MIN_CPMM_PROB,
+        poolYES: f(r.newOther.pool.YES, 3),
+        poolNO: f(r.newOther.pool.NO, 3),
+        p: f(r.newOther.p, 8),
+        liq: f(r.newOther.totalLiquidity, 3),
+        cost10YES: f(t.costYes10, 4),
+        tradeMathOk: t.ok,
+      })
+      if (firstSubFloor === null && r.targetProb < MIN_CPMM_PROB)
+        firstSubFloor = i
+      expect(t.ok).toBe(true) // math never breaks, it just keeps halving
+      // Other' becomes the Other for the next split.
+      Yo = r.newOther.pool.YES
+      No = r.newOther.pool.NO
+      p = r.newOther.p
+    }
+    console.table(rows)
+    console.log(
+      `first split producing children below MIN_CPMM_PROB=${MIN_CPMM_PROB}: split #${firstSubFloor}`
+    )
+    // 0.5 -> 0.25 -> 0.125 -> 0.0625 -> 0.03125 -> 0.015625 -> 0.0078125
+    expect(firstSubFloor).toBe(6)
+    // Nothing NaN/negative even at split 8 (prob ~0.00195):
+    const last = rows[rows.length - 1]
+    expect(last.tradeMathOk).toBe(true)
+    expect(last.childProb).toBeGreaterThan(0)
+  })
+
+  // ------------------------------------------------------------------ edge 3
+  it('3. small pools: Yo/No in {1,5,10} mana vs answerCost {25,100}', () => {
+    const rows: any[] = []
+    for (const answerCost of [25, 100]) {
+      for (const Yo of [1, 5, 10]) {
+        for (const No of [1, 5, 10]) {
+          const r = splitOther(Yo, No, 0.5, answerCost)
+          const t = tradeCheck(r.newAnswer.pool, r.newAnswer.p)
+          const roundTripErr =
+            Math.abs(t.prob - r.targetProb) / r.targetProb
+          rows.push({
+            answerCost,
+            Yo,
+            No,
+            probOther: f(r.probOther),
+            childProb: f(r.targetProb),
+            p: f(r.newAnswer.p),
+            poolYES: f(r.newAnswer.pool.YES, 2),
+            poolNO: f(r.newAnswer.pool.NO, 2),
+            relRoundTripErr: roundTripErr.toExponential(2),
+            tradeMathOk: t.ok,
+          })
+          expect(t.ok).toBe(true)
+          expect(r.newAnswer.p).toBeGreaterThan(0)
+          expect(r.newAnswer.p).toBeLessThan(1)
+          expect(roundTripErr).toBeLessThan(1e-12)
+        }
+      }
+    }
+    console.table(rows)
+    const ps = rows.map((r) => r.p)
+    console.log(`p range across grid: [${Math.min(...ps)}, ${Math.max(...ps)}]`)
+  })
+
+  // ------------------------------------------------------------------ edge 4
+  it('4. pOther != 0.5 (post-drizzle drift): lossless at general p', () => {
+    // Listed answers with general p; v2 never touches their pools
+    // (create-answer-cpmm.ts lines 503-528 only build A and Other';
+    // lines 535-552 credit off-pool redemption bets with
+    // probBefore = probAfter = listed.prob). Verify bit-identity anyway,
+    // plus exact prob-mass conservation: A + Other' == probOther.
+    const listed = [
+      { pool: { YES: 137.2, NO: 84.9 }, p: 0.6321 },
+      { pool: { YES: 12.4, NO: 331.7 }, p: 0.2874 },
+      { pool: { YES: 55.5, NO: 55.5 }, p: 0.5 },
+    ].map((a) => ({ ...a, prob: getCpmmProbability(a.pool, a.p) }))
+    Object.freeze(listed)
+    listed.forEach((a) => Object.freeze(a.pool))
+
+    const rows: any[] = []
+    for (const pOther of [0.3, 0.417, 0.5, 0.7, 0.913]) {
+      for (const [Yo, No] of [
+        [80, 120],
+        [33.7, 210.4],
+        [500, 12],
+      ]) {
+        const probsBefore = listed.map((a) => getCpmmProbability(a.pool, a.p))
+        const r = splitOther(Yo, No, pOther, 25)
+        const probsAfter = listed.map((a) => getCpmmProbability(a.pool, a.p))
+
+        // (a) listed probs bit-identical (=== on doubles)
+        probsBefore.forEach((pb, i) => expect(probsAfter[i]).toBe(pb))
+        // (b) children's displayed prob equals targetProb (weightFor exact
+        //     inverse of getCpmmProbability)
+        const dispA = getCpmmProbability(r.newAnswer.pool, r.newAnswer.p)
+        const dispO = getCpmmProbability(r.newOther.pool, r.newOther.p)
+        // (c) prob mass conserved: A + Other' == probOther (targetProb*2)
+        const massErr = Math.abs(dispA + dispO - r.probOther)
+
+        rows.push({
+          pOther,
+          Yo,
+          No,
+          probOther: f(r.probOther, 8),
+          dispA: f(dispA, 8),
+          dispOther2: f(dispO, 8),
+          massErr: massErr.toExponential(2),
+          childP: f(r.newAnswer.p, 8),
+          listedBitIdentical: probsAfter.every((x, i) => x === probsBefore[i]),
+        })
+        expect(Math.abs(dispA - r.targetProb)).toBeLessThan(1e-15)
+        expect(massErr).toBeLessThan(1e-14)
+      }
+    }
+    console.table(rows)
+  })
+
+  // ------------------------------------------------------------------ edge 5
+  it('5. no guard: math happily splits an Other already at/below 0.02', () => {
+    // Static finding (see report): verifyContract (create-answer-cpmm.ts
+    // lines 80-110) checks token/mechanism/closeTime/addAnswersMode only;
+    // createAnswerCpmmMain checks balance (line 129) and maxAnswers
+    // (line 141). No probOther / MIN_CPMM_PROB check exists on the v2 path.
+    // Here: confirm the math itself raises no error and emits valid-looking
+    // (finite, tradeable) sub-floor answers — i.e. nothing downstream of the
+    // handler would stop it either.
+    const rows: any[] = []
+    for (const q of [0.02, 0.011, 0.0101, 0.005, 0.002]) {
+      const pool = poolAtProb(q, 0.5, 100)
+      const r = splitOther(pool.YES, pool.NO, 0.5, 25)
+      const t = tradeCheck(r.newAnswer.pool, r.newAnswer.p)
+      rows.push({
+        probOther: q,
+        alreadySubFloor: q < MIN_CPMM_PROB,
+        childProb: f(r.targetProb, 8),
+        childBelowFloor: r.targetProb < MIN_CPMM_PROB,
+        p: f(r.newAnswer.p, 8),
+        tradeMathOk: t.ok,
+      })
+      expect(t.ok).toBe(true) // no throw, no NaN — GUARD MISSING upstream
+    }
+    console.table(rows)
+    expect(rows.every((r) => r.tradeMathOk)).toBe(true)
+    expect(
+      rows.filter((r) => r.childBelowFloor).length
+    ).toBeGreaterThanOrEqual(4)
+  })
+
+  // sanity: floor constants are what we think they are
+  it('constants', () => {
+    expect(MIN_CPMM_PROB).toBe(0.01)
+    expect(MAX_CPMM_PROB).toBe(0.99)
+  })
+})

--- a/common/src/payouts.ts
+++ b/common/src/payouts.ts
@@ -6,6 +6,7 @@ import {
   Contract,
   CPMMContract,
   CPMMMultiContract,
+  isMultiCpmm,
   tradingAllowed,
 } from './contract'
 import { ContractMetric } from './contract-metric'
@@ -78,7 +79,7 @@ export const getPayouts = (
     )
   }
   if (
-    contract.mechanism === 'cpmm-multi-1' &&
+    isMultiCpmm(contract) &&
     !contract.shouldAnswersSumToOne &&
     answerId
   ) {
@@ -95,7 +96,7 @@ export const getPayouts = (
       resolutionProbability ?? answer.prob
     )
   }
-  if (contract.mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     if (outcome === 'CANCEL') {
       return getFixedCancelPayouts(contractMetrics, liquidities)
     }

--- a/common/src/sell-bet.ts
+++ b/common/src/sell-bet.ts
@@ -36,7 +36,9 @@ export const getCpmmSellBetInfo = (
   answer?: Answer
 ) => {
   if (isMultiCpmm(contract) && !answer) {
-    throw new Error('getCpmmSellBetInfo: answer required for cpmm-multi-1')
+    throw new Error(
+      'getCpmmSellBetInfo: answer required for multi-choice cpmm contracts'
+    )
   }
 
   const startCpmmState =
@@ -277,7 +279,9 @@ export const getSaleResult = (
   answer?: Answer
 ) => {
   if (isMultiCpmm(contract) && !answer)
-    throw new Error('getSaleResult: answer must be defined for cpmm-multi-1')
+    throw new Error(
+      'getSaleResult: answer must be defined for multi-choice cpmm contracts'
+    )
 
   const initialProb = answer
     ? answer.prob

--- a/common/src/sell-bet.ts
+++ b/common/src/sell-bet.ts
@@ -7,6 +7,7 @@ import {
 import {
   Contract,
   CPMMContract,
+  isMultiCpmm,
   MarketContract,
   MultiContract,
 } from './contract'
@@ -34,7 +35,7 @@ export const getCpmmSellBetInfo = (
   loanPaid: number,
   answer?: Answer
 ) => {
-  if (contract.mechanism === 'cpmm-multi-1' && !answer) {
+  if (isMultiCpmm(contract) && !answer) {
     throw new Error('getCpmmSellBetInfo: answer required for cpmm-multi-1')
   }
 
@@ -275,7 +276,7 @@ export const getSaleResult = (
   balanceByUserId: { [userId: string]: number },
   answer?: Answer
 ) => {
-  if (contract.mechanism === 'cpmm-multi-1' && !answer)
+  if (isMultiCpmm(contract) && !answer)
     throw new Error('getSaleResult: answer must be defined for cpmm-multi-1')
 
   const initialProb = answer

--- a/common/src/sell-bet.ts
+++ b/common/src/sell-bet.ts
@@ -44,7 +44,7 @@ export const getCpmmSellBetInfo = (
       ? contract
       : {
           pool: { YES: answer!.poolYes, NO: answer!.poolNo },
-          p: 0.5,
+          p: answer!.p,
           collectedFees: contract.collectedFees,
         }
 
@@ -127,7 +127,7 @@ export const getCpmmMultiSellBetInfo = (
   const { cpmmState, makers, takers, ordersToCancel, totalFees } = newBetResult!
 
   const probBefore = answerToSell.prob
-  const probAfter = getCpmmProbability(cpmmState.pool, 0.5)
+  const probAfter = getCpmmProbability(cpmmState.pool, cpmmState.p)
 
   const takerAmount = sumBy(takers, 'amount')
   const takerShares = sumBy(takers, 'shares')
@@ -285,7 +285,7 @@ export const getSaleResult = (
   const initialCpmmState = answer
     ? {
         pool: { YES: answer.poolYes, NO: answer.poolNo },
-        p: 0.5,
+        p: answer.p,
         collectedFees: contract.collectedFees,
       }
     : {

--- a/common/src/sell-domain-probe.test.ts
+++ b/common/src/sell-domain-probe.test.ts
@@ -450,39 +450,43 @@ d('cpmm-multi-2 sell-path domain probe (general p)', () => {
       return { res, after, stats, anyNaNp }
     }
 
-    it('BUG repro: sell 10,000 YES into thin pools (L=2), p far from 0.5', () => {
+    it('FIXED: sell 10,000 YES into thin pools (L=2), p far from 0.5', () => {
       const answers = mkV2Market([0.1, 0.1, 0.8], 2)
       const { res, stats, anyNaNp } = sellAndInspect(answers, answers[2], 10_000, 'YES')
       record(
         'P2 oversell 10k YES (L=2, p=0.8)',
-        'BUG',
+        'FIXED',
         `NaN newP=${anyNaNp} ${fmtStats(stats)} saleValue=${res.saleValue.toFixed(4)} ` +
-          `— corner collapse: solver skipped the arb legs entirely, market left at ` +
-          `sumProb=${(1 + stats.sumProbResidual).toFixed(3)} with a pool side exactly 0`
+          `— solver finds the interior root; pool side still underflows to exactly 0 ` +
+          `(physical; execution guarded by CPMM_MIN_POOL_QTY) but sum-to-one holds`
       )
-      // These assertions PIN the buggy behavior so a fix flips them loudly:
-      expect(anyNaNp).toBe(true) // newP = NaN out of addCpmmLiquidity
-      expect(stats.minPool).toBe(0) // pool side cancelled to exactly 0
-      expect(stats.sumProbResidual).toBeLessThan(-0.5) // sum-to-one destroyed
+      // These assertions PIN the fixed behavior (was: NaN newP -> silent corner
+      // collapse with sumProb ~ 0.1; addCpmmLiquidity's 0/0 rescue + binarySearch
+      // NaN fail-fast repaired it):
+      expect(anyNaNp).toBe(false) // no NaN out of addCpmmLiquidity
+      expect(stats.minPool).toBe(0) // the underflow itself is physical, still present
+      expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-9) // sum-to-one restored
+      expect(isFinite(res.saleValue) && res.saleValue > 0).toBe(true)
     })
 
-    it('BUG repro: sell 10,000 NO into thin pools (L=2)', () => {
+    it('FIXED: sell 10,000 NO into thin pools (L=2)', () => {
       const answers = mkV2Market([0.1, 0.1, 0.8], 2)
       const { res, stats, anyNaNp } = sellAndInspect(answers, answers[0], 10_000, 'NO')
       record(
         'P2 oversell 10k NO (L=2, p=0.1)',
-        'BUG',
+        'FIXED',
         `NaN newP=${anyNaNp} ${fmtStats(stats)} saleValue=${res.saleValue.toFixed(4)} ` +
-          `— mirror-image corner collapse, market left at sumProb=${(1 + stats.sumProbResidual).toFixed(3)}`
+          `— mirror-image of the YES case: interior root found, sum-to-one holds`
       )
-      expect(anyNaNp).toBe(true)
+      expect(anyNaNp).toBe(false)
       expect(stats.minPool).toBe(0)
-      expect(Math.abs(stats.sumProbResidual)).toBeGreaterThan(0.5)
+      expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-9)
+      expect(isFinite(res.saleValue) && res.saleValue > 0).toBe(true)
     })
 
-    it('threshold: realistic p=0.9 answer with L=100 breaks near ~5,000 shares', () => {
+    it('threshold sweep: p=0.9 with L=100 stays NaN-free through the old ~5,000-share cliff', () => {
       const rows: string[] = []
-      let threshold: number | undefined
+      let firstNaN: number | undefined
       for (const S of [500, 1000, 2000, 4000, 5000, 10000]) {
         const answers = [
           mkV2Answer(0, 0.05), mkV2Answer(1, 0.05), mkV2Answer(2, 0.9),
@@ -492,15 +496,18 @@ d('cpmm-multi-2 sell-path domain probe (general p)', () => {
           `S=${S}: sumProb=${(1 + stats.sumProbResidual).toFixed(4)} ` +
             `minPool=${stats.minPool.toExponential(1)} NaN=${anyNaNp} perShare=${(res.saleValue / S).toFixed(4)}`
         )
-        if (anyNaNp && threshold === undefined) threshold = S
+        if (anyNaNp && firstNaN === undefined) firstNaN = S
+        // The old bug NaN'd from S≈5,000 (a realistic position size); pin clean math
+        // and Σ=1 at every size now.
+        expect(anyNaNp).toBe(false)
+        expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-9)
       }
       record(
         'P2 breakdown threshold (p=0.9, L=100)',
-        'BUG',
-        rows.join(' | ') + ` — first NaN at S=${threshold}`
+        'FIXED',
+        rows.join(' | ') + ` — first NaN at S=${firstNaN} (was S=5000 pre-fix)`
       )
-      expect(threshold).toBeDefined()
-      expect(threshold!).toBeLessThanOrEqual(5000) // realistic position size
+      expect(firstNaN).toBeUndefined()
     })
 
     it('control: p=0.5 pools never hit the NaN hole even at S=1e9', () => {

--- a/common/src/sell-domain-probe.test.ts
+++ b/common/src/sell-domain-probe.test.ts
@@ -1,0 +1,756 @@
+// Adversarial domain probe of the cpmm-multi-2 SELL paths at general p.
+//
+// Context: external review of the cpmm-multi-2 PR flagged that the sell-side
+// code at p != 0.5 is untested and has no domain theorem. This probe exercises
+// the sell entry points on sum-to-one markets with per-answer p far from 0.5
+// and reports domain facts: NaN/throw, pool positivity, sum-to-one restoration,
+// per-answer liquidity-invariant (k = Y^p * N^(1-p)) conservation, mana
+// conservation from raw pool deltas, path independence, and buy->sell
+// round-trip residuals.
+//
+// Sell entry points probed (all general-p on this branch, no version dispatch —
+// v1 markets have answer.p == 0.5 so the same code is byte-identical for them):
+//   - calculateCpmmMultiSumsToOneSale -> calculateCpmmMultiArbitrageSellYes/SellNo
+//     (backend/api/src/sell-shares.ts -> common/src/sell-bet.ts:getCpmmMultiSellBetInfo)
+//   - calculateCpmmMultiArbitrageSellYesEqually
+//     (backend/api/src/multi-sell.ts -> common/src/sell-bet.ts:getCpmmMultiSellSharesInfo)
+//
+// Run with:  cd common && PROBE=1 npx jest sell-domain-probe --silent=false
+// Skipped (describe.skip) in normal test runs.
+
+import { sumBy } from 'lodash'
+import { Answer } from './answer'
+import { Bet, LimitBet } from './bet'
+import {
+  calculateCpmmMultiSumsToOneSale,
+  getCpmmLiquidity,
+  getCpmmProbability,
+} from './calculate-cpmm'
+import {
+  calculateCpmmMultiArbitrageBet,
+  calculateCpmmMultiArbitrageSellYesEqually,
+  calculateCpmmMultiArbitrageYesBets,
+} from './calculate-cpmm-arbitrage'
+import { noFees } from './fees'
+
+const d = process.env.PROBE ? describe : describe.skip
+
+// ---------------------------------------------------------------- fixtures
+
+// Answer with arbitrary (prob, p) and liquidity L = Y^p * N^(1-p).
+// N/Y ratio r solves prob = p*N / (p*N + (1-p)*Y)  =>  r = (1-p)prob / (p(1-prob)).
+const mkAnswer = (index: number, prob: number, p: number, L = 100): Answer => {
+  const r = ((1 - p) * prob) / (p * (1 - prob))
+  const poolYes = L / r ** (1 - p)
+  const poolNo = poolYes * r
+  return {
+    id: `answer${index}`,
+    contractId: `contract`,
+    userId: `user${index}`,
+    text: `Answer ${index}`,
+    createdTime: 0,
+    index,
+    prob,
+    poolYes,
+    poolNo,
+    p,
+    totalLiquidity: 0,
+    subsidyPool: 0,
+    probChanges: { day: 0, week: 0, month: 0 },
+    volume: 0,
+  } as Answer
+}
+
+// v2-creation-style answer: p = prob (balanced pools Y = N = L), which is what
+// the cpmm-multi-2 sqrt-variance creation rule produces.
+const mkV2Answer = (index: number, prob: number, L = 100) =>
+  mkAnswer(index, prob, prob, L)
+
+const mkV2Market = (probs: number[], L = 100) =>
+  probs.map((prob, i) => mkV2Answer(i, prob, L))
+
+const bets = (shares: number) => [{ shares } as Bet]
+
+const noBets: LimitBet[] = []
+const noBalances: { [userId: string]: number } = {}
+
+// ---------------------------------------------------------------- helpers
+
+const probOf = (a: Answer) =>
+  getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, a.p)
+const sumProb = (answers: Answer[]) => sumBy(answers, probOf)
+const liqOf = (a: Answer) =>
+  getCpmmLiquidity({ YES: a.poolYes, NO: a.poolNo }, a.p)
+
+// Apply a calculateCpmmMultiSumsToOneSale result to an answers array.
+type CpmmStateLike = { pool: { [outcome: string]: number }; p: number }
+const applySale = (
+  answers: Answer[],
+  answerToSellId: string,
+  saleResult: {
+    newBetResult: { cpmmState: CpmmStateLike }
+    otherBetResults: { answer: Answer; cpmmState: CpmmStateLike }[]
+  }
+) =>
+  answers.map((a) => {
+    const r =
+      a.id === answerToSellId
+        ? saleResult.newBetResult
+        : saleResult.otherBetResults.find((r) => r.answer.id === a.id)
+    if (!r) return a
+    const { pool, p } = r.cpmmState
+    return {
+      ...a,
+      poolYes: pool.YES,
+      poolNo: pool.NO,
+      prob: getCpmmProbability(pool, p),
+    }
+  })
+
+type Finding = {
+  probe: string
+  verdict: string
+  detail: string
+}
+const findings: Finding[] = []
+const record = (probe: string, verdict: string, detail: string) => {
+  findings.push({ probe, verdict, detail })
+  console.log(`[${verdict}] ${probe}: ${detail}`)
+}
+
+// Domain facts common to every probe: all pools finite & positive, sum-to-one
+// restored, per-answer liquidity invariant preserved (fee constant is 0 and no
+// makers, so k must be exactly conserved by AMM-only fills).
+const domainStats = (before: Answer[], after: Answer[]) => {
+  const pools = after.flatMap((a) => [a.poolYes, a.poolNo])
+  const allFinite = pools.every((x) => Number.isFinite(x))
+  const minPool = Math.min(...pools)
+  const sumProbResidual = sumProb(after) - 1
+  const maxLiqDrift = Math.max(
+    ...after.map((a, i) => Math.abs(liqOf(a) / liqOf(before[i]) - 1))
+  )
+  return { allFinite, minPool, sumProbResidual, maxLiqDrift }
+}
+
+const fmtStats = (s: ReturnType<typeof domainStats>) =>
+  `finite=${s.allFinite} minPool=${s.minPool.toExponential(2)} ` +
+  `sumProb-1=${s.sumProbResidual.toExponential(2)} ` +
+  `maxLiqDrift=${s.maxLiqDrift.toExponential(2)}`
+
+// ---------------------------------------------------------------- probes
+
+d('cpmm-multi-2 sell-path domain probe (general p)', () => {
+  afterAll(() => {
+    console.log('\n================ FINDINGS ================')
+    console.table(findings)
+  })
+
+  // ---------------------------------------------------------------- P1
+  describe('P1: sell on sum-to-one markets with p far from 0.5', () => {
+    const markets: [string, number[]][] = [
+      ['n=3 probs 0.1/0.1/0.8', [0.1, 0.1, 0.8]],
+      ['n=10 probs 0.55 + 9x0.05', [0.55, ...Array(9).fill(0.05)]],
+      ['n=30 probs 0.42 + 29x0.02', [0.42, ...Array(29).fill(0.02)]],
+    ]
+
+    it.each(markets)('single-answer sell YES + conservation: %s', (label, probs) => {
+      const answers = mkV2Market(probs)
+      // Sell YES of the highest-prob answer (largest arb footprint at general p)
+      const idx = probs.indexOf(Math.max(...probs))
+      const toSell = answers[idx]
+      const S = 50
+
+      const res = calculateCpmmMultiSumsToOneSale(
+        answers,
+        toSell,
+        S,
+        'YES',
+        undefined,
+        noBets,
+        noBalances,
+        noFees
+      )
+      const after = applySale(answers, toSell.id, res)
+      const stats = domainStats(answers, after)
+
+      // Mana conservation from raw pool deltas (fees are 0, no makers):
+      // sold answer got one NO buy: b_i = dY_i; every other answer got one YES
+      // buy: b_j = dN_j. Complete-set redemption identity: proceeds = S - sum(b).
+      const bSold = after[idx].poolYes - answers[idx].poolYes
+      const bOthers = after
+        .filter((_, j) => j !== idx)
+        .map((a, j2) => {
+          const beforeA = answers.filter((_, j) => j !== idx)[j2]
+          return a.poolNo - beforeA.poolNo
+        })
+      const totalBuy = bSold + sumBy(bOthers, (x) => x)
+      const conservationResidual = res.saleValue - (S - totalBuy)
+
+      // YES shares extracted per other answer should be equal across answers
+      const sOthers = after
+        .filter((_, j) => j !== idx)
+        .map((a, j2) => {
+          const beforeA = answers.filter((_, j) => j !== idx)[j2]
+          return a.poolNo - beforeA.poolNo - (a.poolYes - beforeA.poolYes)
+        })
+      const sSpread = Math.max(...sOthers) - Math.min(...sOthers)
+
+      const ok =
+        stats.allFinite &&
+        stats.minPool > 0 &&
+        Math.abs(stats.sumProbResidual) < 1e-6 &&
+        stats.maxLiqDrift < 1e-9 &&
+        Math.abs(conservationResidual) < 1e-6 &&
+        Number.isFinite(res.saleValue) &&
+        res.saleValue > 0 &&
+        res.saleValue < S
+
+      record(
+        `P1 sellYES ${label}`,
+        ok ? 'SAFE' : 'BUG',
+        `${fmtStats(stats)} saleValue=${res.saleValue.toFixed(6)} ` +
+          `conservation=${conservationResidual.toExponential(2)} ` +
+          `otherLegShareSpread=${sSpread.toExponential(2)}`
+      )
+      expect(stats.allFinite).toBe(true)
+      expect(stats.minPool).toBeGreaterThan(0)
+      expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-6)
+      expect(stats.maxLiqDrift).toBeLessThan(1e-9)
+      expect(Math.abs(conservationResidual)).toBeLessThan(1e-6)
+    })
+
+    it.each(markets)('single-answer sell NO + conservation: %s', (label, probs) => {
+      const answers = mkV2Market(probs)
+      // Sell NO of the LOWEST-prob answer (NO shares near price 1, extreme p)
+      const idx = probs.indexOf(Math.min(...probs))
+      const toSell = answers[idx]
+      const S = 50
+      const n = answers.length
+
+      const res = calculateCpmmMultiSumsToOneSale(
+        answers,
+        toSell,
+        S,
+        'NO',
+        undefined,
+        noBets,
+        noBalances,
+        noFees
+      )
+      const after = applySale(answers, toSell.id, res)
+      const stats = domainStats(answers, after)
+
+      // sold answer got one YES buy: b_i = dN_i, yesShares = dN_i - dY_i.
+      // others got one NO buy each: b_j = dY_j.
+      // redemption = yesShares + (n-1)*(S - yesShares); proceeds = redemption - sum(b)
+      const bSold = after[idx].poolNo - answers[idx].poolNo
+      const yesShares =
+        after[idx].poolNo -
+        answers[idx].poolNo -
+        (after[idx].poolYes - answers[idx].poolYes)
+      const bOthers = after
+        .filter((_, j) => j !== idx)
+        .map((a, j2) => {
+          const beforeA = answers.filter((_, j) => j !== idx)[j2]
+          return a.poolYes - beforeA.poolYes
+        })
+      const totalBuy = bSold + sumBy(bOthers, (x) => x)
+      const redemption = yesShares + (n - 1) * (S - yesShares)
+      const conservationResidual = res.saleValue - (redemption - totalBuy)
+
+      const ok =
+        stats.allFinite &&
+        stats.minPool > 0 &&
+        Math.abs(stats.sumProbResidual) < 1e-6 &&
+        stats.maxLiqDrift < 1e-9 &&
+        Math.abs(conservationResidual) < 1e-6 &&
+        Number.isFinite(res.saleValue) &&
+        res.saleValue > 0 &&
+        res.saleValue < S
+
+      record(
+        `P1 sellNO ${label}`,
+        ok ? 'SAFE' : 'BUG',
+        `${fmtStats(stats)} saleValue=${res.saleValue.toFixed(6)} ` +
+          `conservation=${conservationResidual.toExponential(2)}`
+      )
+      expect(stats.allFinite).toBe(true)
+      expect(stats.minPool).toBeGreaterThan(0)
+      expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-6)
+      expect(stats.maxLiqDrift).toBeLessThan(1e-9)
+      expect(Math.abs(conservationResidual)).toBeLessThan(1e-6)
+    })
+
+    it('sell YES equally across a basket (multi-sell path), n=10', () => {
+      const probs = [0.55, ...Array(9).fill(0.05)]
+      const answers = mkV2Market(probs)
+      // Unequal holdings across two answers exercises the while-loop passes
+      const userBets = {
+        [answers[0].id]: bets(50), // prob/p = 0.55
+        [answers[1].id]: bets(30), // prob/p = 0.05
+      }
+      const res = calculateCpmmMultiArbitrageSellYesEqually(
+        answers,
+        userBets,
+        noBets,
+        noBalances,
+        noFees
+      )
+      const after = res.updatedAnswers
+      const stats = domainStats(answers, after)
+      const proceeds = -sumBy(
+        res.newBetResults.flatMap((r) => r.takers),
+        'amount'
+      )
+      // opposite-side arb buys must net to zero mana and shares for the user
+      const otherAmount = sumBy(
+        res.otherBetResults.flatMap((r) => r.takers),
+        'amount'
+      )
+      const otherShares = sumBy(
+        res.otherBetResults.flatMap((r) => r.takers),
+        'shares'
+      )
+      const ok =
+        stats.allFinite &&
+        stats.minPool > 0 &&
+        Math.abs(stats.sumProbResidual) < 1e-6 &&
+        stats.maxLiqDrift < 1e-9 &&
+        proceeds > 0 &&
+        proceeds < 80 &&
+        Math.abs(otherAmount) < 1e-6
+
+      record(
+        'P1 sellYesEqually n=10 (50 @p=.55, 30 @p=.05)',
+        ok ? 'SAFE' : 'BUG',
+        `${fmtStats(stats)} proceeds=${proceeds.toFixed(6)} ` +
+          `otherNetMana=${otherAmount.toExponential(2)} otherNetShares=${otherShares.toExponential(2)}`
+      )
+      expect(stats.allFinite).toBe(true)
+      expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-6)
+      expect(stats.maxLiqDrift).toBeLessThan(1e-9)
+      expect(Math.abs(otherAmount)).toBeLessThan(1e-6)
+    })
+
+    it('sell equal shares in ALL answers = exact complete-set redemption', () => {
+      const probs = [0.1, 0.1, 0.8]
+      const answers = mkV2Market(probs)
+      const X = 37.5
+      const userBets = Object.fromEntries(answers.map((a) => [a.id, bets(X)]))
+      const res = calculateCpmmMultiArbitrageSellYesEqually(
+        answers,
+        userBets,
+        noBets,
+        noBalances,
+        noFees
+      )
+      const proceeds = -sumBy(
+        res.newBetResults.flatMap((r) => r.takers),
+        'amount'
+      )
+      const poolsMoved = res.updatedAnswers.some(
+        (a, i) => a.poolYes !== answers[i].poolYes || a.poolNo !== answers[i].poolNo
+      )
+      const ok = Math.abs(proceeds - X) < 1e-9 && !poolsMoved
+      record(
+        'P1 sell-all redemption n=3',
+        ok ? 'SAFE' : 'BUG',
+        `proceeds=${proceeds} (expected exactly ${X}), poolsMoved=${poolsMoved}`
+      )
+      expect(proceeds).toBeCloseTo(X, 9)
+      expect(poolsMoved).toBe(false)
+    })
+
+    it('path independence: sell 50 once vs 25 + 25 sequentially', () => {
+      const probs = [0.1, 0.1, 0.8]
+      const answers = mkV2Market(probs)
+      const toSell = answers[2]
+
+      const once = calculateCpmmMultiSumsToOneSale(
+        answers, toSell, 50, 'YES', undefined, noBets, noBalances, noFees
+      )
+
+      const first = calculateCpmmMultiSumsToOneSale(
+        answers, toSell, 25, 'YES', undefined, noBets, noBalances, noFees
+      )
+      const mid = applySale(answers, toSell.id, first)
+      const second = calculateCpmmMultiSumsToOneSale(
+        mid, mid[2], 25, 'YES', undefined, noBets, noBalances, noFees
+      )
+      const afterOnce = applySale(answers, toSell.id, once)
+      const afterTwice = applySale(mid, mid[2].id, second)
+
+      const proceedsDiff =
+        once.saleValue - (first.saleValue + second.saleValue)
+      const maxPoolDiff = Math.max(
+        ...afterOnce.flatMap((a, i) => [
+          Math.abs(a.poolYes - afterTwice[i].poolYes),
+          Math.abs(a.poolNo - afterTwice[i].poolNo),
+        ])
+      )
+      const ok = Math.abs(proceedsDiff) < 1e-6 && maxPoolDiff < 1e-6
+      record(
+        'P1 path independence n=3',
+        ok ? 'SAFE' : 'BUG',
+        `proceedsDiff=${proceedsDiff.toExponential(2)} maxPoolDiff=${maxPoolDiff.toExponential(2)}`
+      )
+      expect(Math.abs(proceedsDiff)).toBeLessThan(1e-6)
+      expect(maxPoolDiff).toBeLessThan(1e-6)
+    })
+  })
+
+  // ---------------------------------------------------------------- P2
+  //
+  // CONFIRMED BUG (general-p specific): oversized sells NaN-poison the solver
+  // and silently corner-collapse.
+  //
+  // Mechanism:
+  //  1. A large opposite-outcome buy drives the off-side pool to
+  //     residual = k^{1/(1-p)} / (pool+b)^{p/(1-p)}. At p far from 0.5 the
+  //     exponent p/(1-p) makes this underflow below one ulp of (pool+b) at
+  //     MODEST sizes (p=0.9, L=100: ~5,000 shares), so `n + b - s` in
+  //     calculateCpmmPurchase cancels to EXACTLY 0. At p=0.5 the residual is
+  //     k^2/b — it stays positive past b=1e9 (control below), so v1 never hits this.
+  //  2. calculateCpmmPurchase -> addCpmmLiquidity(postBetPool, p, 0)
+  //     (calculate-cpmm.ts:744) then computes newP = numerator/denominator
+  //     with BOTH terms 0 when a pool side is 0  =>  newP = NaN.
+  //  3. The sell binary search's comparator sums
+  //     getCpmmProbability(pool, NaN) = NaN; binarySearch (util/algos.ts)
+  //     treats NaN as "comparison <= 0" and walks min up  =>  silently returns
+  //     the corner noShares = sharesSold, skipping the real interior root.
+  //  4. Result: the market is left violating sum-to-one (Sigma prob = 0.1 in the
+  //     fixture below), the sold answer's pool side is exactly 0 (liquidity
+  //     invariant destroyed), and saleValue is discontinuously wrong
+  //     (per-share value drops ~3x across the threshold).
+  //
+  // Blast radius: execution is saved by the CPMM_MIN_POOL_QTY (=0.01) check in
+  // place-bet.ts validation (min pool 0 < 0.01 => APIError), so the corrupt
+  // state should not persist — but the user's legitimate sell is rejected with
+  // a misleading error, and CLIENT preview paths (getSaleResult /
+  // getSaleResultMultiSumsToOne / expected-value displays) render the garbage
+  // numbers. The same primitive (computeFills -> calculateCpmmPurchase) is
+  // shared by buyNoSharesUntilAnswersSumToOne, so the sellYesEqually path and
+  // v1-style arb loops share the exposure at general p.
+  describe('P2: sell far more shares than the marginal pool can absorb', () => {
+    const sellAndInspect = (
+      answers: Answer[],
+      toSell: Answer,
+      S: number,
+      outcome: 'YES' | 'NO'
+    ) => {
+      const res = calculateCpmmMultiSumsToOneSale(
+        answers, toSell, S, outcome, undefined, noBets, noBalances, noFees
+      )
+      const after = applySale(answers, toSell.id, res)
+      const stats = domainStats(answers, after)
+      const anyNaNp = [
+        res.newBetResult.cpmmState,
+        ...res.otherBetResults.map((r) => r.cpmmState),
+      ].some((st) => isNaN(st.p))
+      return { res, after, stats, anyNaNp }
+    }
+
+    it('BUG repro: sell 10,000 YES into thin pools (L=2), p far from 0.5', () => {
+      const answers = mkV2Market([0.1, 0.1, 0.8], 2)
+      const { res, stats, anyNaNp } = sellAndInspect(answers, answers[2], 10_000, 'YES')
+      record(
+        'P2 oversell 10k YES (L=2, p=0.8)',
+        'BUG',
+        `NaN newP=${anyNaNp} ${fmtStats(stats)} saleValue=${res.saleValue.toFixed(4)} ` +
+          `— corner collapse: solver skipped the arb legs entirely, market left at ` +
+          `sumProb=${(1 + stats.sumProbResidual).toFixed(3)} with a pool side exactly 0`
+      )
+      // These assertions PIN the buggy behavior so a fix flips them loudly:
+      expect(anyNaNp).toBe(true) // newP = NaN out of addCpmmLiquidity
+      expect(stats.minPool).toBe(0) // pool side cancelled to exactly 0
+      expect(stats.sumProbResidual).toBeLessThan(-0.5) // sum-to-one destroyed
+    })
+
+    it('BUG repro: sell 10,000 NO into thin pools (L=2)', () => {
+      const answers = mkV2Market([0.1, 0.1, 0.8], 2)
+      const { res, stats, anyNaNp } = sellAndInspect(answers, answers[0], 10_000, 'NO')
+      record(
+        'P2 oversell 10k NO (L=2, p=0.1)',
+        'BUG',
+        `NaN newP=${anyNaNp} ${fmtStats(stats)} saleValue=${res.saleValue.toFixed(4)} ` +
+          `— mirror-image corner collapse, market left at sumProb=${(1 + stats.sumProbResidual).toFixed(3)}`
+      )
+      expect(anyNaNp).toBe(true)
+      expect(stats.minPool).toBe(0)
+      expect(Math.abs(stats.sumProbResidual)).toBeGreaterThan(0.5)
+    })
+
+    it('threshold: realistic p=0.9 answer with L=100 breaks near ~5,000 shares', () => {
+      const rows: string[] = []
+      let threshold: number | undefined
+      for (const S of [500, 1000, 2000, 4000, 5000, 10000]) {
+        const answers = [
+          mkV2Answer(0, 0.05), mkV2Answer(1, 0.05), mkV2Answer(2, 0.9),
+        ]
+        const { res, stats, anyNaNp } = sellAndInspect(answers, answers[2], S, 'YES')
+        rows.push(
+          `S=${S}: sumProb=${(1 + stats.sumProbResidual).toFixed(4)} ` +
+            `minPool=${stats.minPool.toExponential(1)} NaN=${anyNaNp} perShare=${(res.saleValue / S).toFixed(4)}`
+        )
+        if (anyNaNp && threshold === undefined) threshold = S
+      }
+      record(
+        'P2 breakdown threshold (p=0.9, L=100)',
+        'BUG',
+        rows.join(' | ') + ` — first NaN at S=${threshold}`
+      )
+      expect(threshold).toBeDefined()
+      expect(threshold!).toBeLessThanOrEqual(5000) // realistic position size
+    })
+
+    it('control: p=0.5 pools never hit the NaN hole even at S=1e9', () => {
+      const answers = [
+        mkAnswer(0, 1 / 3, 0.5), mkAnswer(1, 1 / 3, 0.5), mkAnswer(2, 1 / 3, 0.5),
+      ]
+      const { stats, anyNaNp } = sellAndInspect(answers, answers[2], 1e9, 'YES')
+      record(
+        'P2 p=0.5 control (S=1e9, L=100)',
+        'SAFE',
+        `NaN newP=${anyNaNp} ${fmtStats(stats)} — residual pool decays only like k^2/b at p=0.5, ` +
+          `so exact-zero cancellation is unreachable; the hole is general-p specific`
+      )
+      expect(anyNaNp).toBe(false)
+      expect(stats.minPool).toBeGreaterThan(0)
+      expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-4)
+    })
+  })
+
+  // ---------------------------------------------------------------- P3
+  describe('P3: sells near the prob clamps (0.011 / 0.989)', () => {
+    const cases: [string, number[], number, 'YES' | 'NO'][] = [
+      ['sell YES of 0.989 answer (n=2)', [0.989, 0.011], 0, 'YES'],
+      ['sell YES of 0.011 answer (n=2)', [0.989, 0.011], 1, 'YES'],
+      ['sell NO of 0.011 answer (n=2, pushes it up through clamp)', [0.989, 0.011], 1, 'NO'],
+      ['sell NO of 0.989 answer (n=2)', [0.989, 0.011], 0, 'NO'],
+      ['sell YES of 0.011 answer (n=3 with 0.978)', [0.978, 0.011, 0.011], 1, 'YES'],
+    ]
+    it.each(cases)('%s', (label, probs, idx, outcome) => {
+      const answers = mkV2Market(probs)
+      const toSell = answers[idx]
+      const S = 100
+      let res
+      let threw: string | undefined
+      try {
+        res = calculateCpmmMultiSumsToOneSale(
+          answers, toSell, S, outcome, undefined, noBets, noBalances, noFees
+        )
+      } catch (e) {
+        threw = (e as Error).message
+      }
+      if (threw) {
+        record(`P3 ${label}`, 'THROWS', `throws: ${threw}`)
+        return
+      }
+      const after = applySale(answers, toSell.id, res!)
+      const stats = domainStats(answers, after)
+      const probsAfter = after.map((a) => probOf(a).toFixed(6)).join(',')
+      const ok =
+        stats.allFinite &&
+        stats.minPool > 0 &&
+        Math.abs(stats.sumProbResidual) < 1e-6 &&
+        stats.maxLiqDrift < 1e-9 &&
+        Number.isFinite(res!.saleValue) &&
+        res!.saleValue >= 0 &&
+        res!.saleValue < S
+      record(
+        `P3 ${label}`,
+        ok ? 'SAFE' : 'BUG',
+        `${fmtStats(stats)} saleValue=${res!.saleValue.toFixed(6)} probsAfter=[${probsAfter}]`
+      )
+      expect(stats.allFinite).toBe(true)
+      expect(stats.minPool).toBeGreaterThan(0)
+      expect(Math.abs(stats.sumProbResidual)).toBeLessThan(1e-6)
+      expect(stats.maxLiqDrift).toBeLessThan(1e-9)
+    })
+  })
+
+  // ---------------------------------------------------------------- P4
+  describe('P4: buy -> sell round trip (reversibility on the sell side)', () => {
+    it('v2 basket buy (Approach C) then sellYesEqually back, n=5 general p', () => {
+      const probs = [0.4, 0.3, 0.15, 0.1, 0.05]
+      const answers = mkV2Market(probs)
+      const basket = [answers[2], answers[4]] // p = 0.15 and 0.05
+      const budget = 100
+
+      const buy = calculateCpmmMultiArbitrageYesBets(
+        answers,
+        basket,
+        budget,
+        undefined,
+        noBets,
+        noBalances,
+        noFees,
+        'cpmm-multi-2'
+      )
+      const spent = sumBy(
+        buy.newBetResults.flatMap((r) => r.takers),
+        'amount'
+      )
+      const sharesByAnswerId = Object.fromEntries(
+        buy.newBetResults.map((r) => [
+          r.answer.id,
+          sumBy(r.takers, 'shares'),
+        ])
+      )
+      const userBets = Object.fromEntries(
+        Object.entries(sharesByAnswerId).map(([id, s]) => [id, bets(s)])
+      )
+
+      const sell = calculateCpmmMultiArbitrageSellYesEqually(
+        buy.updatedAnswers,
+        userBets,
+        noBets,
+        noBalances,
+        noFees
+      )
+      const proceeds = -sumBy(
+        sell.newBetResults.flatMap((r) => r.takers),
+        'amount'
+      )
+      const after = sell.updatedAnswers
+      const stats = domainStats(answers, after)
+      const netCost = spent - proceeds // fees are 0 => should be ~0
+      const maxPoolRestoreErr = Math.max(
+        ...answers.flatMap((a, i) => [
+          Math.abs(a.poolYes - after[i].poolYes),
+          Math.abs(a.poolNo - after[i].poolNo),
+        ])
+      )
+      const ok =
+        stats.allFinite &&
+        Math.abs(stats.sumProbResidual) < 1e-6 &&
+        Math.abs(netCost) < 0.01 &&
+        maxPoolRestoreErr < 0.01
+      record(
+        'P4 round-trip basket (v2 buy M$100 -> sellYesEqually)',
+        ok ? 'SAFE' : 'BUG',
+        `spent=${spent.toFixed(8)} proceeds=${proceeds.toFixed(8)} ` +
+          `netCost=${netCost.toExponential(3)} maxPoolRestoreErr=${maxPoolRestoreErr.toExponential(3)} ` +
+          fmtStats(stats)
+      )
+      expect(Math.abs(netCost)).toBeLessThan(0.01)
+      expect(maxPoolRestoreErr).toBeLessThan(0.01)
+    })
+
+    it('single-answer buy then sell back, extreme p (0.05), n=10', () => {
+      const probs = [0.55, ...Array(9).fill(0.05)]
+      const answers = mkV2Market(probs)
+      const toBuy = answers[3]
+      const budget = 100
+
+      const buy = calculateCpmmMultiArbitrageBet(
+        answers,
+        toBuy,
+        'YES',
+        budget,
+        undefined,
+        noBets,
+        noBalances,
+        noFees
+      )
+      const spent = sumBy(buy.newBetResult.takers, 'amount')
+      const shares = sumBy(buy.newBetResult.takers, 'shares')
+      const mid = answers.map((a) => {
+        const r =
+          a.id === toBuy.id
+            ? buy.newBetResult
+            : buy.otherBetResults.find((r) => r.answer.id === a.id)
+        if (!r) return a
+        const { pool, p } = r.cpmmState
+        return {
+          ...a,
+          poolYes: pool.YES,
+          poolNo: pool.NO,
+          prob: getCpmmProbability(pool, p),
+        }
+      })
+
+      const sell = calculateCpmmMultiSumsToOneSale(
+        mid,
+        mid[3],
+        shares,
+        'YES',
+        undefined,
+        noBets,
+        noBalances,
+        noFees
+      )
+      const after = applySale(mid, mid[3].id, sell)
+      const stats = domainStats(answers, after)
+      const netCost = spent - sell.saleValue
+      const maxPoolRestoreErr = Math.max(
+        ...answers.flatMap((a, i) => [
+          Math.abs(a.poolYes - after[i].poolYes),
+          Math.abs(a.poolNo - after[i].poolNo),
+        ])
+      )
+      const ok =
+        stats.allFinite &&
+        Math.abs(stats.sumProbResidual) < 1e-6 &&
+        Math.abs(netCost) < 0.01 &&
+        maxPoolRestoreErr < 0.01
+      record(
+        'P4 round-trip single answer (buy M$100 YES @p=0.05 -> sell)',
+        ok ? 'SAFE' : 'BUG',
+        `spent=${spent.toFixed(8)} shares=${shares.toFixed(6)} proceeds=${sell.saleValue.toFixed(8)} ` +
+          `netCost=${netCost.toExponential(3)} maxPoolRestoreErr=${maxPoolRestoreErr.toExponential(3)} ` +
+          fmtStats(stats)
+      )
+      expect(Math.abs(netCost)).toBeLessThan(0.01)
+      expect(maxPoolRestoreErr).toBeLessThan(0.01)
+    })
+  })
+
+  // ---------------------------------------------------------------- P5
+  describe('P5: what v1 (p=0.5-hardcoded) sell math would do on a v2 market', () => {
+    // The branch threads answer.p through every sell path, so there is no
+    // missing-dispatch hole to demonstrate on live code. This probe instead
+    // quantifies what ANY missed call site would cost: run the same sale with
+    // the pre-branch behavior (states built at p=0.5 over the same pools) and
+    // evaluate the resulting pools under the TRUE p.
+    it('divergence of p=0.5 sell math on a general-p fixture', () => {
+      const probs = [0.1, 0.1, 0.8]
+      const answersV2 = mkV2Market(probs)
+      // Pre-branch emulation: identical pools, but every cpmm state gets p=0.5
+      // (this is exactly what the old `p: 0.5` hardcodes produced).
+      const answersV1math = answersV2.map((a) => ({
+        ...a,
+        p: 0.5,
+        prob: getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, 0.5),
+      }))
+      const S = 50
+
+      const v2res = calculateCpmmMultiSumsToOneSale(
+        answersV2, answersV2[2], S, 'YES', undefined, noBets, noBalances, noFees
+      )
+      const v1res = calculateCpmmMultiSumsToOneSale(
+        answersV1math, answersV1math[2], S, 'YES', undefined, noBets, noBalances, noFees
+      )
+
+      // Evaluate the v1-math result under the TRUE per-answer p
+      const afterV1 = applySale(answersV1math, answersV1math[2].id, v1res)
+      const sumProbTrue = afterV1
+        .map((a, i) =>
+          getCpmmProbability({ YES: a.poolYes, NO: a.poolNo }, answersV2[i].p)
+        )
+        .reduce((x, y) => x + y, 0)
+      const saleValueDiff = v1res.saleValue - v2res.saleValue
+
+      record(
+        'P5 v1-math-on-v2 divergence (hypothetical missed dispatch)',
+        'INFO',
+        `saleValue v2=${v2res.saleValue.toFixed(4)} v1math=${v1res.saleValue.toFixed(4)} ` +
+          `diff=${saleValueDiff.toFixed(4)} (${((saleValueDiff / v2res.saleValue) * 100).toFixed(2)}%); ` +
+          `sumProb under TRUE p after v1-math sell=${sumProbTrue.toFixed(6)} (should be 1)`
+      )
+      // No assertion: current code paths all use answer.p (verified by P1-P4).
+      // This documents the blast radius if a future call site regresses.
+      expect(Number.isFinite(saleValueDiff)).toBe(true)
+    })
+  })
+})

--- a/common/src/supabase/contracts.ts
+++ b/common/src/supabase/contracts.ts
@@ -107,6 +107,7 @@ export const convertAnswer = (row: Row<'answers'>): Answer =>
 
     poolYes: row.pool_yes!,
     poolNo: row.pool_no!,
+    p: row.p ?? 0.5,
     prob: row.prob!,
     totalLiquidity: row.total_liquidity!,
     subsidyPool: row.subsidy_pool!,

--- a/common/src/supabase/schema.ts
+++ b/common/src/supabase/schema.ts
@@ -24,6 +24,7 @@ export type Database = {
           index: number | null
           is_other: boolean
           midpoint: number | null
+          p: number
           pool_no: number | null
           pool_yes: number | null
           prob: number | null
@@ -51,6 +52,7 @@ export type Database = {
           index?: number | null
           is_other?: boolean
           midpoint?: number | null
+          p?: number
           pool_no?: number | null
           pool_yes?: number | null
           prob?: number | null
@@ -78,6 +80,7 @@ export type Database = {
           index?: number | null
           is_other?: boolean
           midpoint?: number | null
+          p?: number
           pool_no?: number | null
           pool_yes?: number | null
           prob?: number | null

--- a/common/src/util/algos.ts
+++ b/common/src/util/algos.ts
@@ -13,6 +13,15 @@ export function binarySearch(
     if (mid === min || mid === max) break
 
     const comparison = comparator(mid)
+    // NaN compares false with everything, so it would silently take the else branch
+    // and walk min up to a corner — returning a plausible-looking wrong answer.
+    // A NaN objective is always a caller bug: fail fast instead.
+    if (isNaN(comparison)) {
+      throw new Error(
+        'binarySearch: comparator returned NaN at ' +
+          JSON.stringify({ min, max, mid, i })
+      )
+    }
     if (comparison === 0) break
     else if (comparison > 0) {
       max = mid

--- a/common/src/util/format.ts
+++ b/common/src/util/format.ts
@@ -1,5 +1,5 @@
 import { ENV_CONFIG } from '../envs/constants'
-import { ContractToken, MarketContract } from 'common/contract'
+import { ContractToken, isMultiCpmm, MarketContract } from 'common/contract'
 import { STONK_NO, STONK_YES } from 'common/stonk'
 import { floatingEqual } from './math'
 
@@ -260,7 +260,7 @@ export const formatOutcomeLabel = (
   }
   if (
     contract.outcomeType === 'BINARY' ||
-    contract.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(contract)
   ) {
     return outcomeLabel
   }

--- a/web/components/ai-forecast.tsx
+++ b/web/components/ai-forecast.tsx
@@ -5,6 +5,7 @@ import {
   Contract,
   contractPath,
   MultiNumericContract,
+  isMultiCpmm,
 } from 'common/contract'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
@@ -507,7 +508,7 @@ function CapabilityCard({
   const multiNumericValue =
     liveContract &&
     liveContract.outcomeType === 'MULTI_NUMERIC' &&
-    liveContract.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(liveContract)
       ? getExpectedValue(liveContract as unknown as MultiNumericContract)
       : null
 
@@ -616,7 +617,7 @@ function CapabilityCard({
   } else if (displayType === 'numeric' && liveContract) {
     if (
       multiNumericValue !== null &&
-      liveContract.mechanism === 'cpmm-multi-1'
+      isMultiCpmm(liveContract)
     ) {
       // For multi-numeric contracts
       displayValue = formatExpectedValue(

--- a/web/components/ai-forecast.tsx
+++ b/web/components/ai-forecast.tsx
@@ -615,10 +615,7 @@ function CapabilityCard({
       displayValue = formatPercent(prob)
     }
   } else if (displayType === 'numeric' && liveContract) {
-    if (
-      multiNumericValue !== null &&
-      isMultiCpmm(liveContract)
-    ) {
+    if (multiNumericValue !== null && isMultiCpmm(liveContract)) {
       // For multi-numeric contracts
       displayValue = formatExpectedValue(
         multiNumericValue,

--- a/web/components/answers/answers-panel.tsx
+++ b/web/components/answers/answers-panel.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowRightIcon,
+  CashIcon,
   ChatIcon,
   ChevronDownIcon,
   DotsVerticalIcon,
@@ -26,8 +27,10 @@ import { getAnswerProbability } from 'common/calculate'
 import {
   CPMMMultiContract,
   Contract,
+  MarketContract,
   MultiContract,
   contractPath,
+  isMultiCpmm,
   tradingAllowed,
 } from 'common/contract'
 import { ContractMetric, isSummary } from 'common/contract-metric'
@@ -68,6 +71,7 @@ import {
   getOrderBookButtonLabel,
 } from '../bet/order-book'
 import { getAnswerColor } from '../charts/contract/choice'
+import { AddLiquidityModal } from '../contract/liquidity-modal'
 import { Col } from '../layout/col'
 import { RelativeTimestamp } from '../relative-timestamp'
 import { UserHovercard } from '../user/user-hovercard'
@@ -590,6 +594,14 @@ export function AnswerComponent(props: {
 
   const [tradesModalOpen, setTradesModalOpen] = useState(false)
   const [limitBetModalOpen, setLimitBetModalOpen] = useState(false)
+  const [addLiquidityOpen, setAddLiquidityOpen] = useState(false)
+
+  // Per-answer subsidy: deepen this answer's own binary CPMM (cpmm-multi only, open market).
+  const canSubsidizeAnswer =
+    isMultiCpmm(contract) &&
+    !contract.isResolved &&
+    (contract.closeTime ?? Infinity) > Date.now() &&
+    answer.poolYes != undefined
 
   const hasLimitOrders = unfilledBets?.length && limitOrderVolume
   const answerCreator = useDisplayUserByIdOrAnswer(answer)
@@ -656,6 +668,11 @@ export function AnswerComponent(props: {
       icon: <ScaleIcon className="h-4 w-4" />,
       name: getOrderBookButtonLabel(unfilledBets),
       onClick: () => setLimitBetModalOpen(true),
+    },
+    canSubsidizeAnswer && {
+      icon: <CashIcon className="h-4 w-4" />,
+      name: 'Add liquidity',
+      onClick: () => setAddLiquidityOpen(true),
     }
   )
 
@@ -767,6 +784,15 @@ export function AnswerComponent(props: {
           modalOpen={tradesModalOpen}
           setModalOpen={setTradesModalOpen}
           answer={answer}
+        />
+      )}
+      {addLiquidityOpen && isMultiCpmm(contract) && (
+        <AddLiquidityModal
+          contract={contract as MarketContract}
+          isOpen={addLiquidityOpen}
+          setOpen={setAddLiquidityOpen}
+          answerId={answer.id}
+          answerText={answer.text}
         />
       )}
       {!!hasLimitOrders && (

--- a/web/components/answers/numeric-bet-panel.tsx
+++ b/web/components/answers/numeric-bet-panel.tsx
@@ -216,7 +216,9 @@ export const NumericBetPanel = (props: {
         undefined,
         unfilledBets,
         balanceByUserId,
-        contract.collectedFees
+        contract.collectedFees,
+        // The preview must price with the same arb the backend will use.
+        contract.mechanism
       )
     const fees = [...newBetResults, ...otherBetResults].reduce(
       (acc, r) => addObjects(acc, r.totalFees),

--- a/web/components/answers/small-answer.tsx
+++ b/web/components/answers/small-answer.tsx
@@ -2,7 +2,12 @@ import { ArrowRightIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import { OTHER_TOOLTIP_TEXT, sortAnswers, type Answer } from 'common/answer'
 import { getAnswerProbability } from 'common/calculate'
-import { CPMMMultiContract, MultiContract, contractPath } from 'common/contract'
+import {
+  CPMMMultiContract,
+  MultiContract,
+  contractPath,
+  isMultiCpmm,
+} from 'common/contract'
 import { User } from 'common/user'
 import Link from 'next/link'
 import { useUser } from 'web/hooks/use-user'
@@ -87,7 +92,7 @@ export function SmallAnswer(props: {
 
   const prob = getAnswerProbability(contract, answer.id)
 
-  const isCpmm = contract.mechanism === 'cpmm-multi-1'
+  const isCpmm = isMultiCpmm(contract)
 
   const { resolution, resolutions } = contract
   const resolvedProb =

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -15,6 +15,7 @@ import { Bet, LimitBet } from 'common/bet'
 import { calculateCpmmAmountToBuyShares } from 'common/calculate-cpmm'
 import {
   isBinaryMulti,
+  isMultiCpmm,
   MarketContract,
   MAX_CPMM_PROB,
   MAX_STONK_PROB,
@@ -300,7 +301,7 @@ export const BuyPanelBody = (
 
   const quickAddButtonSize =
     liquidityTier === 0 ||
-    (contract.mechanism === 'cpmm-multi-1' &&
+    (isMultiCpmm(contract) &&
       liquidityTier === 1 &&
       !contract.shouldAnswersSumToOne)
       ? 'small'
@@ -349,7 +350,7 @@ export const BuyPanelBody = (
   const [dismissTimeoutRef, setDismissTimeoutRef] =
     useState<NodeJS.Timeout | null>(null)
 
-  const isCpmmMulti = contract.mechanism === 'cpmm-multi-1'
+  const isCpmmMulti = isMultiCpmm(contract)
   if (isCpmmMulti && !multiProps) {
     throw new Error('multiProps must be defined for cpmm-multi-1')
   }
@@ -1126,7 +1127,7 @@ export const BuyPanelBody = (
         )}
       </Col>
 
-      {contract.mechanism === 'cpmm-multi-1' && (
+      {isMultiCpmm(contract) && (
         <YourOrders
           className="mt-2 py-4"
           contract={contract}

--- a/web/components/bet/contract-bets-table.tsx
+++ b/web/components/bet/contract-bets-table.tsx
@@ -4,6 +4,7 @@ import {
   CPMMNumericContract,
   getBinaryMCProb,
   isBinaryMulti,
+  isMultiCpmm,
 } from 'common/contract'
 import { TRADE_TERM } from 'common/envs/constants'
 import {
@@ -63,7 +64,7 @@ export function ContractBetsTable(props: {
   )
 
   const isCPMM = mechanism === 'cpmm-1'
-  const isCpmmMulti = mechanism === 'cpmm-multi-1'
+  const isCpmmMulti = isMultiCpmm(contract)
   const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
   const isStonk = outcomeType === 'STONK'
   const isBinaryMC = isBinaryMulti(contract)
@@ -188,7 +189,7 @@ function BetRow(props: { bet: Bet; contract: Contract }) {
   const { mechanism, outcomeType } = contract
 
   const isCPMM = mechanism === 'cpmm-1'
-  const isCpmmMulti = mechanism === 'cpmm-multi-1'
+  const isCpmmMulti = isMultiCpmm(contract)
   const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
   const isStonk = outcomeType === 'STONK'
   const isBinaryMC = isBinaryMulti(contract)

--- a/web/components/bet/limit-order-panel.tsx
+++ b/web/components/bet/limit-order-panel.tsx
@@ -9,6 +9,7 @@ import { getProbability } from 'common/calculate'
 import {
   getBinaryMCProb,
   isBinaryMulti,
+  isMultiCpmm,
   MarketContract,
   MultiContract,
 } from 'common/contract'
@@ -94,7 +95,7 @@ export default function LimitOrderPanel(props: {
         ? 'YES'
         : 'NO'
       : undefined
-  const isCpmmMulti = contract.mechanism === 'cpmm-multi-1'
+  const isCpmmMulti = isMultiCpmm(contract)
   if (isCpmmMulti && !multiProps) {
     throw new Error('multiProps must be defined for cpmm-multi-1')
   }

--- a/web/components/bet/limit-orders-table.tsx
+++ b/web/components/bet/limit-orders-table.tsx
@@ -527,10 +527,9 @@ export function LimitOrdersTable(props: {
   )
 }
 const getProb = (bet: LimitBet, contract: MarketContract) => {
-  const prob =
-    isMultiCpmm(contract)
-      ? contract.answers.find((a) => a.id === bet.answerId)?.prob ?? 0
-      : contract.prob
+  const prob = isMultiCpmm(contract)
+    ? contract.answers.find((a) => a.id === bet.answerId)?.prob ?? 0
+    : contract.prob
   return prob
 }
 

--- a/web/components/bet/limit-orders-table.tsx
+++ b/web/components/bet/limit-orders-table.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo, useEffect } from 'react'
 import clsx from 'clsx'
 import { groupBy, maxBy, sortBy, uniqBy } from 'lodash'
 import { BiCaretDown, BiCaretUp } from 'react-icons/bi'
-import { contractPath, MarketContract } from 'common/contract'
+import { contractPath, isMultiCpmm, MarketContract } from 'common/contract'
 import { LimitBet } from 'common/bet'
 import { formatPercent } from 'common/util/format'
 import Link from 'next/link'
@@ -103,7 +103,7 @@ export function LimitOrdersTable(props: {
     resolved: (b) =>
       !!b.contract.resolutionTime ||
       !!(
-        b.contract.mechanism === 'cpmm-multi-1' &&
+        isMultiCpmm(b.contract) &&
         b.contract.answers.find((a) => a.id === b.answerId)?.resolutionTime
       ),
     closed: (b) =>
@@ -528,7 +528,7 @@ export function LimitOrdersTable(props: {
 }
 const getProb = (bet: LimitBet, contract: MarketContract) => {
   const prob =
-    contract.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(contract)
       ? contract.answers.find((a) => a.id === bet.answerId)?.prob ?? 0
       : contract.prob
   return prob
@@ -567,7 +567,7 @@ const RefreshLimitOrderModal = (props: {
         <LimitOrderPanel
           initialProb={limitProb}
           multiProps={
-            contract.mechanism === 'cpmm-multi-1'
+            isMultiCpmm(contract)
               ? {
                   answers: contract.answers,
                   answerToBuy: contract.answers.find((a) => a.id === answerId)!,

--- a/web/components/bet/order-book.tsx
+++ b/web/components/bet/order-book.tsx
@@ -10,6 +10,7 @@ import {
   CPMMMultiContract,
   getBinaryMCProb,
   isBinaryMulti,
+  isMultiCpmm,
   MultiContract,
   PseudoNumericContract,
   StonkContract,
@@ -135,7 +136,7 @@ export function OrderTable(props: {
 }) {
   const { limitBets, contract, isYou, showAnswers } = props
   const answers =
-    showAnswers && contract.mechanism === 'cpmm-multi-1'
+    showAnswers && isMultiCpmm(contract)
       ? contract.answers.filter((a) =>
           limitBets.map((b) => b.answerId).includes(a.id)
         )
@@ -486,7 +487,7 @@ export function OrderBookPanel(props: {
     (bet) => bet.createdTime
   )
 
-  const isCPMMMulti = contract.mechanism === 'cpmm-multi-1'
+  const isCPMMMulti = isMultiCpmm(contract)
   const isPseudoNumeric = contract.outcomeType === 'PSEUDO_NUMERIC'
 
   if (limitBets.length === 0) return <></>

--- a/web/components/bet/quick-limit-order-buttons.tsx
+++ b/web/components/bet/quick-limit-order-buttons.tsx
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast'
 
 import { Answer } from 'common/answer'
 import { APIError } from 'common/api/utils'
-import { CPMMContract, MultiContract } from 'common/contract'
+import { CPMMContract, isMultiCpmm, MultiContract } from 'common/contract'
 import { TRADE_TERM } from 'common/envs/constants'
 import { formatPercent, formatWithToken } from 'common/util/format'
 import { removeUndefinedProps } from 'common/util/object'
@@ -25,7 +25,7 @@ export const QuickLimitOrderButtons = (props: {
   className?: string
 }) => {
   const { contract, answer, className } = props
-  if (!answer && contract.mechanism === 'cpmm-multi-1') {
+  if (!answer && isMultiCpmm(contract)) {
     throw new Error('Answer must be provided for multi contracts')
   }
 

--- a/web/components/bet/sell-panel.tsx
+++ b/web/components/bet/sell-panel.tsx
@@ -8,6 +8,7 @@ import {
   CPMMContract,
   CPMMMultiContract,
   CPMMNumericContract,
+  isMultiCpmm,
   MultiContract,
 } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
@@ -72,7 +73,7 @@ export function SellPanel(props: {
   const isPseudoNumeric = outcomeType === 'PSEUDO_NUMERIC'
   const isStonk = outcomeType === 'STONK'
   const isMultiSumsToOne =
-    contract.mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne
+    isMultiCpmm(contract) && contract.shouldAnswersSumToOne
   const answer =
     answerId && 'answers' in contract
       ? contract.answers.find((a) => a.id === answerId)

--- a/web/components/bet/user-bet-summary.tsx
+++ b/web/components/bet/user-bet-summary.tsx
@@ -241,8 +241,7 @@ export function BetsSummary(props: {
             contract.creatorBannedFromBetting &&
             includeSellButton.id === contract.creatorId
           ) &&
-          (!isMultiCpmm(contract) ||
-            isBinaryMulti(contract)) && (
+          (!isMultiCpmm(contract) || isBinaryMulti(contract)) && (
             <Row className="items-center gap-2">
               <SellRow
                 contract={contract as CPMMContract}

--- a/web/components/bet/user-bet-summary.tsx
+++ b/web/components/bet/user-bet-summary.tsx
@@ -7,6 +7,7 @@ import {
   CPMMMultiContract,
   getMainBinaryMCAnswer,
   isBinaryMulti,
+  isMultiCpmm,
 } from 'common/contract'
 import { ContractMetric, getMaxSharesOutcome } from 'common/contract-metric'
 import { TRADE_TERM } from 'common/envs/constants'
@@ -240,7 +241,7 @@ export function BetsSummary(props: {
             contract.creatorBannedFromBetting &&
             includeSellButton.id === contract.creatorId
           ) &&
-          (contract.mechanism !== 'cpmm-multi-1' ||
+          (!isMultiCpmm(contract) ||
             isBinaryMulti(contract)) && (
             <Row className="items-center gap-2">
               <SellRow

--- a/web/components/bet/user-bets-table.tsx
+++ b/web/components/bet/user-bets-table.tsx
@@ -16,6 +16,7 @@ import {
   Contract,
   contractPath,
   CPMMContract,
+  isMultiCpmm,
   MarketContract,
 } from 'common/contract'
 import { ContractMetric, getMaxSharesOutcome } from 'common/contract-metric'
@@ -721,7 +722,7 @@ function BetsTable(props: {
               const metric = metricsByContractId[contract.id]
               const closeDate = contract.resolutionTime ?? contract.closeTime
               const resolvedAnswer =
-                contract.mechanism === 'cpmm-multi-1'
+                isMultiCpmm(contract)
                   ? contract.answers.find(
                       (a) =>
                         a.id === contract.resolution ||

--- a/web/components/bet/user-bets-table.tsx
+++ b/web/components/bet/user-bets-table.tsx
@@ -721,14 +721,13 @@ function BetsTable(props: {
             {visibleContracts.map((contract) => {
               const metric = metricsByContractId[contract.id]
               const closeDate = contract.resolutionTime ?? contract.closeTime
-              const resolvedAnswer =
-                isMultiCpmm(contract)
-                  ? contract.answers.find(
-                      (a) =>
-                        a.id === contract.resolution ||
-                        (contract.resolutions?.[a.id] ?? 0) >= 99
-                    )
-                  : undefined
+              const resolvedAnswer = isMultiCpmm(contract)
+                ? contract.answers.find(
+                    (a) =>
+                      a.id === contract.resolution ||
+                      (contract.resolutions?.[a.id] ?? 0) >= 99
+                  )
+                : undefined
 
               const maxOutcome =
                 metricsByContractId[contract.id].maxSharesOutcome

--- a/web/components/buttons/duplicate-contract-button.tsx
+++ b/web/components/buttons/duplicate-contract-button.tsx
@@ -96,6 +96,19 @@ export function duplicateContractHref(contract: Contract) {
   if (isMultiCpmm(contract)) {
     params.addAnswersMode = contract.addAnswersMode
     params.shouldAnswersSumToOne = contract.shouldAnswersSumToOne
+    // cpmm-multi-2: carry the answers' CURRENT probabilities as the duplicate's
+    // custom initial probs (a duplicate should start where the original stands,
+    // not reset to uniform). Only when every kept answer is carried (no Other,
+    // matching the answers list above) and probs are inside the creatable [1,99].
+    if (
+      contract.mechanism === 'cpmm-multi-2' &&
+      contract.outcomeType === 'MULTIPLE_CHOICE' &&
+      contract.addAnswersMode === 'DISABLED'
+    ) {
+      params.initialProbs = contract.answers
+        .filter((a) => !a.isOther)
+        .map((a) => Math.min(99, Math.max(1, Math.round(a.prob * 100))))
+    }
   }
 
   if (contract.groupSlugs && contract.groupSlugs.length > 0) {

--- a/web/components/buttons/duplicate-contract-button.tsx
+++ b/web/components/buttons/duplicate-contract-button.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import { getMappedValue } from 'common/pseudo-numeric'
 import { trackCallback } from 'web/lib/service/analytics'
 import { buttonClass } from './button'
@@ -93,7 +93,7 @@ export function duplicateContractHref(contract: Contract) {
     params.unit = contract.unit
   }
 
-  if (contract.mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     params.addAnswersMode = contract.addAnswersMode
     params.shouldAnswersSumToOne = contract.shouldAnswersSumToOne
   }

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -1,7 +1,7 @@
 import { formatTimeWithTimezone } from 'client-common/lib/time'
 import clsx from 'clsx'
 import { ELASTICITY_BET_AMOUNT } from 'common/calculate-metrics'
-import { Contract, contractPool } from 'common/contract'
+import { Contract, contractPool, isMultiCpmm } from 'common/contract'
 import {
   ENV_CONFIG,
   isAdminId,
@@ -44,11 +44,11 @@ export const Stats = (props: {
   const { contract, user, onRequestCreatorBan } = props
   const { creatorId } = contract
   const shouldAnswersSumToOne =
-    contract.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(contract)
       ? contract.shouldAnswersSumToOne
       : false
   const addAnswersMode =
-    contract.mechanism === 'cpmm-multi-1' ? contract.addAnswersMode : 'DISABLED'
+    isMultiCpmm(contract) ? contract.addAnswersMode : 'DISABLED'
   const isCashContract = contract.token === 'CASH'
 
   const hideAdvanced = !user
@@ -58,7 +58,7 @@ export const Stats = (props: {
   const isMod = isAdmin || isTrusty
   const isCreator = user?.id === creatorId
   const isPublic = contract.visibility === 'public'
-  const isMulti = contract.mechanism === 'cpmm-multi-1'
+  const isMulti = isMultiCpmm(contract)
   const addAnswersPossible =
     isMulti && (shouldAnswersSumToOne ? addAnswersMode !== 'DISABLED' : true)
   const creatorOnly = isMulti && addAnswersMode === 'ONLY_CREATOR'
@@ -97,7 +97,7 @@ export const Stats = (props: {
           label: 'Fixed',
           desc: `Each YES share is worth ${ENV_CONFIG.moneyMoniker}1 if YES wins`,
         }
-      : mechanism === 'cpmm-multi-1'
+      : isMultiCpmm(contract)
       ? contract.shouldAnswersSumToOne
         ? {
             label: 'Dependent',
@@ -112,7 +112,7 @@ export const Stats = (props: {
       : { label: 'Mistake', desc: "Likely one of Austin's bad ideas" }
 
   const isBettingContract = contract.mechanism !== 'none'
-  const drizzler = mechanism === 'cpmm-1' || mechanism === 'cpmm-multi-1'
+  const drizzler = mechanism === 'cpmm-1' || isMultiCpmm(contract)
   const drizzled = drizzler
     ? contract.totalLiquidity -
       contract.subsidyPool -

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -43,12 +43,12 @@ export const Stats = (props: {
 }) => {
   const { contract, user, onRequestCreatorBan } = props
   const { creatorId } = contract
-  const shouldAnswersSumToOne =
-    isMultiCpmm(contract)
-      ? contract.shouldAnswersSumToOne
-      : false
-  const addAnswersMode =
-    isMultiCpmm(contract) ? contract.addAnswersMode : 'DISABLED'
+  const shouldAnswersSumToOne = isMultiCpmm(contract)
+    ? contract.shouldAnswersSumToOne
+    : false
+  const addAnswersMode = isMultiCpmm(contract)
+    ? contract.addAnswersMode
+    : 'DISABLED'
   const isCashContract = contract.token === 'CASH'
 
   const hideAdvanced = !user

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -22,6 +22,7 @@ import {
   dayProbChange,
   getMainBinaryMCAnswer,
   isBinaryMulti,
+  isMultiCpmm,
   tradingAllowed,
 } from 'common/contract'
 import { isAdminId, isModId } from 'common/envs/constants'
@@ -483,7 +484,7 @@ const ChoiceOverview = (props: {
           </>
         )}
       </Row>
-      {contract.mechanism == 'cpmm-multi-1' && !hideGraph && (
+      {isMultiCpmm(contract) && !hideGraph && (
         <SizedContainer
           className={clsx(
             'h-[150px] w-full pb-4 pr-10 sm:h-[250px]',
@@ -541,14 +542,14 @@ const ChoiceOverview = (props: {
         />
       ) : null}
       {!shouldAnswersSumToOne &&
-      contract.mechanism === 'cpmm-multi-1' &&
+      isMultiCpmm(contract) &&
       showUnresolver ? (
         <IndependentAnswersUnresolvePanel
           contract={contract}
           onClose={() => setShowUnresolver(false)}
           show={showUnresolver}
         />
-      ) : !shouldAnswersSumToOne && contract.mechanism === 'cpmm-multi-1' ? (
+      ) : !shouldAnswersSumToOne && isMultiCpmm(contract) ? (
         <IndependentAnswersResolvePanel
           contract={contract}
           onClose={() => setShowResolver(false)}
@@ -666,7 +667,7 @@ const NumberOverview = (props: {
           />
         </Row>
       </Row>
-      {!!Object.keys(points).length && contract.mechanism == 'cpmm-multi-1' && (
+      {!!Object.keys(points).length && isMultiCpmm(contract) && (
         <SizedContainer
           className={clsx(
             'h-[150px] w-full pb-4 pr-10 sm:h-[250px]',
@@ -989,7 +990,7 @@ const BinaryChoiceOverview = (props: {
           />
         </Row>
       </Row>
-      {!!Object.keys(points).length && contract.mechanism == 'cpmm-multi-1' && (
+      {!!Object.keys(points).length && isMultiCpmm(contract) && (
         <SizedContainer
           className={clsx(
             'h-[150px] w-full pb-4 pr-10 sm:h-[250px]',

--- a/web/components/contract/contract-overview.tsx
+++ b/web/components/contract/contract-overview.tsx
@@ -541,9 +541,7 @@ const ChoiceOverview = (props: {
           answers={contract.answers}
         />
       ) : null}
-      {!shouldAnswersSumToOne &&
-      isMultiCpmm(contract) &&
-      showUnresolver ? (
+      {!shouldAnswersSumToOne && isMultiCpmm(contract) && showUnresolver ? (
         <IndependentAnswersUnresolvePanel
           contract={contract}
           onClose={() => setShowUnresolver(false)}

--- a/web/components/contract/contract-table-action.tsx
+++ b/web/components/contract/contract-table-action.tsx
@@ -1,4 +1,9 @@
-import { Contract, BinaryContract, CPMMMultiContract } from 'common/contract'
+import {
+  Contract,
+  BinaryContract,
+  CPMMMultiContract,
+  isMultiCpmm,
+} from 'common/contract'
 import { User } from 'common/user'
 import { useState } from 'react'
 import { firebaseLogin } from 'web/lib/firebase/users'
@@ -83,7 +88,7 @@ export function BetButton(props: {
   if (
     !isClosed(contract) &&
     !contract.isResolved &&
-    (contract.mechanism === 'cpmm-1' || contract.mechanism === 'cpmm-multi-1')
+    (contract.mechanism === 'cpmm-1' || isMultiCpmm(contract))
   ) {
     return (
       <>

--- a/web/components/contract/contract-table-col-formats.tsx
+++ b/web/components/contract/contract-table-col-formats.tsx
@@ -1,5 +1,5 @@
 import { ChatIcon, UserIcon } from '@heroicons/react/solid'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import { useNumContractComments } from 'web/hooks/use-comments'
 import { shortenNumber } from 'common/util/formatNumber'
 import { Row } from '../layout/row'
@@ -115,7 +115,7 @@ export const liquidityColumn = {
   content: (props: { contract: Contract }) => {
     const { contract } = props
 
-    const hasAnswers = contract.mechanism === 'cpmm-multi-1'
+    const hasAnswers = isMultiCpmm(contract)
     const isCashContract = contract.token === 'CASH'
     const totalLiquidity =
       'totalLiquidity' in contract ? contract.totalLiquidity : 0

--- a/web/components/contract/contract-tabs.tsx
+++ b/web/components/contract/contract-tabs.tsx
@@ -4,7 +4,7 @@ import { Answer } from 'common/answer'
 import { DisplayUser } from 'common/api/user-types'
 import { Bet } from 'common/bet'
 import { ContractComment } from 'common/comment'
-import { BinaryContract, Contract } from 'common/contract'
+import { BinaryContract, Contract, isMultiCpmm } from 'common/contract'
 import { buildArray } from 'common/util/array'
 import { maybePluralize, shortFormatNumber } from 'common/util/format'
 import { BetsTabContent } from 'web/components/contract/bets-tab-content'
@@ -106,7 +106,7 @@ export function ContractTabs(props: {
         },
         totalBets > 0 &&
           (liveContract.mechanism === 'cpmm-1' ||
-            liveContract.mechanism === 'cpmm-multi-1') && {
+            isMultiCpmm(liveContract)) && {
             title: positionsTitle,
             content: (
               <UserPositionsTable

--- a/web/components/contract/creator-share-panel.tsx
+++ b/web/components/contract/creator-share-panel.tsx
@@ -42,8 +42,7 @@ export function CreatorSharePanel(props: { contract: Contract }) {
           )}
         </Row>
 
-        {(contract.mechanism === 'cpmm-1' ||
-          isMultiCpmm(contract)) && (
+        {(contract.mechanism === 'cpmm-1' || isMultiCpmm(contract)) && (
           <div className="text-ink-500 text-base">
             Earn{' '}
             {formatMoney(

--- a/web/components/contract/creator-share-panel.tsx
+++ b/web/components/contract/creator-share-panel.tsx
@@ -1,7 +1,7 @@
 import { LinkIcon } from '@heroicons/react/outline'
 import { ShareIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import { getShareUrl } from 'common/util/share'
 import toast from 'react-hot-toast'
 import { trackShareEvent } from 'web/lib/service/analytics'
@@ -43,7 +43,7 @@ export function CreatorSharePanel(props: { contract: Contract }) {
         </Row>
 
         {(contract.mechanism === 'cpmm-1' ||
-          contract.mechanism === 'cpmm-multi-1') && (
+          isMultiCpmm(contract)) && (
           <div className="text-ink-500 text-base">
             Earn{' '}
             {formatMoney(

--- a/web/components/contract/danger-zone.tsx
+++ b/web/components/contract/danger-zone.tsx
@@ -1,4 +1,8 @@
-import { Contract, MINUTES_ALLOWED_TO_UNRESOLVE } from 'common/contract'
+import {
+  Contract,
+  isMultiCpmm,
+  MINUTES_ALLOWED_TO_UNRESOLVE,
+} from 'common/contract'
 import { WEEK_MS } from 'common/util/time'
 import dayjs from 'dayjs'
 import { useEffect } from 'react'
@@ -95,7 +99,7 @@ export function DangerZone(props: {
     (outcomeType === 'MULTIPLE_CHOICE' ||
       outcomeType === 'MULTI_NUMERIC' ||
       outcomeType === 'DATE') &&
-    mechanism === 'cpmm-multi-1' &&
+    isMultiCpmm(contract) &&
     'shouldAnswersSumToOne' in contract &&
     !contract.shouldAnswersSumToOne
   const hasResolvedIndependentAnswers =

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -1,7 +1,12 @@
 import clsx from 'clsx'
 import Link from 'next/link'
 import Router from 'next/router'
-import { Contract, contractPath, isBinaryMulti } from 'common/contract'
+import {
+  Contract,
+  contractPath,
+  isBinaryMulti,
+  isMultiCpmm,
+} from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
 import { ENV_CONFIG, SWEEPIES_NAME } from 'common/envs/constants'
 import { ContractCardView } from 'common/events'
@@ -301,7 +306,7 @@ export function FeedContractCard(props: {
         )}
 
         {isBinaryMc &&
-          contract.mechanism === 'cpmm-multi-1' &&
+          isMultiCpmm(contract) &&
           contract.outcomeType !== 'NUMBER' &&
           contract.outcomeType !== 'MULTI_NUMERIC' &&
           contract.outcomeType !== 'DATE' && (

--- a/web/components/contract/header-actions.tsx
+++ b/web/components/contract/header-actions.tsx
@@ -4,7 +4,7 @@ import {
   EyeOffIcon,
   InformationCircleIcon,
 } from '@heroicons/react/solid'
-import { Contract, contractPath } from 'common/contract'
+import { Contract, contractPath, isMultiCpmm } from 'common/contract'
 import { ENV_CONFIG } from 'common/envs/constants'
 import { getShareUrl } from 'common/util/share'
 import { useEffect, useState } from 'react'
@@ -86,7 +86,7 @@ export function HeaderActions(props: {
   }
 
   const addLiquidityPossible =
-    contract.mechanism == 'cpmm-1' || contract.mechanism == 'cpmm-multi-1'
+    contract.mechanism == 'cpmm-1' || isMultiCpmm(contract)
 
   const [following, setFollowing] = useState<boolean>()
   const [followingOpen, setFollowingOpen] = useState(false)

--- a/web/components/contract/liquidity-modal.tsx
+++ b/web/components/contract/liquidity-modal.tsx
@@ -27,8 +27,11 @@ export function AddLiquidityModal(props: {
   contract: MarketContract
   isOpen: boolean
   setOpen: (open: boolean) => void
+  // When set, subsidize a single answer (its own binary CPMM) instead of the whole market.
+  answerId?: string
+  answerText?: string
 }) {
-  const { contract, isOpen, setOpen } = props
+  const { contract, isOpen, setOpen, answerId, answerText } = props
 
   const lps = useLiquidity(contract.id) ?? []
 
@@ -43,7 +46,11 @@ export function AddLiquidityModal(props: {
             Liquidity
           </h2>
           <p className="text-ink-500 mt-1 text-sm">
-            Subsidize this market to incentivize more accurate predictions
+            {answerId
+              ? `Subsidize "${
+                  answerText ?? 'this answer'
+                }" to incentivize more accurate predictions`
+              : 'Subsidize this market to incentivize more accurate predictions'}
           </p>
         </div>
 
@@ -55,6 +62,7 @@ export function AddLiquidityModal(props: {
           contract={contract}
           amount={amount}
           setAmount={setAmount}
+          answerId={answerId}
         />
 
         {/* Contributors Section */}
@@ -125,8 +133,10 @@ export function AddLiquidityControl(props: {
   contract: MarketContract
   amount: number | undefined
   setAmount: (amount: number | undefined) => void
+  // When set, the subsidy targets a single answer (its own binary CPMM).
+  answerId?: string
 }) {
-  const { contract, amount, setAmount } = props
+  const { contract, amount, setAmount, answerId } = props
   const { id: contractId, slug, totalLiquidity } = contract
 
   const [error, setError] = useState<string | undefined>(undefined)
@@ -180,6 +190,7 @@ export function AddLiquidityControl(props: {
         await api('market/:contractId/add-liquidity', {
           amount,
           contractId,
+          ...(answerId ? { answerId } : {}),
         })
         toast.success(
           <>

--- a/web/components/contract/liquidity-modal.tsx
+++ b/web/components/contract/liquidity-modal.tsx
@@ -4,7 +4,7 @@ import {
   maximumRemovableLiquidity,
   removeCpmmLiquidity,
 } from 'common/calculate-cpmm'
-import { type MarketContract } from 'common/contract'
+import { isMultiCpmm, type MarketContract } from 'common/contract'
 import { isAdminId } from 'common/envs/constants'
 import { formatMoney, formatWithCommas } from 'common/util/format'
 import { floatingEqual } from 'common/util/math'
@@ -140,7 +140,7 @@ export function AddLiquidityControl(props: {
 
   const addLiquidityEnabled =
     user &&
-    (contract.mechanism == 'cpmm-1' || contract.mechanism == 'cpmm-multi-1') &&
+    (contract.mechanism == 'cpmm-1' || isMultiCpmm(contract)) &&
     contractOpenAndPublic
   const [mode, setMode] = useState<'add' | 'remove'>('add')
   const canWithdraw =

--- a/web/components/contract/user-positions-table.tsx
+++ b/web/components/contract/user-positions-table.tsx
@@ -479,8 +479,7 @@ const BinaryUserPositionsTable = memo(
 
     const largestColumnLength = Math.max(totalYesPositions, totalNoPositions)
 
-    const isBinary =
-      contract.outcomeType === 'BINARY' || isMultiCpmm(contract)
+    const isBinary = contract.outcomeType === 'BINARY' || isMultiCpmm(contract)
     const isStonk = contract.outcomeType === 'STONK'
     const isPseudoNumeric = contract.outcomeType === 'PSEUDO_NUMERIC'
     const mainBinaryMCAnswer = getMainBinaryMCAnswer(contract)

--- a/web/components/contract/user-positions-table.tsx
+++ b/web/components/contract/user-positions-table.tsx
@@ -7,6 +7,7 @@ import {
   CPMMMultiContract,
   getMainBinaryMCAnswer,
   isBinaryMulti,
+  isMultiCpmm,
 } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
 import { getStonkDisplayShares } from 'common/stonk'
@@ -90,7 +91,7 @@ export const UserPositionsTable = memo(
     )
     const answers = answer
       ? [answer]
-      : contract.mechanism !== 'cpmm-multi-1'
+      : !isMultiCpmm(contract)
       ? []
       : contract.answers
 
@@ -328,7 +329,7 @@ export const UserPositionsTable = memo(
           />
         </Col>
       )
-    } else if (contract.mechanism === 'cpmm-multi-1') {
+    } else if (isMultiCpmm(contract)) {
       return (
         <Col className={'w-full'}>
           {!answer && answers.length < 4 && (
@@ -479,7 +480,7 @@ const BinaryUserPositionsTable = memo(
     const largestColumnLength = Math.max(totalYesPositions, totalNoPositions)
 
     const isBinary =
-      contract.outcomeType === 'BINARY' || contract.mechanism === 'cpmm-multi-1'
+      contract.outcomeType === 'BINARY' || isMultiCpmm(contract)
     const isStonk = contract.outcomeType === 'STONK'
     const isPseudoNumeric = contract.outcomeType === 'PSEUDO_NUMERIC'
     const mainBinaryMCAnswer = getMainBinaryMCAnswer(contract)

--- a/web/components/dashboard/horizontal-dashboard-card.tsx
+++ b/web/components/dashboard/horizontal-dashboard-card.tsx
@@ -1,7 +1,12 @@
 import clsx from 'clsx'
 import Link from 'next/link'
 import Router from 'next/router'
-import { Contract, contractPath, isBinaryMulti } from 'common/contract'
+import {
+  Contract,
+  contractPath,
+  isBinaryMulti,
+  isMultiCpmm,
+} from 'common/contract'
 import { ContractCardView } from 'common/events'
 import { BinaryMultiAnswersPanel } from 'web/components/answers/binary-multi-answers-panel'
 import {
@@ -153,7 +158,7 @@ export function HorizontalDashboardCard(props: {
           )}
 
           {isBinaryMc &&
-            contract.mechanism === 'cpmm-multi-1' &&
+            isMultiCpmm(contract) &&
             contract.outcomeType !== 'NUMBER' &&
             contract.outcomeType !== 'MULTI_NUMERIC' &&
             contract.outcomeType !== 'DATE' && (

--- a/web/components/feed/activity-card.tsx
+++ b/web/components/feed/activity-card.tsx
@@ -390,10 +390,9 @@ const BetLog = memo(function BetLog(props: { bet: Bet; contract: Contract }) {
   const bought = amount >= 0 ? 'bought' : 'sold'
   const absAmount = Math.abs(amount)
 
-  const answer =
-    isMultiCpmm(contract)
-      ? contract.answers?.find((a) => a.id === answerId)
-      : undefined
+  const answer = isMultiCpmm(contract)
+    ? contract.answers?.find((a) => a.id === answerId)
+    : undefined
 
   const fromProb = `${(probBefore * 100).toFixed(0)}%`
   const toProb = `${(probAfter * 100).toFixed(0)}%`

--- a/web/components/feed/activity-card.tsx
+++ b/web/components/feed/activity-card.tsx
@@ -14,6 +14,7 @@ import {
   contractPath,
   CPMMMultiContract,
   CPMMNumericContract,
+  isMultiCpmm,
   PollContract,
 } from 'common/contract'
 import { ENV_CONFIG } from 'common/envs/constants'
@@ -187,7 +188,7 @@ export const ActivityCard = memo(function ActivityCard(props: {
 
         {/* Answer bars for multiple choice markets */}
         {contract.outcomeType === 'MULTIPLE_CHOICE' &&
-          contract.mechanism === 'cpmm-multi-1' && (
+          isMultiCpmm(contract) && (
             <div onClick={(e) => e.stopPropagation()} className="mt-2">
               <SimpleAnswerBars
                 contract={contract as CPMMMultiContract}
@@ -390,7 +391,7 @@ const BetLog = memo(function BetLog(props: { bet: Bet; contract: Contract }) {
   const absAmount = Math.abs(amount)
 
   const answer =
-    contract.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(contract)
       ? contract.answers?.find((a) => a.id === answerId)
       : undefined
 

--- a/web/components/feed/feed-bets.tsx
+++ b/web/components/feed/feed-bets.tsx
@@ -65,8 +65,7 @@ function BetTooltipContent(props: {
 }) {
   const { bet, isCashContract, contract } = props
   const formatAmount = isCashContract ? formatSweepies : formatMoneyWithDecimals
-  const answerId =
-    isMultiCpmm(contract) ? bet.answerId : undefined
+  const answerId = isMultiCpmm(contract) ? bet.answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, answerId)
   const { answer: fetchedAnswer } = useAnswer(answerId)
   const answer = answerFromContract ?? fetchedAnswer
@@ -263,8 +262,7 @@ function BetActionText(props: { bet: Bet; contract: Contract }) {
       </span>
     ) : null
 
-  const resolvedAnswerId =
-    isMultiCpmm(contract) ? answerId : undefined
+  const resolvedAnswerId = isMultiCpmm(contract) ? answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, resolvedAnswerId)
   const { answer: fetchedAnswer } = useAnswer(resolvedAnswerId)
   const answer = answerFromContract ?? fetchedAnswer
@@ -641,8 +639,7 @@ export function BetStatusesText(props: {
   const { amount, outcome, createdTime, answerId, userId } = bets[0]
   const user = useDisplayUserById(userId)
   const isCashContract = contract.token === 'CASH'
-  const resolvedAnswerId =
-    isMultiCpmm(contract) ? answerId : undefined
+  const resolvedAnswerId = isMultiCpmm(contract) ? answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, resolvedAnswerId)
   const { answer: fetchedAnswer } = useAnswer(resolvedAnswerId)
   const answer = answerFromContract ?? fetchedAnswer
@@ -730,8 +727,7 @@ export function BetStatusText(props: {
     ? getFormattedMappedValue(contract, probAfter)
     : getFormattedMappedValue(contract, limitProb ?? probAfter)
 
-  const resolvedAnswerId =
-    isMultiCpmm(contract) ? answerId : undefined
+  const resolvedAnswerId = isMultiCpmm(contract) ? answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, resolvedAnswerId)
   const { answer: fetchedAnswer } = useAnswer(resolvedAnswerId)
   const answer = answerFromContract ?? fetchedAnswer

--- a/web/components/feed/feed-bets.tsx
+++ b/web/components/feed/feed-bets.tsx
@@ -5,6 +5,7 @@ import {
   Contract,
   getBinaryMCProb,
   isBinaryMulti,
+  isMultiCpmm,
   MarketContract,
 } from 'common/contract'
 import { TRADE_TERM } from 'common/envs/constants'
@@ -53,7 +54,7 @@ const isNormalLimitOrder = (bet: Bet) =>
   bet.limitProb !== undefined && bet.orderAmount !== undefined && !bet.silent
 
 const getAnswerFromContract = (contract: Contract, answerId?: string) =>
-  contract.mechanism === 'cpmm-multi-1' && answerId && 'answers' in contract
+  isMultiCpmm(contract) && answerId && 'answers' in contract
     ? contract.answers?.find((answer) => answer.id === answerId)
     : undefined
 
@@ -65,7 +66,7 @@ function BetTooltipContent(props: {
   const { bet, isCashContract, contract } = props
   const formatAmount = isCashContract ? formatSweepies : formatMoneyWithDecimals
   const answerId =
-    contract.mechanism === 'cpmm-multi-1' ? bet.answerId : undefined
+    isMultiCpmm(contract) ? bet.answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, answerId)
   const { answer: fetchedAnswer } = useAnswer(answerId)
   const answer = answerFromContract ?? fetchedAnswer
@@ -263,7 +264,7 @@ function BetActionText(props: { bet: Bet; contract: Contract }) {
     ) : null
 
   const resolvedAnswerId =
-    contract.mechanism === 'cpmm-multi-1' ? answerId : undefined
+    isMultiCpmm(contract) ? answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, resolvedAnswerId)
   const { answer: fetchedAnswer } = useAnswer(resolvedAnswerId)
   const answer = answerFromContract ?? fetchedAnswer
@@ -641,7 +642,7 @@ export function BetStatusesText(props: {
   const user = useDisplayUserById(userId)
   const isCashContract = contract.token === 'CASH'
   const resolvedAnswerId =
-    contract.mechanism === 'cpmm-multi-1' ? answerId : undefined
+    isMultiCpmm(contract) ? answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, resolvedAnswerId)
   const { answer: fetchedAnswer } = useAnswer(resolvedAnswerId)
   const answer = answerFromContract ?? fetchedAnswer
@@ -730,7 +731,7 @@ export function BetStatusText(props: {
     : getFormattedMappedValue(contract, limitProb ?? probAfter)
 
   const resolvedAnswerId =
-    contract.mechanism === 'cpmm-multi-1' ? answerId : undefined
+    isMultiCpmm(contract) ? answerId : undefined
   const answerFromContract = getAnswerFromContract(contract, resolvedAnswerId)
   const { answer: fetchedAnswer } = useAnswer(resolvedAnswerId)
   const answer = answerFromContract ?? fetchedAnswer
@@ -853,7 +854,7 @@ function BetActions(props: {
           questionText={contract.question}
           outcome={formatOutcomeLabel(contract, bet.outcome as 'YES' | 'NO')}
           answer={
-            contract.mechanism === 'cpmm-multi-1'
+            isMultiCpmm(contract)
               ? contract.answers?.find((a) => a.id === bet.answerId)?.text
               : undefined
           }
@@ -964,7 +965,7 @@ function BetActionsWithGraph(props: {
           questionText={contract.question}
           outcome={formatOutcomeLabel(contract, bet.outcome as 'YES' | 'NO')}
           answer={
-            contract.mechanism === 'cpmm-multi-1'
+            isMultiCpmm(contract)
               ? contract.answers?.find((a) => a.id === bet.answerId)?.text
               : undefined
           }

--- a/web/components/new-contract/contextual-editor-panel.tsx
+++ b/web/components/new-contract/contextual-editor-panel.tsx
@@ -34,7 +34,8 @@ export type FormState = {
   // useCustomInitialProbs toggles the feature; initialProbs holds raw
   // percentages index-aligned to `answers` (missing entries default to equal).
   useCustomInitialProbs?: boolean
-  initialProbs?: number[]
+  // May contain undefined holes (a cleared input); consumers default per answer.
+  initialProbs?: (number | undefined)[]
   probability?: number
   min?: number
   max?: number

--- a/web/components/new-contract/contextual-editor-panel.tsx
+++ b/web/components/new-contract/contextual-editor-panel.tsx
@@ -30,6 +30,11 @@ export type FormState = {
   liquidityTier: number
   shouldAnswersSumToOne?: boolean
   addAnswersMode?: 'DISABLED' | 'ONLY_CREATOR' | 'ANYONE'
+  // cpmm-multi-2: custom per-answer initial probabilities (MULTIPLE_CHOICE).
+  // useCustomInitialProbs toggles the feature; initialProbs holds raw
+  // percentages index-aligned to `answers` (missing entries default to equal).
+  useCustomInitialProbs?: boolean
+  initialProbs?: number[]
   probability?: number
   min?: number
   max?: number

--- a/web/components/new-contract/contract-types.ts
+++ b/web/components/new-contract/contract-types.ts
@@ -17,6 +17,8 @@ export type NewQuestionParams = {
   answers?: string[]
   addAnswersMode?: add_answers_mode
   shouldAnswersSumToOne?: boolean
+  // cpmm-multi-2: per-answer initial probabilities (percentages, answer-aligned)
+  initialProbs?: number[]
   precision?: number
   sportsStartTimestamp?: string
   sportsEventId?: string

--- a/web/components/new-contract/market-preview.tsx
+++ b/web/components/new-contract/market-preview.tsx
@@ -292,7 +292,10 @@ export function MarketPreview(props: {
     onEditInitialProbs?.(next)
   }
   const initialProbsSumPct = customProbsActive
-    ? answers.reduce((s, _, i) => s + (initialProbs?.[i] ?? defaultInitialPct), 0)
+    ? answers.reduce(
+        (s, _, i) => s + (initialProbs?.[i] ?? defaultInitialPct),
+        0
+      )
     : 0
 
   // Auto-resize question textarea to fit content
@@ -1269,9 +1272,7 @@ export function MarketPreview(props: {
                     meaningful for sum-to-one; Set answers are independent) */}
                 {customProbsActive && isSumToOne && answers.length > 0 && (
                   <Row className="text-ink-500 items-center gap-1 px-1 text-xs">
-                    <span>
-                      Sum {Math.round(initialProbsSumPct * 10) / 10}%
-                    </span>
+                    <span>Sum {Math.round(initialProbsSumPct * 10) / 10}%</span>
                     <span className="text-ink-400">
                       · normalized to 100% on create
                     </span>

--- a/web/components/new-contract/market-preview.tsx
+++ b/web/components/new-contract/market-preview.tsx
@@ -9,7 +9,11 @@ import { JSONContent } from '@tiptap/core'
 import { Editor } from '@tiptap/react'
 import clsx from 'clsx'
 import { MAX_ANSWERS } from 'common/answer'
-import { Contract, CreateableOutcomeType } from 'common/contract'
+import {
+  Contract,
+  CPMM_MULTI_2_CREATION_ENABLED,
+  CreateableOutcomeType,
+} from 'common/contract'
 import { Group } from 'common/group'
 import { User } from 'common/user'
 import { formatMoney } from 'common/util/format'
@@ -134,6 +138,11 @@ export function MarketPreview(props: {
   fieldErrors?: ValidationErrors
   onToggleIncludeSeeResults?: () => void
   onReplaceQuestionText?: (original: string, replacement: string) => void
+  // cpmm-multi-2: custom per-answer initial probabilities (MULTIPLE_CHOICE).
+  useCustomInitialProbs?: boolean
+  initialProbs?: number[]
+  onToggleUseCustomInitialProbs?: () => void
+  onEditInitialProbs?: (probs: number[]) => void
 }) {
   const {
     data,
@@ -170,6 +179,10 @@ export function MarketPreview(props: {
     fieldErrors = {},
     onToggleIncludeSeeResults,
     onReplaceQuestionText,
+    useCustomInitialProbs = false,
+    initialProbs,
+    onToggleUseCustomInitialProbs,
+    onEditInitialProbs,
   } = props
   const [isTopicsModalOpen, setIsTopicsModalOpen] = useState(false)
   const [dismissedSuggestion, setDismissedSuggestion] = useState(false)
@@ -245,6 +258,31 @@ export function MarketPreview(props: {
     shouldAnswersSumToOne,
     addAnswersMode,
   } = data
+
+  // cpmm-multi-2: per-answer initial probabilities are only offered for fixed,
+  // sum-to-one multiple-choice markets (no "Other" answer), behind the
+  // creation kill-switch. customProbsActive = the toggle is also on.
+  const customInitialProbsAvailable =
+    CPMM_MULTI_2_CREATION_ENABLED &&
+    outcomeType === 'MULTIPLE_CHOICE' &&
+    (shouldAnswersSumToOne ?? true) &&
+    (addAnswersMode || 'DISABLED') === 'DISABLED'
+  const customProbsActive = customInitialProbsAvailable && useCustomInitialProbs
+
+  // Set one answer's raw initial-probability percentage, filling any unset
+  // entries with the current equal share so the array stays answer-aligned.
+  const setInitialProb = (i: number, value: number) => {
+    const equalPct = answers.length > 0 ? 100 / answers.length : 0
+    const next = answers.map((_, idx) => initialProbs?.[idx] ?? equalPct)
+    next[i] = value
+    onEditInitialProbs?.(next)
+  }
+  const initialProbsSumPct = customProbsActive
+    ? answers.reduce(
+        (s, _, i) => s + (initialProbs?.[i] ?? 100 / answers.length),
+        0
+      )
+    : 0
 
   // Auto-resize question textarea to fit content
   const resizeQuestionTextarea = useCallback(() => {
@@ -366,7 +404,16 @@ export function MarketPreview(props: {
     if (data.shouldAnswersSumToOne) {
       const totalAnswers = answers.length + (hasOther ? 1 : 0)
       const equalProb = 1 / totalAnswers
-      mcProbs = answers.map(() => equalProb)
+      if (customProbsActive) {
+        // cpmm-multi-2: normalize the raw per-answer percentages to sum to 1 so
+        // the preview matches what the backend will create.
+        const equalPct = 100 / answers.length
+        const raw = answers.map((_, i) => initialProbs?.[i] ?? equalPct)
+        const sum = raw.reduce((s, x) => s + x, 0)
+        mcProbs = raw.map((x) => (sum > 0 ? x / sum : equalProb))
+      } else {
+        mcProbs = answers.map(() => equalProb)
+      }
     } else {
       mcProbs = answers.map(() => 0.5)
     }
@@ -887,6 +934,18 @@ export function MarketPreview(props: {
                 : ''
             )}
           >
+            {customInitialProbsAvailable && (
+              <Row className="items-center justify-between gap-2 px-1">
+                <Row className="text-ink-700 items-center gap-1.5 text-sm">
+                  <span>Custom initial probabilities</span>
+                  <InfoTooltip text="Set each answer's starting probability instead of an equal split. Values are normalized to sum to 100% (cpmm-multi-2)." />
+                </Row>
+                <ShortToggle
+                  on={useCustomInitialProbs}
+                  setOn={() => onToggleUseCustomInitialProbs?.()}
+                />
+              </Row>
+            )}
             {answers.length > 0 || addAnswersModeEnabled ? (
               <>
                 {answers.map((answer, i) => (
@@ -897,9 +956,30 @@ export function MarketPreview(props: {
                     {/* Desktop layout: horizontal */}
                     <Row className="hidden items-center gap-3 sm:flex">
                       {/* Probability - Prominent on left like real markets */}
-                      <span className="text-ink-700 min-w-[3rem] text-lg font-semibold">
-                        {Math.round(mcProbs[i] * 100)}%
-                      </span>
+                      {customProbsActive && isEditable ? (
+                        <Row className="items-center gap-0.5">
+                          <Input
+                            type="number"
+                            min={1}
+                            max={99}
+                            value={
+                              initialProbs?.[i] ??
+                              Math.round((100 / answers.length) * 10) / 10
+                            }
+                            onChange={(e) =>
+                              setInitialProb(i, Number(e.target.value))
+                            }
+                            className="!h-8 w-16 !text-base"
+                          />
+                          <span className="text-ink-700 text-lg font-semibold">
+                            %
+                          </span>
+                        </Row>
+                      ) : (
+                        <span className="text-ink-700 min-w-[3rem] text-lg font-semibold">
+                          {Math.round(mcProbs[i] * 100)}%
+                        </span>
+                      )}
 
                       {/* Answer text/input - grows to fill space */}
                       {isEditable && onEditAnswers ? (
@@ -1007,9 +1087,30 @@ export function MarketPreview(props: {
                     {/* Mobile layout: stacked */}
                     <Row className="items-center gap-2 sm:hidden">
                       {/* Probability - on the left, smaller */}
-                      <span className="text-ink-700 shrink-0 text-sm font-semibold">
-                        {Math.round(mcProbs[i] * 100)}%
-                      </span>
+                      {customProbsActive && isEditable ? (
+                        <Row className="shrink-0 items-center gap-0.5">
+                          <Input
+                            type="number"
+                            min={1}
+                            max={99}
+                            value={
+                              initialProbs?.[i] ??
+                              Math.round((100 / answers.length) * 10) / 10
+                            }
+                            onChange={(e) =>
+                              setInitialProb(i, Number(e.target.value))
+                            }
+                            className="!h-7 w-14 !text-sm"
+                          />
+                          <span className="text-ink-700 text-sm font-semibold">
+                            %
+                          </span>
+                        </Row>
+                      ) : (
+                        <span className="text-ink-700 shrink-0 text-sm font-semibold">
+                          {Math.round(mcProbs[i] * 100)}%
+                        </span>
+                      )}
 
                       {/* Answer text/input - with relative positioning for X button */}
                       <div className="relative flex-1">
@@ -1153,6 +1254,18 @@ export function MarketPreview(props: {
                       </Row>
                     </div>
                   )}
+
+                {/* cpmm-multi-2: running sum of the custom percentages */}
+                {customProbsActive && answers.length > 0 && (
+                  <Row className="text-ink-500 items-center gap-1 px-1 text-xs">
+                    <span>
+                      Sum {Math.round(initialProbsSumPct * 10) / 10}%
+                    </span>
+                    <span className="text-ink-400">
+                      · normalized to 100% on create
+                    </span>
+                  </Row>
+                )}
 
                 {/* Action buttons row */}
                 {isEditable && onEditAnswers && (

--- a/web/components/new-contract/market-preview.tsx
+++ b/web/components/new-contract/market-preview.tsx
@@ -40,7 +40,10 @@ import { Modal } from '../layout/modal'
 import { ContractTopicsList } from '../topics/contract-topics-list'
 import { TopicTag } from '../topics/topic-tag'
 import { InfoTooltip } from '../widgets/info-tooltip'
-import { ProbabilitySlider } from '../widgets/probability-input'
+import {
+  ProbabilityInput,
+  ProbabilitySlider,
+} from '../widgets/probability-input'
 import ShortToggle from '../widgets/short-toggle'
 import { MarketTypeSuggestionBanner } from './market-type-suggestion-banner'
 import {
@@ -140,9 +143,9 @@ export function MarketPreview(props: {
   onReplaceQuestionText?: (original: string, replacement: string) => void
   // cpmm-multi-2: custom per-answer initial probabilities (MULTIPLE_CHOICE).
   useCustomInitialProbs?: boolean
-  initialProbs?: number[]
+  initialProbs?: (number | undefined)[]
   onToggleUseCustomInitialProbs?: () => void
-  onEditInitialProbs?: (probs: number[]) => void
+  onEditInitialProbs?: (probs: (number | undefined)[]) => void
 }) {
   const {
     data,
@@ -278,10 +281,13 @@ export function MarketPreview(props: {
       : 0
     : 50
 
-  // Set one answer's raw initial-probability percentage, filling any unset
-  // entries with the default so the array stays answer-aligned.
-  const setInitialProb = (i: number, value: number) => {
-    const next = answers.map((_, idx) => initialProbs?.[idx] ?? defaultInitialPct)
+  // Set one answer's raw initial-probability percentage. The array stays
+  // answer-aligned; a cleared input stores an undefined hole (every consumer —
+  // sum display, preview, payload — defaults it per answer).
+  const setInitialProb = (i: number, value: number | undefined) => {
+    const next: (number | undefined)[] = answers.map(
+      (_, idx) => initialProbs?.[idx]
+    )
     next[i] = value
     onEditInitialProbs?.(next)
   }
@@ -948,6 +954,7 @@ export function MarketPreview(props: {
                 <ShortToggle
                   on={useCustomInitialProbs}
                   setOn={() => onToggleUseCustomInitialProbs?.()}
+                  ariaLabel="Custom initial probabilities"
                 />
                 <Row className="text-ink-700 items-center gap-1.5 text-sm">
                   <span>Custom initial probabilities</span>
@@ -972,24 +979,18 @@ export function MarketPreview(props: {
                     <Row className="hidden items-center gap-3 sm:flex">
                       {/* Probability - Prominent on left like real markets */}
                       {customProbsActive && isEditable ? (
-                        <Row className="items-center gap-0.5">
-                          <Input
-                            type="number"
-                            min={1}
-                            max={99}
-                            value={
-                              initialProbs?.[i] ??
-                              Math.round(defaultInitialPct * 10) / 10
-                            }
-                            onChange={(e) =>
-                              setInitialProb(i, Number(e.target.value))
-                            }
-                            className="!h-8 w-16 !text-base"
-                          />
-                          <span className="text-ink-700 text-lg font-semibold">
-                            %
-                          </span>
-                        </Row>
+                        <ProbabilityInput
+                          prob={
+                            initialProbs?.[i] !== undefined
+                              ? Math.round(initialProbs[i]!)
+                              : undefined
+                          }
+                          onChange={(newProb) => setInitialProb(i, newProb)}
+                          placeholder={`${Math.round(defaultInitialPct)}`}
+                          ariaLabel={`Initial probability for answer ${i + 1}`}
+                          className="w-20"
+                          inputClassName="!h-8 !pr-8 !text-base"
+                        />
                       ) : (
                         <span className="text-ink-700 min-w-[3rem] text-lg font-semibold">
                           {Math.round(mcProbs[i] * 100)}%
@@ -1103,24 +1104,18 @@ export function MarketPreview(props: {
                     <Row className="items-center gap-2 sm:hidden">
                       {/* Probability - on the left, smaller */}
                       {customProbsActive && isEditable ? (
-                        <Row className="shrink-0 items-center gap-0.5">
-                          <Input
-                            type="number"
-                            min={1}
-                            max={99}
-                            value={
-                              initialProbs?.[i] ??
-                              Math.round(defaultInitialPct * 10) / 10
-                            }
-                            onChange={(e) =>
-                              setInitialProb(i, Number(e.target.value))
-                            }
-                            className="!h-7 w-14 !text-sm"
-                          />
-                          <span className="text-ink-700 text-sm font-semibold">
-                            %
-                          </span>
-                        </Row>
+                        <ProbabilityInput
+                          prob={
+                            initialProbs?.[i] !== undefined
+                              ? Math.round(initialProbs[i]!)
+                              : undefined
+                          }
+                          onChange={(newProb) => setInitialProb(i, newProb)}
+                          placeholder={`${Math.round(defaultInitialPct)}`}
+                          ariaLabel={`Initial probability for answer ${i + 1}`}
+                          className="w-16 shrink-0"
+                          inputClassName="!h-7 !pr-7 !text-sm"
+                        />
                       ) : (
                         <span className="text-ink-700 shrink-0 text-sm font-semibold">
                           {Math.round(mcProbs[i] * 100)}%

--- a/web/components/new-contract/market-preview.tsx
+++ b/web/components/new-contract/market-preview.tsx
@@ -259,29 +259,34 @@ export function MarketPreview(props: {
     addAnswersMode,
   } = data
 
-  // cpmm-multi-2: per-answer initial probabilities are only offered for fixed,
-  // sum-to-one multiple-choice markets (no "Other" answer), behind the
-  // creation kill-switch. customProbsActive = the toggle is also on.
+  // cpmm-multi-2: per-answer initial probabilities are offered for both fixed
+  // sum-to-one ("Multiple Choice") and independent ("Set") multiple-choice
+  // markets (no "Other"/addable answers), behind the creation kill-switch.
+  // customProbsActive = the toggle is also on.
+  const isSumToOne = shouldAnswersSumToOne ?? true
   const customInitialProbsAvailable =
     CPMM_MULTI_2_CREATION_ENABLED &&
     outcomeType === 'MULTIPLE_CHOICE' &&
-    (shouldAnswersSumToOne ?? true) &&
     (addAnswersMode || 'DISABLED') === 'DISABLED'
   const customProbsActive = customInitialProbsAvailable && useCustomInitialProbs
 
+  // Default per-answer percentage when an entry is unset: an equal split for
+  // sum-to-one, 50% for independent (Set) answers (each is its own market).
+  const defaultInitialPct = isSumToOne
+    ? answers.length > 0
+      ? 100 / answers.length
+      : 0
+    : 50
+
   // Set one answer's raw initial-probability percentage, filling any unset
-  // entries with the current equal share so the array stays answer-aligned.
+  // entries with the default so the array stays answer-aligned.
   const setInitialProb = (i: number, value: number) => {
-    const equalPct = answers.length > 0 ? 100 / answers.length : 0
-    const next = answers.map((_, idx) => initialProbs?.[idx] ?? equalPct)
+    const next = answers.map((_, idx) => initialProbs?.[idx] ?? defaultInitialPct)
     next[i] = value
     onEditInitialProbs?.(next)
   }
   const initialProbsSumPct = customProbsActive
-    ? answers.reduce(
-        (s, _, i) => s + (initialProbs?.[i] ?? 100 / answers.length),
-        0
-      )
+    ? answers.reduce((s, _, i) => s + (initialProbs?.[i] ?? defaultInitialPct), 0)
     : 0
 
   // Auto-resize question textarea to fit content
@@ -414,6 +419,10 @@ export function MarketPreview(props: {
       } else {
         mcProbs = answers.map(() => equalProb)
       }
+    } else if (customProbsActive) {
+      // cpmm-multi-2 independent ("Set"): each answer's own absolute prob, no
+      // normalization (they need not sum to 1).
+      mcProbs = answers.map((_, i) => (initialProbs?.[i] ?? 50) / 100)
     } else {
       mcProbs = answers.map(() => 0.5)
     }
@@ -935,15 +944,21 @@ export function MarketPreview(props: {
             )}
           >
             {customInitialProbsAvailable && (
-              <Row className="items-center justify-between gap-2 px-1">
-                <Row className="text-ink-700 items-center gap-1.5 text-sm">
-                  <span>Custom initial probabilities</span>
-                  <InfoTooltip text="Set each answer's starting probability instead of an equal split. Values are normalized to sum to 100% (cpmm-multi-2)." />
-                </Row>
+              <Row className="items-center gap-2 px-1">
                 <ShortToggle
                   on={useCustomInitialProbs}
                   setOn={() => onToggleUseCustomInitialProbs?.()}
                 />
+                <Row className="text-ink-700 items-center gap-1.5 text-sm">
+                  <span>Custom initial probabilities</span>
+                  <InfoTooltip
+                    text={
+                      isSumToOne
+                        ? "Set each answer's starting probability instead of an equal split. Values are normalized to sum to 100% (cpmm-multi-2)."
+                        : "Set each answer's independent starting probability (cpmm-multi-2). Set answers are separate predictions and need not sum to 100%."
+                    }
+                  />
+                </Row>
               </Row>
             )}
             {answers.length > 0 || addAnswersModeEnabled ? (
@@ -964,7 +979,7 @@ export function MarketPreview(props: {
                             max={99}
                             value={
                               initialProbs?.[i] ??
-                              Math.round((100 / answers.length) * 10) / 10
+                              Math.round(defaultInitialPct * 10) / 10
                             }
                             onChange={(e) =>
                               setInitialProb(i, Number(e.target.value))
@@ -1095,7 +1110,7 @@ export function MarketPreview(props: {
                             max={99}
                             value={
                               initialProbs?.[i] ??
-                              Math.round((100 / answers.length) * 10) / 10
+                              Math.round(defaultInitialPct * 10) / 10
                             }
                             onChange={(e) =>
                               setInitialProb(i, Number(e.target.value))
@@ -1255,8 +1270,9 @@ export function MarketPreview(props: {
                     </div>
                   )}
 
-                {/* cpmm-multi-2: running sum of the custom percentages */}
-                {customProbsActive && answers.length > 0 && (
+                {/* cpmm-multi-2: running sum of the custom percentages (only
+                    meaningful for sum-to-one; Set answers are independent) */}
+                {customProbsActive && isSumToOne && answers.length > 0 && (
                   <Row className="text-ink-500 items-center gap-1 px-1 text-xs">
                     <span>
                       Sum {Math.round(initialProbsSumPct * 10) / 10}%

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -931,7 +931,13 @@ export function NewContractPanel(props: {
       if (formState.outcomeType === 'BINARY') {
         payload.initialProb = formState.probability || 50
       } else if (formState.outcomeType === 'MULTIPLE_CHOICE') {
-        const mcAnswers = formState.answers.filter((a) => a.trim().length > 0)
+        // Keep each kept answer's ORIGINAL row index: initialProbs is row-aligned with
+        // the unfiltered editor rows, so filtering blank middle rows and then indexing
+        // probs by filtered position would silently shift every later answer's prob.
+        const mcAnswerRows = formState.answers
+          .map((text, originalIndex) => ({ text, originalIndex }))
+          .filter(({ text }) => text.trim().length > 0)
+        const mcAnswers = mcAnswerRows.map(({ text }) => text)
         payload.answers = mcAnswers
         payload.shouldAnswersSumToOne = formState.shouldAnswersSumToOne
         payload.addAnswersMode = formState.addAnswersMode
@@ -948,8 +954,9 @@ export function NewContractPanel(props: {
           const defaultPct = formState.shouldAnswersSumToOne
             ? 100 / mcAnswers.length
             : 50
-          payload.initialProbs = mcAnswers.map(
-            (_, i) => formState.initialProbs?.[i] ?? defaultPct
+          payload.initialProbs = mcAnswerRows.map(
+            ({ originalIndex }) =>
+              formState.initialProbs?.[originalIndex] ?? defaultPct
           )
         }
       } else if (formState.outcomeType === 'POLL') {

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -935,18 +935,21 @@ export function NewContractPanel(props: {
         payload.answers = mcAnswers
         payload.shouldAnswersSumToOne = formState.shouldAnswersSumToOne
         payload.addAnswersMode = formState.addAnswersMode
-        // cpmm-multi-2: ship per-answer initial probs (raw percentages; the
-        // backend normalizes Σ=1). Missing entries default to an equal share.
+        // cpmm-multi-2: ship per-answer initial probs (raw percentages). The
+        // backend normalizes Σ=1 for sum-to-one ("Multiple Choice") and uses
+        // each as an absolute prob for independent ("Set") markets. Missing
+        // entries default to an equal share (sum-to-one) or 50% (Set).
         if (
           CPMM_MULTI_2_CREATION_ENABLED &&
           formState.useCustomInitialProbs &&
-          formState.shouldAnswersSumToOne &&
           formState.addAnswersMode === 'DISABLED' &&
           mcAnswers.length >= 2
         ) {
-          const equal = 100 / mcAnswers.length
+          const defaultPct = formState.shouldAnswersSumToOne
+            ? 100 / mcAnswers.length
+            : 50
           payload.initialProbs = mcAnswers.map(
-            (_, i) => formState.initialProbs?.[i] ?? equal
+            (_, i) => formState.initialProbs?.[i] ?? defaultPct
           )
         }
       } else if (formState.outcomeType === 'POLL') {

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -1,6 +1,10 @@
 import { useEvent } from 'client-common/hooks/use-event'
 import clsx from 'clsx'
-import { Contract, CreateableOutcomeType } from 'common/contract'
+import {
+  Contract,
+  CPMM_MULTI_2_CREATION_ENABLED,
+  CreateableOutcomeType,
+} from 'common/contract'
 import { MarketDraft } from 'common/drafts'
 import { BOOST_COST_MANA, FREE_MARKET_USER_ID, getAnte } from 'common/economy'
 import { User } from 'common/user'
@@ -80,6 +84,8 @@ export function NewContractPanel(props: {
     liquidityTier: 100,
     shouldAnswersSumToOne: true,
     addAnswersMode: 'DISABLED',
+    useCustomInitialProbs: false,
+    initialProbs: [],
     probability: 50,
     min: undefined,
     max: undefined,
@@ -109,6 +115,8 @@ export function NewContractPanel(props: {
     liquidityTier: 100, // Default to tier 0 (100 mana)
     shouldAnswersSumToOne: params?.shouldAnswersSumToOne ?? true,
     addAnswersMode: params?.addAnswersMode || 'DISABLED',
+    useCustomInitialProbs: false,
+    initialProbs: [],
     probability: 50,
     min: params?.min,
     max: params?.max,
@@ -923,9 +931,24 @@ export function NewContractPanel(props: {
       if (formState.outcomeType === 'BINARY') {
         payload.initialProb = formState.probability || 50
       } else if (formState.outcomeType === 'MULTIPLE_CHOICE') {
-        payload.answers = formState.answers.filter((a) => a.trim().length > 0)
+        const mcAnswers = formState.answers.filter((a) => a.trim().length > 0)
+        payload.answers = mcAnswers
         payload.shouldAnswersSumToOne = formState.shouldAnswersSumToOne
         payload.addAnswersMode = formState.addAnswersMode
+        // cpmm-multi-2: ship per-answer initial probs (raw percentages; the
+        // backend normalizes Σ=1). Missing entries default to an equal share.
+        if (
+          CPMM_MULTI_2_CREATION_ENABLED &&
+          formState.useCustomInitialProbs &&
+          formState.shouldAnswersSumToOne &&
+          formState.addAnswersMode === 'DISABLED' &&
+          mcAnswers.length >= 2
+        ) {
+          const equal = 100 / mcAnswers.length
+          payload.initialProbs = mcAnswers.map(
+            (_, i) => formState.initialProbs?.[i] ?? equal
+          )
+        }
       } else if (formState.outcomeType === 'POLL') {
         const pollAnswers = formState.answers.filter((a) => a.trim().length > 0)
         // Add "See results" option if enabled
@@ -1197,6 +1220,15 @@ export function NewContractPanel(props: {
                 }
               }
             }}
+            useCustomInitialProbs={formState.useCustomInitialProbs}
+            initialProbs={formState.initialProbs}
+            onToggleUseCustomInitialProbs={() =>
+              updateField(
+                'useCustomInitialProbs',
+                !formState.useCustomInitialProbs
+              )
+            }
+            onEditInitialProbs={(probs) => updateField('initialProbs', probs)}
             onToggleShouldAnswersSumToOne={() => {
               const newValue = !formState.shouldAnswersSumToOne
               updateField('shouldAnswersSumToOne', newValue)

--- a/web/components/new-contract/new-contract-panel.tsx
+++ b/web/components/new-contract/new-contract-panel.tsx
@@ -115,8 +115,8 @@ export function NewContractPanel(props: {
     liquidityTier: 100, // Default to tier 0 (100 mana)
     shouldAnswersSumToOne: params?.shouldAnswersSumToOne ?? true,
     addAnswersMode: params?.addAnswersMode || 'DISABLED',
-    useCustomInitialProbs: false,
-    initialProbs: [],
+    useCustomInitialProbs: (params?.initialProbs?.length ?? 0) > 0,
+    initialProbs: params?.initialProbs ?? [],
     probability: 50,
     min: params?.min,
     max: params?.max,

--- a/web/components/outcome-label.tsx
+++ b/web/components/outcome-label.tsx
@@ -7,6 +7,7 @@ import {
   // MultiContract,
   OutcomeType,
   resolution,
+  isMultiCpmmMechanism,
 } from 'common/contract'
 import { formatLargeNumber, formatPercent } from 'common/util/format'
 import { Bet } from 'common/bet'
@@ -87,7 +88,7 @@ export function OutcomeLabel(props: {
     )
   }
 
-  if (mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmmMechanism(mechanism)) {
     return (
       <span>
         {answerText && (

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -3,7 +3,7 @@ import { useEvent } from 'client-common/hooks/use-event'
 import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
 import clsx from 'clsx'
 import { FullUser } from 'common/api/user-types'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import { LiteGroup } from 'common/group'
 import { CONTRACTS_PER_SEARCH_PAGE } from 'common/supabase/contracts'
 import { buildArray } from 'common/util/array'
@@ -381,7 +381,7 @@ export function Search(props: SearchProps) {
   const setQuery = (query: string) => onChange({ [QUERY_KEY]: query })
 
   const answersWithChanges = contracts?.flatMap((c) =>
-    c.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(c)
       ? orderBy(
           c.answers.filter((a) => Math.abs(a.probChanges.day) > 0.02),
           (a) => Math.abs(a.probChanges.day),
@@ -391,7 +391,7 @@ export function Search(props: SearchProps) {
   )
 
   const answersMatchingQuery = contracts?.flatMap((c) =>
-    c.mechanism === 'cpmm-multi-1'
+    isMultiCpmm(c)
       ? c.answers
           .filter((a) => a.text.toLowerCase().includes(query.toLowerCase()))
           .slice(0, 2)

--- a/web/components/sports/sports-bet-panel.tsx
+++ b/web/components/sports/sports-bet-panel.tsx
@@ -15,7 +15,7 @@ import { db } from 'web/lib/supabase/db'
 import { formatMoney } from 'common/util/format'
 import { EXPIRATION_OPTIONS } from 'web/components/bet/order-expiration-options'
 import { getContract, getAnswersForContracts } from 'common/supabase/contracts'
-import { CPMMMultiContract } from 'common/contract'
+import { CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { BuyAmountInput } from 'web/components/widgets/amount-input'
 import { Input } from 'web/components/widgets/input'
 import { ProbabilitySlider } from 'web/components/widgets/probability-input'
@@ -89,7 +89,7 @@ export function SportsBetPanel({
     let cancelled = false
     getContract(db, match.contractId)
       .then(async (c) => {
-        if (cancelled || !c || c.mechanism !== 'cpmm-multi-1') return
+        if (cancelled || !c || !isMultiCpmm(c)) return
         const answerMap = await getAnswersForContracts(db, [c.id])
         if (cancelled) return
         const multi = c as CPMMMultiContract

--- a/web/components/sports/sports-bet-panel.tsx
+++ b/web/components/sports/sports-bet-panel.tsx
@@ -45,7 +45,8 @@ export function SportsVersusBetDialog({
     let cancelled = false
     getContract(db, contractId)
       .then(async (c) => {
-        if (cancelled || !c || c.mechanism !== 'cpmm-multi-1') return
+        // isMultiCpmm: a converted cpmm-multi-2 game would otherwise render a silent null.
+        if (cancelled || !c || !isMultiCpmm(c)) return
         const answerMap = await getAnswersForContracts(db, [c.id])
         if (cancelled) return
         const multi = c as CPMMMultiContract

--- a/web/components/sports/sports-dashboard-page.tsx
+++ b/web/components/sports/sports-dashboard-page.tsx
@@ -23,7 +23,8 @@ import { useUser } from 'web/hooks/use-user'
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd'
 import type { DropResult } from '@hello-pangea/dnd'
 import { Dashboard, DashboardItem, DashboardTextItem } from 'common/dashboard'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
+import { Answer } from 'common/answer'
 import { shortFormatNumber } from 'common/util/format'
 import { ContractRow } from 'web/components/contract/contracts-table'
 import {
@@ -303,7 +304,7 @@ function CommunityTab({
       for (const c of fetched) {
         // Merge answers for all cpmm-multi-1 markets (MC, NUMBER, MULTI_NUMERIC, DATE)
         // regardless of whether 'answers' is already in the data blob
-        if ((c as any).mechanism === 'cpmm-multi-1') {
+        if (isMultiCpmm(c)) {
           ;(c as any).answers =
             answersByContractId[c.id] ?? (c as any).answers ?? []
         }

--- a/web/components/tiers/liquidity-tooltip.tsx
+++ b/web/components/tiers/liquidity-tooltip.tsx
@@ -1,6 +1,6 @@
 import { Placement } from '@floating-ui/react'
 import clsx from 'clsx'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import { formatWithToken } from 'common/util/format'
 
 import { Tooltip } from '../widgets/tooltip'
@@ -20,7 +20,7 @@ export function LiquidityTooltip(props: {
   const { mechanism } = contract
 
   const isCashContract = contract.token === 'CASH'
-  const hasAnswers = contract.mechanism === 'cpmm-multi-1'
+  const hasAnswers = isMultiCpmm(contract)
   const totalLiquidity =
     'totalLiquidity' in contract ? contract.totalLiquidity : 0
   const liquidityTier = hasAnswers
@@ -29,7 +29,7 @@ export function LiquidityTooltip(props: {
         contract.answers.length
       ) - 1
     : getTierIndexFromLiquidity(totalLiquidity)
-  if (mechanism !== 'cpmm-multi-1' && mechanism !== 'cpmm-1') return <></>
+  if (!isMultiCpmm(contract) && mechanism !== 'cpmm-1') return <></>
   const amount = contract.totalLiquidity
   return (
     <Tooltip

--- a/web/components/tv/tv-display.tsx
+++ b/web/components/tv/tv-display.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import Router from 'next/router'
 
-import { Contract, tradingAllowed } from 'common/contract'
+import { Contract, isMultiCpmm, tradingAllowed } from 'common/contract'
 import { SEO } from 'web/components/SEO'
 import { Button } from 'web/components/buttons/button'
 import { BinaryResolutionOrChance } from 'web/components/contract/contract-price'
@@ -41,8 +41,7 @@ export function TVDisplay(props: {
 
   const isBinary = contract.outcomeType === 'BINARY'
   const isMulti =
-    contract.outcomeType === 'MULTIPLE_CHOICE' &&
-    contract.mechanism === 'cpmm-multi-1'
+    contract.outcomeType === 'MULTIPLE_CHOICE' && isMultiCpmm(contract)
 
   const betPanel = (
     <>

--- a/web/components/us-elections/contracts/candidates-panel/candidate-bar.tsx
+++ b/web/components/us-elections/contracts/candidates-panel/candidate-bar.tsx
@@ -1,6 +1,11 @@
 import clsx from 'clsx'
 import { Answer } from 'common/answer'
-import { CPMMMultiContract, MultiContract, contractPath } from 'common/contract'
+import {
+  CPMMMultiContract,
+  MultiContract,
+  contractPath,
+  isMultiCpmm,
+} from 'common/contract'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { IoIosPerson } from 'react-icons/io'
@@ -55,7 +60,7 @@ export const CandidateBar = (props: {
   const hasBets = userBets && !floatingEqual(sharesSum, 0)
   const { resolution } = contract
 
-  const isCpmm = contract.mechanism === 'cpmm-multi-1'
+  const isCpmm = isMultiCpmm(contract)
   return (
     <ClickFrame
       onClick={() => {

--- a/web/components/us-elections/contracts/candidates-panel/small-candidate-bar.tsx
+++ b/web/components/us-elections/contracts/candidates-panel/small-candidate-bar.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { Answer } from 'common/answer'
-import { CPMMMultiContract, MultiContract } from 'common/contract'
+import { CPMMMultiContract, MultiContract, isMultiCpmm } from 'common/contract'
 import Image from 'next/image'
 import { IoIosPerson } from 'react-icons/io'
 import { MultiBettor, OpenProb } from 'web/components/answers/answer-components'
@@ -48,7 +48,7 @@ export const SmallCandidateBar = (props: {
   const hasBets = userBets && !floatingEqual(sharesSum, 0)
   const { resolution } = contract
 
-  const isCpmm = contract.mechanism === 'cpmm-multi-1'
+  const isCpmm = isMultiCpmm(contract)
 
   return (
     <>

--- a/web/components/us-elections/contracts/party-panel/binary-party-panel.tsx
+++ b/web/components/us-elections/contracts/party-panel/binary-party-panel.tsx
@@ -2,7 +2,7 @@ import { track } from 'web/lib/service/analytics'
 import clsx from 'clsx'
 import { Bet } from 'common/bet'
 import { getDisplayProbability, getProbability } from 'common/calculate'
-import { BinaryContract, Contract } from 'common/contract'
+import { BinaryContract, Contract, isMultiCpmm } from 'common/contract'
 import { TRADE_TERM } from 'common/envs/constants'
 import { User } from 'common/user'
 import { formatPercent } from 'common/util/format'
@@ -390,7 +390,7 @@ export function BinaryBetButton(props: {
   if (
     !isClosed(contract) &&
     !contract.isResolved &&
-    (contract.mechanism === 'cpmm-1' || contract.mechanism === 'cpmm-multi-1')
+    (contract.mechanism === 'cpmm-1' || isMultiCpmm(contract))
   ) {
     return (
       <>

--- a/web/components/us-elections/contracts/party-panel/party-panel.tsx
+++ b/web/components/us-elections/contracts/party-panel/party-panel.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { Answer } from 'common/answer'
 import { Bet } from 'common/bet'
 import { getAnswerProbability } from 'common/calculate'
-import { MultiContract } from 'common/contract'
+import { MultiContract, isMultiCpmm } from 'common/contract'
 import { User } from 'common/user'
 import { sortBy } from 'lodash'
 import { useUser } from 'web/hooks/use-user'
@@ -248,7 +248,7 @@ function PartyAnswer(props: {
 
   const hasBets = userBets && !floatingEqual(sharesSum, 0)
 
-  const isCpmm = contract.mechanism === 'cpmm-multi-1'
+  const isCpmm = isMultiCpmm(contract)
 
   const isDemocraticParty = answer.text == 'Democratic Party'
   const isRepublicanParty = answer.text == 'Republican Party'
@@ -342,7 +342,7 @@ function PartyAnswerSnippet(props: {
 
   const hasBets = userBets && !floatingEqual(sharesSum, 0)
 
-  const isCpmm = contract.mechanism === 'cpmm-multi-1'
+  const isCpmm = isMultiCpmm(contract)
 
   const isDemocraticParty = answer.text == 'Democratic Party'
 

--- a/web/components/us-elections/presidency-2028-section.tsx
+++ b/web/components/us-elections/presidency-2028-section.tsx
@@ -8,6 +8,7 @@ import {
   CPMMMultiContract,
   MultiContract,
   contractPath,
+  isMultiCpmm,
 } from 'common/contract'
 import { formatPercent } from 'common/util/format'
 import { sortBy } from 'lodash'
@@ -204,7 +205,7 @@ function PresidencyPartyBar(props: { contract: Contract }) {
   const [betAnswer, setBetAnswer] = useState<Answer | undefined>()
 
   const probs = getPartyProbs(contract)
-  if (!probs || contract.mechanism !== 'cpmm-multi-1') return null
+  if (!probs || !isMultiCpmm(contract)) return null
 
   const { dem, rep, other } = probs
   const demAnswer = contract.answers.find((a) => isDemocraticAnswer(a.text))

--- a/web/components/usa-map/house-map.tsx
+++ b/web/components/usa-map/house-map.tsx
@@ -2,7 +2,7 @@ import { sortBy } from 'lodash'
 import clsx from 'clsx'
 import { useState } from 'react'
 import { Answer } from 'common/answer'
-import { Contract, CPMMMultiContract } from 'common/contract'
+import { Contract, CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { formatPercent } from 'common/util/format'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
@@ -41,7 +41,7 @@ export function parseDistrict(text: string) {
 }
 
 function districtsForState(contract: Contract, stateKey: string): Answer[] {
-  if (contract.mechanism !== 'cpmm-multi-1') return []
+  if (!isMultiCpmm(contract)) return []
   return contract.answers.filter(
     (a) => parseDistrict(a.text)?.stateCode === stateKey
   )

--- a/web/components/usa-map/house-table-helpers.tsx
+++ b/web/components/usa-map/house-table-helpers.tsx
@@ -308,7 +308,10 @@ export const BuyPanelBody = (props: {
       YES: multiProps!.answerToBuy.poolYes,
       NO: multiProps!.answerToBuy.poolNo,
     },
-    p: 0.5,
+    // Per-answer p (defaults 0.5 for cpmm-multi-1); hardcoding 0.5 showed a wrong
+    // probBefore/probAfter/probChange for a cpmm-multi-2 answer with p != 0.5. Mirrors the
+    // shared bet-preview path (client-common/src/lib/bet.ts).
+    p: multiProps!.answerToBuy.p,
     collectedFees: contract.collectedFees,
   }
 

--- a/web/components/usa-map/house-table-helpers.tsx
+++ b/web/components/usa-map/house-table-helpers.tsx
@@ -8,6 +8,7 @@ import {
   MAX_CPMM_PROB,
   MIN_CPMM_PROB,
   isBinaryMulti,
+  isMultiCpmm,
 } from 'common/contract'
 import {
   formatPercent,
@@ -218,7 +219,7 @@ export const BuyPanelBody = (props: {
 
   const [inputRef, focusAmountInput] = useFocus()
 
-  const isCpmmMulti = contract.mechanism === 'cpmm-multi-1'
+  const isCpmmMulti = isMultiCpmm(contract)
   if (isCpmmMulti && !multiProps) {
     throw new Error('multiProps must be defined for cpmm-multi-1')
   }

--- a/web/components/usa-map/house-table-helpers.tsx
+++ b/web/components/usa-map/house-table-helpers.tsx
@@ -1,7 +1,7 @@
 import { XIcon } from '@heroicons/react/outline'
 import { CheckIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
-import { Answer } from 'common/answer'
+import { Answer, answerP } from 'common/answer'
 import { getAnswerProbability } from 'common/calculate'
 import {
   CPMMMultiContract,
@@ -308,10 +308,11 @@ export const BuyPanelBody = (props: {
       YES: multiProps!.answerToBuy.poolYes,
       NO: multiProps!.answerToBuy.poolNo,
     },
-    // Per-answer p (defaults 0.5 for cpmm-multi-1); hardcoding 0.5 showed a wrong
-    // probBefore/probAfter/probChange for a cpmm-multi-2 answer with p != 0.5. Mirrors the
-    // shared bet-preview path (client-common/src/lib/bet.ts).
-    p: multiProps!.answerToBuy.p,
+    // answerP (per-answer p, storage-default 0.5): hardcoding 0.5 showed a wrong
+    // probBefore/probAfter/probChange for a cpmm-multi-2 answer with p != 0.5, and a bare
+    // .p is undefined->NaN on blob-sourced answers. Mirrors the shared bet-preview path
+    // (client-common/src/lib/bet.ts).
+    p: answerP(multiProps!.answerToBuy),
     collectedFees: contract.collectedFees,
   }
 

--- a/web/components/usa-map/state-election-map.tsx
+++ b/web/components/usa-map/state-election-map.tsx
@@ -1,5 +1,5 @@
 import { getAnswerProbability, getDisplayProbability } from 'common/calculate'
-import { Contract } from 'common/contract'
+import { Contract, isMultiCpmm } from 'common/contract'
 import {
   MapContractsDictionary,
   StateElectionMarket,
@@ -55,7 +55,7 @@ export const getPartyProbs = (
   let hasDem: boolean
   let hasRep: boolean
 
-  if (contract.mechanism === 'cpmm-multi-1') {
+  if (isMultiCpmm(contract)) {
     const answers = contract.answers
     const demAnswers = answers.filter((a) => isDemocraticAnswer(a.text))
     const repAnswers = answers.filter((a) => isRepublicanAnswer(a.text))

--- a/web/components/widgets/probability-input.tsx
+++ b/web/components/widgets/probability-input.tsx
@@ -56,6 +56,7 @@ export function ProbabilityInput(props: {
   inputClassName?: string
   error?: boolean
   limitProbs?: { max: number; min: number }
+  ariaLabel?: string
 }) {
   const {
     prob,
@@ -66,6 +67,7 @@ export function ProbabilityInput(props: {
     inputClassName,
     error,
     limitProbs,
+    ariaLabel,
   } = props
   const maxBetProbInt = 100 * (limitProbs?.max ?? 0.99)
   const minBetProbInt = 100 * (limitProbs?.min ?? 0.01)
@@ -97,6 +99,7 @@ export function ProbabilityInput(props: {
         inputMode="numeric"
         maxLength={2}
         placeholder={placeholder ?? '0'}
+        aria-label={ariaLabel}
         value={prob ?? ''}
         disabled={disabled}
         onChange={(e) => onProbChange(e.target.value)}

--- a/web/components/widgets/short-toggle.tsx
+++ b/web/components/widgets/short-toggle.tsx
@@ -10,8 +10,18 @@ export default function ShortToggle(props: {
   className?: string
   colorMode?: ToggleColorMode
   size?: 'sm'
+  // Accessible name for the switch — it renders no visible text of its own.
+  ariaLabel?: string
 }) {
-  const { on, size, setOn, disabled, className, colorMode = 'primary' } = props
+  const {
+    on,
+    size,
+    setOn,
+    disabled,
+    className,
+    colorMode = 'primary',
+    ariaLabel,
+  } = props
 
   const toggleBaseClasses =
     'group relative inline-flex flex-shrink-0 rounded-full border-2 border-transparent ring-offset-2 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2'
@@ -41,6 +51,7 @@ export default function ShortToggle(props: {
       disabled={disabled}
       checked={on}
       onChange={setOn}
+      aria-label={ariaLabel}
       className={clsx(
         toggleBaseClasses,
         toggleColorClasses,

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -12,6 +12,7 @@ import {
   contractPath,
   getMainBinaryMCAnswer,
   isBinaryMulti,
+  isMultiCpmm,
 } from 'common/contract'
 import { getMultiBetPoints, getSingleBetPoints } from 'common/contract-params'
 import { DOMAIN, TRADE_TERM } from 'common/envs/constants'
@@ -99,7 +100,7 @@ export async function getStaticProps(props: {
       contract.outcomeType === 'DATE'
     ) {
       const includeRedemptions =
-        contract.mechanism === 'cpmm-multi-1' && contract.shouldAnswersSumToOne
+        isMultiCpmm(contract) && contract.shouldAnswersSumToOne
       const allBetPoints = await getBetPointsBetween(contract, {
         filterRedemptions: !includeRedemptions,
         includeZeroShareRedemptions: includeRedemptions,
@@ -354,7 +355,7 @@ function ContractSmolView(props: {
           >
             {(w, h) =>
               mainBinaryMCAnswer &&
-              contract.mechanism === 'cpmm-multi-1' &&
+              isMultiCpmm(contract) &&
               contract.outcomeType !== 'NUMBER' ? (
                 <div className="flex h-full flex-col justify-center">
                   {showMultiChart && (

--- a/web/pages/yc-s23.tsx
+++ b/web/pages/yc-s23.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { sortBy } from 'lodash'
 import { useState } from 'react'
 import { Answer } from 'common/answer'
-import { CPMMMultiContract } from 'common/contract'
+import { CPMMMultiContract, isMultiCpmm } from 'common/contract'
 import { SimpleAnswerBars } from 'web/components/answers/answers-panel'
 import { Col } from 'web/components/layout/col'
 import { Page } from 'web/components/layout/page'
@@ -36,8 +36,7 @@ export async function getStaticProps() {
   const companies: Company[] = contracts
     .filter(
       (c) =>
-        c.question.includes('Exit valuation of ') &&
-        c.mechanism === 'cpmm-multi-1'
+        c.question.includes('Exit valuation of ') && isMultiCpmm(c)
     )
     .map((contract) => {
       const name = contract.question

--- a/web/pages/yc-s23.tsx
+++ b/web/pages/yc-s23.tsx
@@ -34,10 +34,7 @@ export async function getStaticProps() {
   }).catch(() => [])
 
   const companies: Company[] = contracts
-    .filter(
-      (c) =>
-        c.question.includes('Exit valuation of ') && isMultiCpmm(c)
-    )
+    .filter((c) => c.question.includes('Exit valuation of ') && isMultiCpmm(c))
     .map((contract) => {
       const name = contract.question
         .split('Exit valuation of ')[1]


### PR DESCRIPTION

### TL;DR — and the safety headline

This adds **`cpmm-multi-2`**, an opt-in multi-choice market mechanism that gives each answer its own
`p` (the degree of freedom a binary `cpmm-1` market already has, but `cpmm-multi-1` lacks).

**Nothing changes for any existing market, user, or integrator.** `cpmm-multi-1` is frozen
bug-for-bug. Everything new is gated behind `CPMM_MULTI_2_CREATION_ENABLED` (`common/src/contract.ts`),
which defaults to **`false`** — so with the flag off, the entire diff is **inert** and v1 is
byte-identical. **Merging this does not launch anything**; it lands the capability, dark. Activation
is a separate one-line flag flip you control later, and rollback is "set it back to false."

### Why — one missing degree of freedom

Three long-standing `cpmm-multi-1` limitations all trace to the same gap: a multi-choice answer has
no per-answer `p`. Add it (defaulting to `0.5` when absent, so every existing market reads back
identically) and all three dissolve at once:

1. **`p = 0.5` is hardcoded** → blocks non-uniform initialization (`initialProb` per answer) and
   *lossless* liquidity addition. Today `addCpmmLiquidityFixedP` literally throws shares away to hold
   probability on a skewed pool — at fixed `p` you can't deepen an asymmetric pool without moving
   price. With per-answer `p`, you inject mana into both reserves and let `p_i` float to absorb it
   losslessly.
2. **Resting limit orders get transient-overshoot fills during multi-leg auto-arb.** A multi-answer
   buy overshoots `Σp > 1`, then the auto-arb bets it back down. A resting limit in that overshoot
   band is consumed on the way up and kept on the way down — filled even though the final price ends
   up *past* it. (Empirically confirmed against current Manifold: a NO maker priced above both the
   initial and final prob is filled for 14–26 mana on the multi-buy path; the single-answer buy is
   monotone and does not exhibit it.) The v2 fix is **net-movement settlement** (a temporary reverse
   limit at the crossed price that a down-move re-crosses for an exact refund): you fill when price
   *reaches* your limit, and the cost curve becomes a state function, `C(δ) + C(−δ) = 0`.
3. **Auto-arb is `O(n log² N)`** (a nested binary search). The per-answer cost legs have direct
   closed forms, collapsing the search structure to `O(n log N)`. *This is a secondary benefit, not
   the pitch* — server-side arb compute is dwarfed by DB/IO, and honest measurement (the in-tree
   `BENCH=1` perf bench) shows the v2 solve is currently ~7–10× v1 **wall-clock** on shallow-pool
   fixtures (~160ms at n=10): the asymptotic win is real but constants aren't tuned, and a perf pass
   gates the **flag flip**, not this merge. The direct formulas earn their place by being the
   **exact, reversible** core that fixes 1 and 2 require, not by shaving milliseconds.

### Design: freeze v1, gate v2, migrate lazily

- **`cpmm-multi-1` stays frozen** — untouched, bug-for-bug. Every live market and every integrator's
  current forecasts keep working.
- **`cpmm-multi-2` = `cpmm-multi-1` + per-answer `p` + reversible-limit auto-arb + direct-formula
  core.** New markets opt in. (Deliberately *out of scope*: retrofitting the closed form onto v1 — it's
  provably identical on the no-limit case but only saves compute, so it's left out for conciseness.)
- **Migration is lazy, no big-bang.** A `cpmm-multi-1` market *is* a `cpmm-multi-2` market with every
  `p_i = 0.5` (same pools, same probabilities). `p` defaults to `0.5` at every read; it's written
  lazily the first time a market converts. The conversion **trigger is an explicit user
  `addLiquidity`** (lossless add = moving `p` off `0.5`), not the scheduler drizzle — so semantics
  never flip under resting orders. The version flip is **API-visible**: behavior never changes without
  the version field changing, so integrators can detect it and switch models.
- **Reserved v2 semantics — per-answer NO resolution of linked answers.** A natural follow-up is
  letting a `shouldAnswersSumToOne` market resolve one answer NO early while the rest stay open
  (probabilities then sum to 1 over the *unresolved* answers; v2's floating per-answer `p` makes the
  renormalization a pure re-pricing with pools untouched — the same move the lossless liquidity add
  already uses). **Nothing in this PR implements or enables that** — linked resolution stays
  whole-market-only — but the semantics are declared now (doc comment on `CPMMMulti`), while zero
  `cpmm-multi-2` markets exist: integrators adding v2 support should not assume "linked ⇒ answers are
  never individually resolved" (`Answer.resolution` already exists and is populated today for
  independent markets). Declaring this before the first v2 market ever mints is what makes the future
  change non-breaking; `cpmm-multi-1` keeps the whole-market-only guarantee unchanged.

### What's in this PR / how to read it

43 commits, grouped into six logical stages (the first five were built and validated to compile
standalone, so you can bisect by stage):

1. **Storage + types** (2 commits) — per-answer `p` column + DB↔TS plumbing. Invisible; defaults `0.5`.
2. **Mechanical widening** (1 commit) — an `isMultiCpmm` helper replaces ~80 `=== 'cpmm-multi-1'` call
   sites across web + backend. **This is find-replace, behavior-preserving, and (with its structural
   sibling in stage 3) accounts for 88 of the 119 files** — skim it. (`isMultiCpmm` matches only
   `cpmm-multi-1` until a v2 market can exist.)
3. **Inert backend engine** (~13 commits, ~18 real `common/` files) — general-`p` cost core, reversible-
   limit YES-basket multi-buy (Approach C), lossless whole-market + independent liquidity add, float-`p`
   subsidy drizzle, an `m>1` basket-redemption conservation fix, and a covering-array **conservation
   grid** (create→buy→sell→limit→resolve, net = 0 across configs) + an out-of-range-limit falsification
   sweep. Unreachable in production (no creation path) — pure latent capability + tests.
4. **Creation + activation** (6 commits) — creation schema (`initialProbs`, sum-to-one *and*
   independent "Set"), √variance creation pools, the general-`p` liquidity invariant at creation, the
   web creation UI, and **the kill-switch** (`CPMM_MULTI_2_CREATION_ENABLED`, default `false`).
5. **Liquidity & answer-management** (6 commits) — lazy v1→v2 conversion, per-answer `addLiquidity`
   (API + UI), the whole-market √variance liquidity-add split, and a lossless **"Other" split** that
   carves a new answer out of the catch-all leaving listed probabilities exactly unchanged.
6. **Review hardening** (15 commits, post-draft) — everything a full adversarial self-review of the
   draft surfaced, each with tests: an always-on post-hoc solve verifier; two flag-off-reachable
   fixes (a per-answer subsidyPool cross-process race → row locks; NaN from `p`-less denormalized
   blob answers → `answerP` accessor); domain guards proven as GP19 (creation feasibility — the
   √variance construction is not total; an add fallback so drizzle can never brick; an Other-split
   floor); a required-`arbVersion` signature so previews can't silently price the wrong mechanism;
   four skip-gated adversarial probe suites + a perf bench; reserved semantics for future per-answer
   NO resolution of linked answers (doc-comment only); a cleanup pass (dedup/dead code/SQL
   constants); and a post-rebase sweep widening two new display gates added by upstream's
   2026-midterms feature.

### Safety & testing

- **Kill-switch off by default** gates both backend creation and the web UI; with it off the diff is
  inert and v1 is byte-identical.
- **`common` jest: 218/218** — incl. the conservation grid (create→trade→limits→sell→add→resolve,
  net = 0 across a covering array), creation tests, GP19 boundary-calibrated guard tests, and the
  existing arb tests — plus 27 skip-gated adversarial probe tests (`PROBE=1`) and a perf bench
  (`BENCH=1`).
- **Always-on post-hoc verification**: every v2 multi-buy solve is checked after the fact (taker
  spend ≡ bet amount, Σ prob = 1, pool positivity, maker pricing, equal basket shares) and fails
  loudly rather than persisting a bad fill.
- **Rebased onto current `main`**; staged so each of the inert-backend / creation / features tips
  compiles clean across `common` + `backend/{api,scheduler,shared}` + `web`.
- **Full lifecycle validated on a local dev instance** (flag flipped locally): create → trade →
  add-liquidity → drizzle → resolve, all three resolution outcomes, conservation **net = 0**;
  v1→v2 lazy conversion validated end-to-end.

### Evidence

Every nontrivial claim is backed by a runnable proof or a differential test:

- **Paper** deriving the three direct-formula algorithms + the general-`p` cost core —
  [paper PDF](https://github.com/evand/manifold-math/blob/main/cpmm-multi-2/paper/auto-arb-algorithms.pdf).
- **Machine-checked proofs GP1–GP18** (sympy + numpy, each standalone) —
  [proofs/](https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/proofs).
- **Reference implementation** that reproduces Manifold's own nested-search solver *and a real captured
  Manifold bet* to ~`1e-13` (GP8) —
  [reference/](https://github.com/evand/manifold-math/tree/main/cpmm-multi-2/reference/manifold) /
  [GP8 test](https://github.com/evand/manifold-math/blob/main/cpmm-multi-2/tests/test_gp8_direct_equivalence.py).
- **Full rationale & evidence bundle** —
  [rationale.md](https://github.com/evand/manifold-math/blob/main/cpmm-multi-2/rationale.md).

### Aside: pre-existing, separable

Things we noticed building this, all pre-existing and separable from this PR:

- Under maker-balance-limited fills, the v1 sum-to-one arb can leave `Σ prob` off by ~2e-3 (the
  solve stops at the maker's balance bound rather than the exact root). v2 inherits this shared
  behavior deliberately — the verifier's tolerance is set to accept what v1 accepts. Tightening it
  is a separate conversation.
- v1 LP accounting: the mana-destruction the lossless add fixes (problem 1 above) is a real v1 bug
  in its own right.
- Orthogonally, v1's LP accounting tracks *net mana* rather than per-provider positions —
  resolution payouts aren't indifferent to a later LP's add, and removal is creator-only & uncapped
  (the creator can pull others' liquidity; non-creators can't pull their own). Not addressed here.

Happy to write either up separately if it's useful — measurements + repro scripts are on hand.

### One judgement call for maintainers (RFC)

The reversible-limit fix means a resting order fills when price *reaches* its limit, rather than on
transient overshoot — a strictly less-surprising contract, but still a **behavior change**, which is
exactly why it rides only in v2 and is never retrofitted to v1 silently. The one call that's yours,
not ours: whether `cpmm-multi-1` ever implicitly promised transient-overshoot fills to existing users.
If so, the v2-only gating is the conservative answer; if not, the retrofit option is on the table.
