### PR TITLE
fix(loans): exclude perp positions from the loan-limit equity base

### DIFF
--- a/backend/api/src/claim-free-loan.ts
+++ b/backend/api/src/claim-free-loan.ts
@@ -8,6 +8,7 @@ import {
   calculateMarketLoanMax,
   calculatePositionFreeLoan,
   canClaimDailyFreeLoan,
+  filterLoanEquityMetrics,
   isMarketEligibleForLoan,
   getMidnightPacific,
 } from 'common/loans'
@@ -85,10 +86,11 @@ export const claimFreeLoan: APIHandler<'claim-free-loan'> = async (_, auth) => {
     await getUnresolvedContractMetricsContractsAnswers(pg, [userId])
   const contractsById = keyBy(contracts, 'id')
 
-  // Calculate portfolio value (net of loans) and loan totals
+  // Calculate portfolio value (net of loans) and loan totals.
+  // Perps neither receive loans nor collateralize them — exclude from equity.
   const { value: portfolioValueNet } = getUnresolvedStatsForToken(
     'MANA',
-    metrics,
+    filterLoanEquityMetrics(metrics, contractsById),
     contractsById
   )
 

--- a/backend/api/src/get-free-loan-available.ts
+++ b/backend/api/src/get-free-loan-available.ts
@@ -10,6 +10,7 @@ import {
   filterLoanEquityMetrics,
   isMarketEligibleForLoan,
   getMidnightPacific,
+  sumExcludedPerpEquity,
 } from 'common/loans'
 import {
   getUnresolvedContractMetricsContractsAnswers,
@@ -73,6 +74,8 @@ export const getFreeLoanAvailable: APIHandler<
     filterLoanEquityMetrics(metrics, contractsById),
     contractsById
   )
+  // Reported so the UI can explain why perp-only portfolios earn no free loan.
+  const perpValueExcluded = sumExcludedPerpEquity(metrics, contractsById)
 
   // Calculate equity from net portfolio value (already excludes loans).
   // Using equity prevents the compounding loop where borrowing increases borrowing capacity.
@@ -259,5 +262,6 @@ export const getFreeLoanAvailable: APIHandler<
     dailyLimit,
     todayLoans,
     todaysFreeLoan,
+    perpValueExcluded,
   }
 }

--- a/backend/api/src/get-free-loan-available.ts
+++ b/backend/api/src/get-free-loan-available.ts
@@ -7,6 +7,7 @@ import {
   calculateMarketLoanMax,
   calculatePositionFreeLoan,
   canClaimDailyFreeLoan,
+  filterLoanEquityMetrics,
   isMarketEligibleForLoan,
   getMidnightPacific,
 } from 'common/loans'
@@ -65,10 +66,11 @@ export const getFreeLoanAvailable: APIHandler<
     await getUnresolvedContractMetricsContractsAnswers(pg, [userId])
   const contractsById = keyBy(contracts, 'id')
 
-  // Calculate portfolio value (net of loans)
+  // Calculate portfolio value (net of loans).
+  // Perps neither receive loans nor collateralize them — exclude from equity.
   const { value: portfolioValueNet } = getUnresolvedStatsForToken(
     'MANA',
-    metrics,
+    filterLoanEquityMetrics(metrics, contractsById),
     contractsById
   )
 

--- a/backend/api/src/get-market-loan-max.ts
+++ b/backend/api/src/get-market-loan-max.ts
@@ -5,6 +5,7 @@ import {
   calculateMarketLoanMax,
   calculateMaxGeneralLoanAmount,
   calculateDailyLoanLimit,
+  filterLoanEquityMetrics,
   MAX_MARKET_LOAN_NET_WORTH_PERCENT,
   MS_PER_DAY,
   isMarketEligibleForLoan,
@@ -73,9 +74,10 @@ export const getMarketLoanMax: APIHandler<'get-market-loan-max'> = async (
   const { metrics, contracts } =
     await getUnresolvedContractMetricsContractsAnswers(pg, [user.id])
   const contractsById = keyBy(contracts, 'id')
+  // Perps neither receive loans nor collateralize them — exclude from equity.
   const { value: portfolioValueNet } = getUnresolvedStatsForToken(
     'MANA',
-    metrics,
+    filterLoanEquityMetrics(metrics, contractsById),
     contractsById
   )
 

--- a/backend/api/src/get-next-loan-amount.ts
+++ b/backend/api/src/get-next-loan-amount.ts
@@ -6,6 +6,7 @@ import {
   calculateDailyLoanLimit,
   canClaimDailyFreeLoan,
   calculateTotalFreeLoanAvailable,
+  filterLoanEquityMetrics,
   isMarketEligibleForLoan,
   getMidnightPacific,
 } from 'common/loans'
@@ -70,9 +71,10 @@ export const getNextLoanAmount: APIHandler<'get-next-loan-amount'> = async ({
   const { metrics, contracts } =
     await getUnresolvedContractMetricsContractsAnswers(pg, [userId])
   const contractsById = keyBy(contracts, 'id')
+  // Perps neither receive loans nor collateralize them — exclude from equity.
   const { value: portfolioValueNet } = getUnresolvedStatsForToken(
     'MANA',
-    metrics,
+    filterLoanEquityMetrics(metrics, contractsById),
     contractsById
   )
 

--- a/backend/api/src/get-next-loan-amount.ts
+++ b/backend/api/src/get-next-loan-amount.ts
@@ -9,6 +9,7 @@ import {
   filterLoanEquityMetrics,
   isMarketEligibleForLoan,
   getMidnightPacific,
+  sumExcludedPerpEquity,
 } from 'common/loans'
 import {
   canAccessMarginLoans,
@@ -77,6 +78,8 @@ export const getNextLoanAmount: APIHandler<'get-next-loan-amount'> = async ({
     filterLoanEquityMetrics(metrics, contractsById),
     contractsById
   )
+  // Reported so the UI can explain the gap vs. the sitewide portfolio value.
+  const perpValueExcluded = sumExcludedPerpEquity(metrics, contractsById)
 
   // Total loan includes both free loans and margin loans
   const currentFreeLoan = sumBy(metrics, (m) => m.loan ?? 0)
@@ -162,5 +165,6 @@ export const getNextLoanAmount: APIHandler<'get-next-loan-amount'> = async ({
     // Equity-based calculation fields (equity = portfolioValue - loans)
     equity,
     portfolioValue,
+    perpValueExcluded,
   }
 }

--- a/backend/api/src/request-loan.ts
+++ b/backend/api/src/request-loan.ts
@@ -5,6 +5,7 @@ import {
   calculateMaxGeneralLoanAmount,
   calculateDailyLoanLimit,
   distributeLoanProportionally,
+  filterLoanEquityMetrics,
   isUserEligibleForGeneralLoan,
   isMarketEligibleForLoan,
   getMidnightPacific,
@@ -105,9 +106,10 @@ export const requestLoan: APIHandler<'request-loan'> = async (props, auth) => {
   const { contracts, metrics } =
     await getUnresolvedContractMetricsContractsAnswers(pg, [user.id])
   const contractsById = keyBy(contracts, 'id')
+  // Perps neither receive loans nor collateralize them — exclude from equity.
   const { value: portfolioValueNet } = getUnresolvedStatsForToken(
     'MANA',
-    metrics,
+    filterLoanEquityMetrics(metrics, contractsById),
     contractsById
   )
 

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -2620,6 +2620,8 @@ export const API = (_apiTypeCheck = {
       // Equity-based calculation fields (equity = portfolioValue - loans)
       equity?: number
       portfolioValue?: number
+      // Perp position value left out of the equity base (display only)
+      perpValueExcluded?: number
     },
     props: z.object({
       userId: z.string(),
@@ -2689,6 +2691,8 @@ export const API = (_apiTypeCheck = {
       todayLoans: number
       // Today's claimed free loan
       todaysFreeLoan: number
+      // Perp position value left out of the equity base (display only)
+      perpValueExcluded?: number
     },
     props: z.object({ userId: z.string() }),
   },

--- a/common/src/loans.test.ts
+++ b/common/src/loans.test.ts
@@ -1,0 +1,56 @@
+import { filterLoanEquityMetrics } from './loans'
+
+// Build minimal shapes — the helper only reads contractId and mechanism.
+const metric = (contractId: string, extra?: Record<string, unknown>) => ({
+  contractId,
+  ...extra,
+})
+
+const contractsById = {
+  perp1: { mechanism: 'perp' as const },
+  perp2: { mechanism: 'perp' as const },
+  binary: { mechanism: 'cpmm-1' as const },
+  multi: { mechanism: 'cpmm-multi-1' as const },
+}
+
+describe('filterLoanEquityMetrics', () => {
+  it('excludes perp positions from loan equity', () => {
+    const metrics = [
+      metric('perp1'),
+      metric('binary'),
+      metric('multi'),
+      metric('perp2'),
+    ]
+    const result = filterLoanEquityMetrics(metrics, contractsById)
+    expect(result.map((m) => m.contractId)).toEqual(['binary', 'multi'])
+  })
+
+  it('returns all metrics when none are perps', () => {
+    const metrics = [metric('binary'), metric('multi')]
+    expect(filterLoanEquityMetrics(metrics, contractsById)).toEqual(metrics)
+  })
+
+  it('returns empty for all-perp portfolios', () => {
+    const metrics = [metric('perp1'), metric('perp2')]
+    expect(filterLoanEquityMetrics(metrics, contractsById)).toEqual([])
+  })
+
+  it('keeps metrics whose contract is missing from the map', () => {
+    const metrics = [metric('unknown'), metric('perp1')]
+    const result = filterLoanEquityMetrics(metrics, contractsById)
+    expect(result.map((m) => m.contractId)).toEqual(['unknown'])
+  })
+
+  it('preserves metric fields and order', () => {
+    const metrics = [
+      metric('multi', { answerId: 'a', payout: 100 }),
+      metric('perp1', { payout: 5000 }),
+      metric('binary', { payout: 50 }),
+    ]
+    const result = filterLoanEquityMetrics(metrics, contractsById)
+    expect(result).toEqual([
+      { contractId: 'multi', answerId: 'a', payout: 100 },
+      { contractId: 'binary', payout: 50 },
+    ])
+  })
+})

--- a/common/src/loans.test.ts
+++ b/common/src/loans.test.ts
@@ -1,4 +1,4 @@
-import { filterLoanEquityMetrics } from './loans'
+import { filterLoanEquityMetrics, sumExcludedPerpEquity } from './loans'
 
 // Build minimal shapes — the helper only reads contractId and mechanism.
 const metric = (contractId: string, extra?: Record<string, unknown>) => ({
@@ -7,10 +7,11 @@ const metric = (contractId: string, extra?: Record<string, unknown>) => ({
 })
 
 const contractsById = {
-  perp1: { mechanism: 'perp' as const },
-  perp2: { mechanism: 'perp' as const },
-  binary: { mechanism: 'cpmm-1' as const },
-  multi: { mechanism: 'cpmm-multi-1' as const },
+  perp1: { mechanism: 'perp' as const, token: 'MANA' as const },
+  perp2: { mechanism: 'perp' as const, token: 'MANA' as const },
+  cashPerp: { mechanism: 'perp' as const, token: 'CASH' as const },
+  binary: { mechanism: 'cpmm-1' as const, token: 'MANA' as const },
+  multi: { mechanism: 'cpmm-multi-1' as const, token: 'MANA' as const },
 }
 
 describe('filterLoanEquityMetrics', () => {
@@ -52,5 +53,53 @@ describe('filterLoanEquityMetrics', () => {
       { contractId: 'multi', answerId: 'a', payout: 100 },
       { contractId: 'binary', payout: 50 },
     ])
+  })
+})
+
+describe('sumExcludedPerpEquity', () => {
+  it('sums the perp payout left out of the equity base', () => {
+    const metrics = [
+      metric('perp1', { payout: 5000 }),
+      metric('binary', { payout: 50 }),
+      metric('perp2', { payout: 250 }),
+    ]
+    expect(sumExcludedPerpEquity(metrics, contractsById)).toEqual(5250)
+  })
+
+  it('is zero when the portfolio holds no perps', () => {
+    const metrics = [metric('binary', { payout: 50 }), metric('multi', {})]
+    expect(sumExcludedPerpEquity(metrics, contractsById)).toEqual(0)
+  })
+
+  it('only counts perps of the requested token', () => {
+    const metrics = [
+      metric('perp1', { payout: 100 }),
+      metric('cashPerp', { payout: 900 }),
+    ]
+    expect(sumExcludedPerpEquity(metrics, contractsById)).toEqual(100)
+    expect(sumExcludedPerpEquity(metrics, contractsById, 'CASH')).toEqual(900)
+  })
+
+  it('ignores non-finite payouts rather than returning NaN', () => {
+    const metrics = [
+      metric('perp1', { payout: NaN }),
+      metric('perp2', { payout: 300 }),
+    ]
+    expect(sumExcludedPerpEquity(metrics, contractsById)).toEqual(300)
+  })
+
+  it('never reports a negative excluded value', () => {
+    const metrics = [metric('perp1', { payout: -40 })]
+    expect(sumExcludedPerpEquity(metrics, contractsById)).toEqual(0)
+  })
+
+  it('agrees with what filterLoanEquityMetrics drops', () => {
+    const metrics = [
+      metric('perp1', { payout: 700 }),
+      metric('binary', { payout: 50 }),
+    ]
+    const kept = filterLoanEquityMetrics(metrics, contractsById)
+    expect(kept.map((m) => m.contractId)).toEqual(['binary'])
+    expect(sumExcludedPerpEquity(metrics, contractsById)).toEqual(700)
   })
 })

--- a/common/src/loans.ts
+++ b/common/src/loans.ts
@@ -1,7 +1,7 @@
 import { sumBy } from 'lodash'
 import { PortfolioMetrics } from './portfolio-metrics'
 import { ContractMetric } from './contract-metric'
-import { Contract } from './contract'
+import { Contract, ContractToken } from './contract'
 
 export type LoanTrackingRow = {
   id?: number
@@ -169,6 +169,29 @@ export const filterLoanEquityMetrics = <M extends { contractId: string }>(
   return metrics.filter(
     (m) => contractsById[m.contractId]?.mechanism !== 'perp'
   )
+}
+
+/**
+ * The position value that `filterLoanEquityMetrics` removes from the equity
+ * base, for the given token. Purely informational: the loan endpoints return
+ * it so the UI can explain why the portfolio value it shows is lower than the
+ * one shown everywhere else on the site.
+ */
+export const sumExcludedPerpEquity = (
+  metrics: { contractId: string; payout?: number }[],
+  contractsById: Record<
+    string,
+    Pick<Contract, 'mechanism' | 'token'> | undefined
+  >,
+  token: ContractToken = 'MANA'
+): number => {
+  const total = sumBy(metrics, (m) => {
+    const contract = contractsById[m.contractId]
+    if (contract?.mechanism !== 'perp' || contract.token !== token) return 0
+    const payout = m.payout ?? 0
+    return Number.isFinite(payout) ? payout : 0
+  })
+  return Math.max(0, total)
 }
 
 export const isUserEligibleForLoan = (portfolio: PortfolioMetrics) => {

--- a/common/src/loans.ts
+++ b/common/src/loans.ts
@@ -1,6 +1,7 @@
 import { sumBy } from 'lodash'
 import { PortfolioMetrics } from './portfolio-metrics'
 import { ContractMetric } from './contract-metric'
+import { Contract } from './contract'
 
 export type LoanTrackingRow = {
   id?: number
@@ -152,6 +153,22 @@ export const calculateEquity = (
   loanTotal: number
 ): number => {
   return Math.max(0, portfolioValue - loanTotal)
+}
+
+/**
+ * Metrics that count as collateral for loan limits. Perp positions are
+ * excluded: they are internally leveraged, can be liquidated to zero before
+ * any loan is recovered, and never carry loans themselves — so counting their
+ * oracle-marked value in equity would let users re-leverage perp exposure
+ * into borrowing capacity against unrelated positions.
+ */
+export const filterLoanEquityMetrics = <M extends { contractId: string }>(
+  metrics: M[],
+  contractsById: Record<string, Pick<Contract, 'mechanism'> | undefined>
+): M[] => {
+  return metrics.filter(
+    (m) => contractsById[m.contractId]?.mechanism !== 'perp'
+  )
 }
 
 export const isUserEligibleForLoan = (portfolio: PortfolioMetrics) => {

--- a/web/components/home/daily-free-loan-modal.tsx
+++ b/web/components/home/daily-free-loan-modal.tsx
@@ -44,6 +44,10 @@ export function DailyFreeLoanModal(props: {
     freeLoanData.totalLoan >= freeLoanData.maxLoan && freeLoanData.maxLoan > 0
   const noEligiblePositions =
     !alreadyClaimedToday && !atMaxLoanLimit && freeLoanAvailable < 1
+  // Perps don't back loans, so a perp-only portfolio reads as "no positions".
+  // Say why instead of telling them to invest when they already have.
+  const perpValueExcluded = freeLoanData.perpValueExcluded ?? 0
+  const onlyPerpPositions = noEligiblePositions && perpValueExcluded >= 1
 
   return (
     <Modal open={isOpen} setOpen={setOpen} size="md">
@@ -162,6 +166,22 @@ export function DailyFreeLoanModal(props: {
                 <>
                   🔒 Max loan ({formatMoney(freeLoanData.maxLoan)}) reached.
                   Repay some to unlock more.
+                </>
+              ) : onlyPerpPositions ? (
+                <>
+                  📊 Your {formatMoney(perpValueExcluded)} in{' '}
+                  <Tooltip text="Perps are already leveraged and can be liquidated to zero, so they don't earn or back loans.">
+                    <span className="cursor-help underline decoration-dotted">
+                      perps
+                    </span>
+                  </Tooltip>{' '}
+                  doesn't earn daily loans. Trade an{' '}
+                  <Tooltip text="Listed, ranked markets with 10+ traders that are 24+ hours old">
+                    <span className="cursor-help underline decoration-dotted">
+                      eligible market
+                    </span>
+                  </Tooltip>{' '}
+                  to start earning!
                 </>
               ) : noEligiblePositions ? (
                 <>

--- a/web/components/home/daily-loan.tsx
+++ b/web/components/home/daily-loan.tsx
@@ -115,11 +115,16 @@ export function DailyLoan(props: {
     freeLoanData.maxLoan > 0
   const hasNoEligiblePositions =
     freeLoanData && !alreadyClaimedToday && !atMaxLoanLimit && !canClaimFreeLoan
+  // Perps don't back loans, so a perp-only portfolio reads as "no positions".
+  const onlyPerpPositions =
+    hasNoEligiblePositions && (freeLoanData?.perpValueExcluded ?? 0) >= 1
 
   // Ineligible = at max limit OR no eligible positions (but NOT if already claimed)
   const isIneligible = atMaxLoanLimit || hasNoEligiblePositions
-  // Disabled = no eligible positions (can't even repay if nothing invested)
-  const isButtonDisabled = hasNoEligiblePositions
+  // Disabled = no eligible positions (can't even repay if nothing invested).
+  // Perp-only holders stay clickable so the modal can explain why perps don't
+  // count — the tooltip alone isn't shown on mobile.
+  const isButtonDisabled = hasNoEligiblePositions && !onlyPerpPositions
 
   const getTooltipText = () => {
     if (isLoading) return 'Loading...'
@@ -131,6 +136,9 @@ export function DailyLoan(props: {
     }
     if (atMaxLoanLimit) {
       return 'At maximum loan limit'
+    }
+    if (onlyPerpPositions) {
+      return "Perps don't earn daily loans — trade a market to start earning"
     }
     if (hasNoEligiblePositions) {
       return 'Invest more to earn daily loan'

--- a/web/components/profile/loans-modal.tsx
+++ b/web/components/profile/loans-modal.tsx
@@ -29,6 +29,9 @@ import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
 import { Tooltip } from 'web/components/widgets/tooltip'
 import Link from 'next/link'
 
+const PERP_EQUITY_TOOLTIP =
+  "Perps are already leveraged and can be liquidated to zero, so they don't back loans. Your portfolio value elsewhere on the site still counts them."
+
 export function LoansModal(props: {
   user: User
   isOpen: boolean
@@ -56,6 +59,10 @@ export function LoansModal(props: {
   const availableToday = loanData?.availableToday ?? 0
   const hasOutstandingLoan = (latestPortfolio?.loanTotal ?? 0) > 0
   const hasMarginLoanAccess = loanData?.hasMarginLoanAccess ?? false
+  // Perps don't back loans, so the equity here is lower than the portfolio
+  // value shown elsewhere. Call the difference out rather than let it look
+  // like a bug.
+  const perpValueExcluded = loanData?.perpValueExcluded ?? 0
 
   const requestLoan = async (
     amountOverride?: number,
@@ -359,9 +366,36 @@ export function LoansModal(props: {
                             (loanData?.currentMarginLoan ?? 0)
                         )}
                         )
+                        {perpValueExcluded >= 1 && (
+                          <>
+                            <br />
+                            Excludes{' '}
+                            <Tooltip text={PERP_EQUITY_TOOLTIP}>
+                              <span className="cursor-help underline decoration-dotted">
+                                {formatMoney(perpValueExcluded)} in perps
+                              </span>
+                            </Tooltip>
+                          </>
+                        )}
                       </span>
                     </>
                   )}
+                  {!(loanData?.equity && loanData.equity > 0) &&
+                    perpValueExcluded >= 1 && (
+                      <>
+                        <br />
+                        <span className="text-ink-500 text-xs">
+                          Your{' '}
+                          <Tooltip text={PERP_EQUITY_TOOLTIP}>
+                            <span className="cursor-help underline decoration-dotted">
+                              {formatMoney(perpValueExcluded)} in perps
+                            </span>
+                          </Tooltip>{' '}
+                          doesn't count toward loan equity — hold a regular
+                          position to borrow
+                        </span>
+                      </>
+                    )}
                   .{' '}
                   {(() => {
                     const equity = loanData?.equity ?? 0


### PR DESCRIPTION
Perps were already excluded from receiving loans (both daily free loans and margin loans), but their oracle-marked value (margin + unrealized PnL) still counted toward the equity that sets every loan cap (total 100-300% by tier, 10% daily, 5% per market). That let leveraged perp exposure inflate borrowing capacity against unrelated positions — indirect double leverage — and since perp metric rows never carry loans, a liquidated perp leaves such a loan with no recovery hook.

Add filterLoanEquityMetrics to common/loans and apply it at the equity computation in all five loan endpoints, so perps neither receive loans nor collateralize them. Portfolio history/display is unchanged.