### PR TITLE
feat(admin): edit bio, website, twitter & discord in update-user panel

### DIFF
--- a/web/pages/admin/update-user.tsx
+++ b/web/pages/admin/update-user.tsx
@@ -7,6 +7,7 @@ import { Page } from 'web/components/layout/page'
 import { Row } from 'web/components/layout/row'
 import { NoSEO } from 'web/components/NoSEO'
 import { Avatar } from 'web/components/widgets/avatar'
+import { ExpandingInput } from 'web/components/widgets/expanding-input'
 import { Input } from 'web/components/widgets/input'
 import { Title } from 'web/components/widgets/title'
 import { useAdmin } from 'web/hooks/use-admin'
@@ -25,6 +26,10 @@ export default function AdminUpdateUserPage() {
     name: '',
     username: '',
     avatarUrl: '',
+    bio: '',
+    website: '',
+    twitterHandle: '',
+    discordHandle: '',
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -51,6 +56,10 @@ export default function AdminUpdateUserPage() {
         name: selectedUser.name || '',
         username: selectedUser.username || '',
         avatarUrl: selectedUser.avatarUrl || '',
+        bio: selectedUser.bio || '',
+        website: selectedUser.website || '',
+        twitterHandle: selectedUser.twitterHandle || '',
+        discordHandle: selectedUser.discordHandle || '',
       })
     }
   }, [selectedUser])
@@ -80,6 +89,18 @@ export default function AdminUpdateUserPage() {
       }
       if (formData.avatarUrl !== selectedUser.avatarUrl) {
         updates.avatarUrl = formData.avatarUrl
+      }
+      if (formData.bio !== (selectedUser.bio || '')) {
+        updates.bio = formData.bio
+      }
+      if (formData.website !== (selectedUser.website || '')) {
+        updates.website = formData.website
+      }
+      if (formData.twitterHandle !== (selectedUser.twitterHandle || '')) {
+        updates.twitterHandle = formData.twitterHandle
+      }
+      if (formData.discordHandle !== (selectedUser.discordHandle || '')) {
+        updates.discordHandle = formData.discordHandle
       }
 
       const result = await api('me/update', updates)
@@ -242,6 +263,79 @@ export default function AdminUpdateUserPage() {
                       Generate New
                     </Button>
                   </Row>
+                </div>
+
+                <div>
+                  <label className="text-ink-700 mb-2 block text-sm font-medium">
+                    Bio
+                  </label>
+                  <ExpandingInput
+                    value={formData.bio}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, bio: e.target.value }))
+                    }
+                    placeholder="e.g. Account moved to @NewHandle"
+                    rows={3}
+                    className="w-full max-w-md"
+                  />
+                  <div className="text-ink-500 mt-1 text-xs">
+                    @mentions and https:// links become clickable on the
+                    profile.
+                  </div>
+                </div>
+
+                <div>
+                  <label className="text-ink-700 mb-2 block text-sm font-medium">
+                    Website
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.website}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        website: e.target.value,
+                      }))
+                    }
+                    placeholder="example.com"
+                    className="w-full max-w-md"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-ink-700 mb-2 block text-sm font-medium">
+                    Twitter / X handle
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.twitterHandle}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        twitterHandle: e.target.value,
+                      }))
+                    }
+                    placeholder="username (no @)"
+                    className="w-full max-w-md"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-ink-700 mb-2 block text-sm font-medium">
+                    Discord handle
+                  </label>
+                  <Input
+                    type="text"
+                    value={formData.discordHandle}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        discordHandle: e.target.value,
+                      }))
+                    }
+                    placeholder="username"
+                    className="w-full max-w-md"
+                  />
                 </div>
 
                 <Row className="gap-4">


### PR DESCRIPTION
## What

The `/admin/update-user` panel could only change **name, username, and avatar**. This adds editable fields for the rest of a user's public profile:

- **Bio** (multi-line)
- **Website**
- **Twitter / X handle**
- **Discord handle**

Each field prefills from the selected user and is sent as a **changed-only** update through the existing `me/update` admin path.

## Why

Admins occasionally need to fix up a profile on a user's behalf — e.g. pointing an abandoned handle at the account someone moved to. Until now that required running a one-off script; the API already supported these fields, the panel just never exposed them.

## No backend change

`me/update`'s schema already accepts `bio`, `website`, `twitterHandle`, and `discordHandle`, and the admin path (`userId` set) already goes through `throwErrorIfNotAdmin`. This PR is frontend-only.

## Notes

- Bio renders through `Linkify`, so `@mentions` and `https://` links become clickable on the profile (the form hints at this).
- Web typecheck clean; Prettier-formatted.

## Test plan

- [ ] As an admin, open `/admin/update-user`, search + select a user
- [ ] Confirm Bio / Website / Twitter / Discord prefill with current values
- [ ] Edit one or more, Update, and confirm the toast + that the profile page reflects the change
- [ ] Confirm an unchanged field isn't sent (changed-only)