### PR TITLE
fix(elections): make map bet buttons work on touch/iOS

### DIFF
--- a/web/components/usa-map/homepage-map.tsx
+++ b/web/components/usa-map/homepage-map.tsx
@@ -9,6 +9,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Spacer } from 'web/components/layout/spacer'
 import { useLiveContract } from 'web/hooks/use-contract'
+import { useHasHover } from 'web/hooks/use-has-hover'
 import {
   EmptyStateContract,
   StateContract,
@@ -68,6 +69,14 @@ export function HomepageMap(props: {
     undefined
   )
 
+  // On touch devices (iOS especially), hover is emulated on tap: the first tap
+  // fires mouseenter and gets swallowed as a hover-reveal, so the detail panel
+  // appears off hoveredState without a click ever pinning targetState. A follow
+  // -up tap then fires mouseleave, collapsing the panel just as the user tries
+  // to hit a bet button. Ignore hover on no-hover devices so taps drive
+  // selection through targetState alone, which fires reliably.
+  const hasHover = useHasHover()
+
   function handleClick(newTargetState: string | undefined) {
     if (targetState && newTargetState == targetState) {
       setTargetState(undefined)
@@ -77,11 +86,11 @@ export function HomepageMap(props: {
   }
 
   function onMouseEnter(hoverState: string) {
-    setHoveredState(hoverState)
+    if (hasHover) setHoveredState(hoverState)
   }
 
   function onMouseLeave() {
-    setHoveredState(undefined)
+    if (hasHover) setHoveredState(undefined)
   }
 
   // The state whose detail (and candidate card) is shown: hover takes priority,

--- a/web/hooks/use-has-hover.ts
+++ b/web/hooks/use-has-hover.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+// True on devices with a pointer that can genuinely hover (desktop with a
+// mouse), false on touch devices (phones/tablets). iOS *emulates* hover on tap:
+// the first tap fires mouseenter and is treated as a hover-reveal, swallowing
+// the click. Hover-driven UI (e.g. the elections map, which shows a state's
+// detail panel on hover) then appears without the click ever registering, so
+// buttons inside that panel don't work. Gating hover behavior on this hook lets
+// touch devices fall back to plain tap-to-select, which fires reliably.
+export function useHasHover() {
+  // Default to true so SSR / first paint matches desktop; corrected on mount
+  // before any hover interaction can happen.
+  const [hasHover, setHasHover] = useState(true)
+  useEffect(() => {
+    const mql = window.matchMedia('(hover: hover)')
+    const update = () => setHasHover(mql.matches)
+    update()
+    mql.addEventListener('change', update)
+    return () => mql.removeEventListener('change', update)
+  }, [])
+  return hasHover
+}


### PR DESCRIPTION
The elections map drove its detail panel and selection off `hoveredState ?? targetState`. On iOS, tapping a state fires an emulated mouseenter (revealing the panel via hoveredState) while the click that would pin targetState is swallowed as a hover-reveal. A subsequent tap on a bet button / district row then fires mouseleave first, clearing hoveredState and collapsing the panel to the empty state right as the tap lands — so the button vanishes and nothing happens.

Gate hover behavior on a new useHasHover() hook so touch devices ignore hover entirely and drive selection through targetState (the tap/click), which fires reliably. Desktop hover-preview behavior is unchanged.


Claude-Session: https://claude.ai/code/session_01LFBvXwEAQqjrs5TihW1RRk