### PR TITLE
fix: Clamp sub-epsilon position residue to zero in share accounting

### DIFF
--- a/backend/api/src/sell-shares.ts
+++ b/backend/api/src/sell-shares.ts
@@ -48,13 +48,18 @@ const calculateSellResult = (
   const maxShares = sharesByOutcome[outcome]
   const sharesToSell = shares ?? maxShares
 
-  if (!maxShares)
+  // A dust or floating-point-negative position (e.g. -4.44e-16) is not a real
+  // holding; feeding it into the sum-to-one arbitrage produces a NaN probability.
+  if (!maxShares || floatingLesserEqual(maxShares, 0))
     throw new APIError(403, `You don't have any ${outcome} shares to sell.`)
 
   if (!floatingLesserEqual(sharesToSell, maxShares))
     throw new APIError(400, `You can only sell up to ${maxShares} shares.`)
 
   const soldShares = Math.min(sharesToSell, maxShares)
+
+  if (floatingLesserEqual(soldShares, 0))
+    throw new APIError(400, `Must sell a positive number of ${outcome} shares.`)
   const saleFrac = soldShares / maxShares
   let loanPaid = saleFrac * loanAmount
   if (!isFinite(loanPaid)) loanPaid = 0

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -504,7 +504,9 @@ export function calculateCpmmMultiSumsToOneSale(
   balanceByUserId: { [userId: string]: number },
   collectedFees: Fees
 ) {
-  if (Math.round(shares) < 0) {
+  // Math.round(shares) < 0 let dust and small-negative amounts through (they
+  // round to 0/-0); an epsilon compare rejects any non-positive sale.
+  if (floatingLesserEqual(shares, 0)) {
     throw new Error('Cannot sell non-positive shares')
   }
 
@@ -634,7 +636,9 @@ export function calculateCpmmSale(
   unfilledBets: LimitBet[],
   balanceByUserId: { [userId: string]: number }
 ) {
-  if (Math.round(shares) < 0) {
+  // Math.round(shares) < 0 let dust and small-negative amounts through (they
+  // round to 0/-0); an epsilon compare rejects any non-positive sale.
+  if (floatingLesserEqual(shares, 0)) {
     throw new Error('Cannot sell non-positive shares')
   }
 

--- a/common/src/calculate.ts
+++ b/common/src/calculate.ts
@@ -198,6 +198,16 @@ export function calculateTotalSpentAndShares(
     }
   }
 
+  // Arb/round-trip fills leave nano-share residue (e.g. -4.44e-16) that never
+  // clears; a later "sell all" then feeds a non-positive amount into the arb and
+  // throws. Snap sub-EPSILON positions to exactly zero, matching how the rest of
+  // the metrics treat them as no holding.
+  for (const outcome of Object.keys(totalShares)) {
+    if (floatingEqual(totalShares[outcome] ?? 0, 0)) {
+      totalShares[outcome] = 0
+    }
+  }
+
   return { totalSpent, totalShares }
 }
 


### PR DESCRIPTION
The sum-to-one arb prices fills with a binary-search + sqrt round-trip that doesn't round-trip exactly, which leaves a small residue which is ignored by most systems but causes issues when trying to sell. See #3955 for guard on pool NaN when selling. This PR clamps the residue position to exactly zero and hardens some other paths where this could cause problems.