### PR TITLE
fix(perps): derive funding from open interest, not the backing pools

### DIFF
--- a/backend/api/src/create-perp.ts
+++ b/backend/api/src/create-perp.ts
@@ -228,6 +228,10 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
       fundingPeriodMs,
       poolLong: subsidyLong,
       poolShort: subsidyShort,
+      // Subsidy is backing, not exposure: a new market has no positions, so
+      // no imbalance and no funding until someone trades.
+      openInterestLong: 0,
+      openInterestShort: 0,
       initialSubsidy: totalSubsidy,
       initialPoolLong: subsidyLong,
       initialPoolShort: subsidyShort,

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -121,6 +121,35 @@ subtracts it: a fresh position starts at PnL = −fee. Admins tune the rate
 live per market via `update-perp-config` (0 disables); contracts created
 before the field default to 10 bps at trade time.
 
+## Funding imbalance
+
+The funding rate is derived from each side's OPEN INTEREST (aggregate open
+notional), not from the backing pools:
+
+`f = I(max(OI_L, OI_S) / min(OI_L, OI_S)) × f_max`, signed toward the crowded
+side.
+
+The pools hold *margin*, so their ratio only tracks exposure when both sides
+run comparable leverage. Where they don't, the two disagree in sign, and a
+pool-derived rate pays the crowded side and charges the scarce one — the
+opposite of what funding is for. On 2026-08-08 two of the four live markets
+were doing exactly that (BTC held 454k long vs 348k short of notional on pools
+of 59.6k vs 83.0k; the OpenRouter market, 1.96 long-heavy on 0.82 pools).
+
+`runFunding` recomputes open interest from the positions it holds under the
+advisory lock. `contract.openInterestLong` / `openInterestShort` are a
+denormalized copy maintained by every transition that can change a position
+size, so read paths (market page, chart, bet panel, embed) can show the live
+rate without loading positions — always via `getPerpFundingRate`
+(`common/perps/funding`), never by calling `computeFundingRate` with pools.
+An absent copy reads as zero, which yields a zero rate rather than a
+direction we cannot substantiate.
+
+A side with no open interest yields no funding: the transfer moves value
+between the two sides' positions, so an empty side has no counterparty to
+receive it. Inducing entry onto an empty side would need a mechanism paying
+from somewhere other than the absent side.
+
 ## Exposure capacity
 
 Opening, adding, or flipping into a side is limited so aggregate open notional

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -21,6 +21,7 @@ import {
   closePosition as closePositionMath,
   computeFundingRate,
   getLeverage,
+  getPerpOpenInterest,
   getPerpOpenInterestCapacity,
   getPositionValue,
   liquidationPrice as computeLiquidationPrice,
@@ -359,6 +360,19 @@ const assertIdempotencyKey = (idempotencyKey: string | undefined) => {
   ) {
     throw new APIError(400, 'Invalid PERP idempotency key')
   }
+}
+
+/**
+ * Contract-patch fragment carrying the post-transition open interest.
+ *
+ * Always derived from the transition's FINAL positions rather than adjusted
+ * incrementally, so the denormalized copy cannot drift from the positions
+ * table however the sizes moved (a trade, a funding haircut, an ADL scale,
+ * a liquidation). Every patch that writes poolLong/poolShort spreads this.
+ */
+const openInterestPatch = (positions: PerpPosition[]) => {
+  const { long, short } = getPerpOpenInterest(positions)
+  return { openInterestLong: long, openInterestShort: short }
 }
 
 const diffForWrite = (
@@ -748,6 +762,7 @@ export const openOrAddPosition = async (
       collectedFees,
       poolLong: open.state.pool.L,
       poolShort: open.state.pool.S,
+      ...openInterestPatch(open.state.positions),
       lastBetTime: now,
       lastUpdatedTime: now,
       volume: (contract.volume ?? 0) + tradeVolume,
@@ -1069,6 +1084,7 @@ export const closePosition = async (
     const contractPatch = removeUndefinedProps({
       poolLong: result.state.pool.L,
       poolShort: result.state.pool.S,
+      ...openInterestPatch(result.state.positions),
       lastBetTime: now,
       lastUpdatedTime: now,
       volume: (contract.volume ?? 0) + position.originalCostBasis,
@@ -1502,6 +1518,7 @@ export const runOracleUpdate = async (
     const contractPatch = removeUndefinedProps({
       poolLong: applied.finalState.pool.L,
       poolShort: applied.finalState.pool.S,
+      ...openInterestPatch(applied.finalState.positions),
       oraclePrice: newPrice,
       oraclePriceTime: ts,
       // null deliberately clears metadata if a newer point does not carry it;
@@ -1650,9 +1667,16 @@ export const runFunding = async (
     })
     await assertPerpEscrowBalance(pgTrans, contractId, state.pool)
 
+    // Open interest, NOT the pools. The pools hold margin, so their ratio
+    // only tracks exposure when both sides run comparable leverage; where
+    // they don't it can invert the sign and pay the crowded side (BTC and
+    // the OpenRouter market were both doing exactly that before this).
+    // Computed from the positions loaded under the advisory lock, never from
+    // the contract's denormalized copy.
+    const openInterest = getPerpOpenInterest(state.positions)
     const fundingRate = computeFundingRate(
-      state.pool.L,
-      state.pool.S,
+      openInterest.long,
+      openInterest.short,
       contract.fundingSensitivity,
       contract.maxFundingRate
     )
@@ -1712,6 +1736,7 @@ export const runFunding = async (
     const contractPatch = removeUndefinedProps({
       poolLong: next.pool.L,
       poolShort: next.pool.S,
+      ...openInterestPatch(next.positions),
       lastFundingTime: ts,
       fundingRate,
       lastUpdatedTime: adlEvents.length > 0 ? ts : undefined,
@@ -1996,6 +2021,9 @@ export const resolvePerp = async (
     const contractPatch = removeUndefinedProps({
       poolLong: 0,
       poolShort: 0,
+      // Resolution settles every open position.
+      openInterestLong: 0,
+      openInterestShort: 0,
       oraclePrice: finalPrice,
       oraclePriceTime: oracleTs,
       oracleSourceTime: oracleSourceTime ?? null,

--- a/backend/supabase/migrations/2026080802_backfill_perp_open_interest.sql
+++ b/backend/supabase/migrations/2026080802_backfill_perp_open_interest.sql
@@ -1,0 +1,38 @@
+-- Funding now derives its rate from each side's open interest instead of the
+-- backing pools (common/perps/amm.ts). The pools hold MARGIN, so their ratio
+-- only tracks exposure when both sides run comparable leverage; where they
+-- don't, the sign inverts and funding pays the crowded side. On 2026-08-08
+-- two of the four live markets were doing exactly that:
+--
+--   bitcoin-price-usd    OI 453,771 L / 348,184 S (1.30 long-heavy)
+--                        pools 59,555 L / 82,975 S (0.72 — reads short-heavy)
+--   openweight-ai        OI  99,722 L /  50,954 S (1.96 long-heavy)
+--                        pools 12,553 L / 15,261 S (0.82 — reads short-heavy)
+--
+-- Read paths (market page, chart, bet panel, embed) show the live rate and
+-- cannot load positions, so the engine denormalizes open interest onto the
+-- contract. Backfill it here rather than waiting for each market's next
+-- engine transition, which would leave the UI showing a rate of zero (the
+-- fail-closed default for an absent field) until then — up to a full day on
+-- the daily-funding markets.
+--
+-- Derived, not incremental: the engine recomputes both values from the
+-- positions it holds under the contract advisory lock on every transition
+-- that can change a position size, so this cannot drift afterwards.
+update contracts c
+set data = c.data || jsonb_build_object(
+  'openInterestLong', coalesce(oi.long_oi, 0),
+  'openInterestShort', coalesce(oi.short_oi, 0)
+)
+from (
+  select
+    c2.id,
+    sum(p.size) filter (where p.direction = 'long') as long_oi,
+    sum(p.size) filter (where p.direction = 'short') as short_oi
+  from contracts c2
+  left join contract_perp_positions p
+    on p.contract_id = c2.id and p.size > 0
+  where c2.data ->> 'outcomeType' = 'PERP'
+  group by c2.id
+) oi
+where c.id = oi.id;

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -81,6 +81,10 @@ export type LiteMarket = {
   oracleSourceTime?: number | null
   poolLong?: number
   poolShort?: number
+  // Drives the live funding rate (getPerpFundingRate) — must travel with the
+  // pools so a polling client's rate stays in step with the engine's.
+  openInterestLong?: number
+  openInterestShort?: number
   fundingRate?: number
   lastFundingTime?: number
   maxLeverage?: number
@@ -224,6 +228,8 @@ export function toLiteMarket(
           oracleSourceTime: contract.oracleSourceTime,
           poolLong: contract.poolLong,
           poolShort: contract.poolShort,
+          openInterestLong: contract.openInterestLong,
+          openInterestShort: contract.openInterestShort,
           fundingRate: contract.fundingRate,
           lastFundingTime: contract.lastFundingTime,
           maxLeverage: contract.maxLeverage,

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -326,6 +326,15 @@ export type PerpMechanism = {
   // after the live pools have moved.
   initialPoolLong?: number
   initialPoolShort?: number
+  // Aggregate open notional per side, refreshed by every engine transition
+  // that can change position size (open, close, funding, liquidation/ADL,
+  // resolution). Denormalized purely so read paths can show the funding rate
+  // without loading positions — the engine always recomputes from the
+  // positions it holds under the lock and never trusts these. Absent on
+  // contracts untouched since the field was added; treat as unknown, not
+  // zero exposure (see getPerpFundingRate).
+  openInterestLong?: number
+  openInterestShort?: number
   oracleFeedId: string // free-text; matches oracle_prices.feed_id
   oraclePrice: number // last applied P
   oraclePriceTime?: number // ts of last applied P

--- a/common/src/perps/amm.test.ts
+++ b/common/src/perps/amm.test.ts
@@ -7,6 +7,7 @@ import {
   closePosition,
   computeFundingRate,
   getPerpBackingPool,
+  getPerpOpenInterest,
   getPerpOpenInterestCapacity,
   getUnrealizedEquity,
   imbalance,
@@ -107,6 +108,49 @@ describe('getUnrealizedEquity', () => {
   })
 })
 
+describe('getPerpOpenInterest', () => {
+  // Leverage varies by side on purpose: open interest must track notional,
+  // and these margins would give the opposite ranking.
+  const pos = (
+    direction: PerpDirection,
+    size: number,
+    costBasis: number,
+    userId: string
+  ) => makePosition({ direction, size, costBasis, entryPrice: 100, userId })
+
+  it('sums open notional per side', () => {
+    expect(
+      getPerpOpenInterest([
+        pos('long', 1000, 50, 'u1'),
+        pos('long', 500, 25, 'u2'),
+        pos('short', 200, 200, 'u3'),
+      ])
+    ).toEqual({ long: 1500, short: 200 })
+  })
+
+  it('ignores closed positions and reports an empty book as zero', () => {
+    // processLiquidations zeroes size but keeps the row until the engine
+    // deletes it; a liquidated position carries no exposure.
+    expect(
+      getPerpOpenInterest([
+        pos('long', 0, 0, 'u1'),
+        pos('short', 300, 100, 'u2'),
+      ])
+    ).toEqual({ long: 0, short: 300 })
+    expect(getPerpOpenInterest([])).toEqual({ long: 0, short: 0 })
+  })
+
+  it('does not let a corrupt size poison the funding input', () => {
+    expect(
+      getPerpOpenInterest([
+        pos('long', NaN, 10, 'u1'),
+        pos('long', 400, 10, 'u2'),
+        pos('short', Infinity, 10, 'u3'),
+      ])
+    ).toEqual({ long: 400, short: 0 })
+  })
+})
+
 describe('funding', () => {
   it('imbalance is 0 at or below balance and rises with r', () => {
     expect(imbalance(1, 1)).toBe(0)
@@ -120,6 +164,29 @@ describe('funding', () => {
     expect(computeFundingRate(500, 1000, 1, 0.01)).toBeCloseTo(-0.005, 10)
     expect(computeFundingRate(700, 700, 1, 0.01)).toBe(0)
     expect(computeFundingRate(0, 500, 1, 0.01)).toBe(0)
+  })
+
+  it('charges the side that is crowded by NOTIONAL, not by margin', () => {
+    // Live BTC market, 2026-08-08: longs held more exposure on less margin
+    // (18.4x vs 9.9x), so the pools read short-heavy while the book was
+    // long-heavy. Funding keyed on pools paid the crowded side.
+    const [oiLong, oiShort] = [453771, 348184]
+    const [poolLong, poolShort] = [59555, 82975]
+    const [k, fMax] = [1, 0.000228]
+
+    const fromOpenInterest = computeFundingRate(oiLong, oiShort, k, fMax)
+    const fromPools = computeFundingRate(poolLong, poolShort, k, fMax)
+
+    expect(fromOpenInterest).toBeGreaterThan(0) // longs crowded → longs pay
+    expect(fromPools).toBeLessThan(0) // what shipped: shorts paid longs
+  })
+
+  it('does not fund a side that nobody is on', () => {
+    // Funding is a transfer between the two sides' positions. With one side
+    // empty there is no counterparty to receive it, so no rate is applied —
+    // rather than haircutting the lone side into the pool.
+    expect(computeFundingRate(1000, 0, 1, 0.01)).toBe(0)
+    expect(computeFundingRate(0, 0, 1, 0.01)).toBe(0)
   })
 
   it('stays finite and below the cap for extreme finite pool ratios', () => {
@@ -391,12 +458,19 @@ describe('funding', () => {
       }
       assertPerpStateSolvent(state, price)
 
-      const fundingRate = computeFundingRate(
+      // Funding keys off open interest, which is independent of the pool
+      // ratio: the side with more notional can be the side with the SMALLER
+      // pool. Drive the sign independently so the fuzz covers the direction
+      // that pool-derived rates could never produce (paying side = smaller
+      // pool), not just the one that shipped.
+      const magnitude = computeFundingRate(
         state.pool.L,
         state.pool.S,
         0.5 + random() * 2,
         0.001 + random() * 0.049
       )
+      const longsPay = random() < 0.5
+      const fundingRate = longsPay ? Math.abs(magnitude) : -Math.abs(magnitude)
       const corrected = applyFundingWithSolvency(state, fundingRate, price)
 
       expect(() => assertPerpStateSolvent(corrected.state, price)).not.toThrow()
@@ -746,10 +820,9 @@ describe('open / close accounting', () => {
       expect(getUnrealizedEquity(position, mark)).toBeCloseTo(separateEquity, 8)
       // Deposited M$600 across six tranches; withdrawable must be the honest
       // figure, not the M$2600 the arithmetic merge produced.
-      expect(position.costBasis + getUnrealizedEquity(position, mark)).toBeCloseTo(
-        600 + separateEquity,
-        8
-      )
+      expect(
+        position.costBasis + getUnrealizedEquity(position, mark)
+      ).toBeCloseTo(600 + separateEquity, 8)
     })
 
     it('merged entry price always lies between the two entry prices', () => {

--- a/common/src/perps/amm.ts
+++ b/common/src/perps/amm.ts
@@ -153,12 +153,49 @@ export const imbalance = (r: number, k: number) => {
 }
 
 /**
- * Funding rate for the period.
- *   +ve means longs pay shorts (L > S); -ve means shorts pay longs (S > L).
+ * Aggregate open notional per side — the exposure actually at risk.
+ *
+ * This is NOT interchangeable with the backing pools. A pool holds margin,
+ * so pool ratio only tracks exposure ratio when both sides run comparable
+ * leverage. Where they don't, the two can disagree in SIGN: on 2026-08-08
+ * the BTC market held 454k long vs 348k short of notional (1.30 long-heavy)
+ * on pools of 59.6k long vs 83.0k short (0.72 — reading short-heavy), so
+ * pool-driven funding paid the crowded side and charged the scarce one.
+ */
+export const getPerpOpenInterest = (positions: PerpPosition[]) => {
+  let long = 0
+  let short = 0
+  for (const p of positions) {
+    if (!Number.isFinite(p.size) || p.size <= 0) continue
+    if (p.direction === 'long') long += p.size
+    else short += p.size
+  }
+  return {
+    long: Number.isFinite(long) ? long : 0,
+    short: Number.isFinite(short) ? short : 0,
+  }
+}
+
+/**
+ * Funding rate for the period, from the two sides' OPEN INTEREST (notional).
+ *
+ *   +ve means longs pay shorts (longs crowded);
+ *   -ve means shorts pay longs (shorts crowded).
+ *
+ * Pass `getPerpOpenInterest(...)`, never the backing pools — see that
+ * function for why the two disagree. The parameters are deliberately named
+ * for the quantity rather than L/S: those names are what invited the pools
+ * in the first place.
+ *
+ * A side with zero open interest yields a rate of zero: funding transfers
+ * between the two sides' positions, so with nobody on one side there is no
+ * counterparty to receive it. Inducing entry onto an empty side needs a
+ * mechanism that pays from somewhere other than the absent side, which is
+ * out of scope here.
  */
 export const computeFundingRate = (
-  L: number,
-  S: number,
+  openInterestLong: number,
+  openInterestShort: number,
   k: number,
   fMax: number
 ) => {
@@ -166,31 +203,31 @@ export const computeFundingRate = (
   // invalid contract configuration before applying funding. Returning zero
   // here prevents corrupt legacy data from turning a React render into NaN.
   if (
-    !Number.isFinite(L) ||
-    !Number.isFinite(S) ||
+    !Number.isFinite(openInterestLong) ||
+    !Number.isFinite(openInterestShort) ||
     !Number.isFinite(k) ||
     !Number.isFinite(fMax) ||
     k <= 0 ||
     fMax <= 0
   )
     return 0
-  if (L <= 0 || S <= 0) return 0
-  if (L === S) return 0
+  if (openInterestLong <= 0 || openInterestShort <= 0) return 0
+  if (openInterestLong === openInterestShort) return 0
 
   // Algebraically equivalent to imbalance(high / low, k), but normalizing
   // low by high avoids an overflowing high / low ratio for extreme yet valid
-  // finite pools:
+  // finite inputs:
   //   (r - 1) / (r - 1 + k)
   //   = (1 - low/high) / (1 - low/high + k * low/high)
-  const high = Math.max(L, S)
-  const low = Math.min(L, S)
+  const high = Math.max(openInterestLong, openInterestShort)
+  const low = Math.min(openInterestLong, openInterestShort)
   const lowOverHigh = low / high
   const gap = 1 - lowOverHigh
   const denominator = gap + k * lowOverHigh
   const fraction = denominator > 0 ? gap / denominator : 0
   const magnitude = fraction * fMax
   if (!Number.isFinite(magnitude) || magnitude === 0) return 0
-  return L > S ? magnitude : -magnitude
+  return openInterestLong > openInterestShort ? magnitude : -magnitude
 }
 
 /**

--- a/common/src/perps/embed.test.ts
+++ b/common/src/perps/embed.test.ts
@@ -14,15 +14,19 @@ const getContract = (
   maxOraclePriceAgeMs: 60_000,
   oraclePrice: 100,
   oraclePriceTime: NOW - 1_000,
-  poolLong: 60_000,
-  poolShort: 40_000,
+  // Long-crowded book (1.5x) sitting on short-heavy pools. The two disagree
+  // whenever the sides run different leverage; funding follows the exposure.
+  openInterestLong: 60_000,
+  openInterestShort: 40_000,
+  poolLong: 40_000,
+  poolShort: 60_000,
   resolution: undefined,
   resolvedOraclePrice: undefined,
   ...overrides,
 })
 
 describe('getPerpEmbedSummary', () => {
-  it('shows a fresh market as tradeable with live pool-derived funding', () => {
+  it('shows a fresh market as tradeable with live open-interest funding', () => {
     const summary = getPerpEmbedSummary(getContract(), NOW)
 
     expect(summary.status).toBe('live')
@@ -118,7 +122,10 @@ describe('getPerpEmbedSummary', () => {
       getContract({
         fundingPeriodMs: Number.POSITIVE_INFINITY,
         maxLeverage: Number.NaN,
+        // Backing and funding read from different fields now: the pool feeds
+        // the displayed backing, open interest feeds the rate.
         poolLong: Number.NaN,
+        openInterestLong: Number.NaN,
       }),
       NOW
     )

--- a/common/src/perps/embed.ts
+++ b/common/src/perps/embed.ts
@@ -1,7 +1,7 @@
 import { PerpContract } from '../contract'
 import { YEAR_MS } from '../util/time'
-import { computeFundingRate, getPerpBackingPool } from './amm'
-import { getFundingPeriodMs } from './funding'
+import { getPerpBackingPool } from './amm'
+import { getFundingPeriodMs, getPerpFundingRate } from './funding'
 import { getOracleFreshness } from './oracle'
 
 export type PerpEmbedStatus =
@@ -19,8 +19,11 @@ export type PerpEmbedContract = Pick<
   | 'maxFundingRate'
   | 'maxLeverage'
   | 'maxOraclePriceAgeMs'
+  | 'openInterestLong'
+  | 'openInterestShort'
   | 'oraclePrice'
   | 'oraclePriceTime'
+  // Backing pool only — the funding rate comes from open interest.
   | 'poolLong'
   | 'poolShort'
   | 'resolution'
@@ -107,12 +110,7 @@ export const getPerpEmbedSummary = (
     ? 'stale'
     : 'unavailable'
   const periodMs = getFundingPeriodMs(contract)
-  const rate = computeFundingRate(
-    contract.poolLong,
-    contract.poolShort,
-    contract.fundingSensitivity,
-    contract.maxFundingRate
-  )
+  const rate = getPerpFundingRate(contract)
   const annualizedRate = rate * (YEAR_MS / periodMs)
 
   return {

--- a/common/src/perps/funding.test.ts
+++ b/common/src/perps/funding.test.ts
@@ -4,8 +4,32 @@ import {
   fundingPeriodNoun,
   fundingPeriodUnit,
   getFundingPeriodMs,
+  getPerpFundingRate,
   shouldApplyFunding,
 } from './funding'
+
+describe('getPerpFundingRate', () => {
+  const config = { fundingSensitivity: 1, maxFundingRate: 0.01 }
+
+  it('reads the rate off open interest, not the pools', () => {
+    // Same disagreement as the live BTC book: pools read short-heavy while
+    // the notional is long-heavy. The displayed rate must match what the
+    // engine will apply, which keys off open interest.
+    const rate = getPerpFundingRate({
+      ...config,
+      openInterestLong: 453771,
+      openInterestShort: 348184,
+    })
+    expect(rate).toBeGreaterThan(0) // longs crowded → longs pay
+  })
+
+  it('reports no funding when open interest is missing', () => {
+    // A contract untouched since the field was added. Zero is the
+    // fail-closed read: never show a direction we cannot substantiate.
+    expect(getPerpFundingRate(config)).toBe(0)
+    expect(getPerpFundingRate({ ...config, openInterestLong: 1000 })).toBe(0)
+  })
+})
 
 describe('getFundingPeriodMs', () => {
   it('defaults legacy contracts (no field) to hourly', () => {

--- a/common/src/perps/funding.ts
+++ b/common/src/perps/funding.ts
@@ -5,7 +5,39 @@
 // so the two runtime gates cannot drift apart (the drift was a live bug:
 // see commit 846752c7d).
 
+import { computeFundingRate } from './amm'
 import { HOUR_MS, MINUTE_MS } from '../util/time'
+
+/**
+ * The funding rate a contract is currently accruing, for display.
+ *
+ * Read-side counterpart to the engine's rate: both feed open interest into
+ * `computeFundingRate`, so the number a trader sees matches the one that
+ * will be applied. Callers must NOT reach for `computeFundingRate` with the
+ * pools — that is the bug this exists to prevent.
+ *
+ * Computed live rather than read from `contract.fundingRate`, which the
+ * scheduler only refreshes at each funding event: a trader who just moved
+ * the imbalance would otherwise see the previous period's rate, often with
+ * the opposite sign, until the next tick.
+ *
+ * Open interest is maintained on the contract by every engine transition
+ * that can change position size. Absent (a contract not yet touched since
+ * the field was added) reads as zero, which yields a zero rate — funding is
+ * never displayed in a direction we cannot substantiate.
+ */
+export const getPerpFundingRate = (contract: {
+  openInterestLong?: number
+  openInterestShort?: number
+  fundingSensitivity: number
+  maxFundingRate: number
+}): number =>
+  computeFundingRate(
+    contract.openInterestLong ?? 0,
+    contract.openInterestShort ?? 0,
+    contract.fundingSensitivity,
+    contract.maxFundingRate
+  )
 
 /**
  * Default funding period. Contracts created before per-contract periods

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -9,12 +9,13 @@ import {
   supabaseConsoleContractPath,
   TRADED_TERM,
 } from 'common/envs/constants'
-import { computeFundingRate, getPerpBackingPool } from 'common/perps/amm'
+import { getPerpBackingPool } from 'common/perps/amm'
 import { getPerpTakerFeeBps } from 'common/perps/fees'
 import {
   fundingPeriodNoun,
   fundingPeriodUnit,
   getFundingPeriodMs,
+  getPerpFundingRate,
 } from 'common/perps/funding'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
 import { UNRANKED_GROUP_ID } from 'common/supabase/groups'
@@ -593,12 +594,7 @@ function PerpStatsRows(props: { contract: PerpContract }) {
     contract.resolution === 'MKT'
       ? Number(contract.resolvedOraclePrice ?? contract.oraclePrice)
       : Number(contract.oraclePrice)
-  const fundingRate = computeFundingRate(
-    contract.poolLong,
-    contract.poolShort,
-    contract.fundingSensitivity,
-    contract.maxFundingRate
-  )
+  const fundingRate = getPerpFundingRate(contract)
   const fundingPeriodMs = getFundingPeriodMs(contract)
   const fundingDirection =
     fundingRate > 0

--- a/web/components/perps/perp-bet-panel.tsx
+++ b/web/components/perps/perp-bet-panel.tsx
@@ -10,7 +10,6 @@ import { toast } from 'react-hot-toast'
 import { PerpContract } from 'common/contract'
 import { ENV_CONFIG } from 'common/envs/constants'
 import {
-  computeFundingRate,
   getPerpOpenInterestCapacity,
   isPerpOpenInterestWithinLimit,
   liquidationPrice as computeLiquidationPrice,
@@ -22,6 +21,7 @@ import {
   fundingPeriodNoun,
   fundingPeriodUnit,
   getFundingPeriodMs,
+  getPerpFundingRate,
 } from 'common/perps/funding'
 import { fundingPerPeriod } from 'common/perps/pnl'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
@@ -155,12 +155,7 @@ export const PerpBetPanel = (props: {
     effectiveLeverage,
   ])
   const liqPrice = preview.liqPrice
-  const fundingRate = computeFundingRate(
-    contract.poolLong,
-    contract.poolShort,
-    contract.fundingSensitivity,
-    contract.maxFundingRate
-  )
+  const fundingRate = getPerpFundingRate(contract)
   // Signed mana per funding period for the position being configured
   // (+ = earns). fundingPerPeriod mirrors applyFunding exactly — in
   // particular the RECEIVING side earns the transfer re-based on its own

--- a/web/components/perps/perp-chart.tsx
+++ b/web/components/perps/perp-chart.tsx
@@ -4,7 +4,6 @@ import dayjs from 'dayjs'
 import { scaleLinear, scaleTime } from 'd3-scale'
 import { line } from 'd3-shape'
 import { PerpContract } from 'common/contract'
-import { computeFundingRate } from 'common/perps/amm'
 import {
   carryNeutralPath,
   clusterLiquidationBands,
@@ -21,6 +20,7 @@ import {
   fundingPeriodNoun,
   fundingPeriodUnit,
   getFundingPeriodMs,
+  getPerpFundingRate,
 } from 'common/perps/funding'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
 import { median } from 'common/util/math'
@@ -199,14 +199,9 @@ export const PerpChart = (props: {
   // phone widths.
   const { elemRef: containerRef, width: measuredWidth } = useMeasureSize()
 
-  // Live rate from the current pools, not the per-funding-event-refreshed
-  // contract.fundingRate — same rationale as perp-overview.tsx.
-  const liveFundingRate = computeFundingRate(
-    contract.poolLong,
-    contract.poolShort,
-    contract.fundingSensitivity,
-    contract.maxFundingRate
-  )
+  // Live rate from the current open interest, not the per-funding-event-
+  // refreshed contract.fundingRate — same rationale as perp-overview.tsx.
+  const liveFundingRate = getPerpFundingRate(contract)
   // Frozen at create from the feed's cadence; hourly on legacy contracts.
   // Everything time-denominated on this chart (projections, diamond gating,
   // axis/hover units) keys off it.

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -3,12 +3,12 @@ import clsx from 'clsx'
 import { fromNow } from 'client-common/lib/time'
 import { PerpContract } from 'common/contract'
 import { PERPS_SKIP_ORACLE_FRESHNESS } from 'common/envs/constants'
-import { computeFundingRate } from 'common/perps/amm'
 import { nextFundingTimes } from 'common/perps/chart-projections'
 import {
   fundingPeriodNoun,
   fundingPeriodUnit,
   getFundingPeriodMs,
+  getPerpFundingRate,
 } from 'common/perps/funding'
 import {
   formatCountdown,
@@ -96,17 +96,12 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
   // decimals, fractional prices scale to their magnitude.
   const priceDecimals = inferPriceDecimals([price])
 
-  // Compute the funding rate live from the current pool balances rather than
+  // Compute the funding rate live from the current open interest rather than
   // reading `contract.fundingRate`, which the scheduler only refreshes at
-  // each funding event. Without this, a user who just flipped the pool balance would
-  // still see the previous period's rate — often with the opposite sign —
-  // until the next funding tick, which reads as "backwards".
-  const liveFundingRate = computeFundingRate(
-    contract.poolLong,
-    contract.poolShort,
-    contract.fundingSensitivity,
-    contract.maxFundingRate
-  )
+  // each funding event. Without this, a user who just moved the imbalance
+  // would still see the previous period's rate — often with the opposite
+  // sign — until the next funding tick, which reads as "backwards".
+  const liveFundingRate = getPerpFundingRate(contract)
   const oracleFreshness = useOracleFreshness(contract)
   const oracleTradingPaused =
     !PERPS_SKIP_ORACLE_FRESHNESS &&

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -2,9 +2,12 @@ import clsx from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { PerpContract } from 'common/contract'
-import { computeFundingRate } from 'common/perps/amm'
 import { nextFundingTimes } from 'common/perps/chart-projections'
-import { fundingPeriodUnit, getFundingPeriodMs } from 'common/perps/funding'
+import {
+  fundingPeriodUnit,
+  getFundingPeriodMs,
+  getPerpFundingRate,
+} from 'common/perps/funding'
 import {
   fundingPerPeriod,
   getUserFacingPnl,
@@ -378,15 +381,10 @@ const PositionCard = (props: {
   const pnlColor = pnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'
 
   // What the next funding transfer does to this position, in mana
-  // (+ = you receive). Uses the live pool-derived rate, and the exact
-  // applyFunding scaling — a receiver on the thin side earns the transfer
-  // re-based on its own pool, not just rate × margin.
-  const liveFundingRate = computeFundingRate(
-    contract.poolLong,
-    contract.poolShort,
-    contract.fundingSensitivity,
-    contract.maxFundingRate
-  )
+  // (+ = you receive). Uses the live open-interest-derived rate, and the
+  // exact applyFunding scaling — a receiver on the thin side earns the
+  // transfer re-based on its own pool, not just rate × margin.
+  const liveFundingRate = getPerpFundingRate(contract)
   const fundingMana = fundingPerPeriod(
     p,
     markPrice,

--- a/web/components/perps/use-live-perp-contract.ts
+++ b/web/components/perps/use-live-perp-contract.ts
@@ -49,6 +49,11 @@ export const useLivePerpContract = (ssrContract: PerpContract) => {
                   oracleSourceTime: market.oracleSourceTime,
                   poolLong: market.poolLong,
                   poolShort: market.poolShort,
+                  // The displayed funding rate is derived from these, so a
+                  // trade that moves the imbalance must refresh them or the
+                  // page keeps showing the pre-trade rate.
+                  openInterestLong: market.openInterestLong,
+                  openInterestShort: market.openInterestShort,
                   fundingRate: market.fundingRate,
                   volume: market.volume,
                   uniqueBettorCount: market.uniqueBettorCount,


### PR DESCRIPTION
## The bug

The funding rate was computed from `poolLong` / `poolShort`. Those hold **margin**, so their ratio only tracks exposure when both sides run comparable leverage. Where they don't, the two disagree in **sign** — and funding then pays the crowded side while charging the scarce one, the exact opposite of what the mechanism exists to do.

Three of the four live markets were inverted when this was written:

| market | open interest | pool ratio | funding was |
|---|---|---|---|
| `bitcoin-price-usd` | 454.0k L / 256.2k S (**1.77 long-heavy**) | 59.7k / 82.1k = 0.73 (reads short-heavy) | ❌ shorts paying longs |
| `openweight-ai` | 99.7k L / 51.0k S (**1.96 long-heavy**) | 12.6k / 15.3k = 0.82 (reads short-heavy) | ❌ shorts paying longs |
| `uk-grid-carbon` | 17.6k L / 28.6k S (**short-heavy**) | 18.9k / 15.4k (reads long-heavy) | ❌ longs paying shorts |
| `trump-approval` | 51.1k L / 141.7k S | 24.2k / 30.5k | ✅ (coincidentally) |

The divergence appears exactly where leverage differs between sides — BTC was running 18.4× long vs 9.9× short.

**This is not a stable property of a market.** `uk-grid-carbon` was correctly signed a few hours before this table was taken and had flipped by the time the migration was validated. It drifts in and out as the leverage mix moves, which is why it can't be tuned around with `maxFundingRate` or `fundingSensitivity` — those only scale whichever sign the input produced.

## The change

- `computeFundingRate` keeps its math unchanged; its parameters are renamed for the quantity rather than `L`/`S`. Those names are what invited the pools in.
- `runFunding` recomputes open interest from the positions it **already holds under the contract advisory lock**, so the engine never depends on cached state.
- Read paths can't load positions, so open interest is denormalized onto the contract by every transition that can change a position size. Always derived from that transition's *final* positions rather than adjusted incrementally, so it cannot drift from the positions table.
- All six display call sites now go through one `getPerpFundingRate` helper, so the number a trader sees is the number the engine will apply. It travels through `LiteMarket` so the market page's live poll keeps it in step.
- Migration backfills the live markets. Without it, each would show a zero rate until its next engine transition — up to a full day on the daily-funding markets.

## Fail-closed choices

- **Absent denormalized value → rate 0.** Never display a funding direction we can't substantiate.
- **A side with no open interest → no funding.** The transfer moves value between the two sides' positions; an empty side has no counterparty to receive it. Inducing entry onto an empty side needs a mechanism that pays from somewhere other than the absent side — out of scope here.

## New state space

Funding sign is now independent of the pool ratio, so the paying side can be the one with the **smaller** pool. That was unreachable before: a pool-derived rate always flowed from the larger pool to the smaller. The randomized solvency fuzz in `amm.test.ts` now drives the sign independently to cover it. (It's the benign direction — `g = f·L/S` shrinks rather than amplifies — but it should be tested, not assumed.)

## Deploy order

Migration **before** API/scheduler. The migration only adds fields; the pre-deploy code ignores them, so there's no window where either half misbehaves.

## Explicitly not addressed

Funding is still charged in proportion to **margin**, not notional — `applyFunding` scales `costBasis` by `(1-f)`. A 100× and a 1× position with equal margin pay the same amount for 100× the exposure, which makes leverage the cheapest way to buy exposure. Fixing that means changing the distribution (and cutting `maxFundingRate` roughly proportionally so aggregate flow is unchanged), and it needs care to preserve the escrow invariant. Separate PR.

## Testing

- `common`: 424 tests pass, including new coverage for `getPerpOpenInterest`, the sign regression using the live BTC numbers, the empty-side case, and the extended fuzz.
- `common`, `backend/shared`, `backend/api`, `web` all typecheck clean.
- Migration's derivation validated read-only against prod.
