### PR TITLE
perf(web): cut CLS and INP on the browse/search feed

### DIFF
--- a/client-common/src/hooks/use-contract-updates.ts
+++ b/client-common/src/hooks/use-contract-updates.ts
@@ -5,11 +5,13 @@ import { Answer } from 'common/answer'
 import { uniqBy } from 'lodash'
 export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
   initial: C,
-  setContract: (value: SetStateAction<C>) => void
+  setContract: (value: SetStateAction<C>) => void,
+  enabled = true
 ) => {
   useApiSubscription({
     topics: [`contract/${initial.id}/new-answer`],
-    enabled: 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
+    enabled:
+      enabled && 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
     onBroadcast: ({ data }) => {
       setContract((contract) => {
         return {
@@ -28,7 +30,8 @@ export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
 
   useApiSubscription({
     topics: [`contract/${initial.id}/updated-answers`],
-    enabled: 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
+    enabled:
+      enabled && 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
     onBroadcast: ({ data }) => {
       const newAnswerUpdates = data.answers as (Partial<Answer> & {
         id: string
@@ -70,6 +73,7 @@ export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
 
   useApiSubscription({
     topics: [`contract/${initial.id}`],
+    enabled,
     onBroadcast: ({ data }) => {
       setContract((contract) => {
         return { ...contract, ...(data.contract as C) }

--- a/web/components/contract/combined-results.tsx
+++ b/web/components/contract/combined-results.tsx
@@ -3,7 +3,7 @@ import { Contract } from 'common/contract'
 import { TopLevelPost } from 'common/top-level-post'
 import { buildArray } from 'common/util/array'
 import { sortBy } from 'lodash'
-import { Key } from 'react'
+import { Key, useMemo } from 'react'
 import { PostRow } from '../posts/post-row'
 import {
   SearchParams,
@@ -30,6 +30,7 @@ type CombinedResultsProps = {
   hideAvatars?: boolean
   hideActions?: boolean
   hasBets?: boolean
+  disableLiveUpdates?: boolean
 }
 
 // Type guard to check if an item is a Contract
@@ -53,7 +54,22 @@ export function CombinedResults(props: CombinedResultsProps) {
     hideAvatars,
     hideActions,
     hasBets,
+    disableLiveUpdates,
   } = props
+
+  // Define columns for ContractRow, similar to how ContractsTable did.
+  // Memoized so the array ref is stable and ContractRow's memo can skip re-renders.
+  const contractDisplayColumns = useMemo(
+    () =>
+      buildArray([
+        !hasBets && boostedColumn,
+        traderColumn,
+        liquidityColumn,
+        probColumn,
+        !hideActions && actionColumn,
+      ]),
+    [hasBets, hideActions]
+  )
 
   const sort =
     searchParams[TOPIC_FILTER_KEY] === 'recent'
@@ -69,15 +85,6 @@ export function CombinedResults(props: CombinedResultsProps) {
         })
       : [...contracts, ...posts]
   if (!combinedItems.length) return null
-
-  // Define columns for ContractRow, similar to how ContractsTable did
-  const contractDisplayColumns = buildArray([
-    !hasBets && boostedColumn,
-    traderColumn,
-    liquidityColumn,
-    probColumn,
-    !hideActions && actionColumn,
-  ])
 
   return (
     <>
@@ -95,6 +102,7 @@ export function CombinedResults(props: CombinedResultsProps) {
               hideAvatar={hideAvatars}
               columns={contractDisplayColumns} // Pass the defined columns
               showPosition={hasBets}
+              disableLiveUpdates={disableLiveUpdates}
             />
           )
         } else if (isPost(item)) {

--- a/web/components/contract/contracts-table.tsx
+++ b/web/components/contract/contracts-table.tsx
@@ -1,4 +1,5 @@
 import { EyeOffIcon } from '@heroicons/react/solid'
+import { memo } from 'react'
 import clsx from 'clsx'
 import { getDisplayProbability } from 'common/calculate'
 import {
@@ -180,7 +181,7 @@ function PositionRow(props: {
   )
 }
 
-export function ContractRow(props: {
+function ContractRowInner(props: {
   contract: Contract
   columns: ColumnFormat[]
   highlighted?: boolean
@@ -189,8 +190,9 @@ export function ContractRow(props: {
   hideAvatar?: boolean
   answers?: Answer[]
   showPosition?: boolean
+  disableLiveUpdates?: boolean
 }) {
-  const contract = useLiveContract(props.contract)
+  const contract = useLiveContract(props.contract, !props.disableLiveUpdates)
   const isPoll = contract.outcomeType === 'POLL'
 
   const {
@@ -356,6 +358,10 @@ export function ContractRow(props: {
     </Col>
   )
 }
+
+// Memoized so typing/filtering in search doesn't re-render every row (and re-run
+// its per-row hooks) when the row's own props haven't changed.
+export const ContractRow = memo(ContractRowInner)
 
 export function LoadingContractRow() {
   return (

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -7,9 +7,17 @@ import { Contract } from 'common/contract'
 import { LiteGroup } from 'common/group'
 import { CONTRACTS_PER_SEARCH_PAGE } from 'common/supabase/contracts'
 import { buildArray } from 'common/util/array'
-import { capitalize, groupBy, minBy, orderBy, sample, uniqBy } from 'lodash'
+import {
+  capitalize,
+  groupBy,
+  minBy,
+  orderBy,
+  range,
+  sample,
+  uniqBy,
+} from 'lodash'
 import Link from 'next/link'
-import { ReactNode, useEffect, useRef, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from 'web/components/buttons/button'
 import { AddContractToGroupButton } from 'web/components/topics/add-contract-to-group-modal'
 import { useDebouncedEffect } from 'web/hooks/use-debounced-effect'
@@ -380,29 +388,40 @@ export function Search(props: SearchProps) {
 
   const setQuery = (query: string) => onChange({ [QUERY_KEY]: query })
 
-  const answersWithChanges = contracts?.flatMap((c) =>
-    c.mechanism === 'cpmm-multi-1'
-      ? orderBy(
-          c.answers.filter((a) => Math.abs(a.probChanges.day) > 0.02),
-          (a) => Math.abs(a.probChanges.day),
-          'desc'
-        ).slice(0, 2)
-      : []
+  const answersWithChanges = useMemo(
+    () =>
+      contracts?.flatMap((c) =>
+        c.mechanism === 'cpmm-multi-1'
+          ? orderBy(
+              c.answers.filter((a) => Math.abs(a.probChanges.day) > 0.02),
+              (a) => Math.abs(a.probChanges.day),
+              'desc'
+            ).slice(0, 2)
+          : []
+      ),
+    [contracts]
   )
 
-  const answersMatchingQuery = contracts?.flatMap((c) =>
-    c.mechanism === 'cpmm-multi-1'
-      ? c.answers
-          .filter((a) => a.text.toLowerCase().includes(query.toLowerCase()))
-          .slice(0, 2)
-      : []
+  const answersMatchingQuery = useMemo(
+    () =>
+      contracts?.flatMap((c) =>
+        c.mechanism === 'cpmm-multi-1'
+          ? c.answers
+              .filter((a) => a.text.toLowerCase().includes(query.toLowerCase()))
+              .slice(0, 2)
+          : []
+      ),
+    [contracts, query]
   )
-  const answersByContractId =
-    answersWithChanges && filter === 'news'
-      ? groupBy(answersWithChanges, 'contractId')
-      : query !== ''
-      ? groupBy(answersMatchingQuery, 'contractId')
-      : undefined
+  const answersByContractId = useMemo(
+    () =>
+      answersWithChanges && filter === 'news'
+        ? groupBy(answersWithChanges, 'contractId')
+        : query !== ''
+        ? groupBy(answersMatchingQuery, 'contractId')
+        : undefined,
+    [answersWithChanges, answersMatchingQuery, filter, query]
+  )
   const emptyContractsState =
     props.emptyState ??
     (filter !== 'all' ||
@@ -847,7 +866,7 @@ export function Search(props: SearchProps) {
         )}
 
         {!contracts && !posts ? (
-          <LoadingContractResults />
+          <LoadingContractResults count={8} className="min-h-screen" />
         ) : contracts?.length === 0 && posts?.length === 0 ? (
           emptyContractsState
         ) : (
@@ -863,6 +882,7 @@ export function Search(props: SearchProps) {
                 hideAvatars={hideAvatars}
                 hideActions={hideActions}
                 hasBets={hasBets}
+                disableLiveUpdates={!user}
               />
             ) : null}
             <LoadMoreUntilNotVisible loadMore={loadMoreContracts} />
@@ -899,12 +919,16 @@ const NoResults = () => {
   )
 }
 
-export const LoadingContractResults = () => {
+export const LoadingContractResults = (props?: {
+  count?: number
+  className?: string
+}) => {
+  const { count = 3, className } = props ?? {}
   return (
-    <Col className="w-full">
-      <LoadingContractRow />
-      <LoadingContractRow />
-      <LoadingContractRow />
+    <Col className={clsx('w-full', className)}>
+      {range(count).map((i) => (
+        <LoadingContractRow key={i} />
+      ))}
     </Col>
   )
 }

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -347,6 +347,7 @@ export function Search(props: SearchProps) {
     users,
     topics,
     loading,
+    loadingMore,
     shouldLoadMore,
     loadMoreContracts,
     refreshContracts,
@@ -886,7 +887,11 @@ export function Search(props: SearchProps) {
               />
             ) : null}
             <LoadMoreUntilNotVisible loadMore={loadMoreContracts} />
-            {shouldLoadMore && <LoadingContractResults />}
+            {shouldLoadMore && (
+              <LoadingContractResults
+                count={loadingMore ? CONTRACTS_PER_SEARCH_PAGE : 3}
+              />
+            )}
             {!shouldLoadMore && (
               <NoMoreResults params={searchParams} onChange={onChange} />
             )}
@@ -988,6 +993,7 @@ export const useSearchResults = (props: {
     `${persistPrefix}-supabase-contract-search`
   )
   const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [lastSearchParams, setLastSearchParams] =
     usePersistentInMemoryState<SearchParams | null>(
       null,
@@ -1283,8 +1289,16 @@ export const useSearchResults = (props: {
     users: state.users,
     topics: state.topics,
     loading,
+    loadingMore,
     shouldLoadMore: state.shouldLoadMore,
-    loadMoreContracts: () => querySearchResults(false, true),
+    loadMoreContracts: async () => {
+      setLoadingMore(true)
+      try {
+        return await querySearchResults(false, true)
+      } finally {
+        setLoadingMore(false)
+      }
+    },
     refreshContracts: () => querySearchResults(true, true),
     posts: state.posts,
   }

--- a/web/components/widgets/visibility-observer.tsx
+++ b/web/components/widgets/visibility-observer.tsx
@@ -49,8 +49,11 @@ export function LoadMoreUntilNotVisible(props: {
   return (
     <div className="relative">
       <VisibilityObserver
-        // Loads more as soon as one screen height of content is left.
-        className="pointer-events-none absolute bottom-0 h-screen w-full select-none"
+        // Prefetch ~2 screens of content ahead of the viewport so the appended
+        // page lands off-screen. Otherwise, on a slow connection the user scrolls
+        // to the bottom before the page arrives, and inserting it shoves the
+        // in-viewport footer/skeleton down — a major source of feed CLS.
+        className="pointer-events-none absolute bottom-0 h-[200vh] w-full select-none"
         onVisibilityUpdated={onVisibilityUpdated}
       />
     </div>

--- a/web/hooks/use-contract.ts
+++ b/web/hooks/use-contract.ts
@@ -94,7 +94,10 @@ export function useLiveAllNewContracts(limit: number) {
   return contracts
 }
 
-export function useLiveContract<C extends Contract = Contract>(initial: C): C {
+export function useLiveContract<C extends Contract = Contract>(
+  initial: C,
+  live = true
+): C {
   const isPageVisible = useIsPageVisible()
   // ian: Batching is helpful on pages like /browse
   const [contract, setContract] = useBatchedGetter<C>(
@@ -105,6 +108,6 @@ export function useLiveContract<C extends Contract = Contract>(initial: C): C {
     isPageVisible
   )
 
-  useContractUpdates(initial, setContract)
+  useContractUpdates(initial, setContract, live)
   return contract ?? initial
 }

--- a/web/hooks/use-saved-contract-metrics.ts
+++ b/web/hooks/use-saved-contract-metrics.ts
@@ -38,8 +38,12 @@ export const useAllSavedContractMetrics = (
     return metricsByContract[contract.id] as ContractMetric[]
   }
   useEffect(() => {
+    // Logged-out visitors have no saved metrics; skip the per-row recompute and
+    // localStorage write entirely (matters on the feed, which renders many rows).
+    if (!user) return
     setSavedMetrics(updateMetricsWithNewProbs(savedMetrics ?? []))
   }, [
+    user?.id,
     'answers' in contract
       ? JSON.stringify(contract.answers)
       : contract.lastBetTime,

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -227,10 +227,12 @@ function MyApp({ Component, pageProps }: AppProps<ManifoldPageProps>) {
       <Script
         src="https://analytics.umami.is/script.js"
         data-website-id="ee5d6afd-5009-405b-a69f-04e3e4e3a685"
+        strategy="lazyOnload"
       />
 
       <Script
         id="gtm"
+        strategy="lazyOnload"
         dangerouslySetInnerHTML={{
           __html: `
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
GSC field data: desktop CLS 0.77 (Poor) on the homepage and mobile INP
>200ms on ~2k URLs, both from the client-only, un-virtualized market feed.
Low-risk first pass; no virtualization.

CLS
- Reserve a viewport of height on the first-paint feed skeleton (min-h-screen, 8 rows not 3) so the footer starts below the fold and the 3->40 row swap no longer shifts in-viewport content.

INP (mostly the logged-out homepage that CrUX measures)
- Skip the per-row contract/<id> WebSocket subscription for logged-out visitors: new enabled/disableLiveUpdates flag threaded through useContractUpdates -> useLiveContract -> ContractRow -> CombinedResults.
- Memoize ContractRow and its columns prop so typing/filtering doesn't re-render all 40 rows and re-run their per-row hooks.
- Memoize the list-wide derived arrays in <Search>.
- Skip the per-row metrics recompute + localStorage write for logged-out users.
- Defer GTM and Umami analytics to lazyOnload.

All new params default to prior behavior, so logged-in and other ContractsTable usages are unchanged.