### PR TITLE
fix(create): numeric market blocked when a bucket midpoint is 0

### DIFF
--- a/web/lib/validation/contract-validation.ts
+++ b/web/lib/validation/contract-validation.ts
@@ -170,7 +170,7 @@ export function validateContractForm(
         if (
           !state.midpoints ||
           state.midpoints.length < nonEmptyAnswers.length ||
-          state.midpoints.some((m) => !m || isNaN(m))
+          state.midpoints.some((m) => !Number.isFinite(m))
         ) {
           errors.answers = 'Please wait for numeric buckets to generate'
         } else if (nonEmptyAnswers.length < MIN_ANSWERS) {
@@ -194,7 +194,7 @@ export function validateContractForm(
         if (
           !state.midpoints ||
           state.midpoints.length < nonEmptyAnswers.length ||
-          state.midpoints.some((m) => !m || isNaN(m))
+          state.midpoints.some((m) => !Number.isFinite(m))
         ) {
           errors.answers = 'Please wait for date buckets to generate'
         } else if (nonEmptyAnswers.length < MIN_ANSWERS) {


### PR DESCRIPTION
Minimal two-line fix, split out of #3940 for immediate merge.

**Bug** (user report, AlexanderTheGreater): any MULTI_NUMERIC market whose first bucket is exactly `0` (e.g. *How many goals will Messi score…*, min 0 / max 5, buckets `0…5, Above 5`) could never be created — validation checked midpoints with `(m) => !m || isNaN(m)`, and `!0 === true`, so the legitimate midpoint 0 read as 'not generated yet'. The form permanently showed the red ring on **Regenerate numeric ranges**, and regenerating always produced midpoint 0 again.

**Fix**: `(m) => !Number.isFinite(m)` in both the MULTI_NUMERIC and DATE branches. Newly accepts 0 and negative midpoints (verified safe through creation, expected-value math, charts, and resolution — all pure arithmetic); still rejects undefined/NaN and is stricter on Infinity. Backend create schema already accepts 0 (`z.number().safe()`).

Verified against the reporter's saved prod draft (midpoints `[0,1,2,3,4,5,6.5]`): rejected by the old check, passes the new one. `tsc --noEmit` clean.

The draft-persistence work and review-driven hardening remain on #3940 for a later pass.