### PR TITLE
fix: don't misfire "insufficient balance" error on the sentinel baseline

### DIFF
--- a/backend/api/src/place-bet.ts
+++ b/backend/api/src/place-bet.ts
@@ -636,10 +636,13 @@ export const executeNewBetResult = async (
   if (userUpdates.length) {
     // if negative balances, make sure the balance is higher than when they started
     for (const userUpdate of userUpdates) {
-      if (userUpdate.balance < -EPSILON) {
-        if (userUpdate.balance < balanceByUserId[userUpdate.id]) {
-          throw new APIError(403, 'Maker has insufficient balance.')
-        }
+      const startBalance = balanceByUserId[userUpdate.id]
+      if (
+        userUpdate.balance < -EPSILON &&
+        startBalance !== Number.MAX_SAFE_INTEGER &&
+        userUpdate.balance < startBalance
+      ) {
+        throw new APIError(403, 'Maker has insufficient balance.')
       }
     }
   }


### PR DESCRIPTION
MAX_SAFE_INTEGER is the sentinel we stamp on limit-order owners whose real balance we never fetched (they weren't matched by this bet, see the "infinite balance" assumption above). It's only meant for the fill math, not as a real starting balance — such a user is never charged here (a charge would have tripped the simulated-vs-actual makerIds check first), so they can only appear via a credit (e.g. the creator's unique-bettor bonus). Comparing their ending balance against the sentinel would always throw, so skip it.