### PR TITLE
feat(elections): automate the Trending carousel and move it to the top

### DIFF
--- a/web/components/elections-page.tsx
+++ b/web/components/elections-page.tsx
@@ -1,10 +1,9 @@
 import { ReactNode, useState } from 'react'
 import clsx from 'clsx'
-import Link from 'next/link'
 import { Col } from 'web/components/layout/col'
 import { Row } from './layout/row'
 import { HomepageMap } from './usa-map/homepage-map'
-import { HorizontalDashboard } from './dashboard/horizontal-dashboard'
+import { TrendingMidtermsCarousel } from './us-elections/trending-midterms-carousel'
 import { FeedContractCard } from './contract/feed-contract-card'
 import { BalanceOfPowerPanel } from './us-elections/balance-of-power-panel'
 import { Presidency2028Section } from './us-elections/presidency-2028-section'
@@ -68,7 +67,7 @@ export function USElectionsPage(
     houseDistrictsContract,
     primaryContracts,
     redistrictingContracts,
-    trendingDashboard,
+    trendingContracts,
     hideTitle,
   } = props
 
@@ -85,28 +84,6 @@ export function USElectionsPage(
   const shareUrl = `https://${ENV_CONFIG.domain}/election${
     user?.username ? referralQuery(user.username) : ''
   }`
-
-  const trending =
-    trendingDashboard.state == 'not found' ? null : (
-      <Col className="gap-2">
-        <Link
-          href="/election/politicsheadline"
-          className="text-primary-700 hover:text-primary-800 flex w-fit items-center gap-1.5 text-xl font-semibold sm:text-2xl"
-        >
-          <span className="relative h-4 w-4">
-            <span className="block h-4 w-4 animate-pulse rounded-full bg-indigo-500/40" />
-            <span className="absolute left-1 top-1 block h-2 w-2 rounded-full bg-indigo-500" />
-          </span>
-          Trending
-        </Link>
-        <HorizontalDashboard
-          initialDashboard={trendingDashboard.initialDashboard}
-          previews={trendingDashboard.previews}
-          initialContracts={trendingDashboard.initialContracts}
-          slug={trendingDashboard.slug}
-        />
-      </Col>
-    )
 
   return (
     <Col className="mb-8 gap-6 px-1 sm:px-2">
@@ -132,6 +109,28 @@ export function USElectionsPage(
           Share
         </CopyLinkOrShareButton>
       </Row>
+
+      {/* Trending — the hottest open midterm markets right now, auto-selected
+          by daily score server-side (getTrendingMidtermContracts) and
+          refreshed on every revalidation, so the top of the page always shows
+          today's action with zero curation. */}
+      {trendingContracts.length > 0 && (
+        <Col className="gap-2">
+          <Col className="gap-0.5">
+            <Row className="text-primary-700 w-fit items-center gap-1.5 text-xl font-semibold sm:text-2xl">
+              <span className="relative h-4 w-4">
+                <span className="block h-4 w-4 animate-pulse rounded-full bg-indigo-500/40" />
+                <span className="absolute left-1 top-1 block h-2 w-2 rounded-full bg-indigo-500" />
+              </span>
+              Trending
+            </Row>
+            <div className="text-ink-500 text-sm">
+              The hottest midterm markets right now
+            </div>
+          </Col>
+          <TrendingMidtermsCarousel contracts={trendingContracts} />
+        </Col>
+      )}
 
       {/* 2026 Midterms — the balance-of-power levers and the race map together
           in a single card so the section reads as one unit. */}
@@ -186,10 +185,8 @@ export function USElectionsPage(
         </Col>
       )}
 
-      {trending}
-
       {/* 2028 outlook — one collapsible card (party split + candidate field).
-          Sits below the midterms + trending so the 2026 races (the page's focus)
+          Sits below the midterms sections so the 2026 races (the page's focus)
           lead, with the longer-range 2028 outlook just above the general feed. */}
       {presidency2028Contract && (
         <Presidency2028Section

--- a/web/components/us-elections/trending-midterms-carousel.tsx
+++ b/web/components/us-elections/trending-midterms-carousel.tsx
@@ -1,0 +1,27 @@
+import { Contract } from 'common/contract'
+import { HorizontalDashboardCard } from 'web/components/dashboard/horizontal-dashboard-card'
+import { Carousel } from 'web/components/widgets/carousel'
+
+// Automated replacement for the old hand-curated politicsheadline dashboard
+// carousel: the server selects the hottest open midterm markets by daily
+// score (see getTrendingMidtermContracts in web/lib/politics/home.ts), and
+// each card keeps its odds live via useLiveContract inside the card.
+export function TrendingMidtermsCarousel(props: { contracts: Contract[] }) {
+  const { contracts } = props
+
+  if (contracts.length === 0) return null
+
+  return (
+    <Carousel className="w-full">
+      {contracts.map((contract) => (
+        <HorizontalDashboardCard
+          key={contract.id}
+          contract={contract}
+          showGraph
+          trackingPostfix="election trending"
+          className="mb-8 min-w-[332px] shadow-xl shadow-indigo-500/20"
+        />
+      ))}
+    </Carousel>
+  )
+}

--- a/web/lib/politics/home.ts
+++ b/web/lib/politics/home.ts
@@ -1,3 +1,5 @@
+import { uniqBy } from 'lodash'
+
 import { Contract } from 'common/contract'
 import { getContractFromSlug } from 'common/supabase/contracts'
 import { initSupabaseAdmin } from 'web/lib/supabase/admin-db'
@@ -20,7 +22,50 @@ import {
   senateCandidates2026,
 } from 'web/public/data/senate-state-data'
 import { api } from 'web/lib/api/api'
-import { getDashboardProps } from 'web/lib/politics/news-dashboard'
+
+// The Trending carousel picks itself: the hottest open midterm markets right
+// now, by dailyScore (the platform's rolling one-day activity metric, kept
+// current by the score-contracts job), backfilled with the best overall (by
+// score) so the row stays full on slow news days. It re-fetches on every ISR
+// revalidation, so it can't drift the way the old hand-curated
+// politicsheadline dashboard did.
+const TRENDING_TOPIC_SLUG = '2026-midterms'
+const TRENDING_SIZE = 10
+
+async function getTrendingMidtermContracts(): Promise<Contract[]> {
+  try {
+    const [hotToday, bestOverall] = await Promise.all([
+      api('search-markets-full', {
+        term: '',
+        sort: 'daily-score',
+        filter: 'open',
+        topicSlug: TRENDING_TOPIC_SLUG,
+        limit: TRENDING_SIZE * 2,
+      }),
+      api('search-markets-full', {
+        term: '',
+        sort: 'score',
+        filter: 'open',
+        topicSlug: TRENDING_TOPIC_SLUG,
+        limit: TRENDING_SIZE,
+      }),
+    ])
+    // The hero markets (balance of power, chamber control, districts) are
+    // always visible just below the carousel — don't spend slots on them.
+    const featured = Object.values(MIDTERMS_2026) as string[]
+    const hot = hotToday.filter(
+      (c) => Number.isFinite(c.dailyScore) && c.dailyScore > 0
+    )
+    return uniqBy([...hot, ...bestOverall], (c) => c.id)
+      .filter((c) => !featured.includes(c.slug))
+      .slice(0, TRENDING_SIZE)
+  } catch (e) {
+    // Trending is a nice-to-have: render the page without it rather than
+    // failing the whole revalidation when search is unavailable.
+    console.error('getTrendingMidtermContracts failed', e)
+    return []
+  }
+}
 
 export async function getElectionsPageProps(): Promise<ElectionsPageProps> {
   const adminDb = await initSupabaseAdmin()
@@ -32,7 +77,7 @@ export async function getElectionsPageProps(): Promise<ElectionsPageProps> {
     governorStateContracts,
     senateCandidateContracts,
     governorCandidateContracts,
-    headlines,
+    trendingContracts,
     balanceOfPowerContract,
     houseControlContract,
     senateControlContract,
@@ -46,7 +91,7 @@ export async function getElectionsPageProps(): Promise<ElectionsPageProps> {
     getStateContracts(getContractFromSlugFunction, governors2026),
     getStateContracts(getContractFromSlugFunction, senateCandidates2026),
     getStateContracts(getContractFromSlugFunction, governorCandidates2026),
-    api('headlines', { slug: 'politics' }),
+    getTrendingMidtermContracts(),
     getContractFromSlugFunction(MIDTERMS_2026.balanceOfPower),
     getContractFromSlugFunction(MIDTERMS_2026.houseControl),
     getContractFromSlugFunction(MIDTERMS_2026.senateControl),
@@ -68,12 +113,6 @@ export async function getElectionsPageProps(): Promise<ElectionsPageProps> {
     (c): c is Contract => !!c && !c.isResolved && !c.resolution
   )
 
-  const newsDashboards = await Promise.all(
-    headlines.map(async (headline) => getDashboardProps(headline.slug))
-  )
-
-  const trendingDashboard = await getDashboardProps('politicsheadline')
-
   return {
     presidency2028Contract,
     presidency2028PartyContract,
@@ -87,9 +126,7 @@ export async function getElectionsPageProps(): Promise<ElectionsPageProps> {
     houseDistrictsContract,
     primaryContracts,
     redistrictingContracts,
-    newsDashboards,
-    headlines,
-    trendingDashboard,
+    trendingContracts,
   }
 }
 

--- a/web/public/data/elections-data.ts
+++ b/web/public/data/elections-data.ts
@@ -299,10 +299,9 @@ export type ElectionsPageProps = {
   primaryContracts: Contract[]
   // Mid-decade redistricting markets (open only), for the watch-list section.
   redistrictingContracts: Contract[]
-  // Trending politics dashboards.
-  newsDashboards: NewsDashboardPageProps[]
-  headlines: Headline[]
-  trendingDashboard: NewsDashboardPageProps
+  // Hottest open midterm markets right now, auto-selected by daily score in
+  // getTrendingMidtermContracts — no editorial curation.
+  trendingContracts: Contract[]
 }
 
 export type SuccesNewsDashboardPageProps = {


### PR DESCRIPTION
## What

The /election Trending row was fed by the hand-curated `politicsheadline` dashboard, which hasn't been touched since 2024 — the most prominent 'fresh' section of the page served the stalest content. This PR:

- **Automates the carousel**: `getTrendingMidtermContracts()` in `web/lib/politics/home.ts` queries `search-markets-full` for open markets in the `2026-midterms` topic sorted by `daily-score` (the platform's rolling one-day activity metric), backfilled by overall `score` so the row stays full on quiet days; deduped, minus the page's four always-visible hero markets, capped at 10. Runs in `getStaticProps`, so ISR (`revalidate: 60`) re-picks the selection every minute — zero curation forever. If search errors, it returns `[]` and the page renders without the section rather than failing revalidation.
- **Moves Trending to the top** of the page, directly under the hero, above the midterms map card.
- **New `TrendingMidtermsCarousel`** reuses `HorizontalDashboardCard`, so cards look identical to before (graph, bet button) and live-update odds via `useLiveContract`.
- **Drops dead props**: `headlines` / `newsDashboards` / `trendingDashboard` were fetched and serialized into page props but never rendered. Removing them makes revalidation cheaper and page JSON smaller. `welcomeoffer` and `complexsystems` spread the same props object, so they're covered.

## Notes

- Web-only; no backend or API changes. The `/election/politicsheadline` URL still resolves via the catch-all route — it's just no longer linked.
- Typecheck clean; eslint findings on changed files are Windows CRLF noise only.