### PR TITLE
feat(perps): admin tool to adjust max leverage live

### DIFF
--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -73,6 +73,7 @@ import { createMarket } from './create-market'
 import { createPerp } from './create-perp'
 import { placePerpTrade } from './place-perp-trade'
 import { closePerpPosition } from './close-perp-position'
+import { updatePerpConfig } from './update-perp-config'
 import {
   getOraclePrice,
   getOraclePriceSeries,
@@ -442,6 +443,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'create-perp': createPerp,
   'place-perp-trade': placePerpTrade,
   'close-perp-position': closePerpPosition,
+  'update-perp-config': updatePerpConfig,
   'get-oracle-price': getOraclePrice,
   'get-oracle-price-series': getOraclePriceSeries,
   'get-known-oracle-feeds': getKnownOracleFeeds,

--- a/backend/api/src/update-perp-config.ts
+++ b/backend/api/src/update-perp-config.ts
@@ -1,0 +1,50 @@
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { recordContractEdit } from 'shared/record-contract-edit'
+import { updateContract } from 'shared/supabase/contracts'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { getContract, log, revalidateContractStaticProps } from 'shared/utils'
+import { broadcastUpdatedContract } from 'shared/websockets/helpers'
+import { APIError, APIHandler } from './helpers/endpoint'
+
+// Admin-only live tuning of a perp's risk config. Takes effect on the NEXT
+// trade with no deploy or restart: the engine re-reads the contract inside
+// every trade transaction (engine.ts checks leverage > contract.maxLeverage
+// under the advisory lock). Lowering the cap only constrains new opens and
+// adds — leverage is checked at trade time, never retroactively — so
+// existing positions above a lowered cap are grandfathered and a cut can
+// never force-close or liquidate anyone by itself.
+export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
+  body,
+  auth
+) => {
+  throwErrorIfNotAdmin(auth.uid)
+  const { contractId, maxLeverage } = body
+
+  const pg = createSupabaseDirectClient()
+  const contract = await getContract(pg, contractId)
+  if (!contract) throw new APIError(404, `Contract ${contractId} not found`)
+  if (contract.mechanism !== 'perp')
+    throw new APIError(400, 'Only perp markets have a max leverage')
+  if (contract.isResolved)
+    throw new APIError(403, 'Cannot update a resolved market')
+
+  const prev = contract.maxLeverage
+  const lastUpdatedTime = Date.now()
+  await updateContract(pg, contractId, { maxLeverage, lastUpdatedTime })
+  log(
+    `admin ${auth.uid} set maxLeverage on ${contract.slug}: ${prev} -> ${maxLeverage}`
+  )
+  broadcastUpdatedContract(contract.visibility, {
+    id: contractId,
+    maxLeverage,
+    lastUpdatedTime,
+  })
+
+  return {
+    result: { success: true as const, maxLeverage },
+    continue: async () => {
+      await recordContractEdit(contract, auth.uid, ['maxLeverage'])
+      await revalidateContractStaticProps(contract)
+    },
+  }
+}

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1069,6 +1069,21 @@ export const API = (_apiTypeCheck = {
     returns: {} as { payout: number; pnl: number },
     props: closePerpPositionSchema,
   },
+  // Admin-only live risk tuning; undocumented deliberately — internal
+  // operator tooling, not part of the public perp API surface.
+  'update-perp-config': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    returns: {} as { success: true; maxLeverage: number },
+    props: z
+      .object({
+        contractId: z.string().min(1),
+        // Same bound as createPerpSchema.
+        maxLeverage: z.number().gt(1).lte(100),
+      })
+      .strict(),
+  },
   'get-oracle-price': {
     method: 'GET',
     visibility: 'public',

--- a/web/components/perps/perp-admin-panel.tsx
+++ b/web/components/perps/perp-admin-panel.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { toast } from 'react-hot-toast'
+import { PerpContract } from 'common/contract'
+import { Button } from 'web/components/buttons/button'
+import { Col } from 'web/components/layout/col'
+import { Row } from 'web/components/layout/row'
+import { Input } from 'web/components/widgets/input'
+import { useAdmin } from 'web/hooks/use-admin'
+import { api } from 'web/lib/api/api'
+
+// Admin-only live risk tuning for a perp market. The change applies to the
+// next trade immediately (the engine re-reads the contract per trade), and
+// other open pages converge within one 15s poll via useLivePerpContract's
+// maxLeverage overlay.
+export const PerpAdminPanel = (props: { contract: PerpContract }) => {
+  const { contract } = props
+  const isAdmin = useAdmin()
+  const [input, setInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  // Bridge the gap between a successful save and the next contract poll so
+  // the panel never shows the pre-save cap right after confirming.
+  const [justSaved, setJustSaved] = useState<number | null>(null)
+  if (!isAdmin || contract.isResolved) return null
+
+  const current =
+    justSaved != null && justSaved !== contract.maxLeverage
+      ? justSaved
+      : contract.maxLeverage
+  const parsed = Number(input)
+  const valid =
+    input !== '' && Number.isFinite(parsed) && parsed > 1 && parsed <= 100
+  const isLowering = valid && parsed < current
+
+  const submit = async () => {
+    if (!valid || saving) return
+    setSaving(true)
+    try {
+      const res = await api('update-perp-config', {
+        contractId: contract.id,
+        maxLeverage: parsed,
+      })
+      setJustSaved(res.maxLeverage)
+      setInput('')
+      toast.success(`Max leverage is now ${res.maxLeverage}×`)
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to update max leverage'
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Col className="border-ink-300 bg-canvas-50 gap-1.5 rounded-lg border border-dashed p-3">
+      <Row className="items-center justify-between">
+        <span className="text-ink-600 text-sm font-semibold">
+          Admin: max leverage
+        </span>
+        <span className="text-ink-900 font-mono text-sm font-semibold tabular-nums">
+          {current}×
+        </span>
+      </Row>
+      <Row className="items-center gap-2">
+        <Input
+          type="number"
+          min={1}
+          max={100}
+          step={0.5}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={`${current}`}
+          className="h-8 w-24 text-sm"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submit()
+          }}
+        />
+        <Button
+          size="2xs"
+          color="indigo-outline"
+          disabled={!valid || saving || parsed === current}
+          loading={saving}
+          onClick={submit}
+        >
+          Set
+        </Button>
+        <span className="text-ink-500 text-xs">
+          {valid
+            ? isLowering
+              ? 'Lowering only limits new positions — existing ones are untouched.'
+              : 'Applies to the next trade; open pages converge within 15s.'
+            : 'Between 1 and 100 (exclusive of 1).'}
+        </span>
+      </Row>
+    </Col>
+  )
+}

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -21,6 +21,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Tooltip } from 'web/components/widgets/tooltip'
 import { useIsClient } from 'web/hooks/use-is-client'
+import { PerpAdminPanel } from './perp-admin-panel'
 import { PerpChart } from './perp-chart'
 import { PerpBetPanel } from './perp-bet-panel'
 import { PerpOracleAttribution } from './perp-oracle-attribution'
@@ -228,6 +229,7 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
         positions={positions}
         oracleTradingPaused={oracleTradingPaused}
       />
+      <PerpAdminPanel contract={contract} />
     </Col>
   )
 }

--- a/web/components/perps/use-live-perp-contract.ts
+++ b/web/components/perps/use-live-perp-contract.ts
@@ -61,6 +61,12 @@ export const useLivePerpContract = (ssrContract: PerpContract) => {
                   ...(market.lastFundingTime != null
                     ? { lastFundingTime: market.lastFundingTime }
                     : {}),
+                  // Admins can retune the leverage cap live
+                  // (update-perp-config); the bet panel's clamp and slider
+                  // marks key off it, so every open page must converge.
+                  ...(market.maxLeverage != null
+                    ? { maxLeverage: market.maxLeverage }
+                    : {}),
                 }
           )
         })


### PR DESCRIPTION
New admin-only endpoint update-perp-config sets a perp's maxLeverage (same 1-100 bound as creation) with no deploy or restart: the engine re-reads the contract inside every trade transaction, so the change applies to the next trade. Lowering the cap only constrains new opens and adds - leverage is checked at trade time, never retroactively - so existing positions above a lowered cap are grandfathered and a cut can never force-close anyone. Edits are recorded to contract_edits and the update is broadcast + revalidated.

The market page gets a dashed admin box (admins only, hidden on resolved markets) under the position panel showing the current cap with an input to set a new one. useLivePerpContract now overlays maxLeverage from the lite-market poll, so every open page - bet panel clamp, slider marks - converges on the new cap within 15s without a reload.