### PR TITLE
feat(perps): admin tools to adjust max funding rate and top up backing pools live

### DIFF
--- a/backend/api/src/add-perp-subsidy.ts
+++ b/backend/api/src/add-perp-subsidy.ts
@@ -1,0 +1,33 @@
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { addPerpPoolSubsidy } from 'shared/perps/engine'
+import { log } from 'shared/utils'
+import { broadcastUpdatedContract } from 'shared/websockets/helpers'
+import { APIHandler } from './helpers/endpoint'
+
+// Admin-only escrow top-up of one side's backing pool on a live perp. The
+// admin pays from their own balance; all state checks (unresolved, MANA
+// token, escrow invariant) and locking live in the engine.
+export const addPerpSubsidy: APIHandler<'add-perp-subsidy'> = async (
+  body,
+  auth
+) => {
+  throwErrorIfNotAdmin(auth.uid)
+  const { contractId, side, amount } = body
+
+  const { contract, poolLong, poolShort } = await addPerpPoolSubsidy(
+    contractId,
+    auth.uid,
+    side,
+    amount
+  )
+  log(
+    `admin ${auth.uid} added M$${amount} ${side} pool subsidy on ${contract.slug}: L=${poolLong} S=${poolShort}`
+  )
+  broadcastUpdatedContract(contract.visibility, {
+    id: contractId,
+    poolLong,
+    poolShort,
+  })
+
+  return { success: true as const, poolLong, poolShort }
+}

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -74,6 +74,7 @@ import { createPerp } from './create-perp'
 import { placePerpTrade } from './place-perp-trade'
 import { closePerpPosition } from './close-perp-position'
 import { updatePerpConfig } from './update-perp-config'
+import { addPerpSubsidy } from './add-perp-subsidy'
 import {
   getOraclePrice,
   getOraclePriceSeries,
@@ -444,6 +445,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'place-perp-trade': placePerpTrade,
   'close-perp-position': closePerpPosition,
   'update-perp-config': updatePerpConfig,
+  'add-perp-subsidy': addPerpSubsidy,
   'get-oracle-price': getOraclePrice,
   'get-oracle-price-series': getOraclePriceSeries,
   'get-known-oracle-feeds': getKnownOracleFeeds,

--- a/backend/api/src/update-perp-config.ts
+++ b/backend/api/src/update-perp-config.ts
@@ -1,3 +1,4 @@
+import { removeUndefinedProps } from 'common/util/object'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { recordContractEdit } from 'shared/record-contract-edit'
 import { updateContract } from 'shared/supabase/contracts'
@@ -6,44 +7,61 @@ import { getContract, log, revalidateContractStaticProps } from 'shared/utils'
 import { broadcastUpdatedContract } from 'shared/websockets/helpers'
 import { APIError, APIHandler } from './helpers/endpoint'
 
-// Admin-only live tuning of a perp's risk config. Takes effect on the NEXT
-// trade with no deploy or restart: the engine re-reads the contract inside
-// every trade transaction (engine.ts checks leverage > contract.maxLeverage
-// under the advisory lock). Lowering the cap only constrains new opens and
-// adds — leverage is checked at trade time, never retroactively — so
-// existing positions above a lowered cap are grandfathered and a cut can
-// never force-close or liquidate anyone by itself.
+// Admin-only live tuning of a perp's risk config. Takes effect with no
+// deploy or restart: the engine re-reads the contract inside every trade and
+// funding transaction under the advisory lock.
+// - maxLeverage: lowering the cap only constrains new opens and adds —
+//   leverage is checked at trade time, never retroactively — so existing
+//   positions above a lowered cap are grandfathered and a cut can never
+//   force-close or liquidate anyone by itself.
+// - maxFundingRate: applies from the NEXT funding event. It is the
+//   per-PERIOD cap on the imbalance haircut, so on an hourly market 0.02
+//   means up to 2% of the crowded side's positions per hour at full
+//   imbalance. The schema keeps it inside assertPerpFundingConfig's (0, 1)
+//   domain; a value at or above 1 would make every funding tick fail closed.
 export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
   body,
   auth
 ) => {
   throwErrorIfNotAdmin(auth.uid)
-  const { contractId, maxLeverage } = body
+  const { contractId, maxLeverage, maxFundingRate } = body
 
   const pg = createSupabaseDirectClient()
   const contract = await getContract(pg, contractId)
   if (!contract) throw new APIError(404, `Contract ${contractId} not found`)
   if (contract.mechanism !== 'perp')
-    throw new APIError(400, 'Only perp markets have a max leverage')
+    throw new APIError(400, 'Only perp markets have a perp risk config')
   if (contract.isResolved)
     throw new APIError(403, 'Cannot update a resolved market')
 
-  const prev = contract.maxLeverage
   const lastUpdatedTime = Date.now()
-  await updateContract(pg, contractId, { maxLeverage, lastUpdatedTime })
-  log(
-    `admin ${auth.uid} set maxLeverage on ${contract.slug}: ${prev} -> ${maxLeverage}`
-  )
-  broadcastUpdatedContract(contract.visibility, {
-    id: contractId,
+  const patch = removeUndefinedProps({
     maxLeverage,
+    maxFundingRate,
     lastUpdatedTime,
   })
+  await updateContract(pg, contractId, patch)
+  if (maxLeverage !== undefined)
+    log(
+      `admin ${auth.uid} set maxLeverage on ${contract.slug}: ${contract.maxLeverage} -> ${maxLeverage}`
+    )
+  if (maxFundingRate !== undefined)
+    log(
+      `admin ${auth.uid} set maxFundingRate on ${contract.slug}: ${contract.maxFundingRate} -> ${maxFundingRate}`
+    )
+  broadcastUpdatedContract(contract.visibility, { id: contractId, ...patch })
 
+  const editedFields = Object.keys(
+    removeUndefinedProps({ maxLeverage, maxFundingRate })
+  )
   return {
-    result: { success: true as const, maxLeverage },
+    result: {
+      success: true as const,
+      maxLeverage: maxLeverage ?? contract.maxLeverage,
+      maxFundingRate: maxFundingRate ?? contract.maxFundingRate,
+    },
     continue: async () => {
-      await recordContractEdit(contract, auth.uid, ['maxLeverage'])
+      await recordContractEdit(contract, auth.uid, editedFields)
       await revalidateContractStaticProps(contract)
     },
   }

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -982,6 +982,83 @@ export const closePosition = async (
 }
 
 // -----------------------------------------------------------------------
+// pool subsidy (admin top-up)
+// -----------------------------------------------------------------------
+
+/**
+ * Add mana to one side's backing pool of a live perp, paid from the funder's
+ * balance.
+ *
+ * Ops tool for restoring a side's margin cover: a side's pool can fall below
+ * that side's aggregate cost basis when realized profits were paid against
+ * opposing unrealized losses that later recovered (UK carbon, 2026-08-07) —
+ * a state ADL cannot repair because it never touches cost bases, so every
+ * oracle apply fail-closes and the market freezes at a stale price.
+ *
+ * Runs under the same advisory lock + serializable transaction as every
+ * other pool mutation, so it cannot race the oracle tick, funding, or
+ * trades. The funder pays with a real ADD_SUBSIDY transaction so
+ * assertPerpEscrowBalance remains a checkable invariant.
+ */
+export const addPerpPoolSubsidy = async (
+  contractId: string,
+  funderId: string,
+  side: PerpDirection,
+  amount: number
+) => {
+  if (!Number.isFinite(amount) || amount <= 0)
+    throw new APIError(400, 'amount must be a finite positive number')
+
+  return runPerpTransaction(async (pgTrans) => {
+    // Rejects resolved markets and non-MANA tokens, and serializes against
+    // every other engine writer on this contract.
+    const { contract, state } = await loadStateForUpdate(pgTrans, contractId)
+
+    const funder = await pgTrans.oneOrNone<{ id: string; balance: number }>(
+      `select id, balance from users where id = $1 for update`,
+      [funderId]
+    )
+    if (!funder) throw new APIError(404, `User ${funderId} not found`)
+    if (!Number.isFinite(funder.balance) || funder.balance < amount)
+      throw new APIError(
+        403,
+        `Insufficient balance: needed ${amount}, have ${funder.balance}`
+      )
+
+    await assertPerpEscrowBalance(pgTrans, contractId, state.pool)
+
+    await runTxnOutsideBetQueue(pgTrans, {
+      category: 'ADD_SUBSIDY',
+      fromId: funderId,
+      fromType: 'USER',
+      toId: contractId,
+      toType: 'CONTRACT',
+      amount,
+      token: 'M$',
+      data: { side, reason: 'perp-pool-subsidy' },
+    })
+
+    const pool = {
+      L: state.pool.L + (side === 'long' ? amount : 0),
+      S: state.pool.S + (side === 'short' ? amount : 0),
+    }
+    await assertPerpEscrowBalance(pgTrans, contractId, pool)
+
+    // mergeContractDataQuery ends in `returning *` — .one(), not .none()
+    // (see the fast path in runOracleUpdate for the failure mode).
+    await pgTrans.one(
+      mergeContractDataQuery(contractId, {
+        poolLong: pool.L,
+        poolShort: pool.S,
+        lastUpdatedTime: Date.now(),
+      })
+    )
+
+    return { contract, poolLong: pool.L, poolShort: pool.S }
+  })
+}
+
+// -----------------------------------------------------------------------
 // oracle update: liquidation + ADL
 // -----------------------------------------------------------------------
 

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1075,12 +1075,41 @@ export const API = (_apiTypeCheck = {
     method: 'POST',
     visibility: 'undocumented',
     authed: true,
-    returns: {} as { success: true; maxLeverage: number },
+    returns: {} as {
+      success: true
+      maxLeverage: number
+      maxFundingRate: number
+    },
     props: z
       .object({
         contractId: z.string().min(1),
-        // Same bound as createPerpSchema.
-        maxLeverage: z.number().gt(1).lte(100),
+        // Same bounds as createPerpSchema. maxFundingRate must stay inside
+        // the engine's assertPerpFundingConfig domain (0, 1) — at >= 1 the
+        // funding tick fail-closes and the market stops funding entirely.
+        maxLeverage: z.number().gt(1).lte(100).optional(),
+        maxFundingRate: z.number().gt(0).lt(1).optional(),
+      })
+      .strict()
+      .refine(
+        (p) => p.maxLeverage !== undefined || p.maxFundingRate !== undefined,
+        { message: 'Provide at least one field to update' }
+      ),
+  },
+  // Admin-only escrow top-up of one side's backing pool on a live perp.
+  // Ops tool for restoring margin cover (a side's pool can fall below its
+  // side's aggregate cost basis when realized profits were paid against
+  // opposing unrealized losses that later recovered — see the UK carbon
+  // incident 2026-08-07). The funder pays from their own balance.
+  'add-perp-subsidy': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    returns: {} as { success: true; poolLong: number; poolShort: number },
+    props: z
+      .object({
+        contractId: z.string().min(1),
+        side: z.enum(['long', 'short']),
+        amount: z.number().gt(0).lte(1_000_000),
       })
       .strict(),
   },

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -15,6 +15,7 @@ import { formatPrice, inferPriceDecimals } from 'common/perps/format'
 import { UNRANKED_GROUP_ID } from 'common/supabase/groups'
 import { BETTORS, User } from 'common/user'
 import { formatWithCommas } from 'common/util/format'
+import { YEAR_MS } from 'common/util/time'
 import dayjs from 'dayjs'
 import { capitalize, sumBy } from 'lodash'
 import Link from 'next/link'
@@ -582,7 +583,7 @@ export const Stats = (props: {
 function PerpStatsRows(props: { contract: PerpContract }) {
   const { contract } = props
   const isAdmin = useAdmin()
-  const canEditLeverage = isAdmin && !contract.isResolved
+  const canEdit = isAdmin && !contract.isResolved
   const price =
     contract.resolution === 'MKT'
       ? Number(contract.resolvedOraclePrice ?? contract.oraclePrice)
@@ -630,15 +631,31 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           />
         </td>
       </tr>
-      <tr className={clsx(canEditLeverage && 'bg-purple-500/30')}>
+      <tr className={clsx(canEdit && 'bg-purple-500/30')}>
         <td>Maximum leverage</td>
         <td>
-          {canEditLeverage ? (
+          {canEdit ? (
             <MaxLeverageInput contract={contract} />
           ) : Number.isFinite(contract.maxLeverage) ? (
             `${formatWithCommas(contract.maxLeverage)}×`
           ) : (
             '—'
+          )}
+        </td>
+      </tr>
+      <tr className={clsx(canEdit && 'bg-purple-500/30')}>
+        <td>
+          Max funding rate{' '}
+          <InfoTooltip text="Per-period cap on the funding haircut at full pool imbalance" />
+        </td>
+        <td>
+          {canEdit ? (
+            <MaxFundingRateInput contract={contract} />
+          ) : (
+            <MaxFundingRateDisplay
+              maxFundingRate={contract.maxFundingRate}
+              fundingPeriodMs={fundingPeriodMs}
+            />
           )}
         </td>
       </tr>
@@ -652,7 +669,36 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           <span className="text-ink-500 text-xs">({fundingDirection})</span>
         </td>
       </tr>
+      {canEdit && (
+        <tr className="bg-purple-500/30">
+          <td>
+            Pool subsidy{' '}
+            <InfoTooltip text="Add mana from your balance into one side's backing pool. Use to restore a side's margin cover (pool below its side's total cost basis)." />
+          </td>
+          <td>
+            <AddPerpSubsidyInput contract={contract} />
+          </td>
+        </tr>
+      )}
     </>
+  )
+}
+
+function MaxFundingRateDisplay(props: {
+  maxFundingRate: number
+  fundingPeriodMs: number
+}) {
+  const { maxFundingRate, fundingPeriodMs } = props
+  if (!Number.isFinite(maxFundingRate) || !(fundingPeriodMs > 0)) return <>—</>
+  const annualPct = maxFundingRate * (YEAR_MS / fundingPeriodMs) * 100
+  return (
+    <span className="tabular-nums">
+      {(maxFundingRate * 100).toFixed(4)}% /{' '}
+      {fundingPeriodNoun(fundingPeriodMs)}{' '}
+      <span className="text-ink-500 text-xs">
+        (~{annualPct.toFixed(0)}%/yr)
+      </span>
+    </span>
   )
 }
 
@@ -723,6 +769,176 @@ function MaxLeverageInput(props: { contract: PerpContract }) {
         Set
       </Button>
     </Row>
+  )
+}
+
+// Inline admin editor for a perp's per-period funding cap. Input is in
+// PERCENT PER PERIOD (e.g. 2 = 2% of the crowded side per period at full
+// imbalance) — the engine stores the fraction. Applies from the next
+// funding event; must stay under 100% or funding fail-closes entirely.
+function MaxFundingRateInput(props: { contract: PerpContract }) {
+  const { contract } = props
+  const fundingPeriodMs = getFundingPeriodMs(contract)
+  const [input, setInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [justSaved, setJustSaved] = useState<number | null>(null)
+  const current =
+    justSaved != null && justSaved !== contract.maxFundingRate
+      ? justSaved
+      : contract.maxFundingRate
+  const parsed = Number(input) / 100
+  const valid =
+    input !== '' && Number.isFinite(parsed) && parsed > 0 && parsed < 1
+
+  const submit = async () => {
+    if (!valid || saving || parsed === current) return
+    setSaving(true)
+    try {
+      const res = await api('update-perp-config', {
+        contractId: contract.id,
+        maxFundingRate: parsed,
+      })
+      setJustSaved(res.maxFundingRate)
+      setInput('')
+      toast.success(
+        `Max funding rate is now ${(res.maxFundingRate * 100).toFixed(
+          4
+        )}% / ${fundingPeriodNoun(fundingPeriodMs)}`
+      )
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to update max funding rate'
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Row className="items-center gap-2">
+      <MaxFundingRateDisplay
+        maxFundingRate={current}
+        fundingPeriodMs={fundingPeriodMs}
+      />
+      <input
+        type="number"
+        min={0}
+        max={99}
+        step={0.1}
+        value={input}
+        disabled={saving}
+        placeholder="%/period"
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') submit()
+        }}
+        className="bg-canvas-0 border-ink-300 h-7 w-24 rounded-md border px-2 text-sm"
+      />
+      <Button
+        size="2xs"
+        color="indigo-outline"
+        disabled={!valid || saving || parsed === current}
+        loading={saving}
+        onClick={submit}
+      >
+        Set
+      </Button>
+    </Row>
+  )
+}
+
+// Inline admin tool to top up one side's backing pool from the admin's own
+// balance. Shows the live per-side split so a margin-cover hole (pool below
+// the side's total cost basis) can be sized and filled in one place.
+function AddPerpSubsidyInput(props: { contract: PerpContract }) {
+  const { contract } = props
+  const [side, setSide] = useState<'long' | 'short'>('short')
+  const [input, setInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [justSaved, setJustSaved] = useState<{
+    poolLong: number
+    poolShort: number
+  } | null>(null)
+  const pools =
+    justSaved != null &&
+    (justSaved.poolLong !== contract.poolLong ||
+      justSaved.poolShort !== contract.poolShort)
+      ? justSaved
+      : { poolLong: contract.poolLong, poolShort: contract.poolShort }
+  const parsed = Number(input)
+  const valid = input !== '' && Number.isFinite(parsed) && parsed > 0
+
+  const submit = async () => {
+    if (!valid || saving) return
+    setSaving(true)
+    try {
+      const res = await api('add-perp-subsidy', {
+        contractId: contract.id,
+        side,
+        amount: parsed,
+      })
+      setJustSaved({ poolLong: res.poolLong, poolShort: res.poolShort })
+      setInput('')
+      toast.success(
+        `Added M$${formatWithCommas(
+          parsed
+        )} to the ${side} pool. L=${res.poolLong.toFixed(
+          2
+        )} S=${res.poolShort.toFixed(2)}`
+      )
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to add pool subsidy'
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Col className="gap-1">
+      <span className="text-ink-500 text-xs tabular-nums">
+        L: {pools.poolLong.toFixed(2)} · S: {pools.poolShort.toFixed(2)}
+      </span>
+      <Row className="items-center gap-2">
+        <Row className="border-ink-300 overflow-hidden rounded-md border">
+          {(['long', 'short'] as const).map((s) => (
+            <button
+              key={s}
+              className={clsx(
+                'px-2 py-0.5 text-xs',
+                side === s ? 'bg-primary-500 text-white' : 'text-ink-700'
+              )}
+              disabled={saving}
+              onClick={() => setSide(s)}
+            >
+              {s}
+            </button>
+          ))}
+        </Row>
+        <input
+          type="number"
+          min={0}
+          value={input}
+          disabled={saving}
+          placeholder="M$"
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') submit()
+          }}
+          className="bg-canvas-0 border-ink-300 h-7 w-24 rounded-md border px-2 text-sm"
+        />
+        <Button
+          size="2xs"
+          color="indigo-outline"
+          disabled={!valid || saving}
+          loading={saving}
+          onClick={submit}
+        >
+          Add
+        </Button>
+      </Row>
+    </Col>
   )
 }
 

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -10,7 +10,11 @@ import {
   TRADED_TERM,
 } from 'common/envs/constants'
 import { computeFundingRate, getPerpBackingPool } from 'common/perps/amm'
-import { fundingPeriodNoun, getFundingPeriodMs } from 'common/perps/funding'
+import {
+  fundingPeriodNoun,
+  fundingPeriodUnit,
+  getFundingPeriodMs,
+} from 'common/perps/funding'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
 import { UNRANKED_GROUP_ID } from 'common/supabase/groups'
 import { BETTORS, User } from 'common/user'
@@ -815,11 +819,14 @@ function MaxFundingRateInput(props: { contract: PerpContract }) {
   }
 
   return (
-    <Row className="items-center gap-2">
-      <MaxFundingRateDisplay
-        maxFundingRate={current}
-        fundingPeriodMs={fundingPeriodMs}
-      />
+    <Row className="flex-wrap items-center gap-1.5">
+      <span className="tabular-nums">
+        {Number.isFinite(current)
+          ? `${(current * 100).toFixed(4)}%/${fundingPeriodUnit(
+              fundingPeriodMs
+            )}`
+          : '—'}
+      </span>
       <input
         type="number"
         min={0}
@@ -827,12 +834,12 @@ function MaxFundingRateInput(props: { contract: PerpContract }) {
         step={0.1}
         value={input}
         disabled={saving}
-        placeholder="%/period"
+        placeholder="New %"
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'Enter') submit()
         }}
-        className="bg-canvas-0 border-ink-300 h-7 w-24 rounded-md border px-2 text-sm"
+        className="bg-canvas-0 border-ink-300 h-7 w-20 rounded-md border px-2 text-sm"
       />
       <Button
         size="2xs"
@@ -900,13 +907,13 @@ function AddPerpSubsidyInput(props: { contract: PerpContract }) {
       <span className="text-ink-500 text-xs tabular-nums">
         L: {pools.poolLong.toFixed(2)} · S: {pools.poolShort.toFixed(2)}
       </span>
-      <Row className="items-center gap-2">
-        <Row className="border-ink-300 overflow-hidden rounded-md border">
+      <Row className="flex-wrap items-center gap-1.5">
+        <Row className="border-ink-300 shrink-0 overflow-hidden rounded-md border">
           {(['long', 'short'] as const).map((s) => (
             <button
               key={s}
               className={clsx(
-                'px-2 py-0.5 text-xs',
+                'px-1.5 py-0.5 text-xs',
                 side === s ? 'bg-primary-500 text-white' : 'text-ink-700'
               )}
               disabled={saving}
@@ -926,7 +933,7 @@ function AddPerpSubsidyInput(props: { contract: PerpContract }) {
           onKeyDown={(e) => {
             if (e.key === 'Enter') submit()
           }}
-          className="bg-canvas-0 border-ink-300 h-7 w-24 rounded-md border px-2 text-sm"
+          className="bg-canvas-0 border-ink-300 h-7 w-20 rounded-md border px-2 text-sm"
         />
         <Button
           size="2xs"


### PR DESCRIPTION
## What

Two admin ops tools for live perps, copying the max-leverage tool's structure (#3970):

- **`update-perp-config`** now also accepts an optional `maxFundingRate` (per-period fraction). Schema enforces the engine's `assertPerpFundingConfig` domain `(0, 1)` — a value ≥ 1 would make every funding tick fail closed. Applies from the next funding event, no redeploy.
- **New `add-perp-subsidy` endpoint** → engine fn `addPerpPoolSubsidy`: debits the calling admin's balance with a real `ADD_SUBSIDY` txn into contract escrow and bumps the chosen side's pool, so `assertPerpEscrowBalance` remains a checkable invariant. Runs under the engine's advisory lock + serializable transaction, so it cannot race the 15s oracle tick, funding, or trades.
- **See-info dialog**: inline admin editors for max funding rate (%/period input, annualized display) and pool subsidy (long/short + amount), plus a live L/S pool split.

## Why

The UK grid carbon perp has been frozen at oracle price 179 since 00:11 UTC 2026-08-07: the short pool fell ~442 M$ below the shorts' aggregate cost basis (realized long profits were paid out of cover backed by since-recovered unrealized short losses), so every oracle apply below ~178.8 throws `long solvency factor must be finite or +Infinity` in `assertPerpStateSolvent` and rolls back. ADL cannot repair a margin-cover deficit (it scales sizes, never cost bases). Funding is blocked by the same throw; trading is paused on staleness.

- The **subsidy tool** is the unfreeze: top up the short pool ≥ 443 M$ and the next tick applies the current feed price (shorts then take the designed ADL haircut, ~0.47 at 150).
- The **funding-cap tool** is the prevention lever: the current cap (1/8760 per hour ≈ 100%/yr) is ~2 orders of magnitude too small to tax riding this feed's predictable ±30%+/day cycle; 0.01–0.02/period is the intended range for this market.

Deeper mechanism fix (cross-side deficit transfer in `applyADL` + insurance-fund backstop) is deliberately out of scope here.

## Verification

- `tsc -b` clean on backend/api (+ common, shared via project refs); `tsc --noEmit` clean on web.
- Engine math for the frozen market reproduced against compiled `common/lib` with exact prod state (deficit −442.30; assert throws at ≤ ~178.8, passes at 179).