### PR TITLE
fix(elections): purple crosshatch for split-delegation states + contr…

### DIFF
--- a/web/components/elections-page.tsx
+++ b/web/components/elections-page.tsx
@@ -20,13 +20,16 @@ export const ELECTIONS_PARTY_QUESTION_PSEUDONYM =
 
 // Topic tags for the bottom feed, so visitors can sort the election markets by
 // race/subject from this page. Each slug is a real Manifold group with a healthy
-// number of open markets (verified against prod).
+// number of open markets (verified against prod). The first entry is the default
+// view: the 2026 Midterms tag — tightly scoped to this page's focus, rather than
+// the much broader "us-politics", which pulled in a lot of off-topic markets.
 const ELECTION_FEED_TOPICS = [
-  { slug: 'us-politics', label: 'All politics' },
+  { slug: '2026-midterms', label: '2026 Midterms' },
   { slug: '2026-us-congressional-elections', label: '2026 Congress' },
   { slug: '2028-us-presidential-election-6tdsp26zly', label: '2028 President' },
   { slug: 'us-senate', label: 'Senate' },
   { slug: 'donald-trump', label: 'Trump' },
+  { slug: 'us-politics', label: 'All politics' },
   { slug: 'elections', label: 'All elections' },
 ]
 

--- a/web/components/us-elections/balance-of-power-panel.tsx
+++ b/web/components/us-elections/balance-of-power-panel.tsx
@@ -10,6 +10,7 @@ import { BetDialog } from 'web/components/bet/bet-dialog'
 import { BinaryOutcomes } from 'web/components/bet/bet-panel'
 import { sliderColors } from 'web/components/widgets/slider'
 import { DEM_COLOR, REP_COLOR } from 'web/components/usa-map/state-election-map'
+import { InfoTooltip } from 'web/components/widgets/info-tooltip'
 
 const DEM_LOGO = '/politics-party/democrat_symbol.png'
 const REP_LOGO = '/politics-party/republican_symbol.png'
@@ -40,20 +41,41 @@ export function BalanceOfPowerPanel(props: {
   // subtitle, and background.
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-      <PowerLever title="Senate" contract={senateControl} />
-      <PowerLever title="House" contract={houseControl} />
+      <PowerLever
+        title="Senate Control"
+        contract={senateControl}
+        info="Senate control requires 51 seats, or 50 with the Republican Vice President casting the tie-breaking vote."
+      />
+      <PowerLever title="House Control" contract={houseControl} />
     </div>
   )
 }
 
-function PowerLever(props: { title: string; contract: Contract | null }) {
-  const { title, contract } = props
+function PowerLever(props: {
+  title: string
+  contract: Contract | null
+  info?: string
+}) {
+  const { title, contract, info } = props
   const [betOutcome, setBetOutcome] = useState<BinaryOutcomes>()
+
+  const titleEl = (
+    <Row className="text-ink-700 items-center gap-1 font-medium">
+      {title}
+      {info && (
+        <InfoTooltip
+          size="sm"
+          text={info}
+          tooltipParams={{ className: 'text-xs' }}
+        />
+      )}
+    </Row>
+  )
 
   if (!contract) {
     return (
       <Col className="bg-canvas-50 gap-2 rounded-lg p-3">
-        <span className="text-ink-700 font-medium">{title}</span>
+        {titleEl}
         <span className="text-ink-500 text-sm">No market yet</span>
       </Col>
     )
@@ -66,7 +88,7 @@ function PowerLever(props: { title: string; contract: Contract | null }) {
   return (
     <Col className="bg-canvas-50 gap-2 rounded-lg p-3">
       <Row className="items-center justify-between">
-        <span className="text-ink-700 font-medium">{title}</span>
+        {titleEl}
         <Link
           href={contractPath(contract)}
           className="text-ink-400 hover:text-primary-600 text-xs hover:underline"

--- a/web/components/usa-map/senate-state.tsx
+++ b/web/components/usa-map/senate-state.tsx
@@ -188,7 +188,7 @@ export function SenateCurrentCard(props: {
         </span>
         <span
           className={
-            party1 == 'Republican' ? 'text-sienna-700' : 'text-azure-700'
+            party2 == 'Republican' ? 'text-sienna-700' : 'text-azure-700'
           }
         >
           <span className="font-semibold">{name2}</span>, <span>{party2}</span>

--- a/web/components/usa-map/usa-map.tsx
+++ b/web/components/usa-map/usa-map.tsx
@@ -15,6 +15,10 @@ const DEM_BACKGROUND = '#4a5fa8'
 const REP_BACKGROUND = '#9d3336'
 const DEM_CROSSHATCH = '#262c45'
 const REP_CROSSHATCH = '#3e1316'
+// Split delegations (one Dem + one Rep senator not up this cycle, e.g. PA, WI)
+// fill with a purple crosshatch — a blend of the Dem/Rep colors above.
+const SPLIT_BACKGROUND = '#73496f'
+const SPLIT_CROSSHATCH = '#321f2d'
 
 export type ClickHandler<
   E = SVGPathElement | SVGTextElement | SVGCircleElement,
@@ -110,6 +114,36 @@ export const USAMap = (props: {
                 x2="0"
                 y2={PATTERN_SIZE}
                 stroke={DEM_CROSSHATCH}
+                strokeWidth="2"
+              />
+            </pattern>
+            <pattern
+              id="crossHatchPurple"
+              patternUnits="userSpaceOnUse"
+              width={PATTERN_SIZE}
+              height={PATTERN_SIZE}
+            >
+              <rect
+                width={PATTERN_SIZE}
+                height={PATTERN_SIZE}
+                fill={SPLIT_BACKGROUND}
+              />
+              {/* Horizontal line */}
+              <line
+                x1="0"
+                y1="0"
+                x2={PATTERN_SIZE}
+                y2={PATTERN_SIZE}
+                stroke={SPLIT_CROSSHATCH}
+                strokeWidth="2"
+              />
+              {/* Vertical line */}
+              <line
+                x1={PATTERN_SIZE}
+                y1="0"
+                x2="0"
+                y2={PATTERN_SIZE}
+                stroke={SPLIT_CROSSHATCH}
                 strokeWidth="2"
               />
             </pattern>


### PR DESCRIPTION
…ol labels + midterms feed default

Three fixes to the 2026 midterms election page:

- Senate map: PA and WI rendered white and unclickable. They're the only split-delegation states in currentSenate2026 (one Dem + one Rep senator not up in 2026), so getSenateFill() returns url(#crossHatchPurple) — but the SVG <defs> only defined crossHatchRed/Blue. The missing paint server left the path with fill:none, which also swallows pointer events on the interior. Add the crossHatchPurple pattern (a blend of the Dem/Rep colors).

- Balance-of-power panel: rename "Senate"/"House" to "Senate Control"/"House Control" and add an (i) tooltip on Senate Control clarifying that YES needs 51 seats, or 50 with the Republican VP breaking ties (matches the market's resolution criteria).

- Bottom market feed: default the topic from the broad "us-politics" (which pulled in many off-topic markets) to the "2026-midterms" tag. All chips are preserved; us-politics stays available.