### PR TITLE
feat(elections): add Florida 2026 Senate special election to the map

### DIFF
--- a/web/components/us-elections/contracts/party-panel/binary-party-panel.tsx
+++ b/web/components/us-elections/contracts/party-panel/binary-party-panel.tsx
@@ -26,7 +26,10 @@ import { useSaveBinaryShares } from 'web/hooks/use-save-binary-shares'
 import { useUser } from 'web/hooks/use-user'
 import { useUserContractBets } from 'client-common/hooks/use-user-bets'
 import { firebaseLogin } from 'web/lib/firebase/users'
-import { BubblePercentChange } from '../candidates-panel/candidate-bar'
+import {
+  BubblePercentChange,
+  PercentChangeToday,
+} from '../candidates-panel/candidate-bar'
 import { BinaryUserPosition } from '../candidates-panel/candidates-user-position'
 import { ELECTIONS_PARTY_QUESTION_PSEUDONYM } from 'web/components/elections-page'
 import { sliderColors } from 'web/components/widgets/slider'
@@ -42,6 +45,124 @@ const politicsBinaryPseudonym = {
     pseudonymName: 'HARRIS',
     pseudonymColor: 'azure' as keyof typeof sliderColors,
   },
+}
+
+const statePartyBinaryPseudonym = {
+  YES: {
+    pseudonymName: 'Republican',
+    pseudonymColor: 'sienna' as keyof typeof sliderColors,
+  },
+  NO: {
+    pseudonymName: 'Democratic',
+    pseudonymColor: 'azure' as keyof typeof sliderColors,
+  },
+}
+
+// Party bars for a binary state market (e.g. the FL Senate special, "Will a
+// Republican win ...?"). YES = Republican, NO = Democratic — the same
+// convention getPartyProbs uses to color the map.
+export function StateBinaryPartyPanel(props: { contract: BinaryContract }) {
+  const { contract } = props
+  const user = useUser()
+
+  const userBets = useUserContractBets(
+    user?.id,
+    contract.id,
+    (params) => api('bets', params),
+    useIsPageVisible
+  )
+  const { sharesOutcome } = useSaveBinaryShares(contract, userBets)
+
+  return (
+    <Col className="gap-2">
+      {(['YES', 'NO'] as const).map((outcome) => (
+        <StateBinaryPartyBar
+          key={outcome}
+          contract={contract}
+          outcome={outcome}
+          userBets={userBets}
+          user={user}
+          showPosition={sharesOutcome === outcome}
+        />
+      ))}
+    </Col>
+  )
+}
+
+function StateBinaryPartyBar(props: {
+  contract: BinaryContract
+  outcome: 'YES' | 'NO'
+  userBets?: Bet[]
+  user?: User | null
+  showPosition: boolean
+}) {
+  const { contract, outcome, userBets, user, showPosition } = props
+  const { resolution } = contract
+
+  const isRep = outcome === 'YES'
+  const partyName = isRep ? 'Republican Party' : 'Democratic Party'
+  const repProb = getDisplayProbability(contract)
+  const prob = isRep ? repProb : 1 - repProb
+  const resolvedProb =
+    resolution === 'YES'
+      ? isRep
+        ? 1
+        : 0
+      : resolution === 'NO'
+      ? isRep
+        ? 0
+        : 1
+      : resolution === 'MKT'
+      ? prob
+      : undefined
+  const probChange = isRep
+    ? contract.probChanges.day
+    : -contract.probChanges.day
+
+  return (
+    <AnswerBar
+      color={getPartyColor(partyName)}
+      prob={prob}
+      resolvedProb={resolvedProb}
+      className={clsx('cursor-pointer py-1.5')}
+      label={
+        <Row className="relative h-8">
+          <Col>
+            <CreatorAndAnswerLabel
+              text={partyName}
+              createdTime={contract.createdTime}
+              className={clsx('items-center !leading-none')}
+            />
+            {!resolution && showPosition && user && !!userBets && (
+              <BinaryUserPosition
+                contract={contract}
+                userBets={userBets}
+                user={user}
+                className="text-ink-700 dark:text-ink-800 text-left text-xs hover:underline"
+                binaryPseudonym={statePartyBinaryPseudonym}
+              />
+            )}
+          </Col>
+        </Row>
+      }
+      end={
+        <Row className={'items-center gap-1 sm:gap-2'}>
+          <div className="relative">
+            <div className="text-lg font-bold">{formatPercent(prob)}</div>
+            <PercentChangeToday
+              probChange={probChange}
+              className="absolute right-1 top-6 whitespace-nowrap text-xs"
+            />
+          </div>
+          <BinaryBetButton
+            contract={contract}
+            initialOutcome={outcome}
+            binaryPseudonym={statePartyBinaryPseudonym}
+          />
+        </Row>
+      }
+    />
+  )
 }
 
 // just the bars

--- a/web/components/us-elections/contracts/state-contract-card.tsx
+++ b/web/components/us-elections/contracts/state-contract-card.tsx
@@ -3,7 +3,12 @@ import Link from 'next/link'
 import Router from 'next/router'
 import { useState } from 'react'
 
-import { Contract, MultiContract, contractPath } from 'common/contract'
+import {
+  BinaryContract,
+  Contract,
+  MultiContract,
+  contractPath,
+} from 'common/contract'
 import { VisibilityIcon } from 'web/components/contract/contracts-table'
 import { Col } from 'web/components/layout/col'
 import {
@@ -15,6 +20,7 @@ import { Row } from 'web/components/layout/row'
 import { ClickFrame } from 'web/components/widgets/click-frame'
 import { track } from 'web/lib/service/analytics'
 import { DATA, StateDataType } from '../../usa-map/usa-map-data'
+import { StateBinaryPartyPanel } from './party-panel/binary-party-panel'
 import { PartyPanel } from './party-panel/party-panel'
 
 // This is not live updated from the object, so expects to be passed a contract with updated stuff
@@ -94,11 +100,18 @@ export function StateContractCard(props: {
       </Col>
 
       <div className="w-full overflow-hidden pt-2">
-        <PartyPanel
-          contract={contract as MultiContract}
-          maxAnswers={3}
-          includeHead={includeHead}
-        />
+        {/* Some state races only have a binary market (e.g. the FL Senate
+        special, "Will a Republican win ...?") — render party bars from its
+        YES/NO prob instead of multi-choice answers. */}
+        {contract.outcomeType === 'BINARY' ? (
+          <StateBinaryPartyPanel contract={contract as BinaryContract} />
+        ) : (
+          <PartyPanel
+            contract={contract as MultiContract}
+            maxAnswers={3}
+            includeHead={includeHead}
+          />
+        )}
       </div>
     </ClickFrame>
   )

--- a/web/public/data/senate-state-data.ts
+++ b/web/public/data/senate-state-data.ts
@@ -139,7 +139,7 @@ export const senate2024: StateElectionMarket[] = [
   },
 ]
 
-// 2026 midterm Senate races (Class 2 seats + the OH/VA specials). These are
+// 2026 midterm Senate races (Class 2 seats + the OH/VA/FL specials). These are
 // community-created "which party will win" markets — the best-trafficked
 // party-outcome market per state as of the 2026 rebuild. Answer labels vary
 // across creators ("Democrats" / "Democratic party" / "Democratic"); the map's
@@ -150,6 +150,9 @@ export const senate2026: StateElectionMarket[] = [
   { state: 'AR', slug: 'what-party-will-win-the-2026-arkans' },
   { state: 'CO', slug: 'which-party-will-win-the-2026-color' },
   { state: 'DE', slug: 'which-party-will-win-the-2026-delaw' },
+  // FL: special election for Marco Rubio's seat (Ashley Moody appointed).
+  // Binary market — YES = Republican wins, which getPartyProbs handles.
+  { state: 'FL', slug: 'will-a-republican-win-the-us-senate' },
   { state: 'GA', slug: 'which-party-will-win-the-2026-us-se' },
   { state: 'ID', slug: 'which-party-will-win-the-2026-idaho' },
   { state: 'IL', slug: 'which-party-will-win-the-2026-illin' },
@@ -354,13 +357,6 @@ export const currentSenate2026: CurrentSenateState[] = [
     party2: 'Democrat',
   },
   {
-    state: 'FL',
-    name1: 'Rick Scott',
-    party1: 'Republican',
-    name2: 'Ashley Moody',
-    party2: 'Republican',
-  },
-  {
     state: 'HI',
     name1: 'Brian Schatz',
     party1: 'Democrat',
@@ -462,6 +458,7 @@ export const senateHeldSeats2026: Record<
   AR: { name: 'John Boozman', party: 'Republican' },
   CO: { name: 'Michael Bennet', party: 'Democrat' },
   DE: { name: 'Lisa Blunt Rochester', party: 'Democrat' },
+  FL: { name: 'Rick Scott', party: 'Republican' },
   GA: { name: 'Raphael Warnock', party: 'Democrat' },
   ID: { name: 'Mike Crapo', party: 'Republican' },
   IL: { name: 'Tammy Duckworth', party: 'Democrat' },


### PR DESCRIPTION
Florida holds a 2026 special election for Marco Rubio's old Senate seat (Ashley Moody was appointed after he became Secretary of State), but the elections page listed FL as having no race.

- Add FL to senate2026 using the community market will-a-republican-win-the-us-senate (binary, YES = Republican, which getPartyProbs already handles)
- Remove FL from currentSenate2026 (no-race states) since Moody's seat is now on the ballot
- Add Rick Scott to senateHeldSeats2026 as the seat not up in 2026

Contested + no-race states still sum to 50, keeping the projection bar partitioned correctly.


Claude-Session: https://claude.ai/code/session_01GcE2rSvCHnztmerXkxG5L4