### PR TITLE
fix: disable Redis in deploy-api-windows.sh prod to match deploy-api.sh (#3921)

### DIFF
--- a/backend/api/deploy-api-windows.sh
+++ b/backend/api/deploy-api-windows.sh
@@ -34,8 +34,11 @@ case $ENV in
         NEXT_PUBLIC_FIREBASE_ENV=PROD
         # Private Memorystore instance. Passed at the container level so both
         # the main API process and PM2 read replicas inherit it.
-        REDIS_URL=redis://10.215.204.211:6379
-        DISABLE_REDIS_CACHE=false
+        # Disabled since we scaled back down to one instance.
+        # REDIS_URL=redis://10.215.204.211:6379
+        # DISABLE_REDIS_CACHE=false
+        REDIS_URL=
+        DISABLE_REDIS_CACHE=true
         GCLOUD_PROJECT=mantic-markets
         MACHINE_TYPE=c2-standard-4 ;;
     *)


### PR DESCRIPTION
`deploy-api-windows.sh` was never updated when #3921 ("Scale back api servers from 2-3 to 1") disabled Redis in the canonical `deploy-api.sh`. The Windows script kept the old 2-3-instance config:

- `REDIS_URL=redis://10.215.204.211:6379`
- `DISABLE_REDIS_CACHE=false`

so `deploy-api-windows.sh prod` re-enables Redis in prod (the L2 cache + inter-instance websocket relay from #3888/#3902), which is redundant at a single instance. This happened on a prod deploy on 2026-07-21 — no outage (the Memorystore instance is still `READY`), but it's unintended config drift.

This mirrors #3921's change to `deploy-api.sh`: comment out the Memorystore config and set `REDIS_URL=` / `DISABLE_REDIS_CACHE=true`. The two scripts' prod env blocks are now byte-for-byte identical.

No change to the API image — only the container env for Windows-originated prod deploys.
