### PR TITLE
feat(elections): referral-tagged share button for the elections page

### DIFF
--- a/web/components/elections-page.tsx
+++ b/web/components/elections-page.tsx
@@ -13,6 +13,11 @@ import { ContractsTable } from './contract/contracts-table'
 import { Search } from './search'
 import { FilterPill } from './search/filter-pills'
 import { ElectionsPageProps } from 'web/public/data/elections-data'
+import { useUser } from 'web/hooks/use-user'
+import { useSaveReferral } from 'web/hooks/use-save-referral'
+import { CopyLinkOrShareButton } from 'web/components/buttons/copy-link-button'
+import { referralQuery } from 'common/util/share'
+import { ENV_CONFIG } from 'common/envs/constants'
 
 // Kept for legacy political market panels that still reference it.
 export const ELECTIONS_PARTY_QUESTION_PSEUDONYM =
@@ -69,6 +74,18 @@ export function USElectionsPage(
 
   const [feedTopic, setFeedTopic] = useState(ELECTION_FEED_TOPICS[0])
 
+  const user = useUser()
+  // Capture an incoming ?r= referral when a logged-out visitor lands here from
+  // a shared link (the trending dashboard also does this, but do it at the page
+  // level so it works even when trending is absent).
+  useSaveReferral(user)
+
+  // Share the page itself, tagged with the sharer's referral code so sign-ups
+  // from the link are credited.
+  const shareUrl = `https://${ENV_CONFIG.domain}/election${
+    user?.username ? referralQuery(user.username) : ''
+  }`
+
   const trending =
     trendingDashboard.state == 'not found' ? null : (
       <Col className="gap-2">
@@ -104,6 +121,16 @@ export function USElectionsPage(
             Live prediction market odds on US elections
           </div>
         </Col>
+        <CopyLinkOrShareButton
+          url={shareUrl}
+          eventTrackingName="share elections page"
+          tooltip="Share this page"
+          color="gray-outline"
+          size="sm"
+          className="ml-auto shrink-0 gap-1.5"
+        >
+          Share
+        </CopyLinkOrShareButton>
       </Row>
 
       {/* 2026 Midterms — the balance-of-power levers and the race map together


### PR DESCRIPTION
## What

Adds a native **Share** button to the `/election` page hero, wired for referrals — a follow-up to the 2026 midterms rebuild (#3919).

- Uses the app's `CopyLinkOrShareButton`, so it fires the iOS/Android share sheet in-app (or copy-link + "Link copied!" toast on web) — no need to grab the URL from a browser.
- Shares `/election` tagged with the sharer's referral code via `referralQuery(user.username)` → `/election?r=<code>`, the same scheme markets and dashboards use.
- Adds `useSaveReferral(user)` at the page level so a logged-out visitor who lands on `/election?r=…` actually credits the referrer (previously this only happened incidentally through the Trending dashboard, which isn't always rendered).

Reuses existing primitives (`CopyLinkOrShareButton`, `referralQuery`, `useSaveReferral`) — no new share/referral logic.

## Scope

One file, +27 lines (`web/components/elections-page.tsx`). Rebased onto `main` after #3919 merged, so the diff is just the share button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)