### PR TITLE
fix(scheduler): score-write lock select must be tx.any, not tx.none — scores frozen since #3973 deployed

### DIFF
--- a/backend/shared/src/importance-score.ts
+++ b/backend/shared/src/importance-score.ts
@@ -46,7 +46,10 @@ const updateContractScores = async (
 ) => {
   if (!updates.length) return
   await pg.tx(async (tx) => {
-    await tx.none(
+    // .any, NOT .none: the lock select returns one row per contract, and
+    // pg-promise's none() rejects on any returned row ("No return data was
+    // expected"), which aborted the transaction before the score write.
+    await tx.any(
       `select 1 from contracts where id in ($1:csv) order by id for update`,
       [updates.map((u) => u.id)]
     )


### PR DESCRIPTION
## Regression (introduced by #3973 — my bug)
The id-ordered `FOR UPDATE` lock select added in #3973 returns one row per contract, but was called with `tx.none(...)`. pg-promise's `none()` **rejects when any row comes back** (`No return data was expected`), so since the main-scheduler deploy picked it up (~2026-08-08):

- `score-contracts` has crashed on **every run** (~26 job-crash alerts/day — this is the current alert stream)
- the transaction aborts **before the bulk score write**, so contracts' `importance_score`/`freshness_score`/`daily_score` have not updated since the deploy — homepage/feed ranking has been serving stale scores for ~3 days

The deadlock-retry path was unaffected (real 40P01s during lock acquisition were retried — those log lines are in prod), but the retry only catches deadlocks, so the QueryResultError crashed straight through.

## Fix
One word: `tx.none` → `tx.any` on the lock select, with a comment so it can't regress silently. `tsc -b` clean.

## Deploy
**Urgent-ish**: needs a `prod main` scheduler deploy (`./deploy-scheduler-windows.sh prod main`) to unfreeze score updates. First clean run after deploy recomputes and writes current scores — no backfill needed, the job is self-correcting by design.