### PR TITLE
feat(perps): tokenized-equity oracle feeds — SPYx, QQQx, GLDx

### DIFF
--- a/backend/scripts/backfill-xstocks-oracle.ts
+++ b/backend/scripts/backfill-xstocks-oracle.ts
@@ -1,5 +1,6 @@
 import {
   GLDX_USD_FEED_ID,
+  NVDAX_USD_FEED_ID,
   QQQX_USD_FEED_ID,
   SPYX_USD_FEED_ID,
   insertOraclePrices,
@@ -16,8 +17,8 @@ import { runScript } from './run-script'
 // in consistent units. Each candle is recorded at its CLOSE time; the live
 // feed then takes over at 15s cadence via update-oracle-feeds.
 //
-// Args: <SPYX|QQQX|GLDX> [days] [interval] — defaults 90 days of 1h candles.
-// Example: `ts-node backfill-xstocks-oracle.ts SPYX 90 1h`
+// Args: <SPYX|QQQX|GLDX|NVDAX> [days] [interval] — defaults 90 days of 1h
+// candles. Example: `ts-node backfill-xstocks-oracle.ts SPYX 90 1h`
 // Finer patching: `ts-node backfill-xstocks-oracle.ts SPYX 2 5m`
 // (interval must be one Gate supports: 1m/5m/15m/30m/1h/4h/8h/1d).
 
@@ -25,6 +26,7 @@ const FEED_BY_KEY = {
   SPYX: SPYX_USD_FEED_ID,
   QQQX: QQQX_USD_FEED_ID,
   GLDX: GLDX_USD_FEED_ID,
+  NVDAX: NVDAX_USD_FEED_ID,
 } as const
 
 const INTERVAL_S: Record<string, number> = {

--- a/backend/scripts/backfill-xstocks-oracle.ts
+++ b/backend/scripts/backfill-xstocks-oracle.ts
@@ -1,0 +1,120 @@
+import {
+  GLDX_USD_FEED_ID,
+  QQQX_USD_FEED_ID,
+  SPYX_USD_FEED_ID,
+  insertOraclePrices,
+} from 'shared/oracle'
+import { XSTOCK_SPECS } from 'shared/xstocks-price'
+import { log } from 'shared/utils'
+import { runScript } from './run-script'
+
+// Backfill an xStocks oracle feed with closes from the public Gate spot
+// candlesticks API (no auth, max 1000 candles per request). Gate is the
+// backfill source because it is the live-feed venue with the deepest
+// accessible history for these pairs; its quotes are the same raw-token
+// USDT prices the live composite publishes, so history and live points are
+// in consistent units. Each candle is recorded at its CLOSE time; the live
+// feed then takes over at 15s cadence via update-oracle-feeds.
+//
+// Args: <SPYX|QQQX|GLDX> [days] [interval] — defaults 90 days of 1h candles.
+// Example: `ts-node backfill-xstocks-oracle.ts SPYX 90 1h`
+// Finer patching: `ts-node backfill-xstocks-oracle.ts SPYX 2 5m`
+// (interval must be one Gate supports: 1m/5m/15m/30m/1h/4h/8h/1d).
+
+const FEED_BY_KEY = {
+  SPYX: SPYX_USD_FEED_ID,
+  QQQX: QQQX_USD_FEED_ID,
+  GLDX: GLDX_USD_FEED_ID,
+} as const
+
+const INTERVAL_S: Record<string, number> = {
+  '1m': 60,
+  '5m': 300,
+  '15m': 900,
+  '30m': 1800,
+  '1h': 3600,
+  '4h': 14400,
+  '8h': 28800,
+  '1d': 86400,
+}
+
+const KEY = (process.argv[2] ?? '').toUpperCase() as keyof typeof FEED_BY_KEY
+const DAYS = Number(process.argv[3]) || 90
+const INTERVAL = process.argv[4] || '1h'
+const CANDLES_PER_REQ = 1000
+
+// Gate candle: [ts bucket-start seconds, quote volume, close, high, low,
+// open, base volume, "true" when the window has closed] — all strings.
+type GateCandle = [string, string, string, string, string, string, string, string]
+
+const fetchCandles = async (
+  pair: string,
+  fromS: number,
+  toS: number
+): Promise<GateCandle[]> => {
+  const url = new URL('https://api.gateio.ws/api/v4/spot/candlesticks')
+  url.searchParams.set('currency_pair', pair)
+  url.searchParams.set('interval', INTERVAL)
+  url.searchParams.set('from', String(fromS))
+  url.searchParams.set('to', String(toS))
+  const res = await fetch(url.toString(), {
+    headers: { 'user-agent': 'Manifold/1.0 (+https://manifold.markets)' },
+    signal: AbortSignal.timeout(15_000),
+  })
+  if (!res.ok) throw new Error(`gate candles: ${res.status} ${res.statusText}`)
+  return (await res.json()) as GateCandle[]
+}
+
+if (require.main === module)
+  runScript(async ({ pg }) => {
+    const feedId = FEED_BY_KEY[KEY]
+    const spec = XSTOCK_SPECS[KEY]
+    const intervalS = INTERVAL_S[INTERVAL]
+    if (!feedId || !spec)
+      throw new Error(
+        `usage: backfill-xstocks-oracle.ts <${Object.keys(FEED_BY_KEY).join(
+          '|'
+        )}> [days] [interval]`
+      )
+    if (!intervalS)
+      throw new Error(
+        `unsupported interval ${INTERVAL}; use one of ${Object.keys(
+          INTERVAL_S
+        ).join('/')}`
+      )
+
+    const nowS = Math.floor(Date.now() / 1000)
+    const startS = nowS - Math.floor(DAYS * 24 * 60 * 60)
+    const chunkS = CANDLES_PER_REQ * intervalS
+
+    const points: { ts: number; price: number }[] = []
+    for (let from = startS; from < nowS; from += chunkS) {
+      const to = Math.min(from + chunkS - intervalS, nowS)
+      const candles = await fetchCandles(spec.gatePair, from, to)
+      for (const [bucketStartS, , close, , , , , windowClosed] of candles) {
+        // Skip the still-open candle: its close isn't final.
+        if (windowClosed !== 'true') continue
+        const closeTimeMs = (Number(bucketStartS) + intervalS) * 1000
+        const price = Number(close)
+        if (
+          Number.isFinite(closeTimeMs) &&
+          closeTimeMs <= Date.now() &&
+          Number.isFinite(price) &&
+          price > 0
+        )
+          points.push({ ts: closeTimeMs, price })
+      }
+      log(
+        `fetched ${candles.length} candles ending ${new Date(
+          to * 1000
+        ).toISOString()}`
+      )
+      // Public endpoint is rate-limited; be polite.
+      await new Promise((r) => setTimeout(r, 300))
+    }
+
+    points.sort((a, b) => a.ts - b.ts)
+    log(`inserting ${points.length} ${INTERVAL} closes`)
+    await insertOraclePrices(pg, feedId, points)
+    log(`backfilled ${points.length} ${feedId} oracle points`)
+  })

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -4,11 +4,15 @@ import { validateBasicOraclePoint } from 'common/perps/oracle'
 import { fetchBtcUsdSpot } from './btc-price'
 import {
   BTC_USD_FEED_ID,
+  GLDX_USD_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
+  QQQX_USD_FEED_ID,
+  SPYX_USD_FEED_ID,
   TRUMP_APPROVAL_FEED_ID,
   UK_GRID_CARBON_FEED_ID,
 } from './oracle'
 import { fetchUkGridCarbonRecent } from './uk-grid-carbon'
+import { XSTOCK_SPECS, fetchXStockUsdPrice } from './xstocks-price'
 
 // Registry of known oracle feeds. This is the single place that says how a
 // feed updates, what values are plausible, and when its silence is an
@@ -94,6 +98,51 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     staleAfterMs: 2 * HOUR_MS,
     updatePeriodMs: 30 * MINUTE_MS,
     fetchRecent: fetchUkGridCarbonRecent,
+  },
+  // Tokenized-equity (xStocks) feeds. Corruption is caught at the source —
+  // fetchXStockUsdPrice requires cross-venue agreement, like BTC — so bounds
+  // here only reject unit-confused garbage (a cents-denominated or
+  // percent-scaled value), not fast moves. Uniform wide bounds on purpose:
+  // all three tokens trade in the $300–800 range today and a genuine 10×
+  // move in either direction should still publish. staleAfterMs is looser
+  // than BTC's because these books are thin: consensus can transiently fail
+  // on quiet weekend prints, and five minutes tolerates a few skipped ticks
+  // without paging while still bounding how old an executable price can get
+  // (markets pause at the same threshold via maxOraclePriceAgeMs).
+  {
+    id: SPYX_USD_FEED_ID,
+    description:
+      'SPYx/USD (tokenized S&P 500 ETF), median of Jupiter/Gate/MEXC',
+    marketCreationEnabled: true,
+    cadence: 'fast',
+    minPrice: 10,
+    maxPrice: 50_000,
+    staleAfterMs: 5 * MINUTE_MS,
+    updatePeriodMs: 15_000,
+    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.SPYX),
+  },
+  {
+    id: QQQX_USD_FEED_ID,
+    description:
+      'QQQx/USD (tokenized Nasdaq-100 ETF), Jupiter+Gate agreement',
+    marketCreationEnabled: true,
+    cadence: 'fast',
+    minPrice: 10,
+    maxPrice: 50_000,
+    staleAfterMs: 5 * MINUTE_MS,
+    updatePeriodMs: 15_000,
+    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.QQQX),
+  },
+  {
+    id: GLDX_USD_FEED_ID,
+    description: 'GLDx/USD (tokenized gold ETF), Jupiter+Gate agreement',
+    marketCreationEnabled: true,
+    cadence: 'fast',
+    minPrice: 10,
+    maxPrice: 50_000,
+    staleAfterMs: 5 * MINUTE_MS,
+    updatePeriodMs: 15_000,
+    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.GLDX),
   },
   // Daily feeds use a 26h threshold (one missed daily run + slack) rather
   // than a lazy 3d: the hourly update-perps job turns feed staleness into

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -5,6 +5,7 @@ import { fetchBtcUsdSpot } from './btc-price'
 import {
   BTC_USD_FEED_ID,
   GLDX_USD_FEED_ID,
+  NVDAX_USD_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
   QQQX_USD_FEED_ID,
   SPYX_USD_FEED_ID,
@@ -103,7 +104,7 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
   // fetchXStockUsdPrice requires cross-venue agreement, like BTC — so bounds
   // here only reject unit-confused garbage (a cents-denominated or
   // percent-scaled value), not fast moves. Uniform wide bounds on purpose:
-  // all three tokens trade in the $300–800 range today and a genuine 10×
+  // the four tokens trade in the $200–800 range today and a genuine 10×
   // move in either direction should still publish. staleAfterMs is looser
   // than BTC's because these books are thin: consensus can transiently fail
   // on quiet weekend prints, and five minutes tolerates a few skipped ticks
@@ -143,6 +144,17 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     staleAfterMs: 5 * MINUTE_MS,
     updatePeriodMs: 15_000,
     fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.GLDX),
+  },
+  {
+    id: NVDAX_USD_FEED_ID,
+    description: 'NVDAx/USD (tokenized Nvidia), median of Jupiter/Gate/MEXC',
+    marketCreationEnabled: true,
+    cadence: 'fast',
+    minPrice: 10,
+    maxPrice: 50_000,
+    staleAfterMs: 5 * MINUTE_MS,
+    updatePeriodMs: 15_000,
+    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.NVDAX),
   },
   // Daily feeds use a 26h threshold (one missed daily run + slack) rather
   // than a lazy 3d: the hourly update-perps job turns feed staleness into

--- a/backend/shared/src/oracle.ts
+++ b/backend/shared/src/oracle.ts
@@ -12,6 +12,7 @@ export const OPENROUTER_OPEN_WEIGHT_FEED_ID = 'openrouter-open-weight-share'
 export const SPYX_USD_FEED_ID = 'spyx-usd'
 export const QQQX_USD_FEED_ID = 'qqqx-usd'
 export const GLDX_USD_FEED_ID = 'gldx-usd'
+export const NVDAX_USD_FEED_ID = 'nvdax-usd'
 
 // Append oracle price points for a feed. Published history is immutable:
 // duplicate (feed_id, ts) values remain unchanged even if a source later

--- a/backend/shared/src/oracle.ts
+++ b/backend/shared/src/oracle.ts
@@ -9,6 +9,9 @@ export const TRUMP_APPROVAL_FEED_ID = 'trump-approval-rating'
 export const BTC_USD_FEED_ID = 'btc-usd'
 export const UK_GRID_CARBON_FEED_ID = 'uk-grid-carbon'
 export const OPENROUTER_OPEN_WEIGHT_FEED_ID = 'openrouter-open-weight-share'
+export const SPYX_USD_FEED_ID = 'spyx-usd'
+export const QQQX_USD_FEED_ID = 'qqqx-usd'
+export const GLDX_USD_FEED_ID = 'gldx-usd'
 
 // Append oracle price points for a feed. Published history is immutable:
 // duplicate (feed_id, ts) values remain unchanged even if a source later

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -136,8 +136,8 @@ Feed adapters live next to it:
 
 - `btc-price.ts` — BTC/USD spot, median of Coinbase/Kraken/Bitstamp (all
   US-accessible; Binance geo-blocks US IPs).
-- `xstocks-price.ts` — tokenized-equity USD prices (SPYx/QQQx/GLDx, xStocks
-  by Backed), consensus median across Jupiter/Gate/MEXC venue quotes. Pure
+- `xstocks-price.ts` — tokenized-equity USD prices (SPYx/QQQx/GLDx/NVDAx,
+  xStocks by Backed), consensus median across Jupiter/Gate/MEXC venue quotes. Pure
   response parsing lives in `common/src/perps/xstocks.ts` (unit-tested,
   including the raw-vs-rebase-scaled unit trap).
 - `uk-grid-carbon.ts` — GB grid carbon intensity (gCO2/kWh), NESO 30-min

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -136,6 +136,10 @@ Feed adapters live next to it:
 
 - `btc-price.ts` — BTC/USD spot, median of Coinbase/Kraken/Bitstamp (all
   US-accessible; Binance geo-blocks US IPs).
+- `xstocks-price.ts` — tokenized-equity USD prices (SPYx/QQQx/GLDx, xStocks
+  by Backed), consensus median across Jupiter/Gate/MEXC venue quotes. Pure
+  response parsing lives in `common/src/perps/xstocks.ts` (unit-tested,
+  including the raw-vs-rebase-scaled unit trap).
 - `uk-grid-carbon.ts` — GB grid carbon intensity (gCO2/kWh), NESO 30-min
   actuals.
 - `trump-approval.ts` — 14-day rolling approval average (VoteHub).
@@ -150,7 +154,7 @@ short thesis. If an ingest-only feed is ever added again, list it in
 enforces that exclusion.
 
 Backfill scripts
-(`backend/scripts/backfill-{btc,uk-carbon,trump-approval,openrouter}-oracle.ts`)
+(`backend/scripts/backfill-{btc,xstocks,uk-carbon,trump-approval,openrouter}-oracle.ts`)
 seed chart history before market creation.
 
 The executable launch set, conservative initial parameters, feed-specific game

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -6,6 +6,7 @@ import { getOracleAttribution } from 'common/perps/oracle-attribution'
 import {
   BTC_USD_FEED_ID,
   GLDX_USD_FEED_ID,
+  NVDAX_USD_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
   QQQX_USD_FEED_ID,
   SPYX_USD_FEED_ID,
@@ -253,6 +254,34 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
       'Macro/safe-haven exposure that diversifies the equity pair; no dividends, so no rebase drift. Thinnest venue set in the trio (Gate turned over ~$56K/day at probe time), hence the same conservative caps despite the calmer underlying.',
     latencyArbitrageRisk:
       'Same pick-off surface and two-source consensus caveat as QQQx, on the thinnest books of the three markets.',
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 5 * MINUTE_MS,
+      subsidyLong: 10_000,
+      subsidyShort: 10_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 * 24 },
+  },
+  {
+    feedId: NVDAX_USD_FEED_ID,
+    question: 'Nvidia — tokenized NVDA price (NVDAx, USD)',
+    requiredTopics: [
+      {
+        name: 'Stocks',
+        slugByEnvironment: {
+          DEV: 'economics-default',
+          PROD: 'stocks',
+        },
+      },
+    ],
+    oracleBehavior: 'continuous-public',
+    requiresSourceAsOf: false,
+    gameDesign:
+      'The only single-name equity in the set: higher volatility and coherent theses on both sides, but earnings and headline gaps land harder than on the index pairs — leverage should stay at the conservative recommendation until post-earnings behavior is observed. Pays a negligible dividend, so rebase drift is immaterial.',
+    latencyArbitrageRisk:
+      'Same pick-off surface as SPYx (all three venues listed), with larger single-name jumps: an earnings gap can exceed the consensus tolerance venue-by-venue for a few ticks while books reprice.',
     recommended: {
       maxLeverage: 3,
       annualMaxFundingRate: 1,

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -5,7 +5,10 @@ import { getOracleAttribution } from 'common/perps/oracle-attribution'
 
 import {
   BTC_USD_FEED_ID,
+  GLDX_USD_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
+  QQQX_USD_FEED_ID,
+  SPYX_USD_FEED_ID,
   TRUMP_APPROVAL_FEED_ID,
   UK_GRID_CARBON_FEED_ID,
 } from '../oracle'
@@ -161,6 +164,104 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
       subsidyShort: 10_000,
     },
     minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+  },
+  // Tokenized-equity trio (xStocks by Backed). These deliberately track the
+  // TOKEN's venue price, not the underlying index: that is what makes the
+  // feed free and licence-clean (we composite public crypto-venue quotes,
+  // like BTC) and what gives it genuine 24/7 price discovery — mint/redeem
+  // arbitrage pins the token to the ETF during US market hours and it trades
+  // like a futures proxy overnight and on weekends. The questions name the
+  // index for discovery but state the tracked instrument.
+  //
+  // Leverage is capped below BTC's because total venue turnover is ~3 orders
+  // of magnitude thinner (~$3-6M/day SPYx, less for the others): the
+  // consensus gate rejects single-venue wicks, but a thin-book move that two
+  // venues echo executes here at zero fees.
+  {
+    feedId: SPYX_USD_FEED_ID,
+    question: 'S&P 500 — tokenized SPY price (SPYx, USD)',
+    requiredTopics: [
+      {
+        // DEV has no Stocks topic; economics-default exists in both
+        // environments (same pattern as BTC's crypto-default).
+        name: 'Stocks',
+        slugByEnvironment: {
+          DEV: 'economics-default',
+          PROD: 'stocks',
+        },
+      },
+    ],
+    oracleBehavior: 'continuous-public',
+    requiresSourceAsOf: false,
+    gameDesign:
+      'Two-sided macro exposure with real 24/7 price discovery: pinned to SPY intraday by issuer arbitrage, a futures-like proxy on nights and weekends. Dividend reinvestment (balance rebasing) makes the raw token drift above SPY spot by roughly 1%/yr; the feed quotes the raw token consistently.',
+    latencyArbitrageRisk:
+      'Venue prices are public before the 15-second poll reaches Manifold, so exact-price zero-fee execution can be picked off, and books are far thinner than BTC. Weekend liquidity is the worst case: consensus can wobble and a genuine fast move executes against the stale cache for up to a tick.',
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 5 * MINUTE_MS,
+      subsidyLong: 10_000,
+      subsidyShort: 10_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 * 24 },
+  },
+  {
+    feedId: QQQX_USD_FEED_ID,
+    question: 'Nasdaq-100 — tokenized QQQ price (QQQx, USD)',
+    requiredTopics: [
+      {
+        name: 'Stocks',
+        slugByEnvironment: {
+          DEV: 'economics-default',
+          PROD: 'stocks',
+        },
+      },
+    ],
+    oracleBehavior: 'continuous-public',
+    requiresSourceAsOf: false,
+    gameDesign:
+      'Higher-beta sibling of the SPYx market with the same 24/7 discovery mechanics; correlated with both SPYx and BTC, which traders can spread against.',
+    latencyArbitrageRisk:
+      'Same pick-off surface as SPYx, plus a two-source consensus (MEXC does not list QQQx): one venue outage stalls the feed until it recovers, pausing trading at maxOraclePriceAgeMs rather than executing one-venue prices.',
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 5 * MINUTE_MS,
+      subsidyLong: 10_000,
+      subsidyShort: 10_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 * 24 },
+  },
+  {
+    feedId: GLDX_USD_FEED_ID,
+    question: 'Gold — tokenized GLD price (GLDx, USD)',
+    requiredTopics: [
+      {
+        name: 'Economics',
+        slugByEnvironment: {
+          DEV: 'economics-default',
+          PROD: 'economics-default',
+        },
+      },
+    ],
+    oracleBehavior: 'continuous-public',
+    requiresSourceAsOf: false,
+    gameDesign:
+      'Macro/safe-haven exposure that diversifies the equity pair; no dividends, so no rebase drift. Thinnest venue set in the trio (Gate turned over ~$56K/day at probe time), hence the same conservative caps despite the calmer underlying.',
+    latencyArbitrageRisk:
+      'Same pick-off surface and two-source consensus caveat as QQQx, on the thinnest books of the three markets.',
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 5 * MINUTE_MS,
+      subsidyLong: 10_000,
+      subsidyShort: 10_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 * 24 },
   },
 ]
 

--- a/backend/shared/src/xstocks-price.ts
+++ b/backend/shared/src/xstocks-price.ts
@@ -1,0 +1,154 @@
+import { getConsensusMedian } from 'common/perps/oracle'
+import {
+  readGateTickerMid,
+  readJupiterRawUsdPrice,
+  readMexcBookTickerMid,
+} from 'common/perps/xstocks'
+
+import { log } from './utils'
+
+// USD prices for tokenized equities (xStocks by Backed Finance), composited
+// across the free, no-auth, US-accessible venues where the tokens actually
+// trade. Same validation stance as btc-price.ts: the oracle point is a
+// median gated on cross-venue agreement, so one venue being down,
+// rate-limited, or wicked by a thin-book print can't move the feed.
+//
+// Venue map (probed 2026-08-07): Jupiter's lite-api aggregates all Solana
+// DEX liquidity ($1.7-2.5M routed per token); Gate and MEXC are CEX spot
+// books. SPYx has all three; QQQx and GLDx are not listed on MEXC, so those
+// feeds run getConsensusMedian's two-source path — both venues must respond
+// AND agree within tolerance or the tick is skipped, and a single venue
+// outage stalls the feed until it recovers (markets pause via
+// maxOraclePriceAgeMs). Kraken is the largest xStocks venue but does not
+// expose them on its public spot API, and Bybit no longer lists them.
+// CoinGecko is deliberately not in the hot path (keyless rate limits,
+// aggregation latency); it is a backfill/sanity source only.
+//
+// Quote currency: Gate and MEXC quote against USDT while Jupiter routes
+// through USD-stable pools. A USDT depeg beyond the divergence tolerance
+// splits the venues and (correctly) stalls the feed rather than publishing a
+// number denominated in a broken stablecoin.
+
+const FETCH_TIMEOUT_MS = 5_000
+const MAX_SOURCE_DIVERGENCE_FRAC = 0.02
+
+export type XStockSpec = {
+  /** Display symbol as the issuer styles it, e.g. 'SPYx'. */
+  symbol: string
+  /** Solana mint address — the id Jupiter's price API is keyed on. */
+  mint: string
+  gatePair: string
+  /** Only some xStocks are listed on MEXC. */
+  mexcSymbol?: string
+}
+
+export const XSTOCK_SPECS = {
+  SPYX: {
+    symbol: 'SPYx',
+    mint: 'XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W',
+    gatePair: 'SPYX_USDT',
+    mexcSymbol: 'SPYXUSDT',
+  },
+  QQQX: {
+    symbol: 'QQQx',
+    mint: 'Xs8S1uUs1zvS2p7iwtsG3b6fkhpvmwz4GYU3gWAmWHZ',
+    gatePair: 'QQQX_USDT',
+  },
+  GLDX: {
+    symbol: 'GLDx',
+    mint: 'Xsv9hRk1z5ystj9MhnA7Lq4vjSsLwzL2nxrwmwtD3re',
+    gatePair: 'GLDX_USDT',
+  },
+} as const satisfies Record<string, XStockSpec>
+
+const fetchJson = async (url: string): Promise<unknown> => {
+  const res = await fetch(url, {
+    headers: { 'user-agent': 'Manifold/1.0 (+https://manifold.markets)' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  if (!res.ok) throw new Error(`${url}: ${res.status} ${res.statusText}`)
+  return res.json()
+}
+
+type XStockSource = {
+  name: string
+  fetchPrice: () => Promise<number>
+}
+
+const buildSources = (spec: XStockSpec): XStockSource[] => {
+  const sources: XStockSource[] = [
+    {
+      name: 'jupiter',
+      fetchPrice: async () =>
+        readJupiterRawUsdPrice(
+          await fetchJson(`https://lite-api.jup.ag/price/v3?ids=${spec.mint}`),
+          spec.mint
+        ),
+    },
+    {
+      name: 'gate',
+      fetchPrice: async () =>
+        readGateTickerMid(
+          await fetchJson(
+            `https://api.gateio.ws/api/v4/spot/tickers?currency_pair=${spec.gatePair}`
+          )
+        ),
+    },
+  ]
+  if (spec.mexcSymbol) {
+    const symbol = spec.mexcSymbol
+    sources.push({
+      name: 'mexc',
+      fetchPrice: async () =>
+        readMexcBookTickerMid(
+          await fetchJson(
+            `https://api.mexc.com/api/v3/ticker/bookTicker?symbol=${symbol}`
+          )
+        ),
+    })
+  }
+  return sources
+}
+
+export const fetchXStockUsdPrice = async (
+  spec: XStockSpec
+): Promise<{ ts: number; price: number } | null> => {
+  const sources = buildSources(spec)
+  const results = await Promise.allSettled(
+    sources.map(async (s) => {
+      const price = await s.fetchPrice()
+      if (!Number.isFinite(price) || price <= 0)
+        throw new Error(`${s.name}: bad price ${price}`)
+      return price
+    })
+  )
+  const quotes: { source: string; price: number }[] = []
+  results.forEach((r, i) => {
+    if (r.status === 'fulfilled')
+      quotes.push({ source: sources[i].name, price: r.value })
+    else log(`[xstocks-price] ${spec.symbol} ${sources[i].name}: ${r.reason}`)
+  })
+
+  if (quotes.length < 2) {
+    log.error(
+      `[xstocks-price] ${spec.symbol}: only ${quotes.length}/${sources.length} sources responded — skipping point`
+    )
+    return null
+  }
+
+  const price = getConsensusMedian(
+    quotes.map((quote) => quote.price),
+    MAX_SOURCE_DIVERGENCE_FRAC
+  )
+  if (price == null) {
+    log.error(
+      `[xstocks-price] ${spec.symbol}: no venue pair agreed within ${
+        MAX_SOURCE_DIVERGENCE_FRAC * 100
+      }% (${quotes
+        .map((quote) => `${quote.source}=${quote.price}`)
+        .join(', ')}) — skipping point`
+    )
+    return null
+  }
+  return { ts: Date.now(), price }
+}

--- a/backend/shared/src/xstocks-price.ts
+++ b/backend/shared/src/xstocks-price.ts
@@ -14,9 +14,9 @@ import { log } from './utils'
 // rate-limited, or wicked by a thin-book print can't move the feed.
 //
 // Venue map (probed 2026-08-07): Jupiter's lite-api aggregates all Solana
-// DEX liquidity ($1.7-2.5M routed per token); Gate and MEXC are CEX spot
-// books. SPYx has all three; QQQx and GLDx are not listed on MEXC, so those
-// feeds run getConsensusMedian's two-source path — both venues must respond
+// DEX liquidity ($0.2-2.5M routed per token); Gate and MEXC are CEX spot
+// books. SPYx and NVDAx have all three; QQQx and GLDx are not listed on
+// MEXC, so those feeds run getConsensusMedian's two-source path — both venues must respond
 // AND agree within tolerance or the tick is skipped, and a single venue
 // outage stalls the feed until it recovers (markets pause via
 // maxOraclePriceAgeMs). Kraken is the largest xStocks venue but does not
@@ -58,6 +58,12 @@ export const XSTOCK_SPECS = {
     symbol: 'GLDx',
     mint: 'Xsv9hRk1z5ystj9MhnA7Lq4vjSsLwzL2nxrwmwtD3re',
     gatePair: 'GLDX_USDT',
+  },
+  NVDAX: {
+    symbol: 'NVDAx',
+    mint: 'Xsc9qvGR1efVDFGLrVsmkzv3qi45LTBjeUKSPmx9qEh',
+    gatePair: 'NVDAX_USDT',
+    mexcSymbol: 'NVDAXUSDT',
   },
 } as const satisfies Record<string, XStockSpec>
 

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -20,6 +20,10 @@
 //     So they get a credit and a link, and no licence label we can't back up.
 //   - BTC — we compute the median ourselves from three public tickers, so
 //     nothing is being republished. Credited for transparency, not obligation.
+//   - xStocks (SPYx/QQQx/GLDx) — same self-computed stance as BTC: we quote
+//     public venue prices for a crypto TOKEN, so no index-provider data is
+//     republished. "xStocks" is named so readers know what instrument the
+//     price belongs to; the venue credits are transparency, not obligation.
 
 export type OracleAttribution = {
   /** Display name of the data provider. */
@@ -52,6 +56,18 @@ export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
   },
   'btc-usd': {
     source: 'Coinbase, Kraken & Bitstamp',
+  },
+  'spyx-usd': {
+    source: 'Jupiter, Gate & MEXC (SPYx by Backed xStocks)',
+    url: 'https://xstocks.fi',
+  },
+  'qqqx-usd': {
+    source: 'Jupiter & Gate (QQQx by Backed xStocks)',
+    url: 'https://xstocks.fi',
+  },
+  'gldx-usd': {
+    source: 'Jupiter & Gate (GLDx by Backed xStocks)',
+    url: 'https://xstocks.fi',
   },
 }
 

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -69,6 +69,10 @@ export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
     source: 'Jupiter & Gate (GLDx by Backed xStocks)',
     url: 'https://xstocks.fi',
   },
+  'nvdax-usd': {
+    source: 'Jupiter, Gate & MEXC (NVDAx by Backed xStocks)',
+    url: 'https://xstocks.fi',
+  },
 }
 
 export const getOracleAttribution = (

--- a/common/src/perps/xstocks.test.ts
+++ b/common/src/perps/xstocks.test.ts
@@ -1,0 +1,140 @@
+import {
+  readGateTickerMid,
+  readJupiterRawUsdPrice,
+  readMexcBookTickerMid,
+} from './xstocks'
+
+// Fixtures are trimmed captures of real venue responses (probed 2026-08-07),
+// so the tests pin the actual wire shapes: Jupiter returns numbers, Gate and
+// MEXC return numeric strings.
+
+const SPYX_MINT = 'XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W'
+const GLDX_MINT = 'Xsv9hRk1z5ystj9MhnA7Lq4vjSsLwzL2nxrwmwtD3re'
+
+const jupiterSpyx = {
+  [SPYX_MINT]: {
+    usdPrice: 769.6353991512417,
+    decimals: 8,
+    scaledUiConfig: {
+      multiplier: 1.003909240011759,
+      newMultiplier: 1.005714560286254,
+      usdPricePrescaled: 774.0335270381266,
+    },
+  },
+}
+
+const jupiterGldx = {
+  [GLDX_MINT]: {
+    usdPrice: 394.2284266101142,
+    decimals: 8,
+    // No scaledUiConfig: GLD pays no dividends, so the token never rebases.
+  },
+}
+
+describe('readJupiterRawUsdPrice', () => {
+  it('prefers the prescaled (raw-unit) price when the token rebases', () => {
+    // The scaled usdPrice (769.64) is a real price for a DIFFERENT unit than
+    // CEX books trade; choosing it would bias the composite by the accrued
+    // dividend multiplier without tripping the consensus gate.
+    expect(readJupiterRawUsdPrice(jupiterSpyx, SPYX_MINT)).toBe(
+      774.0335270381266
+    )
+  })
+
+  it('falls back to usdPrice for tokens without the scaled-ui extension', () => {
+    expect(readJupiterRawUsdPrice(jupiterGldx, GLDX_MINT)).toBe(
+      394.2284266101142
+    )
+  })
+
+  it('falls back to usdPrice when the prescaled value is unusable', () => {
+    const body = {
+      [SPYX_MINT]: {
+        usdPrice: 770,
+        scaledUiConfig: { usdPricePrescaled: 0 },
+      },
+    }
+    expect(readJupiterRawUsdPrice(body, SPYX_MINT)).toBe(770)
+  })
+
+  it('returns NaN when the mint is absent or the body is malformed', () => {
+    expect(readJupiterRawUsdPrice(jupiterSpyx, GLDX_MINT)).toBeNaN()
+    expect(readJupiterRawUsdPrice({}, SPYX_MINT)).toBeNaN()
+    expect(readJupiterRawUsdPrice(null, SPYX_MINT)).toBeNaN()
+    expect(readJupiterRawUsdPrice([jupiterSpyx], SPYX_MINT)).toBeNaN()
+    expect(readJupiterRawUsdPrice('774', SPYX_MINT)).toBeNaN()
+  })
+
+  it('returns NaN for non-positive or non-finite prices', () => {
+    expect(
+      readJupiterRawUsdPrice({ [SPYX_MINT]: { usdPrice: 0 } }, SPYX_MINT)
+    ).toBeNaN()
+    expect(
+      readJupiterRawUsdPrice({ [SPYX_MINT]: { usdPrice: -5 } }, SPYX_MINT)
+    ).toBeNaN()
+    expect(
+      readJupiterRawUsdPrice(
+        { [SPYX_MINT]: { usdPrice: Number.POSITIVE_INFINITY } },
+        SPYX_MINT
+      )
+    ).toBeNaN()
+  })
+})
+
+const gateSpyx = [
+  {
+    currency_pair: 'SPYX_USDT',
+    last: '774.69',
+    lowest_ask: '774.69',
+    highest_bid: '774.57',
+    base_volume: '542.206',
+    quote_volume: '419995.07769',
+  },
+]
+
+describe('readGateTickerMid', () => {
+  it('returns the bid/ask mid of a two-sided book', () => {
+    expect(readGateTickerMid(gateSpyx)).toBeCloseTo((774.57 + 774.69) / 2, 10)
+  })
+
+  it('falls back to last on a one-sided book', () => {
+    expect(
+      readGateTickerMid([
+        { last: '774.69', lowest_ask: '', highest_bid: '774.57' },
+      ])
+    ).toBe(774.69)
+    expect(
+      readGateTickerMid([{ last: '774.69', highest_bid: '774.57' }])
+    ).toBe(774.69)
+  })
+
+  it('falls back to last on a crossed snapshot', () => {
+    expect(
+      readGateTickerMid([
+        { last: '774.69', lowest_ask: '770.00', highest_bid: '775.00' },
+      ])
+    ).toBe(774.69)
+  })
+
+  it('returns NaN for an empty or malformed response', () => {
+    expect(readGateTickerMid([])).toBeNaN()
+    expect(readGateTickerMid(null)).toBeNaN()
+    expect(readGateTickerMid({})).toBeNaN()
+    expect(readGateTickerMid([{ last: '0', lowest_ask: '', highest_bid: '' }])).toBeNaN()
+  })
+})
+
+describe('readMexcBookTickerMid', () => {
+  it('returns the bid/ask mid', () => {
+    expect(
+      readMexcBookTickerMid({ bidPrice: '773.30', askPrice: '773.54' })
+    ).toBeCloseTo((773.3 + 773.54) / 2, 10)
+  })
+
+  it('returns NaN rather than guessing on one-sided, crossed, or malformed books', () => {
+    expect(readMexcBookTickerMid({ bidPrice: '773.30', askPrice: '0' })).toBeNaN()
+    expect(readMexcBookTickerMid({ bidPrice: '775', askPrice: '770' })).toBeNaN()
+    expect(readMexcBookTickerMid({ msg: 'invalid symbol', code: -1121 })).toBeNaN()
+    expect(readMexcBookTickerMid(null)).toBeNaN()
+  })
+})

--- a/common/src/perps/xstocks.ts
+++ b/common/src/perps/xstocks.ts
@@ -1,0 +1,78 @@
+// Pure venue-response parsing for the tokenized-equity (xStocks) oracle
+// sources. The fetch adapter lives in backend/shared/src/xstocks-price.ts;
+// this module isolates the unit-tested decision of WHICH number each venue's
+// response means, because that is where this feed can go quietly wrong.
+//
+// Units: the composite is the price of the RAW token as quoted on CEX order
+// books. xStocks distribute dividends by scaling holder balances up
+// (Token-2022 scaled-ui-amount), so Jupiter's top-level `usdPrice` is the
+// per-SCALED-unit price (≈ underlying ETF spot) while Gate/MEXC books trade
+// the raw token at spot × accumulated multiplier. Mixing the two injects a
+// silent offset equal to the accrued-dividend multiplier (~0.5% on SPYx as of
+// Aug 2026) — inside any sane consensus tolerance, so it would pass the
+// agreement gate and permanently bias the median rather than fail loudly.
+// `scaledUiConfig.usdPricePrescaled` is the raw-unit price. Tokens without
+// the extension (GLDx pays no dividends) have no `scaledUiConfig`, and their
+// top-level price is already the raw price.
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+// Venue APIs return numeric fields as JSON strings (Gate, MEXC) or numbers
+// (Jupiter). Coerce either, and reject non-finite/non-positive results so a
+// missing field ('undefined' → NaN) or an empty book ('0') cannot become a
+// price.
+const toPositivePrice = (value: unknown): number => {
+  if (typeof value !== 'string' && typeof value !== 'number') return Number.NaN
+  const price = Number(value)
+  return Number.isFinite(price) && price > 0 ? price : Number.NaN
+}
+
+/**
+ * Raw-unit USD price from a Jupiter lite-api `price/v3` response, keyed by
+ * mint address. Prefers `scaledUiConfig.usdPricePrescaled` (see module note);
+ * falls back to `usdPrice` for tokens without the scaled-ui extension.
+ */
+export const readJupiterRawUsdPrice = (body: unknown, mint: string): number => {
+  const entry = asRecord(asRecord(body)?.[mint])
+  if (!entry) return Number.NaN
+  const prescaled = toPositivePrice(
+    asRecord(entry.scaledUiConfig)?.usdPricePrescaled
+  )
+  if (Number.isFinite(prescaled)) return prescaled
+  return toPositivePrice(entry.usdPrice)
+}
+
+/**
+ * Mid price from a Gate spot `tickers?currency_pair=` response (an array with
+ * one entry). On these thin books the last trade can be minutes old while the
+ * touch is live, so prefer the bid/ask mid; fall back to `last` when the book
+ * is one-sided or crossed (a crossed snapshot is transient noise, and the
+ * consensus gate — not this reader — is what validates the level).
+ */
+export const readGateTickerMid = (body: unknown): number => {
+  const ticker = asRecord(Array.isArray(body) ? body[0] : null)
+  if (!ticker) return Number.NaN
+  const bid = toPositivePrice(ticker.highest_bid)
+  const ask = toPositivePrice(ticker.lowest_ask)
+  if (Number.isFinite(bid) && Number.isFinite(ask) && ask >= bid)
+    return (bid + ask) / 2
+  return toPositivePrice(ticker.last)
+}
+
+/**
+ * Mid price from a MEXC `ticker/bookTicker` response. No last-trade fallback:
+ * the endpoint doesn't carry one, and a one-sided book on the venue with the
+ * least depth is better treated as "no quote" than guessed at.
+ */
+export const readMexcBookTickerMid = (body: unknown): number => {
+  const ticker = asRecord(body)
+  if (!ticker) return Number.NaN
+  const bid = toPositivePrice(ticker.bidPrice)
+  const ask = toPositivePrice(ticker.askPrice)
+  if (Number.isFinite(bid) && Number.isFinite(ask) && ask >= bid)
+    return (bid + ask) / 2
+  return Number.NaN
+}


### PR DESCRIPTION
## What

Four fast oracle feeds + launch-manifest market entries for tokenized equities (Backed xStocks tokens on Solana):

| Market | Feed | Sources | Live smoke (Aug 8) |
|---|---|---|---|
| S&P 500 — tokenized SPY price (SPYx, USD) | `spyx-usd` | Jupiter + Gate + MEXC | $777.47 |
| Nasdaq-100 — tokenized QQQ price (QQQx, USD) | `qqqx-usd` | Jupiter + Gate | $723.52 |
| Gold — tokenized GLD price (GLDx, USD) | `gldx-usd` | Jupiter + Gate | $399.83 |
| Nvidia — tokenized NVDA price (NVDAx, USD) | `nvdax-usd` | Jupiter + Gate + MEXC | $223.75 |

The merge substance is the **datastreams**: registry entries, the composite adapter, parsing + tests, and the backfill script. The manifest entries are create-time defaults — titles, leverage, subsidies are all editable in the admin create-perp form (and leverage/funding/pools live-editable after), and market creation can lag the merge as long as we want.

## Why this route

Licensed index data is either expensive or newly closed off (Pyth killed its free tier July 31; equities are now $5k/mo; S&P DJI display licensing gates SPX itself). Quoting a crypto token's public venue price is the same licence-clean stance as the BTC feed — nothing republished from an index provider — and the tokens trade 24/7, so funding cadence matches oracle cadence with no market-hours staleness.

## Design notes

- Same validation stance as `btc-price.ts`: consensus median gated on cross-venue agreement (2%), ≥2 quotes or the tick skips. QQQx/GLDx run the two-source path (MEXC doesn't list them): both venues must respond *and* agree; an outage stalls the feed and trading pauses at `maxOraclePriceAgeMs` (5 min).
- **The rebase trap** (unit-tested): xStocks pay dividends by scaling balances, so Jupiter's scaled `usdPrice` and CEX raw-token quotes differ by the accrued multiplier (~0.5% on SPYx) — inside consensus tolerance, so mixing units would silently bias the median. The composite uses raw units (`usdPricePrescaled`) throughout. GLDx pays no dividends and has no scaled config; the fallback covers it.
- Gate/MEXC read bid/ask mids, not last trade — on thin books the last print can be minutes stale while the touch is live.
- NVDAx is the only single-name equity: earnings gaps can exceed consensus tolerance venue-by-venue for a few ticks while books reprice (noted in its manifest entry).
- Pure parsing lives in `common/src/perps/xstocks.ts` (11 tests, fixtures captured from real venue responses); the adapter in `backend/shared/src/xstocks-price.ts`.

## Verification (repeated for the NVDAx commit in an isolated worktree)

- Parsing tests + full `src/perps` suite pass
- `tsc -b` clean for backend/api and backend/scheduler
- `getPerpLaunchManifestErrors()` → `[]`
- Live end-to-end smoke through the real adapter returned consensus points for all four feeds

## Rollout (after merge)

1. Deploy scheduler-perps (feeds ride the existing 15s `update-oracle-feeds` tick; no migration). Feeds start writing `oracle_prices` immediately; markets can be created whenever we're ready.
2. Backfill each feed: `ts-node backfill-xstocks-oracle.ts SPYX 90 1h` (and QQQX/GLDX/NVDAX) — Gate candles, satisfies the 30d minimum-history gate.
3. Create markets via admin create-perp (manifest recommendation applies in one click; everything adjustable there).
4. Preflight `--phase=feeds`. Alerting rides the existing `[oracle-feeds]` log-match policies — no new GCP wiring.

Known risks documented in the manifest: thin-book wicks (consensus rejects single-venue only), USDT depeg splits venues → feed stalls by design, Backed issuer risk, venue delisting churn (Bybit precedent).
