### PR TITLE
Guard against a bad CPMM pool state and log if it does hit

### DIFF
--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -10,6 +10,7 @@ import { LimitBet } from 'common/bet'
 import { MS_PER_DAY } from 'common/loans'
 import { MarketContract } from 'common/contract'
 import { ContractMetric } from 'common/contract-metric'
+import { CPMM_ARBITRAGE_ERROR_PREFIX } from 'common/calculate-cpmm'
 import { getCpmmMultiSellBetInfo, getCpmmSellBetInfo } from 'common/sell-bet'
 import { floatingLesserEqual } from 'common/util/math'
 import { randomString } from 'common/util/random'
@@ -95,9 +96,9 @@ const calculateSellResult = (
         'Cannot bet until at least two answers are added.'
       )
 
-    return {
-      newP: 0.5,
-      ...getCpmmMultiSellBetInfo(
+    let multiSellInfo
+    try {
+      multiSellInfo = getCpmmMultiSellBetInfo(
         contract,
         answers,
         answer,
@@ -107,7 +108,46 @@ const calculateSellResult = (
         unfilledBets,
         balanceByUserId,
         loanPaid
-      ),
+      )
+    } catch (e) {
+      // On a NaN-probability failure in the sum-to-one arbitrage, log the full
+      // read-time pool state for diagnosis, then rethrow unchanged.
+      if (
+        e instanceof Error &&
+        e.message.startsWith(CPMM_ARBITRAGE_ERROR_PREFIX)
+      ) {
+        log.error('Sell arbitrage failed on degenerate pool state', {
+          contractId: contract.id,
+          mechanism: contract.mechanism,
+          answerId,
+          outcome,
+          requestedShares: shares,
+          soldShares,
+          maxShares,
+          userTotalShares: sharesByOutcome,
+          unfilledBetCount: unfilledBets.length,
+          error: e.message,
+          answers: answers.map((a) => ({
+            id: a.id,
+            poolYes: a.poolYes,
+            poolNo: a.poolNo,
+            prob: a.prob,
+            resolution: a.resolution,
+            totalLiquidity: a.totalLiquidity,
+            degenerate:
+              !(a.poolYes > 0) ||
+              !(a.poolNo > 0) ||
+              !isFinite(a.poolYes) ||
+              !isFinite(a.poolNo),
+          })),
+        })
+      }
+      throw e
+    }
+
+    return {
+      newP: 0.5,
+      ...multiSellInfo,
     }
   }
 }

--- a/backend/shared/src/supabase/answers.ts
+++ b/backend/shared/src/supabase/answers.ts
@@ -88,36 +88,61 @@ export const bulkUpdateAnswers = async (
   await bulkUpdate(pg, 'answers', ['id'], updates.map(partialAnswerToRow))
 }
 
-export const answerToRow = (answer: Omit<Answer, 'id'> & { id?: string }) => ({
-  id: answer.id,
-  index: answer.index,
-  contract_id: answer.contractId,
-  user_id: answer.userId,
-  text: answer.text,
-  color: answer.color,
-  pool_yes: answer.poolYes,
-  pool_no: answer.poolNo,
-  prob: answer.prob,
-  total_liquidity: answer.totalLiquidity,
-  subsidy_pool: answer.subsidyPool,
-  created_time: answer.createdTime
-    ? millisToTs(answer.createdTime) + '::timestamptz'
-    : undefined,
-  is_other: answer.isOther,
-  resolution: answer.resolution,
-  resolution_time: answer.resolutionTime
-    ? millisToTs(answer.resolutionTime) + '::timestamptz'
-    : undefined,
-  resolution_probability: answer.resolutionProbability,
-  resolver_id: answer.resolverId,
-  prob_change_day: answer.probChanges?.day,
-  prob_change_week: answer.probChanges?.week,
-  prob_change_month: answer.probChanges?.month,
-  image_url: answer.imageUrl,
-  short_text: answer.shortText,
-  midpoint: answer.midpoint,
-  volume: answer.volume,
-})
+// Reject writes that would persist a degenerate CPMM pool (a pool side <= 0 or
+// non-finite). answerToRow is the single choke point every answer write passes
+// through.
+export const assertValidAnswerPoolWrite = (
+  answer: Pick<Partial<Answer>, 'id' | 'poolYes' | 'poolNo'>
+) => {
+  for (const key of ['poolYes', 'poolNo'] as const) {
+    const value = answer[key]
+    // undefined = not being written in this (partial) update; leave it alone.
+    if (value === undefined) continue
+    if (typeof value !== 'number' || !isFinite(value) || value <= 0) {
+      throw new Error(
+        `Refusing to write degenerate answer pool for answer ${
+          answer.id ?? '(no id)'
+        }: ${key}=${value} (poolYes=${answer.poolYes}, poolNo=${
+          answer.poolNo
+        }). CPMM pool sides must be finite and > 0.`
+      )
+    }
+  }
+}
+
+export const answerToRow = (answer: Omit<Answer, 'id'> & { id?: string }) => {
+  assertValidAnswerPoolWrite(answer)
+  return {
+    id: answer.id,
+    index: answer.index,
+    contract_id: answer.contractId,
+    user_id: answer.userId,
+    text: answer.text,
+    color: answer.color,
+    pool_yes: answer.poolYes,
+    pool_no: answer.poolNo,
+    prob: answer.prob,
+    total_liquidity: answer.totalLiquidity,
+    subsidy_pool: answer.subsidyPool,
+    created_time: answer.createdTime
+      ? millisToTs(answer.createdTime) + '::timestamptz'
+      : undefined,
+    is_other: answer.isOther,
+    resolution: answer.resolution,
+    resolution_time: answer.resolutionTime
+      ? millisToTs(answer.resolutionTime) + '::timestamptz'
+      : undefined,
+    resolution_probability: answer.resolutionProbability,
+    resolver_id: answer.resolverId,
+    prob_change_day: answer.probChanges?.day,
+    prob_change_week: answer.probChanges?.week,
+    prob_change_month: answer.probChanges?.month,
+    image_url: answer.imageUrl,
+    short_text: answer.shortText,
+    midpoint: answer.midpoint,
+    volume: answer.volume,
+  }
+}
 
 // does not convert isOther, loverUserId
 export const partialAnswerToRow = (answer: Partial<Answer>) => {


### PR DESCRIPTION
We've had some issues with bad CPMM pool state on some markets which has led to some users being unable to take certain actions (sell + arbitrage) until the pool is fixed by a later trade. Since the pool state is updated after each trade we can't see exactly why or how the state was degenerated. This PR adds a guard inside `answerToRow` that checks the pool state before each write to prevent it from being written, and then a log line on the sell path that dumps the full read-time pool state if it does happen to make it that far (or an existing market is already in this state).