### PR TITLE
Discovery quick wins: browse ranking, repetition, and dead-end search

### DIFF
--- a/backend/api/src/mcp.ts
+++ b/backend/api/src/mcp.ts
@@ -27,7 +27,7 @@ import { getUser } from './get-user'
 import { searchMarketsLite } from './search-contracts'
 import { searchUsers } from './search-users'
 
-function getServer(): Server {
+function getServer(httpRequest: Request): Server {
   const server = new Server(
     {
       name: 'manifold-markets',
@@ -282,7 +282,7 @@ function getServer(): Server {
             const markets = (await searchMarketsLite(
               searchParams,
               undefined, // auth not required for this endpoint
-              {} as Request // minimal request object since it's not used
+              httpRequest
             )) as LiteMarket[]
 
             const marketsWithProbabilities = markets
@@ -429,7 +429,7 @@ function getServer(): Server {
 
 export const handleMcpRequest = async (req: Request, res: Response) => {
   try {
-    const server = getServer()
+    const server = getServer(req)
     const transport: StreamableHTTPServerTransport =
       new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,

--- a/backend/api/src/mcp.ts
+++ b/backend/api/src/mcp.ts
@@ -27,7 +27,7 @@ import { getUser } from './get-user'
 import { searchMarketsLite } from './search-contracts'
 import { searchUsers } from './search-users'
 
-function getServer(httpRequest: Request): Server {
+function getServer(): Server {
   const server = new Server(
     {
       name: 'manifold-markets',
@@ -282,7 +282,7 @@ function getServer(httpRequest: Request): Server {
             const markets = (await searchMarketsLite(
               searchParams,
               undefined, // auth not required for this endpoint
-              httpRequest
+              {} as Request // minimal request object since it's not used
             )) as LiteMarket[]
 
             const marketsWithProbabilities = markets
@@ -429,7 +429,7 @@ function getServer(httpRequest: Request): Server {
 
 export const handleMcpRequest = async (req: Request, res: Response) => {
   try {
-    const server = getServer(req)
+    const server = getServer()
     const transport: StreamableHTTPServerTransport =
       new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -5,6 +5,10 @@ import {
 } from 'common/api/market-search-types'
 import { toLiteMarket } from 'common/api/market-types'
 import { Contract } from 'common/contract'
+import {
+  DiscoveryExperimentVariant,
+  getEffectiveDiscoveryExperimentVariant,
+} from 'common/discovery-experiment'
 import { convertContract } from 'common/supabase/contracts'
 import { orderBy, uniqBy } from 'lodash'
 import { getGroupIdFromSlug } from 'shared/supabase/groups'
@@ -52,6 +56,7 @@ export const searchMarketsLite: APIHandler<'search-markets'> = async (
   const contracts = await search(props, auth?.uid, {
     markSearchMatches: false,
     allowSemanticFallback: false,
+    discoveryVariant: 'control',
   })
   return contracts.map((c) => toLiteMarket(c, { includeLiteAnswers }))
 }
@@ -61,10 +66,19 @@ export const searchMarketsFull: APIHandler<'search-markets-full'> = async (
   auth,
   req
 ) => {
-  if (!props.enableSemanticSearch) {
+  // Signed-in assignment is independently reproduced on the server, so a
+  // client cannot accidentally move an account between arms. Anonymous
+  // assignment is device-based and therefore has to be supplied by the web.
+  const discoveryVariant = getEffectiveDiscoveryExperimentVariant({
+    userId: auth?.uid,
+    requestedVariant: props.discoveryVariant,
+  })
+
+  if (discoveryVariant === 'control' || !props.enableSemanticSearch) {
     return await search(props, auth?.uid, {
       markSearchMatches: true,
       allowSemanticFallback: false,
+      discoveryVariant,
     })
   }
 
@@ -72,6 +86,7 @@ export const searchMarketsFull: APIHandler<'search-markets-full'> = async (
     markSearchMatches: true,
     allowSemanticFallback: true,
     semanticCallerKey: getSemanticCallerKey(auth?.uid, req),
+    discoveryVariant,
   })
 }
 
@@ -82,6 +97,7 @@ export const getRecentMarkets: APIHandler<'recent-markets'> = async (
   return await search(props, auth.uid, {
     markSearchMatches: false,
     allowSemanticFallback: false,
+    discoveryVariant: 'control',
   })
 }
 
@@ -96,18 +112,34 @@ const getSemanticCallerKey = (
 // The caller key only matters when the fallback can run, so tie the two
 // together rather than making every endpoint derive one.
 type SearchOptions =
-  | { markSearchMatches: boolean; allowSemanticFallback: false }
+  | {
+      markSearchMatches: boolean
+      allowSemanticFallback: false
+      discoveryVariant: DiscoveryExperimentVariant
+    }
   | {
       markSearchMatches: true
       allowSemanticFallback: true
       semanticCallerKey: string
+      discoveryVariant: DiscoveryExperimentVariant
     }
 
 const search = async (
-  props: z.infer<typeof searchProps>,
+  requestProps: z.infer<typeof searchProps>,
   userId: string | undefined,
   options: SearchOptions
 ) => {
+  // Control deliberately ignores a supplied seen anchor. This leaves the
+  // reliability/privacy fixes common to both arms while reproducing the old
+  // product behavior for ranking, repetition, and semantic fallback.
+  const props = {
+    ...requestProps,
+    discoveryVariant: options.discoveryVariant,
+    seenMarketCutoffTime:
+      options.discoveryVariant === 'treatment'
+        ? requestProps.seenMarketCutoffTime
+        : undefined,
+  }
   const {
     term = '',
     filter,

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -15,9 +15,12 @@ import {
   basicSearchSQL,
   getForYouSQL,
   getSearchContractSQL,
+  getSemanticSearchContractSQL,
   SearchTypes,
   sortFields,
 } from 'shared/supabase/search-contracts'
+import { generateEmbeddings } from 'shared/helpers/openai-utils'
+import { cacheGetJson, cacheSetJson } from 'shared/redis/cache'
 import { getPrivateUser, log } from 'shared/utils'
 import { z } from 'zod'
 import { APIError, type APIHandler } from './helpers/endpoint'
@@ -196,7 +199,7 @@ const search = async (
       sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
     )
 
-    return orderBy(
+    const lexicalResults = orderBy(
       uniqBy(
         [
           ...contractsWithStopwords, // most obviously relevant
@@ -208,7 +211,91 @@ const search = async (
       (c) => sortFields[sort].sortCallback(c),
       sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
     )
+
+    const semanticResults = await semanticFallback({
+      ...props,
+      term: cleanTerm,
+      uid: userId,
+      groupId,
+      groupIds,
+      isPrizeMarket,
+      lexicalResults,
+      pg,
+    })
+
+    // Appended in similarity order rather than merged into the sort: these
+    // matched no keyword, so ordering them by importance would float a weak
+    // association above a strong one.
+    return [...lexicalResults, ...semanticResults]
   }
+}
+
+// Below this many lexical hits, the page is effectively a dead end, so it is
+// worth spending an embedding call to fill it.
+const SEMANTIC_FALLBACK_MIN_RESULTS = 5
+// Single characters and pairs are prefix-typing, not a failed search.
+const SEMANTIC_FALLBACK_MIN_TERM_LENGTH = 3
+// The embedding of a given string never changes; this only avoids re-paying
+// the ~100ms OpenAI round-trip on repeated searches. ~30KB per entry, so keep
+// the ttl short enough that one-off queries age out.
+const QUERY_EMBEDDING_CACHE_TTL_S = 24 * 60 * 60
+const queryEmbeddingCacheKey = (term: string) =>
+  `search-embedding:${term.toLowerCase()}`
+
+type SemanticSearchArgs = Parameters<typeof getSemanticSearchContractSQL>[0]
+
+const semanticFallback = async (
+  props: Omit<
+    SemanticSearchArgs,
+    'embedding' | 'privateUser' | 'excludeContractIds'
+  > & {
+    term: string
+    lexicalResults: Contract[]
+    pg: SupabaseDirectClient
+  }
+) => {
+  const { term, uid, limit, offset, lexicalResults, pg } = props
+  if (
+    offset > 0 ||
+    term.length < SEMANTIC_FALLBACK_MIN_TERM_LENGTH ||
+    lexicalResults.length >= SEMANTIC_FALLBACK_MIN_RESULTS
+  ) {
+    return []
+  }
+
+  const cacheKey = queryEmbeddingCacheKey(term)
+  let embedding = await cacheGetJson<number[]>(cacheKey)
+  if (embedding === undefined) {
+    embedding = await generateEmbeddings(term)
+    // No key configured, or OpenAI is down. A search with no results is a
+    // worse page, not a broken one — leave it as it was.
+    if (!embedding) return []
+    await cacheSetJson(cacheKey, embedding, QUERY_EMBEDDING_CACHE_TTL_S)
+  }
+
+  const privateUser = uid ? (await getPrivateUser(uid, pg)) ?? undefined : undefined
+  const results = await pg
+    .map(
+      getSemanticSearchContractSQL({
+        ...props,
+        embedding,
+        privateUser,
+        limit: limit - lexicalResults.length,
+        excludeContractIds: lexicalResults.map((c) => c.id),
+      }),
+      [],
+      convertContract
+    )
+    .catch((e) => {
+      log.error(`Semantic search fallback failed for term: ${term}`, e)
+      return [] as Contract[]
+    })
+
+  log(`Semantic fallback for "${term}"`, {
+    lexicalHits: lexicalResults.length,
+    semanticHits: results.length,
+  })
+  return results
 }
 
 const getAllSubTopicsForParentTopicIds = async (

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -25,12 +25,13 @@ import {
 } from 'shared/helpers/openai-utils'
 import {
   BoundedSingleFlightCache,
+  HierarchicalRollingWindowGate,
   isValidQueryEmbedding,
   normalizeSemanticSearchTerm,
   queryEmbeddingCacheKey,
-  RollingWindowGate,
   shouldAttemptSemanticFallback,
 } from 'shared/helpers/semantic-search-fallback'
+import { getIp } from 'shared/analytics'
 import { cacheGetJson, cacheSetJson } from 'shared/redis/cache'
 import { getPrivateUser, log } from 'shared/utils'
 import { z } from 'zod'
@@ -38,30 +39,46 @@ import { APIError, type APIHandler } from './helpers/endpoint'
 
 export const searchMarketsLite: APIHandler<'search-markets'> = async (
   props,
-  auth
+  auth,
+  req
 ) => {
   const { includeLiteAnswers } = props
-  const contracts = await search(props, auth?.uid)
+  const contracts = await search(
+    props,
+    auth?.uid,
+    getSemanticCallerKey(auth?.uid, req)
+  )
   return contracts.map((c) => toLiteMarket(c, { includeLiteAnswers }))
 }
 
 export const searchMarketsFull: APIHandler<'search-markets-full'> = async (
   props,
-  auth
+  auth,
+  req
 ) => {
-  return await search(props, auth?.uid)
+  return await search(props, auth?.uid, getSemanticCallerKey(auth?.uid, req))
 }
 
 export const getRecentMarkets: APIHandler<'recent-markets'> = async (
   props,
-  auth
+  auth,
+  req
 ) => {
-  return await search(props, auth.uid)
+  return await search(props, auth.uid, getSemanticCallerKey(auth.uid, req))
+}
+
+const getSemanticCallerKey = (
+  userId: string | undefined,
+  req: Parameters<APIHandler<'search-markets'>>[2]
+) => {
+  if (userId) return `user:${userId}`
+  return `ip:${getIp(req) ?? 'unknown'}`
 }
 
 const search = async (
   props: z.infer<typeof searchProps>,
-  userId: string | undefined
+  userId: string | undefined,
+  semanticCallerKey: string
 ) => {
   const {
     term = '',
@@ -231,6 +248,7 @@ const search = async (
       groupIds,
       isPrizeMarket,
       lexicalResults,
+      callerKey: semanticCallerKey,
       pg,
     })
 
@@ -257,7 +275,9 @@ const SEMANTIC_FALLBACK_MAX_INFLIGHT = 10
 // still allows an unauthenticated caller to create an unbounded stream of
 // unique OpenAI requests. Exhausting this budget only disables the optional
 // fallback; lexical search continues normally.
-const SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_MINUTE = 5
+const SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_MINUTE = 60
+const SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_CALLER_PER_MINUTE = 10
+const SEMANTIC_FALLBACK_MAX_CALLER_BUCKETS = 10_000
 // Redis is deliberately disabled in the API deploy config, so keep a small
 // process-local LRU as the dependable cache and use Redis as an optional
 // cross-process layer. One embedding is roughly 30KB in JSON form; 100 entries
@@ -268,16 +288,23 @@ const queryEmbeddingCache = new BoundedSingleFlightCache<number[]>({
   maxEntries: LOCAL_QUERY_EMBEDDING_CACHE_MAX_ENTRIES,
   ttlMs: QUERY_EMBEDDING_CACHE_TTL_S * 1000,
   maxInflightCreates: SEMANTIC_FALLBACK_MAX_INFLIGHT,
-  maxCreatesPerWindow: SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_MINUTE,
-  createWindowMs: 60_000,
 })
+const semanticEmbeddingGate = new HierarchicalRollingWindowGate(
+  SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_MINUTE,
+  SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_CALLER_PER_MINUTE,
+  60_000,
+  SEMANTIC_FALLBACK_MAX_CALLER_BUCKETS
+)
 // Cached terms bypass the embedding budget, so separately bound vector-query
 // work that an unauthenticated caller could otherwise repeat indefinitely.
-const SEMANTIC_FALLBACK_MAX_QUERIES_PER_MINUTE = 60
+const SEMANTIC_FALLBACK_MAX_QUERIES_PER_MINUTE = 120
+const SEMANTIC_FALLBACK_MAX_QUERIES_PER_CALLER_PER_MINUTE = 30
 const SEMANTIC_FALLBACK_MAX_QUERY_INFLIGHT = 10
-const semanticQueryGate = new RollingWindowGate(
+const semanticQueryGate = new HierarchicalRollingWindowGate(
   SEMANTIC_FALLBACK_MAX_QUERIES_PER_MINUTE,
-  60_000
+  SEMANTIC_FALLBACK_MAX_QUERIES_PER_CALLER_PER_MINUTE,
+  60_000,
+  SEMANTIC_FALLBACK_MAX_CALLER_BUCKETS
 )
 let inflightSemanticQueries = 0
 
@@ -290,11 +317,21 @@ const semanticFallback = async (
   > & {
     term: string
     lexicalResults: Contract[]
+    callerKey: string
     pg: SupabaseDirectClient
   }
 ): Promise<Contract[]> => {
-  const { term, uid, limit, offset, sort, beforeTime, lexicalResults, pg } =
-    props
+  const {
+    term,
+    uid,
+    limit,
+    offset,
+    sort,
+    beforeTime,
+    lexicalResults,
+    callerKey,
+    pg,
+  } = props
   const normalizedTerm = normalizeSemanticSearchTerm(term)
   if (
     !shouldAttemptSemanticFallback({
@@ -328,17 +365,21 @@ const semanticFallback = async (
       queryEmbeddingCache.set(cacheKey, embedding)
     }
     if (embedding === undefined) {
-      embedding = await queryEmbeddingCache.getOrCreate(cacheKey, async () => {
-        const generated = await generateEmbeddings(normalizedTerm, {
-          timeoutMs: SEMANTIC_FALLBACK_OPENAI_TIMEOUT_MS,
-          maxRetries: 0,
-        })
-        if (!isValidQueryEmbedding(generated)) return undefined
-        // Optional cross-process cache; cacheSetJson is a no-op when Redis is
-        // disabled and does not reject callers when Redis is unavailable.
-        void cacheSetJson(cacheKey, generated, QUERY_EMBEDDING_CACHE_TTL_S)
-        return generated
-      })
+      embedding = await queryEmbeddingCache.getOrCreate(
+        cacheKey,
+        async () => {
+          const generated = await generateEmbeddings(normalizedTerm, {
+            timeoutMs: SEMANTIC_FALLBACK_OPENAI_TIMEOUT_MS,
+            maxRetries: 0,
+          })
+          if (!isValidQueryEmbedding(generated)) return undefined
+          // Optional cross-process cache; cacheSetJson is a no-op when Redis is
+          // disabled and does not reject callers when Redis is unavailable.
+          void cacheSetJson(cacheKey, generated, QUERY_EMBEDDING_CACHE_TTL_S)
+          return generated
+        },
+        () => semanticEmbeddingGate.take(callerKey)
+      )
       // No key configured, or OpenAI is down. A search with no results is a
       // worse page, not a broken one — leave it as it was.
       if (!embedding) return []
@@ -346,7 +387,7 @@ const semanticFallback = async (
 
     if (
       inflightSemanticQueries >= SEMANTIC_FALLBACK_MAX_QUERY_INFLIGHT ||
-      !semanticQueryGate.take()
+      !semanticQueryGate.take(callerKey)
     )
       return []
     inflightSemanticQueries++

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -18,6 +18,7 @@ import {
   getSearchContractSQL,
   getSemanticSearchContractSQL,
   SearchTypes,
+  shouldSuppressStaleSeenMarkets,
   sortFields,
 } from 'shared/supabase/search-contracts'
 import {
@@ -49,6 +50,7 @@ export const searchMarketsLite: APIHandler<'search-markets'> = async (
   // indistinguishable from real matches to API consumers doing exact-title
   // existence checks, and to the MCP server, which shares this handler.
   const contracts = await search(props, auth?.uid, {
+    markSearchMatches: false,
     allowSemanticFallback: false,
   })
   return contracts.map((c) => toLiteMarket(c, { includeLiteAnswers }))
@@ -59,7 +61,15 @@ export const searchMarketsFull: APIHandler<'search-markets-full'> = async (
   auth,
   req
 ) => {
+  if (!props.enableSemanticSearch) {
+    return await search(props, auth?.uid, {
+      markSearchMatches: true,
+      allowSemanticFallback: false,
+    })
+  }
+
   return await search(props, auth?.uid, {
+    markSearchMatches: true,
     allowSemanticFallback: true,
     semanticCallerKey: getSemanticCallerKey(auth?.uid, req),
   })
@@ -69,7 +79,10 @@ export const getRecentMarkets: APIHandler<'recent-markets'> = async (
   props,
   auth
 ) => {
-  return await search(props, auth.uid, { allowSemanticFallback: false })
+  return await search(props, auth.uid, {
+    markSearchMatches: false,
+    allowSemanticFallback: false,
+  })
 }
 
 const getSemanticCallerKey = (
@@ -83,8 +96,12 @@ const getSemanticCallerKey = (
 // The caller key only matters when the fallback can run, so tie the two
 // together rather than making every endpoint derive one.
 type SearchOptions =
-  | { allowSemanticFallback: false }
-  | { allowSemanticFallback: true; semanticCallerKey: string }
+  | { markSearchMatches: boolean; allowSemanticFallback: false }
+  | {
+      markSearchMatches: true
+      allowSemanticFallback: true
+      semanticCallerKey: string
+    }
 
 const search = async (
   props: z.infer<typeof searchProps>,
@@ -149,6 +166,22 @@ const search = async (
     isForYou,
     userId,
   })
+  // Silently changing from an unfiltered first page to a filtered later page
+  // would invalidate offset pagination once server time catches a fast client
+  // clock. Make the first request fail explicitly instead; the web client can
+  // then retry without an anchor and keep suppression disabled for that result
+  // set. This also gives new web code a safe fallback against an older strict
+  // API schema during a rolling deployment.
+  if (
+    searchRoute === 'for-you' &&
+    props.seenMarketCutoffTime !== undefined &&
+    !shouldSuppressStaleSeenMarkets(props.seenMarketCutoffTime)
+  ) {
+    throw new APIError(
+      400,
+      'seenMarketCutoffTime is too far ahead of server time'
+    )
+  }
   if (searchRoute === 'basic' || searchRoute === 'for-you') {
     // Enforce blocked users/contracts/topics in the query itself — the
     // client-side filter only patches holes in already-fetched pages.
@@ -250,6 +283,8 @@ const search = async (
       (c) => sortFields[sort].sortCallback(c),
       sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
     )
+    if (!options.markSearchMatches) return lexicalResults
+
     const markedLexicalResults: FullMarketSearchResult[] = lexicalResults.map(
       (contract) => ({
         ...contract,

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -235,6 +235,18 @@ const search = async (
 const SEMANTIC_FALLBACK_MIN_RESULTS = 5
 // Single characters and pairs are prefix-typing, not a failed search.
 const SEMANTIC_FALLBACK_MIN_TERM_LENGTH = 3
+// Longer than any real query; embedding pasted walls of text is pure cost.
+const SEMANTIC_FALLBACK_MAX_TERM_LENGTH = 200
+// Interactive search: past this, returning the lexical results we already
+// have beats hanging the page on a slow OpenAI call. No retries for the same
+// reason (the SDK default is 2 retries inside a ~10-minute timeout).
+const SEMANTIC_FALLBACK_OPENAI_TIMEOUT_MS = 3000
+// Bounds concurrent OpenAI calls per server process during incidents or
+// crawler storms (the read API runs a small pm2 cluster, so the fleet-wide
+// cap is a small multiple of this). At the cap, fallback-eligible searches
+// just return their lexical results.
+const SEMANTIC_FALLBACK_MAX_INFLIGHT = 10
+let inflightEmbeddingCalls = 0
 // The embedding of a given string never changes; this only avoids re-paying
 // the ~100ms OpenAI round-trip on repeated searches. ~30KB per entry, so keep
 // the ttl short enough that one-off queries age out.
@@ -253,29 +265,59 @@ const semanticFallback = async (
     lexicalResults: Contract[]
     pg: SupabaseDirectClient
   }
-) => {
-  const { term, uid, limit, offset, lexicalResults, pg } = props
+): Promise<Contract[]> => {
+  const { term, uid, limit, offset, sort, beforeTime, lexicalResults, pg } =
+    props
   if (
     offset > 0 ||
+    // The sort=newest cursor contract reads createdTime off the LAST row of
+    // each page (see beforeTime in market-search-types), and a similarity-
+    // ordered tail poisons that on page 1 just as surely as on later pages —
+    // so the newest sort gets no tail at all, and beforeTime is guarded
+    // separately in case a client sends it with another sort.
+    sort === 'newest' ||
+    beforeTime !== undefined ||
+    // URL terms take the exact slug-lookup branch in getSearchContractSQL;
+    // embedding the URL text would append noise to an exact lookup.
+    term.startsWith('https://') ||
+    term.startsWith('http://') ||
     term.length < SEMANTIC_FALLBACK_MIN_TERM_LENGTH ||
-    lexicalResults.length >= SEMANTIC_FALLBACK_MIN_RESULTS
+    term.length > SEMANTIC_FALLBACK_MAX_TERM_LENGTH ||
+    // Capped at limit: a full page under 5 hits (limit <= 4) is not a dead
+    // end, and this also keeps the semantic query's limit strictly positive.
+    lexicalResults.length >= Math.min(limit, SEMANTIC_FALLBACK_MIN_RESULTS)
   ) {
     return []
   }
 
-  const cacheKey = queryEmbeddingCacheKey(term)
-  let embedding = await cacheGetJson<number[]>(cacheKey)
-  if (embedding === undefined) {
-    embedding = await generateEmbeddings(term)
-    // No key configured, or OpenAI is down. A search with no results is a
-    // worse page, not a broken one — leave it as it was.
-    if (!embedding) return []
-    await cacheSetJson(cacheKey, embedding, QUERY_EMBEDDING_CACHE_TTL_S)
-  }
+  // Fallback of a fallback: nothing in here — OpenAI, redis, the db — may
+  // break the search itself. Any failure returns the lexical results alone.
+  try {
+    const cacheKey = queryEmbeddingCacheKey(term)
+    const [cached, privateUser] = await Promise.all([
+      cacheGetJson<number[]>(cacheKey),
+      uid ? getPrivateUser(uid, pg).then((u) => u ?? undefined) : undefined,
+    ])
+    let embedding = cached
+    if (embedding === undefined) {
+      if (inflightEmbeddingCalls >= SEMANTIC_FALLBACK_MAX_INFLIGHT) return []
+      inflightEmbeddingCalls++
+      try {
+        embedding = await generateEmbeddings(term, {
+          timeoutMs: SEMANTIC_FALLBACK_OPENAI_TIMEOUT_MS,
+          maxRetries: 0,
+        })
+      } finally {
+        inflightEmbeddingCalls--
+      }
+      // No key configured, or OpenAI is down. A search with no results is a
+      // worse page, not a broken one — leave it as it was.
+      if (!embedding) return []
+      // Fire and forget: nothing reads the result and cacheSetJson never throws.
+      void cacheSetJson(cacheKey, embedding, QUERY_EMBEDDING_CACHE_TTL_S)
+    }
 
-  const privateUser = uid ? (await getPrivateUser(uid, pg)) ?? undefined : undefined
-  const results = await pg
-    .map(
+    const results = await pg.map(
       getSemanticSearchContractSQL({
         ...props,
         embedding,
@@ -283,19 +325,20 @@ const semanticFallback = async (
         limit: limit - lexicalResults.length,
         excludeContractIds: lexicalResults.map((c) => c.id),
       }),
-      [],
+      null,
       convertContract
     )
-    .catch((e) => {
-      log.error(`Semantic search fallback failed for term: ${term}`, e)
-      return [] as Contract[]
+    log(`Semantic fallback for "${term}"`, {
+      lexicalHits: lexicalResults.length,
+      semanticHits: results.length,
     })
-
-  log(`Semantic fallback for "${term}"`, {
-    lexicalHits: lexicalResults.length,
-    semanticHits: results.length,
-  })
-  return results
+    return results
+  } catch (e) {
+    log.error(`Semantic search fallback failed for term: ${term}`, {
+      error: e instanceof Error ? e.message : String(e),
+    })
+    return []
+  }
 }
 
 const getAllSubTopicsForParentTopicIds = async (

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -29,6 +29,7 @@ import {
   HierarchicalRollingWindowGate,
   isValidQueryEmbedding,
   normalizeSemanticSearchTerm,
+  QUERY_EMBEDDING_DIMENSIONS,
   queryEmbeddingCacheKey,
   shouldAttemptSemanticFallback,
 } from 'shared/helpers/semantic-search-fallback'
@@ -40,15 +41,16 @@ import { APIError, type APIHandler } from './helpers/endpoint'
 
 export const searchMarketsLite: APIHandler<'search-markets'> = async (
   props,
-  auth,
-  req
+  auth
 ) => {
   const { includeLiteAnswers } = props
-  const contracts = await search(
-    props,
-    auth?.uid,
-    getSemanticCallerKey(auth?.uid, req)
-  )
+  // No semantic tail on the documented endpoint: LiteMarket carries no
+  // searchMatchType marker, so similarity neighbours would be
+  // indistinguishable from real matches to API consumers doing exact-title
+  // existence checks, and to the MCP server, which shares this handler.
+  const contracts = await search(props, auth?.uid, {
+    allowSemanticFallback: false,
+  })
   return contracts.map((c) => toLiteMarket(c, { includeLiteAnswers }))
 }
 
@@ -57,29 +59,37 @@ export const searchMarketsFull: APIHandler<'search-markets-full'> = async (
   auth,
   req
 ) => {
-  return await search(props, auth?.uid, getSemanticCallerKey(auth?.uid, req))
+  return await search(props, auth?.uid, {
+    allowSemanticFallback: true,
+    semanticCallerKey: getSemanticCallerKey(auth?.uid, req),
+  })
 }
 
 export const getRecentMarkets: APIHandler<'recent-markets'> = async (
   props,
-  auth,
-  req
+  auth
 ) => {
-  return await search(props, auth.uid, getSemanticCallerKey(auth.uid, req))
+  return await search(props, auth.uid, { allowSemanticFallback: false })
 }
 
 const getSemanticCallerKey = (
   userId: string | undefined,
-  req: Parameters<APIHandler<'search-markets'>>[2]
+  req: Parameters<APIHandler<'search-markets-full'>>[2]
 ) => {
   if (userId) return `user:${userId}`
   return `ip:${getIp(req) ?? 'unknown'}`
 }
 
+// The caller key only matters when the fallback can run, so tie the two
+// together rather than making every endpoint derive one.
+type SearchOptions =
+  | { allowSemanticFallback: false }
+  | { allowSemanticFallback: true; semanticCallerKey: string }
+
 const search = async (
   props: z.infer<typeof searchProps>,
   userId: string | undefined,
-  semanticCallerKey: string
+  options: SearchOptions
 ) => {
   const {
     term = '',
@@ -246,6 +256,7 @@ const search = async (
         searchMatchType: 'lexical',
       })
     )
+    if (!options.allowSemanticFallback) return markedLexicalResults
 
     const semanticResults: FullMarketSearchResult[] = (
       await semanticFallback({
@@ -256,7 +267,7 @@ const search = async (
         groupIds,
         isPrizeMarket,
         lexicalResults,
-        callerKey: semanticCallerKey,
+        callerKey: options.semanticCallerKey,
         pg,
       })
     ).map((contract) => ({
@@ -380,11 +391,30 @@ const semanticFallback = async (
       embedding = await queryEmbeddingCache.getOrCreate(
         cacheKey,
         async () => {
-          const generated = await generateEmbeddings(normalizedTerm, {
+          // Widened on purpose: the SDK type promises number[], but the
+          // dimension check is about what the API actually sent back, and the
+          // predicate below would otherwise narrow a mismatch to never.
+          const generated: unknown = await generateEmbeddings(normalizedTerm, {
             timeoutMs: SEMANTIC_FALLBACK_OPENAI_TIMEOUT_MS,
             maxRetries: 0,
           })
-          if (!isValidQueryEmbedding(generated)) return undefined
+          // Request failures are logged inside generateEmbeddings.
+          if (generated === undefined) return undefined
+          if (!isValidQueryEmbedding(generated)) {
+            // Paid for but unusable: a model or dimension change would
+            // otherwise switch the feature off with nothing in the logs.
+            log.error('Semantic search fallback got an unusable embedding', {
+              model: EMBEDDING_MODEL,
+              expectedDimensions: QUERY_EMBEDDING_DIMENSIONS,
+              receivedType: Array.isArray(generated)
+                ? 'array'
+                : typeof generated,
+              receivedDimensions: Array.isArray(generated)
+                ? generated.length
+                : undefined,
+            })
+            return undefined
+          }
           // Optional cross-process cache; cacheSetJson is a no-op when Redis is
           // disabled and does not reject callers when Redis is unavailable.
           void cacheSetJson(cacheKey, generated, QUERY_EMBEDDING_CACHE_TTL_S)

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -12,9 +12,12 @@ import {
   basicSearchSQL,
   getForYouSQL,
   getSearchContractSQL,
+  getSemanticSearchContractSQL,
   SearchTypes,
   sortFields,
 } from 'shared/supabase/search-contracts'
+import { generateEmbeddings } from 'shared/helpers/openai-utils'
+import { cacheGetJson, cacheSetJson } from 'shared/redis/cache'
 import { getPrivateUser, log } from 'shared/utils'
 import { z } from 'zod'
 import { APIError, type APIHandler } from './helpers/endpoint'
@@ -190,7 +193,7 @@ const search = async (
       sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
     )
 
-    return orderBy(
+    const lexicalResults = orderBy(
       uniqBy(
         [
           ...contractsWithStopwords, // most obviously relevant
@@ -202,7 +205,91 @@ const search = async (
       (c) => sortFields[sort].sortCallback(c),
       sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
     )
+
+    const semanticResults = await semanticFallback({
+      ...props,
+      term: cleanTerm,
+      uid: userId,
+      groupId,
+      groupIds,
+      isPrizeMarket,
+      lexicalResults,
+      pg,
+    })
+
+    // Appended in similarity order rather than merged into the sort: these
+    // matched no keyword, so ordering them by importance would float a weak
+    // association above a strong one.
+    return [...lexicalResults, ...semanticResults]
   }
+}
+
+// Below this many lexical hits, the page is effectively a dead end, so it is
+// worth spending an embedding call to fill it.
+const SEMANTIC_FALLBACK_MIN_RESULTS = 5
+// Single characters and pairs are prefix-typing, not a failed search.
+const SEMANTIC_FALLBACK_MIN_TERM_LENGTH = 3
+// The embedding of a given string never changes; this only avoids re-paying
+// the ~100ms OpenAI round-trip on repeated searches. ~30KB per entry, so keep
+// the ttl short enough that one-off queries age out.
+const QUERY_EMBEDDING_CACHE_TTL_S = 24 * 60 * 60
+const queryEmbeddingCacheKey = (term: string) =>
+  `search-embedding:${term.toLowerCase()}`
+
+type SemanticSearchArgs = Parameters<typeof getSemanticSearchContractSQL>[0]
+
+const semanticFallback = async (
+  props: Omit<
+    SemanticSearchArgs,
+    'embedding' | 'privateUser' | 'excludeContractIds'
+  > & {
+    term: string
+    lexicalResults: Contract[]
+    pg: SupabaseDirectClient
+  }
+) => {
+  const { term, uid, limit, offset, lexicalResults, pg } = props
+  if (
+    offset > 0 ||
+    term.length < SEMANTIC_FALLBACK_MIN_TERM_LENGTH ||
+    lexicalResults.length >= SEMANTIC_FALLBACK_MIN_RESULTS
+  ) {
+    return []
+  }
+
+  const cacheKey = queryEmbeddingCacheKey(term)
+  let embedding = await cacheGetJson<number[]>(cacheKey)
+  if (embedding === undefined) {
+    embedding = await generateEmbeddings(term)
+    // No key configured, or OpenAI is down. A search with no results is a
+    // worse page, not a broken one — leave it as it was.
+    if (!embedding) return []
+    await cacheSetJson(cacheKey, embedding, QUERY_EMBEDDING_CACHE_TTL_S)
+  }
+
+  const privateUser = uid ? (await getPrivateUser(uid, pg)) ?? undefined : undefined
+  const results = await pg
+    .map(
+      getSemanticSearchContractSQL({
+        ...props,
+        embedding,
+        privateUser,
+        limit: limit - lexicalResults.length,
+        excludeContractIds: lexicalResults.map((c) => c.id),
+      }),
+      [],
+      convertContract
+    )
+    .catch((e) => {
+      log.error(`Semantic search fallback failed for term: ${term}`, e)
+      return [] as Contract[]
+    })
+
+  log(`Semantic fallback for "${term}"`, {
+    lexicalHits: lexicalResults.length,
+    semanticHits: results.length,
+  })
+  return results
 }
 
 const getAllSubTopicsForParentTopicIds = async (

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -19,7 +19,18 @@ import {
   SearchTypes,
   sortFields,
 } from 'shared/supabase/search-contracts'
-import { generateEmbeddings } from 'shared/helpers/openai-utils'
+import {
+  EMBEDDING_MODEL,
+  generateEmbeddings,
+} from 'shared/helpers/openai-utils'
+import {
+  BoundedSingleFlightCache,
+  isValidQueryEmbedding,
+  normalizeSemanticSearchTerm,
+  queryEmbeddingCacheKey,
+  RollingWindowGate,
+  shouldAttemptSemanticFallback,
+} from 'shared/helpers/semantic-search-fallback'
 import { cacheGetJson, cacheSetJson } from 'shared/redis/cache'
 import { getPrivateUser, log } from 'shared/utils'
 import { z } from 'zod'
@@ -241,18 +252,34 @@ const SEMANTIC_FALLBACK_MAX_TERM_LENGTH = 200
 // have beats hanging the page on a slow OpenAI call. No retries for the same
 // reason (the SDK default is 2 retries inside a ~10-minute timeout).
 const SEMANTIC_FALLBACK_OPENAI_TIMEOUT_MS = 3000
-// Bounds concurrent OpenAI calls per server process during incidents or
-// crawler storms (the read API runs a small pm2 cluster, so the fleet-wide
-// cap is a small multiple of this). At the cap, fallback-eligible searches
-// just return their lexical results.
 const SEMANTIC_FALLBACK_MAX_INFLIGHT = 10
-let inflightEmbeddingCalls = 0
-// The embedding of a given string never changes; this only avoids re-paying
-// the ~100ms OpenAI round-trip on repeated searches. ~30KB per entry, so keep
-// the ttl short enough that one-off queries age out.
+// A cache-miss budget also bounds sequential abuse: the in-flight cap alone
+// still allows an unauthenticated caller to create an unbounded stream of
+// unique OpenAI requests. Exhausting this budget only disables the optional
+// fallback; lexical search continues normally.
+const SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_MINUTE = 5
+// Redis is deliberately disabled in the API deploy config, so keep a small
+// process-local LRU as the dependable cache and use Redis as an optional
+// cross-process layer. One embedding is roughly 30KB in JSON form; 100 entries
+// keeps the per-process upper bound modest while retaining common searches.
+const LOCAL_QUERY_EMBEDDING_CACHE_MAX_ENTRIES = 100
 const QUERY_EMBEDDING_CACHE_TTL_S = 24 * 60 * 60
-const queryEmbeddingCacheKey = (term: string) =>
-  `search-embedding:${term.toLowerCase()}`
+const queryEmbeddingCache = new BoundedSingleFlightCache<number[]>({
+  maxEntries: LOCAL_QUERY_EMBEDDING_CACHE_MAX_ENTRIES,
+  ttlMs: QUERY_EMBEDDING_CACHE_TTL_S * 1000,
+  maxInflightCreates: SEMANTIC_FALLBACK_MAX_INFLIGHT,
+  maxCreatesPerWindow: SEMANTIC_FALLBACK_MAX_EMBEDDINGS_PER_MINUTE,
+  createWindowMs: 60_000,
+})
+// Cached terms bypass the embedding budget, so separately bound vector-query
+// work that an unauthenticated caller could otherwise repeat indefinitely.
+const SEMANTIC_FALLBACK_MAX_QUERIES_PER_MINUTE = 60
+const SEMANTIC_FALLBACK_MAX_QUERY_INFLIGHT = 10
+const semanticQueryGate = new RollingWindowGate(
+  SEMANTIC_FALLBACK_MAX_QUERIES_PER_MINUTE,
+  60_000
+)
+let inflightSemanticQueries = 0
 
 type SemanticSearchArgs = Parameters<typeof getSemanticSearchContractSQL>[0]
 
@@ -268,24 +295,19 @@ const semanticFallback = async (
 ): Promise<Contract[]> => {
   const { term, uid, limit, offset, sort, beforeTime, lexicalResults, pg } =
     props
+  const normalizedTerm = normalizeSemanticSearchTerm(term)
   if (
-    offset > 0 ||
-    // The sort=newest cursor contract reads createdTime off the LAST row of
-    // each page (see beforeTime in market-search-types), and a similarity-
-    // ordered tail poisons that on page 1 just as surely as on later pages —
-    // so the newest sort gets no tail at all, and beforeTime is guarded
-    // separately in case a client sends it with another sort.
-    sort === 'newest' ||
-    beforeTime !== undefined ||
-    // URL terms take the exact slug-lookup branch in getSearchContractSQL;
-    // embedding the URL text would append noise to an exact lookup.
-    term.startsWith('https://') ||
-    term.startsWith('http://') ||
-    term.length < SEMANTIC_FALLBACK_MIN_TERM_LENGTH ||
-    term.length > SEMANTIC_FALLBACK_MAX_TERM_LENGTH ||
-    // Capped at limit: a full page under 5 hits (limit <= 4) is not a dead
-    // end, and this also keeps the semantic query's limit strictly positive.
-    lexicalResults.length >= Math.min(limit, SEMANTIC_FALLBACK_MIN_RESULTS)
+    !shouldAttemptSemanticFallback({
+      term: normalizedTerm,
+      offset,
+      sort,
+      beforeTime,
+      lexicalResultCount: lexicalResults.length,
+      limit,
+      minResults: SEMANTIC_FALLBACK_MIN_RESULTS,
+      minTermLength: SEMANTIC_FALLBACK_MIN_TERM_LENGTH,
+      maxTermLength: SEMANTIC_FALLBACK_MAX_TERM_LENGTH,
+    })
   ) {
     return []
   }
@@ -293,48 +315,63 @@ const semanticFallback = async (
   // Fallback of a fallback: nothing in here — OpenAI, redis, the db — may
   // break the search itself. Any failure returns the lexical results alone.
   try {
-    const cacheKey = queryEmbeddingCacheKey(term)
+    const cacheKey = queryEmbeddingCacheKey(normalizedTerm, EMBEDDING_MODEL)
+    const localEmbedding = queryEmbeddingCache.get(cacheKey)
     const [cached, privateUser] = await Promise.all([
-      cacheGetJson<number[]>(cacheKey),
+      localEmbedding === undefined
+        ? cacheGetJson<unknown>(cacheKey)
+        : localEmbedding,
       uid ? getPrivateUser(uid, pg).then((u) => u ?? undefined) : undefined,
     ])
-    let embedding = cached
+    let embedding = isValidQueryEmbedding(cached) ? cached : undefined
+    if (embedding !== undefined && localEmbedding === undefined) {
+      queryEmbeddingCache.set(cacheKey, embedding)
+    }
     if (embedding === undefined) {
-      if (inflightEmbeddingCalls >= SEMANTIC_FALLBACK_MAX_INFLIGHT) return []
-      inflightEmbeddingCalls++
-      try {
-        embedding = await generateEmbeddings(term, {
+      embedding = await queryEmbeddingCache.getOrCreate(cacheKey, async () => {
+        const generated = await generateEmbeddings(normalizedTerm, {
           timeoutMs: SEMANTIC_FALLBACK_OPENAI_TIMEOUT_MS,
           maxRetries: 0,
         })
-      } finally {
-        inflightEmbeddingCalls--
-      }
+        if (!isValidQueryEmbedding(generated)) return undefined
+        // Optional cross-process cache; cacheSetJson is a no-op when Redis is
+        // disabled and does not reject callers when Redis is unavailable.
+        void cacheSetJson(cacheKey, generated, QUERY_EMBEDDING_CACHE_TTL_S)
+        return generated
+      })
       // No key configured, or OpenAI is down. A search with no results is a
       // worse page, not a broken one — leave it as it was.
       if (!embedding) return []
-      // Fire and forget: nothing reads the result and cacheSetJson never throws.
-      void cacheSetJson(cacheKey, embedding, QUERY_EMBEDDING_CACHE_TTL_S)
     }
 
-    const results = await pg.map(
-      getSemanticSearchContractSQL({
-        ...props,
-        embedding,
-        privateUser,
-        limit: limit - lexicalResults.length,
-        excludeContractIds: lexicalResults.map((c) => c.id),
-      }),
-      null,
-      convertContract
+    if (
+      inflightSemanticQueries >= SEMANTIC_FALLBACK_MAX_QUERY_INFLIGHT ||
+      !semanticQueryGate.take()
     )
-    log(`Semantic fallback for "${term}"`, {
-      lexicalHits: lexicalResults.length,
-      semanticHits: results.length,
-    })
-    return results
+      return []
+    inflightSemanticQueries++
+    try {
+      const results = await pg.map(
+        getSemanticSearchContractSQL({
+          ...props,
+          embedding,
+          privateUser,
+          limit: limit - lexicalResults.length,
+          excludeContractIds: lexicalResults.map((c) => c.id),
+        }),
+        null,
+        convertContract
+      )
+      log('Semantic search fallback completed', {
+        lexicalHits: lexicalResults.length,
+        semanticHits: results.length,
+      })
+      return results
+    } finally {
+      inflightSemanticQueries--
+    }
   } catch (e) {
-    log.error(`Semantic search fallback failed for term: ${term}`, {
+    log.error('Semantic search fallback failed', {
       error: e instanceof Error ? e.message : String(e),
     })
     return []

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -1,4 +1,5 @@
 import {
+  type FullMarketSearchResult,
   getMarketSearchRoute,
   searchProps,
 } from 'common/api/market-search-types'
@@ -239,23 +240,34 @@ const search = async (
       (c) => sortFields[sort].sortCallback(c),
       sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
     )
+    const markedLexicalResults: FullMarketSearchResult[] = lexicalResults.map(
+      (contract) => ({
+        ...contract,
+        searchMatchType: 'lexical',
+      })
+    )
 
-    const semanticResults = await semanticFallback({
-      ...props,
-      term: cleanTerm,
-      uid: userId,
-      groupId,
-      groupIds,
-      isPrizeMarket,
-      lexicalResults,
-      callerKey: semanticCallerKey,
-      pg,
-    })
+    const semanticResults: FullMarketSearchResult[] = (
+      await semanticFallback({
+        ...props,
+        term: cleanTerm,
+        uid: userId,
+        groupId,
+        groupIds,
+        isPrizeMarket,
+        lexicalResults,
+        callerKey: semanticCallerKey,
+        pg,
+      })
+    ).map((contract) => ({
+      ...contract,
+      searchMatchType: 'semantic',
+    }))
 
     // Appended in similarity order rather than merged into the sort: these
     // matched no keyword, so ordering them by importance would float a weak
     // association above a strong one.
-    return [...lexicalResults, ...semanticResults]
+    return [...markedLexicalResults, ...semanticResults]
   }
 }
 

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -9,6 +9,7 @@ import {
   DiscoveryExperimentVariant,
   getEffectiveDiscoveryExperimentVariant,
 } from 'common/discovery-experiment'
+import { SEARCH_ANCHOR_CLOCK_SKEW_ERROR } from 'common/search-request-coordination'
 import { convertContract } from 'common/supabase/contracts'
 import { orderBy, uniqBy } from 'lodash'
 import { getGroupIdFromSlug } from 'shared/supabase/groups'
@@ -209,10 +210,7 @@ const search = async (
     props.seenMarketCutoffTime !== undefined &&
     !shouldSuppressStaleSeenMarkets(props.seenMarketCutoffTime)
   ) {
-    throw new APIError(
-      400,
-      'seenMarketCutoffTime is too far ahead of server time'
-    )
+    throw new APIError(400, SEARCH_ANCHOR_CLOCK_SKEW_ERROR)
   }
   if (searchRoute === 'basic' || searchRoute === 'for-you') {
     // Enforce blocked users/contracts/topics in the query itself — the

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -38,6 +38,7 @@ import {
   QUERY_EMBEDDING_DIMENSIONS,
   queryEmbeddingCacheKey,
   shouldAttemptSemanticFallback,
+  withSemanticQueryTimeout,
 } from 'shared/helpers/semantic-search-fallback'
 import { getIp } from 'shared/analytics'
 import { cacheGetJson, cacheSetJson } from 'shared/redis/cache'
@@ -499,16 +500,18 @@ const semanticFallback = async (
       return []
     inflightSemanticQueries++
     try {
-      const results = await pg.map(
-        getSemanticSearchContractSQL({
-          ...props,
-          embedding,
-          privateUser,
-          limit: limit - lexicalResults.length,
-          excludeContractIds: lexicalResults.map((c) => c.id),
-        }),
-        null,
-        convertContract
+      const results = await withSemanticQueryTimeout(pg, (tx) =>
+        tx.map(
+          getSemanticSearchContractSQL({
+            ...props,
+            embedding,
+            privateUser,
+            limit: limit - lexicalResults.length,
+            excludeContractIds: lexicalResults.map((c) => c.id),
+          }),
+          null,
+          convertContract
+        )
       )
       log('Semantic search fallback completed', {
         lexicalHits: lexicalResults.length,

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -1,4 +1,4 @@
-import { calculateUserTopicInterests } from 'shared/calculate-user-topic-interests'
+import { calculateUserTopicInterestsWithCatchUp } from 'shared/calculate-user-topic-interests'
 import { checkPushNotificationReceipts } from 'shared/check-push-receipts'
 import { calculateConversionScore } from 'shared/conversion-score'
 import { downsamplePortfolioHistory } from 'shared/downsample-portfolio-history'
@@ -278,7 +278,7 @@ export function createJobs() {
     createJob(
       'calculate-user-topic-interests',
       '0 0 4 * * *', // daily at 4:00 AM LA
-      () => calculateUserTopicInterests()
+      () => calculateUserTopicInterestsWithCatchUp()
     ),
     createJob(
       'update-stats',

--- a/backend/scripts/compare-for-you-ranking.ts
+++ b/backend/scripts/compare-for-you-ranking.ts
@@ -33,16 +33,24 @@ const rankingSql = `
     select c.id,
            c.question,
            count(gc.group_id) as n_tags,
-           avg(power(coalesce(uti.score, $2), 4) * c.importance_score)
-             as old_rank,
-           power(0.7 * max(coalesce(uti.score, $2))
-               + 0.3 * avg(coalesce(uti.score, $2)), 4)
-             * avg(c.importance_score) as new_rank
+           case when bool_or(uti.score is not null)
+             then avg(power(coalesce(uti.score, $2), 4) * c.importance_score)
+             else avg(c.importance_score * $2)
+           end as old_rank,
+           case when bool_or(uti.score is not null)
+             then power(0.7 * max(coalesce(uti.score, $2))
+                    + 0.3 * avg(coalesce(uti.score, $2)), 4)
+                  * avg(c.importance_score)
+             else avg(c.importance_score * $2)
+           end as new_rank
     from contracts c
     join group_contracts gc on gc.contract_id = c.id
     left join uti on uti.group_id = gc.group_id
-    where c.close_time > now()
+    where c.resolution_time is null
+      and (c.close_time > now() or c.close_time is null)
       and c.visibility = 'public'
+      and c.deleted = false
+      and c.token = 'MANA'
       and c.outcome_type not in ('STONK', 'BOUNTIED_QUESTION')
       and c.importance_score > $3
     group by c.id
@@ -88,17 +96,17 @@ if (require.main === module) {
     }
 
     for (const user of users) {
-      const rows = await pg.map<Row>(rankingSql, [
-        user.id,
-        GROUP_SCORE_PRIOR,
-        MIN_IMPORTANCE,
-      ], (r) => ({
-        id: r.id,
-        question: r.question,
-        n_tags: Number(r.n_tags),
-        old_pos: Number(r.old_pos),
-        new_pos: Number(r.new_pos),
-      }))
+      const rows = await pg.map<Row>(
+        rankingSql,
+        [user.id, GROUP_SCORE_PRIOR, MIN_IMPORTANCE],
+        (r) => ({
+          id: r.id,
+          question: r.question,
+          n_tags: Number(r.n_tags),
+          old_pos: Number(r.old_pos),
+          new_pos: Number(r.new_pos),
+        })
+      )
 
       const oldTop = rows.filter((r) => r.old_pos <= TOP_N)
       const newTop = rows.filter((r) => r.new_pos <= TOP_N)
@@ -108,16 +116,21 @@ if (require.main === module) {
         .sort((a, b) => a.new_pos - b.new_pos)
 
       const avgTags = (rs: Row[]) =>
-        rs.length ? (rs.reduce((s, r) => s + r.n_tags, 0) / rs.length).toFixed(2) : 'n/a'
+        rs.length
+          ? (rs.reduce((s, r) => s + r.n_tags, 0) / rs.length).toFixed(2)
+          : 'n/a'
 
       console.log(`\n=== ${user.username} (${rows.length} candidates) ===`)
       console.log(
-        `top ${TOP_N}: ${TOP_N - promoted.length} unchanged, ${promoted.length} new` +
-          ` | avg tags ${avgTags(oldTop)} -> ${avgTags(newTop)}`
+        `top ${TOP_N}: ${TOP_N - promoted.length} unchanged, ${
+          promoted.length
+        } new` + ` | avg tags ${avgTags(oldTop)} -> ${avgTags(newTop)}`
       )
       for (const r of promoted) {
         console.log(
-          `  #${String(r.new_pos).padStart(2)} (was #${r.old_pos}, ${r.n_tags} tags) ${r.question.slice(0, 80)}`
+          `  #${String(r.new_pos).padStart(2)} (was #${r.old_pos}, ${
+            r.n_tags
+          } tags) ${r.question.slice(0, 80)}`
         )
       }
     }

--- a/backend/scripts/compare-for-you-ranking.ts
+++ b/backend/scripts/compare-for-you-ranking.ts
@@ -1,0 +1,125 @@
+import { runScript } from 'run-script'
+import { GROUP_SCORE_PRIOR } from 'common/feed'
+
+/**
+ * Before/after for the niche-blend change to getForYouSQL.
+ *
+ * Ranks every open market twice for a sample of real users — once with the
+ * old avg(score^4) aggregation, once with the 0.7·max + 0.3·avg blend the
+ * feed already uses — and reports how much of the top 20 moves.
+ *
+ * Approximates the ranking rather than reproducing it: reads topic scores
+ * straight from get_user_topic_interests_2 rather than the in-memory cache,
+ * so followed-topic boosts, blocked topics and the followed-creator
+ * multiplier are not applied. Good enough to see the shape of the change,
+ * not a substitute for watching it in prod.
+ *
+ * Usage:
+ *   ts-node compare-for-you-ranking.ts [username ...]
+ * With no arguments, samples the most recently scored users.
+ */
+
+const TOP_N = 20
+const DEFAULT_SAMPLE_SIZE = 5
+// Cuts ~34k open markets to the few thousand that could plausibly rank, so
+// the double ranking stays a single fast query per user.
+const MIN_IMPORTANCE = 0.2
+
+const rankingSql = `
+  with uti as (
+    select group_id, score from get_user_topic_interests_2($1)
+  ),
+  cand as (
+    select c.id,
+           c.question,
+           count(gc.group_id) as n_tags,
+           avg(power(coalesce(uti.score, $2), 4) * c.importance_score)
+             as old_rank,
+           power(0.7 * max(coalesce(uti.score, $2))
+               + 0.3 * avg(coalesce(uti.score, $2)), 4)
+             * avg(c.importance_score) as new_rank
+    from contracts c
+    join group_contracts gc on gc.contract_id = c.id
+    left join uti on uti.group_id = gc.group_id
+    where c.close_time > now()
+      and c.visibility = 'public'
+      and c.outcome_type not in ('STONK', 'BOUNTIED_QUESTION')
+      and c.importance_score > $3
+    group by c.id
+  )
+  select id, question, n_tags,
+         row_number() over (order by old_rank desc) as old_pos,
+         row_number() over (order by new_rank desc) as new_pos
+  from cand
+`
+
+type Row = {
+  id: string
+  question: string
+  n_tags: number
+  old_pos: number
+  new_pos: number
+}
+
+if (require.main === module) {
+  runScript(async ({ pg }) => {
+    const requested = process.argv.slice(2)
+
+    const users = requested.length
+      ? await pg.map(
+          `select id, username from users where username in ($1:list)`,
+          [requested],
+          (r) => ({ id: r.id as string, username: r.username as string })
+        )
+      : await pg.map(
+          `select u.id, u.username
+           from user_topic_interests uti
+           join users u on u.id = uti.user_id
+           where uti.created_time = (select max(created_time) from user_topic_interests)
+           order by random()
+           limit $1`,
+          [DEFAULT_SAMPLE_SIZE],
+          (r) => ({ id: r.id as string, username: r.username as string })
+        )
+
+    if (!users.length) {
+      console.log('No users found.')
+      return
+    }
+
+    for (const user of users) {
+      const rows = await pg.map<Row>(rankingSql, [
+        user.id,
+        GROUP_SCORE_PRIOR,
+        MIN_IMPORTANCE,
+      ], (r) => ({
+        id: r.id,
+        question: r.question,
+        n_tags: Number(r.n_tags),
+        old_pos: Number(r.old_pos),
+        new_pos: Number(r.new_pos),
+      }))
+
+      const oldTop = rows.filter((r) => r.old_pos <= TOP_N)
+      const newTop = rows.filter((r) => r.new_pos <= TOP_N)
+      const oldIds = new Set(oldTop.map((r) => r.id))
+      const promoted = newTop
+        .filter((r) => !oldIds.has(r.id))
+        .sort((a, b) => a.new_pos - b.new_pos)
+
+      const avgTags = (rs: Row[]) =>
+        rs.length ? (rs.reduce((s, r) => s + r.n_tags, 0) / rs.length).toFixed(2) : 'n/a'
+
+      console.log(`\n=== ${user.username} (${rows.length} candidates) ===`)
+      console.log(
+        `top ${TOP_N}: ${TOP_N - promoted.length} unchanged, ${promoted.length} new` +
+          ` | avg tags ${avgTags(oldTop)} -> ${avgTags(newTop)}`
+      )
+      for (const r of promoted) {
+        console.log(
+          `  #${String(r.new_pos).padStart(2)} (was #${r.old_pos}, ${r.n_tags} tags) ${r.question.slice(0, 80)}`
+        )
+      }
+    }
+  })
+}

--- a/backend/scripts/discovery-v1-report.ts
+++ b/backend/scripts/discovery-v1-report.ts
@@ -1,0 +1,1162 @@
+import { AB_TEST_ACCOUNT_OVERRIDES } from 'common/ab-test'
+import {
+  DISCOVERY_EXPOSURE_EVENT,
+  DISCOVERY_RESULT_CLICK_EVENT,
+  DISCOVERY_RESULTS_EVENT,
+  DISCOVERY_SEARCH_ABORT_EVENT,
+  DISCOVERY_SEARCH_ERROR_EVENT,
+  DISCOVERY_SEARCH_REQUEST_EVENT,
+} from 'common/discovery-experiment'
+import { ENV_CONFIG } from 'common/envs/constants'
+import { READ_ONLY_REPEATABLE_MODE } from 'shared/supabase/init'
+import { runScript } from './run-script'
+
+/**
+ * Read-only scorecard for the discovery-v1 A/B test.
+ *
+ * Usage:
+ *   yarn ts-node discovery-v1-report.ts YYYY-MM-DD [YYYY-MM-DD]
+ *
+ * Dates are midnight-to-midnight in Pacific time; the optional end is
+ * exclusive and defaults to 30 minutes ago, allowing the outcome window to
+ * mature. The causal rows use only the main Browse
+ * Search (`sourceComponent = search`). Forced QA accounts, admins, and bots
+ * are shown separately or excluded from the experiment comparison.
+ */
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+const [start, end] = process.argv.slice(2)
+const MAX_REPORT_DAYS = 31
+const DAY_MS = 24 * 60 * 60 * 1000
+const OUTCOME_WINDOW_MS = 30 * 60 * 1000
+
+if (!start || !DATE_REGEX.test(start) || (end && !DATE_REGEX.test(end))) {
+  console.error(
+    'Usage: yarn ts-node discovery-v1-report.ts YYYY-MM-DD [YYYY-MM-DD]'
+  )
+  process.exit(1)
+}
+
+const parseIsoDate = (date: string) => {
+  const parsed = new Date(`${date}T00:00:00.000Z`)
+  return Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== date
+    ? undefined
+    : parsed
+}
+const parsedStart = parseIsoDate(start)
+const now = new Date()
+const parsedEnd = end ? parseIsoDate(end) : now
+if (
+  !parsedStart ||
+  !parsedEnd ||
+  parsedEnd <= parsedStart ||
+  parsedEnd.getTime() - parsedStart.getTime() > MAX_REPORT_DAYS * DAY_MS ||
+  (end !== undefined && parsedEnd.getTime() > now.getTime() - OUTCOME_WINDOW_MS)
+) {
+  console.error(
+    `Report window must be valid, increasing, at most 31 days, and have a complete 30-minute outcome window.`
+  )
+  process.exit(1)
+}
+// Use one captured time across every query so a live report has one boundary.
+const reportEndTime = now.toISOString()
+
+type ScorecardRow = {
+  segment: string
+  variant: string
+  presentations: number
+  result_sets: number
+  subjects: number
+  market_ctr: number | null
+  meaningful_action_rate: number | null
+  post_ctr: number | null
+  semantic_tail_ctr: number | null
+  zero_market_rate: number | null
+  avg_markets_presented: number | null
+  prior_seen_top_ten_rate: number | null
+  p95_initial_latency_ms: number | null
+  compatibility_fallback_rate: number | null
+}
+
+type LiftRow = {
+  segment: string
+  metric: string
+  desired_direction: string
+  control_subjects: number
+  treatment_subjects: number
+  control_rate: number | null
+  treatment_rate: number | null
+  absolute_lift: number | null
+  relative_lift: number | null
+  ci_95_low: number | null
+  ci_95_high: number | null
+}
+
+type RequestLiftRow = LiftRow & {
+  decision_role: string
+}
+
+type ResultHealthRow = {
+  segment: string
+  variant: string
+  result_sets: number
+  avg_markets_loaded: number | null
+  avg_distinct_markets_loaded: number | null
+  duplicate_rate: number | null
+  compatibility_fallback_rate: number | null
+}
+
+type ReliabilityRow = {
+  surface: string
+  assignment_source: string
+  variant: string
+  request_stage: string
+  attempts: number
+  successes: number
+  terminal_errors: number
+  client_aborts: number
+  missing_outcomes: number
+  success_rate: number | null
+  error_rate: number | null
+  abort_rate: number | null
+  p95_success_latency_ms: number | null
+  p95_terminal_error_latency_ms: number | null
+}
+
+const analysisCtes = `
+with raw_presentations as (
+  select distinct on (ue.data ->> 'presentationId')
+    ue.ts,
+    ue.user_id,
+    ue.data ->> 'deviceId' as device_id,
+    case
+      when ue.user_id is not null then 'user:' || ue.user_id
+      else 'device:' || (ue.data ->> 'deviceId')
+    end as subject_id,
+    ue.data ->> 'presentationId' as presentation_id,
+    ue.data ->> 'resultSetId' as result_set_id,
+    ue.data ->> 'variant' as variant,
+    ue.data ->> 'assignmentSource' as assignment_source,
+    ue.data ->> 'sourceComponent' as source_component,
+    ue.data ->> 'surface' as surface,
+    coalesce((ue.data ->> 'marketCount')::int, 0) as market_count,
+    coalesce((ue.data ->> 'postCount')::int, 0) as post_count,
+    coalesce((ue.data ->> 'semanticEligible')::boolean, false)
+      as semantic_eligible,
+    coalesce((ue.data ->> 'semanticMarketCount')::int, 0)
+      as semantic_count,
+    coalesce((ue.data ->> 'compatibilityFallback')::boolean, false)
+      as compatibility_fallback,
+    (ue.data ->> 'initialLatencyMs')::numeric as initial_latency_ms,
+    ue.data
+  from user_events ue
+  left join users u on u.id = ue.user_id
+  where ue.name = $3
+    and ue.ts >= date_to_midnight_pt($1::date)
+    and ue.ts < case
+      when $2::date is null then $7::timestamptz - interval '30 minutes'
+      else least(
+        date_to_midnight_pt($2::date),
+        $7::timestamptz - interval '30 minutes'
+      )
+    end
+    and ue.data ->> 'presentationId' is not null
+    and ue.data ->> 'variant' in ('control', 'treatment')
+    and ue.data ->> 'assignmentSource' <> 'forced'
+    and ue.data ->> 'sourceComponent' = 'search'
+    and (ue.user_id is null or ue.user_id not in ($6:list))
+    and coalesce(u.is_bot, false) = false
+  order by ue.data ->> 'presentationId', ue.ts
+),
+selected_result_sets as (
+  select distinct result_set_id from raw_presentations
+),
+result_set_compatibility as (
+  select
+    ue.data ->> 'resultSetId' as result_set_id,
+    bool_or(
+      coalesce(
+        (ue.data ->> 'compatibilityFallback')::boolean,
+        false
+      )
+    ) as used_compatibility_fallback
+  from user_events ue
+  join selected_result_sets selected
+    on selected.result_set_id = ue.data ->> 'resultSetId'
+  where ue.name = $4
+    -- A presentation can reuse an SPA-cached result set from before the
+    -- reporting window. Bound that lookup so this script can use the ts index
+    -- instead of scanning the entire user_events table.
+    and ue.ts >= date_to_midnight_pt($1::date) - interval '24 hours'
+    and ue.ts < case
+      when $2::date is null then $7::timestamptz
+      else date_to_midnight_pt($2::date) + interval '30 minutes'
+    end
+  group by ue.data ->> 'resultSetId'
+),
+presentations as (
+  select
+    presentation.*,
+    case
+      when presentation.surface = 'for-you'
+        and presentation.user_id is not null
+        then 'for-you'
+      when presentation.surface = 'for-you'
+        then 'for-you-ineligible'
+      when presentation.surface = 'text-search'
+        and presentation.semantic_eligible
+        then 'text-search-low-hit'
+      when presentation.surface = 'text-search'
+        then 'text-search-other'
+      else 'browse-guardrail'
+    end as segment
+  from raw_presentations presentation
+),
+result_pages as (
+  select
+    ue.ts,
+    ue.data ->> 'resultSetId' as result_set_id,
+    (ue.data ->> 'page')::int as page,
+    ue.data
+  from user_events ue
+  join selected_result_sets selected
+    on selected.result_set_id = ue.data ->> 'resultSetId'
+  where ue.name = $4
+    and ue.ts >= date_to_midnight_pt($1::date) - interval '24 hours'
+    and ue.ts < case
+      when $2::date is null then $7::timestamptz
+      else date_to_midnight_pt($2::date) + interval '30 minutes'
+    end
+),
+page_items as (
+  select
+    page.ts,
+    page.result_set_id,
+    item ->> 'id' as item_id,
+    item ->> 'itemType' as item_type,
+    item ->> 'matchType' as match_type
+  from result_pages page
+  cross join lateral jsonb_array_elements(
+    coalesce(page.data -> 'items', '[]'::jsonb)
+  ) as result_item(item)
+),
+item_availability as (
+  select
+    result_set_id,
+    item_id,
+    item_type,
+    min(ts) as first_loaded_ts
+  from page_items
+  group by result_set_id, item_id, item_type
+),
+exposure_items as (
+  select
+    presentation.presentation_id,
+    item ->> 'id' as item_id,
+    item ->> 'itemType' as item_type,
+    (item ->> 'rank')::int as rank,
+    item ->> 'matchType' as match_type
+  from presentations presentation
+  cross join lateral jsonb_array_elements(
+    coalesce(presentation.data -> 'items', '[]'::jsonb)
+  ) as exposure_item(item)
+),
+candidate_item_availability as (
+  select
+    presentation.presentation_id,
+    item.item_id,
+    item.item_type,
+    presentation.ts as available_ts
+  from presentations presentation
+  join exposure_items item using (presentation_id)
+  union all
+  select
+    presentation.presentation_id,
+    item.item_id,
+    item.item_type,
+    greatest(item.first_loaded_ts, presentation.ts) as available_ts
+  from presentations presentation
+  join item_availability item using (result_set_id)
+),
+presentation_item_availability as (
+  select
+    presentation_id,
+    item_id,
+    item_type,
+    min(available_ts) as available_ts
+  from candidate_item_availability
+  group by presentation_id, item_id, item_type
+),
+click_rollup as (
+  select
+    presentation.presentation_id,
+    count(*) filter (
+      where click.data ->> 'itemType' = 'market'
+    ) as market_clicks,
+    count(*) filter (
+      where click.data ->> 'itemType' = 'post'
+    ) as post_clicks,
+    count(*) filter (
+      where click.data ->> 'matchType' = 'semantic'
+    ) as semantic_clicks
+  from presentations presentation
+  left join user_events click
+    on click.name = $5
+   and click.data ->> 'presentationId' = presentation.presentation_id
+   -- Exposure/click inserts are fire-and-forget and can arrive out of order.
+   and click.ts >= presentation.ts - interval '5 seconds'
+   and click.ts < presentation.ts + interval '30 minutes'
+   and click.ts >= date_to_midnight_pt($1::date) - interval '5 seconds'
+   and click.ts < case
+     when $2::date is null then $7::timestamptz + interval '30 minutes'
+     else date_to_midnight_pt($2::date) + interval '30 minutes'
+   end
+  group by presentation.presentation_id
+),
+action_candidates as (
+  select
+    interaction.id as action_id,
+    presentation.presentation_id,
+    row_number() over (
+      partition by interaction.id
+      order by presentation.ts desc
+    ) as attribution_order
+  from user_contract_interactions interaction
+  join presentations presentation
+    on presentation.user_id = interaction.user_id
+   and presentation.ts <= interaction.created_time + interval '5 seconds'
+   and presentation.ts > interaction.created_time - interval '30 minutes'
+  join presentation_item_availability item
+    on item.presentation_id = presentation.presentation_id
+   and item.item_type = 'market'
+   and item.item_id = interaction.contract_id
+   and item.available_ts <= interaction.created_time + interval '5 seconds'
+  where interaction.name in (
+    'page bet',
+    'page comment',
+    'page repost',
+    'page like',
+    'page share'
+  )
+),
+action_rollup as (
+  select presentation_id, count(*) as actions
+  from action_candidates
+  where attribution_order = 1
+  group by presentation_id
+),
+prior_seen_rollup as (
+  select
+    presentation.presentation_id,
+    count(*) filter (where item.rank <= 10) as top_ten_markets,
+    count(*) filter (
+      where item.rank <= 10
+        and exists (
+          select 1
+          from user_view_events view_event
+          where view_event.user_id = presentation.user_id
+            and view_event.contract_id = item.item_id
+            and view_event.name in ('card', 'page')
+            and view_event.created_time
+                >= presentation.ts - interval '7 days'
+            and view_event.created_time
+                < presentation.ts - interval '1 hour'
+        )
+    ) as previously_seen_top_ten
+  from presentations presentation
+  join exposure_items item
+    on item.presentation_id = presentation.presentation_id
+   and item.item_type = 'market'
+  where presentation.user_id is not null
+  group by presentation.presentation_id
+),
+per_presentation as (
+  select
+    presentation.ts,
+    presentation.subject_id,
+    presentation.user_id,
+    presentation.presentation_id,
+    presentation.result_set_id,
+    presentation.segment,
+    presentation.variant,
+    presentation.assignment_source,
+    presentation.market_count,
+    presentation.post_count,
+    presentation.semantic_count,
+    presentation.initial_latency_ms,
+    presentation.compatibility_fallback,
+    (coalesce(click.market_clicks, 0) > 0)::int as market_clicked,
+    (coalesce(click.post_clicks, 0) > 0)::int as post_clicked,
+    (coalesce(click.semantic_clicks, 0) > 0)::int as semantic_clicked,
+    case
+      when presentation.user_id is null then null
+      else (coalesce(action.actions, 0) > 0)::int
+    end as meaningfully_acted,
+    case
+      when prior_seen.top_ten_markets > 0
+      then prior_seen.previously_seen_top_ten::numeric
+        / prior_seen.top_ten_markets
+    end as prior_seen_top_ten_rate
+  from presentations presentation
+  left join click_rollup click using (presentation_id)
+  left join action_rollup action using (presentation_id)
+  left join prior_seen_rollup prior_seen using (presentation_id)
+)
+`
+
+const scorecardSql = `${analysisCtes}
+select
+  segment,
+  variant,
+  count(*)::int as presentations,
+  count(distinct result_set_id)::int as result_sets,
+  count(distinct subject_id)::int as subjects,
+  round(avg(market_clicked), 4) as market_ctr,
+  round(avg(meaningfully_acted), 4) as meaningful_action_rate,
+  round(avg(post_clicked) filter (where post_count > 0), 4) as post_ctr,
+  round(
+    avg(semantic_clicked) filter (where semantic_count > 0),
+    4
+  ) as semantic_tail_ctr,
+  round(avg((market_count = 0)::int), 4) as zero_market_rate,
+  round(avg(market_count), 2) as avg_markets_presented,
+  round(avg(prior_seen_top_ten_rate), 4) as prior_seen_top_ten_rate,
+  round(
+    percentile_cont(0.95)
+      within group (order by initial_latency_ms)::numeric,
+    0
+  ) as p95_initial_latency_ms,
+  round(avg(compatibility_fallback::int), 4)
+    as compatibility_fallback_rate
+from per_presentation
+group by segment, variant
+order by segment, variant
+`
+
+const subjectLiftSql = `${analysisCtes},
+subject_metrics as (
+  select
+    segment,
+    variant,
+    subject_id,
+    avg(market_clicked::numeric) as market_ctr,
+    avg(meaningfully_acted::numeric) as meaningful_action_rate,
+    avg((market_count = 0)::int::numeric) as zero_market_rate
+  from per_presentation
+  where segment in ('for-you', 'text-search-low-hit')
+    -- Anonymous assignment intentionally changes to an immutable user-based
+    -- assignment after login. Keep those correlated device/user observations
+    -- out of the causal estimate; they remain visible in the scorecard.
+    and user_id is not null
+    and assignment_source = 'user-hash'
+  group by segment, variant, subject_id
+),
+subject_metric_values as (
+  select
+    subject.segment,
+    subject.variant,
+    metric.metric,
+    metric.desired_direction,
+    metric.value
+  from subject_metrics subject
+  cross join lateral (
+    values
+      ('market CTR', 'higher', subject.market_ctr),
+      ('meaningful action rate', 'higher', subject.meaningful_action_rate),
+      ('zero-market rate', 'lower', subject.zero_market_rate)
+  ) as metric(metric, desired_direction, value)
+  where metric.value is not null
+),
+arm_statistics as (
+  select
+    segment,
+    variant,
+    metric,
+    desired_direction,
+    count(*)::int as subjects,
+    avg(value) as rate,
+    var_samp(value) as variance
+  from subject_metric_values
+  group by segment, variant, metric, desired_direction
+),
+comparison as (
+  select
+    segment,
+    metric,
+    desired_direction,
+    max(subjects) filter (where variant = 'control') as control_subjects,
+    max(subjects) filter (where variant = 'treatment') as treatment_subjects,
+    max(rate) filter (where variant = 'control') as control_rate,
+    max(rate) filter (where variant = 'treatment') as treatment_rate,
+    max(variance) filter (where variant = 'control') as control_variance,
+    max(variance) filter (where variant = 'treatment') as treatment_variance
+  from arm_statistics
+  group by segment, metric, desired_direction
+),
+with_standard_error as (
+  select
+    *,
+    sqrt(
+      treatment_variance / nullif(treatment_subjects, 0)
+      + control_variance / nullif(control_subjects, 0)
+    ) as standard_error
+  from comparison
+)
+select
+  segment,
+  metric,
+  desired_direction,
+  control_subjects::int,
+  treatment_subjects::int,
+  round(control_rate, 4) as control_rate,
+  round(treatment_rate, 4) as treatment_rate,
+  round(treatment_rate - control_rate, 4) as absolute_lift,
+  round((treatment_rate - control_rate) / nullif(control_rate, 0), 4)
+    as relative_lift,
+  round(treatment_rate - control_rate - 1.96 * standard_error, 4)
+    as ci_95_low,
+  round(treatment_rate - control_rate + 1.96 * standard_error, 4)
+    as ci_95_high
+from with_standard_error
+where control_subjects is not null and treatment_subjects is not null
+order by segment, metric
+`
+
+const requestLiftSql = `${analysisCtes},
+fresh_requests as (
+  select distinct on (ue.data ->> 'requestAttemptId')
+    ue.ts,
+    ue.user_id,
+    'user:' || ue.user_id as subject_id,
+    ue.data ->> 'requestAttemptId' as request_attempt_id,
+    ue.data ->> 'resultSetId' as result_set_id,
+    ue.data ->> 'variant' as variant,
+    ue.data ->> 'surface' as surface
+  from user_events ue
+  left join users u on u.id = ue.user_id
+  where ue.name = $8
+    and ue.ts >= date_to_midnight_pt($1::date)
+    and ue.ts < case
+      -- Give a request one minute to render, then measure actions for 30
+      -- minutes from that presentation. Requests without a presentation in
+      -- that minute remain in the ITT denominator as zero engagement.
+      when $2::date is null then $7::timestamptz - interval '31 minutes'
+      else least(
+        date_to_midnight_pt($2::date) - interval '1 minute',
+        $7::timestamptz - interval '31 minutes'
+      )
+    end
+    and ue.user_id is not null
+    and ue.data ->> 'requestAttemptId' is not null
+    and ue.data ->> 'resultSetId' is not null
+    and ue.data ->> 'variant' in ('control', 'treatment')
+    and ue.data ->> 'assignmentSource' = 'user-hash'
+    and ue.data ->> 'sourceComponent' = 'search'
+    and ue.data ->> 'surface' in ('for-you', 'text-search')
+    and coalesce((ue.data ->> 'isFresh')::boolean, false)
+    and ue.user_id not in ($6:list)
+    and coalesce(u.is_bot, false) = false
+  order by ue.data ->> 'requestAttemptId', ue.ts
+),
+request_presentations as (
+  select distinct on (request.request_attempt_id)
+    request.subject_id,
+    request.variant,
+    request.surface,
+    request.request_attempt_id,
+    presentation.presentation_id,
+    presentation.market_count,
+    presentation.market_clicked,
+    presentation.meaningfully_acted
+  from fresh_requests request
+  left join per_presentation presentation
+    on presentation.result_set_id = request.result_set_id
+   and presentation.user_id = request.user_id
+   and presentation.ts >= request.ts - interval '5 seconds'
+   and presentation.ts < request.ts + interval '1 minute'
+  order by request.request_attempt_id, presentation.ts
+),
+request_subject_metrics as (
+  select
+    case
+      when surface = 'for-you' then 'for-you-itt'
+      else 'text-search-all-itt'
+    end as segment,
+    variant,
+    subject_id,
+    avg(coalesce(market_clicked, 0)::numeric) as market_ctr,
+    avg(coalesce(meaningfully_acted, 0)::numeric)
+      as meaningful_action_rate,
+    avg((presentation_id is not null)::int::numeric) as render_rate,
+    avg((coalesce(market_count, 0) = 0)::int::numeric) as zero_market_rate
+  from request_presentations
+  group by segment, variant, subject_id
+),
+request_metric_values as (
+  select
+    subject.segment,
+    subject.variant,
+    metric.metric,
+    metric.decision_role,
+    metric.desired_direction,
+    metric.value
+  from request_subject_metrics subject
+  cross join lateral (
+    values
+      (
+        'market CTR',
+        case when subject.segment = 'text-search-all-itt'
+          then 'primary' else 'secondary' end,
+        'higher',
+        subject.market_ctr
+      ),
+      (
+        'meaningful action rate',
+        case when subject.segment = 'for-you-itt'
+          then 'primary' else 'secondary' end,
+        'higher',
+        subject.meaningful_action_rate
+      ),
+      ('render rate', 'reliability guardrail', 'higher', subject.render_rate),
+      ('zero-market rate', 'mechanism', 'lower', subject.zero_market_rate)
+  ) as metric(metric, decision_role, desired_direction, value)
+),
+request_arm_statistics as (
+  select
+    segment,
+    variant,
+    metric,
+    decision_role,
+    desired_direction,
+    count(*)::int as subjects,
+    avg(value) as rate,
+    var_samp(value) as variance
+  from request_metric_values
+  group by segment, variant, metric, decision_role, desired_direction
+),
+request_comparison as (
+  select
+    segment,
+    metric,
+    decision_role,
+    desired_direction,
+    max(subjects) filter (where variant = 'control') as control_subjects,
+    max(subjects) filter (where variant = 'treatment') as treatment_subjects,
+    max(rate) filter (where variant = 'control') as control_rate,
+    max(rate) filter (where variant = 'treatment') as treatment_rate,
+    max(variance) filter (where variant = 'control') as control_variance,
+    max(variance) filter (where variant = 'treatment') as treatment_variance
+  from request_arm_statistics
+  group by segment, metric, decision_role, desired_direction
+),
+request_with_standard_error as (
+  select
+    *,
+    sqrt(
+      treatment_variance / nullif(treatment_subjects, 0)
+      + control_variance / nullif(control_subjects, 0)
+    ) as standard_error
+  from request_comparison
+)
+select
+  segment,
+  metric,
+  decision_role,
+  desired_direction,
+  control_subjects::int,
+  treatment_subjects::int,
+  round(control_rate, 4) as control_rate,
+  round(treatment_rate, 4) as treatment_rate,
+  round(treatment_rate - control_rate, 4) as absolute_lift,
+  round((treatment_rate - control_rate) / nullif(control_rate, 0), 4)
+    as relative_lift,
+  round(treatment_rate - control_rate - 1.96 * standard_error, 4)
+    as ci_95_low,
+  round(treatment_rate - control_rate + 1.96 * standard_error, 4)
+    as ci_95_high
+from request_with_standard_error
+where control_subjects is not null and treatment_subjects is not null
+order by segment, decision_role, metric
+`
+
+const resultHealthSql = `${analysisCtes},
+first_presentation_per_result_set as (
+  select distinct on (result_set_id)
+    presentation.result_set_id,
+    presentation.segment,
+    presentation.variant,
+    coalesce(compatibility.used_compatibility_fallback, false)
+      as compatibility_fallback
+  from presentations presentation
+  -- This diagnostic intentionally includes only result sets whose response
+  -- event is inside the bounded lookup window. Causal fields live directly
+  -- on the exposure event and do not depend on this join.
+  join result_set_compatibility compatibility using (result_set_id)
+  order by presentation.result_set_id, presentation.ts
+),
+result_set_items as (
+  select
+    result_set_id,
+    count(*) filter (where item_type = 'market') as markets_loaded,
+    count(distinct item_id) filter (where item_type = 'market')
+      as distinct_markets_loaded
+  from page_items
+  group by result_set_id
+),
+result_set_health as (
+  select
+    first.segment,
+    first.variant,
+    first.result_set_id,
+    first.compatibility_fallback,
+    coalesce(items.markets_loaded, 0) as markets_loaded,
+    coalesce(items.distinct_markets_loaded, 0) as distinct_markets_loaded
+  from first_presentation_per_result_set first
+  left join result_set_items items using (result_set_id)
+)
+select
+  segment,
+  variant,
+  count(*)::int as result_sets,
+  round(avg(markets_loaded), 2) as avg_markets_loaded,
+  round(avg(distinct_markets_loaded), 2) as avg_distinct_markets_loaded,
+  round(
+    avg(
+      case
+        when markets_loaded > 0
+        then 1 - distinct_markets_loaded::numeric / markets_loaded
+      end
+    ),
+    4
+  ) as duplicate_rate,
+  round(avg(compatibility_fallback::int), 4)
+    as compatibility_fallback_rate
+from result_set_health
+group by segment, variant
+order by segment, variant
+`
+
+const numberOrNull = (value: unknown) =>
+  value === null || value === undefined ? null : Number(value)
+
+runScript(async ({ pg: database }) => {
+  await database.tx({ mode: READ_ONLY_REPEATABLE_MODE }, async (pg) => {
+    // Every statement must fail closed instead of putting sustained load on
+    // the primary database if the event volume or query plan surprises us.
+    await pg.none("set local statement_timeout = '60s'")
+
+    const params = [
+      start,
+      end ?? null,
+      DISCOVERY_EXPOSURE_EVENT,
+      DISCOVERY_RESULTS_EVENT,
+      DISCOVERY_RESULT_CLICK_EVENT,
+      ENV_CONFIG.adminIds,
+      reportEndTime,
+      DISCOVERY_SEARCH_REQUEST_EVENT,
+    ]
+    const scorecard = await pg.map<ScorecardRow>(
+      scorecardSql,
+      params,
+      (row) => ({
+        ...row,
+        presentations: Number(row.presentations),
+        result_sets: Number(row.result_sets),
+        subjects: Number(row.subjects),
+        market_ctr: numberOrNull(row.market_ctr),
+        meaningful_action_rate: numberOrNull(row.meaningful_action_rate),
+        post_ctr: numberOrNull(row.post_ctr),
+        semantic_tail_ctr: numberOrNull(row.semantic_tail_ctr),
+        zero_market_rate: numberOrNull(row.zero_market_rate),
+        avg_markets_presented: numberOrNull(row.avg_markets_presented),
+        prior_seen_top_ten_rate: numberOrNull(row.prior_seen_top_ten_rate),
+        p95_initial_latency_ms: numberOrNull(row.p95_initial_latency_ms),
+        compatibility_fallback_rate: numberOrNull(
+          row.compatibility_fallback_rate
+        ),
+      })
+    )
+
+    console.log(
+      `Discovery v1 scorecard: ${start} to ${
+        end ?? '30 minutes before this run'
+      } (PT)`
+    )
+    console.log('Main Browse only; forced accounts, admins, and bots excluded.')
+    console.table(scorecard)
+
+    const requestLifts = await pg.map<RequestLiftRow>(
+      requestLiftSql,
+      params,
+      (row) => ({
+        ...row,
+        control_subjects: Number(row.control_subjects),
+        treatment_subjects: Number(row.treatment_subjects),
+        control_rate: numberOrNull(row.control_rate),
+        treatment_rate: numberOrNull(row.treatment_rate),
+        absolute_lift: numberOrNull(row.absolute_lift),
+        relative_lift: numberOrNull(row.relative_lift),
+        ci_95_low: numberOrNull(row.ci_95_low),
+        ci_95_high: numberOrNull(row.ci_95_high),
+      })
+    )
+
+    console.log('\nSigned-in request-level intent-to-treat comparisons')
+    console.log(
+      'Primary: For You meaningful-action rate; all-text-search market CTR.'
+    )
+    console.log(
+      'Every fresh request is retained; no presentation counts as zero engagement.'
+    )
+    console.table(requestLifts)
+
+    const lifts = await pg.map<LiftRow>(subjectLiftSql, params, (row) => ({
+      ...row,
+      control_subjects: Number(row.control_subjects),
+      treatment_subjects: Number(row.treatment_subjects),
+      control_rate: numberOrNull(row.control_rate),
+      treatment_rate: numberOrNull(row.treatment_rate),
+      absolute_lift: numberOrNull(row.absolute_lift),
+      relative_lift: numberOrNull(row.relative_lift),
+      ci_95_low: numberOrNull(row.ci_95_low),
+      ci_95_high: numberOrNull(row.ci_95_high),
+    }))
+
+    console.log('\nPresentation-conditional mechanism comparisons')
+    console.log(
+      'A 95% interval crossing zero is inconclusive, not evidence of no effect.'
+    )
+    console.table(lifts)
+
+    const resultHealth = await pg.map<ResultHealthRow>(
+      resultHealthSql,
+      params,
+      (row) => ({
+        ...row,
+        result_sets: Number(row.result_sets),
+        avg_markets_loaded: numberOrNull(row.avg_markets_loaded),
+        avg_distinct_markets_loaded: numberOrNull(
+          row.avg_distinct_markets_loaded
+        ),
+        duplicate_rate: numberOrNull(row.duplicate_rate),
+        compatibility_fallback_rate: numberOrNull(
+          row.compatibility_fallback_rate
+        ),
+      })
+    )
+
+    console.log('\nResult-set pagination health')
+    console.table(resultHealth)
+
+    const reliability = await pg.map<ReliabilityRow>(
+      `with requests as (
+       select distinct on (ue.data ->> 'requestAttemptId')
+         ue.ts,
+         ue.user_id,
+         ue.data ->> 'requestAttemptId' as request_attempt_id,
+         ue.data ->> 'variant' as variant,
+         ue.data ->> 'assignmentSource' as assignment_source,
+         ue.data ->> 'surface' as surface,
+         case
+           when coalesce((ue.data ->> 'isFresh')::boolean, false)
+             then 'fresh'
+           else 'load-more'
+         end as request_stage
+       from user_events ue
+       where ue.name = $1
+         and ue.data ->> 'requestAttemptId' is not null
+         and ue.ts >= date_to_midnight_pt($5::date)
+         and ue.ts < case
+           -- Do not label a currently in-flight request as missing.
+           when $6::date is null
+             then $8::timestamptz - interval '1 minute'
+           else least(
+             date_to_midnight_pt($6::date),
+             $8::timestamptz - interval '1 minute'
+           )
+         end
+         and ue.data ->> 'sourceComponent' = 'search'
+       order by ue.data ->> 'requestAttemptId', ue.ts
+     ), eligible_requests as (
+       select
+         request.*
+       from requests request
+       left join users u on u.id = request.user_id
+       where request.variant in ('control', 'treatment')
+         and request.assignment_source <> 'forced'
+         and (request.user_id is null or request.user_id not in ($7:list))
+         and coalesce(u.is_bot, false) = false
+     ), outcomes as (
+       select
+         request.request_attempt_id,
+         bool_or(event.name = $2) as succeeded,
+         bool_or(event.name = $3) as terminal_error,
+         bool_or(event.name = $4) as client_aborted,
+         max((event.data ->> 'latencyMs')::numeric)
+           filter (where event.name = $2) as success_latency_ms,
+         max((event.data ->> 'latencyMs')::numeric)
+           filter (where event.name = $3) as error_latency_ms
+       from eligible_requests request
+       left join user_events event
+         on event.data ->> 'requestAttemptId' = request.request_attempt_id
+        and event.name in ($2, $3, $4)
+        and event.ts >= date_to_midnight_pt($5::date) - interval '5 seconds'
+        and event.ts < case
+          when $6::date is null
+            then $8::timestamptz + interval '30 minutes'
+          else date_to_midnight_pt($6::date) + interval '30 minutes'
+        end
+       group by request.request_attempt_id
+     )
+     select
+       request.surface,
+       request.assignment_source,
+       request.variant,
+       request.request_stage,
+       count(*)::int as attempts,
+       count(*) filter (where outcome.succeeded)::int as successes,
+       count(*) filter (where outcome.terminal_error)::int as terminal_errors,
+       count(*) filter (where outcome.client_aborted)::int as client_aborts,
+       count(*) filter (
+         where not coalesce(outcome.succeeded, false)
+           and not coalesce(outcome.terminal_error, false)
+           and not coalesce(outcome.client_aborted, false)
+       )::int as missing_outcomes,
+       round(avg(coalesce(outcome.succeeded, false)::int), 4) as success_rate,
+       round(avg(coalesce(outcome.terminal_error, false)::int), 4)
+         as error_rate,
+       round(avg(coalesce(outcome.client_aborted, false)::int), 4)
+         as abort_rate,
+       round(
+         percentile_cont(0.95)
+           within group (order by outcome.success_latency_ms)::numeric,
+         0
+       ) as p95_success_latency_ms,
+       round(
+         percentile_cont(0.95)
+           within group (order by outcome.error_latency_ms)::numeric,
+         0
+       ) as p95_terminal_error_latency_ms
+     from eligible_requests request
+     left join outcomes outcome using (request_attempt_id)
+     group by
+       request.surface,
+       request.assignment_source,
+       request.variant,
+       request.request_stage
+     order by
+       request.surface,
+       request.assignment_source,
+       request.variant,
+       request.request_stage`,
+      [
+        DISCOVERY_SEARCH_REQUEST_EVENT,
+        DISCOVERY_RESULTS_EVENT,
+        DISCOVERY_SEARCH_ERROR_EVENT,
+        DISCOVERY_SEARCH_ABORT_EVENT,
+        start,
+        end ?? null,
+        ENV_CONFIG.adminIds,
+        reportEndTime,
+      ],
+      (row) => ({
+        ...row,
+        attempts: Number(row.attempts),
+        successes: Number(row.successes),
+        terminal_errors: Number(row.terminal_errors),
+        client_aborts: Number(row.client_aborts),
+        missing_outcomes: Number(row.missing_outcomes),
+        success_rate: numberOrNull(row.success_rate),
+        error_rate: numberOrNull(row.error_rate),
+        abort_rate: numberOrNull(row.abort_rate),
+        p95_success_latency_ms: numberOrNull(row.p95_success_latency_ms),
+        p95_terminal_error_latency_ms: numberOrNull(
+          row.p95_terminal_error_latency_ms
+        ),
+      })
+    )
+
+    console.log('\nRequest lifecycle reliability guardrail')
+    console.log(
+      'Missing outcomes are reported separately and may be discarded stale responses.'
+    )
+    console.table(reliability)
+
+    const srm = await pg.map<{
+      assignment_source: string
+      control_subjects: number
+      treatment_subjects: number
+      chi_square: number | null
+      passes_5_percent_srm_check: boolean
+    }>(
+      `with assignment_requests as (
+       select
+         ue.ts,
+         ue.user_id,
+         ue.data ->> 'deviceId' as device_id,
+         ue.data ->> 'assignmentSource' as assignment_source,
+         ue.data ->> 'variant' as variant
+       from user_events ue
+       left join users u on u.id = ue.user_id
+       where ue.name = $1
+         and ue.ts >= date_to_midnight_pt($2::date)
+         and ue.ts < case
+           when $3::date is null then $5::timestamptz
+           else date_to_midnight_pt($3::date)
+         end
+         and ue.data ->> 'assignmentSource' in ('user-hash', 'device-hash')
+         and ue.data ->> 'sourceComponent' = 'search'
+         and (ue.user_id is null or ue.user_id not in ($4:list))
+         and coalesce(u.is_bot, false) = false
+     ), first_assignment as (
+       select distinct on (
+         assignment_source,
+         case assignment_source
+           when 'user-hash' then 'user:' || user_id
+           else 'device:' || device_id
+         end
+       )
+         assignment_source,
+         case assignment_source
+           when 'user-hash' then 'user:' || user_id
+           else 'device:' || device_id
+         end as subject_id,
+         variant
+       from assignment_requests
+       where (assignment_source = 'user-hash' and user_id is not null)
+          or (assignment_source = 'device-hash' and device_id is not null)
+       order by assignment_source, subject_id, ts
+     ), counts as (
+       select
+         assignment_source,
+         count(*) filter (where variant = 'control')::int
+           as control_subjects,
+         count(*) filter (where variant = 'treatment')::int
+           as treatment_subjects
+       from first_assignment
+       group by assignment_source
+     ), result as (
+       select
+         *,
+         power(control_subjects - treatment_subjects, 2)::numeric
+           / nullif(control_subjects + treatment_subjects, 0) as chi_square
+       from counts
+     )
+     select
+       *,
+       coalesce(chi_square <= 3.841, false) as passes_5_percent_srm_check
+     from result
+     order by assignment_source`,
+      [
+        DISCOVERY_SEARCH_REQUEST_EVENT,
+        start,
+        end ?? null,
+        ENV_CONFIG.adminIds,
+        reportEndTime,
+      ],
+      (row) => ({
+        ...row,
+        control_subjects: Number(row.control_subjects),
+        treatment_subjects: Number(row.treatment_subjects),
+        chi_square: numberOrNull(row.chi_square),
+      })
+    )
+
+    console.log('\n50/50 sample-ratio checks (chi-square threshold 3.841)')
+    console.log('The user-hash row is the primary-analysis population.')
+    console.table(srm)
+
+    const forcedIds = Object.keys(AB_TEST_ACCOUNT_OVERRIDES)
+    const forcedAccounts = await pg.manyOrNone<{
+      username: string
+      variant: string
+      assignment_source: string
+      presentations: number
+      latest_presentation: string
+    }>(
+      `select
+       u.username,
+       ue.data ->> 'variant' as variant,
+       ue.data ->> 'assignmentSource' as assignment_source,
+       count(*)::int as presentations,
+       max(ue.ts)::text as latest_presentation
+     from user_events ue
+     join users u on u.id = ue.user_id
+     where ue.name = $1
+       and ue.user_id in ($2:list)
+       and ue.ts >= date_to_midnight_pt($3::date)
+       and ue.ts < case
+         when $4::date is null then $5::timestamptz
+         else date_to_midnight_pt($4::date)
+       end
+       and ue.data ->> 'sourceComponent' = 'search'
+     group by u.username, variant, assignment_source
+     order by u.username`,
+      [DISCOVERY_EXPOSURE_EVENT, forcedIds, start, end ?? null, reportEndTime]
+    )
+
+    console.log('\nForced QA accounts (excluded above)')
+    console.table(forcedAccounts)
+
+    const crossArmSubjects = await pg.manyOrNone<{
+      subject_id: string
+      variants: string[]
+    }>(
+      `with assignments as (
+       select
+         case
+           when user_id is not null then 'user:' || user_id
+           else 'device:' || (data ->> 'deviceId')
+         end as subject_id,
+         data ->> 'variant' as variant
+       from user_events
+       where name = $1
+         and ts >= date_to_midnight_pt($2::date)
+         and ts < case
+           when $3::date is null then $4::timestamptz
+           else date_to_midnight_pt($3::date)
+         end
+         and data ->> 'assignmentSource' <> 'forced'
+         and data ->> 'sourceComponent' = 'search'
+     )
+     select subject_id, array_agg(distinct variant) as variants
+     from assignments
+     group by subject_id
+     having count(distinct variant) > 1`,
+      [DISCOVERY_EXPOSURE_EVENT, start, end ?? null, reportEndTime]
+    )
+
+    console.log(
+      `\nCross-arm assignment subjects (expected 0): ${crossArmSubjects.length}`
+    )
+    if (crossArmSubjects.length) console.table(crossArmSubjects)
+
+    const crossArmDevices = await pg.manyOrNone<{
+      device_id: string
+      variants: string[]
+    }>(
+      `select
+       data ->> 'deviceId' as device_id,
+       array_agg(distinct data ->> 'variant') as variants
+     from user_events
+     where name = $1
+       and ts >= date_to_midnight_pt($2::date)
+       and ts < case
+         when $3::date is null then $4::timestamptz
+         else date_to_midnight_pt($3::date)
+       end
+       and data ->> 'assignmentSource' <> 'forced'
+       and data ->> 'sourceComponent' = 'search'
+       and data ->> 'deviceId' is not null
+     group by data ->> 'deviceId'
+     having count(distinct data ->> 'variant') > 1`,
+      [DISCOVERY_EXPOSURE_EVENT, start, end ?? null, reportEndTime]
+    )
+
+    console.log(
+      `Cross-arm devices after login/account changes (contamination diagnostic): ${crossArmDevices.length}`
+    )
+    if (crossArmDevices.length) console.table(crossArmDevices.slice(0, 20))
+  })
+})

--- a/backend/scripts/discovery-v1-report.ts
+++ b/backend/scripts/discovery-v1-report.ts
@@ -28,7 +28,6 @@ const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
 const [start, end] = process.argv.slice(2)
 const MAX_REPORT_DAYS = 31
 const DAY_MS = 24 * 60 * 60 * 1000
-const OUTCOME_WINDOW_MS = 30 * 60 * 1000
 
 if (!start || !DATE_REGEX.test(start) || (end && !DATE_REGEX.test(end))) {
   console.error(
@@ -51,12 +50,9 @@ if (
   !parsedStart ||
   !parsedEnd ||
   parsedEnd <= parsedStart ||
-  parsedEnd.getTime() - parsedStart.getTime() > MAX_REPORT_DAYS * DAY_MS ||
-  (end !== undefined && parsedEnd.getTime() > now.getTime() - OUTCOME_WINDOW_MS)
+  parsedEnd.getTime() - parsedStart.getTime() > MAX_REPORT_DAYS * DAY_MS
 ) {
-  console.error(
-    `Report window must be valid, increasing, at most 31 days, and have a complete 30-minute outcome window.`
-  )
+  console.error(`Report window must be valid, increasing, and at most 31 days.`)
   process.exit(1)
 }
 // Use one captured time across every query so a live report has one boundary.
@@ -77,6 +73,7 @@ type ScorecardRow = {
   prior_seen_top_ten_rate: number | null
   p95_initial_latency_ms: number | null
   compatibility_fallback_rate: number | null
+  anchor_fallback_rate: number | null
 }
 
 type LiftRow = {
@@ -105,6 +102,7 @@ type ResultHealthRow = {
   avg_distinct_markets_loaded: number | null
   duplicate_rate: number | null
   compatibility_fallback_rate: number | null
+  anchor_fallback_rate: number | null
 }
 
 type ReliabilityRow = {
@@ -148,6 +146,8 @@ with raw_presentations as (
       as semantic_count,
     coalesce((ue.data ->> 'compatibilityFallback')::boolean, false)
       as compatibility_fallback,
+    coalesce((ue.data ->> 'anchorFallback')::boolean, false)
+      as anchor_fallback,
     (ue.data ->> 'initialLatencyMs')::numeric as initial_latency_ms,
     ue.data
   from user_events ue
@@ -172,7 +172,7 @@ with raw_presentations as (
 selected_result_sets as (
   select distinct result_set_id from raw_presentations
 ),
-result_set_compatibility as (
+result_set_fallbacks as (
   select
     ue.data ->> 'resultSetId' as result_set_id,
     bool_or(
@@ -180,7 +180,13 @@ result_set_compatibility as (
         (ue.data ->> 'compatibilityFallback')::boolean,
         false
       )
-    ) as used_compatibility_fallback
+    ) as used_compatibility_fallback,
+    bool_or(
+      coalesce(
+        (ue.data ->> 'anchorFallback')::boolean,
+        false
+      )
+    ) as used_anchor_fallback
   from user_events ue
   join selected_result_sets selected
     on selected.result_set_id = ue.data ->> 'resultSetId'
@@ -386,6 +392,7 @@ per_presentation as (
     presentation.semantic_count,
     presentation.initial_latency_ms,
     presentation.compatibility_fallback,
+    presentation.anchor_fallback,
     (coalesce(click.market_clicks, 0) > 0)::int as market_clicked,
     (coalesce(click.post_clicks, 0) > 0)::int as post_clicked,
     (coalesce(click.semantic_clicks, 0) > 0)::int as semantic_clicked,
@@ -428,7 +435,8 @@ select
     0
   ) as p95_initial_latency_ms,
   round(avg(compatibility_fallback::int), 4)
-    as compatibility_fallback_rate
+    as compatibility_fallback_rate,
+  round(avg(anchor_fallback::int), 4) as anchor_fallback_rate
 from per_presentation
 group by segment, variant
 order by segment, variant
@@ -686,13 +694,15 @@ first_presentation_per_result_set as (
     presentation.result_set_id,
     presentation.segment,
     presentation.variant,
-    coalesce(compatibility.used_compatibility_fallback, false)
-      as compatibility_fallback
+    coalesce(fallbacks.used_compatibility_fallback, false)
+      as compatibility_fallback,
+    coalesce(fallbacks.used_anchor_fallback, false)
+      as anchor_fallback
   from presentations presentation
   -- This diagnostic intentionally includes only result sets whose response
   -- event is inside the bounded lookup window. Causal fields live directly
   -- on the exposure event and do not depend on this join.
-  join result_set_compatibility compatibility using (result_set_id)
+  join result_set_fallbacks fallbacks using (result_set_id)
   order by presentation.result_set_id, presentation.ts
 ),
 result_set_items as (
@@ -710,6 +720,7 @@ result_set_health as (
     first.variant,
     first.result_set_id,
     first.compatibility_fallback,
+    first.anchor_fallback,
     coalesce(items.markets_loaded, 0) as markets_loaded,
     coalesce(items.distinct_markets_loaded, 0) as distinct_markets_loaded
   from first_presentation_per_result_set first
@@ -731,7 +742,8 @@ select
     4
   ) as duplicate_rate,
   round(avg(compatibility_fallback::int), 4)
-    as compatibility_fallback_rate
+    as compatibility_fallback_rate,
+  round(avg(anchor_fallback::int), 4) as anchor_fallback_rate
 from result_set_health
 group by segment, variant
 order by segment, variant
@@ -745,6 +757,24 @@ runScript(async ({ pg: database }) => {
     // Every statement must fail closed instead of putting sustained load on
     // the primary database if the event volume or query plan surprises us.
     await pg.none("set local statement_timeout = '60s'")
+
+    if (end !== undefined) {
+      // Validate against the exact Pacific boundary used by every report query.
+      const { report_end_is_mature: reportEndIsMature } = await pg.one<{
+        report_end_is_mature: boolean
+      }>(
+        `select date_to_midnight_pt($1::date)
+           <= $2::timestamptz - interval '30 minutes'
+           as report_end_is_mature`,
+        [end, reportEndTime]
+      )
+
+      if (!reportEndIsMature) {
+        throw new Error(
+          `Report end ${end} must be at least 30 minutes past its Pacific midnight boundary.`
+        )
+      }
+    }
 
     const params = [
       start,
@@ -775,6 +805,7 @@ runScript(async ({ pg: database }) => {
         compatibility_fallback_rate: numberOrNull(
           row.compatibility_fallback_rate
         ),
+        anchor_fallback_rate: numberOrNull(row.anchor_fallback_rate),
       })
     )
 
@@ -843,6 +874,7 @@ runScript(async ({ pg: database }) => {
         compatibility_fallback_rate: numberOrNull(
           row.compatibility_fallback_rate
         ),
+        anchor_fallback_rate: numberOrNull(row.anchor_fallback_rate),
       })
     )
 

--- a/backend/scripts/discovery-v1-report.ts
+++ b/backend/scripts/discovery-v1-report.ts
@@ -305,7 +305,9 @@ click_rollup as (
     ) as post_clicks,
     count(*) filter (
       where click.data ->> 'matchType' = 'semantic'
-    ) as semantic_clicks
+    ) as semantic_clicks,
+    min(click.ts) filter (where click.data ->> 'itemType' = 'market')
+      as first_market_click_ts
   from presentations presentation
   left join user_events click
     on click.name = $5
@@ -323,6 +325,7 @@ click_rollup as (
 action_candidates as (
   select
     interaction.id as action_id,
+    interaction.created_time as action_ts,
     presentation.presentation_id,
     row_number() over (
       partition by interaction.id
@@ -347,7 +350,8 @@ action_candidates as (
   )
 ),
 action_rollup as (
-  select presentation_id, count(*) as actions
+  select presentation_id, count(*) as actions,
+    min(action_ts) as first_action_ts
   from action_candidates
   where attribution_order = 1
   group by presentation_id
@@ -393,6 +397,8 @@ per_presentation as (
     presentation.initial_latency_ms,
     presentation.compatibility_fallback,
     presentation.anchor_fallback,
+    click.first_market_click_ts,
+    action.first_action_ts,
     (coalesce(click.market_clicks, 0) > 0)::int as market_clicked,
     (coalesce(click.post_clicks, 0) > 0)::int as post_clicked,
     (coalesce(click.semantic_clicks, 0) > 0)::int as semantic_clicked,
@@ -567,16 +573,17 @@ fresh_requests as (
     and coalesce(u.is_bot, false) = false
   order by ue.data ->> 'requestAttemptId', ue.ts
 ),
-request_presentations as (
+request_first_presentations as (
   select distinct on (request.request_attempt_id)
     request.subject_id,
     request.variant,
     request.surface,
     request.request_attempt_id,
+    request.result_set_id,
+    request.user_id,
     presentation.presentation_id,
-    presentation.market_count,
-    presentation.market_clicked,
-    presentation.meaningfully_acted
+    presentation.ts as presentation_ts,
+    presentation.market_count
   from fresh_requests request
   left join per_presentation presentation
     on presentation.result_set_id = request.result_set_id
@@ -584,6 +591,38 @@ request_presentations as (
    and presentation.ts >= request.ts - interval '5 seconds'
    and presentation.ts < request.ts + interval '1 minute'
   order by request.request_attempt_id, presentation.ts
+),
+request_presentations as (
+  select
+    request.subject_id,
+    request.variant,
+    request.surface,
+    request.request_attempt_id,
+    request.presentation_id,
+    request.market_count,
+    -- Returning to cached Browse creates a new presentation, not a request.
+    -- Keep its outcomes with the originating request, without extending that
+    -- request's original 30-minute window or adding an ITT denominator.
+    coalesce(bool_or(
+      revisit.first_market_click_ts
+        >= request.presentation_ts - interval '5 seconds'
+      and revisit.first_market_click_ts
+        < request.presentation_ts + interval '30 minutes'
+    ), false)::int as market_clicked,
+    coalesce(bool_or(
+      revisit.first_action_ts
+        >= request.presentation_ts - interval '5 seconds'
+      and revisit.first_action_ts
+        < request.presentation_ts + interval '30 minutes'
+    ), false)::int as meaningfully_acted
+  from request_first_presentations request
+  left join per_presentation revisit
+    on revisit.result_set_id = request.result_set_id
+   and revisit.user_id = request.user_id
+   and revisit.variant = request.variant
+   and revisit.ts >= request.presentation_ts
+  group by request.subject_id, request.variant, request.surface,
+    request.request_attempt_id, request.presentation_id, request.market_count
 ),
 request_subject_metrics as (
   select

--- a/backend/scripts/tests/discovery-v1-report.test.cjs
+++ b/backend/scripts/tests/discovery-v1-report.test.cjs
@@ -1,0 +1,397 @@
+// Synthetic PostgreSQL integration tests. Requires `yarn build:ci`, Docker,
+// and a locally cached postgres:15-alpine image. No credentials or network.
+// Run: node --test backend/scripts/tests/discovery-v1-report.test.cjs
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const { randomUUID } = require('node:crypto')
+const fs = require('node:fs')
+const path = require('node:path')
+const { after, before, test } = require('node:test')
+const vm = require('node:vm')
+const ts = require('typescript')
+const pgp = require('pg-promise')()
+
+const root = path.resolve(__dirname, '../../..')
+const events = require(path.join(root, 'common/lib/discovery-experiment'))
+const { AB_TEST_ACCOUNT_OVERRIDES } = require(path.join(
+  root,
+  'common/lib/ab-test'
+))
+const container = `discovery-report-test-${randomUUID()}`
+const docker = (args, input) =>
+  execFileSync('docker', args, {
+    input,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+const query = (sql) =>
+  docker(
+    [
+      'exec',
+      '-i',
+      container,
+      'psql',
+      '-U',
+      'postgres',
+      '-X',
+      '-qAt',
+      '-v',
+      'ON_ERROR_STOP=1',
+    ],
+    sql
+  )
+const source = fs.readFileSync(
+  path.join(root, 'backend/scripts/discovery-v1-report.ts'),
+  'utf8'
+)
+const functions = fs.readFileSync(
+  path.join(root, 'backend/supabase/functions.sql'),
+  'utf8'
+)
+const boundary = functions.match(
+  /create\s+or replace function public\.date_to_midnight_pt[^]*?\$function\$;/
+)[0]
+const captured = []
+
+before(async () => {
+  // Capture the actual report statements while replacing every production
+  // dependency. Unknown imports fail closed; run-script is never imported.
+  let completion
+  const database = {
+    tx: async (_, callback) => callback(database),
+    none: async () => {},
+    one: async (sql, params) => {
+      captured.push({ sql, params })
+      return { report_end_is_mature: true }
+    },
+    map: async (sql, params) => {
+      captured.push({ sql, params })
+      return []
+    },
+    manyOrNone: async (sql, params) => {
+      captured.push({ sql, params })
+      return []
+    },
+  }
+  vm.runInNewContext(
+    ts.transpileModule(source, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS },
+    }).outputText,
+    {
+      exports: {},
+      process: { argv: ['node', 'report', '2026-09-01', '2026-09-02'] },
+      Date,
+      console: { log() {}, table() {} },
+      require: (id) => {
+        if (id === './run-script')
+          return {
+            runScript: (callback) => {
+              completion = callback({ pg: database })
+            },
+          }
+        if (id === 'common/ab-test') return { AB_TEST_ACCOUNT_OVERRIDES }
+        if (id === 'common/discovery-experiment') return events
+        if (id === 'common/envs/constants')
+          return { ENV_CONFIG: { adminIds: ['admin'] } }
+        if (id === 'shared/supabase/init')
+          return { READ_ONLY_REPEATABLE_MODE: {} }
+        throw new Error(`Unexpected report import: ${id}`)
+      },
+    }
+  )
+  await completion
+  docker([
+    'run',
+    '--detach',
+    '--rm',
+    '--pull=never',
+    '--name',
+    container,
+    '--network',
+    'none',
+    '--env',
+    'POSTGRES_HOST_AUTH_METHOD=trust',
+    'postgres:15-alpine',
+  ])
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      query('select 1')
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+  }
+  throw new Error('Synthetic PostgreSQL did not become ready')
+})
+after(() => {
+  docker(['stop', container])
+})
+
+const literal = (value) => pgp.as.format('$1', [value])
+const at = (minutes) =>
+  new Date(Date.parse('2026-09-01T12:00:00Z') + minutes * 60_000).toISOString()
+const subjects = [
+  'control-one',
+  'control-two',
+  'treatment-one',
+  'treatment-two',
+]
+const schema = `
+  ${boundary}
+  create temp table users (id text primary key, username text, is_bot boolean);
+  create temp table user_events (ts timestamptz, user_id text, name text, data jsonb);
+  create temp table user_contract_interactions (id text, user_id text, contract_id text, name text, created_time timestamptz);
+  create temp table user_view_events (user_id text, contract_id text, name text, created_time timestamptz);
+  insert into users values ${subjects
+    .map((id) => `(${literal(id)},${literal(id)},false)`)
+    .join(',')};
+`
+const event = (user, name, minute, data) => `insert into user_events values (
+  ${literal(at(minute))},${literal(user)},${literal(name)},${literal(
+  JSON.stringify({
+    variant: user.startsWith('control') ? 'control' : 'treatment',
+    assignmentSource: 'user-hash',
+    sourceComponent: 'search',
+    surface: 'for-you',
+    resultSetId: `${user}-results`,
+    ...data,
+  })
+)}::jsonb);`
+const request = (user, data = {}, minute = 0) =>
+  event(user, events.DISCOVERY_SEARCH_REQUEST_EVENT, minute, {
+    requestAttemptId: `${user}-request`,
+    isFresh: true,
+    ...data,
+  })
+const exposure = (user, suffix = 'first', minute = 0.02, data = {}) =>
+  event(user, events.DISCOVERY_EXPOSURE_EVENT, minute, {
+    presentationId: `${user}-${suffix}`,
+    marketCount: 1,
+    items: [{ id: 'market', itemType: 'market', rank: 1 }],
+    ...data,
+  })
+const action = (
+  user,
+  minute = 3
+) => `insert into user_contract_interactions values (
+  ${literal(user + '-' + minute)},${literal(
+  user
+)},'market','page bet',${literal(at(minute))});`
+const run = (needle, seed = '') => {
+  const statement = captured.find(({ sql }) => sql.includes(needle))
+  assert.ok(statement, `Captured report statement: ${needle}`)
+  return JSON.parse(
+    query(`begin; ${schema} ${seed}
+    select coalesce(json_agg(result), '[]') from (
+      ${pgp.as.format(statement.sql, statement.params)}
+    ) result; rollback;`)
+  )
+}
+const rate = (rows, metric) => rows.find((row) => row.metric === metric)
+
+test('cached Browse clicks and actions remain in the originating request', () => {
+  const seed = subjects
+    .map(
+      (user) =>
+        request(user) +
+        exposure(user) +
+        exposure(user, 'cached', 2) +
+        action(user) +
+        event(user, events.DISCOVERY_RESULT_CLICK_EVENT, 2.1, {
+          presentationId: `${user}-cached`,
+          itemType: 'market',
+        })
+    )
+    .join('')
+  const rows = run('request_subject_metrics', seed)
+  for (const metric of ['market CTR', 'meaningful action rate']) {
+    assert.equal(Number(rate(rows, metric).control_rate), 1)
+    assert.equal(Number(rate(rows, metric).treatment_rate), 1)
+    assert.equal(rate(rows, metric).control_subjects, 2)
+  }
+})
+
+test('cached revisits do not restart the request attribution window', () => {
+  const seed = subjects
+    .map(
+      (user) =>
+        request(user) +
+        exposure(user) +
+        exposure(user, 'cached', 29) +
+        action(user, 31) +
+        event(user, events.DISCOVERY_RESULT_CLICK_EVENT, 31, {
+          presentationId: `${user}-cached`,
+          itemType: 'market',
+        })
+    )
+    .join('')
+  const rows = run('request_subject_metrics', seed)
+  assert.equal(Number(rate(rows, 'meaningful action rate').treatment_rate), 0)
+  assert.equal(Number(rate(rows, 'market CTR').control_rate), 0)
+})
+
+test('an action after a new result set is credited to only the latest request', () => {
+  const seed = subjects
+    .map(
+      (user) =>
+        request(user) +
+        exposure(user) +
+        request(
+          user,
+          {
+            requestAttemptId: `${user}-new-request`,
+            resultSetId: `${user}-new-results`,
+          },
+          2
+        ) +
+        exposure(user, 'new', 2.02, { resultSetId: `${user}-new-results` }) +
+        action(user)
+    )
+    .join('')
+  const primary = rate(
+    run('request_subject_metrics', seed),
+    'meaningful action rate'
+  )
+  assert.equal(Number(primary.control_rate), 0.5)
+  assert.equal(Number(primary.treatment_rate), 0.5)
+})
+
+test('missing and late presentations stay in the ITT denominator as zero', () => {
+  const seed = subjects
+    .map(
+      (user) =>
+        request(user) +
+        (user.endsWith('one') ? '' : exposure(user, 'late', 2) + action(user))
+    )
+    .join('')
+  const rows = run('request_subject_metrics', seed)
+  assert.equal(Number(rate(rows, 'render rate').control_rate), 0)
+  assert.equal(Number(rate(rows, 'meaningful action rate').treatment_rate), 0)
+  assert.equal(rate(rows, 'render rate').control_subjects, 2)
+})
+
+test('duplicate request and exposure deliveries do not change denominators', () => {
+  const seed = subjects
+    .map(
+      (user) =>
+        request(user).repeat(2) +
+        exposure(user).repeat(2) +
+        action(user) +
+        request(
+          user,
+          {
+            requestAttemptId: `${user}-missing-request`,
+            resultSetId: `${user}-missing-results`,
+          },
+          40
+        )
+    )
+    .join('')
+  const score = run('count(*)::int as presentations', seed)
+  assert.equal(score.find((row) => row.variant === 'control').presentations, 2)
+  assert.equal(
+    Number(
+      rate(run('request_subject_metrics', seed), 'meaningful action rate')
+        .control_rate
+    ),
+    0.5
+  )
+})
+
+test('user weighting prevents frequent requesters from dominating the mean', () => {
+  const seed = subjects
+    .map((user) => {
+      const active = user.endsWith('one')
+      return Array.from({ length: active ? 9 : 1 }, (_, index) => {
+        const resultSetId = `${user}-${index}`
+        return (
+          request(
+            user,
+            { requestAttemptId: resultSetId, resultSetId },
+            index * 40
+          ) +
+          exposure(user, String(index), index * 40 + 0.02, { resultSetId }) +
+          (active ? action(user, index * 40 + 3) : '')
+        )
+      }).join('')
+    })
+    .join('')
+  const primary = rate(
+    run('request_subject_metrics', seed),
+    'meaningful action rate'
+  )
+  assert.equal(Number(primary.control_rate), 0.5)
+  assert.equal(Number(primary.treatment_rate), 0.5)
+})
+
+test('forced QA accounts are excluded and 50/50 SRM uses unique subjects', () => {
+  const forced = Object.keys(AB_TEST_ACCOUNT_OVERRIDES)
+  const seed =
+    `insert into users values ${forced
+      .map((user) => `(${literal(user)},${literal(user)},false)`)
+      .join(',')};` +
+    subjects.map((user) => request(user).repeat(3)).join('') +
+    forced
+      .map(
+        (user) =>
+          request(user, { assignmentSource: 'forced' }) +
+          exposure(user, 'first', 0.02, { assignmentSource: 'forced' })
+      )
+      .join('')
+  const srm = run('assignment_requests as', seed)[0]
+  assert.equal(srm.control_subjects, 2)
+  assert.equal(srm.treatment_subjects, 2)
+  assert.equal(srm.passes_5_percent_srm_check, true)
+  assert.equal(run('count(*)::int as presentations', seed).length, 0)
+})
+
+test('report maturity uses the production Pacific function across both DST changes', () => {
+  const statement = captured.find(({ sql }) =>
+    sql.includes('report_end_is_mature')
+  )
+  for (const [date, midnight] of [
+    ['2026-03-08', '2026-03-08T08:00:00Z'],
+    ['2026-03-09', '2026-03-09T07:00:00Z'],
+    ['2026-11-01', '2026-11-01T07:00:00Z'],
+    ['2026-11-02', '2026-11-02T08:00:00Z'],
+  ]) {
+    for (const delta of [30 * 60_000 - 1, 30 * 60_000]) {
+      const result = query(`begin; ${boundary}
+        ${pgp.as.format(statement.sql, [
+          date,
+          new Date(Date.parse(midnight) + delta).toISOString(),
+        ])}; rollback;`).trim()
+      assert.equal(
+        result,
+        delta === 30 * 60_000 ? 't' : 'f',
+        `${date} at ${delta}ms`
+      )
+    }
+  }
+})
+
+test('semantic SQL timeout cancels slow work and does not persist on the connection', async () => {
+  const { withSemanticQueryTimeout } = require(path.join(
+    root,
+    'backend/shared/lib/helpers/semantic-search-fallback'
+  ))
+  const statements = []
+  await withSemanticQueryTimeout(
+    {
+      tx: (callback) => callback({ none: async (sql) => statements.push(sql) }),
+    },
+    async () => {}
+  )
+  const started = Date.now()
+  assert.throws(
+    () => query(`begin; ${statements.join(';')}; select pg_sleep(5); commit;`),
+    /statement timeout/
+  )
+  assert.ok(Date.now() - started < 4000)
+  assert.equal(
+    query(
+      `begin; ${statements.join(';')}; commit; show statement_timeout;`
+    ).trim(),
+    '0'
+  )
+})

--- a/backend/shared/src/calculate-user-topic-interests.ts
+++ b/backend/shared/src/calculate-user-topic-interests.ts
@@ -200,7 +200,19 @@ const getPreviousStats = async (
   userIds: string[],
   createdTimesOnly?: string[]
 ) => {
-  if (createdTimesOnly && createdTimesOnly.length === 0) return
+  // Module-level, so it survives between calls in a long-lived process. It
+  // sums into whatever is already there, so a second call in the same process
+  // would double-count every prior hit/miss. backfillUserTopicInterests calls
+  // this repeatedly in one process, so reset before the early return as well;
+  // a skipped load must not leave the last call's numbers behind.
+  for (const userId of Object.keys(userIdToGroupStats)) {
+    delete userIdToGroupStats[userId]
+  }
+  if (
+    userIds.length === 0 ||
+    (createdTimesOnly && createdTimesOnly.length === 0)
+  )
+    return
   const previousStats = await pg.map(
     `
     select user_id, group_ids_to_activity, created_time from user_topic_interests

--- a/backend/shared/src/calculate-user-topic-interests.ts
+++ b/backend/shared/src/calculate-user-topic-interests.ts
@@ -28,6 +28,65 @@ const BETS_ONLY_FOR_SCORE = [
   UNRANKED_GROUP_ID,
   ...IGNORE_GROUP_IDS,
 ]
+// How far back to look for days we never scored. Anything older than this is
+// written off — the raw view/interaction rows are still there, but a gap that
+// old isn't worth the query time to close.
+const CATCH_UP_LOOKBACK_DAYS = 14
+// Days to process in a single run, including today's. One day takes ~25min in
+// prod, so this bounds the job at roughly 75 minutes; a longer gap heals over
+// consecutive nights rather than in one very long run.
+const MAX_DAYS_PER_RUN = 3
+
+const dayKey = (d: Date | string) =>
+  (typeof d === 'string' ? d : d.toISOString()).slice(0, 10)
+
+/**
+ * Scores yesterday, plus any recent day we never scored.
+ *
+ * calculateUserTopicInterests only ever looks at a single 24h window, and
+ * get_user_topic_interests_2 reads only a user's latest row, whose hit/miss
+ * counts accumulate from the rows before it. So a run that never happens is
+ * not "caught up next time" — that day's views and bets are dropped from the
+ * running counts permanently. In prod only 11 of the 30 days to 2026-07-25 had
+ * been scored, so roughly 60% of the signal behind every personalized surface
+ * was being discarded.
+ *
+ * Modelled on updateStatsCore(7), which recomputes a trailing window for the
+ * same reason and is why daily_stats has no gaps over the same period.
+ */
+export async function calculateUserTopicInterestsWithCatchUp() {
+  const pg = createSupabaseDirectClient()
+  const scoredDays = new Set(
+    await pg.map(
+      `select distinct created_time::date as day from user_topic_interests
+       where created_time > now() - ($1 || ' days')::interval`,
+      [CATCH_UP_LOOKBACK_DAYS + 1],
+      (r) => dayKey(r.day)
+    )
+  )
+
+  // Oldest first: each day's Bayesian prior is built from the days before it,
+  // so processing out of order would score a day against a future prior.
+  const now = Date.now()
+  const missing: number[] = []
+  for (let daysAgo = CATCH_UP_LOOKBACK_DAYS; daysAgo >= 1; daysAgo--) {
+    const startTime = now - DAY_MS * daysAgo
+    if (!scoredDays.has(dayKey(new Date(startTime)))) missing.push(startTime)
+  }
+
+  const toProcess = missing.slice(-MAX_DAYS_PER_RUN)
+  const deferred = missing.length - toProcess.length
+  log(
+    `Topic interests: ${missing.length} unscored day(s) in the last ` +
+      `${CATCH_UP_LOOKBACK_DAYS}; processing ${toProcess.length}` +
+      (deferred > 0 ? `, deferring ${deferred} to later runs` : '')
+  )
+
+  for (const startTime of toProcess) {
+    await calculateUserTopicInterests(startTime)
+  }
+}
+
 export async function calculateUserTopicInterests(
   startTime?: number,
   readOnly?: boolean,
@@ -200,6 +259,15 @@ const getPreviousStats = async (
   userIds: string[],
   createdTimesOnly?: string[]
 ) => {
+  // Module-level, so it survives between calls in a long-lived process. It
+  // sums into whatever is already there, so a second call in the same process
+  // would double-count every prior hit/miss — which now happens on any
+  // catch-up run, and already happens in backfillUserTopicInterests. Reset
+  // before the early return so a skipped load can't leave the last call's
+  // numbers behind either.
+  for (const userId of Object.keys(userIdToGroupStats)) {
+    delete userIdToGroupStats[userId]
+  }
   if (createdTimesOnly && createdTimesOnly.length === 0) return
   const previousStats = await pg.map(
     `

--- a/backend/shared/src/helpers/openai-utils.ts
+++ b/backend/shared/src/helpers/openai-utils.ts
@@ -1,4 +1,5 @@
 import { APIError } from 'common/api/utils'
+import { removeUndefinedProps } from 'common/util/object'
 // import { buildArray } from 'common/util/array'
 import * as dayjs from 'dayjs'
 import * as utc from 'dayjs/plugin/utc'
@@ -11,14 +12,26 @@ export const models = {
   gpt5mini: 'gpt-5.4-mini',
 } as const
 
-export const generateEmbeddings = async (question: string) => {
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+export const generateEmbeddings = async (
+  question: string,
+  opts?: { timeoutMs?: number; maxRetries?: number }
+) => {
   let response
   try {
-    response = await openai.embeddings.create({
-      model: 'text-embedding-3-small',
-      input: question,
-    })
+    // Inside the try: the constructor itself throws when no key is configured.
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+    response = await openai.embeddings.create(
+      {
+        model: 'text-embedding-3-small',
+        input: question,
+      },
+      // Absent keys fall through to the SDK defaults (~10 min, 2 retries);
+      // the SDK rejects explicitly-undefined values, hence the strip.
+      removeUndefinedProps({
+        timeout: opts?.timeoutMs,
+        maxRetries: opts?.maxRetries,
+      })
+    )
   } catch (e: any) {
     log.error(
       'Error generating embeddings ' +
@@ -28,7 +41,7 @@ export const generateEmbeddings = async (question: string) => {
     return undefined
   }
   log('Made embeddings for question', question)
-  return response.data[0].embedding
+  return response.data[0]?.embedding
 }
 
 const imagePrompt = (q: string) =>

--- a/backend/shared/src/helpers/openai-utils.ts
+++ b/backend/shared/src/helpers/openai-utils.ts
@@ -11,6 +11,7 @@ export const models = {
   gpt5: 'gpt-5.4',
   gpt5mini: 'gpt-5.4-mini',
 } as const
+export const EMBEDDING_MODEL = 'text-embedding-3-small'
 
 export const generateEmbeddings = async (
   question: string,
@@ -22,7 +23,7 @@ export const generateEmbeddings = async (
     const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
     response = await openai.embeddings.create(
       {
-        model: 'text-embedding-3-small',
+        model: EMBEDDING_MODEL,
         input: question,
       },
       // Absent keys fall through to the SDK defaults (~10 min, 2 retries);
@@ -32,15 +33,16 @@ export const generateEmbeddings = async (
         maxRetries: opts?.maxRetries,
       })
     )
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e)
     log.error(
       'Error generating embeddings ' +
         (!process.env.OPENAI_API_KEY ? ' (no OpenAI API key found) ' : ' ') +
-        e.message
+        message
     )
     return undefined
   }
-  log('Made embeddings for question', question)
+  log('Made embeddings')
   return response.data[0]?.embedding
 }
 

--- a/backend/shared/src/helpers/semantic-search-fallback.test.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.test.ts
@@ -4,7 +4,6 @@ import {
   isValidQueryEmbedding,
   normalizeSemanticSearchTerm,
   queryEmbeddingCacheKey,
-  RollingWindowGate,
   shouldAttemptSemanticFallback,
 } from './semantic-search-fallback'
 
@@ -73,19 +72,6 @@ describe('BoundedSingleFlightCache', () => {
     ).resolves.toEqual(['value', 'value'])
     expect(allow).toHaveBeenCalledTimes(1)
     expect(create).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('RollingWindowGate', () => {
-  it('enforces its budget and recovers when the window expires', () => {
-    let time = 0
-    const gate = new RollingWindowGate(2, 1_000, () => time)
-
-    expect(gate.take()).toBe(true)
-    expect(gate.take()).toBe(true)
-    expect(gate.take()).toBe(false)
-    time = 1_000
-    expect(gate.take()).toBe(true)
   })
 })
 

--- a/backend/shared/src/helpers/semantic-search-fallback.test.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.test.ts
@@ -1,0 +1,148 @@
+import {
+  BoundedSingleFlightCache,
+  isValidQueryEmbedding,
+  normalizeSemanticSearchTerm,
+  queryEmbeddingCacheKey,
+  RollingWindowGate,
+  shouldAttemptSemanticFallback,
+} from './semantic-search-fallback'
+
+const makeCache = (now: () => number) =>
+  new BoundedSingleFlightCache<string>({
+    maxEntries: 2,
+    ttlMs: 100,
+    maxInflightCreates: 2,
+    maxCreatesPerWindow: 2,
+    createWindowMs: 1_000,
+    now,
+  })
+
+describe('BoundedSingleFlightCache', () => {
+  it('expires entries and evicts the least recently used value', () => {
+    let time = 0
+    const cache = makeCache(() => time)
+    cache.set('a', 'A')
+    cache.set('b', 'B')
+    expect(cache.get('a')).toBe('A')
+    cache.set('c', 'C')
+
+    expect(cache.get('b')).toBeUndefined()
+    expect(cache.get('a')).toBe('A')
+    time = 101
+    expect(cache.get('a')).toBeUndefined()
+  })
+
+  it('shares concurrent creates and caches the result', async () => {
+    const cache = makeCache(() => 0)
+    const create = jest.fn(async () => 'value')
+
+    await expect(
+      Promise.all([
+        cache.getOrCreate('key', create),
+        cache.getOrCreate('key', create),
+      ])
+    ).resolves.toEqual(['value', 'value'])
+    await expect(cache.getOrCreate('key', create)).resolves.toBe('value')
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears a rejected create so a later call can retry', async () => {
+    const cache = makeCache(() => 0)
+
+    await expect(
+      cache.getOrCreate('key', async () => {
+        throw new Error('failed')
+      })
+    ).rejects.toThrow('failed')
+    await expect(cache.getOrCreate('key', async () => 'ok')).resolves.toBe('ok')
+  })
+})
+
+describe('RollingWindowGate', () => {
+  it('enforces its budget and recovers when the window expires', () => {
+    let time = 0
+    const gate = new RollingWindowGate(2, 1_000, () => time)
+
+    expect(gate.take()).toBe(true)
+    expect(gate.take()).toBe(true)
+    expect(gate.take()).toBe(false)
+    time = 1_000
+    expect(gate.take()).toBe(true)
+  })
+})
+
+describe('semantic fallback inputs', () => {
+  const eligibility = {
+    offset: 0,
+    sort: 'score',
+    lexicalResultCount: 0,
+    limit: 40,
+    minResults: 5,
+    minTermLength: 3,
+    maxTermLength: 200,
+  }
+
+  it('normalizes whitespace without conflating case-sensitive cache keys', () => {
+    expect(normalizeSemanticSearchTerm('  US   election ')).toBe('US election')
+  })
+
+  it('uses stable model-versioned cache keys without exposing search text', () => {
+    const key = queryEmbeddingCacheKey('private medical question', 'model-v1')
+
+    expect(key).toBe(
+      queryEmbeddingCacheKey('private medical question', 'model-v1')
+    )
+    expect(key).not.toContain('private medical question')
+    expect(queryEmbeddingCacheKey('US', 'model-v1')).not.toBe(
+      queryEmbeddingCacheKey('us', 'model-v1')
+    )
+    expect(queryEmbeddingCacheKey('US', 'model-v1')).not.toBe(
+      queryEmbeddingCacheKey('US', 'model-v2')
+    )
+  })
+
+  it('skips whitespace, URLs, newest cursors, later pages, and full pages', () => {
+    expect(shouldAttemptSemanticFallback({ ...eligibility, term: '' })).toBe(
+      false
+    )
+    expect(
+      shouldAttemptSemanticFallback({
+        ...eligibility,
+        term: 'HTTP://example.com/market',
+      })
+    ).toBe(false)
+    expect(
+      shouldAttemptSemanticFallback({
+        ...eligibility,
+        term: 'election',
+        sort: 'newest',
+      })
+    ).toBe(false)
+    expect(
+      shouldAttemptSemanticFallback({
+        ...eligibility,
+        term: 'election',
+        offset: 40,
+      })
+    ).toBe(false)
+    expect(
+      shouldAttemptSemanticFallback({
+        ...eligibility,
+        term: 'election',
+        lexicalResultCount: 4,
+        limit: 4,
+      })
+    ).toBe(false)
+  })
+
+  it('validates the exact finite vector shape expected by pgvector', () => {
+    expect(isValidQueryEmbedding(Array(1536).fill(0))).toBe(true)
+    expect(isValidQueryEmbedding(Array(1535).fill(0))).toBe(false)
+    expect(isValidQueryEmbedding([...Array(1535).fill(0), Number.NaN])).toBe(
+      false
+    )
+    expect(
+      isValidQueryEmbedding([...Array(1535).fill(0), Number.POSITIVE_INFINITY])
+    ).toBe(false)
+  })
+})

--- a/backend/shared/src/helpers/semantic-search-fallback.test.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.test.ts
@@ -1,5 +1,6 @@
 import {
   BoundedSingleFlightCache,
+  HierarchicalRollingWindowGate,
   isValidQueryEmbedding,
   normalizeSemanticSearchTerm,
   queryEmbeddingCacheKey,
@@ -12,8 +13,6 @@ const makeCache = (now: () => number) =>
     maxEntries: 2,
     ttlMs: 100,
     maxInflightCreates: 2,
-    maxCreatesPerWindow: 2,
-    createWindowMs: 1_000,
     now,
   })
 
@@ -56,6 +55,25 @@ describe('BoundedSingleFlightCache', () => {
     ).rejects.toThrow('failed')
     await expect(cache.getOrCreate('key', async () => 'ok')).resolves.toBe('ok')
   })
+
+  it('checks caller allowance only for the request that creates a value', async () => {
+    const cache = makeCache(() => 0)
+    const create = jest.fn(async () => 'value')
+    const deny = jest.fn(() => false)
+
+    expect(cache.getOrCreate('key', create, deny)).toBeUndefined()
+    expect(create).not.toHaveBeenCalled()
+
+    const allow = jest.fn(() => true)
+    await expect(
+      Promise.all([
+        cache.getOrCreate('key', create, allow),
+        cache.getOrCreate('key', create, allow),
+      ])
+    ).resolves.toEqual(['value', 'value'])
+    expect(allow).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('RollingWindowGate', () => {
@@ -68,6 +86,32 @@ describe('RollingWindowGate', () => {
     expect(gate.take()).toBe(false)
     time = 1_000
     expect(gate.take()).toBe(true)
+  })
+})
+
+describe('HierarchicalRollingWindowGate', () => {
+  it("keeps one caller from consuming another caller's allowance", () => {
+    let time = 0
+    const gate = new HierarchicalRollingWindowGate(3, 2, 1_000, 100, () => time)
+
+    expect(gate.take('caller-a')).toBe(true)
+    expect(gate.take('caller-a')).toBe(true)
+    expect(gate.take('caller-a')).toBe(false)
+    expect(gate.take('caller-b')).toBe(true)
+
+    time = 1_000
+    expect(gate.take('caller-a')).toBe(true)
+  })
+
+  it('does not charge a caller when the global budget rejects it', () => {
+    let time = 0
+    const gate = new HierarchicalRollingWindowGate(1, 1, 1_000, 100, () => time)
+
+    expect(gate.take('caller-a')).toBe(true)
+    time = 500
+    expect(gate.take('caller-b')).toBe(false)
+    time = 1_000
+    expect(gate.take('caller-b')).toBe(true)
   })
 })
 

--- a/backend/shared/src/helpers/semantic-search-fallback.test.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.test.ts
@@ -5,7 +5,38 @@ import {
   normalizeSemanticSearchTerm,
   queryEmbeddingCacheKey,
   shouldAttemptSemanticFallback,
+  withSemanticQueryTimeout,
 } from './semantic-search-fallback'
+import type { SupabaseTransaction } from 'shared/supabase/init'
+
+describe('withSemanticQueryTimeout', () => {
+  const run = async (query: (tx: SupabaseTransaction) => Promise<string[]>) => {
+    const none = jest.fn(async () => {})
+    const tx = { none } as unknown as SupabaseTransaction
+    const pg = {
+      tx: async (callback: (tx: SupabaseTransaction) => Promise<string[]>) =>
+        callback(tx),
+    } as unknown as Parameters<typeof withSemanticQueryTimeout>[0]
+    return { result: await withSemanticQueryTimeout(pg, query), none }
+  }
+
+  it('sets a transaction-local server timeout before querying', async () => {
+    const { result, none } = await run(async (tx) => {
+      expect(tx.none).toHaveBeenCalledWith('set local statement_timeout = 1000')
+      return ['semantic-market']
+    })
+    expect(result).toEqual(['semantic-market'])
+    expect(none).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates cancellation to the lexical fallback instead of retrying', async () => {
+    const query = jest.fn(async () => {
+      throw Object.assign(new Error('statement timeout'), { code: '57014' })
+    })
+    await expect(run(query)).rejects.toMatchObject({ code: '57014' })
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+})
 
 const makeCache = (now: () => number) =>
   new BoundedSingleFlightCache<string>({

--- a/backend/shared/src/helpers/semantic-search-fallback.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.ts
@@ -72,10 +72,62 @@ export class RollingWindowGate {
   }
 }
 
+/** Atomically enforces a hard global ceiling and a fair per-caller budget. */
+export class HierarchicalRollingWindowGate {
+  private globalEventTimes: number[] = []
+  private readonly eventTimesByKey = new Map<string, number[]>()
+
+  constructor(
+    private readonly maxGlobalEvents: number,
+    private readonly maxEventsPerKey: number,
+    private readonly windowMs: number,
+    private readonly maxKeys: number,
+    private readonly now: Clock = Date.now
+  ) {}
+
+  take(key: string) {
+    const now = this.now()
+    const globalEventTimes = this.globalEventTimes.filter(
+      (time) => now - time < this.windowMs
+    )
+    this.globalEventTimes = globalEventTimes
+
+    // Reject globally before touching caller state. Otherwise attempts during
+    // saturation can leave an innocent caller locally blocked after global
+    // capacity has recovered.
+    if (globalEventTimes.length >= this.maxGlobalEvents) return false
+
+    const eventTimes = (this.eventTimesByKey.get(key) ?? []).filter(
+      (time) => now - time < this.windowMs
+    )
+
+    if (eventTimes.length >= this.maxEventsPerKey) {
+      this.remember(key, eventTimes)
+      return false
+    }
+
+    globalEventTimes.push(now)
+    eventTimes.push(now)
+    this.remember(key, eventTimes)
+    return true
+  }
+
+  private remember(key: string, eventTimes: number[]) {
+    // Refresh insertion order so abandoned callers are evicted before active
+    // ones when a public endpoint sees more distinct IPs than the bound.
+    this.eventTimesByKey.delete(key)
+    this.eventTimesByKey.set(key, eventTimes)
+    while (this.eventTimesByKey.size > this.maxKeys) {
+      const oldestKey = this.eventTimesByKey.keys().next().value
+      if (oldestKey === undefined) break
+      this.eventTimesByKey.delete(oldestKey)
+    }
+  }
+}
+
 export class BoundedSingleFlightCache<T> {
   private readonly values = new Map<string, { value: T; expiresAt: number }>()
   private readonly pending = new Map<string, Promise<T | undefined>>()
-  private readonly createGate: RollingWindowGate
   private inflightCreates = 0
 
   constructor(
@@ -83,17 +135,9 @@ export class BoundedSingleFlightCache<T> {
       maxEntries: number
       ttlMs: number
       maxInflightCreates: number
-      maxCreatesPerWindow: number
-      createWindowMs: number
       now?: Clock
     }
-  ) {
-    this.createGate = new RollingWindowGate(
-      options.maxCreatesPerWindow,
-      options.createWindowMs,
-      options.now
-    )
-  }
+  ) {}
 
   get(key: string) {
     const cached = this.values.get(key)
@@ -121,7 +165,11 @@ export class BoundedSingleFlightCache<T> {
     }
   }
 
-  getOrCreate(key: string, create: () => Promise<T | undefined>) {
+  getOrCreate(
+    key: string,
+    create: () => Promise<T | undefined>,
+    allowCreate: () => boolean = () => true
+  ) {
     const cached = this.get(key)
     if (cached !== undefined) return Promise.resolve(cached)
 
@@ -129,7 +177,7 @@ export class BoundedSingleFlightCache<T> {
     if (pending) return pending
     if (
       this.inflightCreates >= this.options.maxInflightCreates ||
-      !this.createGate.take()
+      !allowCreate()
     )
       return undefined
 

--- a/backend/shared/src/helpers/semantic-search-fallback.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.ts
@@ -52,26 +52,6 @@ export const shouldAttemptSemanticFallback = (args: {
 
 type Clock = () => number
 
-export class RollingWindowGate {
-  private eventTimes: number[] = []
-
-  constructor(
-    private readonly maxEvents: number,
-    private readonly windowMs: number,
-    private readonly now: Clock = Date.now
-  ) {}
-
-  take() {
-    const now = this.now()
-    this.eventTimes = this.eventTimes.filter(
-      (time) => now - time < this.windowMs
-    )
-    if (this.eventTimes.length >= this.maxEvents) return false
-    this.eventTimes.push(now)
-    return true
-  }
-}
-
 /** Atomically enforces a hard global ceiling and a fair per-caller budget. */
 export class HierarchicalRollingWindowGate {
   private globalEventTimes: number[] = []

--- a/backend/shared/src/helpers/semantic-search-fallback.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.ts
@@ -1,0 +1,150 @@
+import { createHash } from 'crypto'
+
+export const QUERY_EMBEDDING_DIMENSIONS = 1536
+
+export const normalizeSemanticSearchTerm = (term: string) =>
+  term.trim().replace(/\s+/g, ' ')
+
+export const queryEmbeddingCacheKey = (term: string, model: string) =>
+  `search-embedding:${model}:${createHash('sha256')
+    .update(term)
+    .digest('base64url')}`
+
+export const isValidQueryEmbedding = (value: unknown): value is number[] =>
+  Array.isArray(value) &&
+  value.length === QUERY_EMBEDDING_DIMENSIONS &&
+  value.every((item) => typeof item === 'number' && Number.isFinite(item))
+
+export const shouldAttemptSemanticFallback = (args: {
+  term: string
+  offset: number
+  sort: string
+  beforeTime?: number
+  lexicalResultCount: number
+  limit: number
+  minResults: number
+  minTermLength: number
+  maxTermLength: number
+}) => {
+  const {
+    term,
+    offset,
+    sort,
+    beforeTime,
+    lexicalResultCount,
+    limit,
+    minResults,
+    minTermLength,
+    maxTermLength,
+  } = args
+  const lowerTerm = term.toLowerCase()
+  return !(
+    offset > 0 ||
+    sort === 'newest' ||
+    beforeTime !== undefined ||
+    lowerTerm.startsWith('https://') ||
+    lowerTerm.startsWith('http://') ||
+    term.length < minTermLength ||
+    term.length > maxTermLength ||
+    lexicalResultCount >= Math.min(limit, minResults)
+  )
+}
+
+type Clock = () => number
+
+export class RollingWindowGate {
+  private eventTimes: number[] = []
+
+  constructor(
+    private readonly maxEvents: number,
+    private readonly windowMs: number,
+    private readonly now: Clock = Date.now
+  ) {}
+
+  take() {
+    const now = this.now()
+    this.eventTimes = this.eventTimes.filter(
+      (time) => now - time < this.windowMs
+    )
+    if (this.eventTimes.length >= this.maxEvents) return false
+    this.eventTimes.push(now)
+    return true
+  }
+}
+
+export class BoundedSingleFlightCache<T> {
+  private readonly values = new Map<string, { value: T; expiresAt: number }>()
+  private readonly pending = new Map<string, Promise<T | undefined>>()
+  private readonly createGate: RollingWindowGate
+  private inflightCreates = 0
+
+  constructor(
+    private readonly options: {
+      maxEntries: number
+      ttlMs: number
+      maxInflightCreates: number
+      maxCreatesPerWindow: number
+      createWindowMs: number
+      now?: Clock
+    }
+  ) {
+    this.createGate = new RollingWindowGate(
+      options.maxCreatesPerWindow,
+      options.createWindowMs,
+      options.now
+    )
+  }
+
+  get(key: string) {
+    const cached = this.values.get(key)
+    if (!cached) return undefined
+    if (cached.expiresAt <= (this.options.now ?? Date.now)()) {
+      this.values.delete(key)
+      return undefined
+    }
+    // Refresh insertion order to make this an LRU rather than FIFO cache.
+    this.values.delete(key)
+    this.values.set(key, cached)
+    return cached.value
+  }
+
+  set(key: string, value: T) {
+    this.values.delete(key)
+    this.values.set(key, {
+      value,
+      expiresAt: (this.options.now ?? Date.now)() + this.options.ttlMs,
+    })
+    while (this.values.size > this.options.maxEntries) {
+      const oldestKey = this.values.keys().next().value
+      if (oldestKey === undefined) break
+      this.values.delete(oldestKey)
+    }
+  }
+
+  getOrCreate(key: string, create: () => Promise<T | undefined>) {
+    const cached = this.get(key)
+    if (cached !== undefined) return Promise.resolve(cached)
+
+    const pending = this.pending.get(key)
+    if (pending) return pending
+    if (
+      this.inflightCreates >= this.options.maxInflightCreates ||
+      !this.createGate.take()
+    )
+      return undefined
+
+    this.inflightCreates++
+    const request = Promise.resolve()
+      .then(create)
+      .then((value) => {
+        if (value !== undefined) this.set(key, value)
+        return value
+      })
+      .finally(() => {
+        this.inflightCreates--
+        this.pending.delete(key)
+      })
+    this.pending.set(key, request)
+    return request
+  }
+}

--- a/backend/shared/src/helpers/semantic-search-fallback.ts
+++ b/backend/shared/src/helpers/semantic-search-fallback.ts
@@ -1,4 +1,19 @@
 import { createHash } from 'crypto'
+import type {
+  SupabaseDirectClient,
+  SupabaseTransaction,
+} from 'shared/supabase/init'
+
+// Cancel optional database work on the server, rather than merely abandoning
+// a client promise while the query keeps occupying a connection/fallback slot.
+export const withSemanticQueryTimeout = <T>(
+  pg: Pick<SupabaseDirectClient, 'tx'>,
+  query: (tx: SupabaseTransaction) => Promise<T>
+): Promise<T> =>
+  pg.tx(async (tx) => {
+    await tx.none('set local statement_timeout = 1000')
+    return query(tx)
+  })
 
 export const QUERY_EMBEDDING_DIMENSIONS = 1536
 

--- a/backend/shared/src/supabase/search-contracts.test.ts
+++ b/backend/shared/src/supabase/search-contracts.test.ts
@@ -1,6 +1,7 @@
 import { HOUR_MS, MINUTE_MS } from 'common/util/time'
 import {
   basicSearchSQL,
+  getForYouTopicRankSql,
   getSemanticSearchContractSQL,
   shouldSuppressStaleSeenMarkets,
   staleSeenMarketsSql,
@@ -16,6 +17,31 @@ const semanticSearchArgs = {
   sort: 'score',
   token: 'MANA' as const,
 }
+
+describe('getForYouTopicRankSql', () => {
+  it('keeps the legacy average in control', () => {
+    const sql = getForYouTopicRankSql('importance_score', 'control')
+
+    expect(sql).toContain(
+      'avg(power(coalesce(uti.avg_conversion_score, 0.34698192227708463), 4) * contracts.importance_score)'
+    )
+    expect(sql).not.toContain('0.7 * max')
+  })
+
+  it('uses the niche blend only in treatment', () => {
+    const sql = getForYouTopicRankSql('importance_score', 'treatment')
+
+    expect(sql).toContain('0.7 * max')
+    expect(sql).toContain('0.3 * avg')
+    expect(sql).toContain('* avg(contracts.importance_score)')
+  })
+
+  it('defaults an unversioned caller to control', () => {
+    expect(getForYouTopicRankSql('importance_score', undefined)).not.toContain(
+      '0.7 * max'
+    )
+  })
+})
 
 describe('getSemanticSearchContractSQL', () => {
   it('keeps the requested limit and excludes lexical results', () => {

--- a/backend/shared/src/supabase/search-contracts.test.ts
+++ b/backend/shared/src/supabase/search-contracts.test.ts
@@ -1,0 +1,96 @@
+import {
+  getSemanticSearchContractSQL,
+  shouldSuppressStaleSeenMarkets,
+  staleSeenMarketsSql,
+} from './search-contracts'
+import { renderSql } from './sql-builder'
+
+const semanticSearchArgs = {
+  embedding: [0.1, 0.2],
+  filter: 'open',
+  contractType: 'ALL',
+  limit: 4,
+  offset: 0,
+  sort: 'score',
+  token: 'MANA' as const,
+}
+
+describe('getSemanticSearchContractSQL', () => {
+  it('keeps the requested limit and excludes lexical results', () => {
+    const sql = getSemanticSearchContractSQL({
+      ...semanticSearchArgs,
+      excludeContractIds: ['lexical-market'],
+    })
+
+    expect(sql).toContain('limit 4')
+    expect(sql).toContain('contracts.id <> all(')
+    expect(sql).toContain('lexical-market')
+  })
+
+  it('defensively renders a positive limit', () => {
+    const sql = getSemanticSearchContractSQL({
+      ...semanticSearchArgs,
+      limit: 0,
+    })
+
+    expect(sql).toContain('limit 1')
+  })
+
+  it('preserves news and has-bets filters', () => {
+    const sql = getSemanticSearchContractSQL({
+      ...semanticSearchArgs,
+      filter: 'news',
+      hasBets: '1',
+      uid: 'user-id',
+    })
+
+    expect(sql).toContain('contract_movement_notifications')
+    expect(sql).toContain('recent_movements rm')
+    expect(sql).toContain('user_contract_metrics cm')
+  })
+
+  it('preserves group filters', () => {
+    const sql = getSemanticSearchContractSQL({
+      ...semanticSearchArgs,
+      groupIds: ['science'],
+    })
+
+    expect(sql).toContain('select 1 from group_contracts gc')
+    expect(sql).toContain('science')
+  })
+})
+
+describe('staleSeenMarketsSql', () => {
+  const sql = renderSql(staleSeenMarketsSql('user-id'))
+
+  it('only suppresses CPMM mechanisms with a supported movement signal', () => {
+    expect(sql).toContain("contracts.mechanism in ('cpmm-1', 'cpmm-multi-1')")
+  })
+
+  it('lets resolutions and new or moving answers resurface', () => {
+    expect(sql).toContain('contracts.resolution_time')
+    expect(sql).toContain('from answers a')
+    expect(sql).toContain('a.created_time')
+    expect(sql).toContain('a.prob_change_day')
+  })
+
+  it('can anchor the seen window for stable offset pagination', () => {
+    const anchoredSql = renderSql(
+      staleSeenMarketsSql('user-id', 1_700_000_000_000)
+    )
+
+    expect(anchoredSql).toContain('millis_to_ts(1700000000000)')
+    expect(anchoredSql).not.toContain('between now()')
+  })
+})
+
+describe('shouldSuppressStaleSeenMarkets', () => {
+  it('uses an anchored seen set on every page', () => {
+    expect(shouldSuppressStaleSeenMarkets(40, 1_700_000_000_000)).toBe(true)
+  })
+
+  it('limits legacy unanchored callers to the first page', () => {
+    expect(shouldSuppressStaleSeenMarkets(0)).toBe(true)
+    expect(shouldSuppressStaleSeenMarkets(40)).toBe(false)
+  })
+})

--- a/backend/shared/src/supabase/search-contracts.test.ts
+++ b/backend/shared/src/supabase/search-contracts.test.ts
@@ -1,4 +1,5 @@
 import {
+  basicSearchSQL,
   getSemanticSearchContractSQL,
   shouldSuppressStaleSeenMarkets,
   staleSeenMarketsSql,
@@ -71,6 +72,7 @@ describe('staleSeenMarketsSql', () => {
     expect(sql).toContain('contracts.resolution_time')
     expect(sql).toContain('from answers a')
     expect(sql).toContain('a.created_time')
+    expect(sql).toContain('a.resolution_time > greatest')
     expect(sql).toContain('a.prob_change_day')
   })
 
@@ -86,11 +88,49 @@ describe('staleSeenMarketsSql', () => {
 
 describe('shouldSuppressStaleSeenMarkets', () => {
   it('uses an anchored seen set on every page', () => {
+    expect(shouldSuppressStaleSeenMarkets(0, 1_700_000_000_000)).toBe(true)
     expect(shouldSuppressStaleSeenMarkets(40, 1_700_000_000_000)).toBe(true)
   })
 
-  it('limits legacy unanchored callers to the first page', () => {
-    expect(shouldSuppressStaleSeenMarkets(0)).toBe(true)
+  it('leaves every page unchanged for legacy unanchored callers', () => {
+    expect(shouldSuppressStaleSeenMarkets(0)).toBe(false)
     expect(shouldSuppressStaleSeenMarkets(40)).toBe(false)
+  })
+})
+
+describe('basicSearchSQL', () => {
+  const basicSearchArgs = {
+    filter: 'open',
+    contractType: 'ALL',
+    limit: 40,
+    offset: 0,
+    sort: 'score',
+    token: 'MANA' as const,
+  }
+
+  it('does not suppress seen markets for ordinary basic browse', () => {
+    expect(basicSearchSQL(basicSearchArgs)).not.toContain('user_contract_views')
+  })
+
+  it('does not enable fallback suppression without an anchor', () => {
+    const sql = basicSearchSQL({
+      ...basicSearchArgs,
+      uid: 'user-id',
+      suppressStaleSeen: true,
+    })
+
+    expect(sql).not.toContain('user_contract_views')
+  })
+
+  it('can preserve stale-seen behavior for an anchored For You fallback', () => {
+    const sql = basicSearchSQL({
+      ...basicSearchArgs,
+      uid: 'user-id',
+      seenMarketCutoffTime: 1_700_000_000_000,
+      suppressStaleSeen: true,
+    })
+
+    expect(sql).toContain('user_contract_views')
+    expect(sql).toContain('millis_to_ts(1700000000000)')
   })
 })

--- a/backend/shared/src/supabase/search-contracts.test.ts
+++ b/backend/shared/src/supabase/search-contracts.test.ts
@@ -1,3 +1,4 @@
+import { HOUR_MS, MINUTE_MS } from 'common/util/time'
 import {
   basicSearchSQL,
   getSemanticSearchContractSQL,
@@ -76,25 +77,52 @@ describe('staleSeenMarketsSql', () => {
     expect(sql).toContain('a.prob_change_day')
   })
 
-  it('can anchor the seen window for stable offset pagination', () => {
+  it('anchors the seen window on server time without a cutoff', () => {
+    expect(sql).toContain("between now() - interval '7 days'")
+    expect(sql).toContain("and now() - interval '1 hour'")
+  })
+
+  it('anchors both bounds of the seen window on the cutoff alone', () => {
     const anchoredSql = renderSql(
       staleSeenMarketsSql('user-id', 1_700_000_000_000)
     )
 
-    expect(anchoredSql).toContain('millis_to_ts(1700000000000)')
-    expect(anchoredSql).not.toContain('between now()')
+    expect(anchoredSql).toContain(
+      "between millis_to_ts(1700000000000) - interval '7 days'"
+    )
+    expect(anchoredSql).toContain(
+      "and millis_to_ts(1700000000000) - interval '1 hour'"
+    )
+    expect(anchoredSql).not.toContain('now()')
   })
 })
 
 describe('shouldSuppressStaleSeenMarkets', () => {
-  it('uses an anchored seen set on every page', () => {
-    expect(shouldSuppressStaleSeenMarkets(0, 1_700_000_000_000)).toBe(true)
-    expect(shouldSuppressStaleSeenMarkets(40, 1_700_000_000_000)).toBe(true)
+  const now = 1_700_000_000_000
+
+  it('applies an anchored seen set', () => {
+    expect(shouldSuppressStaleSeenMarkets(now, now)).toBe(true)
+    expect(shouldSuppressStaleSeenMarkets(now - HOUR_MS, now)).toBe(true)
   })
 
-  it('leaves every page unchanged for legacy unanchored callers', () => {
-    expect(shouldSuppressStaleSeenMarkets(0)).toBe(false)
-    expect(shouldSuppressStaleSeenMarkets(40)).toBe(false)
+  it('tolerates request latency and a slightly fast client clock', () => {
+    expect(shouldSuppressStaleSeenMarkets(now + MINUTE_MS, now)).toBe(true)
+  })
+
+  it('refuses an anchor far ahead of server time', () => {
+    expect(shouldSuppressStaleSeenMarkets(now + HOUR_MS, now)).toBe(false)
+  })
+
+  it('pins the tolerance at five minutes', () => {
+    expect(shouldSuppressStaleSeenMarkets(now + 5 * MINUTE_MS, now)).toBe(true)
+    expect(shouldSuppressStaleSeenMarkets(now + 5 * MINUTE_MS + 1, now)).toBe(
+      false
+    )
+  })
+
+  it('never applies without an anchor', () => {
+    expect(shouldSuppressStaleSeenMarkets()).toBe(false)
+    expect(shouldSuppressStaleSeenMarkets(undefined)).toBe(false)
   })
 })
 
@@ -132,5 +160,16 @@ describe('basicSearchSQL', () => {
 
     expect(sql).toContain('user_contract_views')
     expect(sql).toContain('millis_to_ts(1700000000000)')
+  })
+
+  it('refuses an anchor far ahead of server time', () => {
+    const sql = basicSearchSQL({
+      ...basicSearchArgs,
+      uid: 'user-id',
+      seenMarketCutoffTime: Date.now() + HOUR_MS,
+      suppressStaleSeen: true,
+    })
+
+    expect(sql).not.toContain('user_contract_views')
   })
 })

--- a/backend/shared/src/supabase/search-contracts.test.ts
+++ b/backend/shared/src/supabase/search-contracts.test.ts
@@ -188,6 +188,19 @@ describe('basicSearchSQL', () => {
     expect(sql).toContain('millis_to_ts(1700000000000)')
   })
 
+  it('does not suppress stale-seen markets on the Your bets lookup surface', () => {
+    const sql = basicSearchSQL({
+      ...basicSearchArgs,
+      uid: 'user-id',
+      hasBets: '1',
+      seenMarketCutoffTime: 1_700_000_000_000,
+      suppressStaleSeen: true,
+    })
+
+    expect(sql).toContain('user_contract_metrics')
+    expect(sql).not.toContain('user_contract_views')
+  })
+
   it('refuses an anchor far ahead of server time', () => {
     const sql = basicSearchSQL({
       ...basicSearchArgs,

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -250,8 +250,21 @@ export type SearchTypes =
 // Deliberately lower than TOPIC_SIMILARITY_THRESHOLD (0.5), which compares
 // two full questions. A search term is much shorter than the questions it is
 // being compared against, which drags cosine similarity down for matches that
-// are perfectly good. NOT yet validated against real query embeddings — check
-// this against live searches in dev before trusting the number.
+// are perfectly good.
+//
+// Calibrated 2026-08-14 against real query embeddings on dev (13 short
+// user-style queries vs stored question embeddings, same-model pairs):
+// ordinary good matches score 0.42-0.65, deep synonym matches with zero
+// keyword overlap ("riemann hypothesis" -> the zeta-zeros question) ~0.30,
+// junk-query noise floor 0.31-0.42. There is no clean separating value;
+// 0.35 leans toward recall, which is the right bias for a tail that only
+// appears on otherwise-dead pages. Raising it above ~0.4 silently kills the
+// synonym cases this feature exists for.
+//
+// Caveat: similarity is only meaningful between same-model embeddings. The
+// embedding model changed 2024-06-27 (0329b37ae, ada-002 -> 3-small, same
+// 1536 dims); contracts whose stored embedding predates a re-embed are pure
+// noise against query vectors and can never surface here.
 export const SEMANTIC_SEARCH_SIMILARITY_THRESHOLD = 0.35
 // Over-fetch from the index, then let the normal filters cut it down, the
 // same way close_contract_embeddings does with match_count + 500.
@@ -283,6 +296,20 @@ const groupsFilterSql = (args: {
   )
 }
 
+// News surfaces only markets that moved recently. Shared for the same reason
+// as groupsFilterSql: both search paths must apply it, or the semantic tail
+// would pad the movers page with dormant markets.
+const newsMovementFilterSql = () => [
+  withClause(
+    `recent_movements as (
+        select distinct contract_id
+        from contract_movement_notifications
+        where created_time > now() - interval '72 hours'
+      )`
+  ),
+  join(`recent_movements rm on rm.contract_id = contracts.id`),
+]
+
 /**
  * Nearest markets to an already-computed query embedding, run through the
  * same filters as a normal search so status/type/token/blocks still hold.
@@ -296,7 +323,8 @@ export function getSemanticSearchContractSQL(
     excludeContractIds?: string[]
   }
 ) {
-  const { embedding, limit, privateUser, excludeContractIds } = args
+  const { embedding, limit, filter, uid, hasBets, privateUser, excludeContractIds } =
+    args
   return renderSql(
     select(contractColumnsToSelectWithPrefix('contracts')),
     from(
@@ -310,13 +338,21 @@ export function getSemanticSearchContractSQL(
     ),
     join('contracts on contracts.id = se.contract_id'),
     groupsFilterSql(args),
-    getSearchContractWhereSQL({ ...args, hideStonks: true }),
-    privateUser && privateUserBlocksSql(privateUser),
+    filter === 'news' && newsMovementFilterSql(),
+    hasBets === '1' && uid && userBetsJoinSql,
+    // Both hide* flags mirror what the lexical path computes when a term is
+    // present (always the case here): an explicit search never hides stonks
+    // or resolved sports markets, and the two halves of one response must
+    // obey the same visibility rules.
+    getSearchContractWhereSQL({ ...args, hideStonks: false, hideLove: false }),
+    privateUserBlocksSql(privateUser),
     // Already-returned lexical hits, so the tail can't repeat the head.
     (excludeContractIds?.length ?? 0) > 0 &&
-      where(`contracts.id <> all(array[$1])`, [excludeContractIds]),
+      where(`contracts.id <> all($1)`, [excludeContractIds]),
     orderBy('se.similarity desc'),
-    lim(limit)
+    // sql-builder silently drops a limit of 0 (rendering NO limit clause), so
+    // clamp: callers must never pass 0, but if one does, 1 row beats 200.
+    lim(Math.max(limit, 1))
   )
 }
 
@@ -368,19 +404,7 @@ export function getSearchContractSQL(
   const groupsFilter = groupsFilterSql({ groupId, groupIds, token })
 
   // Recent movements filter
-  const newsFilter =
-    filter === 'news' &&
-    withClause(
-      `recent_movements as (
-        select distinct contract_id
-        from contract_movement_notifications
-        where created_time > now() - interval '72 hours'
-      )`
-    )
-
-  const newsJoin =
-    filter === 'news' &&
-    join(`recent_movements rm on rm.contract_id = contracts.id`)
+  const newsMovement = filter === 'news' && newsMovementFilterSql()
 
   const newsWhere =
     filter === 'news' &&
@@ -393,8 +417,7 @@ export function getSearchContractSQL(
     select(contractColumnsToSelectWithPrefix('contracts')),
     from('contracts'),
     groupsFilter,
-    newsFilter,
-    newsJoin,
+    newsMovement,
     newsWhere,
     userBetsJoin,
     searchType === 'answer' &&

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -85,13 +85,12 @@ const SEEN_CUTOFF_MAX_CLOCK_AHEAD_MS = 5 * MINUTE_MS
  * the exact case the grace period protects. Clamping it to now() would not
  * help: the clamp resolves to a fresh now() on every page until server time
  * catches up, which is the moving boundary described above. Instead
- * shouldSuppressStaleSeenMarkets refuses an anchor too far ahead of server
- * time, so a fast clock gets no suppression rather than a different set on
- * each page. That check is re-evaluated per request, so a clock ahead by
- * almost exactly the tolerance can see it flip from refused to accepted
- * mid-session and shift one page; that narrow case is accepted over hiding
- * fresh views for every fast clock. A clock running behind only ages the
- * window, which at worst means nothing is suppressed.
+ * shouldSuppressStaleSeenMarkets identifies an anchor too far ahead of server
+ * time. The API rejects that first request so the web client can retry without
+ * an anchor and keep suppression off for the whole result set; silently
+ * returning an unfiltered page would let the decision flip during pagination
+ * as server time catches up. A clock running behind only ages the window,
+ * which at worst means nothing is suppressed.
  */
 export const staleSeenMarketsSql = (
   userId: string,

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -33,6 +33,58 @@ type TokenInputType = 'CASH' | 'MANA' | 'ALL' | 'CASH_AND_MANA'
 let importanceScoreThreshold: number | undefined = undefined
 let freshnessScoreThreshold: number | undefined = undefined
 
+// --- Stale-seen suppression (For You only) ------------------------------
+// Nothing is hidden for longer than this. Past it a market is fair game
+// again even if it has been completely quiet, so the shelf can never
+// permanently empty out.
+const SEEN_MEMORY_WINDOW = '7 days'
+// Views younger than this don't count yet. This is what makes going back
+// safe: scroll browse, open the 4th market, hit back — every card you
+// scrolled past is still inside the grace period, so the page you return
+// to looks like the page you left. It also keeps "load more" honest, since
+// paging with a shifting offset over a set that's shrinking underneath you
+// silently skips rows.
+const SEEN_GRACE_PERIOD = '1 hour'
+// Matches PROB_CHANGE_THRESHOLD in feed-market-movement-display.ts: the same
+// move that earns a card its movement badge also earns it another look.
+const SEEN_PROB_MOVE_THRESHOLD = 0.05
+
+/**
+ * Drops markets the user has already looked at and that have gone quiet since.
+ *
+ * Browse ranks on score alone, so the same top markets greet you every visit.
+ * But "seen" is a weak signal and over-trusting it is worse than repetition,
+ * so this only fires in the narrow band where repetition is genuinely stale:
+ * seen, long enough ago to be a separate visit, recently enough to still
+ * remember, and nothing has happened since.
+ *
+ * A view here means the card was ≥90% in the viewport (useIsVisible in
+ * feed-contract-card.tsx) or the market page was opened — not merely that the
+ * card was somewhere on a page that loaded. Promoted impressions are excluded
+ * deliberately: an ad scrolling past is not the user choosing to look at
+ * something.
+ *
+ * Resurfacing is driven by new comments and by significant price movement,
+ * not by last_bet_time — on an active market bets land continuously, so
+ * keying on them would make this a no-op exactly where repetition is worst.
+ */
+const staleSeenMarketsSql = (userId: string) =>
+  where(
+    `not exists (
+      select 1 from user_contract_views ucv
+      where ucv.user_id = $1
+        and ucv.contract_id = contracts.id
+        and greatest(ucv.last_card_view_ts, ucv.last_page_view_ts)
+            between now() - interval '${SEEN_MEMORY_WINDOW}'
+                and now() - interval '${SEEN_GRACE_PERIOD}'
+        and coalesce(contracts.last_comment_time, contracts.created_time)
+            <= greatest(ucv.last_card_view_ts, ucv.last_page_view_ts)
+        and abs(coalesce((contracts.data->'probChanges'->>'day')::numeric, 0))
+            <= ${SEEN_PROB_MOVE_THRESHOLD}
+    )`,
+    [userId]
+  )
+
 type SharedSearchArgs = {
   filter: string
   contractType: string
@@ -117,6 +169,7 @@ export async function getForYouSQL(
         `contracts.id not in (select contract_id from user_disinterests where user_id = $1 and contract_id = contracts.id)`,
         [userId]
       ),
+      staleSeenMarketsSql(userId),
       privateUserBlocksSql(privateUser),
       withClause(
         `user_follows as (select follow_id from user_follows where user_id = $1)`,

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -1,6 +1,6 @@
 import { Contract, isSportsContract } from 'common/contract'
 import { PROD_MANIFOLD_LOVE_GROUP_SLUG } from 'common/envs/constants'
-import { GROUP_SCORE_PRIOR } from 'common/feed'
+import { GROUP_SCORE_PRIOR, nicheBlendTopicScoreSql } from 'common/feed'
 import { getPerpBackingPool } from 'common/perps/amm'
 import { tsToMillis } from 'common/supabase/utils'
 import { answerCostTiers, getTierIndexFromLiquidity } from 'common/tier'
@@ -142,7 +142,9 @@ export async function getForYouSQL(
       orderBy(`case
       when bool_or(contracts.boosted) then avg(contracts.${sortByScore})
       when bool_or(uti.avg_conversion_score is not null)
-      then avg(power(coalesce(uti.avg_conversion_score, ${GROUP_SCORE_PRIOR}), ${GROUP_SCORE_POWER}) * contracts.${sortByScore})
+      then power(${nicheBlendTopicScoreSql(
+        `coalesce(uti.avg_conversion_score, ${GROUP_SCORE_PRIOR})`
+      )}, ${GROUP_SCORE_POWER}) * avg(contracts.${sortByScore})
       else avg(contracts.${sortByScore}*${GROUP_SCORE_PRIOR})
       end * (1 + case
       when bool_or(contracts.creator_id = any(select follow_id from user_follows)) then 0.2

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -41,22 +41,24 @@ const SEEN_MEMORY_WINDOW = '7 days'
 // Views younger than this don't count yet. This is what makes going back
 // safe: scroll browse, open the 4th market, hit back — every card you
 // scrolled past is still inside the grace period, so the page you return
-// to looks like the page you left. It also keeps "load more" honest, since
-// paging with a shifting offset over a set that's shrinking underneath you
-// silently skips rows.
+// to looks like the page you left. The web client anchors this cutoff when a
+// fresh query starts and reuses it so load-more offsets see one stable set.
 const SEEN_GRACE_PERIOD = '1 hour'
 // Matches PROB_CHANGE_THRESHOLD in feed-market-movement-display.ts: the same
-// move that earns a card its movement badge also earns it another look.
+// binary move that earns a card its movement badge also earns it another look.
 const SEEN_PROB_MOVE_THRESHOLD = 0.05
 
 /**
- * Drops markets the user has already looked at and that have gone quiet since.
+ * Drops markets the user has already looked at and that are currently quiet
+ * from For You results. Callers without a session anchor use this only on the
+ * first page so a moving time boundary cannot create pagination holes.
  *
  * Browse ranks on score alone, so the same top markets greet you every visit.
  * But "seen" is a weak signal and over-trusting it is worse than repetition,
- * so this only fires in the narrow band where repetition is genuinely stale:
- * seen, long enough ago to be a separate visit, recently enough to still
- * remember, and nothing has happened since.
+ * so this only fires in the narrow band where repetition is plausibly stale:
+ * seen, long enough ago to be a separate visit, recently enough to remember,
+ * no comment/resolution/new answer after the view, and no significant current
+ * daily movement.
  *
  * A view here means the card was ≥90% in the viewport (useIsVisible in
  * feed-contract-card.tsx) or the market page was opened — not merely that the
@@ -64,26 +66,61 @@ const SEEN_PROB_MOVE_THRESHOLD = 0.05
  * deliberately: an ad scrolling past is not the user choosing to look at
  * something.
  *
- * Resurfacing is driven by new comments and by significant price movement,
- * not by last_bet_time — on an active market bets land continuously, so
- * keying on them would make this a no-op exactly where repetition is worst.
+ * Resurfacing is driven by resolution, comments or answers after the view and
+ * by significant recent price movement. The stored movement metric is a
+ * rolling daily value, not a probability snapshot at view time, so do not
+ * describe it as movement since the view. We deliberately avoid last_bet_time:
+ * continuously traded markets would otherwise make this filter a no-op.
  */
-const staleSeenMarketsSql = (userId: string) =>
-  where(
+export const staleSeenMarketsSql = (
+  userId: string,
+  seenMarketCutoffTime?: number
+) => {
+  const anchor =
+    seenMarketCutoffTime === undefined ? 'now()' : 'millis_to_ts($2)'
+  return where(
     `not exists (
       select 1 from user_contract_views ucv
       where ucv.user_id = $1
         and ucv.contract_id = contracts.id
         and greatest(ucv.last_card_view_ts, ucv.last_page_view_ts)
-            between now() - interval '${SEEN_MEMORY_WINDOW}'
-                and now() - interval '${SEEN_GRACE_PERIOD}'
+            between ${anchor} - interval '${SEEN_MEMORY_WINDOW}'
+                and ${anchor} - interval '${SEEN_GRACE_PERIOD}'
         and coalesce(contracts.last_comment_time, contracts.created_time)
             <= greatest(ucv.last_card_view_ts, ucv.last_page_view_ts)
+        and coalesce(contracts.resolution_time, contracts.created_time)
+            <= greatest(ucv.last_card_view_ts, ucv.last_page_view_ts)
+        -- Only CPMM markets have a normalized daily probability-change
+        -- metric. Perps, polls, and bounties can be active while probChanges
+        -- is absent, so never classify them as quiet from missing data.
+        and contracts.mechanism in ('cpmm-1', 'cpmm-multi-1')
         and abs(coalesce((contracts.data->'probChanges'->>'day')::numeric, 0))
             <= ${SEEN_PROB_MOVE_THRESHOLD}
+        -- Multi-answer markets store movement on answers, not contracts. A
+        -- new or moving answer should resurface the market.
+        and not exists (
+          select 1 from answers a
+          where a.contract_id = contracts.id
+            and (
+              a.created_time > greatest(
+                ucv.last_card_view_ts,
+                ucv.last_page_view_ts
+              )
+              or abs(coalesce(a.prob_change_day, 0))
+                  > ${SEEN_PROB_MOVE_THRESHOLD}
+            )
+        )
     )`,
-    [userId]
+    seenMarketCutoffTime === undefined
+      ? [userId]
+      : [userId, seenMarketCutoffTime]
   )
+}
+
+export const shouldSuppressStaleSeenMarkets = (
+  offset: number,
+  seenMarketCutoffTime?: number
+) => offset === 0 || seenMarketCutoffTime !== undefined
 
 type SharedSearchArgs = {
   filter: string
@@ -98,6 +135,7 @@ type SharedSearchArgs = {
   liquidity?: number
   isPrizeMarket?: boolean
   beforeTime?: number
+  seenMarketCutoffTime?: number
 }
 
 export async function getForYouSQL(
@@ -114,6 +152,7 @@ export async function getForYouSQL(
     privateUser,
     threshold = DEFAULT_THRESHOLD,
     hasBets,
+    seenMarketCutoffTime,
   } = args
 
   const userId = args.uid
@@ -169,7 +208,10 @@ export async function getForYouSQL(
         `contracts.id not in (select contract_id from user_disinterests where user_id = $1 and contract_id = contracts.id)`,
         [userId]
       ),
-      staleSeenMarketsSql(userId),
+      // A client-provided session anchor keeps the seen set stable across
+      // every offset page. Legacy callers get safe top-page-only suppression.
+      shouldSuppressStaleSeenMarkets(offset, seenMarketCutoffTime) &&
+        staleSeenMarketsSql(userId, seenMarketCutoffTime),
       privateUserBlocksSql(privateUser),
       withClause(
         `user_follows as (select follow_id from user_follows where user_id = $1)`,
@@ -323,19 +365,23 @@ export function getSemanticSearchContractSQL(
     excludeContractIds?: string[]
   }
 ) {
-  const { embedding, limit, filter, uid, hasBets, privateUser, excludeContractIds } =
-    args
+  const {
+    embedding,
+    limit,
+    filter,
+    uid,
+    hasBets,
+    privateUser,
+    excludeContractIds,
+  } = args
   return renderSql(
     select(contractColumnsToSelectWithPrefix('contracts')),
-    from(
-      `search_contract_embeddings($1::vector, $2, $3) as se`,
-      [
-        // pgvector parses its literal from a JSON-shaped array string.
-        JSON.stringify(embedding),
-        SEMANTIC_SEARCH_SIMILARITY_THRESHOLD,
-        SEMANTIC_SEARCH_OVERFETCH,
-      ]
-    ),
+    from(`search_contract_embeddings($1::vector, $2, $3) as se`, [
+      // pgvector parses its literal from a JSON-shaped array string.
+      JSON.stringify(embedding),
+      SEMANTIC_SEARCH_SIMILARITY_THRESHOLD,
+      SEMANTIC_SEARCH_OVERFETCH,
+    ]),
     join('contracts on contracts.id = se.contract_id'),
     groupsFilterSql(args),
     filter === 'news' && newsMovementFilterSql(),

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -6,6 +6,7 @@ import { tsToMillis } from 'common/supabase/utils'
 import { answerCostTiers, getTierIndexFromLiquidity } from 'common/tier'
 import { PrivateUser } from 'common/user'
 import { buildArray, filterDefined } from 'common/util/array'
+import { MINUTE_MS } from 'common/util/time'
 import { constructPrefixTsQuery } from 'shared/helpers/search'
 import { getContractPrivacyWhereSQLFilter } from 'shared/supabase/contracts'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
@@ -47,6 +48,10 @@ const SEEN_GRACE_PERIOD = '1 hour'
 // Matches PROB_CHANGE_THRESHOLD in feed-market-movement-display.ts: the same
 // binary move that earns a card its movement badge also earns it another look.
 const SEEN_PROB_MOVE_THRESHOLD = 0.05
+// How far ahead of server time a client anchor may sit before it is refused.
+// Wide enough for request latency and an unsynced clock, narrow enough that
+// the grace period it eats into stays almost whole.
+const SEEN_CUTOFF_MAX_CLOCK_AHEAD_MS = 5 * MINUTE_MS
 
 /**
  * Drops markets the user has already looked at and that are currently quiet
@@ -72,6 +77,21 @@ const SEEN_PROB_MOVE_THRESHOLD = 0.05
  * rolling daily value, not a probability snapshot at view time, so do not
  * describe it as movement since the view. We deliberately avoid last_bet_time:
  * continuously traded markets would otherwise make this filter a no-op.
+ *
+ * The client-supplied anchor exists only to keep the seen set identical
+ * across the pages of one session; it is not trusted as a clock. Both bounds
+ * of the window hang off it, so a client clock running ahead would push the
+ * upper bound past the grace period and hide markets viewed minutes ago —
+ * the exact case the grace period protects. Clamping it to now() would not
+ * help: the clamp resolves to a fresh now() on every page until server time
+ * catches up, which is the moving boundary described above. Instead
+ * shouldSuppressStaleSeenMarkets refuses an anchor too far ahead of server
+ * time, so a fast clock gets no suppression rather than a different set on
+ * each page. That check is re-evaluated per request, so a clock ahead by
+ * almost exactly the tolerance can see it flip from refused to accepted
+ * mid-session and shift one page; that narrow case is accepted over hiding
+ * fresh views for every fast clock. A clock running behind only ages the
+ * window, which at worst means nothing is suppressed.
  */
 export const staleSeenMarketsSql = (
   userId: string,
@@ -123,9 +143,11 @@ export const staleSeenMarketsSql = (
 }
 
 export const shouldSuppressStaleSeenMarkets = (
-  _offset: number,
-  seenMarketCutoffTime?: number
-) => seenMarketCutoffTime !== undefined
+  seenMarketCutoffTime?: number,
+  now = Date.now()
+) =>
+  seenMarketCutoffTime !== undefined &&
+  seenMarketCutoffTime <= now + SEEN_CUTOFF_MAX_CLOCK_AHEAD_MS
 
 type SharedSearchArgs = {
   filter: string
@@ -190,10 +212,7 @@ export async function getForYouSQL(
       privateUser,
       // Keep the same diversity behavior when a new/low-activity user has no
       // topic scores yet. Ordinary basic browse does not opt into this.
-      suppressStaleSeen: shouldSuppressStaleSeenMarkets(
-        offset,
-        seenMarketCutoffTime
-      ),
+      suppressStaleSeen: true,
     })
   }
   const userBetsJoin = hasBets === '1' && userId && userBetsJoinSql
@@ -222,7 +241,7 @@ export async function getForYouSQL(
       // A client-provided session anchor keeps the seen set stable across
       // every offset page. Unanchored callers retain the old unsuppressed
       // behavior so page-one filtering cannot shift their later offsets.
-      shouldSuppressStaleSeenMarkets(offset, seenMarketCutoffTime) &&
+      shouldSuppressStaleSeenMarkets(seenMarketCutoffTime) &&
         staleSeenMarketsSql(userId, seenMarketCutoffTime),
       privateUserBlocksSql(privateUser),
       withClause(
@@ -283,7 +302,7 @@ export const basicSearchSQL = (
     }),
     suppressStaleSeen &&
       args.uid &&
-      args.seenMarketCutoffTime !== undefined &&
+      shouldSuppressStaleSeenMarkets(args.seenMarketCutoffTime) &&
       staleSeenMarketsSql(args.uid, args.seenMarketCutoffTime),
     privateUserBlocksSql(privateUser),
     beforeTime && where(`created_time < millis_to_ts($1)`, [beforeTime]),

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -32,6 +32,58 @@ type TokenInputType = 'CASH' | 'MANA' | 'ALL' | 'CASH_AND_MANA'
 let importanceScoreThreshold: number | undefined = undefined
 let freshnessScoreThreshold: number | undefined = undefined
 
+// --- Stale-seen suppression (For You only) ------------------------------
+// Nothing is hidden for longer than this. Past it a market is fair game
+// again even if it has been completely quiet, so the shelf can never
+// permanently empty out.
+const SEEN_MEMORY_WINDOW = '7 days'
+// Views younger than this don't count yet. This is what makes going back
+// safe: scroll browse, open the 4th market, hit back — every card you
+// scrolled past is still inside the grace period, so the page you return
+// to looks like the page you left. It also keeps "load more" honest, since
+// paging with a shifting offset over a set that's shrinking underneath you
+// silently skips rows.
+const SEEN_GRACE_PERIOD = '1 hour'
+// Matches PROB_CHANGE_THRESHOLD in feed-market-movement-display.ts: the same
+// move that earns a card its movement badge also earns it another look.
+const SEEN_PROB_MOVE_THRESHOLD = 0.05
+
+/**
+ * Drops markets the user has already looked at and that have gone quiet since.
+ *
+ * Browse ranks on score alone, so the same top markets greet you every visit.
+ * But "seen" is a weak signal and over-trusting it is worse than repetition,
+ * so this only fires in the narrow band where repetition is genuinely stale:
+ * seen, long enough ago to be a separate visit, recently enough to still
+ * remember, and nothing has happened since.
+ *
+ * A view here means the card was ≥90% in the viewport (useIsVisible in
+ * feed-contract-card.tsx) or the market page was opened — not merely that the
+ * card was somewhere on a page that loaded. Promoted impressions are excluded
+ * deliberately: an ad scrolling past is not the user choosing to look at
+ * something.
+ *
+ * Resurfacing is driven by new comments and by significant price movement,
+ * not by last_bet_time — on an active market bets land continuously, so
+ * keying on them would make this a no-op exactly where repetition is worst.
+ */
+const staleSeenMarketsSql = (userId: string) =>
+  where(
+    `not exists (
+      select 1 from user_contract_views ucv
+      where ucv.user_id = $1
+        and ucv.contract_id = contracts.id
+        and greatest(ucv.last_card_view_ts, ucv.last_page_view_ts)
+            between now() - interval '${SEEN_MEMORY_WINDOW}'
+                and now() - interval '${SEEN_GRACE_PERIOD}'
+        and coalesce(contracts.last_comment_time, contracts.created_time)
+            <= greatest(ucv.last_card_view_ts, ucv.last_page_view_ts)
+        and abs(coalesce((contracts.data->'probChanges'->>'day')::numeric, 0))
+            <= ${SEEN_PROB_MOVE_THRESHOLD}
+    )`,
+    [userId]
+  )
+
 type SharedSearchArgs = {
   filter: string
   contractType: string
@@ -116,6 +168,7 @@ export async function getForYouSQL(
         `contracts.id not in (select contract_id from user_disinterests where user_id = $1 and contract_id = contracts.id)`,
         [userId]
       ),
+      staleSeenMarketsSql(userId),
       privateUserBlocksSql(privateUser),
       withClause(
         `user_follows as (select follow_id from user_follows where user_id = $1)`,

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -1,6 +1,6 @@
 import { Contract, isSportsContract } from 'common/contract'
 import { PROD_MANIFOLD_LOVE_GROUP_SLUG } from 'common/envs/constants'
-import { GROUP_SCORE_PRIOR } from 'common/feed'
+import { GROUP_SCORE_PRIOR, nicheBlendTopicScoreSql } from 'common/feed'
 import { tsToMillis } from 'common/supabase/utils'
 import { answerCostTiers, getTierIndexFromLiquidity } from 'common/tier'
 import { PrivateUser } from 'common/user'
@@ -141,7 +141,9 @@ export async function getForYouSQL(
       orderBy(`case
       when bool_or(contracts.boosted) then avg(contracts.${sortByScore})
       when bool_or(uti.avg_conversion_score is not null)
-      then avg(power(coalesce(uti.avg_conversion_score, ${GROUP_SCORE_PRIOR}), ${GROUP_SCORE_POWER}) * contracts.${sortByScore})
+      then power(${nicheBlendTopicScoreSql(
+        `coalesce(uti.avg_conversion_score, ${GROUP_SCORE_PRIOR})`
+      )}, ${GROUP_SCORE_POWER}) * avg(contracts.${sortByScore})
       else avg(contracts.${sortByScore}*${GROUP_SCORE_PRIOR})
       end * (1 + case
       when bool_or(contracts.creator_id = any(select follow_id from user_follows)) then 0.2

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -1,4 +1,5 @@
 import { Contract, isSportsContract } from 'common/contract'
+import { DiscoveryExperimentVariant } from 'common/discovery-experiment'
 import { PROD_MANIFOLD_LOVE_GROUP_SLUG } from 'common/envs/constants'
 import { GROUP_SCORE_PRIOR, nicheBlendTopicScoreSql } from 'common/feed'
 import { getPerpBackingPool } from 'common/perps/amm'
@@ -30,6 +31,7 @@ import {
 import { contractColumnsToSelectWithPrefix, log } from 'shared/utils'
 
 const DEFAULT_THRESHOLD = 1000
+const GROUP_SCORE_POWER = 4
 type TokenInputType = 'CASH' | 'MANA' | 'ALL' | 'CASH_AND_MANA'
 let importanceScoreThreshold: number | undefined = undefined
 let freshnessScoreThreshold: number | undefined = undefined
@@ -162,7 +164,18 @@ type SharedSearchArgs = {
   isPrizeMarket?: boolean
   beforeTime?: number
   seenMarketCutoffTime?: number
+  discoveryVariant?: DiscoveryExperimentVariant
 }
+
+export const getForYouTopicRankSql = (
+  sortByScore: string,
+  discoveryVariant: DiscoveryExperimentVariant | undefined
+) =>
+  discoveryVariant === 'treatment'
+    ? `power(${nicheBlendTopicScoreSql(
+        `coalesce(uti.avg_conversion_score, ${GROUP_SCORE_PRIOR})`
+      )}, ${GROUP_SCORE_POWER}) * avg(contracts.${sortByScore})`
+    : `avg(power(coalesce(uti.avg_conversion_score, ${GROUP_SCORE_PRIOR}), ${GROUP_SCORE_POWER}) * contracts.${sortByScore})`
 
 export async function getForYouSQL(
   args: SharedSearchArgs & {
@@ -179,6 +192,7 @@ export async function getForYouSQL(
     threshold = DEFAULT_THRESHOLD,
     hasBets,
     seenMarketCutoffTime,
+    discoveryVariant,
   } = args
 
   const userId = args.uid
@@ -211,11 +225,10 @@ export async function getForYouSQL(
       privateUser,
       // Keep the same diversity behavior when a new/low-activity user has no
       // topic scores yet. Ordinary basic browse does not opt into this.
-      suppressStaleSeen: true,
+      suppressStaleSeen: discoveryVariant === 'treatment',
     })
   }
   const userBetsJoin = hasBets === '1' && userId && userBetsJoinSql
-  const GROUP_SCORE_POWER = 4
   const forYou = renderSql(
     buildArray(
       select(
@@ -240,7 +253,8 @@ export async function getForYouSQL(
       // A client-provided session anchor keeps the seen set stable across
       // every offset page. Unanchored callers retain the old unsuppressed
       // behavior so page-one filtering cannot shift their later offsets.
-      shouldSuppressStaleSeenMarkets(seenMarketCutoffTime) &&
+      discoveryVariant === 'treatment' &&
+        shouldSuppressStaleSeenMarkets(seenMarketCutoffTime) &&
         staleSeenMarketsSql(userId, seenMarketCutoffTime),
       privateUserBlocksSql(privateUser),
       withClause(
@@ -267,9 +281,7 @@ export async function getForYouSQL(
       orderBy(`case
       when bool_or(contracts.boosted) then avg(contracts.${sortByScore})
       when bool_or(uti.avg_conversion_score is not null)
-      then power(${nicheBlendTopicScoreSql(
-        `coalesce(uti.avg_conversion_score, ${GROUP_SCORE_PRIOR})`
-      )}, ${GROUP_SCORE_POWER}) * avg(contracts.${sortByScore})
+      then ${getForYouTopicRankSql(sortByScore, discoveryVariant)}
       else avg(contracts.${sortByScore}*${GROUP_SCORE_PRIOR})
       end * (1 + case
       when bool_or(contracts.creator_id = any(select follow_id from user_follows)) then 0.2

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -240,6 +240,86 @@ export type SearchTypes =
   | 'prefix'
   | 'answer'
 
+// Full-text search finds nothing unless the user guesses a word that is
+// literally in the question, so a near miss lands on "only nothingness"
+// while a well-matched market sits one synonym away. Every open market
+// already has an embedding (contract_embeddings, kept current on create and
+// used by the related-markets rail), so the miss can be answered instead of
+// rendered as a dead end.
+//
+// Deliberately lower than TOPIC_SIMILARITY_THRESHOLD (0.5), which compares
+// two full questions. A search term is much shorter than the questions it is
+// being compared against, which drags cosine similarity down for matches that
+// are perfectly good. NOT yet validated against real query embeddings — check
+// this against live searches in dev before trusting the number.
+export const SEMANTIC_SEARCH_SIMILARITY_THRESHOLD = 0.35
+// Over-fetch from the index, then let the normal filters cut it down, the
+// same way close_contract_embeddings does with match_count + 500.
+const SEMANTIC_SEARCH_OVERFETCH = 200
+
+// Shared by the lexical and semantic paths so a topic-scoped search can't
+// come back with out-of-topic results from one of them.
+const groupsFilterSql = (args: {
+  groupId?: string
+  groupIds?: string[]
+  token: TokenInputType
+}) => {
+  const { groupId, groupIds, token } = args
+  return (
+    (groupIds?.length || groupId) &&
+    where(
+      `
+    exists (
+      select 1 from group_contracts gc
+      where ${
+        token === 'CASH'
+          ? "gc.contract_id = contracts.data->>'siblingContractId'"
+          : 'gc.contract_id = contracts.id'
+      }
+      and gc.group_id = any($1)
+    )`,
+      [filterDefined([groupId, ...(groupIds ?? [])])]
+    )
+  )
+}
+
+/**
+ * Nearest markets to an already-computed query embedding, run through the
+ * same filters as a normal search so status/type/token/blocks still hold.
+ */
+export function getSemanticSearchContractSQL(
+  args: SharedSearchArgs & {
+    embedding: number[]
+    groupId?: string
+    groupIds?: string[]
+    privateUser?: PrivateUser
+    excludeContractIds?: string[]
+  }
+) {
+  const { embedding, limit, privateUser, excludeContractIds } = args
+  return renderSql(
+    select(contractColumnsToSelectWithPrefix('contracts')),
+    from(
+      `search_contract_embeddings($1::vector, $2, $3) as se`,
+      [
+        // pgvector parses its literal from a JSON-shaped array string.
+        JSON.stringify(embedding),
+        SEMANTIC_SEARCH_SIMILARITY_THRESHOLD,
+        SEMANTIC_SEARCH_OVERFETCH,
+      ]
+    ),
+    join('contracts on contracts.id = se.contract_id'),
+    groupsFilterSql(args),
+    getSearchContractWhereSQL({ ...args, hideStonks: true }),
+    privateUser && privateUserBlocksSql(privateUser),
+    // Already-returned lexical hits, so the tail can't repeat the head.
+    (excludeContractIds?.length ?? 0) > 0 &&
+      where(`contracts.id <> all(array[$1])`, [excludeContractIds]),
+    orderBy('se.similarity desc'),
+    lim(limit)
+  )
+}
+
 export function getSearchContractSQL(
   args: SharedSearchArgs & {
     term: string
@@ -285,21 +365,7 @@ export function getSearchContractSQL(
     where(`a.text_fts @@ websearch_to_tsquery('english_extended', $1)`, [term])
   )
 
-  const groupsFilter =
-    (groupIds?.length || groupId) &&
-    where(
-      `
-    exists (
-      select 1 from group_contracts gc
-      where ${
-        token === 'CASH'
-          ? "gc.contract_id = contracts.data->>'siblingContractId'"
-          : 'gc.contract_id = contracts.id'
-      }
-      and gc.group_id = any($1)
-    )`,
-      [filterDefined([groupId, ...(groupIds ?? [])])]
-    )
+  const groupsFilter = groupsFilterSql({ groupId, groupIds, token })
 
   // Recent movements filter
   const newsFilter =

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -50,8 +50,9 @@ const SEEN_PROB_MOVE_THRESHOLD = 0.05
 
 /**
  * Drops markets the user has already looked at and that are currently quiet
- * from For You results. Callers without a session anchor use this only on the
- * first page so a moving time boundary cannot create pagination holes.
+ * from For You results. Suppression requires a session anchor: applying it to
+ * only the first page shifts the raw offsets on later pages and duplicates a
+ * row, while applying an unanchored moving boundary can skip rows.
  *
  * Browse ranks on score alone, so the same top markets greet you every visit.
  * But "seen" is a weak signal and over-trusting it is worse than repetition,
@@ -106,6 +107,10 @@ export const staleSeenMarketsSql = (
                 ucv.last_card_view_ts,
                 ucv.last_page_view_ts
               )
+              or a.resolution_time > greatest(
+                ucv.last_card_view_ts,
+                ucv.last_page_view_ts
+              )
               or abs(coalesce(a.prob_change_day, 0))
                   > ${SEEN_PROB_MOVE_THRESHOLD}
             )
@@ -118,9 +123,9 @@ export const staleSeenMarketsSql = (
 }
 
 export const shouldSuppressStaleSeenMarkets = (
-  offset: number,
+  _offset: number,
   seenMarketCutoffTime?: number
-) => offset === 0 || seenMarketCutoffTime !== undefined
+) => seenMarketCutoffTime !== undefined
 
 type SharedSearchArgs = {
   filter: string
@@ -183,6 +188,12 @@ export async function getForYouSQL(
       ...args,
       uid: userId,
       privateUser,
+      // Keep the same diversity behavior when a new/low-activity user has no
+      // topic scores yet. Ordinary basic browse does not opt into this.
+      suppressStaleSeen: shouldSuppressStaleSeenMarkets(
+        offset,
+        seenMarketCutoffTime
+      ),
     })
   }
   const userBetsJoin = hasBets === '1' && userId && userBetsJoinSql
@@ -209,7 +220,8 @@ export async function getForYouSQL(
         [userId]
       ),
       // A client-provided session anchor keeps the seen set stable across
-      // every offset page. Legacy callers get safe top-page-only suppression.
+      // every offset page. Unanchored callers retain the old unsuppressed
+      // behavior so page-one filtering cannot shift their later offsets.
       shouldSuppressStaleSeenMarkets(offset, seenMarketCutoffTime) &&
         staleSeenMarketsSql(userId, seenMarketCutoffTime),
       privateUserBlocksSql(privateUser),
@@ -254,9 +266,10 @@ export async function getForYouSQL(
 export const basicSearchSQL = (
   args: SharedSearchArgs & {
     privateUser?: PrivateUser
+    suppressStaleSeen?: boolean
   }
 ) => {
-  const { sort, privateUser, beforeTime, ...rest } = args
+  const { sort, privateUser, beforeTime, suppressStaleSeen, ...rest } = args
   const sortByScore = sort === 'score' ? 'importance_score' : 'freshness_score'
   const userBetsJoin = args.hasBets === '1' && args.uid && userBetsJoinSql
   const sql = renderSql(
@@ -268,6 +281,10 @@ export const basicSearchSQL = (
       ...rest,
       hideStonks: true,
     }),
+    suppressStaleSeen &&
+      args.uid &&
+      args.seenMarketCutoffTime !== undefined &&
+      staleSeenMarketsSql(args.uid, args.seenMarketCutoffTime),
     privateUserBlocksSql(privateUser),
     beforeTime && where(`created_time < millis_to_ts($1)`, [beforeTime]),
     lim(args.limit, beforeTime ? 0 : args.offset)

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -239,6 +239,86 @@ export type SearchTypes =
   | 'prefix'
   | 'answer'
 
+// Full-text search finds nothing unless the user guesses a word that is
+// literally in the question, so a near miss lands on "only nothingness"
+// while a well-matched market sits one synonym away. Every open market
+// already has an embedding (contract_embeddings, kept current on create and
+// used by the related-markets rail), so the miss can be answered instead of
+// rendered as a dead end.
+//
+// Deliberately lower than TOPIC_SIMILARITY_THRESHOLD (0.5), which compares
+// two full questions. A search term is much shorter than the questions it is
+// being compared against, which drags cosine similarity down for matches that
+// are perfectly good. NOT yet validated against real query embeddings — check
+// this against live searches in dev before trusting the number.
+export const SEMANTIC_SEARCH_SIMILARITY_THRESHOLD = 0.35
+// Over-fetch from the index, then let the normal filters cut it down, the
+// same way close_contract_embeddings does with match_count + 500.
+const SEMANTIC_SEARCH_OVERFETCH = 200
+
+// Shared by the lexical and semantic paths so a topic-scoped search can't
+// come back with out-of-topic results from one of them.
+const groupsFilterSql = (args: {
+  groupId?: string
+  groupIds?: string[]
+  token: TokenInputType
+}) => {
+  const { groupId, groupIds, token } = args
+  return (
+    (groupIds?.length || groupId) &&
+    where(
+      `
+    exists (
+      select 1 from group_contracts gc
+      where ${
+        token === 'CASH'
+          ? "gc.contract_id = contracts.data->>'siblingContractId'"
+          : 'gc.contract_id = contracts.id'
+      }
+      and gc.group_id = any($1)
+    )`,
+      [filterDefined([groupId, ...(groupIds ?? [])])]
+    )
+  )
+}
+
+/**
+ * Nearest markets to an already-computed query embedding, run through the
+ * same filters as a normal search so status/type/token/blocks still hold.
+ */
+export function getSemanticSearchContractSQL(
+  args: SharedSearchArgs & {
+    embedding: number[]
+    groupId?: string
+    groupIds?: string[]
+    privateUser?: PrivateUser
+    excludeContractIds?: string[]
+  }
+) {
+  const { embedding, limit, privateUser, excludeContractIds } = args
+  return renderSql(
+    select(contractColumnsToSelectWithPrefix('contracts')),
+    from(
+      `search_contract_embeddings($1::vector, $2, $3) as se`,
+      [
+        // pgvector parses its literal from a JSON-shaped array string.
+        JSON.stringify(embedding),
+        SEMANTIC_SEARCH_SIMILARITY_THRESHOLD,
+        SEMANTIC_SEARCH_OVERFETCH,
+      ]
+    ),
+    join('contracts on contracts.id = se.contract_id'),
+    groupsFilterSql(args),
+    getSearchContractWhereSQL({ ...args, hideStonks: true }),
+    privateUser && privateUserBlocksSql(privateUser),
+    // Already-returned lexical hits, so the tail can't repeat the head.
+    (excludeContractIds?.length ?? 0) > 0 &&
+      where(`contracts.id <> all(array[$1])`, [excludeContractIds]),
+    orderBy('se.similarity desc'),
+    lim(limit)
+  )
+}
+
 export function getSearchContractSQL(
   args: SharedSearchArgs & {
     term: string
@@ -284,21 +364,7 @@ export function getSearchContractSQL(
     where(`a.text_fts @@ websearch_to_tsquery('english_extended', $1)`, [term])
   )
 
-  const groupsFilter =
-    (groupIds?.length || groupId) &&
-    where(
-      `
-    exists (
-      select 1 from group_contracts gc
-      where ${
-        token === 'CASH'
-          ? "gc.contract_id = contracts.data->>'siblingContractId'"
-          : 'gc.contract_id = contracts.id'
-      }
-      and gc.group_id = any($1)
-    )`,
-      [filterDefined([groupId, ...(groupIds ?? [])])]
-    )
+  const groupsFilter = groupsFilterSql({ groupId, groupIds, token })
 
   // Recent movements filter
   const newsFilter =

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -225,7 +225,7 @@ export async function getForYouSQL(
       privateUser,
       // Keep the same diversity behavior when a new/low-activity user has no
       // topic scores yet. Ordinary basic browse does not opt into this.
-      suppressStaleSeen: discoveryVariant === 'treatment',
+      suppressStaleSeen: discoveryVariant === 'treatment' && hasBets !== '1',
     })
   }
   const userBetsJoin = hasBets === '1' && userId && userBetsJoinSql
@@ -254,6 +254,7 @@ export async function getForYouSQL(
       // every offset page. Unanchored callers retain the old unsuppressed
       // behavior so page-one filtering cannot shift their later offsets.
       discoveryVariant === 'treatment' &&
+        hasBets !== '1' &&
         shouldSuppressStaleSeenMarkets(seenMarketCutoffTime) &&
         staleSeenMarketsSql(userId, seenMarketCutoffTime),
       privateUserBlocksSql(privateUser),
@@ -312,6 +313,7 @@ export const basicSearchSQL = (
       hideStonks: true,
     }),
     suppressStaleSeen &&
+      args.hasBets !== '1' &&
       args.uid &&
       shouldSuppressStaleSeenMarkets(args.seenMarketCutoffTime) &&
       staleSeenMarketsSql(args.uid, args.seenMarketCutoffTime),

--- a/common/src/ab-test.test.ts
+++ b/common/src/ab-test.test.ts
@@ -1,0 +1,59 @@
+import {
+  AB_TEST_ACCOUNT_OVERRIDES,
+  getDeterministicABTestVariant,
+  getForcedABTestVariant,
+} from './ab-test'
+
+const variants = ['control', 'treatment'] as const
+
+describe('A/B test assignment', () => {
+  it('keeps the designated QA accounts in opposite variants', () => {
+    expect(
+      getForcedABTestVariant('cA1JupYR5AR8btHUs2xvkui7jA93', variants)
+    ).toBe('treatment')
+    expect(
+      getForcedABTestVariant('IPTOzEqrpkWmEzh6hwvAyY9PqFb2', variants)
+    ).toBe('control')
+  })
+
+  it('does not force accounts when an experiment uses other variant names', () => {
+    expect(
+      getForcedABTestVariant('cA1JupYR5AR8btHUs2xvkui7jA93', ['a', 'b'])
+    ).toBeUndefined()
+  })
+
+  it('is stable and independent of caller variant order', () => {
+    const first = getDeterministicABTestVariant('test-v1', 'user:abc', variants)
+    const second = getDeterministicABTestVariant(
+      'test-v1',
+      'user:abc',
+      [...variants].reverse()
+    )
+
+    expect(second).toBe(first)
+  })
+
+  it('honors a valid forced variant', () => {
+    expect(
+      getDeterministicABTestVariant(
+        'test-v1',
+        'user:abc',
+        variants,
+        'treatment'
+      )
+    ).toBe('treatment')
+  })
+
+  it('fails closed on an empty experiment', () => {
+    expect(() =>
+      getDeterministicABTestVariant('test-v1', 'user:abc', [])
+    ).toThrow('must have at least one variant')
+  })
+
+  it('exports only the intended permanent overrides', () => {
+    expect(AB_TEST_ACCOUNT_OVERRIDES).toEqual({
+      cA1JupYR5AR8btHUs2xvkui7jA93: 'treatment',
+      IPTOzEqrpkWmEzh6hwvAyY9PqFb2: 'control',
+    })
+  })
+})

--- a/common/src/ab-test.ts
+++ b/common/src/ab-test.ts
@@ -1,0 +1,43 @@
+import { createRNG } from './util/random'
+
+export type StandardABTestVariant = 'control' | 'treatment'
+
+// These are permanent QA assignments for ordinary control/treatment tests.
+// They make it possible to compare both experiences throughout a rollout.
+// Always exclude forced accounts from experiment-effect estimates.
+export const AB_TEST_ACCOUNT_OVERRIDES: Readonly<
+  Record<string, StandardABTestVariant>
+> = {
+  cA1JupYR5AR8btHUs2xvkui7jA93: 'treatment', // @Gen
+  IPTOzEqrpkWmEzh6hwvAyY9PqFb2: 'control', // @Manifold
+}
+
+export const getForcedABTestVariant = <T extends string>(
+  userId: string | undefined,
+  variants: readonly T[]
+): T | undefined => {
+  const forcedVariant = userId && AB_TEST_ACCOUNT_OVERRIDES[userId]
+  return forcedVariant !== undefined &&
+    variants.some((variant) => variant === forcedVariant)
+    ? (forcedVariant as T)
+    : undefined
+}
+
+export const getDeterministicABTestVariant = <T extends string>(
+  testName: string,
+  assignmentKey: string,
+  variants: readonly T[],
+  forcedVariant?: T
+): T => {
+  if (variants.length === 0) {
+    throw new Error(`A/B test ${testName} must have at least one variant`)
+  }
+  if (forcedVariant !== undefined && variants.includes(forcedVariant)) {
+    return forcedVariant
+  }
+
+  // Never mutate the caller's array: callers commonly pass shared constants.
+  const orderedVariants = [...variants].sort()
+  const rand = createRNG(`${testName}:${assignmentKey}`)
+  return orderedVariants[Math.floor(rand() * orderedVariants.length)]
+}

--- a/common/src/api/market-search-types.test.ts
+++ b/common/src/api/market-search-types.test.ts
@@ -24,6 +24,16 @@ describe('searchProps', () => {
       enableSemanticSearch: false,
     })
   })
+
+  it('accepts only known discovery experiment variants', () => {
+    expect(searchProps.parse({ discoveryVariant: 'control' })).toMatchObject({
+      discoveryVariant: 'control',
+    })
+    expect(searchProps.parse({ discoveryVariant: 'treatment' })).toMatchObject({
+      discoveryVariant: 'treatment',
+    })
+    expect(() => searchProps.parse({ discoveryVariant: 'preview' })).toThrow()
+  })
 })
 
 describe('getMarketSearchRoute', () => {

--- a/common/src/api/market-search-types.test.ts
+++ b/common/src/api/market-search-types.test.ts
@@ -1,10 +1,19 @@
 import { getMarketSearchRoute, searchProps } from './market-search-types'
+import { API } from './schema'
 
 describe('searchProps', () => {
   it('accepts PERP as an exact market type filter', () => {
     const result = searchProps.parse({ contractType: 'PERP' })
 
     expect(result.contractType).toBe('PERP')
+  })
+
+  it('accepts a finite browse-session anchor', () => {
+    const result = searchProps.parse({
+      seenMarketCutoffTime: '1700000000000',
+    })
+
+    expect(result.seenMarketCutoffTime).toBe(1_700_000_000_000)
   })
 })
 
@@ -41,4 +50,13 @@ describe('getMarketSearchRoute', () => {
       })
     ).toBe('filtered')
   })
+})
+
+describe('market search caching', () => {
+  it.each(['search-markets', 'search-markets-full'] as const)(
+    'does not shared-cache auth-sensitive %s results',
+    (endpoint) => {
+      expect(API[endpoint].cache).toBe('private, no-store')
+    }
+  )
 })

--- a/common/src/api/market-search-types.test.ts
+++ b/common/src/api/market-search-types.test.ts
@@ -15,6 +15,15 @@ describe('searchProps', () => {
 
     expect(result.seenMarketCutoffTime).toBe(1_700_000_000_000)
   })
+
+  it('coerces the semantic-search capability flag', () => {
+    expect(searchProps.parse({ enableSemanticSearch: 'true' })).toMatchObject({
+      enableSemanticSearch: true,
+    })
+    expect(searchProps.parse({ enableSemanticSearch: 'false' })).toMatchObject({
+      enableSemanticSearch: false,
+    })
+  })
 })
 
 describe('getMarketSearchRoute', () => {

--- a/common/src/api/market-search-types.ts
+++ b/common/src/api/market-search-types.ts
@@ -113,6 +113,10 @@ export const searchProps = z
     // fallback opt-in prevents a new API worker from returning a semantic
     // tail to an old web bundle that does not understand its ordering marker.
     enableSemanticSearch: coerceBoolean.optional(),
+    // Internal experiment arm. Authenticated requests are independently
+    // assigned by the API; anonymous requests necessarily rely on the
+    // persistent device assignment supplied by the web client.
+    discoveryVariant: z.enum(['control', 'treatment']).optional(),
   })
   .strict()
 

--- a/common/src/api/market-search-types.ts
+++ b/common/src/api/market-search-types.ts
@@ -109,6 +109,10 @@ export const searchProps = z
     liquidity: z.coerce.number().optional(),
     hasBets: z.union([z.literal('1'), z.literal('0')]).optional(),
     includeLiteAnswers: coerceBoolean.optional(),
+    // Capability flag for the internal full-search UI. Keeping semantic
+    // fallback opt-in prevents a new API worker from returning a semantic
+    // tail to an old web bundle that does not understand its ordering marker.
+    enableSemanticSearch: coerceBoolean.optional(),
   })
   .strict()
 

--- a/common/src/api/market-search-types.ts
+++ b/common/src/api/market-search-types.ts
@@ -1,5 +1,14 @@
 import { z } from 'zod'
+import type { Contract } from '../contract'
 import { coerceBoolean } from './zod-types'
+
+export type FullMarketSearchResult = Contract & {
+  // Present on text-search results from marker-aware API workers. Keeping this
+  // on the internal full-search shape lets mixed result UIs preserve
+  // lexical/post ranking without promoting the semantic tail. It remains
+  // optional so old workers and non-text search routes stay compatible.
+  searchMatchType?: 'lexical' | 'semantic'
+}
 
 export const FIRESTORE_DOC_REF_ID_REGEX = /^[a-zA-Z0-9_-]{1,}$/
 

--- a/common/src/api/market-search-types.ts
+++ b/common/src/api/market-search-types.ts
@@ -64,6 +64,14 @@ export const searchProps = z
     // Cursor for efficient pagination: pass the createdTime of the last
     // result from the previous page. Only works with sort=newest.
     beforeTime: z.coerce.number().optional(),
+    // Anchor for a stable seen-market filter across an offset-paginated browse
+    // session. Clients must reuse the first page's value for load-more calls.
+    seenMarketCutoffTime: z.coerce
+      .number()
+      .int()
+      .gte(0)
+      .lte(4_102_444_800_000)
+      .optional(),
     topicSlug: z
       .string()
       .regex(FIRESTORE_DOC_REF_ID_REGEX)

--- a/common/src/api/market-types.test.ts
+++ b/common/src/api/market-types.test.ts
@@ -224,6 +224,9 @@ describe('toLiteMarket', () => {
         resolvedOraclePrice: 42,
       })
     )
+    expect(
+      toLiteMarket({ ...contract, searchMatchType: 'semantic' } as PerpContract)
+    ).not.toHaveProperty('searchMatchType')
     expect(toFullMarket(contract).takerFeeBps).toBe(12)
     expect(toFullMarket(contract).takerFeeImpact).toBe(90)
   })

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1654,7 +1654,11 @@ export const API = (_apiTypeCheck = {
     method: 'GET',
     visibility: 'public',
     authed: false,
-    cache: DEFAULT_CACHE_STRATEGY,
+    // Both search handlers accept optional auth and use it for visibility,
+    // blocks, and personalized ranking. The edge cache does not vary on the
+    // Authorization header, so public caching can serve one user's result to
+    // another user (or to an anonymous caller).
+    cache: 'private, no-store',
     returns: [] as LiteMarket[],
     props: searchProps,
   },
@@ -1663,7 +1667,7 @@ export const API = (_apiTypeCheck = {
     visibility: 'undocumented',
     authed: false,
     preferAuth: true,
-    cache: DEFAULT_CACHE_STRATEGY,
+    cache: 'private, no-store',
     returns: [] as Contract[],
     props: searchProps,
   },

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -53,7 +53,7 @@ import type { ManaPayTxn, Txn } from 'common/txn'
 import { z } from 'zod'
 import { ModReport } from '../mod-report'
 import { PrivateUser, User, UserBan } from '../user'
-import { searchProps } from './market-search-types'
+import { type FullMarketSearchResult, searchProps } from './market-search-types'
 import {
   FullMarket,
   closePerpPositionSchema,
@@ -1668,7 +1668,7 @@ export const API = (_apiTypeCheck = {
     authed: false,
     preferAuth: true,
     cache: 'private, no-store',
-    returns: [] as Contract[],
+    returns: [] as FullMarketSearchResult[],
     props: searchProps,
   },
   'recent-markets': {

--- a/common/src/discovery-experiment.test.ts
+++ b/common/src/discovery-experiment.test.ts
@@ -1,0 +1,104 @@
+import {
+  getDiscoveryExperimentAssignment,
+  getEffectiveDiscoveryExperimentVariant,
+  getDiscoveryQueryLengthBucket,
+} from './discovery-experiment'
+
+describe('discovery experiment assignment', () => {
+  it('forces Gen into treatment and Manifold into control', () => {
+    expect(
+      getDiscoveryExperimentAssignment({
+        userId: 'cA1JupYR5AR8btHUs2xvkui7jA93',
+      })
+    ).toEqual({ variant: 'treatment', source: 'forced' })
+    expect(
+      getDiscoveryExperimentAssignment({
+        userId: 'IPTOzEqrpkWmEzh6hwvAyY9PqFb2',
+      })
+    ).toEqual({ variant: 'control', source: 'forced' })
+  })
+
+  it('keeps signed-in assignment stable across devices', () => {
+    expect(
+      getDiscoveryExperimentAssignment({
+        userId: 'ordinary-user',
+        deviceId: 'device-one',
+      })
+    ).toEqual(
+      getDiscoveryExperimentAssignment({
+        userId: 'ordinary-user',
+        deviceId: 'device-two',
+      })
+    )
+  })
+
+  it('keeps frozen assignment fixtures stable', () => {
+    expect(
+      getDiscoveryExperimentAssignment({ userId: 'ordinary-user' })
+    ).toEqual({ variant: 'treatment', source: 'user-hash' })
+    expect(
+      getDiscoveryExperimentAssignment({ deviceId: 'anonymous-device' })
+    ).toEqual({ variant: 'control', source: 'device-hash' })
+  })
+
+  it('waits when neither identity is available', () => {
+    expect(getDiscoveryExperimentAssignment({})).toBeUndefined()
+  })
+})
+
+describe('effective discovery experiment variant', () => {
+  it('leaves old clients in control when they omit the experiment field', () => {
+    expect(
+      getEffectiveDiscoveryExperimentVariant({ userId: 'ordinary-user' })
+    ).toBe('control')
+  })
+
+  it('reproduces signed-in assignment instead of trusting the request', () => {
+    expect(
+      getEffectiveDiscoveryExperimentVariant({
+        userId: 'ordinary-user',
+        requestedVariant: 'control',
+      })
+    ).toBe('treatment')
+  })
+
+  it('enforces both forced QA assignments on the server', () => {
+    expect(
+      getEffectiveDiscoveryExperimentVariant({
+        userId: 'cA1JupYR5AR8btHUs2xvkui7jA93',
+        requestedVariant: 'control',
+      })
+    ).toBe('treatment')
+    expect(
+      getEffectiveDiscoveryExperimentVariant({
+        userId: 'IPTOzEqrpkWmEzh6hwvAyY9PqFb2',
+        requestedVariant: 'treatment',
+      })
+    ).toBe('control')
+  })
+
+  it('uses the device-assigned arm supplied by an anonymous client', () => {
+    expect(
+      getEffectiveDiscoveryExperimentVariant({
+        requestedVariant: 'treatment',
+      })
+    ).toBe('treatment')
+  })
+})
+
+describe('getDiscoveryQueryLengthBucket', () => {
+  it.each([
+    ['', '0'],
+    ['ab', '1-2'],
+    ['abc', '3-5'],
+    ['sixsix', '6-15'],
+    ['a'.repeat(16), '16-50'],
+    ['a'.repeat(51), '51-200'],
+    ['a'.repeat(201), '201+'],
+  ] as const)(
+    'buckets query length without retaining its text',
+    (query, bucket) => {
+      expect(getDiscoveryQueryLengthBucket(query)).toBe(bucket)
+    }
+  )
+})

--- a/common/src/discovery-experiment.ts
+++ b/common/src/discovery-experiment.ts
@@ -1,0 +1,97 @@
+import {
+  getDeterministicABTestVariant,
+  getForcedABTestVariant,
+} from './ab-test'
+
+export const DISCOVERY_EXPERIMENT_NAME = 'discovery-v1'
+export const DISCOVERY_EXPERIMENT_VARIANTS = ['control', 'treatment'] as const
+export type DiscoveryExperimentVariant =
+  (typeof DISCOVERY_EXPERIMENT_VARIANTS)[number]
+export type DiscoveryExperimentAssignmentSource =
+  | 'forced'
+  | 'user-hash'
+  | 'device-hash'
+export type DiscoveryExperimentSurface = 'for-you' | 'text-search' | 'browse'
+
+export type DiscoveryResultTracking = DiscoveryExperimentAssignment & {
+  assignmentKey: string
+  resultSetId: string
+  presentationId: string
+  sourceComponent: string
+  surface: DiscoveryExperimentSurface
+  semanticEligible: boolean
+  semanticMarketCount: number
+  initialLatencyMs: number
+  compatibilityFallback: boolean
+}
+
+export const DISCOVERY_SEARCH_REQUEST_EVENT = 'discovery_v1 search request'
+export const DISCOVERY_RESULTS_EVENT = 'discovery_v1 results'
+export const DISCOVERY_EXPOSURE_EVENT = 'discovery_v1 exposure'
+export const DISCOVERY_RESULT_CLICK_EVENT = 'discovery_v1 result click'
+export const DISCOVERY_SEARCH_ERROR_EVENT = 'discovery_v1 search error'
+export const DISCOVERY_SEARCH_ABORT_EVENT = 'discovery_v1 search abort'
+
+export type DiscoveryExperimentAssignment = {
+  variant: DiscoveryExperimentVariant
+  source: DiscoveryExperimentAssignmentSource
+}
+
+export const getDiscoveryExperimentAssignment = (args: {
+  userId?: string
+  deviceId?: string
+}): DiscoveryExperimentAssignment | undefined => {
+  const { userId, deviceId } = args
+  const assignmentId = userId ?? deviceId
+  if (!assignmentId) return undefined
+
+  const forcedVariant = getForcedABTestVariant(
+    userId,
+    DISCOVERY_EXPERIMENT_VARIANTS
+  )
+  return {
+    variant: getDeterministicABTestVariant(
+      DISCOVERY_EXPERIMENT_NAME,
+      `${userId ? 'user' : 'device'}:${assignmentId}`,
+      DISCOVERY_EXPERIMENT_VARIANTS,
+      forcedVariant
+    ),
+    source: forcedVariant ? 'forced' : userId ? 'user-hash' : 'device-hash',
+  }
+}
+
+// Omitted means control so older clients do not enter the experiment merely
+// because the API deployed first. When a current signed-in client opts in,
+// independently reproduce its immutable-user assignment on the server rather
+// than trusting the arm in the request.
+export const getEffectiveDiscoveryExperimentVariant = (args: {
+  userId?: string
+  requestedVariant?: DiscoveryExperimentVariant
+}): DiscoveryExperimentVariant => {
+  const { userId, requestedVariant } = args
+  if (requestedVariant === undefined) return 'control'
+  if (!userId) return requestedVariant
+  return getDiscoveryExperimentAssignment({ userId })!.variant
+}
+
+export type DiscoveryQueryLengthBucket =
+  | '0'
+  | '1-2'
+  | '3-5'
+  | '6-15'
+  | '16-50'
+  | '51-200'
+  | '201+'
+
+export const getDiscoveryQueryLengthBucket = (
+  query: string
+): DiscoveryQueryLengthBucket => {
+  const length = query.trim().length
+  if (length === 0) return '0'
+  if (length <= 2) return '1-2'
+  if (length <= 5) return '3-5'
+  if (length <= 15) return '6-15'
+  if (length <= 50) return '16-50'
+  if (length <= 200) return '51-200'
+  return '201+'
+}

--- a/common/src/discovery-experiment.ts
+++ b/common/src/discovery-experiment.ts
@@ -23,6 +23,7 @@ export type DiscoveryResultTracking = DiscoveryExperimentAssignment & {
   semanticMarketCount: number
   initialLatencyMs: number
   compatibilityFallback: boolean
+  anchorFallback: boolean
 }
 
 export const DISCOVERY_SEARCH_REQUEST_EVENT = 'discovery_v1 search request'

--- a/common/src/feed.ts
+++ b/common/src/feed.ts
@@ -25,5 +25,8 @@ export const OLD_USER_FOLLOWED_TOPIC_SCORE_BOOST = 0.3
 
 // 70/30 max/avg blend across a market's matching tags — keeps a strong
 // niche match from being diluted by broad parent tags also on the market.
+export const nicheBlendTopicScoreSql = (scoreExpr: string) =>
+  `(0.7 * max(${scoreExpr}) + 0.3 * avg(${scoreExpr}))`
+
 export const NICHE_BLEND_TOPIC_SCORE_SQL =
-  '(0.7 * max(uti.topic_score) + 0.3 * avg(uti.topic_score))'
+  nicheBlendTopicScoreSql('uti.topic_score')

--- a/common/src/search-request-coordination.test.ts
+++ b/common/src/search-request-coordination.test.ts
@@ -1,0 +1,24 @@
+import { getSearchRequestDebounceMs } from './search-request-coordination'
+
+describe('getSearchRequestDebounceMs', () => {
+  it('keeps the initial blank browse request responsive', () => {
+    expect(getSearchRequestDebounceMs('', undefined)).toBe(50)
+  })
+
+  it('debounces a nonblank query before any request has completed', () => {
+    expect(getSearchRequestDebounceMs('climate', undefined)).toBe(300)
+  })
+
+  it('continues debouncing changed prefixes while the first request is pending', () => {
+    expect(getSearchRequestDebounceMs('clim', undefined)).toBe(300)
+    expect(getSearchRequestDebounceMs('clima', undefined)).toBe(300)
+  })
+
+  it('debounces a term changed from the last completed request', () => {
+    expect(getSearchRequestDebounceMs('climate', 'weather')).toBe(300)
+  })
+
+  it('keeps filter-only changes responsive', () => {
+    expect(getSearchRequestDebounceMs('climate', 'climate')).toBe(50)
+  })
+})

--- a/common/src/search-request-coordination.test.ts
+++ b/common/src/search-request-coordination.test.ts
@@ -2,23 +2,41 @@ import { getSearchRequestDebounceMs } from './search-request-coordination'
 
 describe('getSearchRequestDebounceMs', () => {
   it('keeps the initial blank browse request responsive', () => {
-    expect(getSearchRequestDebounceMs('', undefined)).toBe(50)
+    expect(getSearchRequestDebounceMs('', undefined, undefined)).toBe(50)
+    expect(getSearchRequestDebounceMs('', undefined, '')).toBe(50)
   })
 
-  it('debounces a nonblank query before any request has completed', () => {
-    expect(getSearchRequestDebounceMs('climate', undefined)).toBe(300)
+  it('keeps a deep-linked initial query responsive', () => {
+    expect(getSearchRequestDebounceMs('climate', undefined, 'climate')).toBe(50)
+  })
+
+  it('debounces a typed query before any request has completed', () => {
+    expect(getSearchRequestDebounceMs('climate', undefined, '')).toBe(300)
+    expect(getSearchRequestDebounceMs('climate', undefined, undefined)).toBe(
+      300
+    )
   })
 
   it('continues debouncing changed prefixes while the first request is pending', () => {
-    expect(getSearchRequestDebounceMs('clim', undefined)).toBe(300)
-    expect(getSearchRequestDebounceMs('clima', undefined)).toBe(300)
+    expect(getSearchRequestDebounceMs('clim', undefined, '')).toBe(300)
+    expect(getSearchRequestDebounceMs('clima', undefined, '')).toBe(300)
+    expect(getSearchRequestDebounceMs('climates', undefined, 'climate')).toBe(
+      300
+    )
   })
 
   it('debounces a term changed from the last completed request', () => {
-    expect(getSearchRequestDebounceMs('climate', 'weather')).toBe(300)
+    expect(getSearchRequestDebounceMs('climate', 'weather', '')).toBe(300)
+  })
+
+  it('prefers a query completed since mount over the mount query', () => {
+    expect(getSearchRequestDebounceMs('climate', 'weather', 'climate')).toBe(
+      300
+    )
   })
 
   it('keeps filter-only changes responsive', () => {
-    expect(getSearchRequestDebounceMs('climate', 'climate')).toBe(50)
+    expect(getSearchRequestDebounceMs('climate', 'climate', '')).toBe(50)
+    expect(getSearchRequestDebounceMs('climate', 'climate', undefined)).toBe(50)
   })
 })

--- a/common/src/search-request-coordination.test.ts
+++ b/common/src/search-request-coordination.test.ts
@@ -1,9 +1,21 @@
 import {
   getLoadMoreRequestAction,
   getSearchRequestDebounceMs,
+  shouldSendDiscoveryOptions,
   shouldRetrySearchWithoutDiscoveryOptions,
   shouldRetryStaleSearchRequest,
 } from './search-request-coordination'
+
+describe('discovery compatibility mode', () => {
+  it('pins later pages to legacy/control after a first-page fallback', () => {
+    expect(shouldSendDiscoveryOptions(false, true)).toBe(false)
+  })
+
+  it('allows a new result set to try the current discovery options again', () => {
+    expect(shouldSendDiscoveryOptions(true, true)).toBe(true)
+    expect(shouldSendDiscoveryOptions(false, false)).toBe(true)
+  })
+})
 
 describe('getSearchRequestDebounceMs', () => {
   it('keeps the initial blank browse request responsive', () => {
@@ -53,6 +65,7 @@ describe('shouldRetrySearchWithoutDiscoveryOptions', () => {
         true,
         1_700_000_000_000,
         undefined,
+        undefined,
         400
       )
     ).toBe(true)
@@ -60,10 +73,43 @@ describe('shouldRetrySearchWithoutDiscoveryOptions', () => {
 
   it('retries an unsupported semantic-search opt-in on any page', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(true, undefined, true, 400)
+      shouldRetrySearchWithoutDiscoveryOptions(
+        true,
+        undefined,
+        true,
+        undefined,
+        400
+      )
     ).toBe(true)
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(false, undefined, true, 400)
+      shouldRetrySearchWithoutDiscoveryOptions(
+        false,
+        undefined,
+        true,
+        undefined,
+        400
+      )
+    ).toBe(true)
+  })
+
+  it('retries an unsupported experiment arm on any page', () => {
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(
+        true,
+        undefined,
+        undefined,
+        'control',
+        400
+      )
+    ).toBe(true)
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(
+        false,
+        undefined,
+        undefined,
+        'treatment',
+        400
+      )
     ).toBe(true)
   })
 
@@ -73,7 +119,34 @@ describe('shouldRetrySearchWithoutDiscoveryOptions', () => {
         false,
         1_700_000_000_000,
         undefined,
+        undefined,
         400
+      )
+    ).toBe(false)
+  })
+
+  it('lets control retry an old worker without changing ranking spaces', () => {
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(
+        false,
+        undefined,
+        undefined,
+        'control',
+        400,
+        true
+      )
+    ).toBe(true)
+  })
+
+  it('does not switch treatment For You ranking spaces after page one', () => {
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(
+        false,
+        undefined,
+        undefined,
+        'treatment',
+        400,
+        true
       )
     ).toBe(false)
   })
@@ -84,11 +157,18 @@ describe('shouldRetrySearchWithoutDiscoveryOptions', () => {
         true,
         1_700_000_000_000,
         undefined,
+        undefined,
         500
       )
     ).toBe(false)
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(true, undefined, undefined, 400)
+      shouldRetrySearchWithoutDiscoveryOptions(
+        true,
+        undefined,
+        undefined,
+        undefined,
+        400
+      )
     ).toBe(false)
   })
 })

--- a/common/src/search-request-coordination.test.ts
+++ b/common/src/search-request-coordination.test.ts
@@ -1,4 +1,9 @@
-import { getSearchRequestDebounceMs } from './search-request-coordination'
+import {
+  getLoadMoreRequestAction,
+  getSearchRequestDebounceMs,
+  shouldRetrySearchWithoutDiscoveryOptions,
+  shouldRetryStaleSearchRequest,
+} from './search-request-coordination'
 
 describe('getSearchRequestDebounceMs', () => {
   it('keeps the initial blank browse request responsive', () => {
@@ -38,5 +43,84 @@ describe('getSearchRequestDebounceMs', () => {
   it('keeps filter-only changes responsive', () => {
     expect(getSearchRequestDebounceMs('climate', 'climate', '')).toBe(50)
     expect(getSearchRequestDebounceMs('climate', 'climate', undefined)).toBe(50)
+  })
+})
+
+describe('shouldRetrySearchWithoutDiscoveryOptions', () => {
+  it('retries a rejected anchored first page without suppression', () => {
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(
+        true,
+        1_700_000_000_000,
+        undefined,
+        400
+      )
+    ).toBe(true)
+  })
+
+  it('retries an unsupported semantic-search opt-in on any page', () => {
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(true, undefined, true, 400)
+    ).toBe(true)
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(false, undefined, true, 400)
+    ).toBe(true)
+  })
+
+  it('does not mix filtered and unfiltered pagination spaces', () => {
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(
+        false,
+        1_700_000_000_000,
+        undefined,
+        400
+      )
+    ).toBe(false)
+  })
+
+  it('does not retry unrelated failures or requests without new options', () => {
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(
+        true,
+        1_700_000_000_000,
+        undefined,
+        500
+      )
+    ).toBe(false)
+    expect(
+      shouldRetrySearchWithoutDiscoveryOptions(true, undefined, undefined, 400)
+    ).toBe(false)
+  })
+})
+
+describe('shouldRetryStaleSearchRequest', () => {
+  it('retries a load-more request invalidated by new params', () => {
+    expect(shouldRetryStaleSearchRequest(false, 1, 2)).toBe(true)
+  })
+
+  it('does not fork pagination chains for same-param supersession', () => {
+    expect(shouldRetryStaleSearchRequest(false, 2, 2)).toBe(false)
+  })
+
+  it('does not retry superseded fresh requests', () => {
+    expect(shouldRetryStaleSearchRequest(true, 1, 2)).toBe(false)
+  })
+})
+
+describe('getLoadMoreRequestAction', () => {
+  it('loads only after the current params have a settled fresh result', () => {
+    expect(getLoadMoreRequestAction(false, false, undefined, 2)).toBe('load')
+    expect(getLoadMoreRequestAction(false, false, 2, 2)).toBe('load')
+    expect(getLoadMoreRequestAction(true, false, undefined, 2)).toBe('wait')
+    expect(getLoadMoreRequestAction(false, true, undefined, 2)).toBe('wait')
+  })
+
+  it('stops polling after the current fresh request fails', () => {
+    expect(getLoadMoreRequestAction(false, true, 2, 2)).toBe('stop')
+    expect(getLoadMoreRequestAction(false, true, 1, 2)).toBe('wait')
+  })
+
+  it('waits while a retry is pending after an earlier failure', () => {
+    expect(getLoadMoreRequestAction(true, true, 2, 2)).toBe('wait')
   })
 })

--- a/common/src/search-request-coordination.test.ts
+++ b/common/src/search-request-coordination.test.ts
@@ -1,14 +1,31 @@
 import {
+  getSearchDiscoveryRetryOptions,
+  getSearchDiscoveryRetryMode,
   getLoadMoreRequestAction,
   getSearchRequestDebounceMs,
+  SEARCH_ANCHOR_CLOCK_SKEW_ERROR,
   shouldSendDiscoveryOptions,
-  shouldRetrySearchWithoutDiscoveryOptions,
   shouldRetryStaleSearchRequest,
 } from './search-request-coordination'
+
+const legacySchemaError = (field: string) => ({
+  errorCode: 400,
+  errorMessage: 'Error validating request.',
+  errorDetails: [
+    {
+      field: null,
+      error: `Unrecognized key(s) in object: '${field}'`,
+    },
+  ],
+})
 
 describe('discovery compatibility mode', () => {
   it('pins later pages to legacy/control after a first-page fallback', () => {
     expect(shouldSendDiscoveryOptions(false, true)).toBe(false)
+  })
+
+  it('keeps treatment options on later pages after an anchor-only fallback', () => {
+    expect(shouldSendDiscoveryOptions(false, false)).toBe(true)
   })
 
   it('allows a new result set to try the current discovery options again', () => {
@@ -58,118 +75,163 @@ describe('getSearchRequestDebounceMs', () => {
   })
 })
 
-describe('shouldRetrySearchWithoutDiscoveryOptions', () => {
-  it('retries a rejected anchored first page without suppression', () => {
+describe('getSearchDiscoveryRetryMode', () => {
+  it('drops only a rejected clock-skewed first-page anchor', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        true,
-        1_700_000_000_000,
-        undefined,
-        undefined,
-        400
-      )
-    ).toBe(true)
+      getSearchDiscoveryRetryMode({
+        freshQuery: true,
+        seenMarketCutoffTime: 1_700_000_000_000,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'treatment',
+        errorCode: 400,
+        errorMessage: SEARCH_ANCHOR_CLOCK_SKEW_ERROR,
+        errorDetails: undefined,
+        isForYouRoute: true,
+      })
+    ).toBe('anchor-clock-skew')
   })
 
-  it('retries an unsupported semantic-search opt-in on any page', () => {
+  it('does not treat an unrelated 400 as a clock-skew refusal', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        true,
-        undefined,
-        true,
-        undefined,
-        400
-      )
-    ).toBe(true)
-    expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        false,
-        undefined,
-        true,
-        undefined,
-        400
-      )
-    ).toBe(true)
+      getSearchDiscoveryRetryMode({
+        freshQuery: true,
+        seenMarketCutoffTime: 1_700_000_000_000,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'treatment',
+        errorCode: 400,
+        errorMessage: 'Some other bad request',
+        errorDetails: undefined,
+        isForYouRoute: true,
+      })
+    ).toBeUndefined()
   })
 
-  it('retries an unsupported experiment arm on any page', () => {
+  it('does not use the anchor path outside treatment For You', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        true,
-        undefined,
-        undefined,
-        'control',
-        400
-      )
-    ).toBe(true)
+      getSearchDiscoveryRetryMode({
+        freshQuery: true,
+        seenMarketCutoffTime: 1_700_000_000_000,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'control',
+        errorCode: 400,
+        errorMessage: SEARCH_ANCHOR_CLOCK_SKEW_ERROR,
+        errorDetails: undefined,
+        isForYouRoute: true,
+      })
+    ).toBeUndefined()
+  })
+
+  it('recognizes a strict old worker rejecting discovery fields', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        false,
-        undefined,
-        undefined,
-        'treatment',
-        400
-      )
-    ).toBe(true)
+      getSearchDiscoveryRetryMode({
+        freshQuery: true,
+        seenMarketCutoffTime: 1_700_000_000_000,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'treatment',
+        ...legacySchemaError('seenMarketCutoffTime'),
+        isForYouRoute: true,
+      })
+    ).toBe('legacy-schema')
+  })
+
+  it('can strip an unsupported semantic opt-in on a safe later page', () => {
+    expect(
+      getSearchDiscoveryRetryMode({
+        freshQuery: false,
+        seenMarketCutoffTime: undefined,
+        enableSemanticSearch: true,
+        discoveryVariant: 'treatment',
+        ...legacySchemaError('enableSemanticSearch'),
+      })
+    ).toBe('legacy-schema')
   })
 
   it('does not mix filtered and unfiltered pagination spaces', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        false,
-        1_700_000_000_000,
-        undefined,
-        undefined,
-        400
-      )
-    ).toBe(false)
+      getSearchDiscoveryRetryMode({
+        freshQuery: false,
+        seenMarketCutoffTime: 1_700_000_000_000,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'treatment',
+        ...legacySchemaError('seenMarketCutoffTime'),
+      })
+    ).toBeUndefined()
   })
 
   it('lets control retry an old worker without changing ranking spaces', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        false,
-        undefined,
-        undefined,
-        'control',
-        400,
-        true
-      )
-    ).toBe(true)
+      getSearchDiscoveryRetryMode({
+        freshQuery: false,
+        seenMarketCutoffTime: undefined,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'control',
+        ...legacySchemaError('discoveryVariant'),
+        isForYouRoute: true,
+      })
+    ).toBe('legacy-schema')
   })
 
   it('does not switch treatment For You ranking spaces after page one', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        false,
-        undefined,
-        undefined,
-        'treatment',
-        400,
-        true
-      )
-    ).toBe(false)
+      getSearchDiscoveryRetryMode({
+        freshQuery: false,
+        seenMarketCutoffTime: undefined,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'treatment',
+        ...legacySchemaError('discoveryVariant'),
+        isForYouRoute: true,
+      })
+    ).toBeUndefined()
   })
 
-  it('does not retry unrelated failures or requests without new options', () => {
+  it('does not retry unrelated failures or unrelated schema errors', () => {
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        true,
-        1_700_000_000_000,
-        undefined,
-        undefined,
-        500
-      )
-    ).toBe(false)
+      getSearchDiscoveryRetryMode({
+        freshQuery: true,
+        seenMarketCutoffTime: 1_700_000_000_000,
+        enableSemanticSearch: undefined,
+        discoveryVariant: 'treatment',
+        errorCode: 500,
+        errorMessage: SEARCH_ANCHOR_CLOCK_SKEW_ERROR,
+        errorDetails: undefined,
+      })
+    ).toBeUndefined()
     expect(
-      shouldRetrySearchWithoutDiscoveryOptions(
-        true,
-        undefined,
-        undefined,
-        undefined,
-        400
-      )
-    ).toBe(false)
+      getSearchDiscoveryRetryMode({
+        freshQuery: true,
+        seenMarketCutoffTime: undefined,
+        enableSemanticSearch: true,
+        discoveryVariant: 'treatment',
+        ...legacySchemaError('someOtherField'),
+      })
+    ).toBeUndefined()
+  })
+})
+
+describe('getSearchDiscoveryRetryOptions', () => {
+  const treatmentOptions = {
+    enableSemanticSearch: true,
+    discoveryVariant: 'treatment' as const,
+  }
+
+  it('preserves treatment while removing a rejected anchor', () => {
+    expect(
+      getSearchDiscoveryRetryOptions('anchor-clock-skew', treatmentOptions)
+    ).toEqual({
+      seenMarketCutoffTime: undefined,
+      enableSemanticSearch: true,
+      discoveryVariant: 'treatment',
+    })
+  })
+
+  it('removes every discovery field only for an old schema', () => {
+    expect(
+      getSearchDiscoveryRetryOptions('legacy-schema', treatmentOptions)
+    ).toEqual({
+      seenMarketCutoffTime: undefined,
+      enableSemanticSearch: undefined,
+      discoveryVariant: undefined,
+    })
   })
 })
 

--- a/common/src/search-request-coordination.ts
+++ b/common/src/search-request-coordination.ts
@@ -21,3 +21,39 @@ export const getSearchRequestDebounceMs = (
   currentQuery !== (lastCompletedQuery ?? initialQuery ?? '')
     ? TERM_CHANGE_DEBOUNCE_MS
     : OTHER_SEARCH_CHANGE_DEBOUNCE_MS
+
+/**
+ * New discovery request fields can be rejected by an old strict API worker,
+ * and a new worker deliberately rejects a badly skewed first-page anchor.
+ * Removing a semantic opt-in is safe on any later page because fallback only
+ * runs on page one. Removing a seen-market anchor is safe only on page one;
+ * doing that later could mix filtered and unfiltered offset spaces.
+ */
+export const shouldRetrySearchWithoutDiscoveryOptions = (
+  freshQuery: boolean,
+  seenMarketCutoffTime: number | undefined,
+  enableSemanticSearch: boolean | undefined,
+  errorCode: number | undefined
+) =>
+  errorCode === 400 &&
+  ((freshQuery && seenMarketCutoffTime !== undefined) ||
+    enableSemanticSearch === true)
+
+/** Keep one visibility-observer chain alive after params invalidate a page. */
+export const shouldRetryStaleSearchRequest = (
+  freshQuery: boolean,
+  requestParamsGeneration: number,
+  currentParamsGeneration: number
+) => !freshQuery && requestParamsGeneration !== currentParamsGeneration
+
+/** Decide whether an intersection observer should page, wait, or stop. */
+export const getLoadMoreRequestAction = (
+  freshRequestPending: boolean,
+  searchParamsChanged: boolean,
+  failedParamsGeneration: number | undefined,
+  currentParamsGeneration: number
+): 'load' | 'wait' | 'stop' => {
+  if (freshRequestPending) return 'wait'
+  if (!searchParamsChanged) return 'load'
+  return failedParamsGeneration === currentParamsGeneration ? 'stop' : 'wait'
+}

--- a/common/src/search-request-coordination.ts
+++ b/common/src/search-request-coordination.ts
@@ -27,17 +27,28 @@ export const getSearchRequestDebounceMs = (
  * and a new worker deliberately rejects a badly skewed first-page anchor.
  * Removing a semantic opt-in is safe on any later page because fallback only
  * runs on page one. Removing a seen-market anchor is safe only on page one;
- * doing that later could mix filtered and unfiltered offset spaces.
+ * removing an experiment arm later is also unsafe for For You because it can
+ * switch ranking spaces underneath offset pagination.
  */
 export const shouldRetrySearchWithoutDiscoveryOptions = (
   freshQuery: boolean,
   seenMarketCutoffTime: number | undefined,
   enableSemanticSearch: boolean | undefined,
-  errorCode: number | undefined
+  discoveryVariant: 'control' | 'treatment' | undefined,
+  errorCode: number | undefined,
+  isForYouRoute = false
 ) =>
   errorCode === 400 &&
   ((freshQuery && seenMarketCutoffTime !== undefined) ||
-    enableSemanticSearch === true)
+    enableSemanticSearch === true ||
+    (discoveryVariant !== undefined &&
+      (freshQuery || !isForYouRoute || discoveryVariant === 'control')))
+
+/** Keep every page in the same ranking space after a compatibility retry. */
+export const shouldSendDiscoveryOptions = (
+  freshQuery: boolean,
+  resultSetUsedCompatibilityFallback: boolean
+) => freshQuery || !resultSetUsedCompatibilityFallback
 
 /** Keep one visibility-observer chain alive after params invalidate a page. */
 export const shouldRetryStaleSearchRequest = (

--- a/common/src/search-request-coordination.ts
+++ b/common/src/search-request-coordination.ts
@@ -3,13 +3,21 @@ const OTHER_SEARCH_CHANGE_DEBOUNCE_MS = 50
 
 /**
  * Term changes wait for a typing burst to settle, including before the first
- * request succeeds. Blank initial browse loads and filter-only changes stay
- * responsive.
+ * request succeeds. Blank or deep-linked initial loads and filter-only changes
+ * stay responsive.
+ *
+ * The baseline is the last query the client already committed to: the last
+ * completed one, else the query the page mounted with. A query that arrived
+ * with the URL was never typed, so it must not wait like a keystroke.
+ *
+ * lastCompletedQuery must be a completion from the current mount. A value
+ * remembered from an earlier visit would make a deep-linked query look typed.
  */
 export const getSearchRequestDebounceMs = (
   currentQuery: string,
-  lastCompletedQuery: string | undefined
+  lastCompletedQuery: string | undefined,
+  initialQuery: string | undefined
 ) =>
-  currentQuery !== (lastCompletedQuery ?? '')
+  currentQuery !== (lastCompletedQuery ?? initialQuery ?? '')
     ? TERM_CHANGE_DEBOUNCE_MS
     : OTHER_SEARCH_CHANGE_DEBOUNCE_MS

--- a/common/src/search-request-coordination.ts
+++ b/common/src/search-request-coordination.ts
@@ -1,0 +1,15 @@
+const TERM_CHANGE_DEBOUNCE_MS = 300
+const OTHER_SEARCH_CHANGE_DEBOUNCE_MS = 50
+
+/**
+ * Term changes wait for a typing burst to settle, including before the first
+ * request succeeds. Blank initial browse loads and filter-only changes stay
+ * responsive.
+ */
+export const getSearchRequestDebounceMs = (
+  currentQuery: string,
+  lastCompletedQuery: string | undefined
+) =>
+  currentQuery !== (lastCompletedQuery ?? '')
+    ? TERM_CHANGE_DEBOUNCE_MS
+    : OTHER_SEARCH_CHANGE_DEBOUNCE_MS

--- a/common/src/search-request-coordination.ts
+++ b/common/src/search-request-coordination.ts
@@ -22,27 +22,111 @@ export const getSearchRequestDebounceMs = (
     ? TERM_CHANGE_DEBOUNCE_MS
     : OTHER_SEARCH_CHANGE_DEBOUNCE_MS
 
+export const SEARCH_ANCHOR_CLOCK_SKEW_ERROR =
+  'seenMarketCutoffTime is too far ahead of server time'
+
+export type SearchDiscoveryRetryMode = 'anchor-clock-skew' | 'legacy-schema'
+
+const DISCOVERY_OPTION_NAMES = [
+  'seenMarketCutoffTime',
+  'enableSemanticSearch',
+  'discoveryVariant',
+] as const
+
+const isLegacyDiscoverySchemaError = (details: unknown) =>
+  Array.isArray(details) &&
+  details.some((issue) => {
+    if (typeof issue !== 'object' || issue === null) return false
+    const { field, error } = issue as { field?: unknown; error?: unknown }
+    if (typeof error !== 'string' || !/unrecognized|unknown/i.test(error)) {
+      return false
+    }
+    return DISCOVERY_OPTION_NAMES.some(
+      (option) => field === option || error.includes(option)
+    )
+  })
+
 /**
- * New discovery request fields can be rejected by an old strict API worker,
- * and a new worker deliberately rejects a badly skewed first-page anchor.
- * Removing a semantic opt-in is safe on any later page because fallback only
- * runs on page one. Removing a seen-market anchor is safe only on page one;
- * removing an experiment arm later is also unsafe for For You because it can
+ * Distinguish the new API's explicit clock-skew refusal from an old strict
+ * worker rejecting discovery fields. The former only drops the first-page
+ * anchor and remains in treatment. The latter drops all discovery fields and
+ * pins subsequent pages to legacy behavior.
+ *
+ * Removing a seen-market anchor is safe only on page one. Removing an
+ * experiment arm later is also unsafe for treatment For You because it can
  * switch ranking spaces underneath offset pagination.
  */
-export const shouldRetrySearchWithoutDiscoveryOptions = (
-  freshQuery: boolean,
-  seenMarketCutoffTime: number | undefined,
-  enableSemanticSearch: boolean | undefined,
-  discoveryVariant: 'control' | 'treatment' | undefined,
-  errorCode: number | undefined,
-  isForYouRoute = false
-) =>
-  errorCode === 400 &&
-  ((freshQuery && seenMarketCutoffTime !== undefined) ||
+export const getSearchDiscoveryRetryMode = (args: {
+  freshQuery: boolean
+  seenMarketCutoffTime: number | undefined
+  enableSemanticSearch: boolean | undefined
+  discoveryVariant: 'control' | 'treatment' | undefined
+  errorCode: number | undefined
+  errorMessage: string | undefined
+  errorDetails: unknown
+  isForYouRoute?: boolean
+}): SearchDiscoveryRetryMode | undefined => {
+  const {
+    freshQuery,
+    seenMarketCutoffTime,
+    enableSemanticSearch,
+    discoveryVariant,
+    errorCode,
+    errorMessage,
+    errorDetails,
+    isForYouRoute = false,
+  } = args
+  if (errorCode !== 400) return undefined
+
+  if (
+    freshQuery &&
+    isForYouRoute &&
+    discoveryVariant === 'treatment' &&
+    seenMarketCutoffTime !== undefined &&
+    errorMessage === SEARCH_ANCHOR_CLOCK_SKEW_ERROR
+  ) {
+    return 'anchor-clock-skew'
+  }
+
+  const sentDiscoveryOption =
+    seenMarketCutoffTime !== undefined ||
     enableSemanticSearch === true ||
-    (discoveryVariant !== undefined &&
-      (freshQuery || !isForYouRoute || discoveryVariant === 'control')))
+    discoveryVariant !== undefined
+  if (
+    !sentDiscoveryOption ||
+    errorMessage !== 'Error validating request.' ||
+    !isLegacyDiscoverySchemaError(errorDetails)
+  ) {
+    return undefined
+  }
+
+  const canDropAnchor = freshQuery || seenMarketCutoffTime === undefined
+  const canDropVariant =
+    discoveryVariant === undefined ||
+    freshQuery ||
+    !isForYouRoute ||
+    discoveryVariant === 'control'
+  return canDropAnchor && canDropVariant ? 'legacy-schema' : undefined
+}
+
+export const getSearchDiscoveryRetryOptions = (
+  mode: SearchDiscoveryRetryMode,
+  options: {
+    enableSemanticSearch: boolean | undefined
+    discoveryVariant: 'control' | 'treatment' | undefined
+  }
+) =>
+  mode === 'anchor-clock-skew'
+    ? {
+        seenMarketCutoffTime: undefined,
+        enableSemanticSearch: options.enableSemanticSearch,
+        discoveryVariant: options.discoveryVariant,
+      }
+    : {
+        seenMarketCutoffTime: undefined,
+        enableSemanticSearch: undefined,
+        discoveryVariant: undefined,
+      }
 
 /** Keep every page in the same ranking space after a compatibility retry. */
 export const shouldSendDiscoveryOptions = (

--- a/common/src/search-result-order.test.ts
+++ b/common/src/search-result-order.test.ts
@@ -1,0 +1,81 @@
+import { orderCombinedSearchResults } from './search-result-order'
+
+type Result = {
+  id: string
+  createdTime: number
+  importanceScore: number
+}
+
+const result = (
+  id: string,
+  importanceScore: number,
+  createdTime: number
+): Result => ({ id, importanceScore, createdTime })
+
+const ids = (results: Result[]) => results.map(({ id }) => id)
+
+describe('orderCombinedSearchResults', () => {
+  const lexical = result('lexical', 1, 10)
+  const semantic = result('semantic', 100, 20)
+  const post = result('post', 50, 30)
+
+  it('keeps lexical results ahead of the semantic tail for score searches', () => {
+    const ordered = orderCombinedSearchResults([lexical, semantic], [post], {
+      sort: 'score',
+      preserveContractOrder: true,
+    })
+
+    expect(ids(ordered)).toEqual(['lexical', 'semantic', 'post'])
+  })
+
+  it('retains the supplied similarity order within a semantic tail', () => {
+    const firstBySimilarity = result('first-by-similarity', 2, 10)
+    const secondBySimilarity = result('second-by-similarity', 200, 20)
+
+    const ordered = orderCombinedSearchResults(
+      [firstBySimilarity, secondBySimilarity],
+      [],
+      { sort: 'score', preserveContractOrder: true }
+    )
+
+    expect(ids(ordered)).toEqual([
+      'first-by-similarity',
+      'second-by-similarity',
+    ])
+  })
+
+  it('does not override personalized contract order when there are no posts', () => {
+    const ordered = orderCombinedSearchResults([lexical, semantic], [], {
+      sort: 'score',
+      preserveContractOrder: false,
+    })
+
+    expect(ids(ordered)).toEqual(['lexical', 'semantic'])
+  })
+
+  it('still mixes empty-query score results by importance', () => {
+    const ordered = orderCombinedSearchResults([semantic, lexical], [post], {
+      sort: 'score',
+      preserveContractOrder: false,
+    })
+
+    expect(ids(ordered)).toEqual(['semantic', 'post', 'lexical'])
+  })
+
+  it('still mixes newest results by creation time', () => {
+    const ordered = orderCombinedSearchResults([lexical, semantic], [post], {
+      sort: 'newest',
+      preserveContractOrder: false,
+    })
+
+    expect(ids(ordered)).toEqual(['post', 'semantic', 'lexical'])
+  })
+
+  it('preserves incoming order for recent results', () => {
+    const ordered = orderCombinedSearchResults([semantic, lexical], [post], {
+      preserveContractOrder: false,
+    })
+
+    expect(ids(ordered)).toEqual(['semantic', 'lexical', 'post'])
+  })
+})

--- a/common/src/search-result-order.test.ts
+++ b/common/src/search-result-order.test.ts
@@ -1,81 +1,155 @@
-import { orderCombinedSearchResults } from './search-result-order'
+import {
+  getPostSearchThreshold,
+  orderCombinedSearchResults,
+} from './search-result-order'
 
 type Result = {
   id: string
   createdTime: number
   importanceScore: number
+  searchMatchType?: 'lexical' | 'semantic'
 }
 
 const result = (
   id: string,
   importanceScore: number,
-  createdTime: number
-): Result => ({ id, importanceScore, createdTime })
+  createdTime: number,
+  searchMatchType?: 'lexical' | 'semantic'
+): Result => ({ id, importanceScore, createdTime, searchMatchType })
 
 const ids = (results: Result[]) => results.map(({ id }) => id)
 
 describe('orderCombinedSearchResults', () => {
-  const lexical = result('lexical', 1, 10)
-  const semantic = result('semantic', 100, 20)
+  const lexical = result('lexical', 1, 10, 'lexical')
+  const semantic = result('semantic', 100, 20, 'semantic')
   const post = result('post', 50, 30)
 
-  it('keeps lexical results ahead of the semantic tail for score searches', () => {
+  it('keeps the lexical/post block ahead of the semantic tail', () => {
     const ordered = orderCombinedSearchResults([lexical, semantic], [post], {
       sort: 'score',
-      preserveContractOrder: true,
+      preserveUnmarkedContractOrder: true,
     })
 
-    expect(ids(ordered)).toEqual(['lexical', 'semantic', 'post'])
+    expect(ids(ordered)).toEqual(['post', 'lexical', 'semantic'])
   })
 
   it('retains the supplied similarity order within a semantic tail', () => {
-    const firstBySimilarity = result('first-by-similarity', 2, 10)
-    const secondBySimilarity = result('second-by-similarity', 200, 20)
+    const firstBySimilarity = result('first-by-similarity', 2, 10, 'semantic')
+    const secondBySimilarity = result(
+      'second-by-similarity',
+      200,
+      20,
+      'semantic'
+    )
 
     const ordered = orderCombinedSearchResults(
       [firstBySimilarity, secondBySimilarity],
-      [],
-      { sort: 'score', preserveContractOrder: true }
+      [post],
+      { sort: 'score', preserveUnmarkedContractOrder: true }
     )
 
     expect(ids(ordered)).toEqual([
+      'post',
       'first-by-similarity',
       'second-by-similarity',
     ])
   })
 
+  it('retains semantic classification after client filtering removes lexical rows', () => {
+    const ordered = orderCombinedSearchResults([semantic], [post], {
+      sort: 'score',
+      preserveUnmarkedContractOrder: true,
+    })
+
+    expect(ids(ordered)).toEqual(['post', 'semantic'])
+  })
+
   it('does not override personalized contract order when there are no posts', () => {
     const ordered = orderCombinedSearchResults([lexical, semantic], [], {
       sort: 'score',
-      preserveContractOrder: false,
     })
 
     expect(ids(ordered)).toEqual(['lexical', 'semantic'])
   })
 
   it('still mixes empty-query score results by importance', () => {
-    const ordered = orderCombinedSearchResults([semantic, lexical], [post], {
+    const highMarket = result('high-market', 100, 20)
+    const ordered = orderCombinedSearchResults([lexical, highMarket], [post], {
       sort: 'score',
-      preserveContractOrder: false,
     })
 
-    expect(ids(ordered)).toEqual(['semantic', 'post', 'lexical'])
+    expect(ids(ordered)).toEqual(['high-market', 'post', 'lexical'])
+  })
+
+  it('interleaves posts when semantic fallback returns no results', () => {
+    const higherLexical = result('higher-lexical', 100, 20, 'lexical')
+    const ordered = orderCombinedSearchResults(
+      [lexical, higherLexical],
+      [post],
+      { sort: 'score', preserveUnmarkedContractOrder: true }
+    )
+
+    expect(ids(ordered)).toEqual(['higher-lexical', 'post', 'lexical'])
+  })
+
+  it('interleaves a post across accumulated lexical pages', () => {
+    const accumulatedMarkets = Array.from({ length: 40 }, (_, index) =>
+      result(`market-${index}`, 100 - index * 2, index, 'lexical')
+    )
+    const ordered = orderCombinedSearchResults(accumulatedMarkets, [post], {
+      sort: 'score',
+      preserveUnmarkedContractOrder: true,
+    })
+
+    expect(ids(ordered).indexOf('post')).toBe(26)
+    expect(ids(ordered).indexOf('market-39')).toBe(40)
+  })
+
+  it('fails safe for an unmarked response from an old API worker', () => {
+    const oldLexical = result('old-lexical', 1, 10)
+    const unknownTail = result('unknown-tail', 100, 20)
+    const ordered = orderCombinedSearchResults(
+      [oldLexical, unknownTail],
+      [post],
+      { sort: 'score', preserveUnmarkedContractOrder: true }
+    )
+
+    expect(ids(ordered)).toEqual(['old-lexical', 'unknown-tail', 'post'])
   })
 
   it('still mixes newest results by creation time', () => {
     const ordered = orderCombinedSearchResults([lexical, semantic], [post], {
       sort: 'newest',
-      preserveContractOrder: false,
     })
 
     expect(ids(ordered)).toEqual(['post', 'semantic', 'lexical'])
   })
 
   it('preserves incoming order for recent results', () => {
-    const ordered = orderCombinedSearchResults([semantic, lexical], [post], {
-      preserveContractOrder: false,
-    })
+    const ordered = orderCombinedSearchResults([semantic, lexical], [post], {})
 
     expect(ids(ordered)).toEqual(['semantic', 'lexical', 'post'])
+  })
+})
+
+describe('getPostSearchThreshold', () => {
+  it('ignores semantic importance scores when finding the lexical floor', () => {
+    const lexical = result('lexical', 10, 10)
+    const semantic = result('semantic', 1, 20, 'semantic')
+
+    expect(getPostSearchThreshold([lexical, semantic], 'score')).toBe(10)
+  })
+
+  it('has no score threshold when only semantic markets remain', () => {
+    const semantic = result('semantic', 1, 20, 'semantic')
+
+    expect(getPostSearchThreshold([semantic], 'score')).toBeUndefined()
+  })
+
+  it('uses all finite creation times for newest ordering', () => {
+    const first = result('first', 10, 30)
+    const second = result('second', 20, 20, 'semantic')
+
+    expect(getPostSearchThreshold([first, second], 'newest')).toBe(20)
   })
 })

--- a/common/src/search-result-order.test.ts
+++ b/common/src/search-result-order.test.ts
@@ -1,6 +1,7 @@
 import {
   getPostSearchThreshold,
   orderCombinedSearchResults,
+  shouldPreserveBackendMarketOrder,
 } from './search-result-order'
 
 type Result = {
@@ -27,7 +28,7 @@ describe('orderCombinedSearchResults', () => {
   it('keeps the lexical/post block ahead of the semantic tail', () => {
     const ordered = orderCombinedSearchResults([lexical, semantic], [post], {
       sort: 'score',
-      preserveUnmarkedContractOrder: true,
+      preserveBackendMarketOrder: true,
     })
 
     expect(ids(ordered)).toEqual(['post', 'lexical', 'semantic'])
@@ -45,7 +46,7 @@ describe('orderCombinedSearchResults', () => {
     const ordered = orderCombinedSearchResults(
       [firstBySimilarity, secondBySimilarity],
       [post],
-      { sort: 'score', preserveUnmarkedContractOrder: true }
+      { sort: 'score', preserveBackendMarketOrder: true }
     )
 
     expect(ids(ordered)).toEqual([
@@ -58,24 +59,39 @@ describe('orderCombinedSearchResults', () => {
   it('retains semantic classification after client filtering removes lexical rows', () => {
     const ordered = orderCombinedSearchResults([semantic], [post], {
       sort: 'score',
-      preserveUnmarkedContractOrder: true,
+      preserveBackendMarketOrder: true,
     })
 
     expect(ids(ordered)).toEqual(['post', 'semantic'])
   })
 
-  it('does not override personalized contract order when there are no posts', () => {
+  it('keeps treatment backend order when there are no posts', () => {
     const ordered = orderCombinedSearchResults([lexical, semantic], [], {
       sort: 'score',
+      preserveBackendMarketOrder: true,
     })
 
     expect(ids(ordered)).toEqual(['lexical', 'semantic'])
+  })
+
+  it('keeps the pre-experiment importance sort for control with no posts', () => {
+    const highMarket = result('high-market', 100, 20, 'lexical')
+    const ordered = orderCombinedSearchResults([lexical, highMarket], [], {
+      sort: 'score',
+    })
+
+    expect(ids(ordered)).toEqual(['high-market', 'lexical'])
   })
 
   it('still mixes empty-query score results by importance', () => {
     const highMarket = result('high-market', 100, 20)
     const ordered = orderCombinedSearchResults([lexical, highMarket], [post], {
       sort: 'score',
+      preserveBackendMarketOrder: shouldPreserveBackendMarketOrder(
+        'treatment',
+        '',
+        false
+      ),
     })
 
     expect(ids(ordered)).toEqual(['high-market', 'post', 'lexical'])
@@ -86,7 +102,7 @@ describe('orderCombinedSearchResults', () => {
     const ordered = orderCombinedSearchResults(
       [lexical, higherLexical],
       [post],
-      { sort: 'score', preserveUnmarkedContractOrder: true }
+      { sort: 'score', preserveBackendMarketOrder: true }
     )
 
     expect(ids(ordered)).toEqual(['higher-lexical', 'post', 'lexical'])
@@ -98,7 +114,7 @@ describe('orderCombinedSearchResults', () => {
     )
     const ordered = orderCombinedSearchResults(accumulatedMarkets, [post], {
       sort: 'score',
-      preserveUnmarkedContractOrder: true,
+      preserveBackendMarketOrder: true,
     })
 
     expect(ids(ordered).indexOf('post')).toBe(26)
@@ -111,10 +127,22 @@ describe('orderCombinedSearchResults', () => {
     const ordered = orderCombinedSearchResults(
       [oldLexical, unknownTail],
       [post],
-      { sort: 'score', preserveUnmarkedContractOrder: true }
+      { sort: 'score', preserveBackendMarketOrder: true }
     )
 
     expect(ids(ordered)).toEqual(['old-lexical', 'unknown-tail', 'post'])
+  })
+
+  it('keeps legacy importance sorting for an unmarked control response', () => {
+    const oldLexical = result('old-lexical', 1, 10)
+    const oldHigherMarket = result('old-higher-market', 100, 20)
+    const ordered = orderCombinedSearchResults(
+      [oldLexical, oldHigherMarket],
+      [post],
+      { sort: 'score' }
+    )
+
+    expect(ids(ordered)).toEqual(['old-higher-market', 'post', 'old-lexical'])
   })
 
   it('still mixes newest results by creation time', () => {
@@ -129,6 +157,22 @@ describe('orderCombinedSearchResults', () => {
     const ordered = orderCombinedSearchResults([semantic, lexical], [post], {})
 
     expect(ids(ordered)).toEqual(['semantic', 'lexical', 'post'])
+  })
+})
+
+describe('shouldPreserveBackendMarketOrder', () => {
+  it('preserves treatment order only for For You or text search', () => {
+    expect(shouldPreserveBackendMarketOrder('treatment', '', true)).toBe(true)
+    expect(
+      shouldPreserveBackendMarketOrder('treatment', 'climate', false)
+    ).toBe(true)
+    expect(shouldPreserveBackendMarketOrder('treatment', '', false)).toBe(false)
+  })
+
+  it('keeps every control surface on the legacy client ordering path', () => {
+    expect(shouldPreserveBackendMarketOrder('control', 'climate', true)).toBe(
+      false
+    )
   })
 })
 

--- a/common/src/search-result-order.ts
+++ b/common/src/search-result-order.ts
@@ -1,0 +1,36 @@
+type RankableSearchResult = {
+  createdTime: number
+  importanceScore: number
+}
+
+/**
+ * Mixes posts into market results without accidentally overriding a ranking
+ * that only the market API understands (personalization or lexical relevance).
+ */
+export const orderCombinedSearchResults = <
+  C extends RankableSearchResult,
+  P extends RankableSearchResult
+>(
+  contracts: readonly C[],
+  posts: readonly P[],
+  options: {
+    sort?: string
+    preserveContractOrder: boolean
+  }
+): (C | P)[] => {
+  const { sort, preserveContractOrder } = options
+  if (
+    posts.length === 0 ||
+    preserveContractOrder ||
+    (sort !== 'score' && sort !== 'newest')
+  ) {
+    return [...contracts, ...posts]
+  }
+
+  const value =
+    sort === 'score'
+      ? (item: RankableSearchResult) => item.importanceScore
+      : (item: RankableSearchResult) => item.createdTime
+
+  return [...contracts, ...posts].sort((a, b) => value(b) - value(a))
+}

--- a/common/src/search-result-order.ts
+++ b/common/src/search-result-order.ts
@@ -1,6 +1,33 @@
+import type { FullMarketSearchResult } from './api/market-search-types'
+
 type RankableSearchResult = {
   createdTime: number
   importanceScore: number
+}
+
+type RankableMarketSearchResult = RankableSearchResult & {
+  searchMatchType?: FullMarketSearchResult['searchMatchType']
+}
+
+export const getPostSearchThreshold = <C extends RankableMarketSearchResult>(
+  contracts: readonly C[],
+  sort: 'score' | 'newest'
+): number | undefined => {
+  // Semantic results are similarity-ranked, so their importance scores cannot
+  // define the next lexical/post page boundary.
+  const rankableContracts =
+    sort === 'score'
+      ? contracts.filter(
+          ({ searchMatchType }) => searchMatchType !== 'semantic'
+        )
+      : contracts
+  const values = rankableContracts
+    .map((contract) =>
+      sort === 'score' ? contract.importanceScore : contract.createdTime
+    )
+    .filter(Number.isFinite)
+
+  return values.length === 0 ? undefined : Math.min(...values)
 }
 
 /**
@@ -8,29 +35,47 @@ type RankableSearchResult = {
  * that only the market API understands (personalization or lexical relevance).
  */
 export const orderCombinedSearchResults = <
-  C extends RankableSearchResult,
+  C extends RankableMarketSearchResult,
   P extends RankableSearchResult
 >(
   contracts: readonly C[],
   posts: readonly P[],
   options: {
     sort?: string
-    preserveContractOrder: boolean
+    preserveUnmarkedContractOrder?: boolean
   }
 ): (C | P)[] => {
-  const { sort, preserveContractOrder } = options
+  const { sort, preserveUnmarkedContractOrder } = options
+  if (posts.length === 0 || (sort !== 'score' && sort !== 'newest')) {
+    return [...contracts, ...posts]
+  }
+
+  if (sort === 'newest') {
+    return [...contracts, ...posts].sort(
+      (a, b) => b.createdTime - a.createdTime
+    )
+  }
+
+  // During a rolling deployment, an old API worker can return an unmarked
+  // lexical-plus-semantic array to a marker-aware UI. Preserve that array's
+  // order rather than risk promoting its unknown semantic tail. New workers
+  // mark every text-search market, including lexical-only responses.
   if (
-    posts.length === 0 ||
-    preserveContractOrder ||
-    (sort !== 'score' && sort !== 'newest')
+    preserveUnmarkedContractOrder &&
+    contracts.some(({ searchMatchType }) => searchMatchType === undefined)
   ) {
     return [...contracts, ...posts]
   }
 
-  const value =
-    sort === 'score'
-      ? (item: RankableSearchResult) => item.importanceScore
-      : (item: RankableSearchResult) => item.createdTime
+  const lexicalContracts = contracts.filter(
+    ({ searchMatchType }) => searchMatchType !== 'semantic'
+  )
+  const semanticContracts = contracts.filter(
+    ({ searchMatchType }) => searchMatchType === 'semantic'
+  )
+  const rankedLexicalResults = [...lexicalContracts, ...posts].sort(
+    (a, b) => b.importanceScore - a.importanceScore
+  )
 
-  return [...contracts, ...posts].sort((a, b) => value(b) - value(a))
+  return [...rankedLexicalResults, ...semanticContracts]
 }

--- a/common/src/search-result-order.ts
+++ b/common/src/search-result-order.ts
@@ -9,6 +9,12 @@ type RankableMarketSearchResult = RankableSearchResult & {
   searchMatchType?: FullMarketSearchResult['searchMatchType']
 }
 
+export const shouldPreserveBackendMarketOrder = (
+  discoveryVariant: 'control' | 'treatment' | undefined,
+  query: string,
+  isForYou: boolean
+) => discoveryVariant === 'treatment' && (isForYou || query.trim().length > 0)
+
 export const getPostSearchThreshold = <C extends RankableMarketSearchResult>(
   contracts: readonly C[],
   sort: 'score' | 'newest'
@@ -42,12 +48,20 @@ export const orderCombinedSearchResults = <
   posts: readonly P[],
   options: {
     sort?: string
-    preserveUnmarkedContractOrder?: boolean
+    preserveBackendMarketOrder?: boolean
   }
 ): (C | P)[] => {
-  const { sort, preserveUnmarkedContractOrder } = options
-  if (posts.length === 0 || (sort !== 'score' && sort !== 'newest')) {
+  const { sort, preserveBackendMarketOrder } = options
+  if (sort !== 'score' && sort !== 'newest') {
     return [...contracts, ...posts]
+  }
+
+  // The treatment API can return an order the client cannot reconstruct
+  // (For You personalization or lexical relevance). With no posts to mix in,
+  // keep that order intact. Control intentionally falls through to the legacy
+  // client-side sort so its behavior remains the pre-experiment baseline.
+  if (posts.length === 0 && preserveBackendMarketOrder) {
+    return [...contracts]
   }
 
   if (sort === 'newest') {
@@ -61,7 +75,7 @@ export const orderCombinedSearchResults = <
   // order rather than risk promoting its unknown semantic tail. New workers
   // mark every text-search market, including lexical-only responses.
   if (
-    preserveUnmarkedContractOrder &&
+    preserveBackendMarketOrder &&
     contracts.some(({ searchMatchType }) => searchMatchType === undefined)
   ) {
     return [...contracts, ...posts]

--- a/common/src/util/api.ts
+++ b/common/src/util/api.ts
@@ -56,6 +56,8 @@ export type BaseApiCallOptions = {
   // mutation: cached GET endpoints (max-age + stale-while-revalidate) can
   // otherwise legally serve the pre-mutation state for several seconds.
   cache?: RequestCache
+  // Lets typeahead and other superseding reads stop obsolete client work.
+  signal?: AbortSignal
 }
 
 export async function baseApiCall(
@@ -79,6 +81,7 @@ export async function baseApiCall(
     headers,
     method: method,
     cache: options?.cache,
+    signal: options?.signal,
     body:
       params == null || method === 'GET' ? undefined : JSON.stringify(params),
   })

--- a/web/components/auth-context.tsx
+++ b/web/components/auth-context.tsx
@@ -104,6 +104,8 @@ export function AuthProvider(props: {
   // Whether this page session has ever observed a signed-in Firebase user. Gates
   // the sign-out we forward to the native app — see the null branch below.
   const sawFbUser = useRef(false)
+  const committedUserId = useRef(user?.id)
+  committedUserId.current = user?.id
 
   const authUser = !user
     ? user
@@ -204,6 +206,18 @@ export function AuthProvider(props: {
     return onIdTokenChanged(
       auth,
       async (fbUser) => {
+        // Firebase switches its request credential before the profile lookup
+        // below finishes. Mark real identity changes transitional immediately
+        // so requests cannot use the previous app user with the new token.
+        // Ordinary same-user token refreshes should not blank the UI.
+        if (fbUser?.uid !== committedUserId.current) {
+          setAuthLoaded(false)
+          // A known anonymous context does not carry authLoaded, so changing
+          // null to undefined is what makes consumers wait during login.
+          if (fbUser && committedUserId.current === undefined) {
+            setUser(undefined)
+          }
+        }
         if (fbUser) {
           sawFbUser.current = true
           setUserCookie(fbUser.toJSON())

--- a/web/components/contract/combined-results.tsx
+++ b/web/components/contract/combined-results.tsx
@@ -1,10 +1,16 @@
 import { Answer } from 'common/answer'
 import { FullMarketSearchResult } from 'common/api/market-search-types'
 import { Contract } from 'common/contract'
+import {
+  DISCOVERY_RESULT_CLICK_EVENT,
+  DiscoveryResultTracking,
+} from 'common/discovery-experiment'
 import { orderCombinedSearchResults } from 'common/search-result-order'
 import { TopLevelPost } from 'common/top-level-post'
 import { buildArray } from 'common/util/array'
 import { Key } from 'react'
+import { track } from 'web/lib/service/analytics'
+import { isABTestAssignmentCurrent } from 'web/hooks/use-ab-test'
 import { PostRow } from '../posts/post-row'
 import { QUERY_KEY, SearchParams, SORT_KEY, TOPIC_FILTER_KEY } from '../search'
 import {
@@ -26,6 +32,7 @@ type CombinedResultsProps = {
   hideAvatars?: boolean
   hideActions?: boolean
   hasBets?: boolean
+  discoveryTracking?: DiscoveryResultTracking
 }
 
 // Type guard to check if an item is a Contract
@@ -51,6 +58,7 @@ export function CombinedResults(props: CombinedResultsProps) {
     hideAvatars,
     hideActions,
     hasBets,
+    discoveryTracking,
   } = props
 
   const sort =
@@ -75,7 +83,7 @@ export function CombinedResults(props: CombinedResultsProps) {
 
   return (
     <>
-      {combinedItems.map((item) => {
+      {combinedItems.map((item, index) => {
         if (isContract(item)) {
           return (
             <ContractRow
@@ -89,6 +97,34 @@ export function CombinedResults(props: CombinedResultsProps) {
               hideAvatar={hideAvatars}
               columns={contractDisplayColumns} // Pass the defined columns
               showPosition={hasBets}
+              onTrackClick={
+                discoveryTracking
+                  ? () => {
+                      if (
+                        !isABTestAssignmentCurrent(
+                          discoveryTracking.assignmentKey
+                        )
+                      ) {
+                        return
+                      }
+                      void track(DISCOVERY_RESULT_CLICK_EVENT, {
+                        contractId: item.id,
+                        schemaVersion: 1,
+                        presentationId: discoveryTracking.presentationId,
+                        resultSetId: discoveryTracking.resultSetId,
+                        variant: discoveryTracking.variant,
+                        assignmentSource: discoveryTracking.source,
+                        sourceComponent: discoveryTracking.sourceComponent,
+                        surface: discoveryTracking.surface,
+                        compatibilityFallback:
+                          discoveryTracking.compatibilityFallback,
+                        rank: index + 1,
+                        itemType: 'market',
+                        matchType: item.searchMatchType ?? 'lexical',
+                      })
+                    }
+                  : undefined
+              }
             />
           )
         } else if (isPost(item)) {
@@ -98,6 +134,33 @@ export function CombinedResults(props: CombinedResultsProps) {
               post={item}
               highlighted={highlightContractIds?.includes(item.id)} // Assuming posts can also be highlighted by ID
               hideAvatar={hideAvatars}
+              onTrackClick={
+                discoveryTracking
+                  ? () => {
+                      if (
+                        !isABTestAssignmentCurrent(
+                          discoveryTracking.assignmentKey
+                        )
+                      ) {
+                        return
+                      }
+                      void track(DISCOVERY_RESULT_CLICK_EVENT, {
+                        schemaVersion: 1,
+                        presentationId: discoveryTracking.presentationId,
+                        resultSetId: discoveryTracking.resultSetId,
+                        variant: discoveryTracking.variant,
+                        assignmentSource: discoveryTracking.source,
+                        sourceComponent: discoveryTracking.sourceComponent,
+                        surface: discoveryTracking.surface,
+                        compatibilityFallback:
+                          discoveryTracking.compatibilityFallback,
+                        rank: index + 1,
+                        itemType: 'post',
+                        postId: item.id,
+                      })
+                    }
+                  : undefined
+              }
             />
           )
         }

--- a/web/components/contract/combined-results.tsx
+++ b/web/components/contract/combined-results.tsx
@@ -1,11 +1,12 @@
 import { Answer } from 'common/answer'
+import { FullMarketSearchResult } from 'common/api/market-search-types'
 import { Contract } from 'common/contract'
 import { orderCombinedSearchResults } from 'common/search-result-order'
 import { TopLevelPost } from 'common/top-level-post'
 import { buildArray } from 'common/util/array'
 import { Key } from 'react'
 import { PostRow } from '../posts/post-row'
-import { SearchParams, QUERY_KEY, SORT_KEY, TOPIC_FILTER_KEY } from '../search'
+import { QUERY_KEY, SearchParams, SORT_KEY, TOPIC_FILTER_KEY } from '../search'
 import {
   actionColumn,
   boostedColumn,
@@ -16,7 +17,7 @@ import {
 import { ContractRow } from './contracts-table'
 
 type CombinedResultsProps = {
-  contracts: Contract[]
+  contracts: FullMarketSearchResult[]
   posts: TopLevelPost[]
   searchParams: SearchParams
   onContractClick?: (contract: Contract) => void
@@ -28,7 +29,9 @@ type CombinedResultsProps = {
 }
 
 // Type guard to check if an item is a Contract
-function isContract(item: Contract | TopLevelPost): item is Contract {
+function isContract(
+  item: FullMarketSearchResult | TopLevelPost
+): item is FullMarketSearchResult {
   return 'mechanism' in item
 }
 
@@ -56,10 +59,7 @@ export function CombinedResults(props: CombinedResultsProps) {
       : searchParams[SORT_KEY]
   const combinedItems = orderCombinedSearchResults(contracts, posts, {
     sort,
-    // The API deliberately returns exact/lexical markets before its semantic
-    // tail. Raw importance cannot reproduce that relevance ordering, so posts
-    // follow the ordered market block for a text search.
-    preserveContractOrder:
+    preserveUnmarkedContractOrder:
       sort === 'score' && searchParams[QUERY_KEY].trim().length > 0,
   })
   if (!combinedItems.length) return null

--- a/web/components/contract/combined-results.tsx
+++ b/web/components/contract/combined-results.tsx
@@ -1,16 +1,11 @@
 import { Answer } from 'common/answer'
 import { Contract } from 'common/contract'
+import { orderCombinedSearchResults } from 'common/search-result-order'
 import { TopLevelPost } from 'common/top-level-post'
 import { buildArray } from 'common/util/array'
-import { sortBy } from 'lodash'
 import { Key } from 'react'
 import { PostRow } from '../posts/post-row'
-import {
-  SearchParams,
-  SORT_KEY,
-  SORTS_MIXING_POSTS_AND_MARKETS,
-  TOPIC_FILTER_KEY,
-} from '../search'
+import { SearchParams, QUERY_KEY, SORT_KEY, TOPIC_FILTER_KEY } from '../search'
 import {
   actionColumn,
   boostedColumn,
@@ -59,15 +54,14 @@ export function CombinedResults(props: CombinedResultsProps) {
     searchParams[TOPIC_FILTER_KEY] === 'recent'
       ? undefined
       : searchParams[SORT_KEY]
-  let combinedItems: (Contract | TopLevelPost)[] = []
-  combinedItems =
-    sort && SORTS_MIXING_POSTS_AND_MARKETS.includes(sort)
-      ? sortBy([...contracts, ...posts], (item) => {
-          if (sort === 'newest') return -item.createdTime
-          if (sort === 'score') return -item.importanceScore
-          return 0
-        })
-      : [...contracts, ...posts]
+  const combinedItems = orderCombinedSearchResults(contracts, posts, {
+    sort,
+    // The API deliberately returns exact/lexical markets before its semantic
+    // tail. Raw importance cannot reproduce that relevance ordering, so posts
+    // follow the ordered market block for a text search.
+    preserveContractOrder:
+      sort === 'score' && searchParams[QUERY_KEY].trim().length > 0,
+  })
   if (!combinedItems.length) return null
 
   // Define columns for ContractRow, similar to how ContractsTable did

--- a/web/components/contract/combined-results.tsx
+++ b/web/components/contract/combined-results.tsx
@@ -3,16 +3,26 @@ import { FullMarketSearchResult } from 'common/api/market-search-types'
 import { Contract } from 'common/contract'
 import {
   DISCOVERY_RESULT_CLICK_EVENT,
+  DiscoveryExperimentVariant,
   DiscoveryResultTracking,
 } from 'common/discovery-experiment'
-import { orderCombinedSearchResults } from 'common/search-result-order'
+import {
+  orderCombinedSearchResults,
+  shouldPreserveBackendMarketOrder,
+} from 'common/search-result-order'
 import { TopLevelPost } from 'common/top-level-post'
 import { buildArray } from 'common/util/array'
 import { Key } from 'react'
 import { track } from 'web/lib/service/analytics'
 import { isABTestAssignmentCurrent } from 'web/hooks/use-ab-test'
 import { PostRow } from '../posts/post-row'
-import { QUERY_KEY, SearchParams, SORT_KEY, TOPIC_FILTER_KEY } from '../search'
+import {
+  FOR_YOU_KEY,
+  QUERY_KEY,
+  SearchParams,
+  SORT_KEY,
+  TOPIC_FILTER_KEY,
+} from '../search'
 import {
   actionColumn,
   boostedColumn,
@@ -32,6 +42,7 @@ type CombinedResultsProps = {
   hideAvatars?: boolean
   hideActions?: boolean
   hasBets?: boolean
+  discoveryVariant?: DiscoveryExperimentVariant
   discoveryTracking?: DiscoveryResultTracking
 }
 
@@ -58,6 +69,7 @@ export function CombinedResults(props: CombinedResultsProps) {
     hideAvatars,
     hideActions,
     hasBets,
+    discoveryVariant,
     discoveryTracking,
   } = props
 
@@ -67,8 +79,11 @@ export function CombinedResults(props: CombinedResultsProps) {
       : searchParams[SORT_KEY]
   const combinedItems = orderCombinedSearchResults(contracts, posts, {
     sort,
-    preserveUnmarkedContractOrder:
-      sort === 'score' && searchParams[QUERY_KEY].trim().length > 0,
+    preserveBackendMarketOrder: shouldPreserveBackendMarketOrder(
+      discoveryVariant,
+      searchParams[QUERY_KEY],
+      searchParams[FOR_YOU_KEY] === '1'
+    ),
   })
   if (!combinedItems.length) return null
 

--- a/web/components/contract/contracts-table.tsx
+++ b/web/components/contract/contracts-table.tsx
@@ -194,6 +194,7 @@ export function ContractRow(props: {
   hideAvatar?: boolean
   answers?: Answer[]
   showPosition?: boolean
+  onTrackClick?: () => void
 }) {
   const contract = useLiveContract(props.contract)
   const isPoll = contract.outcomeType === 'POLL'
@@ -206,6 +207,7 @@ export function ContractRow(props: {
     onClick,
     answers,
     showPosition,
+    onTrackClick,
   } = props
 
   const savedMetric = useSavedContractMetrics(contract)
@@ -228,6 +230,7 @@ export function ContractRow(props: {
       <Link
         href={contractPath(contract)}
         onClick={(e) => {
+          onTrackClick?.()
           if (!onClick) {
             track('click browse contract', {
               slug: contract.slug,

--- a/web/components/posts/post-row.tsx
+++ b/web/components/posts/post-row.tsx
@@ -15,12 +15,14 @@ export function PostRow(props: {
   highlighted?: boolean
   faded?: boolean
   hideAvatar?: boolean
+  onTrackClick?: () => void
   // Add any other props similar to ContractRow if needed for styling/functionality
 }) {
-  const { post, highlighted, faded, hideAvatar } = props
+  const { post, highlighted, faded, hideAvatar, onTrackClick } = props
 
   // Example handler, similar to ContractRow's onClick
   const onClick = () => {
+    onTrackClick?.()
     track('click browse post', {
       slug: post.slug,
       postId: post.id,

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -6,20 +6,40 @@ import clsx from 'clsx'
 import { FullMarketSearchResult } from 'common/api/market-search-types'
 import { FullUser } from 'common/api/user-types'
 import { APIError } from 'common/api/utils'
+import { getForcedABTestVariant } from 'common/ab-test'
 import { Contract } from 'common/contract'
+import {
+  DISCOVERY_EXPERIMENT_NAME,
+  DISCOVERY_EXPERIMENT_VARIANTS,
+  DISCOVERY_EXPOSURE_EVENT,
+  DISCOVERY_RESULTS_EVENT,
+  DISCOVERY_SEARCH_ABORT_EVENT,
+  DISCOVERY_SEARCH_ERROR_EVENT,
+  DISCOVERY_SEARCH_REQUEST_EVENT,
+  DiscoveryExperimentAssignmentSource,
+  DiscoveryExperimentSurface,
+  DiscoveryExperimentVariant,
+  DiscoveryResultTracking,
+  getDiscoveryQueryLengthBucket,
+} from 'common/discovery-experiment'
 import { LiteGroup } from 'common/group'
-import { getPostSearchThreshold } from 'common/search-result-order'
+import {
+  getPostSearchThreshold,
+  orderCombinedSearchResults,
+} from 'common/search-result-order'
 import {
   getLoadMoreRequestAction,
   getSearchRequestDebounceMs,
+  shouldSendDiscoveryOptions,
   shouldRetrySearchWithoutDiscoveryOptions,
   shouldRetryStaleSearchRequest,
 } from 'common/search-request-coordination'
 import { CONTRACTS_PER_SEARCH_PAGE } from 'common/supabase/contracts'
 import { buildArray } from 'common/util/array'
+import { randomString } from 'common/util/random'
 import { capitalize, groupBy, orderBy, sample, uniqBy } from 'lodash'
 import Link from 'next/link'
-import { ReactNode, useEffect, useRef, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from 'web/components/buttons/button'
 import { AddContractToGroupButton } from 'web/components/topics/add-contract-to-group-modal'
 import { useDebouncedEffect } from 'web/hooks/use-debounced-effect'
@@ -41,9 +61,13 @@ import { DAY_MS } from 'common/util/time'
 import { isEqual } from 'lodash'
 import { LoadMoreUntilNotVisible } from 'web/components/widgets/visibility-observer'
 import { useAPIGetter } from 'web/hooks/use-api-getter'
+import {
+  isABTestAssignmentCurrent,
+  useABTestAssignment,
+} from 'web/hooks/use-ab-test'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
 import { useIsPageVisible } from 'web/hooks/use-page-visible'
-import { useUser } from 'web/hooks/use-user'
+import { useIsAuthorized, useUser } from 'web/hooks/use-user'
 import { db } from 'web/lib/supabase/db'
 import { CombinedResults } from './contract/combined-results'
 import { LoadingContractRow } from './contract/contracts-table'
@@ -58,6 +82,7 @@ import { LiveRegion } from './widgets/live-region'
 
 const USERS_PER_PAGE = 100
 const TOPICS_PER_PAGE = 100
+const MAX_TRACKED_DISCOVERY_ITEMS = 100
 
 export const SORTS = [
   { label: 'Best', value: 'score' },
@@ -203,6 +228,16 @@ export type SearchState = {
   shouldLoadMore: boolean
   posts: TopLevelPost[] | undefined
   seenMarketCutoffTime: number | undefined
+  discoveryVariant: DiscoveryExperimentVariant | undefined
+  discoveryAssignmentSource: DiscoveryExperimentAssignmentSource | undefined
+  discoveryAssignmentKey: string | undefined
+  discoverySurface: DiscoveryExperimentSurface | undefined
+  discoveryResultSetId: string | undefined
+  discoveryLoadedPageCount: number
+  discoveryCompatibilityFallback: boolean
+  discoverySemanticEligible: boolean | undefined
+  discoverySemanticMarketCount: number | undefined
+  discoveryInitialLatencyMs: number | undefined
 }
 
 type SearchProps = {
@@ -311,6 +346,27 @@ export function Search(props: SearchProps) {
 
   const isMobile = useIsMobile()
   const { prefersPlay, setPrefersPlay } = useSweepstakes()
+  const user = useUser()
+  const isAuthorized = useIsAuthorized()
+  const forcedDiscoveryVariant = getForcedABTestVariant(
+    user?.id,
+    DISCOVERY_EXPERIMENT_VARIANTS
+  )
+  const discoveryAssignment = useABTestAssignment(
+    DISCOVERY_EXPERIMENT_NAME,
+    DISCOVERY_EXPERIMENT_VARIANTS,
+    {
+      isReady: isAuthorized !== undefined,
+      userId: user?.id,
+      forcedVariant: forcedDiscoveryVariant,
+    }
+  )
+  const discoveryVariant = discoveryAssignment?.variant
+  const discoveryAssignmentKey = discoveryAssignment
+    ? `${discoveryAssignment.assignmentUnit}:${discoveryAssignment.assignmentId}`
+    : undefined
+  const discoveryAssignmentSource: DiscoveryExperimentAssignmentSource =
+    forcedDiscoveryVariant ? 'forced' : user ? 'user-hash' : 'device-hash'
   const [searchParams, setSearchParams, isReady] = useSearchQueryState({
     defaultSort,
     defaultFilter,
@@ -355,14 +411,25 @@ export function Search(props: SearchProps) {
     loadMoreContracts,
     refreshContracts,
     posts,
+    discoveryTracking,
   } = useSearchResults({
     persistPrefix,
     searchParams: searchParams,
     includeUsersAndTopics: showSearchTypes,
-    isReady,
+    isReady: isReady && discoveryVariant !== undefined,
+    discoveryVariant,
+    discoveryAssignmentSource,
+    discoveryAssignmentKey,
     additionalFilter,
   })
   const visible = useIsPageVisible()
+  useTrackDiscoveryExposure({
+    contracts,
+    posts,
+    searchParams,
+    tracking: discoveryTracking,
+    visible,
+  })
   useEffect(() => {
     if (visible && refreshOnVisible) {
       refreshContracts()
@@ -476,7 +543,6 @@ export function Search(props: SearchProps) {
     : undefined
   const selectedAll =
     !selectedTopic && !selectedFollowed && !searchParams[TOPIC_FILTER_KEY]
-  const user = useUser()
   const {
     data: followedGroupsData,
     loading: isLoadingFollowedGroups,
@@ -768,6 +834,14 @@ export function Search(props: SearchProps) {
             extraFilterPills={extraFilterPills}
           />
         )}
+        {isWholePage && forcedDiscoveryVariant && discoveryVariant && (
+          <div
+            className="text-ink-400 px-2 text-right text-xs"
+            title="This QA account has a fixed discovery experiment assignment."
+          >
+            Discovery v1 · {capitalize(discoveryVariant)}
+          </div>
+        )}
       </Col>
       <Spacer h={1} />
       <div id={searchResultsId} role="listbox" aria-labelledby={searchInputId}>
@@ -876,6 +950,7 @@ export function Search(props: SearchProps) {
                 hideAvatars={hideAvatars}
                 hideActions={hideActions}
                 hasBets={hasBets}
+                discoveryTracking={discoveryTracking}
               />
             ) : null}
             <LoadMoreUntilNotVisible loadMore={loadMoreContracts} />
@@ -962,6 +1037,16 @@ const FRESH_SEARCH_CHANGED_STATE: SearchState = {
   shouldLoadMore: true,
   posts: undefined,
   seenMarketCutoffTime: undefined,
+  discoveryVariant: undefined,
+  discoveryAssignmentSource: undefined,
+  discoveryAssignmentKey: undefined,
+  discoverySurface: undefined,
+  discoveryResultSetId: undefined,
+  discoveryLoadedPageCount: 0,
+  discoveryCompatibilityFallback: false,
+  discoverySemanticEligible: undefined,
+  discoverySemanticMarketCount: undefined,
+  discoveryInitialLatencyMs: undefined,
 }
 
 export const useSearchResults = (props: {
@@ -969,9 +1054,24 @@ export const useSearchResults = (props: {
   searchParams: SearchParams
   includeUsersAndTopics: boolean
   isReady: boolean
+  discoveryVariant?: DiscoveryExperimentVariant
+  discoveryAssignmentSource?: DiscoveryExperimentAssignmentSource
+  discoveryAssignmentKey?: string
   additionalFilter?: SupabaseAdditionalFilter
 }) => {
-  const { persistPrefix, searchParams, isReady, additionalFilter } = props
+  const {
+    persistPrefix,
+    searchParams,
+    isReady,
+    discoveryVariant,
+    discoveryAssignmentSource,
+    discoveryAssignmentKey,
+    additionalFilter,
+  } = props
+  // The treatment still applies to every Search instance, but the primary
+  // experiment scorecard is Browse-only. Avoid multiplying user_events write
+  // volume for embedded/topic search instances that the analysis excludes.
+  const trackDiscoveryExperiment = persistPrefix === 'search'
 
   const [state, setState] = usePersistentInMemoryState<SearchState>(
     FRESH_SEARCH_CHANGED_STATE,
@@ -1010,16 +1110,23 @@ export const useSearchResults = (props: {
     )
   }
 
+  const requestParamsChanged = () =>
+    searchParamsChanged(searchParams, lastSearchParams) ||
+    state.discoveryAssignmentKey !== discoveryAssignmentKey ||
+    state.discoveryVariant !== discoveryVariant
+
   const querySearchResults = useEvent(
     async (freshQuery?: boolean, contractsOnly?: boolean) => {
-      if (!isReady) return true
+      if (!isReady || !isABTestAssignmentCurrent(discoveryAssignmentKey)) {
+        return true
+      }
       // A visibility callback can be queued while the user changes filters.
       // Wait for the fresh page instead of paging new params from the old
       // offset. If that fresh request fails, stop the observer's timer loop.
       if (!freshQuery) {
         const action = getLoadMoreRequestAction(
           freshRequestAbortController.current !== undefined,
-          searchParamsChanged(searchParams, lastSearchParams),
+          requestParamsChanged(),
           failedParamsGeneration.current,
           paramsGeneration.current
         )
@@ -1038,6 +1145,19 @@ export const useSearchResults = (props: {
         li: liquidity,
         hb: hasBets,
       } = searchParams
+      const usesForYouRoute =
+        forYou === '1' &&
+        query.length === 0 &&
+        filter !== 'news' &&
+        topicSlug.length === 0 &&
+        gids.length === 0 &&
+        (sort === 'score' || sort === 'freshness-score') &&
+        (sweepState === '0' || sweepState === '2')
+      const discoverySurface: DiscoveryExperimentSurface = query.trim()
+        ? 'text-search'
+        : usesForYouRoute
+        ? 'for-you'
+        : 'browse'
 
       const shouldSearchPostsWithContracts =
         SORTS_MIXING_POSTS_AND_MARKETS.includes(sort) &&
@@ -1057,6 +1177,21 @@ export const useSearchResults = (props: {
         !contractsOnly && props.includeUsersAndTopics
 
       if (freshQuery || state.shouldLoadMore) {
+        const discoveryResultSetId = freshQuery
+          ? randomString(16)
+          : state.discoveryResultSetId ?? randomString(16)
+        const discoveryPage = freshQuery
+          ? 0
+          : state.discoveryLoadedPageCount ?? 0
+        const requestStartedAt = Date.now()
+        let discoveryRequestAttemptId: string | undefined
+        let usedCompatibilityFallback = freshQuery
+          ? false
+          : state.discoveryCompatibilityFallback ?? false
+        const sendDiscoveryOptions = shouldSendDiscoveryOptions(
+          !!freshQuery,
+          usedCompatibilityFallback
+        )
         // A no-op load-more must not cancel an active fresh search. Only
         // replace the controller after we know this invocation will request.
         if (freshQuery) freshRequestAbortController.current?.abort()
@@ -1065,9 +1200,12 @@ export const useSearchResults = (props: {
           freshRequestAbortController.current = abortController
           failedParamsGeneration.current = undefined
         }
-        let seenMarketCutoffTime = freshQuery
-          ? Date.now()
-          : state.seenMarketCutoffTime
+        let seenMarketCutoffTime =
+          discoveryVariant === 'treatment'
+            ? freshQuery
+              ? Date.now()
+              : state.seenMarketCutoffTime
+            : undefined
         const requestParamsGeneration = paramsGeneration.current
         const id = ++requestId.current
         const shouldRetryAfterStaleResult = () =>
@@ -1104,7 +1242,10 @@ export const useSearchResults = (props: {
             const posts = await api('get-posts', postApiParams, {
               signal: abortController.signal,
             })
-            if (id !== requestId.current) {
+            if (
+              id !== requestId.current ||
+              !isABTestAssignmentCurrent(discoveryAssignmentKey)
+            ) {
               finishFreshRequest()
               return shouldRetryAfterStaleResult()
             }
@@ -1116,6 +1257,16 @@ export const useSearchResults = (props: {
               posts: uniqBy(buildArray(state.posts, posts), 'id'),
               shouldLoadMore,
               seenMarketCutoffTime,
+              discoveryVariant,
+              discoveryAssignmentSource,
+              discoveryAssignmentKey,
+              discoverySurface,
+              discoveryResultSetId: undefined,
+              discoveryLoadedPageCount: 0,
+              discoveryCompatibilityFallback: false,
+              discoverySemanticEligible: undefined,
+              discoverySemanticMarketCount: undefined,
+              discoveryInitialLatencyMs: undefined,
             })
 
             // Store the search params that were used for this query
@@ -1131,14 +1282,25 @@ export const useSearchResults = (props: {
           }
           const endpoint =
             topicSlug === 'recent' ? 'recent-markets' : 'search-markets-full'
-          const usesForYouRoute =
-            forYou === '1' &&
-            query.length === 0 &&
-            filter !== 'news' &&
-            topicSlug.length === 0 &&
-            gids.length === 0 &&
-            (sort === 'score' || sort === 'freshness-score') &&
-            (sweepState === '0' || sweepState === '2')
+          if (
+            trackDiscoveryExperiment &&
+            isABTestAssignmentCurrent(discoveryAssignmentKey) &&
+            discoveryVariant &&
+            discoveryAssignmentSource
+          ) {
+            discoveryRequestAttemptId = randomString(16)
+            void track(DISCOVERY_SEARCH_REQUEST_EVENT, {
+              schemaVersion: 1,
+              requestAttemptId: discoveryRequestAttemptId,
+              resultSetId: discoveryResultSetId,
+              variant: discoveryVariant,
+              assignmentSource: discoveryAssignmentSource,
+              sourceComponent: persistPrefix,
+              surface: discoverySurface,
+              page: discoveryPage,
+              isFresh: !!freshQuery,
+            })
+          }
           const marketApiParams: APIParams<'search-markets-full'> = {
             term: query,
             filter,
@@ -1168,13 +1330,22 @@ export const useSearchResults = (props: {
             gids,
             liquidity: liquidity === '' ? undefined : parseInt(liquidity),
             hasBets,
+            discoveryVariant: sendDiscoveryOptions
+              ? discoveryVariant
+              : undefined,
             enableSemanticSearch:
-              endpoint === 'search-markets-full' && query.trim().length > 0
+              sendDiscoveryOptions &&
+              discoveryVariant === 'treatment' &&
+              endpoint === 'search-markets-full' &&
+              query.trim().length > 0
                 ? true
                 : undefined,
-            seenMarketCutoffTime: usesForYouRoute
-              ? seenMarketCutoffTime
-              : undefined,
+            seenMarketCutoffTime:
+              sendDiscoveryOptions &&
+              discoveryVariant === 'treatment' &&
+              usesForYouRoute
+                ? seenMarketCutoffTime
+                : undefined,
           }
           const getMarkets = async () => {
             try {
@@ -1187,7 +1358,9 @@ export const useSearchResults = (props: {
                   !!freshQuery,
                   marketApiParams.seenMarketCutoffTime,
                   marketApiParams.enableSemanticSearch,
-                  error instanceof APIError ? error.code : undefined
+                  marketApiParams.discoveryVariant,
+                  error instanceof APIError ? error.code : undefined,
+                  usesForYouRoute
                 )
               ) {
                 throw error
@@ -1198,6 +1371,7 @@ export const useSearchResults = (props: {
               // semantic opt-in is safe on any page because its fallback only
               // runs on page one. Anchor removal is guarded to page one above.
               if (freshQuery) seenMarketCutoffTime = undefined
+              usedCompatibilityFallback = true
               const contracts = await api(
                 endpoint,
                 {
@@ -1206,6 +1380,7 @@ export const useSearchResults = (props: {
                     ? undefined
                     : marketApiParams.seenMarketCutoffTime,
                   enableSemanticSearch: undefined,
+                  discoveryVariant: undefined,
                 },
                 { signal: abortController.signal }
               )
@@ -1250,7 +1425,10 @@ export const useSearchResults = (props: {
 
           const results = await Promise.all(searchPromises)
 
-          if (id === requestId.current) {
+          if (
+            id === requestId.current &&
+            isABTestAssignmentCurrent(discoveryAssignmentKey)
+          ) {
             const newContracts = results[0] as FullMarketSearchResult[]
             let postResultIndex = 1
             const newUsers = includeUsersAndTopics
@@ -1303,6 +1481,37 @@ export const useSearchResults = (props: {
               newContracts.filter((c) => c.searchMatchType !== 'semantic')
                 .length === CONTRACTS_PER_SEARCH_PAGE
 
+            const lexicalMarketCount = newContracts.filter(
+              (contract) => contract.searchMatchType !== 'semantic'
+            ).length
+            const semanticMarketCount = newContracts.length - lexicalMarketCount
+            const requestLatencyMs = Date.now() - requestStartedAt
+            // Match the API's pre-embedding cleanup so the low-hit segment is
+            // classified identically in both experiment arms.
+            const normalizedQuery = query
+              .replace(/['"]/g, '')
+              .trim()
+              .replace(/\s+/g, ' ')
+            const lowerQuery = normalizedQuery.toLowerCase()
+            const semanticEligible =
+              !!freshQuery &&
+              endpoint === 'search-markets-full' &&
+              sort !== 'newest' &&
+              !lowerQuery.startsWith('https://') &&
+              !lowerQuery.startsWith('http://') &&
+              normalizedQuery.length >= 3 &&
+              normalizedQuery.length <= 200 &&
+              lexicalMarketCount < Math.min(CONTRACTS_PER_SEARCH_PAGE, 5)
+            const resultSetSemanticEligible = freshQuery
+              ? semanticEligible
+              : state.discoverySemanticEligible ?? false
+            const resultSetSemanticMarketCount = freshQuery
+              ? semanticMarketCount
+              : state.discoverySemanticMarketCount ?? 0
+            const resultSetInitialLatencyMs = freshQuery
+              ? requestLatencyMs
+              : state.discoveryInitialLatencyMs ?? requestLatencyMs
+
             setState({
               contracts: freshContracts,
               users: includeUsersAndTopics ? newUsers : state.users,
@@ -1310,7 +1519,61 @@ export const useSearchResults = (props: {
               posts: freshPosts,
               shouldLoadMore,
               seenMarketCutoffTime,
+              discoveryVariant,
+              discoveryAssignmentSource,
+              discoveryAssignmentKey,
+              discoverySurface,
+              discoveryResultSetId,
+              discoveryLoadedPageCount: discoveryPage + 1,
+              discoveryCompatibilityFallback: usedCompatibilityFallback,
+              discoverySemanticEligible: resultSetSemanticEligible,
+              discoverySemanticMarketCount: resultSetSemanticMarketCount,
+              discoveryInitialLatencyMs: resultSetInitialLatencyMs,
             })
+
+            if (
+              trackDiscoveryExperiment &&
+              isABTestAssignmentCurrent(discoveryAssignmentKey) &&
+              discoveryVariant &&
+              discoveryAssignmentSource
+            ) {
+              void track(DISCOVERY_RESULTS_EVENT, {
+                schemaVersion: 1,
+                requestAttemptId: discoveryRequestAttemptId,
+                resultSetId: discoveryResultSetId,
+                variant: discoveryVariant,
+                assignmentSource: discoveryAssignmentSource,
+                sourceComponent: persistPrefix,
+                surface: discoverySurface,
+                page: discoveryPage,
+                isFresh: !!freshQuery,
+                resultCount: freshContracts.length + (freshPosts?.length ?? 0),
+                pageResultCount:
+                  newContracts.length + (newPostsResults?.length ?? 0),
+                lexicalMarketCount,
+                semanticMarketCount,
+                semanticEligible,
+                postCount: freshPosts?.length ?? 0,
+                queryLengthBucket: getDiscoveryQueryLengthBucket(query),
+                sort,
+                filter,
+                compatibilityFallback: usedCompatibilityFallback,
+                latencyMs: requestLatencyMs,
+                // Store page deltas so telemetry stays linear as people load
+                // more. The exposure event records exact rendered ordering.
+                items: [
+                  ...newContracts.map((item) => ({
+                    id: item.id,
+                    itemType: 'market',
+                    matchType: item.searchMatchType ?? 'lexical',
+                  })),
+                  ...(newPostsResults ?? []).map((item) => ({
+                    id: item.id,
+                    itemType: 'post',
+                  })),
+                ],
+              })
+            }
 
             // Store the search params that were used for this query
             if (freshQuery) {
@@ -1330,11 +1593,50 @@ export const useSearchResults = (props: {
           clearTimeout(timeoutId)
           finishFreshRequest()
           if (error instanceof Error && error.name === 'AbortError') {
+            if (
+              discoveryRequestAttemptId &&
+              isABTestAssignmentCurrent(discoveryAssignmentKey) &&
+              discoveryVariant &&
+              discoveryAssignmentSource
+            ) {
+              void track(DISCOVERY_SEARCH_ABORT_EVENT, {
+                schemaVersion: 1,
+                requestAttemptId: discoveryRequestAttemptId,
+                variant: discoveryVariant,
+                assignmentSource: discoveryAssignmentSource,
+                sourceComponent: persistPrefix,
+                surface: discoverySurface,
+                page: discoveryPage,
+                isFresh: !!freshQuery,
+                latencyMs: Date.now() - requestStartedAt,
+              })
+            }
             return false
           }
           if (id !== requestId.current) return shouldRetryAfterStaleResult()
           if (freshQuery) {
             failedParamsGeneration.current = requestParamsGeneration
+          }
+          if (
+            discoveryRequestAttemptId &&
+            isABTestAssignmentCurrent(discoveryAssignmentKey) &&
+            discoveryVariant &&
+            discoveryAssignmentSource
+          ) {
+            void track(DISCOVERY_SEARCH_ERROR_EVENT, {
+              schemaVersion: 1,
+              requestAttemptId: discoveryRequestAttemptId,
+              variant: discoveryVariant,
+              assignmentSource: discoveryAssignmentSource,
+              sourceComponent: persistPrefix,
+              surface: discoverySurface,
+              page: discoveryPage,
+              isFresh: !!freshQuery,
+              compatibilityFallback: usedCompatibilityFallback,
+              errorCode: error instanceof APIError ? error.code : undefined,
+              errorType: error instanceof Error ? error.name : typeof error,
+              latencyMs: Date.now() - requestStartedAt,
+            })
           }
           console.error('Error fetching search results:', error)
           setLoading(false)
@@ -1361,7 +1663,11 @@ export const useSearchResults = (props: {
     setLoading(false)
   })
 
-  const serializedSearchParams = JSON.stringify(searchParams)
+  const serializedSearchParams = JSON.stringify({
+    searchParams,
+    discoveryAssignmentKey,
+    discoveryVariant,
+  })
   useSafeLayoutEffect(() => {
     // Invalidate a superseded request immediately. Waiting for the next
     // debounced request would let the old response land during that delay.
@@ -1391,10 +1697,7 @@ export const useSearchResults = (props: {
       // One effect avoids duplicate initial requests. Term typing waits long
       // enough for ordinary keystroke bursts to settle; filter changes stay
       // responsive.
-      if (
-        state.contracts === undefined ||
-        searchParamsChanged(searchParams, lastSearchParams)
-      ) {
+      if (state.contracts === undefined || requestParamsChanged()) {
         querySearchResults(true)
       }
     },
@@ -1402,31 +1705,140 @@ export const useSearchResults = (props: {
     [isReady, serializedSearchParams]
   )
 
-  const contracts = state.contracts
-    ? uniqBy(
-        state.contracts.filter((c) => {
-          return (
-            !additionalFilter?.excludeContractIds?.includes(c.id) &&
-            !additionalFilter?.excludeGroupSlugs?.some((slug) =>
-              c.groupSlugs?.includes(slug)
-            ) &&
-            !additionalFilter?.excludeUserIds?.includes(c.creatorId)
-          )
-        }),
-        'id'
-      )
-    : undefined
+  // Persistent results are shared by the component key, so never render one
+  // account's personalized rows (or stale params) while a replacement loads.
+  const hasCurrentResults = !requestParamsChanged()
+  const contracts =
+    hasCurrentResults && state.contracts
+      ? uniqBy(
+          state.contracts.filter((c) => {
+            return (
+              !additionalFilter?.excludeContractIds?.includes(c.id) &&
+              !additionalFilter?.excludeGroupSlugs?.some((slug) =>
+                c.groupSlugs?.includes(slug)
+              ) &&
+              !additionalFilter?.excludeUserIds?.includes(c.creatorId)
+            )
+          }),
+          'id'
+        )
+      : undefined
+
+  // A result set can be restored from the in-memory cache on a later visit.
+  // Give each mounted presentation its own denominator while keeping the
+  // result-set ID stable for response/page diagnostics.
+  const discoveryPresentationId = useMemo(
+    () => (state.discoveryResultSetId ? randomString(16) : undefined),
+    [state.discoveryResultSetId]
+  )
+
+  const stateAssignmentKey = state.discoveryAssignmentKey
+  const discoveryTracking: DiscoveryResultTracking | undefined =
+    trackDiscoveryExperiment &&
+    stateAssignmentKey &&
+    state.discoveryResultSetId &&
+    discoveryPresentationId &&
+    state.discoveryVariant &&
+    state.discoveryAssignmentSource &&
+    state.discoverySurface &&
+    state.discoverySemanticEligible !== undefined &&
+    state.discoverySemanticMarketCount !== undefined &&
+    state.discoveryInitialLatencyMs !== undefined &&
+    stateAssignmentKey === discoveryAssignmentKey &&
+    state.discoveryVariant === discoveryVariant &&
+    isABTestAssignmentCurrent(discoveryAssignmentKey) &&
+    !requestParamsChanged()
+      ? {
+          assignmentKey: stateAssignmentKey,
+          resultSetId: state.discoveryResultSetId,
+          presentationId: discoveryPresentationId,
+          variant: state.discoveryVariant,
+          source: state.discoveryAssignmentSource,
+          sourceComponent: persistPrefix,
+          surface: state.discoverySurface,
+          semanticEligible: state.discoverySemanticEligible,
+          semanticMarketCount: state.discoverySemanticMarketCount,
+          initialLatencyMs: state.discoveryInitialLatencyMs,
+          compatibilityFallback: state.discoveryCompatibilityFallback ?? false,
+        }
+      : undefined
 
   return {
     contracts,
-    users: state.users,
-    topics: state.topics,
+    users: hasCurrentResults ? state.users : undefined,
+    topics: hasCurrentResults ? state.topics : undefined,
     loading,
-    shouldLoadMore: state.shouldLoadMore,
+    shouldLoadMore: hasCurrentResults ? state.shouldLoadMore : true,
     loadMoreContracts: () => querySearchResults(false, true),
     refreshContracts: () => querySearchResults(true, true),
-    posts: state.posts,
+    posts: hasCurrentResults ? state.posts : undefined,
+    discoveryTracking,
   }
+}
+
+const useTrackDiscoveryExposure = (props: {
+  contracts: FullMarketSearchResult[] | undefined
+  posts: TopLevelPost[] | undefined
+  searchParams: SearchParams
+  tracking: DiscoveryResultTracking | undefined
+  visible: boolean
+}) => {
+  const { contracts, posts, searchParams, tracking, visible } = props
+  const trackedPresentationId = useRef<string>()
+
+  useEffect(() => {
+    if (
+      !visible ||
+      !tracking ||
+      !isABTestAssignmentCurrent(tracking.assignmentKey) ||
+      (contracts === undefined && posts === undefined) ||
+      trackedPresentationId.current === tracking.presentationId
+    ) {
+      return
+    }
+    trackedPresentationId.current = tracking.presentationId
+
+    const sort =
+      searchParams[TOPIC_FILTER_KEY] === 'recent'
+        ? undefined
+        : searchParams[SORT_KEY]
+    const items = orderCombinedSearchResults(contracts ?? [], posts ?? [], {
+      sort,
+      preserveUnmarkedContractOrder:
+        sort === 'score' && searchParams[QUERY_KEY].trim().length > 0,
+    })
+
+    void track(DISCOVERY_EXPOSURE_EVENT, {
+      schemaVersion: 1,
+      presentationId: tracking.presentationId,
+      resultSetId: tracking.resultSetId,
+      variant: tracking.variant,
+      assignmentSource: tracking.source,
+      sourceComponent: tracking.sourceComponent,
+      surface: tracking.surface,
+      semanticEligible: tracking.semanticEligible,
+      semanticMarketCount: tracking.semanticMarketCount,
+      initialLatencyMs: tracking.initialLatencyMs,
+      compatibilityFallback: tracking.compatibilityFallback,
+      resultCount: items.length,
+      marketCount: items.filter((item) => 'mechanism' in item).length,
+      postCount: items.filter((item) => !('mechanism' in item)).length,
+      items: items.slice(0, MAX_TRACKED_DISCOVERY_ITEMS).map((item, index) =>
+        'mechanism' in item
+          ? {
+              id: item.id,
+              itemType: 'market',
+              rank: index + 1,
+              matchType: item.searchMatchType ?? 'lexical',
+            }
+          : {
+              id: item.id,
+              itemType: 'post',
+              rank: index + 1,
+            }
+      ),
+    })
+  }, [visible, tracking, contracts, posts, searchParams])
 }
 
 export const useSearchQueryState = (props: {

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -980,6 +980,8 @@ export const useSearchResults = (props: {
 
   const requestId = useRef(0)
   const freshRequestAbortController = useRef<AbortController>()
+  const initialQuery = useRef<string>()
+  const completedInThisMount = useRef(false)
 
   useEffect(
     () => () => {
@@ -1098,6 +1100,7 @@ export const useSearchResults = (props: {
             // Store the search params that were used for this query
             if (freshQuery) {
               setLastSearchParams(searchParams)
+              completedInThisMount.current = true
             }
 
             clearTimeout(timeoutId)
@@ -1151,7 +1154,11 @@ export const useSearchResults = (props: {
                 gids,
                 liquidity: liquidity === '' ? undefined : parseInt(liquidity),
                 hasBets,
-                seenMarketCutoffTime,
+                // Server only suppresses on For You; sending it elsewhere only
+                // risks strict-schema rejections from an older API worker
+                // during a rolling deploy.
+                seenMarketCutoffTime:
+                  forYou === '1' ? seenMarketCutoffTime : undefined,
               },
               { signal: abortController.signal }
             ),
@@ -1225,8 +1232,10 @@ export const useSearchResults = (props: {
                     'id'
                   )
 
+            // Semantic rows only pad page one, so they never imply a page two.
             const shouldLoadMore =
-              newContracts.length === CONTRACTS_PER_SEARCH_PAGE
+              newContracts.filter((c) => c.searchMatchType !== 'semantic')
+                .length === CONTRACTS_PER_SEARCH_PAGE
 
             setState({
               contracts: freshContracts,
@@ -1240,6 +1249,7 @@ export const useSearchResults = (props: {
             // Store the search params that were used for this query
             if (freshQuery) {
               setLastSearchParams(searchParams)
+              completedInThisMount.current = true
             }
 
             clearTimeout(timeoutId)
@@ -1283,12 +1293,26 @@ export const useSearchResults = (props: {
     cancelFreshRequest()
   }, [serializedSearchParams, cancelFreshRequest])
 
+  // The URL query reaches searchParams a render after isReady, so the query
+  // the page mounted with is whatever the first debounced pass over ready
+  // params sees. Until then the current query stands in for it, which keeps
+  // a deep-linked load as responsive as a blank one.
+  // lastSearchParams outlives this mount, so until a request completes here
+  // it may describe an earlier visit, and a deep-linked query would look
+  // typed next to it.
   const requestDebounceMs = getSearchRequestDebounceMs(
     searchParams[QUERY_KEY],
-    lastSearchParams?.[QUERY_KEY]
+    completedInThisMount.current ? lastSearchParams?.[QUERY_KEY] : undefined,
+    initialQuery.current ?? searchParams[QUERY_KEY]
   )
   useDebouncedEffect(
     () => {
+      // Whether this pass issues the first request or finds results restored
+      // from an earlier visit, the query it sees is the one this mount
+      // committed to, so typing after it waits like a keystroke.
+      if (isReady && initialQuery.current === undefined) {
+        initialQuery.current = searchParams[QUERY_KEY]
+      }
       // One effect avoids duplicate initial requests. Term typing waits long
       // enough for ordinary keystroke bursts to settle; filter changes stay
       // responsive.

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -192,6 +192,7 @@ export type SearchState = {
   topics: LiteGroup[] | undefined
   shouldLoadMore: boolean
   posts: TopLevelPost[] | undefined
+  seenMarketCutoffTime: number | undefined
 }
 
 type SearchProps = {
@@ -950,6 +951,7 @@ const FRESH_SEARCH_CHANGED_STATE: SearchState = {
   topics: undefined,
   shouldLoadMore: true,
   posts: undefined,
+  seenMarketCutoffTime: undefined,
 }
 
 export const useSearchResults = (props: {
@@ -1021,6 +1023,9 @@ export const useSearchResults = (props: {
         !contractsOnly && props.includeUsersAndTopics
 
       if (freshQuery || state.shouldLoadMore) {
+        const seenMarketCutoffTime = freshQuery
+          ? Date.now()
+          : state.seenMarketCutoffTime ?? Date.now()
         const id = ++requestId.current
         let timeoutId: NodeJS.Timeout | undefined
         if (freshQuery) {
@@ -1047,6 +1052,7 @@ export const useSearchResults = (props: {
               topics: undefined,
               posts: uniqBy(buildArray(state.posts, posts), 'id'),
               shouldLoadMore,
+              seenMarketCutoffTime,
             })
 
             // Store the search params that were used for this query
@@ -1100,6 +1106,7 @@ export const useSearchResults = (props: {
               gids,
               liquidity: liquidity === '' ? undefined : parseInt(liquidity),
               hasBets,
+              seenMarketCutoffTime,
             }),
           ]
 
@@ -1200,6 +1207,7 @@ export const useSearchResults = (props: {
               topics: includeUsersAndTopics ? newTopics?.lite : state.topics,
               posts: freshPosts,
               shouldLoadMore,
+              seenMarketCutoffTime,
             })
 
             // Store the search params that were used for this query

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -1,13 +1,17 @@
 'use client'
 import { useEvent } from 'client-common/hooks/use-event'
 import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
+import { useSafeLayoutEffect } from 'client-common/hooks/use-safe-layout-effect'
 import clsx from 'clsx'
+import { FullMarketSearchResult } from 'common/api/market-search-types'
 import { FullUser } from 'common/api/user-types'
 import { Contract } from 'common/contract'
 import { LiteGroup } from 'common/group'
+import { getPostSearchThreshold } from 'common/search-result-order'
+import { getSearchRequestDebounceMs } from 'common/search-request-coordination'
 import { CONTRACTS_PER_SEARCH_PAGE } from 'common/supabase/contracts'
 import { buildArray } from 'common/util/array'
-import { capitalize, groupBy, minBy, orderBy, sample, uniqBy } from 'lodash'
+import { capitalize, groupBy, orderBy, sample, uniqBy } from 'lodash'
 import Link from 'next/link'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 import { Button } from 'web/components/buttons/button'
@@ -187,7 +191,7 @@ export type SupabaseAdditionalFilter = {
 }
 
 export type SearchState = {
-  contracts: Contract[] | undefined
+  contracts: FullMarketSearchResult[] | undefined
   users: FullUser[] | undefined
   topics: LiteGroup[] | undefined
   shouldLoadMore: boolean
@@ -1174,7 +1178,7 @@ export const useSearchResults = (props: {
           const results = await Promise.all(searchPromises)
 
           if (id === requestId.current) {
-            const newContracts = results[0] as Contract[]
+            const newContracts = results[0] as FullMarketSearchResult[]
             let postResultIndex = 1
             const newUsers = includeUsersAndTopics
               ? (results[postResultIndex++] as FullUser[])
@@ -1192,42 +1196,18 @@ export const useSearchResults = (props: {
             const freshContracts = freshQuery
               ? newContracts
               : buildArray(state.contracts, newContracts)
-            const bottomScoreFromAllContracts =
-              sort === 'score'
-                ? minBy(freshContracts, 'importanceScore')?.importanceScore
-                : minBy(freshContracts, 'createdTime')?.createdTime
 
             // This is necessary bc the posts are in a different table than the contracts.
             // TODO: this is bad and will leave posts out of the search results randomly.
             // We should fix this by joining the posts table to the contracts table or something.
-            let postFilteringThreshold: number | undefined
-            if (sort === 'score') {
-              if (
-                !freshQuery &&
-                state.contracts &&
-                state.contracts.length > 0
-              ) {
-                postFilteringThreshold = minBy(
-                  state.contracts,
-                  'importanceScore'
-                )?.importanceScore
-              } else {
-                postFilteringThreshold = bottomScoreFromAllContracts
-              }
-            } else {
-              if (
-                !freshQuery &&
-                state.contracts &&
-                state.contracts.length > 0
-              ) {
-                postFilteringThreshold = minBy(
-                  state.contracts,
-                  'createdTime'
-                )?.createdTime
-              } else {
-                postFilteringThreshold = bottomScoreFromAllContracts
-              }
-            }
+            const contractsBeforeNewPosts =
+              !freshQuery && state.contracts?.length
+                ? state.contracts
+                : freshContracts
+            const postFilteringThreshold = getPostSearchThreshold(
+              contractsBeforeNewPosts,
+              sort === 'score' ? 'score' : 'newest'
+            )
             const freshPosts =
               freshQuery || !state.posts
                 ? newPostsResults
@@ -1283,9 +1263,30 @@ export const useSearchResults = (props: {
     }
   )
 
-  const searchTermChanged =
-    lastSearchParams !== null &&
-    searchParams[QUERY_KEY] !== lastSearchParams[QUERY_KEY]
+  const cancelFreshRequest = useEvent(() => {
+    const controller = freshRequestAbortController.current
+    if (!controller) return
+
+    // Invalidate before aborting so even an already-resolved continuation
+    // cannot publish stale state. The debounced effect issues any replacement
+    // required by the new params.
+    freshRequestAbortController.current = undefined
+    requestId.current++
+    controller.abort()
+    setLoading(false)
+  })
+
+  const serializedSearchParams = JSON.stringify(searchParams)
+  useSafeLayoutEffect(() => {
+    // Invalidate a superseded request immediately. Waiting for the next
+    // debounced request would let the old response land during that delay.
+    cancelFreshRequest()
+  }, [serializedSearchParams, cancelFreshRequest])
+
+  const requestDebounceMs = getSearchRequestDebounceMs(
+    searchParams[QUERY_KEY],
+    lastSearchParams?.[QUERY_KEY]
+  )
   useDebouncedEffect(
     () => {
       // One effect avoids duplicate initial requests. Term typing waits long
@@ -1298,8 +1299,8 @@ export const useSearchResults = (props: {
         querySearchResults(true)
       }
     },
-    searchTermChanged ? 300 : 50,
-    [isReady, JSON.stringify(searchParams)]
+    requestDebounceMs,
+    [isReady, serializedSearchParams]
   )
 
   const contracts = state.contracts

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -5,10 +5,16 @@ import { useSafeLayoutEffect } from 'client-common/hooks/use-safe-layout-effect'
 import clsx from 'clsx'
 import { FullMarketSearchResult } from 'common/api/market-search-types'
 import { FullUser } from 'common/api/user-types'
+import { APIError } from 'common/api/utils'
 import { Contract } from 'common/contract'
 import { LiteGroup } from 'common/group'
 import { getPostSearchThreshold } from 'common/search-result-order'
-import { getSearchRequestDebounceMs } from 'common/search-request-coordination'
+import {
+  getLoadMoreRequestAction,
+  getSearchRequestDebounceMs,
+  shouldRetrySearchWithoutDiscoveryOptions,
+  shouldRetryStaleSearchRequest,
+} from 'common/search-request-coordination'
 import { CONTRACTS_PER_SEARCH_PAGE } from 'common/supabase/contracts'
 import { buildArray } from 'common/util/array'
 import { capitalize, groupBy, orderBy, sample, uniqBy } from 'lodash'
@@ -979,6 +985,8 @@ export const useSearchResults = (props: {
     )
 
   const requestId = useRef(0)
+  const paramsGeneration = useRef(0)
+  const failedParamsGeneration = useRef<number>()
   const freshRequestAbortController = useRef<AbortController>()
   const initialQuery = useRef<string>()
   const completedInThisMount = useRef(false)
@@ -1006,14 +1014,17 @@ export const useSearchResults = (props: {
     async (freshQuery?: boolean, contractsOnly?: boolean) => {
       if (!isReady) return true
       // A visibility callback can be queued while the user changes filters.
-      // Retry it after the fresh page lands instead of paging the new params
-      // with an offset and anchor from the old result set.
-      if (
-        !freshQuery &&
-        (freshRequestAbortController.current !== undefined ||
-          searchParamsChanged(searchParams, lastSearchParams))
-      )
-        return true
+      // Wait for the fresh page instead of paging new params from the old
+      // offset. If that fresh request fails, stop the observer's timer loop.
+      if (!freshQuery) {
+        const action = getLoadMoreRequestAction(
+          freshRequestAbortController.current !== undefined,
+          searchParamsChanged(searchParams, lastSearchParams),
+          failedParamsGeneration.current,
+          paramsGeneration.current
+        )
+        if (action !== 'load') return action === 'wait'
+      }
       const {
         q: query,
         s: sort,
@@ -1050,11 +1061,21 @@ export const useSearchResults = (props: {
         // replace the controller after we know this invocation will request.
         if (freshQuery) freshRequestAbortController.current?.abort()
         const abortController = new AbortController()
-        if (freshQuery) freshRequestAbortController.current = abortController
-        const seenMarketCutoffTime = freshQuery
+        if (freshQuery) {
+          freshRequestAbortController.current = abortController
+          failedParamsGeneration.current = undefined
+        }
+        let seenMarketCutoffTime = freshQuery
           ? Date.now()
-          : state.seenMarketCutoffTime ?? Date.now()
+          : state.seenMarketCutoffTime
+        const requestParamsGeneration = paramsGeneration.current
         const id = ++requestId.current
+        const shouldRetryAfterStaleResult = () =>
+          shouldRetryStaleSearchRequest(
+            !!freshQuery,
+            requestParamsGeneration,
+            paramsGeneration.current
+          )
         const finishFreshRequest = () => {
           if (
             freshQuery &&
@@ -1085,7 +1106,7 @@ export const useSearchResults = (props: {
             })
             if (id !== requestId.current) {
               finishFreshRequest()
-              return false
+              return shouldRetryAfterStaleResult()
             }
             const shouldLoadMore = posts.length === postApiParams.limit
             setState({
@@ -1110,59 +1131,104 @@ export const useSearchResults = (props: {
           }
           const endpoint =
             topicSlug === 'recent' ? 'recent-markets' : 'search-markets-full'
+          const usesForYouRoute =
+            forYou === '1' &&
+            query.length === 0 &&
+            filter !== 'news' &&
+            topicSlug.length === 0 &&
+            gids.length === 0 &&
+            (sort === 'score' || sort === 'freshness-score') &&
+            (sweepState === '0' || sweepState === '2')
+          const marketApiParams: APIParams<'search-markets-full'> = {
+            term: query,
+            filter,
+            sort,
+            contractType,
+            ...(() => {
+              const useCursor =
+                !freshQuery && sort === 'newest' && !!state.contracts?.length
+              return useCursor
+                ? {
+                    offset: 0,
+                    beforeTime:
+                      state.contracts![state.contracts!.length - 1]
+                        ?.createdTime,
+                  }
+                : {
+                    offset: freshQuery ? 0 : state.contracts?.length ?? 0,
+                  }
+            })(),
+            limit: CONTRACTS_PER_SEARCH_PAGE,
+            topicSlug: topicSlug !== '' ? topicSlug : undefined,
+            creatorId: additionalFilter?.creatorId,
+            isPrizeMarket: isPrizeMarketString,
+            forYou,
+            token:
+              sweepState === '2' ? 'ALL' : sweepState === '1' ? 'CASH' : 'MANA',
+            gids,
+            liquidity: liquidity === '' ? undefined : parseInt(liquidity),
+            hasBets,
+            enableSemanticSearch:
+              endpoint === 'search-markets-full' && query.trim().length > 0
+                ? true
+                : undefined,
+            seenMarketCutoffTime: usesForYouRoute
+              ? seenMarketCutoffTime
+              : undefined,
+          }
+          const getMarkets = async () => {
+            try {
+              return await api(endpoint, marketApiParams, {
+                signal: abortController.signal,
+              })
+            } catch (error) {
+              if (
+                !shouldRetrySearchWithoutDiscoveryOptions(
+                  !!freshQuery,
+                  marketApiParams.seenMarketCutoffTime,
+                  marketApiParams.enableSemanticSearch,
+                  error instanceof APIError ? error.code : undefined
+                )
+              ) {
+                throw error
+              }
+
+              // A new API rejects a badly skewed page-one anchor; an old
+              // strict worker rejects the new fields. Retrying without the
+              // semantic opt-in is safe on any page because its fallback only
+              // runs on page one. Anchor removal is guarded to page one above.
+              if (freshQuery) seenMarketCutoffTime = undefined
+              const contracts = await api(
+                endpoint,
+                {
+                  ...marketApiParams,
+                  seenMarketCutoffTime: freshQuery
+                    ? undefined
+                    : marketApiParams.seenMarketCutoffTime,
+                  enableSemanticSearch: undefined,
+                },
+                { signal: abortController.signal }
+              )
+              // Semantic fallback never runs after page one, so any unmarked
+              // rows from an old worker are known to be lexical there. Keep a
+              // fresh unmarked response conservative: an intermediate worker
+              // may have returned an unmarked semantic tail.
+              return freshQuery
+                ? contracts
+                : contracts.map((contract) =>
+                    'searchMatchType' in contract
+                      ? contract
+                      : { ...contract, searchMatchType: 'lexical' as const }
+                  )
+            }
+          }
           const searchPromises: Promise<
             | APIResponse<'recent-markets'>
             | APIResponse<'search-markets-full'>
             | APIResponse<'get-posts'>
             | APIResponse<'search-users'>
             | APIResponse<'search-groups'>
-          >[] = [
-            api(
-              endpoint,
-              {
-                term: query,
-                filter,
-                sort,
-                contractType,
-                ...(() => {
-                  const useCursor =
-                    !freshQuery &&
-                    sort === 'newest' &&
-                    !!state.contracts?.length
-                  return useCursor
-                    ? {
-                        offset: 0,
-                        beforeTime:
-                          state.contracts![state.contracts!.length - 1]
-                            ?.createdTime,
-                      }
-                    : {
-                        offset: freshQuery ? 0 : state.contracts?.length ?? 0,
-                      }
-                })(),
-                limit: CONTRACTS_PER_SEARCH_PAGE,
-                topicSlug: topicSlug !== '' ? topicSlug : undefined,
-                creatorId: additionalFilter?.creatorId,
-                isPrizeMarket: isPrizeMarketString,
-                forYou,
-                token:
-                  sweepState === '2'
-                    ? 'ALL'
-                    : sweepState === '1'
-                    ? 'CASH'
-                    : 'MANA',
-                gids,
-                liquidity: liquidity === '' ? undefined : parseInt(liquidity),
-                hasBets,
-                // Server only suppresses on For You; sending it elsewhere only
-                // risks strict-schema rejections from an older API worker
-                // during a rolling deploy.
-                seenMarketCutoffTime:
-                  forYou === '1' ? seenMarketCutoffTime : undefined,
-              },
-              { signal: abortController.signal }
-            ),
-          ]
+          >[] = [getMarkets()]
 
           if (includeUsersAndTopics) {
             searchPromises.push(
@@ -1259,21 +1325,31 @@ export const useSearchResults = (props: {
             return shouldLoadMore
           }
           finishFreshRequest()
+          return shouldRetryAfterStaleResult()
         } catch (error) {
           clearTimeout(timeoutId)
           finishFreshRequest()
           if (error instanceof Error && error.name === 'AbortError') {
             return false
           }
+          if (id !== requestId.current) return shouldRetryAfterStaleResult()
+          if (freshQuery) {
+            failedParamsGeneration.current = requestParamsGeneration
+          }
           console.error('Error fetching search results:', error)
-          if (id === requestId.current) setLoading(false)
+          setLoading(false)
         }
       }
       return false
     }
   )
 
-  const cancelFreshRequest = useEvent(() => {
+  const invalidateCurrentRequests = useEvent(() => {
+    // Load-more requests intentionally do not replace the fresh-request abort
+    // controller, but their result must still become stale as soon as params
+    // change. Advance the generation before checking for a controller.
+    paramsGeneration.current++
+    requestId.current++
     const controller = freshRequestAbortController.current
     if (!controller) return
 
@@ -1281,7 +1357,6 @@ export const useSearchResults = (props: {
     // cannot publish stale state. The debounced effect issues any replacement
     // required by the new params.
     freshRequestAbortController.current = undefined
-    requestId.current++
     controller.abort()
     setLoading(false)
   })
@@ -1290,8 +1365,8 @@ export const useSearchResults = (props: {
   useSafeLayoutEffect(() => {
     // Invalidate a superseded request immediately. Waiting for the next
     // debounced request would let the old response land during that delay.
-    cancelFreshRequest()
-  }, [serializedSearchParams, cancelFreshRequest])
+    invalidateCurrentRequests()
+  }, [serializedSearchParams, invalidateCurrentRequests])
 
   // The URL query reaches searchParams a render after isReady, so the query
   // the page mounted with is whatever the first debounced pass over ready

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -975,6 +975,14 @@ export const useSearchResults = (props: {
     )
 
   const requestId = useRef(0)
+  const freshRequestAbortController = useRef<AbortController>()
+
+  useEffect(
+    () => () => {
+      freshRequestAbortController.current?.abort()
+    },
+    []
+  )
 
   // Helper function to check if search parameters have meaningfully changed
   const searchParamsChanged = (
@@ -991,6 +999,15 @@ export const useSearchResults = (props: {
   const querySearchResults = useEvent(
     async (freshQuery?: boolean, contractsOnly?: boolean) => {
       if (!isReady) return true
+      // A visibility callback can be queued while the user changes filters.
+      // Retry it after the fresh page lands instead of paging the new params
+      // with an offset and anchor from the old result set.
+      if (
+        !freshQuery &&
+        (freshRequestAbortController.current !== undefined ||
+          searchParamsChanged(searchParams, lastSearchParams))
+      )
+        return true
       const {
         q: query,
         s: sort,
@@ -1023,10 +1040,23 @@ export const useSearchResults = (props: {
         !contractsOnly && props.includeUsersAndTopics
 
       if (freshQuery || state.shouldLoadMore) {
+        // A no-op load-more must not cancel an active fresh search. Only
+        // replace the controller after we know this invocation will request.
+        if (freshQuery) freshRequestAbortController.current?.abort()
+        const abortController = new AbortController()
+        if (freshQuery) freshRequestAbortController.current = abortController
         const seenMarketCutoffTime = freshQuery
           ? Date.now()
           : state.seenMarketCutoffTime ?? Date.now()
         const id = ++requestId.current
+        const finishFreshRequest = () => {
+          if (
+            freshQuery &&
+            freshRequestAbortController.current === abortController
+          ) {
+            freshRequestAbortController.current = undefined
+          }
+        }
         let timeoutId: NodeJS.Timeout | undefined
         if (freshQuery) {
           timeoutId = setTimeout(() => {
@@ -1044,7 +1074,13 @@ export const useSearchResults = (props: {
         }
         try {
           if (contractType === 'POSTS') {
-            const posts = await api('get-posts', postApiParams)
+            const posts = await api('get-posts', postApiParams, {
+              signal: abortController.signal,
+            })
+            if (id !== requestId.current) {
+              finishFreshRequest()
+              return false
+            }
             const shouldLoadMore = posts.length === postApiParams.limit
             setState({
               contracts: [],
@@ -1061,6 +1097,7 @@ export const useSearchResults = (props: {
             }
 
             clearTimeout(timeoutId)
+            finishFreshRequest()
             setLoading(false)
             return shouldLoadMore
           }
@@ -1073,41 +1110,47 @@ export const useSearchResults = (props: {
             | APIResponse<'search-users'>
             | APIResponse<'search-groups'>
           >[] = [
-            api(endpoint, {
-              term: query,
-              filter,
-              sort,
-              contractType,
-              ...(() => {
-                const useCursor =
-                  !freshQuery && sort === 'newest' && !!state.contracts?.length
-                return useCursor
-                  ? {
-                      offset: 0,
-                      beforeTime:
-                        state.contracts![state.contracts!.length - 1]
-                          ?.createdTime,
-                    }
-                  : {
-                      offset: freshQuery ? 0 : state.contracts?.length ?? 0,
-                    }
-              })(),
-              limit: CONTRACTS_PER_SEARCH_PAGE,
-              topicSlug: topicSlug !== '' ? topicSlug : undefined,
-              creatorId: additionalFilter?.creatorId,
-              isPrizeMarket: isPrizeMarketString,
-              forYou,
-              token:
-                sweepState === '2'
-                  ? 'ALL'
-                  : sweepState === '1'
-                  ? 'CASH'
-                  : 'MANA',
-              gids,
-              liquidity: liquidity === '' ? undefined : parseInt(liquidity),
-              hasBets,
-              seenMarketCutoffTime,
-            }),
+            api(
+              endpoint,
+              {
+                term: query,
+                filter,
+                sort,
+                contractType,
+                ...(() => {
+                  const useCursor =
+                    !freshQuery &&
+                    sort === 'newest' &&
+                    !!state.contracts?.length
+                  return useCursor
+                    ? {
+                        offset: 0,
+                        beforeTime:
+                          state.contracts![state.contracts!.length - 1]
+                            ?.createdTime,
+                      }
+                    : {
+                        offset: freshQuery ? 0 : state.contracts?.length ?? 0,
+                      }
+                })(),
+                limit: CONTRACTS_PER_SEARCH_PAGE,
+                topicSlug: topicSlug !== '' ? topicSlug : undefined,
+                creatorId: additionalFilter?.creatorId,
+                isPrizeMarket: isPrizeMarketString,
+                forYou,
+                token:
+                  sweepState === '2'
+                    ? 'ALL'
+                    : sweepState === '1'
+                    ? 'CASH'
+                    : 'MANA',
+                gids,
+                liquidity: liquidity === '' ? undefined : parseInt(liquidity),
+                hasBets,
+                seenMarketCutoffTime,
+              },
+              { signal: abortController.signal }
+            ),
           ]
 
           if (includeUsersAndTopics) {
@@ -1121,7 +1164,11 @@ export const useSearchResults = (props: {
             )
           }
           if (shouldSearchPostsWithContracts) {
-            searchPromises.push(api('get-posts', postApiParams))
+            searchPromises.push(
+              api('get-posts', postApiParams, {
+                signal: abortController.signal,
+              })
+            )
           }
 
           const results = await Promise.all(searchPromises)
@@ -1216,37 +1263,43 @@ export const useSearchResults = (props: {
             }
 
             clearTimeout(timeoutId)
+            finishFreshRequest()
             setLoading(false)
 
             return shouldLoadMore
           }
+          finishFreshRequest()
         } catch (error) {
+          clearTimeout(timeoutId)
+          finishFreshRequest()
+          if (error instanceof Error && error.name === 'AbortError') {
+            return false
+          }
           console.error('Error fetching search results:', error)
-          setLoading(false)
+          if (id === requestId.current) setLoading(false)
         }
       }
       return false
     }
   )
 
+  const searchTermChanged =
+    lastSearchParams !== null &&
+    searchParams[QUERY_KEY] !== lastSearchParams[QUERY_KEY]
   useDebouncedEffect(
     () => {
-      if (!state.contracts?.length) {
+      // One effect avoids duplicate initial requests. Term typing waits long
+      // enough for ordinary keystroke bursts to settle; filter changes stay
+      // responsive.
+      if (
+        state.contracts === undefined ||
+        searchParamsChanged(searchParams, lastSearchParams)
+      ) {
         querySearchResults(true)
       }
     },
-    50,
-    [isReady]
-  )
-  useDebouncedEffect(
-    () => {
-      // Only do a fresh query if search parameters have meaningfully changed
-      if (searchParamsChanged(searchParams, lastSearchParams)) {
-        querySearchResults(true)
-      }
-    },
-    50,
-    [JSON.stringify(searchParams)]
+    searchTermChanged ? 300 : 50,
+    [isReady, JSON.stringify(searchParams)]
   )
 
   const contracts = state.contracts

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -26,12 +26,14 @@ import { LiteGroup } from 'common/group'
 import {
   getPostSearchThreshold,
   orderCombinedSearchResults,
+  shouldPreserveBackendMarketOrder,
 } from 'common/search-result-order'
 import {
+  getSearchDiscoveryRetryOptions,
+  getSearchDiscoveryRetryMode,
   getLoadMoreRequestAction,
   getSearchRequestDebounceMs,
   shouldSendDiscoveryOptions,
-  shouldRetrySearchWithoutDiscoveryOptions,
   shouldRetryStaleSearchRequest,
 } from 'common/search-request-coordination'
 import { CONTRACTS_PER_SEARCH_PAGE } from 'common/supabase/contracts'
@@ -235,6 +237,7 @@ export type SearchState = {
   discoveryResultSetId: string | undefined
   discoveryLoadedPageCount: number
   discoveryCompatibilityFallback: boolean
+  discoveryAnchorFallback: boolean
   discoverySemanticEligible: boolean | undefined
   discoverySemanticMarketCount: number | undefined
   discoveryInitialLatencyMs: number | undefined
@@ -950,6 +953,7 @@ export function Search(props: SearchProps) {
                 hideAvatars={hideAvatars}
                 hideActions={hideActions}
                 hasBets={hasBets}
+                discoveryVariant={discoveryVariant}
                 discoveryTracking={discoveryTracking}
               />
             ) : null}
@@ -1044,6 +1048,7 @@ const FRESH_SEARCH_CHANGED_STATE: SearchState = {
   discoveryResultSetId: undefined,
   discoveryLoadedPageCount: 0,
   discoveryCompatibilityFallback: false,
+  discoveryAnchorFallback: false,
   discoverySemanticEligible: undefined,
   discoverySemanticMarketCount: undefined,
   discoveryInitialLatencyMs: undefined,
@@ -1188,6 +1193,9 @@ export const useSearchResults = (props: {
         let usedCompatibilityFallback = freshQuery
           ? false
           : state.discoveryCompatibilityFallback ?? false
+        let usedAnchorFallback = freshQuery
+          ? false
+          : state.discoveryAnchorFallback ?? false
         const sendDiscoveryOptions = shouldSendDiscoveryOptions(
           !!freshQuery,
           usedCompatibilityFallback
@@ -1264,6 +1272,7 @@ export const useSearchResults = (props: {
               discoveryResultSetId: undefined,
               discoveryLoadedPageCount: 0,
               discoveryCompatibilityFallback: false,
+              discoveryAnchorFallback: false,
               discoverySemanticEligible: undefined,
               discoverySemanticMarketCount: undefined,
               discoveryInitialLatencyMs: undefined,
@@ -1353,37 +1362,42 @@ export const useSearchResults = (props: {
                 signal: abortController.signal,
               })
             } catch (error) {
-              if (
-                !shouldRetrySearchWithoutDiscoveryOptions(
-                  !!freshQuery,
-                  marketApiParams.seenMarketCutoffTime,
-                  marketApiParams.enableSemanticSearch,
-                  marketApiParams.discoveryVariant,
-                  error instanceof APIError ? error.code : undefined,
-                  usesForYouRoute
-                )
-              ) {
-                throw error
-              }
+              const retryMode = getSearchDiscoveryRetryMode({
+                freshQuery: !!freshQuery,
+                seenMarketCutoffTime: marketApiParams.seenMarketCutoffTime,
+                enableSemanticSearch: marketApiParams.enableSemanticSearch,
+                discoveryVariant: marketApiParams.discoveryVariant,
+                errorCode: error instanceof APIError ? error.code : undefined,
+                errorMessage:
+                  error instanceof APIError ? error.message : undefined,
+                errorDetails:
+                  error instanceof APIError ? error.details : undefined,
+                isForYouRoute: usesForYouRoute,
+              })
+              if (!retryMode) throw error
 
-              // A new API rejects a badly skewed page-one anchor; an old
-              // strict worker rejects the new fields. Retrying without the
-              // semantic opt-in is safe on any page because its fallback only
-              // runs on page one. Anchor removal is guarded to page one above.
-              if (freshQuery) seenMarketCutoffTime = undefined
-              usedCompatibilityFallback = true
+              const anchorFallback = retryMode === 'anchor-clock-skew'
+              if (anchorFallback) {
+                seenMarketCutoffTime = undefined
+                usedAnchorFallback = true
+              } else {
+                usedCompatibilityFallback = true
+              }
               const contracts = await api(
                 endpoint,
                 {
                   ...marketApiParams,
-                  seenMarketCutoffTime: freshQuery
-                    ? undefined
-                    : marketApiParams.seenMarketCutoffTime,
-                  enableSemanticSearch: undefined,
-                  discoveryVariant: undefined,
+                  ...getSearchDiscoveryRetryOptions(retryMode, {
+                    enableSemanticSearch: marketApiParams.enableSemanticSearch,
+                    discoveryVariant: marketApiParams.discoveryVariant,
+                  }),
                 },
                 { signal: abortController.signal }
               )
+              // The anchor-only retry still came from a current treatment
+              // worker, including its explicit match markers and ranking.
+              if (anchorFallback) return contracts
+
               // Semantic fallback never runs after page one, so any unmarked
               // rows from an old worker are known to be lexical there. Keep a
               // fresh unmarked response conservative: an intermediate worker
@@ -1526,6 +1540,7 @@ export const useSearchResults = (props: {
               discoveryResultSetId,
               discoveryLoadedPageCount: discoveryPage + 1,
               discoveryCompatibilityFallback: usedCompatibilityFallback,
+              discoveryAnchorFallback: usedAnchorFallback,
               discoverySemanticEligible: resultSetSemanticEligible,
               discoverySemanticMarketCount: resultSetSemanticMarketCount,
               discoveryInitialLatencyMs: resultSetInitialLatencyMs,
@@ -1558,6 +1573,7 @@ export const useSearchResults = (props: {
                 sort,
                 filter,
                 compatibilityFallback: usedCompatibilityFallback,
+                anchorFallback: usedAnchorFallback,
                 latencyMs: requestLatencyMs,
                 // Store page deltas so telemetry stays linear as people load
                 // more. The exposure event records exact rendered ordering.
@@ -1633,6 +1649,7 @@ export const useSearchResults = (props: {
               page: discoveryPage,
               isFresh: !!freshQuery,
               compatibilityFallback: usedCompatibilityFallback,
+              anchorFallback: usedAnchorFallback,
               errorCode: error instanceof APIError ? error.code : undefined,
               errorType: error instanceof Error ? error.name : typeof error,
               latencyMs: Date.now() - requestStartedAt,
@@ -1760,6 +1777,7 @@ export const useSearchResults = (props: {
           semanticMarketCount: state.discoverySemanticMarketCount,
           initialLatencyMs: state.discoveryInitialLatencyMs,
           compatibilityFallback: state.discoveryCompatibilityFallback ?? false,
+          anchorFallback: state.discoveryAnchorFallback ?? false,
         }
       : undefined
 
@@ -1804,8 +1822,11 @@ const useTrackDiscoveryExposure = (props: {
         : searchParams[SORT_KEY]
     const items = orderCombinedSearchResults(contracts ?? [], posts ?? [], {
       sort,
-      preserveUnmarkedContractOrder:
-        sort === 'score' && searchParams[QUERY_KEY].trim().length > 0,
+      preserveBackendMarketOrder: shouldPreserveBackendMarketOrder(
+        tracking.variant,
+        searchParams[QUERY_KEY],
+        searchParams[FOR_YOU_KEY] === '1'
+      ),
     })
 
     void track(DISCOVERY_EXPOSURE_EVENT, {
@@ -1820,6 +1841,7 @@ const useTrackDiscoveryExposure = (props: {
       semanticMarketCount: tracking.semanticMarketCount,
       initialLatencyMs: tracking.initialLatencyMs,
       compatibilityFallback: tracking.compatibilityFallback,
+      anchorFallback: tracking.anchorFallback,
       resultCount: items.length,
       marketCount: items.filter((item) => 'mechanism' in item).length,
       postCount: items.filter((item) => !('mechanism' in item)).length,

--- a/web/hooks/use-ab-test.ts
+++ b/web/hooks/use-ab-test.ts
@@ -1,37 +1,86 @@
-import { createRNG } from 'common/util/random'
+import { getDeterministicABTestVariant } from 'common/ab-test'
 import { track } from 'web/lib/service/analytics'
 import { ensureDeviceToken } from 'web/lib/util/device-token'
 import { useEffectCheckEquality } from './use-effect-check-equality'
-import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
+import { useState } from 'react'
+import { auth } from 'web/lib/firebase/users'
 
 const AB_TEST_CACHE: Record<string, boolean> = {}
+const IS_LOCAL_ONLY = process.env.NEXT_PUBLIC_LOCAL_ONLY === 'true'
+
+export type ABTestAssignment<T extends string> = {
+  assignmentId: string
+  assignmentUnit: 'user' | 'device'
+  variant: T
+}
+
+/** Reject the brief interval where Firebase auth and app-user state differ. */
+export const isABTestAssignmentCurrent = (assignmentKey?: string) => {
+  if (!assignmentKey) return true
+  if (IS_LOCAL_ONLY) return true
+  const userId = auth.currentUser?.uid
+  return userId
+    ? assignmentKey === `user:${userId}`
+    : assignmentKey.startsWith('device:')
+}
+
+type ABTestOptions<T extends string> = {
+  isReady?: boolean
+  userId?: string
+  forcedVariant?: T
+  trackingProperties?: Record<string, unknown>
+}
+
+export const useABTestAssignment = <T extends string>(
+  testName: string,
+  variants: readonly T[],
+  options?: ABTestOptions<T>
+) => {
+  const [assignment, setAssignment] = useState<
+    ABTestAssignment<T> | undefined
+  >()
+  const isReady = options?.isReady ?? true
+
+  useEffectCheckEquality(() => {
+    if (!isReady) return
+    const assignmentUnit = options?.userId ? 'user' : 'device'
+    const assignmentId = options?.userId ?? ensureDeviceToken()
+    if (!assignmentId) return
+    const variant = getDeterministicABTestVariant(
+      testName,
+      `${assignmentUnit}:${assignmentId}`,
+      variants,
+      options?.forcedVariant
+    )
+
+    setAssignment({ assignmentId, assignmentUnit, variant })
+
+    // Only track once per assignment unit per browser session. If somebody
+    // signs into a different account without reloading, that is a new unit.
+    const cacheKey = `${testName}:${assignmentUnit}:${assignmentId}`
+    if (!AB_TEST_CACHE[cacheKey]) {
+      AB_TEST_CACHE[cacheKey] = true
+      track(testName, {
+        ...options?.trackingProperties,
+        variant,
+        assignmentUnit,
+        forced: options?.forcedVariant !== undefined,
+      })
+    }
+  }, [testName, variants, options, isReady])
+
+  if (!isReady || !assignment) return undefined
+  if (options?.userId) {
+    return assignment.assignmentUnit === 'user' &&
+      assignment.assignmentId === options.userId
+      ? assignment
+      : undefined
+  }
+  return assignment.assignmentUnit === 'device' ? assignment : undefined
+}
 
 export const useABTest = <T extends string>(
   testName: string,
-  variants: T[],
-  trackingProperties?: Record<string, unknown>
-) => {
-  const [variant, setVariant] = usePersistentInMemoryState<T | undefined>(
-    undefined,
-    `ab-test-${testName}`
-  )
-
-  useEffectCheckEquality(() => {
-    const deviceId = ensureDeviceToken()
-    if (!deviceId) return
-
-    const rand = createRNG(testName + deviceId)
-    const keys = variants.sort()
-    const randomVariant = keys[Math.floor(rand() * keys.length)]
-
-    setVariant(randomVariant)
-
-    // Only track once per user session
-    if (!AB_TEST_CACHE[testName]) {
-      AB_TEST_CACHE[testName] = true
-      track(testName, { ...trackingProperties, variant: randomVariant })
-    }
-  }, [testName, trackingProperties, variants])
-
-  return variant
-}
+  variants: readonly T[],
+  options?: ABTestOptions<T>
+) => useABTestAssignment(testName, variants, options)?.variant

--- a/web/lib/api/api.ts
+++ b/web/lib/api/api.ts
@@ -2,6 +2,7 @@ import { JSONContent } from '@tiptap/core'
 import { apiWithAuth, callWithAuth } from 'client-common/lib/api'
 import { APIParams, APIPath } from 'common/api/schema'
 import { getApiUrl } from 'common/api/utils'
+import { BaseApiCallOptions } from 'common/util/api'
 import { Bet } from 'common/bet'
 import { ContractComment } from 'common/comment'
 import { Contract } from 'common/contract'
@@ -21,7 +22,7 @@ export async function call(
 export async function api<P extends APIPath>(
   path: P,
   params: APIParams<P> = {},
-  options?: { cache?: RequestCache }
+  options?: BaseApiCallOptions
 ) {
   return apiWithAuth(path, auth, params, options)
 }


### PR DESCRIPTION
This adds a deterministic 50/50 `discovery-v1` experiment for Browse, combining niche-topic ranking, less stale repetition, and a semantic tail for low-hit text searches. Control retains the pre-PR product behavior. Shared reliability and cache-isolation fixes apply to both arms.

## Product behavior

- Treatment For You uses the feed's `0.7 * max + 0.3 * avg` topic-score blend. It also suppresses quiet CPMM markets viewed 1 hour to 7 days ago. Comments, resolution, new or resolved answers, and significant daily probability movement resurface markets. Users without topic scores receive suppression through the basic-ranking fallback; **Your bets** never suppresses seen markets.
- First-page treatment text searches with fewer than five lexical results can append related markets. Semantic results use lexical filters, visibility, and blocks, exclude lexical duplicates, and stay behind lexical markets and appropriately ranked posts. `/v0/search-markets`, MCP, and `recent-markets` remain lexical-only.
- Control retains pre-PR client ordering, including For You responses with no posts. Treatment preserves backend order only for For You and nonblank text search. Ordinary blank Browse keeps market/post interleaving in both arms. Exposure telemetry uses the same ordering function as rendering.
- Optional-auth search endpoints use `private, no-store`. The topic-interest accumulator resets between calls to prevent sequential double counting. Historical topic-interest catch-up is not included; it still requires an atomic completed-run ledger.

`DEFAULT_FOR_YOU` remains `false`: ranking and repetition changes affect people selecting **Your topics** (`fy=1`).

## Assignment, requests, and rollout

Signed-in assignment is a deterministic hash of immutable user ID, independently reproduced by the API. Anonymous assignment uses the persistent device token. `@Gen` is forced treatment and `@Manifold` forced control; Browse displays their QA labels. Forced accounts remain visible in QA reporting and are excluded from causal estimates.

Account transitions invalidate stale requests and cached rows. Omitted discovery fields select control. One accepted seen-market anchor is reused across treatment For You pages; unanchored requests remain unsuppressed. Clock-skew rejection removes only the anchor and retains treatment and semantic options. Only an actual old-worker strict-schema rejection strips discovery fields and pins that result set to legacy compatibility. These fallback modes have separate telemetry.

Typed searches use a 300 ms debounce, including before the first completed request. Blank/deep-linked loads and filter changes remain responsive. Parameter changes invalidate stale reads; load-more waits for the corresponding fresh result. Semantic rows do not imply another lexical page.

The optional fallback has a 3-second embedding timeout with no SDK retries, finite vector validation, a bounded LRU/single-flight cache, hashed model-versioned cache keys, and per-caller budgets within per-worker ceilings. Vector queries run with a **1-second transaction-local PostgreSQL statement timeout**, so slow database work is cancelled on the server and releases its fallback slot. Optional-work failures return lexical results. These limits are not an end-to-end search latency guarantee.

Merge normally and let Vercel deploy from `main` while the backend release proceeds. API-first is preferable, but a short mixed-version rollout is supported: old web clients remain control; new web clients can fall back against old strict workers on safe request paths. Later treatment For You pages refuse to switch ranking spaces. Exclude the rollout period from analysis.

## Experiment and reporting

[Launch and decision protocol](https://app.notion.com/p/3d354492ea7a818b832ccfa8472b716b?pvs=204)

Headline estimates use signed-in, non-admin, non-bot, non-forced `user-hash` assignments. Fresh requests are the intention-to-treat denominator, including errors, aborts, and missing presentations as zero engagement. Request outcomes are averaged within user before arm means and user-level variance are calculated.

- **For You primary:** meaningful market action within 30 minutes.
- **All text-search primary:** market CTR. The low-hit subset is a mechanism diagnostic, not the causal population.

Cached Browse revisits create presentations without a new request. Their clicks and last-touch actions count toward the originating request only within its original 30-minute presentation window; revisits neither add request denominators nor extend that window. Duplicate delivery is deduplicated.

Report safety metrics include render/success/error/abort/missing-outcome rates, p95 latency, post CTR, zero-market and repeated-market rates, pagination duplicates, semantic-tail CTR, separate compatibility and anchor fallbacks, SRM, and cross-arm subjects. The two primaries support separate decisions; this does not measure D1/D7 retention or total-site activity.

```sh
yarn --cwd backend/scripts ts-node discovery-v1-report.ts START_DATE [END_DATE]
```

Dates use Pacific midnight with an exclusive end. Explicit-end maturity is checked using the production SQL boundary, including DST. The report uses a read-only repeatable-read snapshot, a maximum 31-day date span, and a 60-second statement timeout. Experiment analytics store query-length buckets, not raw search text.

Lock a 14-complete-Pacific-day window starting at the first Pacific midnight after both deployments. Final reading is at least 31 minutes after the exclusive end. Follow the predeclared automatic extension to 28 days if either primary has fewer than 200 eligible users per arm. Daily reads are for safety; do not stop or extend based on favorable outcomes.

## Production launch and residual risks

- Privacy follow-up on 6 September 2026: [Manifold's existing policy](https://docs.manifold.markets/privacy-policy) covers search queries, personalization, testing, and service providers. The [standard OpenAI Services Agreement](https://openai.com/policies/services-agreement/) incorporates its DPA when applicable. No missing permission requiring a new human approval gate was identified on that basis. Private account opt-in settings and bespoke contracts were not verified; an account-specific check is optional due diligence, not a demonstrated launch blocker.
- Let Vercel perform its usual automatic production deployment after merge while the user deploys the API. Record both completion times and exclude the partial rollout day from analysis; no special Vercel promotion hold is required.
- Complete the short forced-account smoke check: labels, Browse/post ordering, filters, text search, pagination, cached returns, and logout/login/account switching. Reconcile telemetry in the operator's first matured safety read. Record deployed SHAs and UTC/Pacific timestamps in the launch plan. No production data was accessed during this review.
- Monitor the developer-calibrated `0.35` similarity floor, per-worker rather than fleet-wide budgets, loss of anonymous edge caching, and short For You pages for heavy viewers after filtering the top 1,000 candidates. Optional Redis use and database connection waits are outside the new vector statement timeout.

## Dependency

#3967 is closed. Its relevant no-topic route correction is already in `main` through #3969 (`cd250a5c46d67bbff6c7a45e04e6cdb5746c17a8`), and is common to both arms. It is not an outstanding dependency.

## Verification

Reviewed original head `8441258265929c177587fde46643d160870ccf11`; review fixes are in `c836781a2ba492e5627aeada88dcc2c2b9cc11ed`.

- `yarn.cmd build:ci`: passed.
- Full common/shared tests: 978 common tests passed; after fixes, all 84 shared tests passed. Focused discovery assignment, ordering, retry, and schema tests: 74 passed.
- `node --test backend/scripts/tests/discovery-v1-report.test.cjs`: 9 passed against the actual report SQL in disposable, network-disabled PostgreSQL. Covers cached revisits, fixed windows, last touch, missing outcomes, duplicate delivery, user weighting, forced exclusion/SRM, DST, and server cancellation. Requires a locally cached `postgres:15-alpine` image and is an explicit integration command, separate from the standard Jest suite.
- API/scheduler typechecks and isolated report typecheck: passed. Web typecheck passed with worktree-local path resolution; the unadjusted root command resolves a different checkout through the shared `node_modules` junction and fails on `common/sports-schedule`.
- Full common/API/shared ESLint and web/package/workflow Prettier passed with Windows line-ending normalization. Unadjusted `yarn lint` and `yarn format:check` fail on checkout line endings; `yarn lint:web` also reports existing broader errors. Changed files pass focused lint/format and `git diff --check`.
- Local Next production build and live browser/account QA were not run, to avoid accessing production data. No production report or deployment was run.
- Reviewed-head [GitHub CI](https://github.com/manifoldmarkets/manifold/actions/runs/34020240963) passed build, typecheck, lint, formatting, and tests in 9m8s. Vercel dev/prod previews passed; docs was skipped by its ignored-build rule. The user merged the reviewed head as `5c35fea5f4c53bbf98ee14be8376a92a0facc5fc` on 6 September 2026 at 11:40:58 UTC. Current production rollout status and measurement dates are tracked in the launch plan.
