### PR TITLE
fix(perps): classify deepseek-v4-pro-0813 (open) and grok-4.6 (closed)

### DIFF
--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -50,7 +50,7 @@ import { DAY_MS } from '../util/time'
 // change silently when a third party edits a metadata field.
 
 /** Bump when the map changes. */
-export const OPEN_WEIGHT_LIST_VERSION = '2026-08-13'
+export const OPEN_WEIGHT_LIST_VERSION = '2026-08-14'
 
 /** Trailing window, in whole UTC days, that the index averages over. */
 export const OPEN_WEIGHT_WINDOW_DAYS = 7
@@ -75,6 +75,27 @@ export type ModelClassification = {
  * variant suffixes (`...:free`), which are the same model for index purposes.
  */
 export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
+  // Added 2026-08-14: both entered the top 50 with OpenRouter's 2026-08-13 day
+  // and froze the feed together.
+  //
+  // V4 Pro 0813 is a new dated release, NOT the 20260423 entry below — DeepSeek
+  // ships each one as its own permaslug and each needs its own verdict.
+  // deepseek-ai/DeepSeek-V4-Pro-0813 is public and ungated with 66 safetensors
+  // shards, and third-party quants (unsloth/DeepSeek-V4-Pro-0813-GGUF) are
+  // already up, which nobody could produce without the weights in hand
+  // (verified 2026-08-14).
+  'deepseek/deepseek-v4-pro-20260813': {
+    open: true,
+    weights: 'deepseek-ai/DeepSeek-V4-Pro-0813',
+  }, // DeepSeek: DeepSeek V4 Pro 0813
+  // Grok 4.6 is API-only, consistent with every other xAI model here. No
+  // grok-4.6 repo exists in any org; the xai-org account holds only grok-1 and
+  // grok-2, the two generations they open-sourced after retiring them, and
+  // OpenRouter reports hugging_face_id: null (verified 2026-08-14). Note
+  // OpenRouter now labels the publisher "SpaceXAI" — a vendor rename, not a
+  // licensing change. If a Grok 4.6 release follows the grok-1/grok-2 pattern
+  // later, that counts from the release date forward via a new entry.
+  'x-ai/grok-4.6-20260810': { open: false }, // SpaceXAI: Grok 4.6
   // Added 2026-08-13: entered the top 50 with OpenRouter's 2026-08-12 day and
   // froze the feed (fail-closed). Solar Pro 4 is API-only. No `solar-pro4`
   // repo exists anywhere on HuggingFace (global search, 0 hits), and the whole


### PR DESCRIPTION
Fourth freeze in eight days. Both models entered the top 50 with OpenRouter's 2026-08-13 day and halted the feed together:

```
00:50:00Z [openrouter] unsafe index payload — unclassified models:
          deepseek/deepseek-v4-pro-20260813, x-ai/grok-4.6-20260810
```

Feed last published 2026-08-13T23:50Z. `btc-usd` was 28s fresh and funding ran at 02:00Z throughout, so the perps scheduler was healthy — this was the classification gate alone, as designed.

## deepseek/deepseek-v4-pro-20260813 → open

A **new dated release**, not the existing `deepseek-v4-pro-20260423` entry — DeepSeek ships each as its own permaslug, so each needs its own verdict.

| Check | Result |
|---|---|
| `deepseek-ai/DeepSeek-V4-Pro-0813` | resolves, `private: false`, `gated: false` |
| Weight files | **66 safetensors shards** (92 files total) |
| Third-party quants | `unsloth/DeepSeek-V4-Pro-0813-GGUF` already published |
| OpenRouter `/models` | `hugging_face_id: deepseek-ai/DeepSeek-V4-Pro-0813` |

The unsloth quant is the strongest corroboration available: nobody produces a GGUF without downloading the weights first.

## x-ai/grok-4.6-20260810 → closed

| Check | Result |
|---|---|
| HF search `grok-4.6` | no repo in any org |
| `xai-org` account | only `grok-1` and `grok-2` — the two generations open-sourced after retirement |
| OpenRouter `/models` | `hugging_face_id: null` |

Consistent with every other xAI model in the list. Note OpenRouter now labels the publisher **"SpaceXAI"** — a vendor rename, not a licensing change; the permaslug is unchanged.

## Verification

`common` 20/20 pass, `tsc --noEmit` clean.

## Deploy

`prod perps` scheduler deploy. Index steps on resume — V4 Pro 0813 joins the open side, Grok 4.6 the closed side, plus the window roll.

**#3993 is the fix for the recurrence itself.** Its catalog watcher would have auto-resolved the DeepSeek half of this with no human at all (`hugging_face_id` present and verifiable), and the grace threshold would likely have kept the feed publishing rather than halting on the Grok half.
