### PR TITLE
scheduler: stop alerting on isolated transient infra errors + fix daily reset-pg-stats crash

### DIFF
--- a/backend/scheduler/src/jobs/helpers.ts
+++ b/backend/scheduler/src/jobs/helpers.ts
@@ -10,6 +10,25 @@ export type JobContext = {
   lastStartTime?: number
 }
 
+// Isolated infra blips (DB pool churn, brief network loss) crash a handful of
+// runs a day platform-wide, and the next scheduled run recovers. A single
+// transient failure logs as a WARNING so the job-crash alert policy
+// (severity>=ERROR) stays quiet; it escalates to ERROR when the same job
+// fails twice in a row or the error is not a known-transient class.
+const TRANSIENT_ERROR_SNIPPETS = [
+  'Connection terminated due to connection timeout',
+  'timeout exceeded when trying to connect',
+  'Query read timeout',
+  'Client has encountered a connection error and is not queryable',
+]
+
+const isTransientInfraError = (err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err)
+  return TRANSIENT_ERROR_SNIPPETS.some((s) => message.includes(s))
+}
+
+const consecutiveFailures = new Map<string, number>()
+
 // todo: would be nice if somehow we got these hooked up to the job logging context
 const DEFAULT_OPTS: CronOptions = {
   timezone: 'America/Los_Angeles',
@@ -23,7 +42,17 @@ const DEFAULT_OPTS: CronOptions = {
     if (err instanceof Error) {
       details.stack = err.stack
     }
-    log.error(`[${job.name}] Error during job execution.`, details)
+    const name = job.name ?? 'unnamed'
+    const failures = (consecutiveFailures.get(name) ?? 0) + 1
+    consecutiveFailures.set(name, failures)
+    if (failures === 1 && isTransientInfraError(err)) {
+      log.warn(
+        `[${name}] Run failed on a transient infra error; the next run recovers. Escalates to ERROR if it repeats back-to-back.`,
+        details
+      )
+      return
+    }
+    log.error(`[${name}] Error during job execution.`, details)
   },
 }
 
@@ -71,6 +100,7 @@ export function createJob(
       })
 
       await jobPromise
+      consecutiveFailures.delete(name)
       // Update last end time
       await db
         .from('scheduler_info')

--- a/backend/scheduler/src/jobs/reset-pg-stats.ts
+++ b/backend/scheduler/src/jobs/reset-pg-stats.ts
@@ -2,5 +2,8 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 
 export async function resetPgStats() {
   const pg = createSupabaseDirectClient()
-  await pg.none(`select pg_stat_statements_reset()`)
+  // .any, not .none: pg_stat_statements_reset() returns a row, and
+  // pg-promise's none() rejects on any returned row — this crashed the
+  // daily run (and fired the job-crash alert) every day.
+  await pg.any(`select pg_stat_statements_reset()`)
 }


### PR DESCRIPTION
Kills the last two structural sources of job-crash alert emails, at the source rather than by muting policies.

## 1. reset-pg-stats crashed its daily run, every day
`pg_stat_statements_reset()` returns a row; pg-promise's `none()` rejects on any returned row — same class as #3988. One word: `none` → `any`.

## 2. Transient infra blips no longer alert on first occurrence
Prod sees a handful of isolated crashes/day across heavy jobs (`Connection terminated`, `timeout exceeded when trying to connect`, `Query read timeout`, `not queryable`) — the run is skipped, the next schedule recovers, and no action ever follows. The Croner catch handler now:
- logs the **first consecutive** failure of a job at **WARNING** when the error matches a known-transient class → job-crash policy (severity ≥ ERROR) stays quiet;
- escalates to **ERROR** on a **second consecutive** failure of the same job, or immediately for any non-transient error;
- resets the counter on the next successful run.

Calibration against the last week of prod logs: this would have suppressed ~90% of job-crash emails (all no-action blips) while still alerting on every real incident — the unban-users FK crash, the #3973 lock-select regression, and any sustained DB outage all fail consecutively and still page (one job-interval later at most; the perps dead-man alerts cover total-loss scenarios in ≤2 min regardless).

Typecheck: `tsc -b` clean in backend/scheduler. Takes effect on the next `prod main` + `prod perps` scheduler deploys.