### PR TITLE
fix(scheduler): drop user_bans_ended_by_fkey so unban-users can auto-expire temp bans

### DIFF
--- a/backend/api/knowledge.md
+++ b/backend/api/knowledge.md
@@ -318,8 +318,8 @@ create table
     created_at timestamptz not null default now (),
     created_by text references users (id),
     end_time timestamptz, -- null = permanent ban
-    ended_by text references users (id),
-    ended_at timestamptz -- set when ban is manually lifted
+    ended_by text, -- mod user id, the user themself (modAlert dismissal), or 'system' (auto-expiry); deliberately no FK
+    ended_at timestamptz -- set when ban is lifted, manually or by the hourly unban-users job
   );
 ```
 

--- a/backend/scripts/apply-unban-fkey-migration.ts
+++ b/backend/scripts/apply-unban-fkey-migration.ts
@@ -1,0 +1,43 @@
+// One-off: apply backend/supabase/migrations/2026080601_drop_user_bans_ended_by_fkey.sql
+// to prod. The unban-users scheduler job has crashed hourly since 2026-01-17
+// because user_bans_ended_by_fkey rejects its ended_by = 'system' sentinel.
+// Idempotent; safe to re-run.
+import { runScript } from 'run-script'
+import { getLocalEnv } from 'shared/init-admin'
+
+runScript(async ({ pg }) => {
+  const env = getLocalEnv()
+  console.log(`resolved env: ${env}`)
+  if (env !== 'PROD') {
+    throw new Error(
+      `expected PROD but getLocalEnv() resolved ${env} — check activeProjects casing in firebase-tools.json`
+    )
+  }
+
+  await pg.tx(async (tx) => {
+    await tx.none(
+      `alter table user_bans drop constraint if exists user_bans_ended_by_fkey`
+    )
+    const result = await tx.result(
+      `update user_bans
+       set ended_by = 'system', ended_at = now()
+       where ended_at is null
+         and end_time is not null
+         and end_time <= now()`
+    )
+    console.log(`closed ${result.rowCount} expired temp bans`)
+  })
+
+  const fk = await pg.oneOrNone(
+    `select 1 from pg_constraint where conname = 'user_bans_ended_by_fkey'`
+  )
+  const stuck = await pg.one<{ n: number }>(
+    `select count(*)::int as n from user_bans
+     where ended_at is null and end_time is not null and end_time <= now()`
+  )
+  console.log(
+    `verify: constraint still present = ${!!fk}, remaining stuck rows = ${
+      stuck.n
+    }`
+  )
+})

--- a/backend/supabase/migrations/2026080601_drop_user_bans_ended_by_fkey.sql
+++ b/backend/supabase/migrations/2026080601_drop_user_bans_ended_by_fkey.sql
@@ -1,0 +1,17 @@
+-- The unban-users scheduler job sets ended_by = 'system' when a temp ban
+-- expires, but user_bans_ended_by_fkey (ended_by references users(id)) rejects
+-- that sentinel, so the job has crashed on every hourly run since the first
+-- temp ban expired (2026-01-17). The web UI (ban-modal.tsx) already renders
+-- ended_by = 'system' as "System (auto-expired)", so the sentinel is the
+-- intended design; the FK is the bug. created_by and user_id keep their FKs.
+alter table user_bans
+drop constraint if exists user_bans_ended_by_fkey;
+
+-- Close out the bans left stuck by the crash. Same statement the job runs;
+-- idempotent, and enforcement reads already exclude rows with end_time in the
+-- past, so this only fixes bookkeeping.
+update user_bans
+set ended_by = 'system', ended_at = now()
+where ended_at is null
+  and end_time is not null
+  and end_time <= now();

--- a/backend/supabase/user_bans.sql
+++ b/backend/supabase/user_bans.sql
@@ -17,9 +17,6 @@ alter table user_bans
 add constraint user_bans_created_by_fkey foreign key (created_by) references users (id);
 
 alter table user_bans
-add constraint user_bans_ended_by_fkey foreign key (ended_by) references users (id);
-
-alter table user_bans
 add constraint user_bans_user_id_fkey foreign key (user_id) references users (id);
 
 -- Indexes

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -26,8 +26,9 @@ export type UserBan = {
   created_by: string | null // mod user ID
   // Scheduled expiry for temp bans (null = permanent)
   end_time: string | null
-  ended_by: string | null // mod user ID who ended the ban
-  // When manually lifted by mod (null = still active or expired naturally)
+  // Mod user ID, the user themself (modAlert dismissal), or 'system' (auto-expired temp ban)
+  ended_by: string | null
+  // When the ban was lifted, by a mod or by auto-expiry (null = still active)
   ended_at: string | null
 }
 


### PR DESCRIPTION
## Problem
The hourly `unban-users` scheduler job has crashed on **every run since 2026-01-17** (the day after the ban system shipped in #3653). It marks expired temp bans with `ended_by = 'system'`, but `user_bans_ended_by_fkey` (`ended_by → users.id`) rejects the sentinel, so the UPDATE always fails with a foreign-key violation. Invisible until the new job-crash alert policy (2026-08-06) started emailing on it hourly.

## Why drop the FK (not change the sentinel)
`ended_by = 'system'` is the intended design — the ban-history UI already renders it as "System (auto-expired)" (`ban-modal.tsx`). The FK added in the same PR is the bug. `created_by` and `user_id` keep their FKs.

## Impact of the bug
Bookkeeping only — every enforcement read filters `ended_at is null AND (end_time is null OR end_time > now())`, so nobody was over-banned. 39 rows are stuck with `ended_at` null (oldest 2026-01-17); mod ban-history shows "Unknown" instead of "System (auto-expired)" for them.

## Changes
- Migration `2026080601_drop_user_bans_ended_by_fkey.sql`: drops the FK, then idempotently closes all stuck expired temp bans (same statement the job runs).
- One-off script `backend/scripts/apply-unban-fkey-migration.ts` to apply it to prod (asserts PROD env, verifies after).
- Syncs `user_bans.sql` schema snapshot, `knowledge.md`, and the `UserBan` type comment.

No job-code change needed — the job succeeds on its next hourly run once the migration is applied. Applying the migration is what stops the hourly alert emails.