### PR TITLE
feat(perps): API-trade filter, holders exposure summary & sorting

### DIFF
--- a/backend/api/src/close-perp-position.ts
+++ b/backend/api/src/close-perp-position.ts
@@ -10,12 +10,14 @@ export const closePerpPosition: APIHandler<'close-perp-position'> = async (
 ) => {
   assertPerpCloseEnabled()
   const { contractId, direction, idempotencyKey, expectedOpenedTime } = body
+  const isApi = auth.creds.kind === 'key'
   const { payout, pnl, replayed } = await closePosition(
     contractId,
     auth.uid,
     direction,
     idempotencyKey,
-    expectedOpenedTime
+    expectedOpenedTime,
+    isApi
   )
 
   return {
@@ -26,11 +28,7 @@ export const closePerpPosition: APIHandler<'close-perp-position'> = async (
       // replay is not a trade and must not advance the streak.
       if (replayed) return
       try {
-        await advancePerpBettingStreak(
-          auth.uid,
-          contractId,
-          auth.creds.kind === 'key'
-        )
+        await advancePerpBettingStreak(auth.uid, contractId, isApi)
       } catch (err) {
         log('perp streak update failed (non-fatal):', err)
       }

--- a/backend/api/src/get-perp-events.ts
+++ b/backend/api/src/get-perp-events.ts
@@ -8,7 +8,7 @@ import { APIHandler } from './helpers/endpoint'
 // each affected ADL position already has its own user-attributed event.
 // Used by the Trades tab and user position history.
 export const getPerpEvents: APIHandler<'get-perp-events'> = async (body) => {
-  const { contractId, userId, beforeId, limit = 50 } = body
+  const { contractId, userId, beforeId, limit = 50, excludeApi } = body
   const pg = createSupabaseDirectClient()
 
   const rows = await pg.manyOrNone<{
@@ -38,9 +38,10 @@ export const getPerpEvents: APIHandler<'get-perp-events'> = async (body) => {
         and e.user_id is not null
         and ($2::text is null or e.user_id = $2::text)
         and ($3::bigint is null or e.id < $3::bigint)
+        and ($5::boolean is not true or e.data->>'isApi' is distinct from 'true')
       order by e.id desc
       limit $4`,
-    [contractId, userId ?? null, beforeId ?? null, limit]
+    [contractId, userId ?? null, beforeId ?? null, limit, excludeApi ?? false]
   )
 
   return rows.map((r) => {
@@ -77,6 +78,7 @@ export const getPerpEvents: APIHandler<'get-perp-events'> = async (body) => {
         adlFactor <= 1
           ? adlFactor
           : null,
+      isApi: data.isApi === true,
       userName: r.user_name,
       username: r.username,
       avatarUrl: r.avatar_url,

--- a/backend/api/src/place-perp-trade.ts
+++ b/backend/api/src/place-perp-trade.ts
@@ -16,13 +16,15 @@ export const placePerpTrade: APIHandler<'place-perp-trade'> =
   onlyUsersWhoCanPerformAction('trade', async (body, auth) => {
     assertPerpExposureIncreaseEnabled()
     const { contractId, direction, mana, leverage, idempotencyKey } = body
+    const isApi = auth.creds.kind === 'key'
     const result = await openOrAddPosition(
       contractId,
       auth.uid,
       direction,
       mana,
       leverage,
-      idempotencyKey
+      idempotencyKey,
+      isApi
     )
 
     const { position } = result
@@ -46,11 +48,7 @@ export const placePerpTrade: APIHandler<'place-perp-trade'> =
         // stored request.
         if (result.replayed) return
         try {
-          await advancePerpBettingStreak(
-            auth.uid,
-            contractId,
-            auth.creds.kind === 'key'
-          )
+          await advancePerpBettingStreak(auth.uid, contractId, isApi)
         } catch (err) {
           log('perp streak update failed (non-fatal):', err)
         }

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -419,7 +419,12 @@ export const openOrAddPosition = async (
   direction: PerpDirection,
   mana: number,
   leverage: number,
-  idempotencyKey?: string
+  idempotencyKey?: string,
+  /** Trade arrived via an API key rather than the site — recorded on the
+   * event so readers can filter bot flow out of the Trades tab, matching
+   * `bets.is_api`. Lives in `data` so no migration is needed; events written
+   * before this shipped carry no flag and read as manual. */
+  isApi = false
 ) => {
   assertIdempotencyKey(idempotencyKey)
   if (!Number.isFinite(mana) || mana <= 0)
@@ -728,6 +733,7 @@ export const openOrAddPosition = async (
         leverage,
         fee: openFee,
         feeBps: takerFeeBps,
+        ...(isApi ? { isApi: true } : {}),
         ...(idempotencyKey
           ? {
               idempotencyKey,
@@ -893,7 +899,9 @@ export const closePosition = async (
   userId: string,
   direction: PerpDirection,
   idempotencyKey?: string,
-  expectedOpenedTime?: number
+  expectedOpenedTime?: number,
+  /** See `openOrAddPosition`. */
+  isApi = false
 ) => {
   assertIdempotencyKey(idempotencyKey)
   if (
@@ -1068,6 +1076,7 @@ export const closePosition = async (
         closePrice: price,
         originalCostBasis: position.originalCostBasis,
         takerFeeCostBasis: position.takerFeeCostBasis ?? 0,
+        ...(isApi ? { isApi: true } : {}),
         ...(idempotencyKey
           ? {
               idempotencyKey,

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1262,6 +1262,7 @@ export const API = (_apiTypeCheck = {
       payout: number | null
       pnl: number | null
       adlFactor: number | null
+      isApi: boolean
       userName: string | null
       username: string | null
       avatarUrl: string | null
@@ -1272,6 +1273,10 @@ export const API = (_apiTypeCheck = {
         userId: z.string().min(1).optional(),
         beforeId: z.coerce.number().int().optional(),
         limit: z.coerce.number().int().positive().max(200).optional(),
+        // Drops trades placed with an API key. Liquidations and ADL stay:
+        // they aren't anyone's order. Events written before the flag shipped
+        // carry no marker and read as manual.
+        excludeApi: coerceBoolean.optional(),
       })
       .strict(),
   },

--- a/web/components/perps/perp-holders-tab.tsx
+++ b/web/components/perps/perp-holders-tab.tsx
@@ -1,14 +1,24 @@
+import { ChevronDownIcon } from '@heroicons/react/solid'
+import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
 import clsx from 'clsx'
-import { orderBy } from 'lodash'
+import { orderBy, sumBy } from 'lodash'
 import { useEffect } from 'react'
 import { PerpContract } from 'common/contract'
 import { getUserFacingPnl } from 'common/perps/pnl'
 import { PerpPosition } from 'common/perps/position'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
-import { formatMoney } from 'common/util/format'
+import {
+  fundingPeriodUnit,
+  getFundingPeriodMs,
+  getPerpFundingRate,
+} from 'common/perps/funding'
+import { formatMoney, formatMoneyShort } from 'common/util/format'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
+import generateFilterDropdownItems from 'web/components/search/search-dropdown-helpers'
+import DropdownMenu from 'web/components/widgets/dropdown-menu'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import { Tooltip } from 'web/components/widgets/tooltip'
 import { UserAvatarAndBadge } from 'web/components/widgets/user-link'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
 import { useUser } from 'web/hooks/use-user'
@@ -16,6 +26,16 @@ import { useLivePerpContract } from './use-live-perp-contract'
 import { PerpPositionRow, usePerpPositions } from './use-perp-positions'
 
 type Holder = PerpPositionRow
+
+type SortKey = 'profit' | 'exposure' | 'margin' | 'leverage' | 'liquidation'
+
+const SORT_OPTIONS: { key: SortKey; label: string }[] = [
+  { key: 'profit', label: 'Profit' },
+  { key: 'exposure', label: 'Exposure' },
+  { key: 'margin', label: 'Margin' },
+  { key: 'leverage', label: 'Leverage' },
+  { key: 'liquidation', label: 'Closest to liq' },
+]
 
 export const PerpHoldersTab = (props: {
   contract: PerpContract
@@ -27,6 +47,10 @@ export const PerpHoldersTab = (props: {
   // of freezing at page-load values (they used to fetch exactly once).
   const { contract } = useLivePerpContract(props.contract)
   const holders = usePerpPositions(contract.id)
+  const [sortKey, setSortKey] = usePersistentInMemoryState<SortKey>(
+    'profit',
+    `perp-holders-sort-${contract.id}`
+  )
 
   useEffect(() => {
     if (holders) setTotalHolders?.(holders.length)
@@ -53,51 +77,218 @@ export const PerpHoldersTab = (props: {
   const longs = holders.filter((h) => h.direction === 'long')
   const shorts = holders.filter((h) => h.direction === 'short')
 
-  // Order each side by unrealized PnL so winners float to the top. Using
-  // user-facing PnL (includes funding, excludes ADL haircut from the
-  // original-margin baseline) — this matches what shows on profile pages.
-  const orderByPnl = (hs: Holder[]) =>
-    orderBy(hs, (h) => getUserFacingPnlForHolder(h, price, contract.id), 'desc')
+  // `size` is the position's notional (q = margin × leverage), so summing it
+  // per side is the market's open interest — the same quantity funding is
+  // now derived from. Computed from the rows on screen rather than the
+  // contract's denormalized copy so the header always agrees with the list.
+  const longNotional = sumBy(longs, (h) => h.size)
+  const shortNotional = sumBy(shorts, (h) => h.size)
+
+  // Sorters are descending "most interesting first" except liquidation
+  // distance, where the nearest position is the interesting one.
+  const sortValue = (h: Holder) => {
+    switch (sortKey) {
+      case 'exposure':
+        return h.size
+      case 'margin':
+        return h.originalCostBasis
+      case 'leverage':
+        return h.leverage
+      case 'liquidation':
+        // Ratio, not absolute gap, so the ordering is price-scale free.
+        // Non-finite liq prices (a position that cannot be liquidated at any
+        // reachable price) sort last rather than poisoning the comparison.
+        return Number.isFinite(h.liquidationPrice) && price > 0
+          ? -Math.abs(price - h.liquidationPrice) / price
+          : -Infinity
+      case 'profit':
+      default:
+        return getUserFacingPnlForHolder(h, price, contract.id)
+    }
+  }
+  const sortHolders = (hs: Holder[]) => orderBy(hs, sortValue, 'desc')
 
   return (
-    <Row className="flex-col gap-3 sm:flex-row sm:gap-1">
-      <Col className="w-full sm:w-1/2">
-        <Row className="justify-between p-2">
-          <span className="font-semibold text-teal-600">
-            Longs ({longs.length})
+    <Col className="gap-3">
+      <PerpHoldersSummary
+        contract={contract}
+        longNotional={longNotional}
+        shortNotional={shortNotional}
+        longMargin={sumBy(longs, (h) => h.originalCostBasis)}
+        shortMargin={sumBy(shorts, (h) => h.originalCostBasis)}
+        longCount={longs.length}
+        shortCount={shorts.length}
+      />
+
+      <Row className="items-center gap-1.5">
+        <span className="text-ink-500 text-xs font-medium uppercase tracking-wide">
+          Sort by
+        </span>
+        <DropdownMenu
+          items={generateFilterDropdownItems(
+            SORT_OPTIONS.map((o) => ({ label: o.label, value: o.key })),
+            (value: string) => setSortKey(value as SortKey)
+          )}
+          buttonContent={
+            <Row className="text-ink-900 items-center gap-1 text-sm font-medium">
+              <span className="whitespace-nowrap">
+                {SORT_OPTIONS.find((o) => o.key === sortKey)?.label ?? 'Profit'}
+              </span>
+              <ChevronDownIcon className="text-ink-400 h-4 w-4" />
+            </Row>
+          }
+          menuWidth={'w-36'}
+          selectedItemName={SORT_OPTIONS.find((o) => o.key === sortKey)?.label}
+          closeOnClick
+        />
+      </Row>
+
+      <Row className="flex-col gap-3 sm:flex-row sm:gap-1">
+        <Col className="w-full sm:w-1/2">
+          <Row className="justify-between p-2">
+            <span className="font-semibold text-teal-600">
+              Longs ({longs.length})
+            </span>
+            <span className="text-ink-600">Profit</span>
+          </Row>
+          {sortHolders(longs).map((h) => (
+            <HolderRow
+              key={h.userId + h.direction}
+              holder={h}
+              oraclePrice={price}
+              contractId={contract.id}
+              priceDecimals={priceDecimals}
+              short={isMobile}
+            />
+          ))}
+        </Col>
+        <Col className="w-full sm:w-1/2">
+          <Row className="justify-between p-2">
+            <span className="text-scarlet-600 font-semibold">
+              Shorts ({shorts.length})
+            </span>
+            <span className="text-ink-600">Profit</span>
+          </Row>
+          {sortHolders(shorts).map((h) => (
+            <HolderRow
+              key={h.userId + h.direction}
+              holder={h}
+              oraclePrice={price}
+              contractId={contract.id}
+              priceDecimals={priceDecimals}
+              short={isMobile}
+            />
+          ))}
+        </Col>
+      </Row>
+    </Col>
+  )
+}
+
+/**
+ * Aggregate exposure per side. Leads with notional rather than margin
+ * because notional is what the market is actually long or short — the two
+ * can disagree in sign when the sides run different leverage, which is the
+ * same trap that mispriced funding off the pools.
+ */
+const PerpHoldersSummary = (props: {
+  contract: PerpContract
+  longNotional: number
+  shortNotional: number
+  longMargin: number
+  shortMargin: number
+  longCount: number
+  shortCount: number
+}) => {
+  const {
+    contract,
+    longNotional,
+    shortNotional,
+    longMargin,
+    shortMargin,
+    longCount,
+    shortCount,
+  } = props
+  const total = longNotional + shortNotional
+  const longShare = total > 0 ? longNotional / total : 0.5
+
+  // Live rate off the same open interest shown here, so the bar and the
+  // funding direction can't tell different stories.
+  const fundingRate = getPerpFundingRate({
+    ...contract,
+    openInterestLong: longNotional,
+    openInterestShort: shortNotional,
+  })
+  const fundingUnit = fundingPeriodUnit(getFundingPeriodMs(contract))
+
+  return (
+    <Col className="bg-canvas-50 gap-2 rounded-lg px-3 py-2.5 sm:px-4">
+      <Row className="items-start justify-between gap-2">
+        <Col>
+          <span className="text-xs font-medium uppercase tracking-wide text-teal-600">
+            Long
           </span>
-          <span className="text-ink-600">Profit</span>
-        </Row>
-        {orderByPnl(longs).map((h) => (
-          <HolderRow
-            key={h.userId + h.direction}
-            holder={h}
-            oraclePrice={price}
-            contractId={contract.id}
-            priceDecimals={priceDecimals}
-            short={isMobile}
-          />
-        ))}
-      </Col>
-      <Col className="w-full sm:w-1/2">
-        <Row className="justify-between p-2">
-          <span className="text-scarlet-600 font-semibold">
-            Shorts ({shorts.length})
+          <span className="text-ink-900 text-lg font-semibold tabular-nums">
+            {formatMoney(longNotional)}
           </span>
-          <span className="text-ink-600">Profit</span>
-        </Row>
-        {orderByPnl(shorts).map((h) => (
-          <HolderRow
-            key={h.userId + h.direction}
-            holder={h}
-            oraclePrice={price}
-            contractId={contract.id}
-            priceDecimals={priceDecimals}
-            short={isMobile}
+          <span className="text-ink-500 text-xs">
+            {longCount} {longCount === 1 ? 'trader' : 'traders'} ·{' '}
+            {formatMoneyShort(longMargin)} margin
+          </span>
+        </Col>
+        <Col className="items-end">
+          <span className="text-scarlet-600 text-xs font-medium uppercase tracking-wide">
+            Short
+          </span>
+          <span className="text-ink-900 text-lg font-semibold tabular-nums">
+            {formatMoney(shortNotional)}
+          </span>
+          <span className="text-ink-500 text-xs">
+            {shortCount} {shortCount === 1 ? 'trader' : 'traders'} ·{' '}
+            {formatMoneyShort(shortMargin)} margin
+          </span>
+        </Col>
+      </Row>
+
+      {total > 0 && (
+        <Row className="bg-ink-200 h-2 w-full overflow-hidden rounded-full">
+          <div
+            className="bg-teal-500"
+            style={{ width: `${longShare * 100}%` }}
           />
-        ))}
-      </Col>
-    </Row>
+          <div
+            className="bg-scarlet-500"
+            style={{ width: `${(1 - longShare) * 100}%` }}
+          />
+        </Row>
+      )}
+
+      <Row className="text-ink-500 flex-wrap gap-x-1.5 text-xs">
+        <Tooltip
+          text="Open interest: the notional each side is carrying (margin × leverage) — what the market is actually long or short, which is what funding is priced off."
+          className="underline decoration-dotted underline-offset-2"
+        >
+          {formatMoney(total)} open interest
+        </Tooltip>
+        <span>·</span>
+        <span>
+          {total <= 0
+            ? 'no open exposure'
+            : longNotional <= 0 || shortNotional <= 0
+            ? // A one-sided book is maximally imbalanced, but funding has no
+              // counterparty to pay, so it stays at zero. Saying "balanced"
+              // here would be exactly backwards.
+              `${
+                longNotional > 0 ? 'longs' : 'shorts'
+              } only, so no funding is flowing`
+            : fundingRate === 0
+            ? 'sides balanced, no funding flowing'
+            : `${(longShare * 100).toFixed(0)}% long · ${
+                fundingRate > 0 ? 'longs pay shorts' : 'shorts pay longs'
+              } ${Math.abs(fundingRate * 100).toFixed(3)}%/${fundingUnit}`}
+        </span>
+      </Row>
+    </Col>
   )
 }
 
@@ -149,8 +340,10 @@ const HolderRow = (props: {
             {formatMoney(pnl)}
           </span>
           <span className="text-ink-500 text-xs">
-            {formatMoney(holder.originalCostBasis)} margin ·{' '}
-            {holder.leverage.toFixed(2)}× · liq{' '}
+            {formatMoney(holder.size)} notional · {holder.leverage.toFixed(2)}×
+          </span>
+          <span className="text-ink-500 text-xs">
+            {formatMoney(holder.originalCostBasis)} margin · liq{' '}
             {formatPrice(holder.liquidationPrice, priceDecimals)}
           </span>
         </Col>

--- a/web/components/perps/perp-trades-tab.tsx
+++ b/web/components/perps/perp-trades-tab.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
 import { useEffect, useRef, useState } from 'react'
 import { PerpContract } from 'common/contract'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
@@ -8,9 +9,12 @@ import { Row } from 'web/components/layout/row'
 import { RelativeTimestamp } from 'web/components/relative-timestamp'
 import { LoadMoreUntilNotVisible } from 'web/components/widgets/visibility-observer'
 import { LoadingIndicator } from 'web/components/widgets/loading-indicator'
+import { InfoTooltip } from 'web/components/widgets/info-tooltip'
+import ShortToggle from 'web/components/widgets/short-toggle'
 import { UserAvatarAndBadge } from 'web/components/widgets/user-link'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
 import { api } from 'web/lib/api/api'
+import { track } from 'web/lib/service/analytics'
 import { POSITIONS_POLL_MS as POLL_MS } from './use-perp-positions'
 
 type Event = {
@@ -27,6 +31,7 @@ type Event = {
   payout: number | null
   pnl: number | null
   adlFactor: number | null
+  isApi: boolean
   userName: string | null
   username: string | null
   avatarUrl: string | null
@@ -43,6 +48,13 @@ export const PerpTradesTab = (props: {
   const [hasMore, setHasMore] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const initializedRef = useRef(false)
+  // Filtering is server-side (like the bets tab): dropping API rows on the
+  // client would leave short, ragged pages since pagination counts rows
+  // before the filter.
+  const [hideApiTrades, setHideApiTrades] = usePersistentInMemoryState(
+    false,
+    `hide-api-perp-trades-${contract.id}`
+  )
   // Hoisted out of EventRow: one resize listener for the tab, not one per row.
   const isMobile = useIsMobile(800)
 
@@ -53,10 +65,16 @@ export const PerpTradesTab = (props: {
   useEffect(() => {
     let cancelled = false
     initializedRef.current = false
+    setEvents(null)
+    setHasMore(true)
     const load = () =>
       api('get-perp-events', {
         contractId: contract.id,
         limit: PAGE_SIZE,
+        // Omitted rather than sent as false: the props schema is strict, so
+        // an unknown key 400s. Web deploys ahead of the API, and the default
+        // view must keep working against an API that predates this filter.
+        ...(hideApiTrades ? { excludeApi: true } : {}),
       })
         .then((rows) => {
           if (cancelled) return
@@ -78,7 +96,7 @@ export const PerpTradesTab = (props: {
       cancelled = true
       clearInterval(id)
     }
-  }, [contract.id])
+  }, [contract.id, hideApiTrades])
 
   // Count is a lower bound while pagination is in progress. Good enough for
   // the tab title in v1.
@@ -95,6 +113,7 @@ export const PerpTradesTab = (props: {
         contractId: contract.id,
         beforeId: oldest.id,
         limit: PAGE_SIZE,
+        ...(hideApiTrades ? { excludeApi: true } : {}),
       })
       if (more.length === 0) {
         setHasMore(false)
@@ -108,26 +127,54 @@ export const PerpTradesTab = (props: {
     }
   }
 
-  if (!events) return <LoadingIndicator />
-  if (events.length === 0)
-    return <div className="text-ink-500 p-4 text-sm">No trades yet.</div>
+  const filterRow = (
+    <Row className="bg-canvas-50 items-center gap-2 rounded-lg px-3 py-2 sm:px-4">
+      <span className="text-ink-500 text-xs font-medium uppercase tracking-wide">
+        Hide API trades
+      </span>
+      <ShortToggle
+        on={hideApiTrades}
+        setOn={(enabled) => {
+          setHideApiTrades(enabled)
+          track('toggle-hide-api-trades-filter', {
+            contractSlug: contract.slug,
+            contractName: contract.question,
+            hideApiTrades: enabled,
+            isPerp: true,
+          })
+        }}
+        size="sm"
+      />
+    </Row>
+  )
 
   const priceDecimals = inferPriceDecimals([
     Number(contract.oraclePrice),
-    ...events.map((e) => e.oraclePrice),
+    ...(events ?? []).map((e) => e.oraclePrice),
   ])
 
   return (
     <Col className="gap-2">
-      {events.map((e) => (
-        <EventRow
-          key={e.id}
-          event={e}
-          priceDecimals={priceDecimals}
-          short={isMobile}
-        />
-      ))}
-      {hasMore && <LoadMoreUntilNotVisible loadMore={loadMore} />}
+      {filterRow}
+      {!events ? (
+        <LoadingIndicator />
+      ) : events.length === 0 ? (
+        <div className="text-ink-500 p-4 text-sm">
+          {hideApiTrades ? 'No manual trades yet.' : 'No trades yet.'}
+        </div>
+      ) : (
+        <>
+          {events.map((e) => (
+            <EventRow
+              key={e.id}
+              event={e}
+              priceDecimals={priceDecimals}
+              short={isMobile}
+            />
+          ))}
+          {hasMore && <LoadMoreUntilNotVisible loadMore={loadMore} />}
+        </>
+      )}
     </Col>
   )
 }
@@ -219,6 +266,11 @@ const EventRow = (props: {
             shortened
             className="text-ink-400 !ml-1 text-xs"
           />
+          {event.isApi && (
+            <InfoTooltip text="Placed via the API" className="!ml-1">
+              🤖
+            </InfoTooltip>
+          )}
         </Row>
       </Col>
       <Col className="ml-auto shrink-0 items-end text-sm">


### PR DESCRIPTION
Trades tab had no way to separate bot flow from manual trades, and the holders tab showed neither aggregate exposure nor any ordering but PnL.

- Record whether a perp trade arrived via an API key. Perp events had no equivalent of `bets.is_api`; the flag goes in the event's existing `data` jsonb, so this needs no migration and no deploy ordering. Events written before this ships carry no flag and read as manual.
- get-perp-events returns `isApi` and accepts `excludeApi`. Liquidations and ADL are never filtered out - they are not anyone's order.
- Trades tab: server-side "hide API trades" toggle (client-side would leave ragged pages, since pagination counts rows before the filter) plus the usual robot marker on API rows. The param is only sent when the toggle is on: props are strict, web deploys ahead of the API, and the default view has to keep working against the older API.
- Holders tab: summary header with per-side notional (= open interest, the quantity funding is priced off), trader counts, margin, a skew bar and the funding implication in words. Computed from the rows on screen rather than the contract's denormalized copy so the two cannot disagree. A one-sided book reads as "no counterparty", not "balanced".
- Holders tab: sort by profit / exposure / margin / leverage / closest to liquidation. Liquidation distance sorts on the ratio to mark price so it behaves the same at 64,000 and at 38.