### PR TITLE
fix: ban manager modal cannot touch-scroll on iOS

### DIFF
--- a/web/components/buttons/user-settings-button.tsx
+++ b/web/components/buttons/user-settings-button.tsx
@@ -251,14 +251,17 @@ export function UserSettingButton(props: { user: User }) {
             />
           </div>
         </Col>
-      </Modal>
 
-      <BanModal
-        user={user}
-        bans={bans}
-        isOpen={showBanModal}
-        onClose={() => setShowBanModal(false)}
-      />
+        {/* Must be rendered inside the settings Modal: sibling dialogs break
+            touch scrolling on iOS (headlessui scroll lock treats a sibling
+            dialog's portal as outside the open dialog and cancels touchmove) */}
+        <BanModal
+          user={user}
+          bans={bans}
+          isOpen={showBanModal}
+          onClose={() => setShowBanModal(false)}
+        />
+      </Modal>
     </>
   )
 }

--- a/web/components/moderation/ban-modal.tsx
+++ b/web/components/moderation/ban-modal.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { useState, useEffect } from 'react'
 import { toast } from 'react-hot-toast'
 import {
@@ -22,7 +23,7 @@ import { DAY_MS } from 'common/util/time'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
-import { Modal } from 'web/components/layout/modal'
+import { Modal, SCROLLABLE_MODAL_CLASS } from 'web/components/layout/modal'
 import { Input } from 'web/components/widgets/input'
 import { Title } from 'web/components/widgets/title'
 import { Tooltip } from 'web/components/widgets/tooltip'
@@ -274,8 +275,13 @@ export function BanModal({
   const anyBanSelected = Object.values(banTypes).some((v) => v)
 
   return (
-    <Modal open={isOpen} setOpen={onClose}>
-      <Col className="bg-canvas-0 max-w-2xl gap-4 rounded-md p-6">
+    <Modal
+      open={isOpen}
+      setOpen={onClose}
+      size="lg"
+      className="bg-canvas-0 rounded-md"
+    >
+      <Col className={clsx(SCROLLABLE_MODAL_CLASS, 'gap-4 p-6')}>
         <Title>Ban User: {user.name}</Title>
 
         {/* Bonus Eligibility Section */}


### PR DESCRIPTION
The ban manager is opened from the user settings modal, which stays open underneath — but BanModal was rendered as a JSX sibling of the settings <Modal>, so the two headlessui Dialogs were sibling portals. headlessui's iOS scroll lock (see tailwindlabs/headlessui#3378) only allows touches inside the open dialog's own panel and its registered child portals; a sibling dialog's portal is treated as "outside", so the settings dialog's lock set touch-action:none on the touch target and preventDefault()ed every touchmove on the ban modal. That's why pan gestures did nothing while text-selection drag (not cancelable) still scrolled, why desktop was unaffected (the lock is iOS-only), and why restructuring the ban modal's own markup never fixed it.

Fix: render BanModal inside the settings Modal so its portal registers with the parent dialog and touches are recognized as inside the dialog stack. Also give the ban modal the standard scrollable-modal structure (SCROLLABLE_MODAL_CLASS content inside the panel) used by other modals that scroll correctly on iOS.

Verified with a Playwright repro emulating the iOS scroll lock (navigator.platform=iPhone + touch events): the old sibling structure never scrolls (scrollTop stays 0), the nested structure scrolls, and the nested unban/remove-all confirmation dialogs still open, click, and close correctly, with ESC closing innermost-first.


Claude-Session: https://claude.ai/code/session_016Muhri18Y1DByufT4gSn3D