### PR TITLE
Add partial index for open contract limit orders (fixes /v0/bets kinds=open-limit timeout on high-volume markets)

### DIFF
--- a/backend/supabase/migrations/2026070201_contract_bets_contract_open_limit_orders_idx.sql
+++ b/backend/supabase/migrations/2026070201_contract_bets_contract_open_limit_orders_idx.sql
@@ -1,0 +1,38 @@
+-- Partial index for fetching a market's open limit-order book:
+--
+--   select contract_bets.* from contract_bets
+--   where contract_id = $1
+--     and is_filled = false and is_cancelled = false
+--   order by created_time desc
+--   limit $2
+--
+-- (public API /v0/bets?contractId=…&kinds=open-limit, built in
+-- shared/supabase/bets.ts getBetsWithFilter)
+--
+-- contract_bets_contract_limit_orders (contract_id, is_filled, is_cancelled,
+-- is_redemption, created_time desc) covers the predicate, but the planner
+-- often prefers walking contract_bets_created_time (contract_id, created_time
+-- desc) because it is pre-sorted for the ORDER BY … LIMIT. That walk only
+-- terminates early once it has found `limit` matching rows — so on a
+-- high-volume market with FEWER open limits than the requested limit it scans
+-- the contract's entire bet history and hits the statement timeout.
+-- Measured on prod (2026-07-02): limit=10 → 0.18s (early stop works),
+-- limit=1000 on a market with 725 open limits → 60s, HTTP 500 (pg 57014).
+--
+-- This partial index is both pre-filtered AND pre-sorted, so it dominates the
+-- created_time walk at every limit value and leaves the planner no wrong
+-- choice. Same pattern as contract_bets_expiring_limit_orders (2026061101).
+--
+-- On prod create it CONCURRENTLY by hand to avoid locking the live table:
+--
+--   create index concurrently if not exists contract_bets_contract_open_limit_orders
+--     on contract_bets (contract_id, created_time desc)
+--     where is_filled = false and is_cancelled = false;
+--
+-- This file uses the plain (transaction-safe) form for fresh / CI databases,
+-- where the table is small so a brief lock is fine. IF NOT EXISTS makes it a
+-- no-op wherever the index already exists (incl. prod).
+create index if not exists contract_bets_contract_open_limit_orders
+  on contract_bets (contract_id, created_time desc)
+  where is_filled = false
+  and is_cancelled = false;


### PR DESCRIPTION
Adds a partial index for fetching a market's open limit-order book — fixes `/v0/bets?contractId=…&kinds=open-limit&limit=1000` timing out (HTTP 500, pg `57014`) on high-volume markets.

**The fix** (one migration, same pattern as `2026061101_contract_bets_expiring_limit_orders_idx.sql`):

```sql
create index if not exists contract_bets_contract_open_limit_orders
  on contract_bets (contract_id, created_time desc)
  where is_filled = false
  and is_cancelled = false;
```

Pre-filtered AND pre-sorted for the query's `ORDER BY created_time DESC LIMIT n`, so the planner has no wrong choice at any limit value. On prod it should be created `CONCURRENTLY` by hand (instructions in the migration comment). `contract_bets_contract_limit_orders` is likely subsumed by this for the `getBetsWithFilter` open-limit path and could be dropped as a follow-up, maintainers' call.

Full report below (issues are disabled on this repo, so filing the report as this PR).

---

## Summary

Fetching the open limit-order book for a high-volume market via the public API
reliably takes 10–60s and frequently fails with an HTTP 500 (Postgres
`canceling statement due to statement timeout`). Small markets return in
~0.2s. The purpose-built index (`contract_bets_contract_limit_orders`) exists,
but the query plan appears to walk `(contract_id, created_time desc)` newest-
first to satisfy `ORDER BY created_time DESC LIMIT n` — and when the market
has **fewer open limit orders than `limit`**, that walk can never stop early
and scans the contract's entire bet history.

## Reproduction (public API, 2026-07-02)

Market: `who-will-be-elected-president-in-20` (`tPLAFk3FPVm3xrBmldfh`),
100 answers, M$1.69M volume, 725 open limit orders.

```bash
# 1) Open limit book, limit=1000 → 60s, HTTP 500 (statement timeout)
$ curl -s -o /dev/null -w "%{time_total}s (HTTP %{http_code})\n" \
  "https://api.manifold.markets/v0/bets?contractId=tPLAFk3FPVm3xrBmldfh&kinds=open-limit&limit=1000"
60.162081s (HTTP 500)

# 2) Same query, limit=10 → fast (early stop works when matches ≥ limit)
$ curl -s -o /dev/null -w "%{time_total}s (HTTP %{http_code})\n" \
  "https://api.manifold.markets/v0/bets?contractId=tPLAFk3FPVm3xrBmldfh&kinds=open-limit&limit=10"
0.180669s (HTTP 200)

# 3) Plain recent bets on the same market → fast (created_time index is fine)
$ curl -s -o /dev/null -w "%{time_total}s (HTTP %{http_code})\n" \
  "https://api.manifold.markets/v0/bets?contractId=tPLAFk3FPVm3xrBmldfh&limit=10"
0.230307s (HTTP 200)

# 4) Small market (M$53k volume), open-limit limit=1000 → fast
$ curl -s -o /dev/null -w "%{time_total}s (HTTP %{http_code})\n" \
  "https://api.manifold.markets/v0/bets?contractId=UdTYCYXKJbiGD0c7DojF&kinds=open-limit&limit=1000"
0.168293s (HTTP 200)
```

When it doesn't 500, the same query completes in ~10–45s (observed repeatedly
from our bot; presumably cache-warmth variance). The 500 body helpfully
includes the SQL:

```
canceling statement due to statement timeout   (code 57014)

select contract_bets.*
from contract_bets
where (contract_id = 'tPLAFk3FPVm3xrBmldfh')
  and (contract_bets.is_filled = false and contract_bets.is_cancelled = false)
  and ((shares != 0 or is_redemption = false or loan_amount != 0))
order by contract_bets.created_time desc
limit 1000
```

## Analysis

An index intended for exactly this query exists (added in `2817aa8b2`, July
2024; converted to the plain `is_filled`/`is_cancelled` columns with the
column migration #2760 — the Sept 2024 regen-schema dump shows the current
form):

```sql
create index contract_bets_contract_limit_orders on public.contract_bets
  using btree (contract_id, is_filled, is_cancelled, is_redemption, created_time desc);
```

Using it, this query is ~725 rows + a trivial sort — sub-millisecond. The
observed 60s means the planner isn't choosing it. The `limit=10` vs
`limit=1000` contrast points at the classic `ORDER BY … LIMIT` trap: the
planner prefers walking `contract_bets_created_time (contract_id,
created_time desc)` because it's pre-sorted (no sort node) and it expects to
collect `limit` matching rows quickly. That works when open limits are
plentiful and recent (`limit=10`: 0.18s) — but when the market has fewer open
limits than `limit` (725 < 1000 here), the walk can never terminate early and
reads the contract's entire bet history (order of 10⁶ rows for this market).
Per-column statistics can't see that "open limit" frequency varies enormously
per contract, so the misestimate is structural, not a stale-stats issue.

(Same failure mode as the expire-limit-orders cron that
`contract_bets_expiring_limit_orders` fixed in June 2026 — a predicate on
open limits that the existing indexes don't make unambiguously cheap.)

## Suggested fix

A partial index that is both pre-filtered *and* pre-sorted, so it dominates
the created_time walk for every `limit` value and the planner has no wrong
choice available:

```sql
create index concurrently if not exists contract_bets_contract_open_limit_orders
  on contract_bets (contract_id, created_time desc)
  where is_filled = false and is_cancelled = false;
```

This mirrors the `contract_bets_expiring_limit_orders` pattern (partial on the
open-limit predicate). It would likely also let
`contract_bets_contract_limit_orders` be dropped (its equality-prefix shape is
subsumed for the queries in `backend/shared/src/supabase/bets.ts:69`).

Happy to send this as a PR (schema file + migration comment in the
2026061101 style) if that's welcome.

## Impact

Any API consumer loading full order books for large markets (`kinds=open-limit`
with a limit above the market's open-order count) — for us this turned a
market-scanning bot's forecast pass from seconds into ~40 minutes (30s client
timeouts + retries per market). Each such request also costs the DB a full
scan of the contract's bet history, so fixing it saves server load too.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
