### PR TITLE
feat(perps): require admin to resolve, add resolve control to market info

### DIFF
--- a/backend/api/src/resolve-market.ts
+++ b/backend/api/src/resolve-market.ts
@@ -12,7 +12,7 @@ import {
 import { APIError, type APIHandler, validate } from './helpers/endpoint'
 import { onlyUsersWhoCanPerformAction } from './helpers/rate-limit'
 import { resolveMarketHelper } from 'shared/resolve-market-helpers'
-import { throwErrorIfNotMod } from 'shared/helpers/auth'
+import { throwErrorIfNotAdmin, throwErrorIfNotMod } from 'shared/helpers/auth'
 import { ValidatedAPIParams } from 'common/api/schema'
 import {
   resolveBinarySchema,
@@ -71,6 +71,12 @@ export const resolveMarketMain: APIHandler<
   // price, refund residual pool to the creator, and mark the contract
   // resolved. Bypass the CPMM/multi resolution helper entirely.
   if (outcomeType === 'PERP') {
+    // Stricter than the creator-or-mod gate above. Resolution force-settles
+    // every open position at the oracle price and cannot be undone, and a
+    // perp is meant to run indefinitely — there is no "correct" time to end
+    // one. Match the admin gate already on every other perp state-mutating
+    // endpoint (create-perp, update-perp-config, add-perp-subsidy).
+    throwErrorIfNotAdmin(auth.uid)
     if (contract.isResolved)
       throw new APIError(403, 'Contract already resolved')
     const { resolvePerp } = await import('shared/perps/engine')

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -696,7 +696,94 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           </td>
         </tr>
       )}
+      {canEdit && (
+        <tr className="bg-purple-500/30">
+          <td>
+            Resolve{' '}
+            <InfoTooltip text="Settles every open position at the latest published oracle price and closes the market permanently. Perps are meant to run indefinitely — this is an escape hatch, not routine." />
+          </td>
+          <td>
+            <ResolvePerpButton contract={contract} />
+          </td>
+        </tr>
+      )}
     </>
+  )
+}
+
+// Admin-only escape hatch. `resolvePerp` settles every open position at the
+// newest published feed point — not necessarily the cached oraclePrice, which
+// lags whenever the engine has been rejecting updates — pays the residual pool
+// to the creator, and marks the contract resolved. There is no undo, so the
+// button confirms in place rather than firing on the first click.
+function ResolvePerpButton(props: { contract: PerpContract }) {
+  const { contract } = props
+  const [confirming, setConfirming] = useState(false)
+  const [resolving, setResolving] = useState(false)
+  const price = Number(contract.oraclePrice)
+  // Shown only as orientation: the settlement price is whatever the feed has
+  // published by the time the transaction runs, which is newer than this
+  // whenever the market has been stuck.
+  const cachedLabel = !Number.isFinite(price)
+    ? ''
+    : ` (cached: ${formatPrice(price, inferPriceDecimals([price]))}${
+        contract.oraclePriceTime
+          ? `, ${formatTimeWithTimezone(contract.oraclePriceTime)}`
+          : ''
+      })`
+
+  const resolve = async () => {
+    if (resolving) return
+    setResolving(true)
+    try {
+      // `outcome` is ignored on the PERP path — the engine always writes 'MKT'
+      // with the settlement price — but the shared schema still requires one.
+      await api('market/:contractId/resolve', {
+        contractId: contract.id,
+        outcome: 'MKT',
+      })
+      setConfirming(false)
+      toast.success('Market resolved')
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to resolve market'
+      )
+    } finally {
+      setResolving(false)
+    }
+  }
+
+  if (!confirming)
+    return (
+      <Button
+        size="2xs"
+        color="red-outline"
+        onClick={() => setConfirming(true)}
+      >
+        Resolve market
+      </Button>
+    )
+
+  return (
+    <Col className="gap-1">
+      <span className="text-ink-600 text-xs">
+        Settles every open position at the latest published oracle price
+        {cachedLabel} and closes the market. This cannot be undone.
+      </span>
+      <Row className="items-center gap-1.5">
+        <Button size="2xs" color="red" disabled={resolving} onClick={resolve}>
+          {resolving ? 'Resolving…' : 'Confirm resolve'}
+        </Button>
+        <Button
+          size="2xs"
+          color="gray-outline"
+          disabled={resolving}
+          onClick={() => setConfirming(false)}
+        >
+          Cancel
+        </Button>
+      </Row>
+    </Col>
   )
 }
 


### PR DESCRIPTION
## Why

Perp resolution force-settles every open position at the oracle price, pays the residual pool to the creator, and cannot be undone. It was the only perp state-mutating endpoint still on the creator-or-mod gate — `create-perp`, `update-perp-config` and `add-perp-subsidy` are all `throwErrorIfNotAdmin`. This closes that gap.

There was also no UI for it at all: `resolution-panel.tsx` has no PERP branch, so the only way to retire a perp was a hand-rolled API call with an `outcome` field that the handler ignores.

## What

**Backend** — `throwErrorIfNotAdmin` at the top of the PERP branch in `resolve-market.ts`. Unconditional, so it also overrides the creator bypass above it: the market's creator cannot resolve a perp unless they are an admin. (The Manifold account, which creates the perps, is in `prod.ts` `adminIds`, so nothing operational changes.)

**Web** — a `Resolve` row in `PerpStatsRows` in the market info dialog, under the pool subsidy editor, behind the same `canEdit` gate (`isAdmin && !isResolved`). Arms on first click, fires on second.

The confirm copy deliberately says settlement uses *the latest published oracle price*, and shows the cached price and timestamp only as orientation. Those two diverge exactly in the situation where you would reach for this button — a market whose engine has been rejecting oracle updates keeps serving a stale cached price while `resolvePerp` settles at the newer feed point.

`outcome: 'MKT'` is sent because the shared schema requires an outcome, but the PERP path never reads it — the engine hard-codes `resolution: 'MKT'` with `resolvedOraclePrice` regardless.

## Notes for review

- Perps are meant to run indefinitely; this is an escape hatch, not routine. Tooltip says so.
- Does **not** address the case where resolution throws (an insolvent market cannot be resolved, because `resolvePerp` runs `assertPerpStateSolvent` via `applyOracleUpdate`). The button surfaces the error as a toast instead of failing silently, but the operator still has to know to top up the deficient pool first. A `preview-perp-resolution` dry-run returning settlement price, projected ADL factors, per-position payout and any required top-up would fix that properly — deliberately out of scope here.
- Admins can hold positions in perps, so this gate is protection against accidents and casual mod access, not against a conflict of interest. Settlement timing materially changes payouts, so if that matters, refusing resolution when the caller has an open position in the market is the cheap follow-up.

## Testing

`backend/api` and `web` both typecheck clean. No behaviour change for non-PERP resolution paths.
