### PR TITLE
feat(admin): /admin/jobs recruiting roster with topic ranks

### DIFF
--- a/backend/api/src/get-job-seeker-topic-rank.ts
+++ b/backend/api/src/get-job-seeker-topic-rank.ts
@@ -1,52 +1,69 @@
+import { HIDE_FROM_LEADERBOARD_USER_IDS } from 'common/envs/constants'
 import { JobSeekerTopicRank } from 'common/job-seeker'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { APIError, type APIHandler } from './helpers/endpoint'
 
 // Site-wide profit leaderboard for one topic, filtered to job-board
-// registrants: "Jack1 is #3 of 12,481 traders in us-politics". Aggregates all
-// user_contract_metrics for the topic's contracts, so big topics take a few
-// seconds — called on demand from /admin/jobs, never in a loop.
+// registrants: "Jack1 is #3 of 12,481 traders in us-politics". Mirrors the
+// public topic leaderboard's filters (get-leaderboard.ts) — unranked
+// contracts, banned users, and hidden accounts excluded — so this rank
+// matches the one the candidate can see. Aggregates all user_contract_metrics
+// for the topic's contracts, so big topics take a few seconds — called on
+// demand from /admin/jobs, never in a loop.
 export const getJobSeekerTopicRank: APIHandler<
   'get-job-seeker-topic-rank'
 > = async ({ topic }, auth) => {
   throwErrorIfNotAdmin(auth.uid)
   const pg = createSupabaseDirectClient()
 
-  const group = await pg.oneOrNone(`select id from groups where slug = $1`, [
-    topic,
-  ])
+  const group = await pg.oneOrNone(
+    `select id from groups where slug = $1 limit 1`,
+    [topic]
+  )
   if (!group) throw new APIError(404, `No topic with slug ${topic}`)
 
-  const rows = await pg.manyOrNone(
+  // participants comes from the full ranking pool, independent of the
+  // job-seeker join, so it stays correct when no registrant ranks in the
+  // topic.
+  const result = await pg.one<{
+    participants: number
+    ranks: JobSeekerTopicRank[]
+  }>(
     `with topic_profits as (
        select m.user_id, sum(m.profit) as profit
        from user_contract_metrics m
+       join contracts c on c.id = m.contract_id
+       join users u on u.id = m.user_id
        where m.answer_id is null
-         and m.contract_id in (
+         and c.id in (
            select contract_id from group_contracts where group_id = $1)
+         and coalesce((c.data->'isRanked')::boolean, true) = true
+         and coalesce((u.data->>'isBannedFromPosting')::boolean, false)
+           is not true
+         and c.token = 'MANA'
+         and not m.user_id = any($2)
        group by m.user_id
      ), ranked as (
-       select user_id, profit, rank() over (order by profit desc) as rank
+       select user_id, rank() over (order by profit desc) as rank
        from topic_profits
      )
-     select r.user_id, u.username, r.rank, round(r.profit) as profit,
-       (select count(*) from topic_profits) as participants
-     from ranked r
-     join job_seeker_interest j on j.user_id = r.user_id and j.open_to_contact
-     join users u on u.id = r.user_id
-     order by r.rank`,
-    [group.id]
+     select
+       (select count(*) from topic_profits) as participants,
+       coalesce(
+         (select json_agg(
+            json_build_object('userId', r.user_id, 'rank', r.rank)
+            order by r.rank)
+          from ranked r
+          join job_seeker_interest j
+            on j.user_id = r.user_id and j.open_to_contact),
+         '[]'::json
+       ) as ranks`,
+    [group.id, HIDE_FROM_LEADERBOARD_USER_IDS]
   )
 
-  const ranks: JobSeekerTopicRank[] = rows.map((r) => ({
-    userId: r.user_id,
-    username: r.username,
-    rank: Number(r.rank),
-    profit: Number(r.profit),
-  }))
   return {
-    participants: rows.length > 0 ? Number(rows[0].participants) : 0,
-    ranks,
+    participants: Number(result.participants),
+    ranks: result.ranks,
   }
 }

--- a/backend/api/src/get-job-seeker-topic-rank.ts
+++ b/backend/api/src/get-job-seeker-topic-rank.ts
@@ -1,0 +1,52 @@
+import { JobSeekerTopicRank } from 'common/job-seeker'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { APIError, type APIHandler } from './helpers/endpoint'
+
+// Site-wide profit leaderboard for one topic, filtered to job-board
+// registrants: "Jack1 is #3 of 12,481 traders in us-politics". Aggregates all
+// user_contract_metrics for the topic's contracts, so big topics take a few
+// seconds — called on demand from /admin/jobs, never in a loop.
+export const getJobSeekerTopicRank: APIHandler<
+  'get-job-seeker-topic-rank'
+> = async ({ topic }, auth) => {
+  throwErrorIfNotAdmin(auth.uid)
+  const pg = createSupabaseDirectClient()
+
+  const group = await pg.oneOrNone(`select id from groups where slug = $1`, [
+    topic,
+  ])
+  if (!group) throw new APIError(404, `No topic with slug ${topic}`)
+
+  const rows = await pg.manyOrNone(
+    `with topic_profits as (
+       select m.user_id, sum(m.profit) as profit
+       from user_contract_metrics m
+       where m.answer_id is null
+         and m.contract_id in (
+           select contract_id from group_contracts where group_id = $1)
+       group by m.user_id
+     ), ranked as (
+       select user_id, profit, rank() over (order by profit desc) as rank
+       from topic_profits
+     )
+     select r.user_id, u.username, r.rank, round(r.profit) as profit,
+       (select count(*) from topic_profits) as participants
+     from ranked r
+     join job_seeker_interest j on j.user_id = r.user_id and j.open_to_contact
+     join users u on u.id = r.user_id
+     order by r.rank`,
+    [group.id]
+  )
+
+  const ranks: JobSeekerTopicRank[] = rows.map((r) => ({
+    userId: r.user_id,
+    username: r.username,
+    rank: Number(r.rank),
+    profit: Number(r.profit),
+  }))
+  return {
+    participants: rows.length > 0 ? Number(rows[0].participants) : 0,
+    ranks,
+  }
+}

--- a/backend/api/src/get-job-seeker-topics.ts
+++ b/backend/api/src/get-job-seeker-topics.ts
@@ -1,0 +1,34 @@
+import { JobSeekerTopicProfit } from 'common/job-seeker'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { type APIHandler } from './helpers/endpoint'
+
+// A registrant's most profitable topics, from their contract metrics. Loaded
+// on demand per row on /admin/jobs — bot accounts can have 100k+ positions,
+// so this is too heavy to compute for the whole roster on page load.
+export const getJobSeekerTopics: APIHandler<'get-job-seeker-topics'> = async (
+  { userId },
+  auth
+) => {
+  throwErrorIfNotAdmin(auth.uid)
+  const pg = createSupabaseDirectClient()
+
+  const rows = await pg.manyOrNone(
+    `select g as topic, round(sum(m.profit)) as profit
+     from user_contract_metrics m
+     join contracts c on c.id = m.contract_id
+     cross join lateral unnest(c.group_slugs) as g
+     where m.user_id = $1 and m.answer_id is null
+     group by 1
+     having sum(m.profit) > 1000
+     order by 2 desc
+     limit 15`,
+    [userId]
+  )
+
+  const topics: JobSeekerTopicProfit[] = rows.map((r) => ({
+    topic: r.topic,
+    profit: Number(r.profit),
+  }))
+  return { topics }
+}

--- a/backend/api/src/get-job-seeker-topics.ts
+++ b/backend/api/src/get-job-seeker-topics.ts
@@ -1,7 +1,7 @@
 import { JobSeekerTopicProfit } from 'common/job-seeker'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
-import { type APIHandler } from './helpers/endpoint'
+import { APIError, type APIHandler } from './helpers/endpoint'
 
 // A registrant's most profitable topics, from their contract metrics. Loaded
 // on demand per row on /admin/jobs — bot accounts can have 100k+ positions,
@@ -13,12 +13,29 @@ export const getJobSeekerTopics: APIHandler<'get-job-seeker-topics'> = async (
   throwErrorIfNotAdmin(auth.uid)
   const pg = createSupabaseDirectClient()
 
-  const rows = await pg.manyOrNone(
-    `select g as topic, round(sum(m.profit)) as profit
+  // Same opt-in scoping as the other job-seeker endpoints.
+  const seeker = await pg.oneOrNone(
+    `select 1 from job_seeker_interest
+     where user_id = $1 and open_to_contact
+     limit 1`,
+    [userId]
+  )
+  if (!seeker) {
+    throw new APIError(404, 'User is not an open-to-contact job seeker')
+  }
+
+  // distinct guards against duplicate slugs in the denormalized group_slugs
+  // array double-counting a contract's profit; unranked contracts are
+  // excluded to match the topic-rank endpoint and the public leaderboard.
+  const rows = await pg.manyOrNone<{ topic: string; profit: number }>(
+    `select g.slug as topic, round(sum(m.profit)) as profit
      from user_contract_metrics m
      join contracts c on c.id = m.contract_id
-     cross join lateral unnest(c.group_slugs) as g
+     cross join lateral (
+       select distinct slug from unnest(c.group_slugs) as slug
+     ) g
      where m.user_id = $1 and m.answer_id is null
+       and coalesce((c.data->'isRanked')::boolean, true) = true
      group by 1
      having sum(m.profit) > 1000
      order by 2 desc

--- a/backend/api/src/get-job-seekers.ts
+++ b/backend/api/src/get-job-seekers.ts
@@ -1,0 +1,64 @@
+import { JobSeekerAdminRow } from 'common/job-seeker'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { type APIHandler } from './helpers/endpoint'
+
+// Admin roster for /admin/jobs: everyone who registered job interest, with
+// account stats and their overall all-time-profit rank.
+export const getJobSeekers: APIHandler<'get-job-seekers'> = async (
+  _,
+  auth
+) => {
+  throwErrorIfNotAdmin(auth.uid)
+  const pg = createSupabaseDirectClient()
+
+  const rows = await pg.manyOrNone(
+    `select u.id as user_id, u.username, u.name, u.is_bot,
+       extract(epoch from u.created_time) * 1000 as joined_time,
+       nullif(u.data->>'lastBetTime', '')::bigint as last_bet_time,
+       p.profit,
+       p.balance + p.investment_value as portfolio,
+       j.skills, j.interests, j.region,
+       extract(epoch from j.created_time) * 1000 as registered_time
+     from job_seeker_interest j
+     join users u on u.id = j.user_id
+     left join user_portfolio_history_latest p on p.user_id = j.user_id
+     where j.open_to_contact
+     order by p.profit desc nulls last`
+  )
+
+  // One scan of the portfolio table computes every registrant's rank at once
+  // (there is no index on profit, so per-user subqueries would rescan it).
+  const ranks = await pg.manyOrNone<{ user_id: string; rank: string }>(
+    `with regs as (
+       select p.user_id, p.profit
+       from user_portfolio_history_latest p
+       join job_seeker_interest j on j.user_id = p.user_id and j.open_to_contact
+     )
+     select regs.user_id, count(*) filter (where p.profit > regs.profit) + 1 as rank
+     from user_portfolio_history_latest p
+     cross join regs
+     group by regs.user_id, regs.profit`
+  )
+  const rankByUser = Object.fromEntries(
+    ranks.map((r) => [r.user_id, Number(r.rank)])
+  )
+
+  const seekers: JobSeekerAdminRow[] = rows.map((r) => ({
+    userId: r.user_id,
+    username: r.username,
+    name: r.name,
+    isBot: r.is_bot,
+    joinedTime: Number(r.joined_time),
+    lastBetTime: r.last_bet_time ? Number(r.last_bet_time) : null,
+    profit: r.profit === null ? null : Number(r.profit),
+    portfolio: r.portfolio === null ? null : Number(r.portfolio),
+    overallRank: rankByUser[r.user_id] ?? null,
+    skills: r.skills ?? [],
+    interests: r.interests ?? [],
+    region: r.region ?? null,
+    registeredTime: Number(r.registered_time),
+  }))
+
+  return { seekers }
+}

--- a/backend/api/src/get-job-seekers.ts
+++ b/backend/api/src/get-job-seekers.ts
@@ -1,47 +1,63 @@
-import { JobSeekerAdminRow } from 'common/job-seeker'
+import { HIDE_FROM_LEADERBOARD_USER_IDS } from 'common/envs/constants'
+import {
+  JobInterest,
+  JobRegion,
+  JobSeekerAdminRow,
+  JobSkill,
+} from 'common/job-seeker'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { type APIHandler } from './helpers/endpoint'
 
 // Admin roster for /admin/jobs: everyone who registered job interest, with
 // account stats and their overall all-time-profit rank.
-export const getJobSeekers: APIHandler<'get-job-seekers'> = async (
-  _,
-  auth
-) => {
+export const getJobSeekers: APIHandler<'get-job-seekers'> = async (_, auth) => {
   throwErrorIfNotAdmin(auth.uid)
   const pg = createSupabaseDirectClient()
 
-  const rows = await pg.manyOrNone(
-    `select u.id as user_id, u.username, u.name, u.is_bot,
-       extract(epoch from u.created_time) * 1000 as joined_time,
+  // overall_rank mirrors the profit_rank() function behind /leaderboards:
+  // null profit falls back to balance + spice + investments - deposits, and
+  // hidden accounts are excluded, so the rank shown here matches the one the
+  // candidate sees. One window pass over the portfolio table, joined to the
+  // roster.
+  const rows = await pg.manyOrNone<{
+    user_id: string
+    username: string
+    name: string
+    is_bot: boolean
+    joined_time: number
+    last_bet_time: number | null
+    profit: number | null
+    portfolio: number | null
+    overall_rank: number | null
+    skills: JobSkill[] | null
+    interests: JobInterest[] | null
+    region: JobRegion | null
+    registered_time: number
+  }>(
+    `with ranked as (
+       select user_id, rank() over (order by coalesce(
+           profit, balance + spice_balance + investment_value - total_deposits
+         ) desc) as rank
+       from user_portfolio_history_latest
+       where not user_id = any($1)
+     )
+     select u.id as user_id, u.username, u.name, u.is_bot,
+       ts_to_millis(u.created_time) as joined_time,
        nullif(u.data->>'lastBetTime', '')::bigint as last_bet_time,
        p.profit,
        p.balance + p.investment_value as portfolio,
+       r.rank as overall_rank,
        j.skills, j.interests, j.region,
-       extract(epoch from j.created_time) * 1000 as registered_time
+       ts_to_millis(j.created_time) as registered_time
      from job_seeker_interest j
      join users u on u.id = j.user_id
      left join user_portfolio_history_latest p on p.user_id = j.user_id
+     left join ranked r on r.user_id = j.user_id
      where j.open_to_contact
-     order by p.profit desc nulls last`
-  )
-
-  // One scan of the portfolio table computes every registrant's rank at once
-  // (there is no index on profit, so per-user subqueries would rescan it).
-  const ranks = await pg.manyOrNone<{ user_id: string; rank: string }>(
-    `with regs as (
-       select p.user_id, p.profit
-       from user_portfolio_history_latest p
-       join job_seeker_interest j on j.user_id = p.user_id and j.open_to_contact
-     )
-     select regs.user_id, count(*) filter (where p.profit > regs.profit) + 1 as rank
-     from user_portfolio_history_latest p
-     cross join regs
-     group by regs.user_id, regs.profit`
-  )
-  const rankByUser = Object.fromEntries(
-    ranks.map((r) => [r.user_id, Number(r.rank)])
+       and coalesce((u.data->'userDeleted')::boolean, false) is not true
+     order by p.profit desc nulls last`,
+    [HIDE_FROM_LEADERBOARD_USER_IDS]
   )
 
   const seekers: JobSeekerAdminRow[] = rows.map((r) => ({
@@ -50,10 +66,10 @@ export const getJobSeekers: APIHandler<'get-job-seekers'> = async (
     name: r.name,
     isBot: r.is_bot,
     joinedTime: Number(r.joined_time),
-    lastBetTime: r.last_bet_time ? Number(r.last_bet_time) : null,
+    lastBetTime: r.last_bet_time === null ? null : Number(r.last_bet_time),
     profit: r.profit === null ? null : Number(r.profit),
     portfolio: r.portfolio === null ? null : Number(r.portfolio),
-    overallRank: rankByUser[r.user_id] ?? null,
+    overallRank: r.overall_rank === null ? null : Number(r.overall_rank),
     skills: r.skills ?? [],
     interests: r.interests ?? [],
     region: r.region ?? null,

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -166,6 +166,9 @@ import { updateNotifSettings } from './update-notif-settings'
 import { updatePrivateUser } from './update-private-user'
 import { setJobInterest } from './set-job-interest'
 import { getJobInterest } from './get-job-interest'
+import { getJobSeekers } from './get-job-seekers'
+import { getJobSeekerTopics } from './get-job-seeker-topics'
+import { getJobSeekerTopicRank } from './get-job-seeker-topic-rank'
 
 import { createCategory } from './create-category'
 import { createTask } from './create-task'
@@ -398,6 +401,9 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'update-notif-settings': updateNotifSettings,
   'set-job-interest': setJobInterest,
   'get-job-interest': getJobInterest,
+  'get-job-seekers': getJobSeekers,
+  'get-job-seeker-topics': getJobSeekerTopics,
+  'get-job-seeker-topic-rank': getJobSeekerTopicRank,
   headlines: getHeadlines,
   'politics-headlines': getPoliticsHeadlines,
   post: post,

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -26,7 +26,10 @@ import {
   JOB_INTERESTS,
   JOB_REGIONS,
   JOB_SKILLS,
+  JobSeekerAdminRow,
   JobSeekerInterest,
+  JobSeekerTopicProfit,
+  JobSeekerTopicRank,
 } from 'common/job-seeker'
 import { League } from 'common/leagues'
 import { type LinkPreview } from 'common/link-preview'
@@ -1494,6 +1497,27 @@ export const API = (_apiTypeCheck = {
     authed: true,
     props: z.object({}).strict(),
     returns: {} as { interest: JobSeekerInterest | null },
+  },
+  'get-job-seekers': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({}).strict(),
+    returns: {} as { seekers: JobSeekerAdminRow[] },
+  },
+  'get-job-seeker-topics': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({ userId: z.string() }).strict(),
+    returns: {} as { topics: JobSeekerTopicProfit[] },
+  },
+  'get-job-seeker-topic-rank': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    props: z.object({ topic: z.string() }).strict(),
+    returns: {} as { participants: number; ranks: JobSeekerTopicRank[] },
   },
   headlines: {
     method: 'GET',

--- a/common/src/job-seeker.ts
+++ b/common/src/job-seeker.ts
@@ -105,3 +105,33 @@ export type JobSeekerInterest = {
   createdTime: number
   updatedTime: number
 }
+
+// Admin-only views for /admin/jobs — the recruiting roster with account stats.
+export type JobSeekerAdminRow = {
+  userId: string
+  username: string
+  name: string
+  isBot: boolean
+  joinedTime: number
+  lastBetTime: number | null
+  profit: number | null
+  portfolio: number | null
+  // 1-based position by all-time profit across all users with portfolios
+  overallRank: number | null
+  skills: JobSkill[]
+  interests: JobInterest[]
+  region: JobRegion | null
+  registeredTime: number
+}
+
+export type JobSeekerTopicProfit = {
+  topic: string
+  profit: number
+}
+
+export type JobSeekerTopicRank = {
+  userId: string
+  username: string
+  rank: number
+  profit: number
+}

--- a/common/src/job-seeker.ts
+++ b/common/src/job-seeker.ts
@@ -131,7 +131,5 @@ export type JobSeekerTopicProfit = {
 
 export type JobSeekerTopicRank = {
   userId: string
-  username: string
   rank: number
-  profit: number
 }

--- a/web/pages/admin/jobs.tsx
+++ b/web/pages/admin/jobs.tsx
@@ -1,0 +1,290 @@
+import { useState } from 'react'
+
+import {
+  JOB_INTEREST_LABELS,
+  JOB_REGION_LABELS,
+  JOB_SKILL_LABELS,
+  JobSeekerAdminRow,
+  JobSeekerTopicProfit,
+  JobSeekerTopicRank,
+} from 'common/job-seeker'
+import { formatMoney } from 'common/util/format'
+import { Col } from 'web/components/layout/col'
+import { Page } from 'web/components/layout/page'
+import { Row } from 'web/components/layout/row'
+import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import { Title } from 'web/components/widgets/title'
+import { UserLink } from 'web/components/widgets/user-link'
+import { useAdmin } from 'web/hooks/use-admin'
+import { useAPIGetter } from 'web/hooks/use-api-getter'
+import { useUser } from 'web/hooks/use-user'
+import { api } from 'web/lib/api/api'
+
+export default function AdminJobsPage() {
+  const user = useUser()
+  const isAdmin = useAdmin()
+
+  if (!user || !isAdmin) {
+    return (
+      <Page trackPageView="admin-jobs">
+        <Col className="items-center justify-center py-20">
+          <p className="text-ink-500">Admin access required</p>
+        </Col>
+      </Page>
+    )
+  }
+
+  return (
+    <Page trackPageView="admin-jobs" className="!col-span-10">
+      <Col className="gap-6">
+        <Title>Job Board Candidates</Title>
+        <SeekersTable />
+      </Col>
+    </Page>
+  )
+}
+
+function SeekersTable() {
+  const { data } = useAPIGetter('get-job-seekers', {})
+  const [expandedUser, setExpandedUser] = useState<string | null>(null)
+
+  if (data === undefined) return <LoadingIndicator />
+  const { seekers } = data
+
+  const trading = seekers.filter(
+    (s) =>
+      s.interests.includes('trading-firms') ||
+      s.interests.includes('hedge-funds')
+  ).length
+
+  return (
+    <Col className="gap-4">
+      <Row className="flex-wrap gap-4">
+        <SummaryCard label="Active candidates" value={seekers.length} />
+        <SummaryCard label="Want trading roles" value={trading} />
+        <SummaryCard
+          label="Profit > 100k"
+          value={seekers.filter((s) => (s.profit ?? 0) > 100_000).length}
+        />
+      </Row>
+
+      <div className="bg-canvas-0 overflow-x-auto rounded-lg border">
+        <table className="w-full">
+          <thead>
+            <tr className="bg-canvas-50 border-b">
+              {[
+                'User',
+                'Profit',
+                'Rank',
+                'Portfolio',
+                'Joined',
+                'Last bet',
+                'Region',
+                'Skills',
+                'Wants',
+                'Topics',
+              ].map((h) => (
+                <th
+                  key={h}
+                  className="text-ink-600 whitespace-nowrap px-3 py-3 text-left text-sm font-medium"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {seekers.map((s) => (
+              <SeekerRow
+                key={s.userId}
+                seeker={s}
+                expanded={expandedUser === s.userId}
+                onToggle={() =>
+                  setExpandedUser(expandedUser === s.userId ? null : s.userId)
+                }
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-ink-400 text-xs">
+        Candidates opted in to employer contact via /jobs. Profiles are private
+        until they reply — share anonymized stats only. Topic ranks are computed
+        live against all traders in that topic and can take several seconds for
+        large topics.
+      </p>
+    </Col>
+  )
+}
+
+function SeekerRow(props: {
+  seeker: JobSeekerAdminRow
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const { seeker: s, expanded, onToggle } = props
+
+  return (
+    <>
+      <tr className="border-b last:border-b-0">
+        <td className="whitespace-nowrap px-3 py-2">
+          <Row className="items-center gap-1.5">
+            <UserLink
+              user={{ id: s.userId, username: s.username, name: s.name }}
+            />
+            {s.isBot && (
+              <span className="rounded-full bg-indigo-100 px-1.5 py-0.5 text-xs text-indigo-700">
+                bot
+              </span>
+            )}
+          </Row>
+        </td>
+        <td className="whitespace-nowrap px-3 py-2 text-right font-medium">
+          {s.profit === null ? '—' : formatMoney(s.profit)}
+        </td>
+        <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-right text-sm">
+          {s.overallRank === null ? '—' : `#${s.overallRank}`}
+        </td>
+        <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-right text-sm">
+          {s.portfolio === null ? '—' : formatMoney(s.portfolio)}
+        </td>
+        <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-sm">
+          {formatDate(s.joinedTime)}
+        </td>
+        <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-sm">
+          {s.lastBetTime === null ? 'never' : formatDate(s.lastBetTime)}
+        </td>
+        <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-sm">
+          {s.region ? JOB_REGION_LABELS[s.region] : '—'}
+        </td>
+        <td className="px-3 py-2">
+          <ChipList items={s.skills.map((k) => JOB_SKILL_LABELS[k])} />
+        </td>
+        <td className="px-3 py-2">
+          <ChipList items={s.interests.map((i) => JOB_INTEREST_LABELS[i])} />
+        </td>
+        <td className="px-3 py-2">
+          <button
+            className="text-primary-600 hover:text-primary-700 text-sm underline"
+            onClick={onToggle}
+          >
+            {expanded ? 'Hide' : 'Show'}
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b last:border-b-0">
+          <td colSpan={10} className="bg-canvas-50 px-4 py-3">
+            <TopicsPanel userId={s.userId} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function TopicsPanel(props: { userId: string }) {
+  const { userId } = props
+  const { data } = useAPIGetter('get-job-seeker-topics', { userId })
+  const [rankByTopic, setRankByTopic] = useState<
+    Record<
+      string,
+      { participants: number; ranks: JobSeekerTopicRank[] } | 'loading'
+    >
+  >({})
+
+  const loadRank = async (topic: string) => {
+    setRankByTopic((cur) => ({ ...cur, [topic]: 'loading' }))
+    try {
+      const res = await api('get-job-seeker-topic-rank', { topic })
+      setRankByTopic((cur) => ({ ...cur, [topic]: res }))
+    } catch {
+      setRankByTopic((cur) => {
+        const { [topic]: _, ...rest } = cur
+        return rest
+      })
+    }
+  }
+
+  if (data === undefined) return <LoadingIndicator size="sm" />
+  if (data.topics.length === 0)
+    return <span className="text-ink-500 text-sm">No profitable topics</span>
+
+  return (
+    <Col className="gap-2">
+      <span className="text-ink-500 font-mono text-xs uppercase tracking-widest">
+        Top topics by profit — click for site-wide rank
+      </span>
+      <Row className="flex-wrap gap-2">
+        {data.topics.map((t: JobSeekerTopicProfit) => {
+          const rank = rankByTopic[t.topic]
+          const mine =
+            rank && rank !== 'loading'
+              ? rank.ranks.find((r) => r.userId === userId)
+              : undefined
+          return (
+            <button
+              key={t.topic}
+              onClick={() => !rank && loadRank(t.topic)}
+              className="bg-canvas-0 border-ink-200 hover:border-primary-400 rounded-full border px-2.5 py-1 text-xs"
+            >
+              <span className="text-ink-700 font-medium">{t.topic}</span>{' '}
+              <span className="text-ink-500">{formatMoney(t.profit)}</span>
+              {rank === 'loading' && (
+                <span className="text-ink-400"> · ranking…</span>
+              )}
+              {mine && rank !== 'loading' && rank && (
+                <span className="text-primary-600 font-semibold">
+                  {' '}
+                  · #{mine.rank} of {rank.participants.toLocaleString()}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </Row>
+    </Col>
+  )
+}
+
+function ChipList(props: { items: string[] }) {
+  const { items } = props
+  if (items.length === 0) return <span className="text-ink-400 text-xs">—</span>
+  const shown = items.slice(0, 3)
+  const extra = items.length - shown.length
+  return (
+    <Row className="max-w-[16rem] flex-wrap gap-1">
+      {shown.map((label) => (
+        <span
+          key={label}
+          className="bg-ink-100 text-ink-600 whitespace-nowrap rounded-full px-2 py-0.5 text-xs"
+        >
+          {label}
+        </span>
+      ))}
+      {extra > 0 && (
+        <span className="text-ink-400 text-xs" title={items.join(', ')}>
+          +{extra}
+        </span>
+      )}
+    </Row>
+  )
+}
+
+function SummaryCard(props: { label: string; value: number }) {
+  const { label, value } = props
+  return (
+    <div className="bg-canvas-50 border-canvas-200 rounded-lg border px-4 py-3">
+      <div className="text-ink-500 text-xs font-medium">{label}</div>
+      <div className="text-ink-900 text-xl font-bold">{value}</div>
+    </div>
+  )
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}

--- a/web/pages/admin/jobs.tsx
+++ b/web/pages/admin/jobs.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
 
+import { formatJustDateShort } from 'client-common/lib/time'
 import {
   JOB_INTEREST_LABELS,
   JOB_REGION_LABELS,
   JOB_SKILL_LABELS,
   JobSeekerAdminRow,
-  JobSeekerTopicProfit,
-  JobSeekerTopicRank,
 } from 'common/job-seeker'
 import { formatMoney } from 'common/util/format'
 import { Col } from 'web/components/layout/col'
@@ -18,7 +17,6 @@ import { UserLink } from 'web/components/widgets/user-link'
 import { useAdmin } from 'web/hooks/use-admin'
 import { useAPIGetter } from 'web/hooks/use-api-getter'
 import { useUser } from 'web/hooks/use-user'
-import { api } from 'web/lib/api/api'
 
 export default function AdminJobsPage() {
   const user = useUser()
@@ -133,7 +131,7 @@ function SeekerRow(props: {
               user={{ id: s.userId, username: s.username, name: s.name }}
             />
             {s.isBot && (
-              <span className="rounded-full bg-indigo-100 px-1.5 py-0.5 text-xs text-indigo-700">
+              <span className="rounded-full bg-indigo-100 px-1.5 py-0.5 text-xs text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300">
                 bot
               </span>
             )}
@@ -149,10 +147,12 @@ function SeekerRow(props: {
           {s.portfolio === null ? '—' : formatMoney(s.portfolio)}
         </td>
         <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-sm">
-          {formatDate(s.joinedTime)}
+          {formatJustDateShort(s.joinedTime)}
         </td>
         <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-sm">
-          {s.lastBetTime === null ? 'never' : formatDate(s.lastBetTime)}
+          {s.lastBetTime === null
+            ? 'never'
+            : formatJustDateShort(s.lastBetTime)}
         </td>
         <td className="text-ink-600 whitespace-nowrap px-3 py-2 text-sm">
           {s.region ? JOB_REGION_LABELS[s.region] : '—'}
@@ -185,26 +185,14 @@ function SeekerRow(props: {
 
 function TopicsPanel(props: { userId: string }) {
   const { userId } = props
-  const { data } = useAPIGetter('get-job-seeker-topics', { userId })
-  const [rankByTopic, setRankByTopic] = useState<
-    Record<
-      string,
-      { participants: number; ranks: JobSeekerTopicRank[] } | 'loading'
-    >
-  >({})
-
-  const loadRank = async (topic: string) => {
-    setRankByTopic((cur) => ({ ...cur, [topic]: 'loading' }))
-    try {
-      const res = await api('get-job-seeker-topic-rank', { topic })
-      setRankByTopic((cur) => ({ ...cur, [topic]: res }))
-    } catch {
-      setRankByTopic((cur) => {
-        const { [topic]: _, ...rest } = cur
-        return rest
-      })
-    }
-  }
+  // Keyed per user: the hook's data slot defaults to the path alone, which
+  // would leak the previously expanded seeker's topics into this panel.
+  const { data } = useAPIGetter(
+    'get-job-seeker-topics',
+    { userId },
+    undefined,
+    `get-job-seeker-topics-${userId}`
+  )
 
   if (data === undefined) return <LoadingIndicator size="sm" />
   if (data.topics.length === 0)
@@ -216,34 +204,66 @@ function TopicsPanel(props: { userId: string }) {
         Top topics by profit — click for site-wide rank
       </span>
       <Row className="flex-wrap gap-2">
-        {data.topics.map((t: JobSeekerTopicProfit) => {
-          const rank = rankByTopic[t.topic]
-          const mine =
-            rank && rank !== 'loading'
-              ? rank.ranks.find((r) => r.userId === userId)
-              : undefined
-          return (
-            <button
-              key={t.topic}
-              onClick={() => !rank && loadRank(t.topic)}
-              className="bg-canvas-0 border-ink-200 hover:border-primary-400 rounded-full border px-2.5 py-1 text-xs"
-            >
-              <span className="text-ink-700 font-medium">{t.topic}</span>{' '}
-              <span className="text-ink-500">{formatMoney(t.profit)}</span>
-              {rank === 'loading' && (
-                <span className="text-ink-400"> · ranking…</span>
-              )}
-              {mine && rank !== 'loading' && rank && (
-                <span className="text-primary-600 font-semibold">
-                  {' '}
-                  · #{mine.rank} of {rank.participants.toLocaleString()}
-                </span>
-              )}
-            </button>
-          )
-        })}
+        {data.topics.map((t) => (
+          <TopicRankChip
+            key={t.topic}
+            topic={t.topic}
+            profit={t.profit}
+            userId={userId}
+          />
+        ))}
       </Row>
     </Col>
+  )
+}
+
+// Rank responses are per-topic, not per-seeker, so they're cached under a
+// topic-keyed slot shared by every row and kept across expand/collapse —
+// the multi-second aggregation runs once per topic per session.
+function TopicRankChip(props: {
+  topic: string
+  profit: number
+  userId: string
+}) {
+  const { topic, profit, userId } = props
+  const [clicked, setClicked] = useState(false)
+  const { data, error, loading, refresh } = useAPIGetter(
+    'get-job-seeker-topic-rank',
+    { topic },
+    undefined,
+    `get-job-seeker-topic-rank-${topic}`,
+    clicked
+  )
+  const mine = data?.ranks.find((r) => r.userId === userId)
+
+  return (
+    <button
+      onClick={() => {
+        if (!clicked) setClicked(true)
+        else if (error) refresh()
+      }}
+      className="bg-canvas-0 border-ink-200 hover:border-primary-400 rounded-full border px-2.5 py-1 text-xs"
+    >
+      <span className="text-ink-700 font-medium">{topic}</span>{' '}
+      <span className="text-ink-500">{formatMoney(profit)}</span>
+      {loading && <span className="text-ink-400"> · ranking…</span>}
+      {error && !loading && (
+        <span className="text-scarlet-500" title={error.message}>
+          {' '}
+          · failed — click to retry
+        </span>
+      )}
+      {data &&
+        !loading &&
+        (mine ? (
+          <span className="text-primary-600 font-semibold">
+            {' '}
+            · #{mine.rank} of {data.participants.toLocaleString()}
+          </span>
+        ) : (
+          <span className="text-ink-400"> · not ranked</span>
+        ))}
+    </button>
   )
 }
 
@@ -274,17 +294,9 @@ function ChipList(props: { items: string[] }) {
 function SummaryCard(props: { label: string; value: number }) {
   const { label, value } = props
   return (
-    <div className="bg-canvas-50 border-canvas-200 rounded-lg border px-4 py-3">
+    <div className="bg-canvas-50 border-canvas-100 rounded-lg border px-4 py-3">
       <div className="text-ink-500 text-xs font-medium">{label}</div>
       <div className="text-ink-900 text-xl font-bold">{value}</div>
     </div>
   )
-}
-
-function formatDate(timestamp: number): string {
-  return new Date(timestamp).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
 }


### PR DESCRIPTION
Admin-gated view of job-board registrants for pitching employers:

- get-job-seekers: roster + profit, portfolio, overall all-time profit rank (single-scan rank computation; no profit index on portfolio table)
- get-job-seeker-topics: a registrant's most profitable topics, loaded on demand per row (bot accounts have too many positions for page load)
- get-job-seeker-topic-rank: site-wide rank within one topic ("#3 of 12,481 in us-politics"), computed on click — the shareable pitch stat that doesn't fingerprint candidates the way exact mana amounts do

All three endpoints require isAdminId via throwErrorIfNotAdmin.