### PR TITLE
fix(kyc): scope verify-bonus dedupe by description so next-day bonus doesn't block it

### DIFF
--- a/backend/api/src/idenfy/callback.ts
+++ b/backend/api/src/idenfy/callback.ts
@@ -6,7 +6,11 @@ import { getUser, log, getContractSupabase } from 'shared/utils'
 import { broadcastUpdatedPrivateUser } from 'shared/websockets/helpers'
 import { runTxnFromBank } from 'shared/txn/run-txn'
 import { runTransactionWithRetries } from 'shared/transact-with-retries'
-import { STARTING_BALANCE, REFERRAL_VERIFY_BONUS } from 'common/economy'
+import {
+  STARTING_BALANCE,
+  REFERRAL_VERIFY_BONUS,
+  VERIFIED_SIGNUP_BONUS_DESCRIPTION,
+} from 'common/economy'
 import { SignupBonusTxn } from 'common/txn'
 import { isUnderageDenial } from 'common/idenfy-helpers'
 import { createReferralNotification } from 'shared/create-notification'
@@ -315,11 +319,15 @@ export const idenfyCallback = async (req: Request, res: Response) => {
               : {}),
           })
 
-          // Pay signup bonus if not already paid
+          // Pay signup bonus if not already paid. Match on description, not
+          // category alone: the next-day signup bonus shares the SIGNUP_BONUS
+          // category, and a category-only check skipped this payment for any
+          // user whose next-day bonus landed before iDenfy approval.
           const existingSignupTxn = await tx.oneOrNone(
             `SELECT 1 FROM txns WHERE to_id = $1
-           AND category = 'SIGNUP_BONUS'`,
-            [userId]
+           AND category = 'SIGNUP_BONUS'
+           AND data->>'description' = $2`,
+            [userId, VERIFIED_SIGNUP_BONUS_DESCRIPTION]
           )
           if (!alreadyPaidBonus && !existingSignupTxn) {
             const signupBonusTxn: Omit<
@@ -332,7 +340,7 @@ export const idenfyCallback = async (req: Request, res: Response) => {
               amount: STARTING_BALANCE,
               token: 'M$',
               category: 'SIGNUP_BONUS',
-              description: 'Signup bonus (identity verified)',
+              description: VERIFIED_SIGNUP_BONUS_DESCRIPTION,
             }
             await runTxnFromBank(tx, signupBonusTxn)
             await updateUser(tx, userId, { signupBonusPaid: STARTING_BALANCE })

--- a/backend/scripts/backfill-missed-verify-bonuses.ts
+++ b/backend/scripts/backfill-missed-verify-bonuses.ts
@@ -1,0 +1,101 @@
+import { runScript } from 'run-script'
+import {
+  STARTING_BALANCE,
+  VERIFIED_SIGNUP_BONUS_DESCRIPTION,
+} from 'common/economy'
+import { runTxnFromBank } from 'shared/txn/run-txn'
+import { updateUser } from 'shared/supabase/users'
+
+// Pays the identity-verification signup bonus to users the iDenfy callback
+// skipped: its dedupe matched on category = 'SIGNUP_BONUS' alone, which
+// collides with the next-day signup bonus (same category), so anyone whose
+// next-day bonus landed before iDenfy approval was never paid. The callback
+// now matches on VERIFIED_SIGNUP_BONUS_DESCRIPTION as well; this backfills
+// the users skipped before that fix.
+//
+// Dry-runs by default (lists the cohort, pays nothing). Pass --commit to pay.
+
+const commit = process.argv.includes('--commit')
+
+runScript(async ({ pg }) => {
+  const users = await pg.manyOrNone<{
+    user_id: string
+    username: string
+    approved_time: string
+  }>(
+    `select
+        v.user_id,
+        u.username,
+        min(v.updated_time)::text as approved_time
+     from idenfy_verifications v
+     join users u on u.id = v.user_id
+     where v.status = 'approved'
+       and coalesce((u.data->>'signupBonusPaid')::numeric, 0) < $2
+       and not exists (
+         select 1
+         from txns t
+         where t.to_id = v.user_id
+           and t.category = 'SIGNUP_BONUS'
+           and t.data->>'description' = $1
+       )
+     group by v.user_id, u.id
+     order by approved_time`,
+    [VERIFIED_SIGNUP_BONUS_DESCRIPTION, STARTING_BALANCE]
+  )
+
+  console.log(`${users.length} users missing the verification signup bonus:`)
+  for (const u of users) {
+    console.log(`  ${u.user_id} (${u.username}) approved ${u.approved_time}`)
+  }
+  console.log(`Total to pay: ${users.length * STARTING_BALANCE} M$`)
+
+  if (!commit) {
+    console.log('Dry run only — rerun with --commit to pay.')
+    return
+  }
+
+  let paid = 0
+  for (const u of users) {
+    try {
+      const result = await pg.tx(async (tx) => {
+        // Re-check inside the transaction so reruns of this script (or a
+        // concurrent webhook retry) can't double-pay.
+        const existing = await tx.oneOrNone(
+          `select 1 from txns
+           where to_id = $1
+             and category = 'SIGNUP_BONUS'
+             and data->>'description' = $2`,
+          [u.user_id, VERIFIED_SIGNUP_BONUS_DESCRIPTION]
+        )
+        if (existing) return 'skipped'
+
+        await runTxnFromBank(tx, {
+          fromType: 'BANK',
+          toId: u.user_id,
+          toType: 'USER',
+          amount: STARTING_BALANCE,
+          token: 'M$',
+          category: 'SIGNUP_BONUS',
+          description: VERIFIED_SIGNUP_BONUS_DESCRIPTION,
+          data: { backfill: true },
+        })
+        await updateUser(tx, u.user_id, { signupBonusPaid: STARTING_BALANCE })
+        return 'paid'
+      })
+
+      if (result === 'paid') {
+        paid++
+        console.log(`Paid ${STARTING_BALANCE} to ${u.username} (${u.user_id})`)
+      } else {
+        console.log(`Skipped ${u.username} (${u.user_id}) — already paid`)
+      }
+    } catch (error) {
+      console.error(
+        `Failed for ${u.username} (${u.user_id}): ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    }
+  }
+  console.log(`Done. Paid ${paid}/${users.length} users.`)
+})

--- a/common/src/economy.ts
+++ b/common/src/economy.ts
@@ -43,6 +43,11 @@ export const BETTING_STREAK_SWEEPS_BONUS_MAX = 0.25
 // mana a fully-verified new user receives is PRE_KYC_STARTING_BALANCE + STARTING_BALANCE.
 export const PRE_KYC_STARTING_BALANCE = 500
 export const STARTING_BALANCE = 500
+// Also the dedupe key for the verification bonus txn: the SIGNUP_BONUS
+// category is shared with the next-day signup bonus, so payment checks must
+// match on this description too, not category alone.
+export const VERIFIED_SIGNUP_BONUS_DESCRIPTION =
+  'Signup bonus (identity verified)'
 // for sus users, i.e. multiple sign ups for same person
 export const SUS_STARTING_BALANCE = 10
 export const PHONE_VERIFICATION_BONUS = 1000


### PR DESCRIPTION
## Problem

The iDenfy approval callback (`backend/api/src/idenfy/callback.ts`) deduped the 500 M\$ verification signup bonus on `category = 'SIGNUP_BONUS'` **alone**:

```sql
SELECT 1 FROM txns WHERE to_id = $1 AND category = 'SIGNUP_BONUS'
```

But the **100 M\$ "Next day signup bonus"** (paid by the onboarding scheduler ~24h after signup) uses the *same* category. So any user whose next-day bonus landed **before** their iDenfy approval tripped the dedupe — the 500 M\$ top-up was silently skipped, while the same transaction still set `bonusEligibility = 'verified'` and left `signupBonusPaid = 0`. Users who verify within their first day are unaffected, which is why this went unnoticed.

Reported by user 2qb.

## Blast radius (prod)

- 973 iDenfy-approved users → **945 paid, 28 skipped**.
- All 28 skipped users have a next-day bonus txn dated before approval; **0 of the 945** paid users had any prior `SIGNUP_BONUS` txn — a clean split on the dedupe condition.
- Total owed: **28 × 500 = 14,000 M\$**.

## Fix

- New `VERIFIED_SIGNUP_BONUS_DESCRIPTION` constant in `common/src/economy.ts`, used by both the dedupe check and the payment so they can't drift.
- Dedupe now also requires `data->>'description' = VERIFIED_SIGNUP_BONUS_DESCRIPTION`. Retry/double-fire protection is intact — all 945 legitimately-paid txns carry that exact description; the only txns that no longer block payment are the next-day bonuses that were never meant to.

## Backfill

`backend/scripts/backfill-missed-verify-bonuses.ts` pays the affected cohort:
- Dry-run by default; `--commit` to pay.
- One transaction per user with an in-transaction recheck of the dedupe condition, so reruns (or a race with a live webhook) can't double-pay.
- Uses `runTxnFromBank` + sets `signupBonusPaid = 500`, exactly mirroring the callback. Backfill txns tagged `data.backfill = true`.
- Also serves as the safe rerunnable sweep for any stragglers that verify between now and this deploying.

## Validation

- `backend/api` + `common` typecheck clean.
- Cohort SQL validated read-only against prod: returns exactly the 28 users, 2qb included.