### PR TITLE
feat(perps): stop the openrouter feed halting on every new model

### DIFF
--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -1,0 +1,123 @@
+import {
+  OPEN_WEIGHT_LIST_VERSION,
+  OPEN_WEIGHT_MODELS,
+  UNCLASSIFIED_GRACE_WINDOW_MS,
+  basePermaslug,
+} from 'common/perps/open-weight-models'
+import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import {
+  ClassificationRow,
+  upsertClassification,
+} from 'shared/perps/model-classifications'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+import { APIError, APIHandler } from './helpers/endpoint'
+
+// Operator tooling for the open-weight index's classification queue.
+//
+// Classifications used to be a code change: PR, merge, image build, VM
+// redeploy, hours — for one boolean, while the perp marked and funded against
+// a halted oracle. These endpoints write the override table the scheduler
+// re-reads every tick, so a verdict takes effect on the next run.
+
+export const getModelClassifications: APIHandler<
+  'get-model-classifications'
+> = async (_, auth) => {
+  throwErrorIfNotAdmin(auth.uid)
+  const pg = createSupabaseDirectClient()
+
+  const rows = await pg.manyOrNone<ClassificationRow>(
+    `select permaslug, open, weights, source, evidence,
+            first_seen, first_ranked_at, classified_at, classified_by
+     from model_classifications
+     where open is null
+        or classified_at > now() - interval '30 days'
+     order by first_ranked_at asc nulls last, first_seen asc`
+  )
+
+  const now = Date.now()
+  const evidenceString = (row: ClassificationRow, key: string) => {
+    const value = row.evidence?.[key]
+    return typeof value === 'string' ? value : null
+  }
+
+  return {
+    // A pending row for a model the seed already classifies is inert — the
+    // seed verdict stands — so it must not appear as work to do.
+    pending: rows
+      .filter((r) => r.open === null && !OPEN_WEIGHT_MODELS[r.permaslug])
+      .map((r) => {
+        const firstSeen = new Date(r.first_seen).getTime()
+        const firstRankedAt = r.first_ranked_at
+          ? new Date(r.first_ranked_at).getTime()
+          : null
+        return {
+          permaslug: r.permaslug,
+          openRouterName: evidenceString(r, 'openRouterName'),
+          huggingFaceId: evidenceString(r, 'huggingFaceId'),
+          discoveredVia: evidenceString(r, 'discoveredVia'),
+          firstSeen,
+          ageMs: now - firstSeen,
+          // Only a ranked model has a deadline — an unranked one is not
+          // affecting the index, so it is queue backlog, not an outage.
+          firstRankedAt,
+          rankedAgeMs: firstRankedAt === null ? null : now - firstRankedAt,
+          graceExpired:
+            firstRankedAt !== null &&
+            now - firstRankedAt > UNCLASSIFIED_GRACE_WINDOW_MS,
+        }
+      }),
+    recent: rows
+      .filter((r) => r.open !== null)
+      .map((r) => ({
+        permaslug: r.permaslug,
+        open: r.open as boolean,
+        weights: r.weights,
+        source: r.source,
+        classifiedAt: r.classified_at
+          ? new Date(r.classified_at).getTime()
+          : null,
+        classifiedBy: r.classified_by,
+      }))
+      .sort((a, b) => (b.classifiedAt ?? 0) - (a.classifiedAt ?? 0)),
+    seedVersion: OPEN_WEIGHT_LIST_VERSION,
+    graceWindowMs: UNCLASSIFIED_GRACE_WINDOW_MS,
+  }
+}
+
+export const setModelClassification: APIHandler<
+  'set-model-classification'
+> = async (body, auth) => {
+  throwErrorIfNotAdmin(auth.uid)
+  const permaslug = basePermaslug(body.permaslug.trim())
+  const { open, weights } = body
+
+  // The seed list is the published methodology and is version-stamped on every
+  // point the oracle writes. Silently overriding an entry from an admin form
+  // would make the stamp a lie, so a genuine reclassification has to go
+  // through the file — which is also where the reasoning gets recorded.
+  if (OPEN_WEIGHT_MODELS[permaslug])
+    throw new APIError(
+      400,
+      `${permaslug} is classified in the audited seed list (version ` +
+        `${OPEN_WEIGHT_LIST_VERSION}). Reclassifying it is a change to the ` +
+        `published methodology — edit common/src/perps/open-weight-models.ts.`
+    )
+
+  const pg = createSupabaseDirectClient()
+  await upsertClassification(pg, {
+    permaslug,
+    open,
+    weights: weights?.trim() || null,
+    source: 'admin',
+    evidence: { classifiedByAdmin: auth.uid, weightsCitedAt: Date.now() },
+    classifiedBy: auth.uid,
+  })
+
+  log(
+    `admin ${auth.uid} classified ${permaslug} as ${
+      open ? `open (${weights})` : 'closed'
+    }`
+  )
+  return { success: true as const, permaslug, open }
+}

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -76,6 +76,10 @@ import { closePerpPosition } from './close-perp-position'
 import { updatePerpConfig } from './update-perp-config'
 import { addPerpSubsidy } from './add-perp-subsidy'
 import {
+  getModelClassifications,
+  setModelClassification,
+} from './model-classifications'
+import {
   getOraclePrice,
   getOraclePriceSeries,
 } from './get-oracle-price'
@@ -446,6 +450,8 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'close-perp-position': closePerpPosition,
   'update-perp-config': updatePerpConfig,
   'add-perp-subsidy': addPerpSubsidy,
+  'get-model-classifications': getModelClassifications,
+  'set-model-classification': setModelClassification,
   'get-oracle-price': getOraclePrice,
   'get-oracle-price-series': getOraclePriceSeries,
   'get-known-oracle-feeds': getKnownOracleFeeds,

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -244,9 +244,14 @@ export function createJobs(jobSet: SchedulerJobSet) {
       // outbound HuggingFace calls, and the perps instance exists to keep the
       // 15s oracle tick on an unshared event loop. It only writes a table the
       // perps instance reads, so the split costs nothing.
-      // Hours chosen to miss the 08:00 UTC API restart window and the
-      // ~10:00-11:30 UTC scheduler memory pressure window.
-      '0 15 2,8,14,20 * * *',
+      // LA hours, like every schedule in this file. Chosen to miss both the
+      // 08:00 UTC API restart window and the ~10:00-11:30 UTC scheduler memory
+      // pressure window in BOTH DST offsets: 05/11/17/23 LA is 12/18/00/06 UTC
+      // in PDT and 13/19/01/07 UTC in PST. Those windows land on 00:00-04:30 LA
+      // across the two offsets, which makes this the only 6-hourly cycle that
+      // clears them year-round — do not shift it by an hour without redoing
+      // that arithmetic.
+      '0 15 5,11,17,23 * * *',
       updateModelClassifications
     ),
     // Daily jobs:

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -63,6 +63,7 @@ import { updateStatsCore } from './update-stats'
 import { updatePerps } from './update-perps'
 import { updateOracleFeeds } from './update-oracle-feeds'
 import { updateOpenRouterShare } from './update-openrouter-share'
+import { updateModelClassifications } from './update-model-classifications'
 import { updateTrumpApproval } from './update-trump-approval'
 import { resolveSportsMarkets } from './sports-resolve'
 import { createUpcomingSportsMarkets } from './sports-create-markets'
@@ -236,6 +237,17 @@ export function createJobs(jobSet: SchedulerJobSet) {
       // 24 calls/day against OpenRouter's 500/day account limit.
       '0 50 * * * *',
       updateOpenRouterShare
+    ),
+    createJob(
+      'update-model-classifications',
+      // Every 6 hours. Deliberately NOT a perp job: it makes a few hundred
+      // outbound HuggingFace calls, and the perps instance exists to keep the
+      // 15s oracle tick on an unshared event loop. It only writes a table the
+      // perps instance reads, so the split costs nothing.
+      // Hours chosen to miss the 08:00 UTC API restart window and the
+      // ~10:00-11:30 UTC scheduler memory pressure window.
+      '0 15 2,8,14,20 * * *',
+      updateModelClassifications
     ),
     // Daily jobs:
     createJob(

--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -1,0 +1,117 @@
+import { OPEN_WEIGHT_MODELS } from 'common/perps/open-weight-models'
+import {
+  logHuggingFaceVerification,
+  verifyHuggingFaceWeights,
+} from 'shared/huggingface'
+import {
+  getPendingClassifications,
+  recordPendingModels,
+  upsertClassification,
+} from 'shared/perps/model-classifications'
+import { fetchOpenRouterCatalog } from 'shared/openrouter-tokens'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+
+// Classify new OpenRouter models BEFORE they reach the top 50.
+//
+// The open-weight index halts on models it cannot classify. That is the right
+// default — a mis-defaulted frontier launch would move an executable index
+// several points on a guess — but for three weeks running it meant the feed
+// froze overnight whenever a new model climbed into the rankings, while the
+// perp kept marking and charging funding against a stale oracle.
+//
+// The models were never actually a surprise. Each one sat in OpenRouter's
+// catalog first: muse-spark for 22 days, solar-pro4 for three, nemotron-3.5-
+// lightning for one. This job spends that lead time, so the common case is
+// resolved before it can matter and the rest is a review queue rather than an
+// outage.
+//
+// It only ever decides OPEN, and only on confirmed public weight files. It
+// never concludes closed — see the directionality note in shared/huggingface.
+// Anything it cannot confirm stays pending for a human, which is what the
+// admin tool and the grace window exist for.
+export const updateModelClassifications = async () => {
+  try {
+    await updateModelClassificationsInternal()
+  } catch (err) {
+    // Tagged so a watcher outage is findable on its own, rather than only
+    // showing up later as an unexplained feed halt.
+    log.error(`[model-classifier] run failed — ${err}`)
+  }
+}
+
+const updateModelClassificationsInternal = async () => {
+  const pg = createSupabaseDirectClient()
+
+  const catalog = await fetchOpenRouterCatalog()
+  const adjudicated = await pg.manyOrNone<{ permaslug: string }>(
+    `select permaslug from model_classifications where open is not null`
+  )
+  const settled = new Set(adjudicated.map((r) => r.permaslug))
+
+  const unknown = catalog.filter(
+    (m) => !OPEN_WEIGHT_MODELS[m.permaslug] && !settled.has(m.permaslug)
+  )
+  if (unknown.length === 0) {
+    log('[model-classifier] catalog fully classified')
+    return
+  }
+
+  // Start the grace clock from when WE first saw the model, not from
+  // OpenRouter's listing date: backdating would expire the entire first-run
+  // backlog on the spot and halt the feed for a problem nobody has had a
+  // chance to look at yet.
+  await recordPendingModels(
+    pg,
+    unknown.map((m) => ({
+      permaslug: m.permaslug,
+      name: m.name,
+      huggingFaceId: m.huggingFaceId,
+      discoveredVia: 'catalog' as const,
+    }))
+  )
+
+  // Re-verify every pending model each run, not just the newly seen ones:
+  // OpenRouter frequently populates `hugging_face_id` days after listing, and
+  // labs publish weights after launch. Both cases resolve themselves here.
+  let confirmed = 0
+  let unresolved = 0
+  for (const model of unknown) {
+    if (!model.huggingFaceId) {
+      unresolved++
+      continue
+    }
+    const verification = await verifyHuggingFaceWeights(model.huggingFaceId)
+    logHuggingFaceVerification(model.permaslug, verification)
+    if (!verification.confirmed) {
+      unresolved++
+      continue
+    }
+    await upsertClassification(pg, {
+      permaslug: model.permaslug,
+      open: true,
+      weights: verification.repo,
+      source: 'auto',
+      evidence: { ...verification.evidence, openRouterName: model.name },
+    })
+    confirmed++
+  }
+
+  const pending = await getPendingClassifications(pg)
+  log(
+    `[model-classifier] ${unknown.length} unclassified in catalog: ` +
+      `${confirmed} auto-classified open, ${unresolved} unresolved; ` +
+      `${pending.length} awaiting review`
+  )
+
+  // Warn rather than error: a pending model is not yet a problem — the index
+  // publishes under grace while it is small and fresh. It becomes an error
+  // only when the publication gate actually halts on it, which the
+  // [openrouter] tag reports with the numbers that justify it.
+  if (pending.length > 0)
+    log.warn(
+      `[model-classifier] awaiting human classification: ${pending
+        .map((p) => p.permaslug)
+        .join(', ')}`
+    )
+}

--- a/backend/scheduler/src/jobs/update-openrouter-share.ts
+++ b/backend/scheduler/src/jobs/update-openrouter-share.ts
@@ -1,9 +1,14 @@
 import {
   computeOpenWeightShare,
   OPEN_WEIGHT_LIST_VERSION,
+  OPEN_WEIGHT_WINDOW_DAYS,
   openWeightWindowRange,
   validateOpenWeightPublication,
 } from 'common/perps/open-weight-models'
+import {
+  recordUnclassifiedInRankings,
+  resolveModelClassifications,
+} from 'shared/perps/model-classifications'
 import { fetchOpenRouterRankings } from 'shared/openrouter-tokens'
 import {
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
@@ -61,14 +66,43 @@ const updateOpenRouterShareInternal = async () => {
     return
   }
 
-  const result = computeOpenWeightShare(rankings.rows)
-  const publication = validateOpenWeightPublication(result)
+  // Seed list plus any operator/auto overrides that landed since the last
+  // deploy, so a classification takes effect on the next tick rather than the
+  // next release.
+  const { classifications, expiredUnclassified } =
+    await resolveModelClassifications(pg)
+
+  const result = computeOpenWeightShare(
+    rankings.rows,
+    OPEN_WEIGHT_WINDOW_DAYS,
+    classifications
+  )
+
+  // Start the grace clock for anything unknown that is actually in the ranked
+  // window — creating the row if the catalog sweep never saw it, since the
+  // rankings dataset carries models /models does not list.
+  if (result.unclassified.length > 0)
+    await recordUnclassifiedInRankings(pg, result.unclassified)
+
+  const publication = validateOpenWeightPublication(result, {
+    expiredUnclassified,
+  })
   if (!publication.ok) {
     log.error(
       `[openrouter] unsafe index payload — ${publication.reason}; skipping publication`
     )
     return
   }
+  if (publication.grace)
+    log.warn(
+      `[openrouter] publishing under grace — excluding ${publication.grace.unclassified.join(
+        ', '
+      )} (${(publication.grace.shareOfClassified * 100).toFixed(
+        3
+      )}% of classified tokens, index off by at most ${publication.grace.maxIndexError.toFixed(
+        3
+      )}pp)`
+    )
 
   const point = {
     ts: now,

--- a/backend/scripts/backfill-openrouter-oracle.ts
+++ b/backend/scripts/backfill-openrouter-oracle.ts
@@ -71,7 +71,25 @@ if (require.main === module)
       const window = dates.slice(i - OPEN_WEIGHT_WINDOW_DAYS + 1, i + 1)
       const rows = window.flatMap((d) => byDate[d])
       const result = computeOpenWeightShare(rows)
-      const publication = validateOpenWeightPublication(result)
+      // Cap 0 = halt on ANY unclassified model, which is what this call meant
+      // before the grace window existed and still has to mean here.
+      //
+      // Grace is a trade the LIVE feed can make: publishing a bounded sub-point
+      // error for a few hours beats marking a live market against a stale
+      // oracle, and the error is temporary because the model gets classified
+      // and the next tick is correct. A backfill has neither half of that.
+      // There is no stale-oracle harm to weigh against — nothing is trading on
+      // a point from six months ago — and nothing self-corrects, because
+      // insertOraclePrices never overwrites an existing (feed_id, ts). A point
+      // written under grace here is a permanently wrong point in published
+      // history, computed from a denominator that silently omitted a model.
+      //
+      // So this script keeps its original posture: any unclassified model in
+      // any window aborts the whole run with no inserts, and a human extends
+      // the seed list before retrying.
+      const publication = validateOpenWeightPublication(result, {
+        unclassifiedShareCap: 0,
+      })
       if (!publication.ok) {
         rejections.push(`${dates[i]}: ${publication.reason}`)
         continue

--- a/backend/shared/src/huggingface.ts
+++ b/backend/shared/src/huggingface.ts
@@ -40,10 +40,14 @@ export type HuggingFaceVerification =
 /**
  * Verify that `repo` holds publicly downloadable weights.
  *
- * Gated repos still count as public — Llama and Gemma sit behind a
- * click-through licence that any member of the public can accept, and the
- * methodology's line is "can anyone get them", not "is the licence tidy". A
- * private repo does not count, and neither does a repo with no weight files
+ * Click-through gating still counts as public — Llama and Gemma sit behind a
+ * licence any member of the public can accept, and the methodology's line is
+ * "can anyone get them", not "is the licence tidy". Discretionary gating does
+ * NOT: HF's `gated` is a trichotomy, and `"manual"` means the owner approves
+ * each request individually, so the public cannot in fact get the weights.
+ * Hence the accept-list below — any value HF invents later reads as unresolved
+ * rather than silently confirming, per the directionality note above. A private
+ * repo does not count either, and neither does a repo with no weight files
  * (tokenizer-only publications are the exact trap Upstage's `solar-pro*` line
  * sets: `solar-pro3-tokenizer` resolves while the weights never shipped).
  */
@@ -74,11 +78,20 @@ export const verifyHuggingFaceWeights = async (
 
   const body = (await res.json()) as {
     private?: boolean
-    gated?: string | boolean
+    // Not a boolean: HF returns false | "auto" (click-through) | "manual"
+    // (owner approves each request), and the three do not mean the same thing.
+    gated?: string | boolean | null
     siblings?: { rfilename?: string }[]
   }
   if (body.private)
     return { confirmed: false, repo, reason: 'repo is private' }
+
+  if (!isPubliclyGettable(body.gated))
+    return {
+      confirmed: false,
+      repo,
+      reason: `gating is not public: ${JSON.stringify(body.gated)}`,
+    }
 
   const weightFiles = (body.siblings ?? [])
     .map((s) => s.rfilename ?? '')
@@ -102,6 +115,16 @@ export const verifyHuggingFaceWeights = async (
     },
   }
 }
+
+/**
+ * Whether HF's `gated` value still leaves the weights gettable by anyone.
+ *
+ * An accept-list, not a reject-list, so a value HF adds later ("research",
+ * "waitlist", whatever) fails closed into "unresolved" and waits for a human
+ * instead of quietly counting on the open side of an executable index.
+ */
+const isPubliclyGettable = (gated: string | boolean | null | undefined) =>
+  gated == null || gated === false || gated === 'auto'
 
 /** Repo ids are `org/name`; the slash is structural and must not be escaped. */
 const encodeRepo = (repo: string) =>

--- a/backend/shared/src/huggingface.ts
+++ b/backend/shared/src/huggingface.ts
@@ -1,0 +1,125 @@
+import { log } from './utils'
+
+// HuggingFace repo verification for the open-weight index.
+//
+// This automates exactly the check the methodology in
+// `common/perps/open-weight-models.ts` demands of an `open` verdict: the repo
+// resolves, is not private, and carries actual weight files. Nothing else here
+// is authoritative — least of all a model's name.
+//
+// DIRECTIONALITY IS THE WHOLE DESIGN. A confirmed repo is proof the weights are
+// public, so `open` can be decided by machine. A missing or unresolvable repo
+// is NOT proof of the opposite: the index file documents several models with
+// demonstrably public weights whose OpenRouter `hugging_face_id` was absent
+// (Ling-2.6-flash, Qwen3-Embedding-8B, pplx-embed-v1, MiMo-V2-Flash,
+// Trinity-Large-Preview, the TNG Chimera merges). So this module only ever
+// returns "confirmed open" or "not confirmed" — it never concludes closed.
+// Calling something closed stays a human judgement.
+
+const HF_API = 'https://huggingface.co/api/models'
+const FETCH_TIMEOUT_MS = 15_000
+
+/** Extensions that constitute publicly downloadable weights. */
+const WEIGHT_FILE_PATTERN = /\.(safetensors|bin|pt|pth|gguf|onnx|msgpack|h5)$/i
+
+export type HuggingFaceVerification =
+  | {
+      confirmed: true
+      repo: string
+      /** Evidence recorded alongside the verdict so it can be re-audited. */
+      evidence: {
+        repo: string
+        gated: string | boolean | null
+        weightFileCount: number
+        sampleWeightFiles: string[]
+        checkedAt: string
+      }
+    }
+  | { confirmed: false; repo: string | null; reason: string }
+
+/**
+ * Verify that `repo` holds publicly downloadable weights.
+ *
+ * Gated repos still count as public — Llama and Gemma sit behind a
+ * click-through licence that any member of the public can accept, and the
+ * methodology's line is "can anyone get them", not "is the licence tidy". A
+ * private repo does not count, and neither does a repo with no weight files
+ * (tokenizer-only publications are the exact trap Upstage's `solar-pro*` line
+ * sets: `solar-pro3-tokenizer` resolves while the weights never shipped).
+ */
+export const verifyHuggingFaceWeights = async (
+  repo: string
+): Promise<HuggingFaceVerification> => {
+  if (!repo || !repo.includes('/'))
+    return { confirmed: false, repo: repo || null, reason: 'no repo id' }
+
+  let res: Response
+  try {
+    res = await fetch(`${HF_API}/${encodeRepo(repo)}`, {
+      headers: { 'user-agent': 'Manifold/1.0 (+https://manifold.markets)' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+  } catch (err) {
+    return { confirmed: false, repo, reason: `fetch failed: ${err}` }
+  }
+
+  // HF answers 401 for both "private" and "does not exist" when unauthenticated,
+  // so neither can be distinguished — and neither is confirmation.
+  if (!res.ok)
+    return {
+      confirmed: false,
+      repo,
+      reason: `not public: ${res.status} ${res.statusText}`,
+    }
+
+  const body = (await res.json()) as {
+    private?: boolean
+    gated?: string | boolean
+    siblings?: { rfilename?: string }[]
+  }
+  if (body.private)
+    return { confirmed: false, repo, reason: 'repo is private' }
+
+  const weightFiles = (body.siblings ?? [])
+    .map((s) => s.rfilename ?? '')
+    .filter((name) => WEIGHT_FILE_PATTERN.test(name))
+  if (weightFiles.length === 0)
+    return {
+      confirmed: false,
+      repo,
+      reason: 'repo resolves but carries no weight files',
+    }
+
+  return {
+    confirmed: true,
+    repo,
+    evidence: {
+      repo,
+      gated: body.gated ?? null,
+      weightFileCount: weightFiles.length,
+      sampleWeightFiles: weightFiles.slice(0, 5),
+      checkedAt: new Date().toISOString(),
+    },
+  }
+}
+
+/** Repo ids are `org/name`; the slash is structural and must not be escaped. */
+const encodeRepo = (repo: string) =>
+  repo.split('/').map(encodeURIComponent).join('/')
+
+export const logHuggingFaceVerification = (
+  permaslug: string,
+  verification: HuggingFaceVerification
+) => {
+  if (verification.confirmed)
+    log(
+      `[model-classifier] ${permaslug} -> open (${verification.repo}, ` +
+        `${verification.evidence.weightFileCount} weight files)`
+    )
+  else
+    log(
+      `[model-classifier] ${permaslug} -> unresolved (${
+        verification.repo ?? 'no repo'
+      }: ${verification.reason})`
+    )
+}

--- a/backend/shared/src/openrouter-tokens.ts
+++ b/backend/shared/src/openrouter-tokens.ts
@@ -115,6 +115,79 @@ export const parseRankingRows = (data: unknown): RankingRow[] => {
   })
 }
 
+export const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models'
+
+export type OpenRouterCatalogEntry = {
+  /** The key the rankings payload uses, and the key the index classifies on. */
+  permaslug: string
+  name: string
+  /** Publisher-declared weights repo. A HINT ONLY — see huggingface.ts. */
+  huggingFaceId: string | null
+  /** When OpenRouter listed it; the head start a watcher gets. */
+  listedAt: number | null
+}
+
+/**
+ * The full model catalog — every model OpenRouter serves, not just the ranked
+ * top 50. Unauthenticated and separate from the rankings dataset.
+ *
+ * This is the lead time the nightly watcher runs on. Models appear here before
+ * they climb into the rankings: of the three that froze the feed in the week to
+ * 2026-08-13, muse-spark was listed 22 days ahead, solar-pro4 three days, and
+ * nemotron-3.5-lightning one. Classifying from the catalog turns "the index
+ * halted overnight" into "there is a row to review in the morning".
+ */
+export const fetchOpenRouterCatalog = async (): Promise<
+  OpenRouterCatalogEntry[]
+> => {
+  const res = await fetch(OPENROUTER_MODELS_URL, {
+    headers: { 'user-agent': 'Manifold/1.0 (+https://manifold.markets)' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  if (!res.ok)
+    throw new Error(
+      `OpenRouter models: ${res.status} ${res.statusText}`
+    )
+
+  const body = (await res.json()) as unknown
+  const data =
+    body && typeof body === 'object' && 'data' in body ? body.data : undefined
+  if (!Array.isArray(data))
+    throw new Error('OpenRouter models payload data is not an array')
+
+  const entries: OpenRouterCatalogEntry[] = []
+  for (const row of data) {
+    if (!row || typeof row !== 'object') continue
+    // `canonical_slug` is what the rankings dataset keys on; `id` is the
+    // routing alias and drops the dated suffix, so it would not match.
+    const permaslug =
+      'canonical_slug' in row && typeof row.canonical_slug === 'string'
+        ? row.canonical_slug
+        : 'id' in row && typeof row.id === 'string'
+        ? row.id
+        : null
+    if (!permaslug) continue
+
+    const hf =
+      'hugging_face_id' in row && typeof row.hugging_face_id === 'string'
+        ? row.hugging_face_id.trim()
+        : ''
+    const created =
+      'created' in row && typeof row.created === 'number' ? row.created : null
+
+    entries.push({
+      permaslug,
+      name:
+        'name' in row && typeof row.name === 'string' ? row.name : permaslug,
+      huggingFaceId: hf.length > 0 ? hf : null,
+      listedAt: created ? created * 1000 : null,
+    })
+  }
+
+  log(`[openrouter] catalog has ${entries.length} models`)
+  return entries
+}
+
 /**
  * The attribution string OpenRouter's dataset terms require wherever this
  * data is republished. `as_of` is not optional and cannot be hardcoded — it

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -10,9 +10,12 @@ import { SupabaseDirectClient } from 'shared/supabase/init'
 // overrides in `model_classifications`.
 //
 // The seed file stays the published methodology; this decides what the oracle
-// actually scores against on a given tick. Overrides win, because the whole
-// point is that a classification can land without a deploy — but every override
-// carries its evidence and its author, so the merged map is still auditable.
+// actually scores against on a given tick. Overrides win on models the seed
+// does NOT classify, because the whole point is that a classification can land
+// without a deploy — but every override carries its evidence and its author, so
+// the merged map is still auditable. Where the seed does classify a model the
+// seed wins, on read as well as on write: reclassifying an audited entry is a
+// change to the published methodology, not an admin-form decision.
 
 export type ClassificationRow = {
   permaslug: string
@@ -77,6 +80,12 @@ export const resolveModelClassifications = async (
       else pendingUnclassified.push(slug)
       continue
     }
+    // The seed list is the published methodology and is version-stamped onto
+    // every point the oracle writes, so an override of a seeded model would
+    // make that stamp a lie. `setModelClassification` refuses to write one;
+    // this enforces the same invariant on read, which also covers the rows
+    // `upsertClassification` wrote automatically before the seed caught up.
+    if (OPEN_WEIGHT_MODELS[slug]) continue
     classifications[slug] = row.open
       ? { open: true, weights: row.weights ?? undefined }
       : { open: false }

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -1,0 +1,244 @@
+import {
+  ModelClassifications,
+  OPEN_WEIGHT_MODELS,
+  UNCLASSIFIED_GRACE_WINDOW_MS,
+  basePermaslug,
+} from 'common/perps/open-weight-models'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+// Resolution layer between the audited seed list and the operator/auto
+// overrides in `model_classifications`.
+//
+// The seed file stays the published methodology; this decides what the oracle
+// actually scores against on a given tick. Overrides win, because the whole
+// point is that a classification can land without a deploy — but every override
+// carries its evidence and its author, so the merged map is still auditable.
+
+export type ClassificationRow = {
+  permaslug: string
+  open: boolean | null
+  weights: string | null
+  source: 'auto' | 'admin'
+  evidence: Record<string, unknown>
+  first_seen: string
+  first_ranked_at: string | null
+  classified_at: string | null
+  classified_by: string | null
+}
+
+export type ResolvedClassifications = {
+  /** Seed + adjudicated overrides, ready for computeOpenWeightShare. */
+  classifications: ModelClassifications
+  /**
+   * Pending models whose grace window has run out. The publication gate halts
+   * on these however small they are.
+   */
+  expiredUnclassified: string[]
+  /** Pending models still inside their window — published under grace. */
+  pendingUnclassified: string[]
+}
+
+/**
+ * Build the classification map the index scores against.
+ *
+ * Pending rows (`open is null`) are deliberately NOT merged in: an unadjudicated
+ * model must keep reading as unclassified so it stays out of both sides of the
+ * index. Their only job here is to supply the grace-window clock.
+ */
+export const resolveModelClassifications = async (
+  pg: SupabaseDirectClient,
+  now = Date.now(),
+  graceWindowMs = UNCLASSIFIED_GRACE_WINDOW_MS
+): Promise<ResolvedClassifications> => {
+  const rows = await pg.manyOrNone<ClassificationRow>(
+    `select permaslug, open, weights, source, evidence,
+            first_seen, first_ranked_at, classified_at, classified_by
+     from model_classifications`
+  )
+
+  const classifications: ModelClassifications = { ...OPEN_WEIGHT_MODELS }
+  const expiredUnclassified: string[] = []
+  const pendingUnclassified: string[] = []
+
+  for (const row of rows) {
+    const slug = basePermaslug(row.permaslug)
+    if (row.open === null) {
+      // A pending row for a model the seed already classifies is inert — the
+      // seed verdict stands and there is nothing to wait for.
+      if (OPEN_WEIGHT_MODELS[slug]) continue
+      // Never ranked -> no deadline. It is not affecting the index, so there
+      // is nothing to expire; the clock starts the first time it does.
+      if (!row.first_ranked_at) {
+        pendingUnclassified.push(slug)
+        continue
+      }
+      const age = now - new Date(row.first_ranked_at).getTime()
+      if (age > graceWindowMs) expiredUnclassified.push(slug)
+      else pendingUnclassified.push(slug)
+      continue
+    }
+    classifications[slug] = row.open
+      ? { open: true, weights: row.weights ?? undefined }
+      : { open: false }
+  }
+
+  return {
+    classifications,
+    expiredUnclassified: expiredUnclassified.sort(),
+    pendingUnclassified: pendingUnclassified.sort(),
+  }
+}
+
+export type PendingModelSeed = {
+  permaslug: string
+  name?: string
+  huggingFaceId?: string | null
+  /** Which surface turned it up — the catalog sweep, or a live rankings tick. */
+  discoveredVia?: 'catalog' | 'rankings'
+}
+
+/**
+ * Start the grace clock for models we have just discovered.
+ *
+ * `first_seen` must never move once set: it is the deadline the publication
+ * gate enforces, so re-inserting on every tick would keep an unadjudicated
+ * model permanently inside its window. Hence DO NOTHING on conflict rather
+ * than a touch-on-write upsert.
+ */
+export const recordPendingModels = async (
+  pg: SupabaseDirectClient,
+  models: PendingModelSeed[],
+  firstSeen?: number
+) => {
+  const seen = new Set<string>()
+  const rows: { slug: string; evidence: string }[] = []
+  for (const model of models) {
+    const slug = basePermaslug(model.permaslug)
+    if (OPEN_WEIGHT_MODELS[slug] || seen.has(slug)) continue
+    seen.add(slug)
+    rows.push({
+      slug,
+      // Carried so the admin queue can show what the model is and where its
+      // weights would live, instead of a bare permaslug to go and google.
+      evidence: JSON.stringify({
+        openRouterName: model.name ?? null,
+        huggingFaceId: model.huggingFaceId ?? null,
+        discoveredVia: model.discoveredVia ?? 'catalog',
+      }),
+    })
+  }
+  if (rows.length === 0) return 0
+
+  await pg.none(
+    `insert into model_classifications (permaslug, open, source, evidence, first_seen)
+     select slug, null::boolean, 'auto', evidence::jsonb, $2::timestamptz
+     from unnest($1::text[], $3::text[]) as t(slug, evidence)
+     on conflict (permaslug) do nothing`,
+    [
+      rows.map((r) => r.slug),
+      firstSeen
+        ? new Date(firstSeen).toISOString()
+        : new Date().toISOString(),
+      rows.map((r) => r.evidence),
+    ]
+  )
+  return rows.length
+}
+
+/**
+ * Note that these models are in the ranked window and still unclassified,
+ * starting the grace clock the first time each one appears.
+ *
+ * Creates the pending row if the catalog sweep never saw the model — the
+ * rankings dataset carries models that `/models` does not list, and those are
+ * precisely the ones that would otherwise halt the index with no row for
+ * anyone to review.
+ *
+ * `first_ranked_at` is only ever set once (`coalesce` on the existing value):
+ * it is a deadline, and a deadline that resets every hour is not a deadline.
+ */
+export const recordUnclassifiedInRankings = async (
+  pg: SupabaseDirectClient,
+  permaslugs: string[],
+  rankedAt = Date.now()
+) => {
+  const slugs = Array.from(
+    new Set(permaslugs.map(basePermaslug))
+  ).filter((slug) => !OPEN_WEIGHT_MODELS[slug])
+  if (slugs.length === 0) return 0
+
+  await pg.none(
+    `insert into model_classifications
+       (permaslug, open, source, evidence, first_seen, first_ranked_at)
+     select unnest($1::text[]), null::boolean, 'auto',
+            jsonb_build_object('discoveredVia', 'rankings'),
+            $2::timestamptz, $2::timestamptz
+     on conflict (permaslug) do update set
+       first_ranked_at = coalesce(
+         model_classifications.first_ranked_at, $2::timestamptz
+       ),
+       updated_time = now()
+     where model_classifications.open is null`,
+    [slugs, new Date(rankedAt).toISOString()]
+  )
+  return slugs.length
+}
+
+/**
+ * Record a verdict. `open: true` requires the weights repo that proves it —
+ * the table's check constraint enforces the same invariant the seed file's
+ * test does, so a mistake here fails loudly rather than publishing an
+ * unevidenced claim.
+ */
+export const upsertClassification = async (
+  pg: SupabaseDirectClient,
+  params: {
+    permaslug: string
+    open: boolean
+    weights?: string | null
+    source: 'auto' | 'admin'
+    evidence?: Record<string, unknown>
+    classifiedBy?: string | null
+  }
+) => {
+  const { permaslug, open, source, classifiedBy } = params
+  const weights = open ? params.weights ?? null : null
+  if (open && !weights)
+    throw new Error(
+      `refusing to classify ${permaslug} open without a weights repo`
+    )
+
+  await pg.none(
+    `insert into model_classifications
+       (permaslug, open, weights, source, evidence, classified_at, classified_by, updated_time)
+     values ($1, $2, $3, $4, $5::jsonb, now(), $6, now())
+     on conflict (permaslug) do update set
+       open = excluded.open,
+       weights = excluded.weights,
+       source = excluded.source,
+       evidence = excluded.evidence,
+       classified_at = excluded.classified_at,
+       classified_by = excluded.classified_by,
+       updated_time = now()`,
+    [
+      basePermaslug(permaslug),
+      open,
+      weights,
+      source,
+      JSON.stringify(params.evidence ?? {}),
+      classifiedBy ?? null,
+    ]
+  )
+}
+
+/** Pending rows for the admin tool, oldest first — the review queue. */
+export const getPendingClassifications = async (
+  pg: SupabaseDirectClient
+): Promise<ClassificationRow[]> =>
+  pg.manyOrNone<ClassificationRow>(
+    `select permaslug, open, weights, source, evidence,
+            first_seen, first_ranked_at, classified_at, classified_by
+     from model_classifications
+     where open is null
+     order by first_ranked_at asc nulls last, first_seen asc`
+  )

--- a/backend/supabase/migrations/2026081301_model_classifications.sql
+++ b/backend/supabase/migrations/2026081301_model_classifications.sql
@@ -69,4 +69,26 @@ create index if not exists model_classifications_pending_idx
   on model_classifications (first_seen)
   where open is null;
 
+-- RLS on, with NO policy: deny-all for anon and authenticated.
+--
+-- Not hygiene — this table is a lever on an executable index.
+-- resolveModelClassifications merges these rows into the classification map the
+-- oracle scores against, so a row anyone can write is a row that can move a
+-- market that settles real money. A table in the public schema is reachable
+-- through PostgREST, and with RLS disabled the only thing standing between the
+-- anon key and this table is whatever grants happen to be in place.
+--
+-- Deny-all is the correct policy rather than the cautious one, because nothing
+-- legitimate reads this from a client. Both surfaces that touch it — the
+-- `get-model-classifications` and `set-model-classification` endpoints — are
+-- admin-gated and run on createSupabaseDirectClient(), a direct connection that
+-- bypasses RLS entirely. The admin page reaches them through useAPIGetter, never
+-- through Supabase. So there is no client read to preserve, and adding a public
+-- read policy (as oracle_prices does, for data that IS rendered client-side)
+-- would grant reach nothing needs.
+--
+-- Every one of the 119 tables in prod's public schema has RLS enabled. Without
+-- this line, model_classifications would be the only exception.
+alter table model_classifications enable row level security;
+
 commit;

--- a/backend/supabase/migrations/2026081301_model_classifications.sql
+++ b/backend/supabase/migrations/2026081301_model_classifications.sql
@@ -1,0 +1,72 @@
+begin;
+
+-- Open-weight classifications for the OpenRouter token-share index.
+--
+-- The audited seed stays in common/src/perps/open-weight-models.ts — that file
+-- is the published methodology and must remain readable as one artifact. This
+-- table layers on top of it, for two reasons:
+--
+--  1. A new model entering OpenRouter's top 50 froze the feed until someone
+--     shipped a one-line map entry: PR, merge, image build, VM redeploy. Hours,
+--     for a boolean. Three times in the week to 2026-08-13 (muse-spark,
+--     nemotron-3.5-lightning, solar-pro4).
+--  2. `first_seen` gives the grace window a clock. The publication gate lets a
+--     small unknown through while it is fresh and halts once it goes stale, so
+--     the row has to exist before anyone classifies it.
+--
+-- `open is null` means PENDING: seen in the catalog, not yet adjudicated.
+-- Pending rows are excluded from both sides of the index, exactly as an absent
+-- entry is — they record that we know about the model, not what it is.
+create table if not exists model_classifications (
+  permaslug text primary key,
+  -- null = pending. Deliberately nullable rather than defaulted: defaulting a
+  -- frontier launch to either side would move an executable index on a guess.
+  open boolean,
+  -- Public weights repo backing an `open` verdict; the evidence, not a label.
+  weights text,
+  -- 'auto'  — HuggingFace verification by the nightly catalog watcher
+  -- 'admin' — a human decision through the admin tool
+  source text not null check (source in ('auto', 'admin')),
+  -- What was checked and what came back, so an `open` call can be re-audited
+  -- without re-deriving it: hugging_face_id, repo visibility, weight files.
+  evidence jsonb not null default '{}'::jsonb,
+  -- When the catalog watcher first saw the model. Orders the review queue.
+  first_seen timestamptz not null default now(),
+  -- When the model first appeared in the ranked window while still unclassified
+  -- — i.e. when it started actually affecting the index. The grace deadline
+  -- runs from HERE, not from first_seen.
+  --
+  -- The distinction matters: the catalog carries hundreds of models that never
+  -- rank, and most sit unclassified indefinitely because nobody needs to
+  -- adjudicate a model with no tokens. If the deadline ran from first_seen,
+  -- every one of those would silently become a landmine that halts the feed the
+  -- instant it cracked the top 50, with its grace already long expired. Dating
+  -- from first rank instead gives every model the same window measured from the
+  -- moment it starts to matter.
+  first_ranked_at timestamptz,
+  classified_at timestamptz,
+  classified_by text,
+  updated_time timestamptz not null default now(),
+
+  -- Mirrors the invariant the seed file's own test enforces: every open model
+  -- cites weights, no closed model pretends to.
+  constraint model_classifications_open_cites_weights check (
+    (open is true and weights is not null) or
+    (open is not true and weights is null)
+  ),
+  -- A verdict always records when it was reached; pending never does.
+  constraint model_classifications_verdict_timestamped check (
+    (open is null) = (classified_at is null)
+  )
+);
+
+comment on table model_classifications is
+  'Operator/auto overrides layered over the audited seed in common/src/perps/open-weight-models.ts; open is null means pending adjudication';
+
+-- The publication gate reads pending rows on every tick to decide whose grace
+-- window has expired, and the admin tool lists them oldest-first.
+create index if not exists model_classifications_pending_idx
+  on model_classifications (first_seen)
+  where open is null;
+
+commit;

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1072,6 +1072,61 @@ export const API = (_apiTypeCheck = {
     returns: {} as { payout: number; pnl: number },
     props: closePerpPositionSchema,
   },
+  // The open-weight index halts on models it cannot classify. These two
+  // endpoints are how that gets cleared without a deploy: the queue of models
+  // the nightly watcher could not confirm, and the verdict on one.
+  'get-model-classifications': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    returns: {} as {
+      pending: {
+        permaslug: string
+        openRouterName: string | null
+        huggingFaceId: string | null
+        discoveredVia: string | null
+        firstSeen: number
+        ageMs: number
+        /** Null until the model actually enters the ranked window. */
+        firstRankedAt: number | null
+        rankedAgeMs: number | null
+        /** Past the window: the index is already halting on this one. */
+        graceExpired: boolean
+      }[]
+      recent: {
+        permaslug: string
+        open: boolean
+        weights: string | null
+        source: string
+        classifiedAt: number | null
+        classifiedBy: string | null
+      }[]
+      seedVersion: string
+      graceWindowMs: number
+    },
+    props: z.object({}).strict(),
+  },
+  'set-model-classification': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    returns: {} as { success: true; permaslug: string; open: boolean },
+    props: z
+      .object({
+        permaslug: z.string().min(1),
+        open: z.boolean(),
+        // The HuggingFace repo proving the weights are downloadable.
+        weights: z.string().min(1).optional(),
+      })
+      .strict()
+      // Same invariant the seed list's test and the table's check constraint
+      // enforce: an `open` verdict cites its evidence or it does not land.
+      // Rejecting here means the operator finds out at the form, not from a
+      // constraint violation.
+      .refine((p) => !p.open || !!p.weights, {
+        message: 'An open classification must cite a public weights repo',
+      }),
+  },
   // Admin-only live risk tuning; undocumented deliberately — internal
   // operator tooling, not part of the public perp API surface.
   'update-perp-config': {

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -81,6 +81,52 @@ describe('computeOpenWeightShare', () => {
     expect(computeOpenWeightShare(rows).unclassified).toEqual([])
   })
 
+  it('does not read unclassified tokens as the excluded `other` row', () => {
+    // Unknown tokens also push payloadTokens above classifiedTokens, so the
+    // looser "payload exceeds classified" form passed a payload that had no
+    // `other` row at all.
+    const rows = [
+      row('2026-07-26', OPEN, 600),
+      row('2026-07-26', CLOSED, 400),
+      row('2026-07-26', 'newlab/unknown', 50),
+    ]
+    const res = computeOpenWeightShare(rows)
+    expect(res.hasExcludedPayload).toBe(false)
+    expect(res.otherTokens).toBe(0)
+    expect(res.unclassifiedTokens).toBe(50)
+  })
+
+  it('honours a caller-supplied classification map (database overrides)', () => {
+    const rows = [
+      row('2026-07-26', 'newlab/pending', 1000),
+      row('2026-07-26', CLOSED, 1000),
+      row('2026-07-26', 'other', 500),
+    ]
+    expect(computeOpenWeightShare(rows).unclassified).toEqual([
+      'newlab/pending',
+    ])
+
+    const overridden = computeOpenWeightShare(rows, OPEN_WEIGHT_WINDOW_DAYS, {
+      ...OPEN_WEIGHT_MODELS,
+      'newlab/pending': { open: true, weights: 'newlab/pending-weights' },
+    })
+    expect(overridden.unclassified).toEqual([])
+    expect(overridden.share).toBeCloseTo(50)
+  })
+
+  it('measures the unclassified share against classified tokens, not payload', () => {
+    // `other` dwarfs everything, and must not dilute the ratio the cap reads.
+    const rows = [
+      row('2026-07-26', OPEN, 600),
+      row('2026-07-26', CLOSED, 400),
+      row('2026-07-26', 'newlab/unknown', 10),
+      row('2026-07-26', 'other', 1_000_000),
+    ]
+    expect(
+      computeOpenWeightShare(rows).unclassifiedShareOfClassified
+    ).toBeCloseTo(0.01)
+  })
+
   it('keeps only the newest N dates', () => {
     // 9 days present; only the last 7 may count.
     const rows: RankingRow[] = []
@@ -153,6 +199,7 @@ describe('publication validation', () => {
 
   it('rejects unknown models instead of publishing a shrunken denominator', () => {
     const rows = completeWindow()
+    // 1000 unknown against 7000 classified — 14%, far over the cap.
     rows.push(row('2026-07-26', 'newlab/unknown', 1000))
     const validation = validateOpenWeightPublication(
       computeOpenWeightShare(rows)
@@ -160,6 +207,81 @@ describe('publication validation', () => {
     expect(validation.ok).toBe(false)
     if (!validation.ok)
       expect(validation.reason).toContain('unclassified models')
+  })
+
+  it('publishes under grace when the unknown is below the cap', () => {
+    const rows = completeWindow()
+    // 35 unknown against 7000 classified = 0.5%, inside the 1% cap.
+    rows.push(row('2026-07-26', 'newlab/tiny-newcomer', 35))
+    const result = computeOpenWeightShare(rows)
+    const validation = validateOpenWeightPublication(result)
+
+    expect(validation.ok).toBe(true)
+    if (!validation.ok) return
+    // The index itself is untouched — the unknown is still out of both sides.
+    expect(validation.share).toBeCloseTo(60)
+    expect(validation.grace?.unclassified).toEqual(['newlab/tiny-newcomer'])
+    expect(validation.grace?.shareOfClassified).toBeCloseTo(0.005)
+    // 0.005 * max(0.6, 0.4) / 1.005 * 100 = 0.2985 points.
+    expect(validation.grace?.maxIndexError).toBeCloseTo(0.2985, 3)
+  })
+
+  it('reports no grace at all when everything is classified', () => {
+    const validation = validateOpenWeightPublication(
+      computeOpenWeightShare(completeWindow())
+    )
+    expect(validation.ok).toBe(true)
+    if (validation.ok) expect(validation.grace).toBeUndefined()
+  })
+
+  it('halts on a below-cap unknown once its grace window has expired', () => {
+    const rows = completeWindow()
+    rows.push(row('2026-07-26', 'newlab/tiny-newcomer', 35))
+    const result = computeOpenWeightShare(rows)
+    // Small enough to publish, but the operator says time is up.
+    expect(validateOpenWeightPublication(result).ok).toBe(true)
+    const validation = validateOpenWeightPublication(result, {
+      expiredUnclassified: ['newlab/tiny-newcomer'],
+    })
+    expect(validation.ok).toBe(false)
+    if (!validation.ok) expect(validation.reason).toContain('grace window')
+  })
+
+  it('restores halt-on-any-unknown when the cap is zero', () => {
+    const rows = completeWindow()
+    rows.push(row('2026-07-26', 'newlab/tiny-newcomer', 1))
+    const validation = validateOpenWeightPublication(
+      computeOpenWeightShare(rows),
+      { unclassifiedShareCap: 0 }
+    )
+    expect(validation.ok).toBe(false)
+  })
+
+  it('bounds the real error a grace publication can cause', () => {
+    // Property check of the documented bound: whatever side the unknown
+    // actually falls on, the published index is within maxIndexError of it.
+    const rows = completeWindow()
+    rows.push(row('2026-07-26', 'newlab/tiny-newcomer', 35))
+    const validation = validateOpenWeightPublication(
+      computeOpenWeightShare(rows)
+    )
+    if (!validation.ok || !validation.grace) throw new Error('expected grace')
+
+    const asOpen = computeOpenWeightShare(rows, OPEN_WEIGHT_WINDOW_DAYS, {
+      ...OPEN_WEIGHT_MODELS,
+      'newlab/tiny-newcomer': { open: true, weights: 'newlab/tiny' },
+    }).share
+    const asClosed = computeOpenWeightShare(rows, OPEN_WEIGHT_WINDOW_DAYS, {
+      ...OPEN_WEIGHT_MODELS,
+      'newlab/tiny-newcomer': { open: false },
+    }).share
+
+    for (const truth of [asOpen, asClosed]) {
+      expect(truth).not.toBeNull()
+      expect(Math.abs((truth as number) - validation.share)).toBeLessThanOrEqual(
+        validation.grace.maxIndexError + 1e-9
+      )
+    }
   })
 
   it('rejects short, gapped, and missing-other windows', () => {

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -247,6 +247,35 @@ describe('publication validation', () => {
     if (!validation.ok) expect(validation.reason).toContain('grace window')
   })
 
+  it('halts on an expired unknown that only ever ranks as its :free variant', () => {
+    // The grace rows are stored under base slugs, so an unknown reported as
+    // `foo:free` has to match the expiry list's `foo` or the deadline never
+    // fires and the model publishes under grace forever. This is not a
+    // hypothetical shape — nemotron-3.5-lightning reached the top 50 as its
+    // :free variant.
+    const rows = completeWindow()
+    rows.push(row('2026-07-26', 'newlab/tiny-newcomer:free', 35))
+    const result = computeOpenWeightShare(rows)
+
+    expect(result.unclassified).toEqual(['newlab/tiny-newcomer'])
+    const validation = validateOpenWeightPublication(result, {
+      expiredUnclassified: ['newlab/tiny-newcomer'],
+    })
+    expect(validation.ok).toBe(false)
+    if (!validation.ok) expect(validation.reason).toContain('grace window')
+  })
+
+  it('reports one unknown when the same model ranks paid and :free', () => {
+    const rows = completeWindow()
+    rows.push(row('2026-07-26', 'newlab/tiny-newcomer', 20))
+    rows.push(row('2026-07-26', 'newlab/tiny-newcomer:free', 15))
+    const result = computeOpenWeightShare(rows)
+
+    expect(result.unclassified).toEqual(['newlab/tiny-newcomer'])
+    // Both variants' tokens still count toward the unclassified pressure.
+    expect(result.unclassifiedShareOfClassified).toBeCloseTo(0.005)
+  })
+
   it('restores halt-on-any-unknown when the cap is zero', () => {
     const rows = completeWindow()
     rows.push(row('2026-07-26', 'newlab/tiny-newcomer', 1))

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -791,7 +791,14 @@ export const computeOpenWeightShare = (
     // Its tokens are still counted, because how MUCH is unclassified is what
     // decides whether the index may publish at all.
     if (!classification) {
-      unclassifiedSet[row.model_permaslug] = true
+      // Keyed on the BASE slug, like everything else that touches an
+      // unclassified model: the grace-window rows are stored base, so the
+      // publication gate's expiry check compares these strings against base
+      // slugs. A raw `foo:free` key here would never match `foo` there, and a
+      // model that only ever ranks as its :free variant would publish under
+      // grace forever — which is exactly how nemotron-3.5-lightning entered
+      // the top 50 (see its note above).
+      unclassifiedSet[basePermaslug(row.model_permaslug)] = true
       unclassifiedTokens += tokens
       continue
     }

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -32,6 +32,15 @@ import { DAY_MS } from '../util/time'
 //     denominator, and alerted on. Never defaulted to a side: a mis-defaulted
 //     frontier launch would move the index several points overnight for no
 //     real reason.
+//   - An unclassified model does NOT halt the index outright while it is
+//     small. Halting on any unknown treats a model with 0.1% of tokens the
+//     same as one with 15%, and in practice that meant a live market marking
+//     against a hours-stale oracle — and charging funding against it — every
+//     time a new model cracked the top 50. The rule instead bounds the error
+//     it can cause: see UNCLASSIFIED_TOKEN_SHARE_CAP. Above the cap, or once
+//     an unknown has gone unclassified for longer than the operator's grace
+//     window, the index halts as before. Exclusion is never silent — every
+//     grace publication names the excluded models.
 //
 // The list covers every model that entered OpenRouter's top 50 in the year to
 // the version date, not just today's top 50, because the backfilled chart is
@@ -56,6 +65,49 @@ export const OPEN_WEIGHT_LIST_VERSION = '2026-08-13'
 export const OPEN_WEIGHT_WINDOW_DAYS = 7
 
 /**
+ * How much of the classified token pool may sit in unclassified models before
+ * the index refuses to publish, as a fraction U/C (unclassified tokens over
+ * classified tokens).
+ *
+ * The bound this buys, exactly. With p the reported share (as a fraction), C
+ * classified tokens, U unclassified, and w = U/C, the true share lies in
+ *
+ *     [ p/(1+w) , (p + w)/(1 + w) ]
+ *
+ * — the low end if every unclassified token is closed, the high end if every
+ * one is open. So the worst-case error is w * max(p, 1-p) / (1 + w), i.e.
+ * strictly under w. At this cap and an index near 70%, publishing with an
+ * unknown excluded is off by at most ~0.7 percentage points, and only until
+ * the model is classified.
+ *
+ * That is the trade being made: a bounded sub-point error for a few hours,
+ * versus halting the feed and leaving a live market marking (and funding)
+ * against an oracle that is hours stale and unbounded in error. The stale
+ * oracle is strictly worse, which is why the cap exists at all.
+ *
+ * NEEDS CALIBRATION against real rankings data — a model entering at #50
+ * displaces the previous #50, so the realistic entry share sets how often the
+ * grace path actually saves a freeze. Tune from `unclassifiedShareOfClassified`
+ * on published points before trusting this number.
+ */
+export const UNCLASSIFIED_TOKEN_SHARE_CAP = 0.01
+
+/**
+ * How long a below-cap unknown may keep publishing before the index halts on
+ * it anyway, measured from when the catalog watcher first saw the model.
+ *
+ * The cap bounds how wrong a single publication can be; this bounds how long
+ * we are willing to be wrong at all. Without it a model that never gets
+ * adjudicated would sit excluded from the denominator forever, and the index
+ * would quietly stop meaning what the methodology says it means.
+ *
+ * Two days: the watcher runs nightly, so this is roughly two chances to notice
+ * plus a weekend's slack, and still far short of the multi-day drift that
+ * would make the published definition a fiction.
+ */
+export const UNCLASSIFIED_GRACE_WINDOW_MS = 2 * DAY_MS
+
+/**
  * OpenRouter aggregates everything outside the top 50 into a single row under
  * this key. It cannot be classified, so it is excluded from the denominator —
  * the index is defined over the top 50, and the market description must say
@@ -69,6 +121,15 @@ export type ModelClassification = {
   /** Public weights repo — the evidence backing an `open` call. */
   weights?: string
 }
+
+/**
+ * A resolved classification map. The constant below is the audited seed; the
+ * backend layers operator/auto-classifier overrides from the database on top
+ * and passes the merged map in, so a classification can land without a deploy.
+ * Every consumer takes the map as an argument for exactly that reason — the
+ * module-level default keeps pure callers (tests, the methodology UI) honest.
+ */
+export type ModelClassifications = Record<string, ModelClassification>
 
 /**
  * Keyed on the BASE permaslug. OpenRouter bills the same weights under
@@ -609,9 +670,10 @@ export const basePermaslug = (permaslug: string): string => {
 }
 
 export const classifyModel = (
-  permaslug: string
+  permaslug: string,
+  classifications: ModelClassifications = OPEN_WEIGHT_MODELS
 ): ModelClassification | undefined =>
-  OPEN_WEIGHT_MODELS[basePermaslug(permaslug)]
+  classifications[basePermaslug(permaslug)]
 
 /** One row of OpenRouter's `datasets/rankings-daily` payload. */
 export type RankingRow = {
@@ -629,11 +691,18 @@ export type OpenWeightShareResult = {
   unclassified: string[]
   /** Rows in the window whose token count could not be parsed. */
   invalidTokenRows: string[]
-  /** True when `other` or another excluded row is present in the payload. */
+  /** True when the aggregated `other` row is present in the payload. */
   hasExcludedPayload: boolean
+  /**
+   * U/C — unclassified tokens over classified tokens, the quantity
+   * UNCLASSIFIED_TOKEN_SHARE_CAP bounds. 0 when everything is classified.
+   */
+  unclassifiedShareOfClassified: number
   /** Token counts, as doubles — display/telemetry only, never the divisor. */
   openTokens: number
   classifiedTokens: number
+  unclassifiedTokens: number
+  otherTokens: number
   /** Everything in the payload including `other` and unclassified models. */
   payloadTokens: number
 }
@@ -685,7 +754,8 @@ export const newestWindowDates = (
  */
 export const computeOpenWeightShare = (
   allRows: RankingRow[],
-  days = OPEN_WEIGHT_WINDOW_DAYS
+  days = OPEN_WEIGHT_WINDOW_DAYS,
+  classifications: ModelClassifications = OPEN_WEIGHT_MODELS
 ): OpenWeightShareResult => {
   const dates = newestWindowDates(allRows, days)
   const inWindow: Record<string, true> = {}
@@ -694,6 +764,8 @@ export const computeOpenWeightShare = (
 
   let openTokens = 0n
   let classifiedTokens = 0n
+  let unclassifiedTokens = 0n
+  let otherTokens = 0n
   let payloadTokens = 0n
   const unclassifiedSet: Record<string, true> = {}
   const invalidTokenRowSet: Record<string, true> = {}
@@ -708,13 +780,19 @@ export const computeOpenWeightShare = (
 
     // Rule 1: `other` is unclassifiable by construction — never in the
     // denominator, never estimated.
-    if (basePermaslug(row.model_permaslug) === OTHER_MODEL_KEY) continue
+    if (basePermaslug(row.model_permaslug) === OTHER_MODEL_KEY) {
+      otherTokens += tokens
+      continue
+    }
 
-    const classification = classifyModel(row.model_permaslug)
+    const classification = classifyModel(row.model_permaslug, classifications)
     // Rule 2: unknown model -> out of BOTH sides, and surfaced so the caller
     // can alert. Defaulting it either way would move the index on a guess.
+    // Its tokens are still counted, because how MUCH is unclassified is what
+    // decides whether the index may publish at all.
     if (!classification) {
       unclassifiedSet[row.model_permaslug] = true
+      unclassifiedTokens += tokens
       continue
     }
 
@@ -735,12 +813,34 @@ export const computeOpenWeightShare = (
     dates,
     unclassified: Object.keys(unclassifiedSet).sort(),
     invalidTokenRows,
-    hasExcludedPayload: payloadTokens > classifiedTokens,
+    // Checked against `other` specifically, not "payload exceeds classified":
+    // unclassified tokens also widen that gap, so the loose form would read a
+    // payload with an unknown model but NO `other` row as healthy.
+    hasExcludedPayload: otherTokens > 0n,
+    unclassifiedShareOfClassified: ratioOfBigInts(
+      unclassifiedTokens,
+      classifiedTokens
+    ),
     openTokens: finiteBigIntTelemetry(openTokens),
     classifiedTokens: finiteBigIntTelemetry(classifiedTokens),
+    unclassifiedTokens: finiteBigIntTelemetry(unclassifiedTokens),
+    otherTokens: finiteBigIntTelemetry(otherTokens),
     payloadTokens: finiteBigIntTelemetry(payloadTokens),
   }
 }
+
+/**
+ * numerator/denominator without going through doubles first — both sides
+ * routinely exceed Number.MAX_SAFE_INTEGER, where the naive Number(a)/Number(b)
+ * has already dropped units. Returns 0 for an empty denominator so a payload
+ * with nothing classified reports "no unclassified pressure" and is rejected
+ * by the share check instead.
+ */
+const ratioOfBigInts = (numerator: bigint, denominator: bigint): number =>
+  denominator > 0n
+    ? Number((numerator * OPEN_WEIGHT_SHARE_SCALE) / denominator) /
+      Number(OPEN_WEIGHT_SHARE_SCALE)
+    : 0
 
 const OPEN_WEIGHT_SHARE_SCALE = 1_000_000_000n
 
@@ -760,30 +860,59 @@ const parseTokens = (raw: string): bigint | null => {
   return m ? BigInt(m[1]) : null
 }
 
+/** Details of a publication that excluded unknown models under the cap. */
+export type OpenWeightGrace = {
+  /** The excluded permaslugs — named on every grace publication, never silent. */
+  unclassified: string[]
+  /** U/C at publication time. */
+  shareOfClassified: number
+  /** Worst-case error, in percentage POINTS, the exclusion can cause. */
+  maxIndexError: number
+}
+
 export type OpenWeightPublicationValidation =
-  | { ok: true; share: number }
+  | { ok: true; share: number; grace?: OpenWeightGrace }
   | { ok: false; reason: string }
+
+export type OpenWeightPublicationOptions = {
+  expectedDays?: number
+  /** Override the cap; 0 restores the old halt-on-any-unknown behaviour. */
+  unclassifiedShareCap?: number
+  /**
+   * Unknowns that have been unclassified for longer than the operator's grace
+   * window. Present here they halt the index regardless of how small they are:
+   * the cap buys time to classify, it is not a licence to run indefinitely on
+   * a knowingly incomplete denominator. Supplied by the caller because the
+   * first-seen timestamps live in the database, not in this leaf package.
+   */
+  expiredUnclassified?: string[]
+}
 
 /**
  * Fail-closed publication gate shared by the live writer and backfill.
  * Computing a diagnostic share is useful, but it is not enough to make that
  * share safe to expose as an executable oracle price.
+ *
+ * Structural checks run before the unclassified decision so that a payload
+ * which is broken in several ways reports the more fundamental fault, and so
+ * the grace path can quote a share it has already validated.
  */
 export const validateOpenWeightPublication = (
   result: OpenWeightShareResult,
-  expectedDays = OPEN_WEIGHT_WINDOW_DAYS
+  options: OpenWeightPublicationOptions = {}
 ): OpenWeightPublicationValidation => {
+  const {
+    expectedDays = OPEN_WEIGHT_WINDOW_DAYS,
+    unclassifiedShareCap = UNCLASSIFIED_TOKEN_SHARE_CAP,
+    expiredUnclassified = [],
+  } = options
+
   if (result.invalidTokenRows.length > 0)
     return {
       ok: false,
       reason: `malformed token count rows: ${result.invalidTokenRows.join(
         ', '
       )}`,
-    }
-  if (result.unclassified.length > 0)
-    return {
-      ok: false,
-      reason: `unclassified models: ${result.unclassified.join(', ')}`,
     }
   if (result.dates.length !== expectedDays)
     return {
@@ -815,5 +944,52 @@ export const validateOpenWeightPublication = (
     result.share > 100
   )
     return { ok: false, reason: `invalid share ${result.share}` }
-  return { ok: true, share: result.share }
+
+  if (result.unclassified.length === 0) return { ok: true, share: result.share }
+
+  const expired = result.unclassified.filter((slug) =>
+    expiredUnclassified.includes(slug)
+  )
+  if (expired.length > 0)
+    return {
+      ok: false,
+      reason: `unclassified models past their grace window: ${expired.join(
+        ', '
+      )}`,
+    }
+
+  const w = result.unclassifiedShareOfClassified
+  if (!Number.isFinite(w) || w > unclassifiedShareCap)
+    return {
+      ok: false,
+      reason:
+        `unclassified models hold ${(w * 100).toFixed(3)}% of classified ` +
+        `tokens, over the ${(unclassifiedShareCap * 100).toFixed(3)}% cap: ` +
+        result.unclassified.join(', '),
+    }
+
+  return {
+    ok: true,
+    share: result.share,
+    grace: {
+      unclassified: result.unclassified,
+      shareOfClassified: w,
+      maxIndexError: maxIndexErrorPoints(result.share, w),
+    },
+  }
+}
+
+/**
+ * Worst-case percentage-POINT error from excluding unknowns, per the bound
+ * documented on UNCLASSIFIED_TOKEN_SHARE_CAP: w * max(p, 1-p) / (1 + w), with
+ * p the reported share as a fraction. Attained when every unclassified token
+ * turns out to sit on one side.
+ */
+export const maxIndexErrorPoints = (
+  sharePercent: number,
+  unclassifiedShareOfClassified: number
+): number => {
+  const p = sharePercent / 100
+  const w = unclassifiedShareOfClassified
+  return (100 * w * Math.max(p, 1 - p)) / (1 + w)
 }

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -50,7 +50,7 @@ import { DAY_MS } from '../util/time'
 // change silently when a third party edits a metadata field.
 
 /** Bump when the map changes. */
-export const OPEN_WEIGHT_LIST_VERSION = '2026-08-12'
+export const OPEN_WEIGHT_LIST_VERSION = '2026-08-13'
 
 /** Trailing window, in whole UTC days, that the index averages over. */
 export const OPEN_WEIGHT_WINDOW_DAYS = 7
@@ -75,6 +75,18 @@ export type ModelClassification = {
  * variant suffixes (`...:free`), which are the same model for index purposes.
  */
 export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
+  // Added 2026-08-13: entered the top 50 with OpenRouter's 2026-08-12 day and
+  // froze the feed (fail-closed). Solar Pro 4 is API-only. No `solar-pro4`
+  // repo exists anywhere on HuggingFace (global search, 0 hits), and the whole
+  // `solar-pro*` line publishes tokenizer-only repos — `solar-pro2-tokenizer`
+  // and `solar-pro3-tokenizer` resolve, `upstage/solar-pro3` itself does not.
+  // Upstage's downloadable weights ship under the separately branded Solar
+  // Open line (`upstage/Solar-Open-100B`, `upstage/Solar-Open2-250B`), which
+  // is not what OpenRouter is serving here; their `/models` entry for this
+  // permaslug carries `hugging_face_id: null` (verified 2026-08-13). If
+  // Upstage later publishes the weights, that counts from the release date
+  // forward via a new entry — never retroactively.
+  'upstage/solar-pro4-20260810': { open: false }, // Upstage: Solar Pro 4
   // Added 2026-08-07: entered the top 50 and froze the feed (fail-closed).
   // Muse Spark is Meta's first CLOSED-weights family — API-only via
   // api.meta.ai, no repo in meta-llama/facebook HF orgs, widely reported as

--- a/web/pages/admin/model-classifications.tsx
+++ b/web/pages/admin/model-classifications.tsx
@@ -1,0 +1,250 @@
+import { useState } from 'react'
+import { toast } from 'react-hot-toast'
+import clsx from 'clsx'
+import { Button } from 'web/components/buttons/button'
+import { Col } from 'web/components/layout/col'
+import { Page } from 'web/components/layout/page'
+import { Row } from 'web/components/layout/row'
+import { NoSEO } from 'web/components/NoSEO'
+import { Input } from 'web/components/widgets/input'
+import { Title } from 'web/components/widgets/title'
+import { useAdmin } from 'web/hooks/use-admin'
+import { useAPIGetter } from 'web/hooks/use-api-getter'
+import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
+import { api } from 'web/lib/api/api'
+
+// The review queue for the open-weight index.
+//
+// Everything here is a model the nightly watcher could not confirm by itself.
+// It only ever auto-decides `open`, and only against public weight files — so
+// what lands on this page is the judgement calls: API-only models, and models
+// whose weights exist somewhere the publisher never declared.
+
+export default function AdminModelClassificationsPage() {
+  useRedirectIfSignedOut()
+  const isAdmin = useAdmin()
+  const { data, refresh } = useAPIGetter('get-model-classifications', {})
+
+  if (!isAdmin)
+    return (
+      <Page trackPageView={false}>
+        <NoSEO />
+        <Title>Admin only</Title>
+      </Page>
+    )
+
+  const pending = data?.pending ?? []
+  const expired = pending.filter((p) => p.graceExpired)
+  // Ranked models are the ones actually affecting the index; the rest are
+  // backlog that can wait. Sorting by it puts the real work at the top.
+  const ranked = pending.filter((p) => p.rankedAgeMs !== null)
+  const backlog = pending.filter((p) => p.rankedAgeMs === null)
+
+  return (
+    <Page trackPageView={false}>
+      <NoSEO />
+      <Col className="mx-auto w-full max-w-4xl gap-4 p-4">
+        <Title>Model classifications</Title>
+
+        <Col className="bg-canvas-50 gap-1 rounded p-3 text-sm">
+          <div className="text-ink-700">
+            The open-weight index scores OpenRouter's top 50 on one test:{' '}
+            <b>are the weights publicly downloadable?</b> Downloadable is open;
+            API-only is closed. Unknown models are excluded from both sides of
+            the index, so a wrong call here moves a market people trade.
+          </div>
+          <div className="text-ink-500">
+            Seed list version {data?.seedVersion ?? '—'} · grace window{' '}
+            {data ? Math.round(data.graceWindowMs / 3_600_000) : '—'}h
+          </div>
+        </Col>
+
+        {expired.length > 0 && (
+          <div className="bg-scarlet-100 text-scarlet-700 rounded p-3 text-sm">
+            <b>{expired.length} past the grace window.</b> The index is halting
+            on these right now — the feed is not publishing until they are
+            classified.
+          </div>
+        )}
+
+        <Col className="gap-2">
+          <div className="text-ink-700 font-semibold">
+            In the index right now ({ranked.length})
+          </div>
+          {ranked.length === 0 && (
+            <div className="text-ink-500 text-sm">
+              Nothing unclassified is currently ranked — the index is scoring a
+              complete denominator.
+            </div>
+          )}
+          {ranked.map((model) => (
+            <PendingRow key={model.permaslug} model={model} onDone={refresh} />
+          ))}
+        </Col>
+
+        {backlog.length > 0 && (
+          <Col className="gap-2 pt-2">
+            <div className="text-ink-700 font-semibold">
+              Not yet ranked ({backlog.length})
+            </div>
+            <div className="text-ink-500 text-sm">
+              In OpenRouter's catalog but outside the top 50, so they are not
+              affecting the index. Classifying them ahead of time is what stops
+              the next one becoming an outage.
+            </div>
+            {backlog.map((model) => (
+              <PendingRow
+                key={model.permaslug}
+                model={model}
+                onDone={refresh}
+              />
+            ))}
+          </Col>
+        )}
+
+        {!!data?.recent.length && (
+          <Col className="gap-1 pt-4">
+            <div className="text-ink-700 font-semibold">Recently decided</div>
+            {data.recent.map((r) => (
+              <Row
+                key={r.permaslug}
+                className="text-ink-600 items-center gap-2 text-xs"
+              >
+                <span className={r.open ? 'text-teal-600' : 'text-ink-500'}>
+                  {r.open ? 'open' : 'closed'}
+                </span>
+                <span className="font-mono">{r.permaslug}</span>
+                {r.weights && (
+                  <span className="text-ink-400 font-mono">{r.weights}</span>
+                )}
+                <span className="text-ink-400">via {r.source}</span>
+              </Row>
+            ))}
+          </Col>
+        )}
+      </Col>
+    </Page>
+  )
+}
+
+function PendingRow(props: {
+  model: {
+    permaslug: string
+    openRouterName: string | null
+    huggingFaceId: string | null
+    discoveredVia: string | null
+    ageMs: number
+    rankedAgeMs: number | null
+    graceExpired: boolean
+  }
+  onDone: () => void
+}) {
+  const { model, onDone } = props
+  // Prefilled from OpenRouter's declared repo when there is one, but it is a
+  // starting point, not evidence: the publisher field is routinely absent for
+  // models whose weights are public, and present for repos that hold only a
+  // tokenizer. Confirm it resolves and carries weight files before saving.
+  const [weights, setWeights] = useState(model.huggingFaceId ?? '')
+  const [saving, setSaving] = useState(false)
+
+  const classify = async (open: boolean) => {
+    if (open && !weights.trim()) {
+      toast.error('An open call needs the weights repo that proves it')
+      return
+    }
+    setSaving(true)
+    try {
+      await api('set-model-classification', {
+        permaslug: model.permaslug,
+        open,
+        weights: open ? weights.trim() : undefined,
+      })
+      toast.success(`${model.permaslug} → ${open ? 'open' : 'closed'}`)
+      onDone()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const hours = Math.floor(model.ageMs / 3_600_000)
+  const rankedHours =
+    model.rankedAgeMs === null
+      ? null
+      : Math.floor(model.rankedAgeMs / 3_600_000)
+
+  return (
+    <Col
+      className={clsx(
+        'gap-2 rounded border p-3',
+        model.graceExpired ? 'border-scarlet-300' : 'border-ink-200'
+      )}
+    >
+      <Row className="flex-wrap items-baseline gap-2">
+        <span className="font-mono text-sm font-semibold">
+          {model.permaslug}
+        </span>
+        {model.openRouterName && (
+          <span className="text-ink-600 text-sm">{model.openRouterName}</span>
+        )}
+        <span
+          className={clsx(
+            'text-xs',
+            model.graceExpired ? 'text-scarlet-600' : 'text-ink-400'
+          )}
+        >
+          seen {hours}h ago
+          {rankedHours !== null && ` · ranked ${rankedHours}h`} · via{' '}
+          {model.discoveredVia ?? 'unknown'}
+        </span>
+      </Row>
+
+      <Row className="flex-wrap items-center gap-2">
+        <Input
+          className="w-72 font-mono text-xs"
+          placeholder="HuggingFace repo, e.g. deepseek-ai/DeepSeek-V4-Pro"
+          value={weights}
+          onChange={(e) => setWeights(e.target.value)}
+        />
+        {!!weights.trim() && (
+          <a
+            className="text-primary-600 text-xs hover:underline"
+            href={`https://huggingface.co/${weights.trim()}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            check repo ↗
+          </a>
+        )}
+        <a
+          className="text-primary-600 text-xs hover:underline"
+          href={`https://openrouter.ai/${model.permaslug.split(':')[0]}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          OpenRouter ↗
+        </a>
+      </Row>
+
+      <Row className="gap-2">
+        <Button
+          size="xs"
+          color="green"
+          disabled={saving}
+          onClick={() => classify(true)}
+        >
+          Open — weights public
+        </Button>
+        <Button
+          size="xs"
+          color="gray"
+          disabled={saving}
+          onClick={() => classify(false)}
+        >
+          Closed — API only
+        </Button>
+      </Row>
+    </Col>
+  )
+}


### PR DESCRIPTION
Stacked on #3992 — the first commit here is that one-line classification fix, and this diff cleans up once #3992 merges.

## The problem

The index halts on models it cannot classify. That default is correct: a mis-defaulted frontier launch would move an executable index several points on a guess. But for three weeks running it meant the feed froze overnight while the perp kept marking and charging funding against a stale oracle.

Three freezes in a week. The models were never actually a surprise — every one sat in OpenRouter's catalog first:

| Model | Listed on OpenRouter | Froze the feed | Lead time |
|---|---|---|---|
| `meta/muse-spark-1.1` | 2026-07-16 | 2026-08-07 | 22 days |
| `upstage/solar-pro4` | 2026-08-10 | 2026-08-13 | 3 days |
| `nvidia/nemotron-3.5-lightning` | 2026-08-11 | 2026-08-12 | 1 day |

Today's gap (re-measured against the live catalog on 2026-08-15): OpenRouter lists **413 models**, the seed map classifies **243**, leaving **183** unclassified — **53** of which carry a `hugging_face_id` and can be resolved by machine.

## What changed

**1. Catalog watcher** (`update-model-classifications`, every 6h). Sweeps `/models`, verifies weights against the HuggingFace API — repo resolves, not private, carries actual weight files. Spends the lead time above so the common case is settled before it can matter.

It only ever decides **open**, and only on confirmed weight files. It never concludes closed. A missing repo is not evidence of anything: the seed file documents six models with demonstrably public weights whose `hugging_face_id` was absent. Calling something closed stays a human judgement.

No LLM anywhere in this PR — the watcher is plain HTTP and costs nothing to run.

Runs on the `main` scheduler instance, not `perps` — it makes a few hundred outbound calls and the perps instance exists to keep the 15s oracle tick on an unshared event loop.

**2. Bounded grace instead of an unconditional halt.** The gate treated a model with 0.1% of tokens exactly like one with 15%. Now, excluding an unknown holding fraction `w` of classified tokens moves the index by at most

```
w * max(p, 1-p) / (1 + w)
```

— under **0.7pp** at the 1% cap and today's ~70% index. Publishing with a bounded sub-point error beats halting into an unbounded one on a market that keeps funding regardless. Over the cap, or past the grace window, it still halts, and every grace publication names the models it excluded. A property test asserts the bound holds against both possible truths (all-open and all-closed).

**3. Classifications move to a table.** A verdict now takes effect on the next tick instead of the next deploy — the old path was PR, merge, image build, VM redeploy, hours, for one boolean. The seed list stays the published methodology and still wins: overriding a seeded model is refused outright, because every published point is stamped with the seed version and a silent override would make that stamp a lie.

**4. Admin review queue** at `/admin/model-classifications`, split by whether a model is actually ranked — ranked models are an outage in progress, unranked ones are backlog.

## One design note worth reviewing

The grace clock runs from **first rank**, not first sighting. Dating it from first sighting would turn all 183 backlog models into landmines: each would enter the top 50 with its window long expired and halt the feed instantly. `first_ranked_at` is set once and never reset.

The flip side, and it is a real edge: a model that ranks briefly, goes unclassified, drops out, and returns months later is instantly past its window and halts the feed on re-entry. That is defensible — it had its window — but it will be surprising at 3am.

## Review fixes since first push

- **RLS enabled on `model_classifications` (deny-all, no policy).** All 119 tables in prod's public schema have RLS on; this table would have been the only exception. It is not cosmetic: `resolveModelClassifications` merges these rows into the map the oracle scores against, so a row reachable through PostgREST is a lever on an executable index. Deny-all is correct rather than merely cautious — both endpoints are admin-gated and run on `createSupabaseDirectClient()`, which bypasses RLS, and the admin page reaches them via `useAPIGetter`, never Supabase. There is no client read to preserve.
- **Backfill kept fail-closed.** The grace change flipped `validateOpenWeightPublication`'s default from halt-on-any-unknown to the 1% cap, and `backfill-openrouter-oracle.ts` calls it with no options — so it silently inherited grace. Grace is a trade only the live feed can make: it is bounded, temporary, and self-corrects on the next tick. A backfill has neither half — nothing is trading on a six-month-old point, and `insertOraclePrices` never overwrites, so a grace-written point is permanently wrong history. Now passes `unclassifiedShareCap: 0`.
- Merged `main` (resolved one textual conflict in the seed map: kept main's `2026-08-14` list version and its `deepseek-v4-pro-20260813` / `grok-4.6-20260810` entries alongside this branch's grace constants).

## Verification

- `common`: **456/456** across 29 suites, including 8 new tests (grace publish, expiry, cap-zero restores old behaviour, the error-bound property test, the `other`-row fix)
- `tsc -b` clean on `common`, `backend/shared`, `backend/scheduler`, `backend/api`; `web` clean
- Migration **applied and verified on dev and prod**: table created, RLS enabled, 0 policies, both named check constraints present, partial pending index present

Also fixes a latent bug the grace path would have made reachable: `hasExcludedPayload` was `payloadTokens > classifiedTokens`, which unclassified tokens also satisfy — so a payload with an unknown model but no `other` row read as healthy. Now checks `other` specifically.

## Deploy order

Migration is already applied to both environments. Remaining: **API, then scheduler.** The scheduler reads `model_classifications` every tick; if the table were missing the read throws and the feed halts.

## Open

The 1% cap needs calibrating against real rankings data — a model entering at #50 displaces the previous #50, so the realistic entry share decides how often grace actually saves a freeze. It becomes measurable as soon as this is live: `unclassifiedShareOfClassified` is recorded on every published point. `OPENROUTER_API_KEY` was not readable from my environment, so it is set conservatively; it is a constant, tunable without a schema change.
