### PR TITLE
fix(browse): restore the default-browse query path (`!groupIds` was always false)

### DIFF
--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -97,7 +97,7 @@ const search = async (
     filter !== 'news' &&
     !term &&
     !topicSlugForGroupIdLookup &&
-    !groupIds &&
+    !groupIds.length &&
     (sort === 'score' || sort === 'freshness-score') &&
     (token === 'MANA' || token === 'ALL') &&
     !isRecent


### PR DESCRIPTION
One-line fix, but it turns a query path back on that has been dead for ~14 months. Worth reading before approving.

## The bug

`backend/api/src/search-contracts.ts:99` decides between three ways of answering a search request. Entering the first branch — the default, no-search-term, personalized path — requires seven conditions. One of them is `!groupIds`.

`groupIds` is a locally-computed array. In JS `![]` is `false`, so that condition can never pass. **The branch never executes.** Every request falls through to the lexical `else` branch, which unions five full-text query types against an empty term.

## How it got there

`eebf7d4af` (May 2025, "Replace news with 'followed' topic") changed:

```ts
-    gids: groupIds,          // string | undefined  -> !groupIds meant "no topic filter"
+    gids,
```

and introduced a locally-computed `const groupIds = ...` array under the same name, without updating the check written for the string.

## What this restores

`basicSearchSQL` and `getForYouSQL` become reachable from the API again. Their only reachable caller today is the weekly trending email (`backend/shared/src/weekly-markets-emails.ts:92`, via `getForYouMarkets`) — `basicSearchSQL` additionally via `getForYouSQL`'s no-topic-interests early return.

So this changes what /browse and /home are served by. It is not a no-op refactor.

## What to watch after deploy

- **Latency on /browse and /home.** These queries have had no production traffic since May 2025.
- **Ranking quality.** `getForYouSQL` ranks by `power(blend, 4) * importance_score`; the current fallthrough ranks by full-text relevance on an empty term. Results will visibly change for logged-in users with For You on.
- **Logged-out users** now get `basicSearchSQL` instead of the lexical branch.

One behavior change worth naming: a logged-out user on the `followed` tab now enters the personalized branch (`topicSlugForGroupIdLookup` is undefined for `followed`, and `groupIds` is empty without a `userId`), so they get generic top markets rather than an empty-term full-text search. That seems strictly better, but it is new.

## Why it is on its own branch

#3966 builds two ranking changes on top of `getForYouSQL`. Landing those together with this would make any latency or quality regression unattributable. This goes first; #3966 rebases on top once this is known-good.

`yarn build:ci && yarn typecheck:api && yarn lint:api` pass.
