### PR TITLE
fix(emails): screen sensitive market titles from digest subjects & notification previews

### DIFF
--- a/backend/email-templates/interesting-markets.html
+++ b/backend/email-templates/interesting-markets.html
@@ -229,7 +229,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question1Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question1Title}}</a>
                                                 <a href="{{question1Link}}">
                                                     <img alt="{{question1Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question1ImgSrc}}">
@@ -241,7 +240,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question1Link}}" target="_blank"
                                                             style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -255,7 +254,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question2Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question2Title}}</a>
                                                 <a href="{{question2Link}}">
                                                     <img alt="{{question2Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question2ImgSrc}}">
@@ -267,7 +265,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question2Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -281,7 +279,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question3Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question3Title}}</a>
                                                 <a href="{{question3Link}}">
                                                     <img alt="{{question3Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question3ImgSrc}}">
@@ -293,7 +290,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question3Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -307,7 +304,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question4Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question4Title}}</a>
                                                 <a href="{{question4Link}}">
                                                     <img alt="{{question4Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question4ImgSrc}}">
@@ -319,7 +315,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question4Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -333,7 +329,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question5Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question5Title}}</a>
                                                 <a href="{{question5Link}}">
                                                     <img alt="{{question5Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question5ImgSrc}}">
@@ -345,7 +340,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question5Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -359,7 +354,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question6Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question6Title}}</a>
                                                 <a href="{{question6Link}}">
                                                     <img alt="{{question6Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question6ImgSrc}}">
@@ -371,7 +365,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question6Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>

--- a/backend/email-templates/interesting-markets.html
+++ b/backend/email-templates/interesting-markets.html
@@ -103,6 +103,7 @@
 </head>
 
 <body style="word-spacing: normal; background-color: #f4f4f4">
+    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;">{{previewText}}</div>
     <div style="margin:0px auto;max-width:600px;">
 
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -228,6 +229,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question1Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question1Title}}</a>
                                                 <a href="{{question1Link}}">
                                                     <img alt="{{question1Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question1ImgSrc}}">
@@ -239,7 +241,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question1Link}}" target="_blank"
                                                             style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -253,6 +255,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question2Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question2Title}}</a>
                                                 <a href="{{question2Link}}">
                                                     <img alt="{{question2Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question2ImgSrc}}">
@@ -264,7 +267,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question2Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -278,6 +281,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question3Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question3Title}}</a>
                                                 <a href="{{question3Link}}">
                                                     <img alt="{{question3Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question3ImgSrc}}">
@@ -289,7 +293,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question3Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -303,6 +307,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question4Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question4Title}}</a>
                                                 <a href="{{question4Link}}">
                                                     <img alt="{{question4Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question4ImgSrc}}">
@@ -314,7 +319,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question4Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -328,6 +333,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question5Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question5Title}}</a>
                                                 <a href="{{question5Link}}">
                                                     <img alt="{{question5Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question5ImgSrc}}">
@@ -339,7 +345,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question5Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -353,6 +359,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question6Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question6Title}}</a>
                                                 <a href="{{question6Link}}">
                                                     <img alt="{{question6Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question6ImgSrc}}">
@@ -364,7 +371,7 @@
                                                     <td style="border-radius: 4px; padding-top: 5px" bgcolor="white">
                                                         <a href="{{question6Link}}" target="_blank"
                                                            style="padding: 8px 10px; border: 1px solid #4337c9;border-radius: 5px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>

--- a/backend/email-templates/sign-up-bonus-with-interesting-markets.html
+++ b/backend/email-templates/sign-up-bonus-with-interesting-markets.html
@@ -235,7 +235,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question1Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question1Title}}</a>
                                                 <a href="{{question1Link}}">
                                                     <img alt="{{question1Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question1ImgSrc}}">
@@ -247,7 +246,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question1Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -261,7 +260,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question2Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question2Title}}</a>
                                                 <a href="{{question2Link}}">
                                                     <img alt="{{question2Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question2ImgSrc}}">
@@ -273,7 +271,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question2Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -287,7 +285,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question3Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question3Title}}</a>
                                                 <a href="{{question3Link}}">
                                                     <img alt="{{question3Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question3ImgSrc}}">
@@ -299,7 +296,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question3Link}}" target="_blank"
                                                            style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -313,7 +310,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question4Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question4Title}}</a>
                                                 <a href="{{question4Link}}">
                                                     <img alt="{{question4Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question4ImgSrc}}">
@@ -325,7 +321,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question4Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -339,7 +335,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question5Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question5Title}}</a>
                                                 <a href="{{question5Link}}">
                                                     <img alt="{{question5Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question5ImgSrc}}">
@@ -351,7 +346,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question5Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -365,7 +360,6 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
-                                                <a href="{{question6Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question6Title}}</a>
                                                 <a href="{{question6Link}}">
                                                     <img alt="{{question6Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question6ImgSrc}}">
@@ -377,7 +371,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question6Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Place your bet
+                                                            Bet on question
                                                         </a>
                                                     </td>
                                                 </tr>

--- a/backend/email-templates/sign-up-bonus-with-interesting-markets.html
+++ b/backend/email-templates/sign-up-bonus-with-interesting-markets.html
@@ -103,6 +103,7 @@
 </head>
 
 <body style="word-spacing: normal; background-color: #f4f4f4">
+    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;mso-hide:all;">{{previewText}}</div>
     <div style="margin:0px auto;max-width:600px;">
 
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
@@ -234,6 +235,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question1Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question1Title}}</a>
                                                 <a href="{{question1Link}}">
                                                     <img alt="{{question1Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question1ImgSrc}}">
@@ -245,7 +247,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question1Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -259,6 +261,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question2Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question2Title}}</a>
                                                 <a href="{{question2Link}}">
                                                     <img alt="{{question2Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question2ImgSrc}}">
@@ -270,7 +273,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question2Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -284,6 +287,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question3Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question3Title}}</a>
                                                 <a href="{{question3Link}}">
                                                     <img alt="{{question3Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question3ImgSrc}}">
@@ -295,7 +299,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question3Link}}" target="_blank"
                                                            style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -309,6 +313,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question4Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question4Title}}</a>
                                                 <a href="{{question4Link}}">
                                                     <img alt="{{question4Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question4ImgSrc}}">
@@ -320,7 +325,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question4Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -334,6 +339,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question5Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question5Title}}</a>
                                                 <a href="{{question5Link}}">
                                                     <img alt="{{question5Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question5ImgSrc}}">
@@ -345,7 +351,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question5Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>
@@ -359,6 +365,7 @@
                                             style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:20px;word-break:break-word;">
                                             <div
                                                 style="font-family:Arial, sans-serif;font-size:18px;letter-spacing:normal;line-height:1;text-align:center;color:#000000;">
+                                                <a href="{{question6Link}}" target="_blank" style="display:block;padding-bottom:8px;font-family:Arial, sans-serif;font-size:18px;font-weight:bold;line-height:1.3;color:#4337c9;text-decoration:none;">{{question6Title}}</a>
                                                 <a href="{{question6Link}}">
                                                     <img alt="{{question6Title}}" width="375" height="200"
                                                         style="border: 1px solid #4337c9;" src="{{question6ImgSrc}}">
@@ -370,7 +377,7 @@
                                                     <td style="border-radius: 4px;" bgcolor="white">
                                                         <a href="{{question6Link}}" target="_blank"
                                                             style="padding: 6px 10px; border: 1px solid #4337c9;border-radius: 12px;font-family: Helvetica, Arial, sans-serif;font-size: 16px; color: black;text-decoration: none;font-weight:semibold;display: inline-block;">
-                                                            Bet on question
+                                                            Place your bet
                                                         </a>
                                                     </td>
                                                 </tr>

--- a/backend/scripts/test-email-subject-safety.ts
+++ b/backend/scripts/test-email-subject-safety.ts
@@ -1,0 +1,124 @@
+// Dress rehearsal for the digest email subject/preview sensitivity pipeline.
+//
+// Default (no args): classifier dry run — classifies a hardcoded sample of
+// real prod titles, prints keyword vs final verdicts, and prints the subject
+// and previewText that would result. No email is sent and nothing is written
+// to the DB. Only needs GEMINI_API_KEY (loaded by runScript).
+//
+// --send-to <username>: full dress rehearsal — looks up the user, fetches
+// their 6 for-you markets, and sends ONE real digest email via Mailgun to
+// that user's address (also uses MAILGUN_KEY). Note: until the new template
+// version is uploaded to Mailgun, the {{previewText}} preheader won't appear
+// in the email — old template + new code is safe (the extra var is ignored).
+import { runScript } from 'run-script'
+import {
+  classifyQuestionSensitivity,
+  isSensitiveQuestion,
+} from 'shared/helpers/email-subject-safety'
+import { sendInterestingMarketsEmail } from 'shared/emails'
+import { getPrivateUser, getUserByUsername } from 'shared/utils'
+import { getForYouMarkets } from 'shared/weekly-markets-emails'
+
+const SAMPLE_QUESTIONS = [
+  {
+    id: 's1',
+    question:
+      'Will there be a second shooting event related to the Bondi Beach mass shooting within one year?',
+  },
+  { id: 's2', question: 'Mitch McConnell alive all of July 2026?' },
+  {
+    id: 's3',
+    question: 'Which AI lab will get a perfect score on the IMO 2026?',
+  },
+  { id: 's4', question: '2026 FIFA World Cup prop bets' },
+  { id: 's5', question: 'Silver below $50/ oz by close on Friday?' },
+  {
+    id: 's6',
+    question:
+      'Will an AI solve any important mathematical conjecture before January 1st, 2030?',
+  },
+]
+
+const truncate = (s: string, n = 60) =>
+  s.length > n ? s.slice(0, n - 3) + '...' : s
+
+if (require.main === module) {
+  runScript(async ({ pg }) => {
+    const args = process.argv.slice(2)
+    const sendToIdx = args.indexOf('--send-to')
+
+    if (sendToIdx !== -1) {
+      const username = args[sendToIdx + 1]
+      if (!username) {
+        console.error(
+          'Usage: ts-node test-email-subject-safety.ts --send-to <username>'
+        )
+        return
+      }
+      const user = await getUserByUsername(username, pg)
+      if (!user) {
+        console.error(`No user found with username '${username}'`)
+        return
+      }
+      const privateUser = await getPrivateUser(user.id, pg)
+      if (!privateUser) {
+        console.error(`No private user found for user id ${user.id}`)
+        return
+      }
+
+      // getForYouSQL self-builds the topic-interests cache for the user if
+      // it is empty, so no explicit buildUserInterestsCache call is needed.
+      const contracts = await getForYouMarkets(user.id, 6, privateUser)
+      if (contracts.length < 6) {
+        console.error(
+          `Only got ${contracts.length} contracts for '${username}' but the digest template indexes [0..5]. Not sending.`
+        )
+        return
+      }
+
+      console.log(`Markets chosen for ${username} (first 6 are used):`)
+      for (const c of contracts.slice(0, 6)) {
+        console.log(`- [${c.id}] ${c.question}`)
+      }
+      await sendInterestingMarketsEmail(user.name, privateUser, contracts)
+      console.log(
+        'Done. The subject used is logged by sendTemplateEmail above. (If the user has unsubscribed from trending_markets emails, sending is silently skipped.)'
+      )
+      return
+    }
+
+    // Default: classifier dry run on the sample titles.
+    const verdicts = await classifyQuestionSensitivity(SAMPLE_QUESTIONS)
+
+    console.log(
+      `${'title'.padEnd(62)} | ${'keyword'.padEnd(7)} | final`
+    )
+    console.log('-'.repeat(82))
+    for (const { id, question } of SAMPLE_QUESTIONS) {
+      const keyword = isSensitiveQuestion(question)
+      const final = verdicts.get(id) ?? false
+      console.log(
+        `${truncate(question).padEnd(62)} | ${String(keyword).padEnd(
+          7
+        )} | ${final}`
+      )
+    }
+
+    // Same derivation as sendInterestingMarketsEmail.
+    const safeQuestions = SAMPLE_QUESTIONS.filter(
+      (c) => !verdicts.get(c.id)
+    ).map((c) => c.question)
+    const subject =
+      safeQuestions.length > 0
+        ? `${safeQuestions[0]} & 5 more interesting markets on Manifold`
+        : `6 interesting markets on Manifold this week`
+    const previewText =
+      safeQuestions.length > 0
+        ? safeQuestions.join(' · ')
+        : 'Six markets picked for you this week'
+
+    console.log('')
+    console.log(`Subject:     ${subject}`)
+    console.log(`PreviewText: ${previewText}`)
+  })
+}

--- a/backend/scripts/update-email-templates.ts
+++ b/backend/scripts/update-email-templates.ts
@@ -1,0 +1,77 @@
+// Syncs repo copies of email templates (backend/email-templates/<name>.html)
+// to the live Mailgun-hosted templates on mg.manifold.markets. Repo edits do
+// nothing until uploaded with this script.
+//
+// Usage:
+//   ts-node update-email-templates.ts interesting-markets sign-up-bonus-with-interesting-markets
+//   ts-node update-email-templates.ts interesting-markets --go
+//
+// Dry-runs by default; pass --go to actually POST a new active version.
+// Mailgun keeps prior versions of each template, so this is reversible from
+// the Mailgun dashboard (Sending > Templates > <name> > Versions). Mailgun
+// also caps the number of stored versions per template — if the POST returns
+// a version-limit error, delete old versions in the dashboard and re-run.
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { runScript } from 'run-script'
+
+const MAILGUN_DOMAIN = 'mg.manifold.markets'
+
+if (require.main === module) {
+  runScript(async () => {
+    const args = process.argv.slice(2)
+    const go = args.includes('--go')
+    const templateNames = args.filter((a) => a !== '--go')
+
+    if (templateNames.length === 0) {
+      console.log(
+        'Usage: ts-node update-email-templates.ts <template-name> [<template-name> ...] [--go]'
+      )
+      console.log(
+        'Template names correspond to files in backend/email-templates/<name>.html'
+      )
+      console.log(
+        'Dry-runs by default; pass --go to upload a new active version to Mailgun.'
+      )
+      return
+    }
+
+    for (const name of templateNames) {
+      const filePath = join(__dirname, '..', 'email-templates', `${name}.html`)
+      const template = readFileSync(filePath, 'utf8')
+      const bytes = Buffer.byteLength(template, 'utf8')
+      const url = `https://api.mailgun.net/v3/${MAILGUN_DOMAIN}/templates/${name}/versions`
+
+      if (!go) {
+        console.log(
+          `[dry run] ${name}: ${bytes} bytes — would POST a new active version to ${url}`
+        )
+        continue
+      }
+
+      const apiKey = process.env.MAILGUN_KEY
+      if (!apiKey) throw new Error('Missing MAILGUN_KEY')
+
+      const tag = `repo-sync-${new Date().toISOString().slice(0, 10)}`
+      console.log(`Uploading ${name} (${bytes} bytes) as version ${tag}...`)
+
+      const body = new URLSearchParams({
+        template,
+        tag,
+        active: 'yes',
+      })
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${Buffer.from(`api:${apiKey}`).toString(
+            'base64'
+          )}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      })
+      console.log(`${name}: ${res.status} ${res.statusText}`)
+      console.log(await res.text())
+    }
+  })
+}

--- a/backend/shared/src/emails.ts
+++ b/backend/shared/src/emails.ts
@@ -16,10 +16,7 @@ import {
 } from 'common/util/format'
 import { formatNumericProbability } from 'common/pseudo-numeric'
 import { sendTemplateEmail, sendTextEmail } from './send-email'
-import {
-  isSensitiveQuestion,
-  pickSubjectQuestion,
-} from 'shared/helpers/email-subject-safety'
+import { classifyQuestionSensitivity } from 'shared/helpers/email-subject-safety'
 import { contractUrl, getPrivateUser, getUser, log } from 'shared/utils'
 import { getContractOGProps } from 'common/contract-seo'
 import {
@@ -542,21 +539,21 @@ export const sendInterestingMarketsEmail = async (
   const firstName = userName.split(' ')[0]
 
   const shownContracts = contractsToSend.slice(0, 6)
-  const subjectQuestion = pickSubjectQuestion(
-    shownContracts.map((c) => c.question)
+  const sensitiveById = await classifyQuestionSensitivity(
+    shownContracts.map((c) => ({ id: c.id, question: c.question }))
   )
-  const subject = subjectQuestion
-    ? `${subjectQuestion} & 5 more interesting markets on Manifold`
-    : `6 interesting markets on Manifold this week`
-
+  const safeQuestions = shownContracts
+    .filter((c) => !sensitiveById.get(c.id))
+    .map((c) => c.question)
+  const subject =
+    safeQuestions.length > 0
+      ? `${safeQuestions[0]} & 5 more interesting markets on Manifold`
+      : `6 interesting markets on Manifold this week`
   // Shown in the inbox preview / push notification via a hidden preheader
   // div in the template, so it is screened like the subject.
-  const previewQuestions = shownContracts
-    .map((c) => c.question)
-    .filter((q) => !isSensitiveQuestion(q))
   const previewText =
-    previewQuestions.length > 0
-      ? previewQuestions.join(' · ')
+    safeQuestions.length > 0
+      ? safeQuestions.join(' · ')
       : 'Six markets picked for you this week'
 
   await sendTemplateEmail(
@@ -611,13 +608,16 @@ export const sendBonusWithInterestingMarketsEmail = async (
 
   // Shown in the inbox preview / push notification via a hidden preheader
   // div in the template, so it is screened like the subject.
-  const previewQuestions = contractsToSend
-    .slice(0, 6)
+  const shownContracts = contractsToSend.slice(0, 6)
+  const sensitiveById = await classifyQuestionSensitivity(
+    shownContracts.map((c) => ({ id: c.id, question: c.question }))
+  )
+  const safeQuestions = shownContracts
+    .filter((c) => !sensitiveById.get(c.id))
     .map((c) => c.question)
-    .filter((q) => !isSensitiveQuestion(q))
   const previewText =
-    previewQuestions.length > 0
-      ? previewQuestions.join(' · ')
+    safeQuestions.length > 0
+      ? safeQuestions.join(' · ')
       : 'Six markets picked for you this week'
 
   await sendTemplateEmail(

--- a/backend/shared/src/emails.ts
+++ b/backend/shared/src/emails.ts
@@ -16,6 +16,10 @@ import {
 } from 'common/util/format'
 import { formatNumericProbability } from 'common/pseudo-numeric'
 import { sendTemplateEmail, sendTextEmail } from './send-email'
+import {
+  isSensitiveQuestion,
+  pickSubjectQuestion,
+} from 'shared/helpers/email-subject-safety'
 import { contractUrl, getPrivateUser, getUser, log } from 'shared/utils'
 import { getContractOGProps } from 'common/contract-seo'
 import {
@@ -537,13 +541,32 @@ export const sendInterestingMarketsEmail = async (
 
   const firstName = userName.split(' ')[0]
 
+  const shownContracts = contractsToSend.slice(0, 6)
+  const subjectQuestion = pickSubjectQuestion(
+    shownContracts.map((c) => c.question)
+  )
+  const subject = subjectQuestion
+    ? `${subjectQuestion} & 5 more interesting markets on Manifold`
+    : `6 interesting markets on Manifold this week`
+
+  // Shown in the inbox preview / push notification via a hidden preheader
+  // div in the template, so it is screened like the subject.
+  const previewQuestions = shownContracts
+    .map((c) => c.question)
+    .filter((q) => !isSensitiveQuestion(q))
+  const previewText =
+    previewQuestions.length > 0
+      ? previewQuestions.join(' · ')
+      : 'Six markets picked for you this week'
+
   await sendTemplateEmail(
     privateUser.email,
-    `${contractsToSend[0].question} & 5 more interesting markets on Manifold`,
+    subject,
     'interesting-markets',
     {
       name: firstName,
       unsubscribeUrl,
+      previewText,
       question1Title: contractsToSend[0].question,
       question1Link: contractUrl(contractsToSend[0]),
       question1ImgSrc: imageSourceUrl(contractsToSend[0]),
@@ -586,6 +609,17 @@ export const sendBonusWithInterestingMarketsEmail = async (
   const { name } = user
   const firstName = name.split(' ')[0]
 
+  // Shown in the inbox preview / push notification via a hidden preheader
+  // div in the template, so it is screened like the subject.
+  const previewQuestions = contractsToSend
+    .slice(0, 6)
+    .map((c) => c.question)
+    .filter((q) => !isSensitiveQuestion(q))
+  const previewText =
+    previewQuestions.length > 0
+      ? previewQuestions.join(' · ')
+      : 'Six markets picked for you this week'
+
   await sendTemplateEmail(
     privateUser.email,
     `Interesting questions on Manifold + ${bonusAmount} bonus mana`,
@@ -593,6 +627,7 @@ export const sendBonusWithInterestingMarketsEmail = async (
     {
       name: firstName,
       unsubscribeUrl,
+      previewText,
       bonusAmount: formatMoney(bonusAmount),
       question1Title: contractsToSend[0].question,
       question1Link: contractUrl(contractsToSend[0]),

--- a/backend/shared/src/helpers/email-subject-safety.ts
+++ b/backend/shared/src/helpers/email-subject-safety.ts
@@ -1,11 +1,11 @@
 import { log } from 'shared/utils'
-import { models, promptClaudeParsingJson } from './claude'
+import { models, promptGeminiParsingJson } from './gemini'
 
 // Screens market titles before they are used in email subject lines and
 // inbox preview text. Markets about violent or tragic events are fine to
 // include in the email body, but should not headline a push notification.
 // Over-blocking is cheap (the next market's title is used instead), so this
-// list errs broad. It is the floor and the fallback: the Haiku classifier
+// list errs broad. It is the floor and the fallback: the Gemini classifier
 // below can only add sensitivity on top of it, never clear a keyword flag.
 const SENSITIVE_TITLE_PATTERNS = [
   /\bshoot(ing|ings|er|ers|out)?s?\b/i,
@@ -59,7 +59,7 @@ const isVerdictEntry = (v: unknown): v is { id: string; sensitive: boolean } =>
 
 // Returns a contract id -> isSensitive map for exactly the requested
 // contracts. Verdict = keyword screen OR LLM verdict. On any LLM failure or
-// timeout (including a missing ANTHROPIC_API_KEY), falls back to
+// timeout (including a missing GEMINI_API_KEY), falls back to
 // keyword-only verdicts — an email must never fail or block on this.
 export const classifyQuestionSensitivity = async (
   contracts: { id: string; question: string }[]
@@ -86,9 +86,10 @@ export const classifyQuestionSensitivity = async (
       )
     })
     const response = await Promise.race([
-      promptClaudeParsingJson<unknown>(prompt, {
-        model: models.haiku,
+      promptGeminiParsingJson<unknown>(prompt, {
+        model: models.flash,
         system: CLASSIFY_SYSTEM_PROMPT,
+        thinkingLevel: 'minimal',
       }),
       timeout,
     ]).finally(() => clearTimeout(timer))
@@ -102,6 +103,7 @@ export const classifyQuestionSensitivity = async (
       : []
 
     const uncachedIds = new Set(uncached.map((c) => c.id))
+    const answeredIds: string[] = []
     for (const { id, sensitive } of llmVerdicts) {
       if (!uncachedIds.has(id)) continue
       // Union: the LLM can only add sensitivity, never clear a keyword flag.
@@ -111,7 +113,12 @@ export const classifyQuestionSensitivity = async (
       // not cached, so they get retried on the next call.
       if (sensitivityCache.size > 20_000) sensitivityCache.clear()
       sensitivityCache.set(id, final)
+      answeredIds.push(id)
     }
+    log('Classified email question sensitivity', {
+      classified: answeredIds.length,
+      flagged: answeredIds.filter((id) => verdicts.get(id)),
+    })
   } catch (error) {
     log.warn('Sensitivity classification failed; using keyword verdicts', {
       error: error instanceof Error ? error.message : String(error),

--- a/backend/shared/src/helpers/email-subject-safety.ts
+++ b/backend/shared/src/helpers/email-subject-safety.ts
@@ -1,0 +1,43 @@
+// Screens market titles before they are used in email subject lines and
+// inbox preview text. Markets about violent or tragic events are fine to
+// include in the email body, but should not headline a push notification.
+// Over-blocking is cheap (the next market's title is used instead), so this
+// list errs broad. A cached per-contract LLM verdict can be layered on later.
+const SENSITIVE_TITLE_PATTERNS = [
+  /\bshoot(ing|ings|er|ers|out)?s?\b/i,
+  /\bshot\b/i,
+  /\bgun(man|men|fire|shot|shots)?\b/i,
+  /\bkill(ed|ing|ings|s|er|ers)?\b/i,
+  /\bmurder/i,
+  /\bsuicide/i,
+  /\bdie(s|d)?\b/i,
+  /\bdeath(s)?\b/i,
+  /\bdead(ly)?\b/i,
+  /\bfatal(ity|ities)?\b/i,
+  /\bcasualt(y|ies)\b/i,
+  /\bmassacre/i,
+  /\bterror(ism|ist|ists)?\b/i,
+  /\bbomb(ing|ings|er|ers|s)?\b/i,
+  /\bassassinat/i,
+  /\bgenocide/i,
+  /\bhostage/i,
+  /\brape\b/i,
+  /\bsexual (assault|abuse)/i,
+  /\bwar(s)?\b/i,
+  /\binvasion\b|\binvade(s|d)?\b/i,
+  /\bairstrike(s)?\b|\bair strike(s)?\b/i,
+  /\bnuke(s|d)?\b|\bnuclear (war|strike|attack|weapon)/i,
+  /\boverdose/i,
+  /\bexecution(s)?\b/i,
+  /\bkidnap/i,
+  /\bstabb(ed|ing)/i,
+  /\bhate crime/i,
+  /\b(plane|helicopter|train) crash/i,
+]
+
+export const isSensitiveQuestion = (question: string) =>
+  SENSITIVE_TITLE_PATTERNS.some((re) => re.test(question))
+
+// First question safe to headline the email subject, if any.
+export const pickSubjectQuestion = (questions: string[]) =>
+  questions.find((q) => !isSensitiveQuestion(q))

--- a/backend/shared/src/helpers/email-subject-safety.ts
+++ b/backend/shared/src/helpers/email-subject-safety.ts
@@ -1,8 +1,12 @@
+import { log } from 'shared/utils'
+import { models, promptClaudeParsingJson } from './claude'
+
 // Screens market titles before they are used in email subject lines and
 // inbox preview text. Markets about violent or tragic events are fine to
 // include in the email body, but should not headline a push notification.
 // Over-blocking is cheap (the next market's title is used instead), so this
-// list errs broad. A cached per-contract LLM verdict can be layered on later.
+// list errs broad. It is the floor and the fallback: the Haiku classifier
+// below can only add sensitivity on top of it, never clear a keyword flag.
 const SENSITIVE_TITLE_PATTERNS = [
   /\bshoot(ing|ings|er|ers|out)?s?\b/i,
   /\bshot\b/i,
@@ -38,6 +42,81 @@ const SENSITIVE_TITLE_PATTERNS = [
 export const isSensitiveQuestion = (question: string) =>
   SENSITIVE_TITLE_PATTERNS.some((re) => re.test(question))
 
-// First question safe to headline the email subject, if any.
-export const pickSubjectQuestion = (questions: string[]) =>
-  questions.find((q) => !isSensitiveQuestion(q))
+// Contract id -> final sensitivity verdict. The weekly digest draws every
+// user's 6 markets from a shared pool of roughly the top-200 markets, so
+// classification is per unique contract, never per email.
+const sensitivityCache = new Map<string, boolean>()
+
+const CLASSIFY_TIMEOUT_MS = 10_000
+
+const CLASSIFY_SYSTEM_PROMPT = `You screen prediction-market question titles before they are used as email subject lines and push-notification previews for a betting platform. A title is sensitive if it references violence, death, tragedy, disaster, self-harm, sexual content, or would otherwise be jarring or distasteful as a notification headline inviting the reader to bet. Err on the side of sensitive.`
+
+const isVerdictEntry = (v: unknown): v is { id: string; sensitive: boolean } =>
+  typeof v === 'object' &&
+  v !== null &&
+  typeof (v as { id?: unknown }).id === 'string' &&
+  typeof (v as { sensitive?: unknown }).sensitive === 'boolean'
+
+// Returns a contract id -> isSensitive map for exactly the requested
+// contracts. Verdict = keyword screen OR LLM verdict. On any LLM failure or
+// timeout (including a missing ANTHROPIC_API_KEY), falls back to
+// keyword-only verdicts — an email must never fail or block on this.
+export const classifyQuestionSensitivity = async (
+  contracts: { id: string; question: string }[]
+): Promise<Map<string, boolean>> => {
+  const verdicts = new Map<string, boolean>()
+  for (const { id, question } of contracts) {
+    const cached = sensitivityCache.get(id)
+    verdicts.set(id, cached ?? isSensitiveQuestion(question))
+  }
+
+  const uncached = contracts.filter((c) => !sensitivityCache.has(c.id))
+  if (uncached.length === 0) return verdicts
+
+  try {
+    const prompt = `Classify each of these prediction-market question titles. Respond with strict JSON of the form {"verdicts": [{"id": string, "sensitive": boolean}]} and nothing else.\n\n${JSON.stringify(
+      uncached.map(({ id, question }) => ({ id, question }))
+    )}`
+
+    let timer: NodeJS.Timeout | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error('Sensitivity classification timed out')),
+        CLASSIFY_TIMEOUT_MS
+      )
+    })
+    const response = await Promise.race([
+      promptClaudeParsingJson<unknown>(prompt, {
+        model: models.haiku,
+        system: CLASSIFY_SYSTEM_PROMPT,
+      }),
+      timeout,
+    ]).finally(() => clearTimeout(timer))
+
+    const rawVerdicts =
+      typeof response === 'object' && response !== null
+        ? (response as { verdicts?: unknown }).verdicts
+        : undefined
+    const llmVerdicts = Array.isArray(rawVerdicts)
+      ? rawVerdicts.filter(isVerdictEntry)
+      : []
+
+    const uncachedIds = new Set(uncached.map((c) => c.id))
+    for (const { id, sensitive } of llmVerdicts) {
+      if (!uncachedIds.has(id)) continue
+      // Union: the LLM can only add sensitivity, never clear a keyword flag.
+      const final = (verdicts.get(id) ?? false) || sensitive
+      verdicts.set(id, final)
+      // Contracts the LLM did not answer keep their keyword verdict and are
+      // not cached, so they get retried on the next call.
+      if (sensitivityCache.size > 20_000) sensitivityCache.clear()
+      sensitivityCache.set(id, final)
+    }
+  } catch (error) {
+    log.warn('Sensitivity classification failed; using keyword verdicts', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return verdicts
+}


### PR DESCRIPTION
**Avoid future email subjects with sensitive topics** — last week's digest went out titled *"Will there be a mass shooting on Wednesday? & 5 more interesting markets on Manifold"*. The subject line blindly used the recipient's #1 ranked market. This PR screens what headlines the subject and the notification preview, without changing which markets appear in the email body.

## What changed

**Subject screening, two layers** (`backend/shared/src/helpers/email-subject-safety.ts`):
- **Keyword screen** — regex list for violence/death/tragedy terms. Deliberately broad: a false positive just means the next market's title headlines instead.
- **Gemini Flash classification** — `classifyQuestionSensitivity` batches uncached titles into one `promptGeminiParsingJson` call (`gemini-3.5-flash`, `thinkingLevel: 'minimal'`). Verdicts are cached per contract id in-process, and since every digest draws its 6 markets from roughly the top-200 by importance score, a full weekly send costs ~200 Flash calls total — not one per email.
- Final verdict is the **union** (the LLM can add sensitivity, never clear a keyword flag). Any LLM failure, timeout (10s), or missing `GEMINI_API_KEY` falls back to keyword-only — an email can never fail or block on the classifier. Each classified batch logs `Classified email question sensitivity { classified, flagged }` for observability.

The subject becomes the first non-sensitive question among the 6 shown; if all 6 are flagged, it falls back to a generic *"6 interesting markets on Manifold this week"*.

**Notification preview fix** — Gmail's snippet was "Bet on question" ×5 because question titles only existed as image alt text. Both digest templates now start with a hidden preheader div rendering `{{previewText}}` (the screened titles), which Gmail uses for the snippet/notification instead. This is the *only* template change — one line each.

**Mailgun sync script** (`backend/scripts/update-email-templates.ts`) — the live templates are Mailgun-hosted; repo edits do nothing until uploaded. Dry-runs by default, `--go` posts a new active version (reversible from the dashboard).

**Dress rehearsal script** (`backend/scripts/test-email-subject-safety.ts`) — default mode dry-runs the classifier on sample titles (no email, no DB writes) and prints keyword-vs-final verdicts plus the derived subject/previewText; `--send-to <username>` sends one real digest via Mailgun for an end-to-end check.

## Deploy notes

- Deploy-order safe both ways: a missing handlebars var renders empty, an extra var is ignored — so the template can be uploaded before or after the code ships.
- ⚠️ Template name check before `update-email-templates.ts --go`: code sends `signup-bonus-with-interesting-markets`, repo file is `sign-up-bonus-with-interesting-markets.html` — confirm the live Mailgun name.
- The Gemini path hasn't been executed live yet — run the dress-rehearsal script's dry-run mode before Monday's send. Keyword screen + preheader work regardless.
