### PR TITLE
fix: migrate the two Claude calls to Gemini (no Anthropic credits + retired model)

### DIFF
--- a/backend/api/src/generate-concise-title.ts
+++ b/backend/api/src/generate-concise-title.ts
@@ -49,8 +49,9 @@ Example transformations:
 Your concise version, without any other text or commentary:`
 
       const response = await promptAI(prompt, {
-        model: aiModels.sonnet3,
+        model: aiModels.flashLite,
         system,
+        thinkingLevel: 'low',
       })
 
       let trimmedResponse = response.trim()

--- a/backend/api/src/on-create-comment-on-contract.ts
+++ b/backend/api/src/on-create-comment-on-contract.ts
@@ -345,9 +345,9 @@ Only return the raw JSON object without any markdown code blocks, backticks, add
 
   try {
     const clarification = await promptAI<ClarificationResponse>(prompt, {
-      model: aiModels.sonnet45,
+      model: aiModels.flash,
       parseAsJson: true,
-      reasoning: { effort: 'high' },
+      thinkingLevel: 'high',
     })
     log('Clarification response:', {
       question: contract.question,

--- a/backend/shared/src/helpers/claude.ts
+++ b/backend/shared/src/helpers/claude.ts
@@ -4,7 +4,6 @@ import { removeUndefinedProps } from 'common/util/object'
 import { parseAIResponseAsJson } from './gemini'
 
 export const models = {
-  sonnet3: 'claude-3-7-sonnet-latest' as const,
   haiku: 'claude-haiku-4-5-20251001' as const,
   sonnet45: 'claude-sonnet-4-6' as const,
 }


### PR DESCRIPTION
## Why
The org has **no Anthropic API credits**, so both Claude-backed calls have been failing. One of them also pointed at `claude-3-7-sonnet-latest`, which Anthropic **retired 2026-02-19** (now 404). Gemini is already the funded default provider for every other AI call in the repo, so these two are routed through it too. **No new credentials needed** — `GEMINI_API_KEY` is already configured. Provider routing is automatic (by model-ID prefix in `prompt-ai.ts`).

This also un-breaks two silently-failing features (title generation; creator-comment clarification).

## Changes
| Call site | Was | Now |
|---|---|---|
| `generate-concise-title` | `claude-3-7-sonnet-latest` (retired) | `gemini-3.1-flash-lite` + `thinkingLevel: 'low'` |
| `checkForClarification` (`on-create-comment-on-contract`) | `claude-sonnet-4-6` | `gemini-3.5-flash` + `thinkingLevel: 'high'` |
| `claude.ts` | had retired `sonnet3` alias | alias removed |

Notes:
- `thinkingLevel: 'low'` (not `'minimal'`) on flash-lite — `'minimal'`/`'medium'` are Gemini-3-Flash-only per `gemini.ts`.
- The old `reasoning: { effort: 'high' }` on the clarification call was silently dropped for Claude (router never forwarded it); `thinkingLevel: 'high'` preserves the intended reasoning depth on Gemini.
- The `claude.ts` helper and `@anthropic-ai/sdk` dep are now unused but left in place (harmless); full removal can follow once a build+typecheck can verify it.

## Not touched (intentionally)
OpenAI embeddings (`text-embedding-3-small` — changing provider would break stored pgvector embeddings), `auto-award-bounty` (OpenAI, 0 active), and all existing Gemini calls.

## Verification
- Grep confirms zero remaining `aiModels.sonnet3` / `aiModels.sonnet45` / `claude-3-7-sonnet` references.
- ⚠️ Backend typecheck/lint not run in this branch (isolated worktree, no `node_modules`). Please let CI run, or `yarn && typecheck` `backend/shared` + `backend/api` before merge. Edits use only pre-existing valid aliases/fields, so they're type-correct by construction.