### PR TITLE
fix(perps): tolerance on the open-gate solvency check

### DIFF
--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -26,6 +26,7 @@ import {
   liquidationPrice as computeLiquidationPrice,
   openPosition as openPositionMath,
   PERP_OPEN_INTEREST_COVER_MULTIPLE,
+  PERP_SOLVENCY_FACTOR_TOLERANCE,
   PerpState,
   processLiquidations,
   solvencyFactor,
@@ -608,12 +609,17 @@ export const openOrAddPosition = async (
       )
     }
 
-    // Post-trade solvency must be >= 1.
+    // Post-trade solvency must be >= 1, within the same relative tolerance
+    // the engine's own assert uses. ADL deliberately scales winners so the
+    // factor lands at EXACTLY 1, so after any ADL event the book sits on the
+    // boundary within float dust — a strict `< 1` then rejects every open on
+    // the winning side with "solvency 1.000 < 1" (a new position has zero
+    // unrealized PnL and cannot move the factor at all).
     const solv = solvencyFactor(direction, open.state, price)
-    if (solv < 1)
+    if (solv < 1 - PERP_SOLVENCY_FACTOR_TOLERANCE)
       throw new APIError(
         400,
-        `Post-trade solvency ${solv.toFixed(3)} < 1; try lower leverage or size`
+        `Post-trade solvency ${solv.toFixed(6)} < 1; try lower leverage or size`
       )
 
     const { upserts, deletes } = diffForWrite(


### PR DESCRIPTION
## Bug

User report: opening a 100 M$ 1× short on the UK carbon perp fails with **`Post-trade solvency 1.000 < 1; try lower leverage or size`** — even at minimal size and leverage.

## Root cause

ADL deliberately scales winners so the side's solvency factor lands at **exactly 1** (`PERP_SOLVENCY_FACTOR_TOLERANCE` exists precisely because of this). On the price fall from ~150 to 116, repeated ADL events pinned the short side at the boundary: short cover (L − CL ≈ 9,688) equals short unrealized PnL (ES ≈ 9,688) in live prod state.

A new position at its own entry price has zero unrealized PnL and adds margin only to its **own** side's pool, so it cannot move the opposing cover or E at all — post-trade solvency recomputes to 1 ± float dust. The open gate checked `solv < 1` **with no tolerance** (unlike `assertPerpStateSolvent`, which allows the 1e-12 relative tolerance), so opens on the winning side were rejected whenever the dust landed a few ulps under — rendered as the absurd "1.000 < 1" by `toFixed(3)`.

## Fix

Use the same `PERP_SOLVENCY_FACTOR_TOLERANCE` in the open gate that the engine's own solvency assert accepts, so any state the engine certifies as solvent cannot block opens. Also print 6 digits so a genuine rejection never renders as "1.000 < 1".

## Deploy

API only — the gate lives in `openOrAddPosition`, which only the API calls. No scheduler redeploy needed.