### PR TITLE
fix: return 503 (not 500 + stack trace) when a transaction aborts under contention

### DIFF
--- a/backend/api/src/app.ts
+++ b/backend/api/src/app.ts
@@ -79,6 +79,17 @@ const getBaseName = (path: string) => {
   return base
 }
 
+// Postgres error codes for transactions that were aborted and rolled back under
+// contention. Both are already treated as retryable inside runTransactionWithRetries;
+// these are the ones that escape after its retry budget is exhausted.
+const RETRYABLE_PG_ERROR_CODES = new Set([
+  '40001', // serialization_failure
+  '40P01', // deadlock_detected
+])
+
+const isRetryablePgError = (error: any) =>
+  typeof error?.code === 'string' && RETRYABLE_PG_ERROR_CODES.has(error.code)
+
 export const apiErrorHandler: ErrorRequestHandler = (
   error,
   _req,
@@ -93,6 +104,16 @@ export const apiErrorHandler: ErrorRequestHandler = (
         output.details = error.details
       }
       res.status(error.code).json(output)
+    }
+  } else if (isRetryablePgError(error)) {
+    // The transaction was aborted and rolled back — nothing was committed, and a
+    // retry is expected to succeed. That is a 503, not a 500, and it must not leak
+    // a stack trace to the client.
+    log.info(`Transaction conflict (${error.code}); returning 503.`)
+    if (!res.headersSent) {
+      res
+        .status(503)
+        .json({ message: 'Transaction conflict. Please try again.' })
     }
   } else {
     log.error(error)


### PR DESCRIPTION
> **Note:** issues are disabled on this repo, so I'm carrying a bug report in a PR. The code change is small and stands alone; the context below is the part I actually want to put in front of you, and the last section has two things I deliberately did **not** change because they need your judgement.

### What this changes

`apiErrorHandler` maps Postgres `40001` (serialization_failure) and `40P01` (deadlock_detected) to `503 Transaction conflict. Please try again.` instead of falling through to `res.status(500).json({ message: error.stack, error })`.

### Why

A bet POST from an API client returned:

```
HTTP 500
{"message":"error: could not serialize access due to read/write dependencies among
 transactions\n    at Parser.parseErrorMessage (/usr/src/app/node_modules/pg-protocol/
 src/parser.ts:368:69)\n    at Parser.handlePacket ...
```

Two problems with that response:

1. **It leaks an internal stack trace** (that body is `error.stack`), including server paths.
2. **It misinforms the client.** A 500 says "server fault, state unknown". But this transaction was *aborted and rolled back* — `placeBetMain` does all of its writes in a single `runTransactionWithRetries` (`place-bet.ts:149`, batch at `:626`), so nothing was committed. A client receiving this cannot distinguish "retryable contention, nothing happened" from "the bet may have half-landed", so a conservative client has to stop and ask a human. Ours does exactly that, which is how we noticed.

Worth noting the response *shape* already proves this is pre-commit: `endpoint.ts:213-221` sends the 200 **before** awaiting `continue()`, and every `apiErrorHandler` write is guarded by `!res.headersSent`. So a failure in post-commit work (e.g. `payReferralBetBonus`, which opens its own serializable transaction at `on-create-bet.ts:244`) can only ever produce a 200. Receiving a 500 therefore *guarantees* the throw preceded the commit — which is what makes a clean 503 both safe and correct here.

### What triggered it

Not an attack or a misbehaving client — a **declared market maker** (`isBot: true`) run by a market's own creator, refreshing a two-sided ladder on contract `OOAyLEyAqu`: **20 zero-fill limit orders in ~1.3s, repeating every ~35-60s.** That's 10 answers x 2 sides, i.e. one legitimate quote refresh. It was ~67% of all `contract_bets` inserts site-wide in a sampled 10-minute window (479 rows, 342 zero-amount, 320 from that one account).

Our bet's three server-side attempts spanned 23:02:24-25.0 UTC; that cycle's burst ran 23:02:23.607-23:02:25.189. All three attempts landed inside it. **`runTransactionWithRetries` allows 3 attempts with 100ms + 200ms backoff (~300ms), which is shorter than the burst**, so the retries had no chance of finding a quiet moment.

There was **no row-level overlap** between the two transactions — different contract, different answers, different user. So this is predicate-lock false sharing under SSI, not genuine contention for the same rows.

### Two things I did *not* change

Both need your judgement and a view of production I don't have:

1. **The retry budget.** 3 attempts over ~300ms is shorter than an observed real-world contention burst (~1.3-1.6s) from a legitimate client. More attempts and/or jittered backoff reaching ~2s would absorb this class entirely. I didn't touch it because retry counts have latency and connection-pool implications under load that you understand better than I do.

2. **Predicate-lock granularity.** With default `max_pred_locks_per_page` (2) and `max_pred_locks_per_relation` (32) — I found no tuning in the repo — a bet on a market with a large open-limit-order footprint can escalate its SIREAD locks to page or relation scope on `contract_bets`, at which point it conflicts with *unrelated* markets' inserts. The market we were betting had **98 open limit orders created across 36 distinct days spanning 2024-08 to 2026-07**, i.e. heavily scattered across heap pages. Raising those GUCs trades memory for precision and may be the highest-leverage single change, but it's infra config, not a repo change.

### One diagnostic ask

I can't see inside the database, so I can't tell which coarsening is responsible. Three candidates, distinguishable by you in about five minutes:

- **A.** Bitmap heap scan over the scattered open-limit rows → many heap *page* locks → over the 32 threshold → relation-level SIREAD on `contract_bets` (would conflict with every serializable insert site-wide).
- **B.** Shared btree leaf pages in the partial index on open limit orders — that index is small and hot, and this MM churns entries through it continuously.
- **C.** `users` page overlap between the readers' join and bettors' balance writes.

`EXPLAIN` on the `lockContractAndGetBetData` open-limit query for a market with ~100 scattered open limits (does it choose a bitmap heap scan?), plus `pg_locks` filtered to `mode = 'SIReadLock'` grouped by `locktype` during a busy period, should settle it.

### Scope

The trigger scales with market maturity: a fresh market with a handful of open limit orders stays at tuple-lock granularity and is unaffected, while a long-lived market accumulates scattered open limits and becomes progressively more exposed. It also compounds with concurrency — `betsQueue` serializes same-contract bets per replica, so the danger case is several clients trading *different* markets simultaneously.

### Reproducing

Any bet on a market with ~100 scattered open limit orders, issued while another client is inserting limit orders at ~15/s, should reproduce it within a few attempts. Happy to run a controlled experiment and report numbers if useful — I have a harness built for it — but the `pg_locks` check above is far more decisive than anything measurable from outside.

### Testing

`backend/api` typechecks; the changed file is prettier-clean and `eslint` passes (`no-explicit-any` is off in `backend/api/.eslintrc.js`, and `error: any` has precedent in `mcp.ts`). The new branch is additive — the existing `APIError` and generic-500 paths are untouched.
