### PR TITLE
fix(perps): classify meta/muse-spark-1.1 (closed) to unfreeze the openrouter feed

### DIFF
--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -50,7 +50,7 @@ import { DAY_MS } from '../util/time'
 // change silently when a third party edits a metadata field.
 
 /** Bump when the map changes. */
-export const OPEN_WEIGHT_LIST_VERSION = '2026-08-05'
+export const OPEN_WEIGHT_LIST_VERSION = '2026-08-07'
 
 /** Trailing window, in whole UTC days, that the index averages over. */
 export const OPEN_WEIGHT_WINDOW_DAYS = 7
@@ -75,6 +75,15 @@ export type ModelClassification = {
  * variant suffixes (`...:free`), which are the same model for index purposes.
  */
 export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
+  // Added 2026-08-07: entered the top 50 and froze the feed (fail-closed).
+  // Muse Spark is Meta's first CLOSED-weights family — API-only via
+  // api.meta.ai, no repo in meta-llama/facebook HF orgs, widely reported as
+  // Meta's break from open-weights (verified 2026-08-07). Muse Spark 1.2
+  // (OpenRouter-listed 2026-08-05) and Muse Code are closed on the same
+  // evidence; add their exact permaslugs when the fail-closed alert names
+  // them. If Meta later opens the weights, new entries count from that
+  // release forward only — never reclassify retroactively.
+  'meta/muse-spark-1.1-20260709': { open: false }, // Meta: Muse Spark 1.1
   // Added 2026-08-05: these four entered the top 50 during the week of
   // 2026-07-29 and froze the feed (fail-closed on unclassified models, as
   // designed — see the header comment).


### PR DESCRIPTION
## What happened
`meta/muse-spark-1.1-20260709` entered OpenRouter's top-50 rankings, and the open-weight index **fail-closed on the unclassified model** (as designed): the feed stopped publishing after its 2026-08-06T23:50Z point, the `[openrouter]` alert fired, and the market's trading is paused by the oracle freshness gate.

## Classification: closed
Muse Spark is **Meta's first closed-weights model family** — API-only via `api.meta.ai/v1`, no repository in the `meta-llama` or `facebook` HuggingFace orgs (verified 2026-08-07 via the HF org catalogues; OpenRouter `/models` shows no `hugging_face_id`), and widely reported as Meta's departure from open weights. Per the settled methodology: no public weight files → closed. This is exactly the kind of event the index exists to capture — expect the published share to **step down** when the feed resumes, since Muse Spark's tokens now count in the denominator as closed.

Muse Spark 1.2 (listed on OpenRouter 2026-08-05) and Muse Code are pre-decided **closed** on the same evidence; their exact date-stamped permaslugs can't be verified until they chart, so the header comment documents the decision for a 2-minute follow-up when the fail-closed alert names them.

## Changes
- `meta/muse-spark-1.1-20260709`: `{ open: false }`
- `OPEN_WEIGHT_LIST_VERSION` → `2026-08-07`

Tests: `open-weight-models.test.ts` 20/20 pass; `tsc -b` clean in `common`.

## Deploy
Requires a **scheduler-perps** redeploy to take effect (note: the oracle-tick-absent alert fires on every scheduler-perps deploy — expected, self-resolves). The feed's next hourly :50 run after deploy publishes and un-pauses the market.