### PR TITLE
Web-side data plumbing for the native streak widget

### DIFF
--- a/common/src/native-message.ts
+++ b/common/src/native-message.ts
@@ -1,5 +1,11 @@
 import { GPSData } from 'common/gidx/gidx'
 import { Notification } from 'common/notification'
+import {
+  BETTING_STREAK_BONUS_AMOUNT,
+  BETTING_STREAK_BONUS_MAX,
+} from 'common/economy'
+import { getEffectiveTier, User } from 'common/user'
+import { getEffectiveBonusMultiplier } from 'common/supporter-config'
 
 export type nativeToWebMessageType =
   | 'iapReceipt'
@@ -13,6 +19,10 @@ export type nativeToWebMessageType =
   | 'locationPermissionStatus'
   | 'hasReviewAction'
   | 'version'
+  // Native asks the web to re-push quest completion to the streak widget (sent on
+  // app-foreground, since quest scores aren't on the public API the native streak
+  // sync uses). Payload is empty.
+  | 'refreshQuests'
 export type nativeToWebMessage = {
   type: nativeToWebMessageType
   data: any
@@ -45,8 +55,70 @@ export type webToNativeMessageType =
   | 'versionRequested'
   | 'setAppUrl'
   | 'copyImageToClipboard'
+  | 'setStreak'
+  | 'setQuests'
+  // Android-only: ask the native app to show the system "add widget to home
+  // screen" dialog for the streak widget (AppWidgetManager.requestPinAppWidget).
+  // No-ops on iOS (no such API) and on web. Payload is empty.
+  | 'pinStreakWidget'
 export const IS_NATIVE_KEY = 'is-native'
 export const PLATFORM_KEY = 'native-platform'
+
+// Streak snapshot sent to the native app, which mirrors it into a shared App
+// Group container for the home/lock-screen streak widget to read. All times are
+// ms-epoch; 0 means "never". The widget recomputes lit/pending/frozen state
+// itself from these vs. the next midnight-Pacific reset, so it stays correct
+// even hours after this snapshot was written.
+export type NativeStreakData = {
+  loggedIn: boolean
+  streak: number
+  lastBetTime: number // 0 if never bet
+  lastStreakFreezeTime: number // 0 if no freeze ever used
+  freezesLeft: number // == user.streakForgiveness
+  updatedAt: number // when this snapshot was taken
+  // Today's streak bonus with the tier's streak multiplier applied — shown on
+  // the widget as "+M50 / day". Optional so legacy blobs stay decodable.
+  streakBonus?: number
+}
+
+// The daily betting-streak bonus for the widget, streak multiplier applied —
+// the same formula the streak progress bar shows. Computed wherever the full
+// user object lives (web setStreak push AND the native API self-fetch) so the
+// snapshot stays correct whichever path wrote it last.
+export function streakBonusPerDay(user: User): number {
+  const base = Math.min(
+    BETTING_STREAK_BONUS_AMOUNT * Math.max(user.currentBettingStreak ?? 0, 1),
+    BETTING_STREAK_BONUS_MAX
+  )
+  return Math.floor(
+    base * getEffectiveBonusMultiplier(getEffectiveTier(user), 'streak')
+  )
+}
+
+// A single widget quest. State is binary (done this period or not). `period`
+// tells the widget when to reset `done` back to false on its own: 'daily' rolls
+// at midnight PT, 'weekly' at Monday midnight PT (matching the backend reset
+// jobs). The streak quest is the widget's main display, so it's not included
+// here — only the secondary quest rows.
+export type NativeQuestItem = {
+  title: string
+  rewardMana: number
+  done: boolean
+  period: 'daily' | 'weekly'
+}
+
+export type NativeQuestData = {
+  quests: NativeQuestItem[]
+  updatedAt: number
+  // Supporter-tier badge shown above the quest rewards ("PRO ×2"), present
+  // only when the user has a paid multiplier. Display-ready so tier renames
+  // don't need an app update; `color` picks the widget's metallic gradient.
+  tier?: {
+    label: string // e.g. 'PLUS' | 'PRO' | 'PREMIUM'
+    multiplier: number // e.g. 1.5 | 2 | 3
+    color: 'silver' | 'indigo' | 'amber'
+  }
+}
 
 export type MesageTypeMap = {
   version: {
@@ -74,4 +146,5 @@ export type MesageTypeMap = {
   link: {
     url: string
   }
+  refreshQuests: object
 }

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -16,7 +16,12 @@ import {
   type User,
   type UserAndPrivateUser,
 } from 'common/user'
-import { nativePassUsers, nativeSignOut } from 'web/lib/native/native-messages'
+import {
+  nativePassUsers,
+  nativeSetStreak,
+  nativeSignOut,
+} from 'web/lib/native/native-messages'
+import { streakBonusPerDay } from 'common/native-message'
 import { safeLocalStorage } from 'web/lib/util/local'
 import { getSavedContractVisitsLocally } from 'web/hooks/use-save-visits'
 import { getSupabaseToken } from 'web/lib/api/api'
@@ -260,6 +265,28 @@ export function AuthProvider(props: {
   useEffectCheckEquality(() => {
     if (authLoaded && listenPrivateUser) setPrivateUser(listenPrivateUser)
   }, [authLoaded, listenPrivateUser])
+
+  // Mirror the streak snapshot to the native app for the home/lock-screen
+  // streak widget. Fires on initial load and whenever the live user's streak
+  // fields change (e.g. right after a bet lights up the streak). No-ops on web.
+  useEffect(() => {
+    if (!user) return
+    nativeSetStreak({
+      loggedIn: true,
+      streak: user.currentBettingStreak ?? 0,
+      lastBetTime: user.lastBetTime ?? 0,
+      lastStreakFreezeTime: user.lastStreakFreezeTime ?? 0,
+      freezesLeft: user.streakForgiveness ?? 0,
+      streakBonus: streakBonusPerDay(user),
+      updatedAt: Date.now(),
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    user?.currentBettingStreak,
+    user?.lastBetTime,
+    user?.lastStreakFreezeTime,
+    user?.streakForgiveness,
+  ])
 
   return (
     <AuthContext.Provider value={authUser}>{children}</AuthContext.Provider>

--- a/web/components/native-message-provider.tsx
+++ b/web/components/native-message-provider.tsx
@@ -21,6 +21,7 @@ import { MesageTypeMap, nativeToWebMessageType } from 'common/native-message'
 import { usePersistentLocalState } from 'web/hooks/use-persistent-local-state'
 import { api } from 'web/lib/api/api'
 import { track } from 'web/lib/service/analytics'
+import { useNativeQuestSync } from 'web/hooks/use-native-quest-sync'
 
 type NativeContextType = {
   isNative: boolean
@@ -43,6 +44,9 @@ export const NativeMessageProvider = (props: { children: React.ReactNode }) => {
     'native-platform-v2'
   )
   const [version, setVersion] = usePersistentLocalState('', 'native-version')
+
+  // Push quest completion to the streak widget (native only, once per session).
+  useNativeQuestSync(privateUser?.id, isNative)
 
   useEffect(() => {
     postMessageToNative('startedListening', {})

--- a/web/hooks/use-native-quest-sync.ts
+++ b/web/hooks/use-native-quest-sync.ts
@@ -1,0 +1,102 @@
+import { useEffect } from 'react'
+import { QUEST_DETAILS, QuestType } from 'common/quest'
+import { NativeQuestItem } from 'common/native-message'
+import { getQuestScores } from 'common/supabase/set-scores'
+import { getEffectiveTier } from 'common/user'
+import {
+  getEffectiveBonusMultiplier,
+  SUPPORTER_TIERS,
+  SupporterTier,
+} from 'common/supporter-config'
+import { db } from 'web/lib/supabase/db'
+import { nativeSetQuests } from 'web/lib/native/native-messages'
+import { useNativeMessages } from 'web/hooks/use-native-messages'
+import { useUser } from 'web/hooks/use-user'
+import { useEvent } from 'client-common/hooks/use-event'
+
+// The secondary quests shown as rows on the widget. The betting-streak quest is
+// the widget's main display, so it's deliberately omitted here. Titles are the
+// action-oriented widget labels (not the internal QUEST_DETAILS titles).
+const WIDGET_QUESTS: {
+  type: QuestType
+  title: string
+  period: 'daily' | 'weekly'
+}[] = [
+  { type: 'SHARES', title: 'Share a market', period: 'daily' },
+  { type: 'MARKETS_CREATED', title: 'Create a market', period: 'weekly' },
+]
+
+// Metallic capsule colour family per paid tier (Plus silver / Pro indigo /
+// Premium gold), matching each tier's brand colour in SUPPORTER_TIERS.
+const TIER_BADGE_COLOR: Record<SupporterTier, 'silver' | 'indigo' | 'amber'> = {
+  basic: 'silver',
+  plus: 'indigo',
+  premium: 'amber',
+}
+
+// Native-only: push the (binary) quest completion to the streak widget. Runs once
+// when the user is known, and again whenever the native app foregrounds (the
+// 'refreshQuests' message), so completing a quest reaches the widget without a
+// full reload. Gated on `isNative` so web users never incur the extra
+// user_quest_metrics query.
+export const useNativeQuestSync = (
+  userId: string | undefined,
+  isNative: boolean
+) => {
+  const user = useUser()
+  // Supporter tiers earn multiplied quest rewards — mirror the quests modal so
+  // the widget shows what the user will actually receive (e.g. PRO = 2x).
+  const effectiveTier = user ? getEffectiveTier(user) : undefined
+  const questMultiplier = effectiveTier
+    ? getEffectiveBonusMultiplier(effectiveTier, 'quest')
+    : 1
+  // Paid tiers also get a metallic badge above the rewards ("PRO ×2").
+  const supporterTier =
+    effectiveTier && effectiveTier in SUPPORTER_TIERS
+      ? (effectiveTier as SupporterTier)
+      : undefined
+
+  const syncQuests = useEvent(async () => {
+    if (!isNative || !userId) return
+    const scoreIds = WIDGET_QUESTS.map((q) => QUEST_DETAILS[q.type].scoreId)
+    try {
+      const scores = await getQuestScores(userId, scoreIds, db)
+      const quests: NativeQuestItem[] = WIDGET_QUESTS.map((q) => {
+        const { scoreId, requiredCount, rewardAmount } = QUEST_DETAILS[q.type]
+        return {
+          title: q.title,
+          rewardMana: Math.floor(rewardAmount * questMultiplier),
+          done: (scores[scoreId]?.score ?? 0) >= requiredCount,
+          period: q.period,
+        }
+      })
+      nativeSetQuests({
+        quests,
+        updatedAt: Date.now(),
+        ...(supporterTier
+          ? {
+              tier: {
+                label: SUPPORTER_TIERS[supporterTier].name.toUpperCase(),
+                multiplier: questMultiplier,
+                color: TIER_BADGE_COLOR[supporterTier],
+              },
+            }
+          : {}),
+      })
+    } catch (e) {
+      console.error('Error syncing quests to widget', e)
+    }
+  })
+
+  // Initial sync once the user / native status is known; re-push if the
+  // multiplier changes (the full user can load after the first sync).
+  useEffect(() => {
+    syncQuests()
+  }, [userId, isNative, questMultiplier])
+
+  // Re-sync on app-foreground (native sends 'refreshQuests' from its AppState
+  // listener) so a just-completed quest updates the widget promptly.
+  useNativeMessages(['refreshQuests'], () => {
+    syncQuests()
+  })
+}

--- a/web/lib/native/native-messages.ts
+++ b/web/lib/native/native-messages.ts
@@ -1,3 +1,4 @@
+import { NativeQuestData, NativeStreakData } from 'common/native-message'
 import { postMessageToNative } from 'web/lib/native/post-message'
 
 export const nativePassUsers = (userJson: string) => {
@@ -5,4 +6,19 @@ export const nativePassUsers = (userJson: string) => {
 }
 export const nativeSignOut = () => {
   postMessageToNative('signOut', {})
+}
+// Pushes the current streak snapshot to the native app for the streak widget.
+// No-ops on web (postMessageToNative guards on getIsNative()).
+export const nativeSetStreak = (streak: NativeStreakData) => {
+  postMessageToNative('setStreak', streak)
+}
+// Pushes the current quest completion to the native app for the streak widget.
+export const nativeSetQuests = (quests: NativeQuestData) => {
+  postMessageToNative('setQuests', quests)
+}
+// Android-only: asks the native app to show the system "add widget to home
+// screen" dialog. No-ops on web (postMessageToNative guards on getIsNative());
+// the native side no-ops on iOS.
+export const nativePinStreakWidget = () => {
+  postMessageToNative('pinStreakWidget', {})
 }


### PR DESCRIPTION
The web half of the streak home/lock-screen widget (full widget PR to follow), shipped ahead so in-development widget builds receive live quest data against prod.

**What's in it** (5 files, all additive):
- \common/native-message.ts\: NativeStreakData / NativeQuestItem / NativeQuestData types, the setStreak / setQuests / refreshQuests / pinStreakWidget message types, and \streakBonusPerDay()\ (daily streak bonus with the tier's streak multiplier).
- \uth-context\: mirrors the streak snapshot to the native shell whenever the live user's streak fields change.
- \use-native-quest-sync\ (new hook): pushes daily/weekly quest completion — rewards honor supporter multipliers, and paid tiers get a badge payload — on login and whenever the native app foregrounds (\efreshQuests\ ping).
- \
ative-messages\ senders.

**Why it's safe to ship now:**
- Every code path is gated on \isNative\ — web users execute nothing new beyond one \user_quest_metrics\ read for native sessions.
- Current App Store/Play builds ignore unknown webview message types.
- The in-app 'add the widget' prompt is deliberately NOT in this PR — it ships with the app release, so no user is ever prompted to add a widget their build doesn't have.

Extracted from \eat/streak-android-widget\ (widget itself: both platforms device-verified there).