### PR TITLE
Remove World Cup pill from homepage search topic row

### DIFF
--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -575,20 +575,6 @@ export function Search(props: SearchProps) {
                   </button>
                 )}
                 <Link
-                  href="/sports/world-cup-2026"
-                  onClick={() =>
-                    track('select search topic', { topic: 'world-cup-2026' })
-                  }
-                  className={clsx(
-                    'shrink-0 self-center whitespace-nowrap rounded-full px-2.5 py-0.5 font-medium text-white',
-                    'bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500',
-                    'shadow-sm shadow-purple-500/30 ring-1 ring-white/20',
-                    'transition-all hover:brightness-110'
-                  )}
-                >
-                  ⚽ World Cup
-                </Link>
-                <Link
                   href="/election"
                   onClick={() =>
                     track('select search topic', { topic: 'midterms-2026' })
@@ -677,6 +663,7 @@ export function Search(props: SearchProps) {
                   ? 'Search'
                   : 'Search questions, users, topics, and posts'
               }
+              // eslint-disable-next-line jsx-a11y/no-autofocus -- intentional: only true when opening the search popover, where focusing the input is expected
               autoFocus={autoFocus}
               loading={loading}
               inputId={searchInputId}


### PR DESCRIPTION
## What

The FIFA World Cup 2026 is over (and was a success! ⚽), so this removes the promotional **⚽ World Cup** pill from the topic carousel at the top of the browse/search page — the gradient link that pointed to `/sports/world-cup-2026`.

## Scope

- **Removed:** just the homepage pill link in `web/components/search.tsx`. The `2026 Midterms` pill and the rest of the topic row are untouched.
- **Left in place:** the dashboard page itself (`web/pages/sports/world-cup-2026.tsx`) and all underlying sports/topic infrastructure — it's simply no longer surfaced from the topic row. Happy to retire the page too in a follow-up if wanted.

## Note on the extra one-line change

`lint-staged` re-lints the entire file on commit and tripped on a **pre-existing** `jsx-a11y/no-autofocus` violation on the search input (on `main` since April 2026, unrelated to this change). Since that `autoFocus` is only ever `true` when opening the search popover — where focusing the input is the intended, expected behavior — I added a documented `eslint-disable-next-line` rather than changing any behavior. This unblocks the hook.