### PR TITLE
fix(perps): classify upstage/solar-pro4 (closed) to unfreeze the openrouter feed

### DIFF
--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -50,7 +50,7 @@ import { DAY_MS } from '../util/time'
 // change silently when a third party edits a metadata field.
 
 /** Bump when the map changes. */
-export const OPEN_WEIGHT_LIST_VERSION = '2026-08-12'
+export const OPEN_WEIGHT_LIST_VERSION = '2026-08-13'
 
 /** Trailing window, in whole UTC days, that the index averages over. */
 export const OPEN_WEIGHT_WINDOW_DAYS = 7
@@ -75,6 +75,18 @@ export type ModelClassification = {
  * variant suffixes (`...:free`), which are the same model for index purposes.
  */
 export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
+  // Added 2026-08-13: entered the top 50 with OpenRouter's 2026-08-12 day and
+  // froze the feed (fail-closed). Solar Pro 4 is API-only. No `solar-pro4`
+  // repo exists anywhere on HuggingFace (global search, 0 hits), and the whole
+  // `solar-pro*` line publishes tokenizer-only repos — `solar-pro2-tokenizer`
+  // and `solar-pro3-tokenizer` resolve, `upstage/solar-pro3` itself does not.
+  // Upstage's downloadable weights ship under the separately branded Solar
+  // Open line (`upstage/Solar-Open-100B`, `upstage/Solar-Open2-250B`), which
+  // is not what OpenRouter is serving here; their `/models` entry for this
+  // permaslug carries `hugging_face_id: null` (verified 2026-08-13). If
+  // Upstage later publishes the weights, that counts from the release date
+  // forward via a new entry — never retroactively.
+  'upstage/solar-pro4-20260810': { open: false }, // Upstage: Solar Pro 4
   // Added 2026-08-07: entered the top 50 and froze the feed (fail-closed).
   // Muse Spark is Meta's first CLOSED-weights family — API-only via
   // api.meta.ai, no repo in meta-llama/facebook HF orgs, widely reported as


### PR DESCRIPTION
## What broke

The open-weight share feed wrote no point after `2026-08-12T23:50Z`. Six hourly runs skipped, well past the 3h `staleAfterMs`:

```
05:50:00Z [openrouter] unsafe index payload — unclassified models: upstage/solar-pro4-20260810; skipping publication
05:50:45Z [oracle-feeds] daily feed openrouter-open-weight-share is stale
06:00:00Z [update-perps] feed openrouter-open-weight-share is stale (age 22200251ms > 10800000ms)
```

Upstage Solar Pro 4 entered OpenRouter's top 50 with the 2026-08-12 UTC day. Unclassified models fail closed by design, so the index stopped publishing rather than silently shrinking its denominator — same failure mode as muse-spark (#3980) and nemotron (#3989).

Meanwhile the market kept running on the frozen mark: funding charged all six cycles (00:00–05:00Z) at `69.705732943`, 27 open positions, 0 liquidations.

## The call: closed

Verified against the HuggingFace API on the version date, per the methodology in the file header:

| Check | Result |
|---|---|
| Global HF search `solar-pro4` | **0 models** — no org has it |
| `upstage` org listing | No Solar Pro 4 repo |
| `solar-pro*` line | Tokenizer-only (`solar-pro2-tokenizer`, `solar-pro3-tokenizer`, 0 downloads); `upstage/solar-pro3` itself 401s |
| Upstage's open weights | Separately branded **Solar Open** line (`Solar-Open-100B`, `Solar-Open2-250B`) — not what OpenRouter serves here |
| OpenRouter `/models` | `canonical_slug: upstage/solar-pro4-20260810`, `hugging_face_id: null` |

If Upstage later publishes the weights, that counts from the release date forward via a new entry — never retroactively.

## Verification

- `common` tests: 20/20 pass
- `tsc --noEmit` on `common`: clean

## Deploy

Needs a **`prod perps` scheduler deploy** to take effect — `backend/scheduler` is the only consumer; web doesn't import the list. The `oracle-tick-absent` alert will fire on the deploy, as documented.

On resume the index **steps down**: solar-pro4 joins the denominator on the closed side, and the window rolls forward 1–2 days on top of that. No backfill — each point is an immutable per-run measurement, so the gap simply stays a gap.

## Note

Third freeze in a week (muse-spark 8/7, nemotron 8/12, solar-pro4 8/13). Fail-closed is the right default, but each occurrence costs hours of stale oracle on a live market that keeps charging funding. Worth considering paging directly on the unclassified-model rejection rather than waiting for the generic stale-feed path.
