### PR TITLE
feat(perps): research agent for models the deterministic classifier can't settle

### DIFF
--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -96,6 +96,15 @@ export const getModelClassifications: APIHandler<
           // write-only in the evidence column, asked the operator to confirm
           // an unverifiable claim on the strength of an unverifiable summary.
           agentSearches: evidenceSearches(r),
+          // The repo the agent proposed and the live API confirmed. Carried so
+          // the operator confirms a filled-in form rather than retyping a repo
+          // id from the reasoning text — the recommendation is only worth
+          // having if acting on it is one click.
+          agentProposedWeights: evidenceString(r, 'agentProposedWeights'),
+          agentWeightFileCount:
+            typeof r.evidence?.['weightFileCount'] === 'number'
+              ? (r.evidence['weightFileCount'] as number)
+              : null,
         }
       }),
     recent: rows

--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -41,6 +41,27 @@ export const getModelClassifications: APIHandler<
     return typeof value === 'string' ? value : null
   }
 
+  // Defensive on shape rather than trusting it: this column is jsonb written
+  // by a job that has changed twice, and rows survive across deploys, so an
+  // older row can carry an older shape. Anything unrecognised reads as "no
+  // searches recorded", which is honest, instead of throwing in an admin tool.
+  const evidenceSearches = (row: ClassificationRow) => {
+    const raw = row.evidence?.['agentSearches']
+    if (!Array.isArray(raw)) return []
+    return raw.flatMap((entry) => {
+      if (!entry || typeof entry !== 'object') return []
+      const { tool, input, result } = entry as Record<string, unknown>
+      if (typeof tool !== 'string') return []
+      return [
+        {
+          tool,
+          input: input === undefined ? null : JSON.stringify(input),
+          result: typeof result === 'string' ? result : '',
+        },
+      ]
+    })
+  }
+
   return {
     // A pending row for a model the seed already classifies is inert — the
     // seed verdict stands — so it must not appear as work to do.
@@ -67,6 +88,14 @@ export const getModelClassifications: APIHandler<
             now - firstRankedAt > UNCLASSIFIED_GRACE_WINDOW_MS,
           agentRecommendation: evidenceString(r, 'agentRecommendation'),
           agentReasoning: evidenceString(r, 'agentReasoning'),
+          // The searches, not just the summary of them. A closed verdict is a
+          // negative claim with nothing to machine-check it, which is exactly
+          // why it comes to a human — and the only thing that makes it
+          // checkable is what the searches actually returned. Shipping the
+          // model's own prose about its searches, while the searches sat
+          // write-only in the evidence column, asked the operator to confirm
+          // an unverifiable claim on the strength of an unverifiable summary.
+          agentSearches: evidenceSearches(r),
         }
       }),
     recent: rows

--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -65,6 +65,8 @@ export const getModelClassifications: APIHandler<
           graceExpired:
             firstRankedAt !== null &&
             now - firstRankedAt > UNCLASSIFIED_GRACE_WINDOW_MS,
+          agentRecommendation: evidenceString(r, 'agentRecommendation'),
+          agentReasoning: evidenceString(r, 'agentReasoning'),
         }
       }),
     recent: rows

--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -35,10 +35,19 @@ import { log } from 'shared/utils'
 // resolved before it can matter and the rest is a review queue rather than an
 // outage.
 //
-// It only ever decides OPEN, and only on confirmed public weight files. It
-// never concludes closed — see the directionality note in shared/huggingface.
-// Anything it cannot confirm stays pending for a human, which is what the
-// admin tool and the grace window exist for.
+// It decides one thing on its own: OPEN, from a repo the PUBLISHER declared,
+// confirmed to carry public weight files. That is safe to automate because the
+// publisher is the authority on which repo is theirs — there is no identity
+// inference involved, only verification of a claim they made. Measured against
+// the 243 audited seed entries, `hugging_face_id` present agrees with the audit
+// on 96 of 99 open models, and the three disagreements are declared-but-empty
+// repos that verification rejects anyway.
+//
+// Everything else is a recommendation for a human, including the research
+// agent's OPEN verdicts — see researchRemainingModels for why a verified,
+// name-matched repo still is not proof of identity. The admin tool and the
+// grace window are what make that affordable: an unclassified model no longer
+// halts the index while it waits for a click.
 /**
  * Hard ceiling on research calls in one sweep.
  *
@@ -129,8 +138,7 @@ const updateModelClassificationsInternal = async () => {
   log(
     `[model-classifier] ${unknown.length} unclassified in catalog: ` +
       `${confirmed} auto-classified open from a declared repo, ` +
-      `${researched.confirmed} open via research, ` +
-      `${researched.recommended} closed-recommendations for review, ` +
+      `${researched.recommended} agent recommendations for review, ` +
       `${researched.unresolved} unresolved; ${rankedPending.length} ranked ` +
       `awaiting review, ${pending.length - rankedPending.length} unranked backlog`
   )
@@ -156,12 +164,24 @@ const updateModelClassificationsInternal = async () => {
  * are re-verified against the live API before they land, so the automation can
  * only ever be as wrong as the API is.
  *
- * `closed` comes back as a recommendation, not a classification. Nothing
- * machine-checks a negative claim, and with the grace threshold in place an
- * unclassified model no longer halts the index — so the cheap, correct move is
- * to leave it pending with the research attached and let a human confirm in
- * one click. Set PERPS_AUTOCLASSIFY_CLOSED=true to apply them automatically;
- * it is off by default deliberately.
+ * NOTHING the agent concludes is applied automatically. Every verdict lands as
+ * a recommendation on a still-pending row, and a human confirms it in one click
+ * from the admin queue.
+ *
+ * That holds for `open` as well as `closed`, and the `open` case is the
+ * deliberate part. An open verdict looks machine-checkable — the cited repo is
+ * re-fetched from the live API and must carry public weight files, and its name
+ * must fully match the model's. But those checks establish that a real,
+ * public, weight-bearing repo exists under a similar name; they cannot
+ * establish that it is THIS model's. Identity is not a string comparison, and
+ * the guard has already been wrong twice in review on repos that passed
+ * verification cleanly. Patching each case closes that case; requiring a human
+ * closes the class.
+ *
+ * The trade is affordable precisely because of the ranked-only gate above: the
+ * queue is a handful of models a week, so this is a click each, and the agent
+ * still does all the legwork — the repo, its verification, and every search are
+ * attached to the row.
  *
  * Because a recommendation leaves the row pending by design, the candidate set
  * does NOT shrink on its own — which is what makes the two filters below load-
@@ -173,8 +193,6 @@ const researchRemainingModels = async (
   pg: SupabaseDirectClient,
   candidates: OpenRouterCatalogEntry[]
 ) => {
-  const autoApplyClosed = process.env.PERPS_AUTOCLASSIFY_CLOSED === 'true'
-  let confirmed = 0
   let recommended = 0
   let unresolved = 0
 
@@ -235,30 +253,39 @@ const researchRemainingModels = async (
     }
 
     if (result.verdict.verdict === 'open') {
-      await upsertClassification(pg, {
-        permaslug: model.permaslug,
-        open: true,
-        weights: result.verdict.weights,
-        source: 'auto',
-        evidence: { ...evidence, ...(result.confirmation?.confirmed
-          ? result.confirmation.evidence
-          : {}) },
+      // A verified, name-matched repo is still only a RECOMMENDATION.
+      //
+      // Verification proves the cited repo is public and carries weight files.
+      // The name guard proves the repo's name looks like this model's. Neither
+      // proves the repo IS this model — that is an identity claim, and no
+      // string comparison establishes identity. The guard has now been wrong
+      // twice in review, in a class we only found by going looking: a
+      // single-token family name matching any sibling, and parameter counts
+      // tokenized away so a 30B repo matched a 480B model. Both cited real,
+      // public, weight-bearing repos, so verification confirmed both.
+      //
+      // Each patch closed the case we thought of. Requiring a human closes the
+      // class. The cost is one click on a handful of models a week; the thing
+      // it buys is that a name heuristic can no longer move a market that
+      // settles real money.
+      //
+      // The repo and its verification ride along so the click stays one click:
+      // the queue prefills the input with the repo and shows what the live API
+      // returned for it.
+      await recordAgentRecommendation(pg, model.permaslug, 'open', {
+        ...evidence,
+        agentProposedWeights: result.verdict.weights,
+        ...(result.confirmation?.confirmed ? result.confirmation.evidence : {}),
       })
-      confirmed++
+      recommended++
+      log(
+        `[model-classifier] ${model.permaslug}: agent recommends OPEN — ` +
+          `${result.verdict.weights} (verified, awaiting confirmation)`
+      )
       continue
     }
 
     if (result.verdict.verdict === 'closed') {
-      if (autoApplyClosed) {
-        await upsertClassification(pg, {
-          permaslug: model.permaslug,
-          open: false,
-          source: 'auto',
-          evidence,
-        })
-        confirmed++
-        continue
-      }
       await recordAgentRecommendation(pg, model.permaslug, 'closed', evidence)
       recommended++
       log.warn(
@@ -283,5 +310,5 @@ const researchRemainingModels = async (
     unresolved++
   }
 
-  return { confirmed, recommended, unresolved }
+  return { recommended, unresolved }
 }

--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -5,6 +5,7 @@ import {
 } from 'shared/huggingface'
 import {
   getPendingClassifications,
+  getResearchEligibility,
   recordAgentRecommendation,
   recordPendingModels,
   upsertClassification,
@@ -38,6 +39,16 @@ import { log } from 'shared/utils'
 // never concludes closed — see the directionality note in shared/huggingface.
 // Anything it cannot confirm stays pending for a human, which is what the
 // admin tool and the grace window exist for.
+/**
+ * Hard ceiling on research calls in one sweep.
+ *
+ * Sized against reality rather than ambition: in the worst week on record
+ * three previously-unseen models entered the top 50, and the job runs four
+ * times a day. Ten leaves a wide margin over that while bounding a runaway
+ * sweep to a known, small number.
+ */
+const MAX_RESEARCH_PER_SWEEP = 10
+
 export const updateModelClassifications = async () => {
   try {
     await updateModelClassificationsInternal()
@@ -108,21 +119,29 @@ const updateModelClassificationsInternal = async () => {
   const researched = await researchRemainingModels(pg, needsResearch)
 
   const pending = await getPendingClassifications(pg)
+  // Split the queue the way the index sees it. A pending model that has never
+  // ranked is backlog — it is excluded from an index it was never part of, and
+  // nobody needs to act on it. A pending model that HAS ranked is the live
+  // queue: it is being excluded under grace right now, and its window is
+  // running. Reporting one number for both buried three urgent rows in a
+  // hundred-plus inert ones and made the warning unreadable.
+  const rankedPending = pending.filter((p) => p.first_ranked_at)
   log(
     `[model-classifier] ${unknown.length} unclassified in catalog: ` +
       `${confirmed} auto-classified open from a declared repo, ` +
       `${researched.confirmed} open via research, ` +
       `${researched.recommended} closed-recommendations for review, ` +
-      `${researched.unresolved} unresolved; ${pending.length} awaiting review`
+      `${researched.unresolved} unresolved; ${rankedPending.length} ranked ` +
+      `awaiting review, ${pending.length - rankedPending.length} unranked backlog`
   )
 
   // Warn rather than error: a pending model is not yet a problem — the index
   // publishes under grace while it is small and fresh. It becomes an error
   // only when the publication gate actually halts on it, which the
   // [openrouter] tag reports with the numbers that justify it.
-  if (pending.length > 0)
+  if (rankedPending.length > 0)
     log.warn(
-      `[model-classifier] awaiting human classification: ${pending
+      `[model-classifier] ranked and awaiting human classification: ${rankedPending
         .map((p) => p.permaslug)
         .join(', ')}`
     )
@@ -143,15 +162,58 @@ const updateModelClassificationsInternal = async () => {
  * to leave it pending with the research attached and let a human confirm in
  * one click. Set PERPS_AUTOCLASSIFY_CLOSED=true to apply them automatically;
  * it is off by default deliberately.
+ *
+ * Because a recommendation leaves the row pending by design, the candidate set
+ * does NOT shrink on its own — which is what makes the two filters below load-
+ * bearing rather than an optimisation. Without them this loop re-researches
+ * every unsettled model on every sweep, indefinitely: ~130 catalog models,
+ * four times a day, whose verdicts cannot change between runs.
  */
 const researchRemainingModels = async (
   pg: SupabaseDirectClient,
-  models: OpenRouterCatalogEntry[]
+  candidates: OpenRouterCatalogEntry[]
 ) => {
   const autoApplyClosed = process.env.PERPS_AUTOCLASSIFY_CLOSED === 'true'
   let confirmed = 0
   let recommended = 0
   let unresolved = 0
+
+  // Spend follows the index, not the catalog: research only models that have
+  // actually entered the ranked window, and not ones researched recently
+  // enough that the answer cannot have changed. See getResearchEligibility.
+  const { everRanked, recentlyResearched } = await getResearchEligibility(pg)
+  const rankedSet = new Set(everRanked)
+  const cooledSet = new Set(recentlyResearched)
+
+  const eligible = candidates.filter(
+    (m) => rankedSet.has(m.permaslug) && !cooledSet.has(m.permaslug)
+  )
+  const skippedUnranked = candidates.filter((m) => !rankedSet.has(m.permaslug))
+  const skippedCooldown = candidates.filter(
+    (m) => rankedSet.has(m.permaslug) && cooledSet.has(m.permaslug)
+  )
+
+  // A last-resort ceiling on a single sweep, so a pathological run (an
+  // upstream shape change, a HuggingFace outage pushing every declared-repo
+  // model into this path) cannot turn into an unbounded bill. Reaching it is
+  // an anomaly, not a routine truncation — hence log.error, not a silent slice.
+  const models = eligible.slice(0, MAX_RESEARCH_PER_SWEEP)
+  if (eligible.length > models.length)
+    log.error(
+      `[model-classifier] ${eligible.length} models eligible for research, ` +
+        `capped at ${MAX_RESEARCH_PER_SWEEP} this sweep — deferring: ` +
+        eligible
+          .slice(MAX_RESEARCH_PER_SWEEP)
+          .map((m) => m.permaslug)
+          .join(', ')
+    )
+
+  log(
+    `[model-classifier] research candidates: ${candidates.length} unsettled, ` +
+      `${skippedUnranked.length} never ranked (cannot move the index), ` +
+      `${skippedCooldown.length} inside the research cooldown, ` +
+      `${models.length} researched this sweep`
+  )
 
   for (const model of models) {
     const result = await classifyModelWithAgent({

--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -5,11 +5,19 @@ import {
 } from 'shared/huggingface'
 import {
   getPendingClassifications,
+  recordAgentRecommendation,
   recordPendingModels,
   upsertClassification,
 } from 'shared/perps/model-classifications'
-import { fetchOpenRouterCatalog } from 'shared/openrouter-tokens'
-import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { classifyModelWithAgent } from 'shared/perps/classify-model-agent'
+import {
+  fetchOpenRouterCatalog,
+  OpenRouterCatalogEntry,
+} from 'shared/openrouter-tokens'
+import {
+  createSupabaseDirectClient,
+  SupabaseDirectClient,
+} from 'shared/supabase/init'
 import { log } from 'shared/utils'
 
 // Classify new OpenRouter models BEFORE they reach the top 50.
@@ -75,16 +83,16 @@ const updateModelClassificationsInternal = async () => {
   // OpenRouter frequently populates `hugging_face_id` days after listing, and
   // labs publish weights after launch. Both cases resolve themselves here.
   let confirmed = 0
-  let unresolved = 0
+  const needsResearch: typeof unknown = []
   for (const model of unknown) {
     if (!model.huggingFaceId) {
-      unresolved++
+      needsResearch.push(model)
       continue
     }
     const verification = await verifyHuggingFaceWeights(model.huggingFaceId)
     logHuggingFaceVerification(model.permaslug, verification)
     if (!verification.confirmed) {
-      unresolved++
+      needsResearch.push(model)
       continue
     }
     await upsertClassification(pg, {
@@ -97,11 +105,15 @@ const updateModelClassificationsInternal = async () => {
     confirmed++
   }
 
+  const researched = await researchRemainingModels(pg, needsResearch)
+
   const pending = await getPendingClassifications(pg)
   log(
     `[model-classifier] ${unknown.length} unclassified in catalog: ` +
-      `${confirmed} auto-classified open, ${unresolved} unresolved; ` +
-      `${pending.length} awaiting review`
+      `${confirmed} auto-classified open from a declared repo, ` +
+      `${researched.confirmed} open via research, ` +
+      `${researched.recommended} closed-recommendations for review, ` +
+      `${researched.unresolved} unresolved; ${pending.length} awaiting review`
   )
 
   // Warn rather than error: a pending model is not yet a problem — the index
@@ -114,4 +126,89 @@ const updateModelClassificationsInternal = async () => {
         .map((p) => p.permaslug)
         .join(', ')}`
     )
+}
+
+/**
+ * Hand whatever the deterministic pass could not settle to the research agent.
+ *
+ * This is the half that kept freezing the feed: models with no declared repo,
+ * where deciding means actually searching HuggingFace rather than fetching one
+ * URL. The agent runs the same searches a human would and its `open` verdicts
+ * are re-verified against the live API before they land, so the automation can
+ * only ever be as wrong as the API is.
+ *
+ * `closed` comes back as a recommendation, not a classification. Nothing
+ * machine-checks a negative claim, and with the grace threshold in place an
+ * unclassified model no longer halts the index — so the cheap, correct move is
+ * to leave it pending with the research attached and let a human confirm in
+ * one click. Set PERPS_AUTOCLASSIFY_CLOSED=true to apply them automatically;
+ * it is off by default deliberately.
+ */
+const researchRemainingModels = async (
+  pg: SupabaseDirectClient,
+  models: OpenRouterCatalogEntry[]
+) => {
+  const autoApplyClosed = process.env.PERPS_AUTOCLASSIFY_CLOSED === 'true'
+  let confirmed = 0
+  let recommended = 0
+  let unresolved = 0
+
+  for (const model of models) {
+    const result = await classifyModelWithAgent({
+      permaslug: model.permaslug,
+      name: model.name,
+      declaredHuggingFaceId: model.huggingFaceId,
+    })
+    const evidence = {
+      openRouterName: model.name,
+      agentReasoning: result.verdict.reasoning,
+      // The tool calls the verdict rests on, so an operator reviewing this
+      // sees what was actually searched rather than a bare assertion.
+      agentSearches: result.searches.map((s) => ({
+        tool: s.tool,
+        input: s.input,
+        result: s.result.slice(0, 1000),
+      })),
+      rejectedReason: result.rejectedReason ?? null,
+    }
+
+    if (result.verdict.verdict === 'open') {
+      await upsertClassification(pg, {
+        permaslug: model.permaslug,
+        open: true,
+        weights: result.verdict.weights,
+        source: 'auto',
+        evidence: { ...evidence, ...(result.confirmation?.confirmed
+          ? result.confirmation.evidence
+          : {}) },
+      })
+      confirmed++
+      continue
+    }
+
+    if (result.verdict.verdict === 'closed') {
+      if (autoApplyClosed) {
+        await upsertClassification(pg, {
+          permaslug: model.permaslug,
+          open: false,
+          source: 'auto',
+          evidence,
+        })
+        confirmed++
+        continue
+      }
+      await recordAgentRecommendation(pg, model.permaslug, 'closed', evidence)
+      recommended++
+      log.warn(
+        `[model-classifier] ${model.permaslug}: agent recommends CLOSED — ` +
+          `${result.verdict.reasoning.slice(0, 300)}`
+      )
+      continue
+    }
+
+    await recordAgentRecommendation(pg, model.permaslug, null, evidence)
+    unresolved++
+  }
+
+  return { confirmed, recommended, unresolved }
 }

--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -268,7 +268,18 @@ const researchRemainingModels = async (
       continue
     }
 
-    await recordAgentRecommendation(pg, model.permaslug, null, evidence)
+    // A transient failure starts no cooldown. Recording `agentRanAt` here
+    // would mark the model researched when nothing was learned, and since the
+    // cooldown is a fraction of the grace window, that would burn one of the
+    // few retries a ranked model gets before its window expires and the feed
+    // halts. Attach the evidence either way so the queue shows what happened.
+    await recordAgentRecommendation(
+      pg,
+      model.permaslug,
+      null,
+      evidence,
+      !result.transient
+    )
     unresolved++
   }
 

--- a/backend/shared/src/huggingface.ts
+++ b/backend/shared/src/huggingface.ts
@@ -130,6 +130,77 @@ const isPubliclyGettable = (gated: string | boolean | null | undefined) =>
 const encodeRepo = (repo: string) =>
   repo.split('/').map(encodeURIComponent).join('/')
 
+export type HuggingFaceRepoSummary = {
+  id: string
+  downloads?: number
+  lastModified?: string
+}
+
+/**
+ * Search repos by name fragment across every org.
+ *
+ * The decisive NEGATIVE signal: a global search for a model's name returning
+ * nothing is the strongest available evidence that no public weights exist
+ * anywhere. It is what settled Solar Pro 4 and Grok 4.6.
+ */
+export const searchHuggingFaceModels = async (
+  query: string,
+  limit = 20
+): Promise<HuggingFaceRepoSummary[]> => {
+  if (!query) return []
+  return fetchRepoList(
+    `${HF_API}?search=${encodeURIComponent(query)}&limit=${limit}`
+  )
+}
+
+/**
+ * List an org's repos, most recently modified first.
+ *
+ * Reveals what a single-repo lookup cannot: that a publisher ships weights
+ * under a separately branded line (Upstage's Solar Open vs Solar Pro), or that
+ * a line publishes tokenizers only.
+ */
+export const listHuggingFaceOrgModels = async (
+  org: string,
+  limit = 30
+): Promise<HuggingFaceRepoSummary[]> => {
+  if (!org) return []
+  return fetchRepoList(
+    `${HF_API}?author=${encodeURIComponent(
+      org
+    )}&sort=lastModified&direction=-1&limit=${limit}`
+  )
+}
+
+const fetchRepoList = async (
+  url: string
+): Promise<HuggingFaceRepoSummary[]> => {
+  const res = await fetch(url, {
+    headers: { 'user-agent': 'Manifold/1.0 (+https://manifold.markets)' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  if (!res.ok)
+    throw new Error(`HuggingFace list: ${res.status} ${res.statusText}`)
+
+  const body = (await res.json()) as unknown
+  if (!Array.isArray(body)) return []
+  return body.flatMap((row) => {
+    if (!row || typeof row !== 'object' || !('id' in row)) return []
+    const id = (row as { id: unknown }).id
+    if (typeof id !== 'string') return []
+    const downloads = (row as { downloads?: unknown }).downloads
+    const lastModified = (row as { lastModified?: unknown }).lastModified
+    return [
+      {
+        id,
+        downloads: typeof downloads === 'number' ? downloads : undefined,
+        lastModified:
+          typeof lastModified === 'string' ? lastModified : undefined,
+      },
+    ]
+  })
+}
+
 export const logHuggingFaceVerification = (
   permaslug: string,
   verification: HuggingFaceVerification

--- a/backend/shared/src/perps/classify-model-agent.ts
+++ b/backend/shared/src/perps/classify-model-agent.ts
@@ -25,29 +25,40 @@ import { log } from 'shared/utils'
 // asking a model whether a model it has never heard of is open-weights would
 // be asking it to guess.
 //
-// WHAT THIS DOES AND DOES NOT DECIDE. An `open` verdict is machine-checkable:
-// the cited repo must resolve, be public, carry weight files, and pass the
-// name guard in common/perps/weights-repo-match. Those checks run after the
-// agent returns, against the live API, so a fabricated repo fails on contact
-// with reality rather than reaching the index. A `closed` verdict has no
-// equivalent check — it is a negative claim, and the strongest form of it is
-// "these searches came back empty". So closed comes back as a RECOMMENDATION
-// with its evidence, for a human to confirm in one click. Auto-applying it is
-// opt-in, and off by default: excluding an unknown model costs less index
-// error than mis-siding one (see UNCLASSIFIED_TOKEN_SHARE_CAP), so waiting is
-// genuinely cheaper than guessing.
+// WHAT THIS DOES AND DOES NOT DECIDE. Nothing here is applied automatically.
+// Every verdict comes back as a RECOMMENDATION on a still-pending row, and a
+// human confirms it from the admin queue.
+//
+// For `closed` that was always true: it is a negative claim, and the strongest
+// available form of it is "these specific searches came back empty" — so the
+// verdict is only as good as the searches, which is why it now requires them
+// and why they are rendered for the operator.
+//
+// For `open` it is the considered position rather than the obvious one. An
+// open verdict looks checkable: the cited repo is re-fetched from the live API
+// and must carry public weight files, and its name must fully match the
+// model's. Those checks are real and they run — but they establish that a
+// public weight-bearing repo exists under a matching name, not that it is THIS
+// model's. Identity is not a string comparison. The guard has been wrong twice
+// in review, both times on repos that verified perfectly: a single-token family
+// name matching any sibling, and parameter counts tokenized away so a 30B repo
+// matched a 480B model. Each fix closed the case we had found. Requiring a
+// human closes the class.
+//
+// The cost of that is one click on a handful of models a week, because only
+// ranked models are researched at all. The cost of getting it wrong is an
+// executable index moving on a false positive. The repo, its verification, and
+// every search ride along on the row so the click stays a click.
 
 // Haiku, not Opus, and the reasoning is about what actually protects the index.
 //
 // This is a search-and-cite task, not a reasoning task: the agent runs the HF
-// searches a human would run and names a repo. Everything that makes an `open`
-// verdict safe runs AFTER the model answers and does not care which model
-// produced the citation — the repo is re-fetched from the live HuggingFace API
-// and must carry public weight files, and the name must clear the deterministic
-// guard in common/perps/weights-repo-match. A weaker model therefore cannot
-// produce a WRONG `open`; it can only fail to find a repo that exists, which
-// comes back as `unresolved` and lands in the human review queue. The failure
-// mode degrades into queue depth, not into index error.
+// searches a human would run and names a repo. Nothing it concludes reaches the
+// index without a human, and the repo it names is re-fetched from the live API
+// and shown to that human alongside every search it ran. So the model tier
+// cannot buy or lose correctness here — a weaker model produces a worse
+// SHORTLIST, not a wrong classification, and the failure mode is an operator
+// reading one unhelpful recommendation rather than an index moving on it.
 //
 // The cost difference is the reason it matters. At Opus-5 rates a single
 // classification runs ~$0.27 (roughly 30k input + 4.6k output across ~6 turns,
@@ -384,8 +395,8 @@ const finalizeVerdict = async (
     // came back empty" — so a closed call with no searches behind it is not a
     // weak conclusion, it is the model answering from memory about a model
     // released after its training data ended. That is precisely the guess the
-    // system prompt forbids, and the one PERPS_AUTOCLASSIFY_CLOSED would
-    // otherwise write straight into the index.
+    // system prompt forbids, and it would reach an operator dressed as a
+    // researched conclusion.
     //
     // Downgraded rather than rejected: `unresolved` keeps the model pending,
     // which is where an unadjudicated model belongs anyway, and leaves it for

--- a/backend/shared/src/perps/classify-model-agent.ts
+++ b/backend/shared/src/perps/classify-model-agent.ts
@@ -86,6 +86,16 @@ export type AgentClassification = {
   confirmation?: HuggingFaceVerification
   /** Why a proposed `open` was downgraded, when it was. */
   rejectedReason?: string
+  /**
+   * True when the run failed for an infrastructural reason rather than
+   * reaching a conclusion — no key, the API unreachable, turns exhausted.
+   *
+   * The caller uses this to decide whether to start a research cooldown. A
+   * verdict is worth not re-asking; a failed call carries no information and
+   * must be retried on the next sweep, because the model's grace window is
+   * running the whole time.
+   */
+  transient?: boolean
 }
 
 const SYSTEM_PROMPT = `You classify AI models for a published market index. The index measures what fraction of tokens on OpenRouter go to models whose weights the public can download, and it settles real money, so a wrong call moves a market.
@@ -204,6 +214,7 @@ export const classifyModelWithAgent = async (params: {
         reasoning: 'ANTHROPIC_API_KEY not set',
       },
       searches,
+      transient: true,
     }
 
   const anthropic = new Anthropic({ apiKey })
@@ -249,6 +260,7 @@ export const classifyModelWithAgent = async (params: {
           reasoning: `classifier request failed — ${err}`,
         },
         searches,
+        transient: true,
       }
     }
 
@@ -269,6 +281,7 @@ export const classifyModelWithAgent = async (params: {
           reasoning: 'agent stopped without submitting a classification',
         },
         searches,
+        transient: true,
       }
 
     const submission = toolUses.find(
@@ -299,6 +312,7 @@ export const classifyModelWithAgent = async (params: {
       reasoning: `no classification after ${MAX_TURNS} turns`,
     },
     searches,
+    transient: true,
   }
 }
 
@@ -364,8 +378,32 @@ const finalizeVerdict = async (
   const weights =
     typeof fields.weights === 'string' ? fields.weights.trim() : ''
 
-  if (verdict === 'closed')
+  if (verdict === 'closed') {
+    // A closed verdict IS its searches. Nothing machine-checks a negative
+    // claim — the strongest available form of it is "these specific searches
+    // came back empty" — so a closed call with no searches behind it is not a
+    // weak conclusion, it is the model answering from memory about a model
+    // released after its training data ended. That is precisely the guess the
+    // system prompt forbids, and the one PERPS_AUTOCLASSIFY_CLOSED would
+    // otherwise write straight into the index.
+    //
+    // Downgraded rather than rejected: `unresolved` keeps the model pending,
+    // which is where an unadjudicated model belongs anyway, and leaves it for
+    // a human. Not marked transient — the agent ran fine, it just did not look,
+    // and an immediate retry would produce the same answer.
+    const searched = searches.some((s) => s.tool !== 'submit_classification')
+    if (!searched)
+      return {
+        permaslug,
+        verdict: {
+          verdict: 'unresolved',
+          reasoning: `claimed closed without running any searches — ${reasoning}`,
+        },
+        searches,
+        rejectedReason: 'closed verdict rested on no evidence',
+      }
     return { permaslug, verdict: { verdict: 'closed', reasoning }, searches }
+  }
 
   if (verdict !== 'open')
     return {

--- a/backend/shared/src/perps/classify-model-agent.ts
+++ b/backend/shared/src/perps/classify-model-agent.ts
@@ -37,7 +37,33 @@ import { log } from 'shared/utils'
 // error than mis-siding one (see UNCLASSIFIED_TOKEN_SHARE_CAP), so waiting is
 // genuinely cheaper than guessing.
 
-const CLASSIFIER_MODEL = 'claude-opus-5'
+// Haiku, not Opus, and the reasoning is about what actually protects the index.
+//
+// This is a search-and-cite task, not a reasoning task: the agent runs the HF
+// searches a human would run and names a repo. Everything that makes an `open`
+// verdict safe runs AFTER the model answers and does not care which model
+// produced the citation — the repo is re-fetched from the live HuggingFace API
+// and must carry public weight files, and the name must clear the deterministic
+// guard in common/perps/weights-repo-match. A weaker model therefore cannot
+// produce a WRONG `open`; it can only fail to find a repo that exists, which
+// comes back as `unresolved` and lands in the human review queue. The failure
+// mode degrades into queue depth, not into index error.
+//
+// The cost difference is the reason it matters. At Opus-5 rates a single
+// classification runs ~$0.27 (roughly 30k input + 4.6k output across ~6 turns,
+// history resent each turn); on Haiku the same session is ~$0.05. Combined with
+// the ranked-only gate and the cooldown in update-model-classifications, that
+// is the difference between a job that costs a few cents a day and one that
+// does not fit in the budget this feed is worth.
+//
+// Override per-environment if a specific model ever proves necessary; the
+// verification path is unchanged either way.
+const CLASSIFIER_MODEL = process.env.PERPS_CLASSIFIER_MODEL || 'claude-haiku-4-5'
+// No prompt caching here on purpose: Haiku 4.5's minimum cacheable prefix is
+// 4096 tokens and this system prompt plus tool definitions is ~1.5k, so a
+// cache_control breakpoint would silently never engage. (It WOULD engage on
+// Opus 5, whose minimum is 512 — the two levers interact, and picking the
+// cheaper model is worth more here than caching a prefix this small.)
 const MAX_TURNS = 12
 const MAX_TOKENS = 16_000
 
@@ -203,9 +229,14 @@ export const classifyModelWithAgent = async (params: {
       response = await anthropic.messages.create({
         model: CLASSIFIER_MODEL,
         max_tokens: MAX_TOKENS,
-        // No temperature: Claude Opus 5 rejects sampling parameters outright,
-        // and the shared promptClaude helper hardcodes temperature: 0, which
-        // is why this does not go through it.
+        // No sampling parameters, and deliberately not routed through the
+        // shared promptClaude helper, which hardcodes temperature: 0. Haiku
+        // accepts temperature, but the Opus/Sonnet 5 generation rejects
+        // sampling parameters with a 400 — so promptClaude cannot be pointed
+        // at those models at all, and this call stays portable across whatever
+        // PERPS_CLASSIFIER_MODEL is set to. Worth knowing independently of
+        // this file: any other promptClaude call site aimed at a 5-series
+        // model fails the same way.
         system: SYSTEM_PROMPT,
         tools: TOOLS,
         messages,

--- a/backend/shared/src/perps/classify-model-agent.ts
+++ b/backend/shared/src/perps/classify-model-agent.ts
@@ -1,0 +1,391 @@
+import Anthropic from '@anthropic-ai/sdk'
+import { proposedRepoMatchesModel } from 'common/perps/weights-repo-match'
+import {
+  HuggingFaceVerification,
+  searchHuggingFaceModels,
+  listHuggingFaceOrgModels,
+  verifyHuggingFaceWeights,
+} from 'shared/huggingface'
+import { log } from 'shared/utils'
+
+// Agentic classifier for models the deterministic watcher could not settle.
+//
+// The watcher resolves a model on its own when the publisher declared a
+// HuggingFace repo: fetch it, confirm public weight files, done. What it
+// cannot do is the case that keeps freezing the feed — a model with no
+// declared repo, where deciding requires actually looking: search HuggingFace
+// for the name, list the publisher's org, notice that `solar-pro3-tokenizer`
+// resolves while `solar-pro3` does not, and conclude the whole product line is
+// API-only.
+//
+// That is a search procedure, not knowledge. It has to be, because these
+// models postdate any model's training data — Grok 4.6 and Solar Pro 4 were
+// released days before they entered the index. So the agent gets the same
+// tools a human would use and is graded on evidence it produced in-session;
+// asking a model whether a model it has never heard of is open-weights would
+// be asking it to guess.
+//
+// WHAT THIS DOES AND DOES NOT DECIDE. An `open` verdict is machine-checkable:
+// the cited repo must resolve, be public, carry weight files, and pass the
+// name guard in common/perps/weights-repo-match. Those checks run after the
+// agent returns, against the live API, so a fabricated repo fails on contact
+// with reality rather than reaching the index. A `closed` verdict has no
+// equivalent check — it is a negative claim, and the strongest form of it is
+// "these searches came back empty". So closed comes back as a RECOMMENDATION
+// with its evidence, for a human to confirm in one click. Auto-applying it is
+// opt-in, and off by default: excluding an unknown model costs less index
+// error than mis-siding one (see UNCLASSIFIED_TOKEN_SHARE_CAP), so waiting is
+// genuinely cheaper than guessing.
+
+const CLASSIFIER_MODEL = 'claude-opus-5'
+const MAX_TURNS = 12
+const MAX_TOKENS = 16_000
+
+export type AgentVerdict =
+  | {
+      verdict: 'open'
+      /** The repo the agent cited, re-verified below before it is trusted. */
+      weights: string
+      reasoning: string
+    }
+  | { verdict: 'closed'; reasoning: string }
+  | { verdict: 'unresolved'; reasoning: string }
+
+export type AgentClassification = {
+  permaslug: string
+  verdict: AgentVerdict
+  /** Every tool call the agent made, in order — the audit trail for a verdict. */
+  searches: { tool: string; input: unknown; result: string }[]
+  /** Populated for an `open` verdict: the independent re-check of the citation. */
+  confirmation?: HuggingFaceVerification
+  /** Why a proposed `open` was downgraded, when it was. */
+  rejectedReason?: string
+}
+
+const SYSTEM_PROMPT = `You classify AI models for a published market index. The index measures what fraction of tokens on OpenRouter go to models whose weights the public can download, and it settles real money, so a wrong call moves a market.
+
+THE TEST, and the only test: are the model's weights publicly downloadable?
+- Downloadable by any member of the public -> open.
+- API-only -> closed.
+
+This is deliberately not "open source". A click-through licence is still public: Llama and Gemma are gated on HuggingFace, but anyone can accept the terms and download, so they are open. Research-only access, discretionary approval, and private repos are not public.
+
+You are almost certainly being asked about a model released after your training data ends. Do not answer from memory or from what a name resembles. Use the tools to look, every time, and base your verdict only on what the tools returned in this session.
+
+Useful signals, learned from real cases:
+- A publisher's org listing shows their whole line at once. A line that publishes ONLY tokenizer repos (e.g. "solar-pro2-tokenizer" resolving while "solar-pro2" does not) is an API-only line.
+- Publishers often brand open and closed lines differently. Upstage ships weights as "Solar Open" while "Solar Pro" is API-only. A repo from the same org is not automatically the same model.
+- Third-party quantisations (unsloth, TheBloke, GGUF conversions) are strong corroboration: nobody can quantise weights they could not download.
+- A repo that resolves but carries no weight files does not count.
+
+When you have looked enough, call submit_classification. Cite a repo ONLY if you saw it resolve with weight files in this session. If the searches came back empty, say closed and describe which searches you ran and what they returned. If you genuinely could not tell, say unresolved — that is a useful answer, and better than a confident wrong one.`
+
+const TOOLS: Anthropic.Tool[] = [
+  {
+    name: 'hf_search_models',
+    description:
+      'Search HuggingFace model repos by name fragment, across all orgs. Use this first to find out whether a weights repo exists anywhere. Returns repo ids with download counts.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Name fragment, e.g. "solar-pro4" or "DeepSeek-V4-Pro"',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'hf_list_org_models',
+    description:
+      "List a HuggingFace organization's repos, most recently modified first. Use this to see a publisher's whole line at once — it reveals tokenizer-only lines and separately branded open lines.",
+    input_schema: {
+      type: 'object',
+      properties: {
+        org: {
+          type: 'string',
+          description: 'HuggingFace org name, e.g. "upstage" or "deepseek-ai"',
+        },
+      },
+      required: ['org'],
+    },
+  },
+  {
+    name: 'hf_get_model',
+    description:
+      'Fetch one HuggingFace repo and report whether it is public, gated, and how many actual weight files it carries. This is the decisive check for an open verdict.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        repo: {
+          type: 'string',
+          description: 'Full repo id, e.g. "deepseek-ai/DeepSeek-V4-Pro-0813"',
+        },
+      },
+      required: ['repo'],
+    },
+  },
+  {
+    name: 'submit_classification',
+    description:
+      'Submit the final verdict. Call this exactly once, when your searches are done.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        verdict: {
+          type: 'string',
+          enum: ['open', 'closed', 'unresolved'],
+        },
+        weights: {
+          type: 'string',
+          description:
+            'Required for `open`: the repo id you saw resolve with weight files. Omit otherwise.',
+        },
+        reasoning: {
+          type: 'string',
+          description:
+            'What you searched and what came back. Name the repos you checked and what each returned.',
+        },
+      },
+      required: ['verdict', 'reasoning'],
+    },
+  },
+]
+
+/**
+ * Research one model and return a verdict plus the evidence behind it.
+ *
+ * Never throws on a classification failure — an unreachable API or a
+ * malformed answer comes back as `unresolved`, which the caller treats the
+ * same as "leave it pending". A model this cannot settle is not an outage; it
+ * is a queue item.
+ */
+export const classifyModelWithAgent = async (params: {
+  permaslug: string
+  name?: string
+  declaredHuggingFaceId?: string | null
+}): Promise<AgentClassification> => {
+  const { permaslug, name, declaredHuggingFaceId } = params
+  const searches: AgentClassification['searches'] = []
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey)
+    return {
+      permaslug,
+      verdict: {
+        verdict: 'unresolved',
+        reasoning: 'ANTHROPIC_API_KEY not set',
+      },
+      searches,
+    }
+
+  const anthropic = new Anthropic({ apiKey })
+  const messages: Anthropic.MessageParam[] = [
+    {
+      role: 'user',
+      content:
+        `Classify this OpenRouter model.\n\n` +
+        `permaslug: ${permaslug}\n` +
+        `display name: ${name ?? '(unknown)'}\n` +
+        `publisher-declared HuggingFace repo: ${
+          declaredHuggingFaceId ?? 'none — OpenRouter reports no repo'
+        }\n\n` +
+        `Note the permaslug's leading segment is the OpenRouter publisher, ` +
+        `which often differs from the HuggingFace org name (z-ai -> zai-org, ` +
+        `deepseek -> deepseek-ai). Search rather than assuming.`,
+    },
+  ]
+
+  for (let turn = 0; turn < MAX_TURNS; turn++) {
+    let response: Anthropic.Message
+    try {
+      response = await anthropic.messages.create({
+        model: CLASSIFIER_MODEL,
+        max_tokens: MAX_TOKENS,
+        // No temperature: Claude Opus 5 rejects sampling parameters outright,
+        // and the shared promptClaude helper hardcodes temperature: 0, which
+        // is why this does not go through it.
+        system: SYSTEM_PROMPT,
+        tools: TOOLS,
+        messages,
+      })
+    } catch (err) {
+      return {
+        permaslug,
+        verdict: {
+          verdict: 'unresolved',
+          reasoning: `classifier request failed — ${err}`,
+        },
+        searches,
+      }
+    }
+
+    messages.push({ role: 'assistant', content: response.content })
+
+    // A server-side tool run can pause mid-turn; re-sending the conversation
+    // resumes it. Nothing to execute on our side.
+    if (response.stop_reason === 'pause_turn') continue
+
+    const toolUses = response.content.filter(
+      (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use'
+    )
+    if (toolUses.length === 0)
+      return {
+        permaslug,
+        verdict: {
+          verdict: 'unresolved',
+          reasoning: 'agent stopped without submitting a classification',
+        },
+        searches,
+      }
+
+    const submission = toolUses.find(
+      (use) => use.name === 'submit_classification'
+    )
+    if (submission)
+      return finalizeVerdict(permaslug, submission.input, searches)
+
+    const results: Anthropic.ToolResultBlockParam[] = []
+    for (const use of toolUses) {
+      const result = await runResearchTool(use.name, use.input)
+      searches.push({ tool: use.name, input: use.input, result })
+      results.push({
+        type: 'tool_result',
+        tool_use_id: use.id,
+        content: result,
+      })
+    }
+    // All results go back in ONE user message — splitting them trains the
+    // model out of making parallel tool calls.
+    messages.push({ role: 'user', content: results })
+  }
+
+  return {
+    permaslug,
+    verdict: {
+      verdict: 'unresolved',
+      reasoning: `no classification after ${MAX_TURNS} turns`,
+    },
+    searches,
+  }
+}
+
+const runResearchTool = async (
+  toolName: string,
+  input: unknown
+): Promise<string> => {
+  const arg = (key: string): string => {
+    const value = (input as Record<string, unknown> | null)?.[key]
+    return typeof value === 'string' ? value.trim() : ''
+  }
+
+  try {
+    if (toolName === 'hf_search_models') {
+      const hits = await searchHuggingFaceModels(arg('query'))
+      if (hits.length === 0) return 'No repos matched this query.'
+      return hits
+        .map((h) => `${h.id} (downloads: ${h.downloads ?? 0})`)
+        .join('\n')
+    }
+    if (toolName === 'hf_list_org_models') {
+      const repos = await listHuggingFaceOrgModels(arg('org'))
+      if (repos.length === 0)
+        return 'No repos found for that org (it may not exist under this name).'
+      return repos
+        .map((r) => `${r.id} (modified: ${r.lastModified ?? 'unknown'})`)
+        .join('\n')
+    }
+    if (toolName === 'hf_get_model') {
+      const verification = await verifyHuggingFaceWeights(arg('repo'))
+      return verification.confirmed
+        ? `PUBLIC WEIGHTS CONFIRMED: ${verification.repo}, ` +
+            `${verification.evidence.weightFileCount} weight files, ` +
+            `gated: ${verification.evidence.gated ?? 'no'}`
+        : `NOT CONFIRMED: ${verification.reason}`
+    }
+    return `Unknown tool ${toolName}`
+  } catch (err) {
+    // Returned as a tool result rather than thrown: the agent can react to a
+    // failed lookup, and one flaky call should not abort the classification.
+    return `Tool error: ${err}`
+  }
+}
+
+/**
+ * Turn the agent's submission into a verdict we are willing to act on.
+ *
+ * An `open` claim is re-verified here against the live HuggingFace API — not
+ * against anything the agent reported. Two independent things must hold: the
+ * repo really carries public weight files, and its name really looks like this
+ * model's (the Solar-Open2 trap). Failing either downgrades to `unresolved`
+ * with the reason recorded, which is a queue item rather than a wrong price.
+ */
+const finalizeVerdict = async (
+  permaslug: string,
+  input: unknown,
+  searches: AgentClassification['searches']
+): Promise<AgentClassification> => {
+  const fields = (input ?? {}) as Record<string, unknown>
+  const verdict = typeof fields.verdict === 'string' ? fields.verdict : ''
+  const reasoning =
+    typeof fields.reasoning === 'string' ? fields.reasoning : '(none given)'
+  const weights =
+    typeof fields.weights === 'string' ? fields.weights.trim() : ''
+
+  if (verdict === 'closed')
+    return { permaslug, verdict: { verdict: 'closed', reasoning }, searches }
+
+  if (verdict !== 'open')
+    return {
+      permaslug,
+      verdict: { verdict: 'unresolved', reasoning },
+      searches,
+    }
+
+  if (!weights)
+    return {
+      permaslug,
+      verdict: {
+        verdict: 'unresolved',
+        reasoning: `claimed open with no weights repo cited — ${reasoning}`,
+      },
+      searches,
+      rejectedReason: 'open verdict cited no repo',
+    }
+
+  if (!proposedRepoMatchesModel(permaslug, weights))
+    return {
+      permaslug,
+      verdict: {
+        verdict: 'unresolved',
+        reasoning: `cited ${weights}, whose name does not match ${permaslug} — ${reasoning}`,
+      },
+      searches,
+      rejectedReason: `name mismatch: ${weights}`,
+    }
+
+  const confirmation = await verifyHuggingFaceWeights(weights)
+  if (!confirmation.confirmed)
+    return {
+      permaslug,
+      verdict: {
+        verdict: 'unresolved',
+        reasoning: `cited ${weights}, which did not verify (${confirmation.reason}) — ${reasoning}`,
+      },
+      searches,
+      confirmation,
+      rejectedReason: `citation failed verification: ${confirmation.reason}`,
+    }
+
+  log(
+    `[model-classifier] agent classified ${permaslug} open, citation ` +
+      `${weights} independently re-verified`
+  )
+  return {
+    permaslug,
+    verdict: { verdict: 'open', weights: confirmation.repo, reasoning },
+    searches,
+    confirmation,
+  }
+}

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -4,7 +4,6 @@ import {
   UNCLASSIFIED_GRACE_WINDOW_MS,
   basePermaslug,
 } from 'common/perps/open-weight-models'
-import { DAY_MS } from 'common/util/time'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 
 // Resolution layer between the audited seed list and the operator/auto
@@ -258,7 +257,14 @@ export const recordAgentRecommendation = async (
   pg: SupabaseDirectClient,
   permaslug: string,
   recommendation: 'closed' | null,
-  evidence: Record<string, unknown>
+  evidence: Record<string, unknown>,
+  /**
+   * Whether this run counts as "researched" for cooldown purposes. False for
+   * transient failures: the evidence is still attached so the queue shows what
+   * happened, but the clock does not start, so the next sweep retries. See
+   * AGENT_RESEARCH_COOLDOWN_MS for why burning a retry here is a live outage.
+   */
+  startCooldown = true
 ) => {
   await pg.none(
     `update model_classifications
@@ -269,7 +275,7 @@ export const recordAgentRecommendation = async (
       JSON.stringify({
         ...evidence,
         agentRecommendation: recommendation,
-        agentRanAt: new Date().toISOString(),
+        ...(startCooldown ? { agentRanAt: new Date().toISOString() } : {}),
       }),
     ]
   )
@@ -287,8 +293,29 @@ export const getPendingClassifications = async (
      order by first_ranked_at asc nulls last, first_seen asc`
   )
 
-/** How long a researched-but-unsettled model is left alone before a re-run. */
-export const AGENT_RESEARCH_COOLDOWN_MS = 7 * DAY_MS
+/**
+ * How long a researched-but-unsettled model is left alone before a re-run.
+ *
+ * DERIVED from the grace window rather than chosen independently, because the
+ * two are not independent quantities and drifting them apart is a live outage.
+ *
+ * Only ranked models are researched at all, so every model under cooldown has
+ * a grace clock already running. A cooldown longer than that window means a
+ * model researched once is never retried before its grace expires and the feed
+ * halts. That is not a theoretical ordering: a transient failure — Anthropic
+ * unreachable, a missing key, a run that burns its turns — comes back as
+ * `unresolved`, and a flat seven-day cooldown against a two-day window turned
+ * one bad API call into a guaranteed halt two days later, with seven sweeps
+ * sitting idle in between that could each have fixed it.
+ *
+ * A quarter of the window gives roughly four attempts before the deadline,
+ * which is enough to ride out a transient outage, while still cutting the
+ * four-sweeps-a-day re-ask that motivated a cooldown in the first place. The
+ * cost that buys is negligible: the ranked population is a handful of models,
+ * so four retries is cents. Expressed as a fraction so that changing the grace
+ * window moves this with it and the invariant cannot silently break.
+ */
+export const AGENT_RESEARCH_COOLDOWN_MS = UNCLASSIFIED_GRACE_WINDOW_MS / 4
 
 export type ResearchEligibility = {
   /** Base slugs that have entered the ranked window at least once. */

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -4,6 +4,7 @@ import {
   UNCLASSIFIED_GRACE_WINDOW_MS,
   basePermaslug,
 } from 'common/perps/open-weight-models'
+import { DAY_MS } from 'common/util/time'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 
 // Resolution layer between the audited seed list and the operator/auto
@@ -285,3 +286,63 @@ export const getPendingClassifications = async (
      where open is null
      order by first_ranked_at asc nulls last, first_seen asc`
   )
+
+/** How long a researched-but-unsettled model is left alone before a re-run. */
+export const AGENT_RESEARCH_COOLDOWN_MS = 7 * DAY_MS
+
+export type ResearchEligibility = {
+  /** Base slugs that have entered the ranked window at least once. */
+  everRanked: string[]
+  /** Base slugs researched recently enough to skip this sweep. */
+  recentlyResearched: string[]
+}
+
+/**
+ * Who is worth spending a research call on right now.
+ *
+ * Two independent filters, and between them they are the whole cost story.
+ *
+ * RANKED. The index is defined over OpenRouter's top 50, so a model that has
+ * never ranked cannot move it. The catalog carries ~130 unclassified models
+ * with no declared repo and most will never rank, so researching all of them
+ * is spend with no reachable effect on the published number. `first_ranked_at`
+ * already records exactly the models that started mattering, and the grace
+ * window already covers the gap between ranking and adjudication — so research
+ * follows ranking rather than trying to pre-empt it.
+ *
+ * COOLDOWN. A `closed` recommendation and an `unresolved` both leave the row
+ * `open is null` on purpose (only a human may conclude closed). Without a
+ * cooldown those rows re-enter the candidate set on the very next sweep and
+ * are researched again, unchanged, four times a day, forever — the answer does
+ * not improve on re-asking, because nothing about the model changed. A week is
+ * long enough that a re-run is only paid when a publisher plausibly shipped
+ * weights in the interim, which is the one thing that would change the verdict.
+ */
+export const getResearchEligibility = async (
+  pg: SupabaseDirectClient,
+  now = Date.now(),
+  cooldownMs = AGENT_RESEARCH_COOLDOWN_MS
+): Promise<ResearchEligibility> => {
+  const rows = await pg.manyOrNone<{
+    permaslug: string
+    first_ranked_at: string | null
+    agent_ran_at: string | null
+  }>(
+    `select permaslug, first_ranked_at, evidence->>'agentRanAt' as agent_ran_at
+     from model_classifications
+     where open is null`
+  )
+
+  const everRanked: string[] = []
+  const recentlyResearched: string[] = []
+  for (const row of rows) {
+    const slug = basePermaslug(row.permaslug)
+    if (row.first_ranked_at) everRanked.push(slug)
+    const ranAt = row.agent_ran_at ? Date.parse(row.agent_ran_at) : NaN
+    // A malformed timestamp reads as "never researched" rather than blocking
+    // the model forever — it costs one extra call, not a permanent hole.
+    if (Number.isFinite(ranAt) && now - ranAt < cooldownMs)
+      recentlyResearched.push(slug)
+  }
+  return { everRanked, recentlyResearched }
+}

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -256,7 +256,12 @@ export const upsertClassification = async (
 export const recordAgentRecommendation = async (
   pg: SupabaseDirectClient,
   permaslug: string,
-  recommendation: 'closed' | null,
+  /**
+   * What the agent concluded — including `open`, which is a recommendation
+   * like any other rather than a classification. The row stays pending either
+   * way; only a human moves it off `null`.
+   */
+  recommendation: 'open' | 'closed' | null,
   evidence: Record<string, unknown>,
   /**
    * Whether this run counts as "researched" for cooldown purposes. False for

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -240,6 +240,40 @@ export const upsertClassification = async (
   )
 }
 
+/**
+ * Attach the research agent's findings to a PENDING row without adjudicating
+ * it.
+ *
+ * The row stays `open is null`, so the model remains excluded from both sides
+ * of the index exactly as before — nothing about the published number changes.
+ * What changes is the review queue: instead of a bare permaslug to go and
+ * google, the operator sees a recommendation and the searches behind it, and
+ * confirms with one click.
+ *
+ * Only ever touches unadjudicated rows: the `where` clause means a human
+ * verdict can never be overwritten by a later agent run.
+ */
+export const recordAgentRecommendation = async (
+  pg: SupabaseDirectClient,
+  permaslug: string,
+  recommendation: 'closed' | null,
+  evidence: Record<string, unknown>
+) => {
+  await pg.none(
+    `update model_classifications
+     set evidence = evidence || $2::jsonb, updated_time = now()
+     where permaslug = $1 and open is null`,
+    [
+      basePermaslug(permaslug),
+      JSON.stringify({
+        ...evidence,
+        agentRecommendation: recommendation,
+        agentRanAt: new Date().toISOString(),
+      }),
+    ]
+  )
+}
+
 /** Pending rows for the admin tool, oldest first — the review queue. */
 export const getPendingClassifications = async (
   pg: SupabaseDirectClient

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1095,6 +1095,16 @@ export const API = (_apiTypeCheck = {
         /** The research agent's recommendation, if it ran. Never auto-applied. */
         agentRecommendation: string | null
         agentReasoning: string | null
+        /**
+         * The tool calls the recommendation rests on, in order. A closed
+         * verdict cannot be machine-checked, so this is what the operator
+         * actually adjudicates against — the summary alone is not evidence.
+         */
+        agentSearches: {
+          tool: string
+          input: string | null
+          result: string
+        }[]
       }[]
       recent: {
         permaslug: string

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1092,6 +1092,9 @@ export const API = (_apiTypeCheck = {
         rankedAgeMs: number | null
         /** Past the window: the index is already halting on this one. */
         graceExpired: boolean
+        /** The research agent's recommendation, if it ran. Never auto-applied. */
+        agentRecommendation: string | null
+        agentReasoning: string | null
       }[]
       recent: {
         permaslug: string

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1105,6 +1105,15 @@ export const API = (_apiTypeCheck = {
           input: string | null
           result: string
         }[]
+        /**
+         * A repo the agent proposed and the live HuggingFace API confirmed.
+         * Never applied automatically — verification and a name match cannot
+         * establish that the repo is THIS model's — but prefilled so the
+         * operator confirms rather than retypes.
+         */
+        agentProposedWeights: string | null
+        /** Weight files the live API reported for that repo, when known. */
+        agentWeightFileCount: number | null
       }[]
       recent: {
         permaslug: string

--- a/common/src/perps/weights-repo-match.test.ts
+++ b/common/src/perps/weights-repo-match.test.ts
@@ -60,6 +60,36 @@ describe('the repos that actually froze the feed', () => {
     ).toBe(false)
   })
 
+  it('rejects a SIBLING in the same family, which verification cannot catch', () => {
+    // The dropped token is the one that names the model. Every repo here is
+    // real, public and weight-bearing, so live HF verification confirms all of
+    // them — the guard is the only thing standing between a sibling's weights
+    // and a closed model being marked open.
+    for (const [permaslug, repo] of [
+      // pro vs flash: same publisher, same version, different product
+      ['deepseek/deepseek-v4-pro-20260813', 'deepseek-ai/DeepSeek-V4-Flash-0731'],
+      ['deepseek/deepseek-v4-flash-20260731', 'deepseek-ai/DeepSeek-V4-Pro-0813'],
+      // lightning vs ultra
+      [
+        'nvidia/nemotron-3.5-lightning-20260807',
+        'nvidia/NVIDIA-Nemotron-3.5-Ultra-BF16',
+      ],
+      // same family and shape, different SIZE — the case that scored a perfect
+      // 1.00 while sizes were being tokenized away to a bare unit letter
+      ['qwen/qwen3-coder-480b-a35b-07-25', 'Qwen/Qwen3-Coder-30B-A3B-Instruct'],
+    ] as [string, string][])
+      expect([permaslug, repo, proposedRepoMatchesModel(permaslug, repo)]).toEqual(
+        [permaslug, repo, false]
+      )
+  })
+
+  it('keeps parameter counts distinguishable through tokenization', () => {
+    // If 480b and 30b both collapse to `b`, siblings become indistinguishable.
+    expect(identifierTokens('qwen/qwen3-coder-480b-a35b-07-25')).not.toEqual(
+      identifierTokens('Qwen/Qwen3-Coder-30B-A3B-Instruct')
+    )
+  })
+
   it('rejects a same-org repo for an unrelated model family', () => {
     expect(
       proposedRepoMatchesModel('x-ai/grok-4.6-20260810', 'xai-org/grok-1')

--- a/common/src/perps/weights-repo-match.test.ts
+++ b/common/src/perps/weights-repo-match.test.ts
@@ -71,6 +71,48 @@ describe('the repos that actually froze the feed', () => {
       )
     ).toBe(false)
   })
+
+  it('refuses to auto-apply when the model name is a single family token', () => {
+    // `<family>-<integer>-<date>` reduces to ONE token, because bare integers
+    // are dropped as noise. The ratio is then 1.00 against any repo carrying
+    // the family name — and those repos are real, public, and weight-bearing,
+    // so verification clears them too. Without a floor on the denominator both
+    // guards pass and a closed frontier model lands on the open side.
+    for (const [permaslug, repo] of [
+      ['x-ai/grok-5-20260901', 'xai-org/grok-1'],
+      ['openai/gpt-6-20260901', 'openai-community/gpt-2'],
+      ['meta/llama-5-20260901', 'unsloth/Llama-3.1-8B-Instruct-GGUF'],
+      ['z-ai/glm-6-20260901', 'zai-org/GLM-4.6'],
+    ] as [string, string][]) {
+      expect([permaslug, identifierTokens(permaslug).length]).toEqual([
+        permaslug,
+        1,
+      ])
+      // The ratio alone would accept every one of these.
+      expect([permaslug, weightsRepoNameOverlap(permaslug, repo)]).toEqual([
+        permaslug,
+        1,
+      ])
+      expect([permaslug, proposedRepoMatchesModel(permaslug, repo)]).toEqual([
+        permaslug,
+        false,
+      ])
+    }
+  })
+
+  it('still accepts real pairs, which all clear the token floor', () => {
+    // The floor must not cost us any genuine match: every real pair observed
+    // contributes three or more distinctive tokens.
+    for (const permaslug of [
+      'deepseek/deepseek-v4-pro-20260813',
+      'nvidia/nemotron-3.5-lightning-20260807',
+      'qwen/qwen3-coder-480b-a35b-07-25',
+    ])
+      expect([
+        permaslug,
+        identifierTokens(permaslug).length >= 2,
+      ]).toEqual([permaslug, true])
+  })
 })
 
 describe('weightsRepoNameOverlap', () => {

--- a/common/src/perps/weights-repo-match.test.ts
+++ b/common/src/perps/weights-repo-match.test.ts
@@ -1,0 +1,98 @@
+import {
+  identifierTokens,
+  proposedRepoMatchesModel,
+  weightsRepoNameOverlap,
+} from './weights-repo-match'
+
+describe('identifierTokens', () => {
+  it('drops the org, splits digits from letters, and strips noise', () => {
+    expect(identifierTokens('deepseek/deepseek-v4-pro-20260813')).toEqual([
+      'deepseek',
+      'v4',
+      'pro',
+    ])
+    expect(identifierTokens('deepseek-ai/DeepSeek-V4-Pro-0813')).toEqual([
+      'deepseek',
+      'v4',
+      'pro',
+    ])
+  })
+
+  it('keeps version numbers attached to their letter', () => {
+    // `v4` and `k2` discriminate; a bare `70` or `2507` does not.
+    expect(identifierTokens('moonshotai/Kimi-K2-Instruct-0905')).toEqual([
+      'kimi',
+      'k2',
+    ])
+  })
+})
+
+describe('the repos that actually froze the feed', () => {
+  it('accepts the real weights repo for each open model', () => {
+    const realPairs: [string, string][] = [
+      [
+        'deepseek/deepseek-v4-pro-20260813',
+        'deepseek-ai/DeepSeek-V4-Pro-0813',
+      ],
+      [
+        'nvidia/nemotron-3.5-lightning-20260807',
+        'nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16',
+      ],
+      ['moonshotai/kimi-k2.5-0127', 'moonshotai/Kimi-K2.5'],
+      ['qwen/qwen3-coder-480b-a35b-07-25', 'Qwen/Qwen3-Coder-480B-A35B-Instruct'],
+      ['z-ai/glm-5.2-20260616', 'zai-org/GLM-5.2'],
+    ]
+    for (const [permaslug, repo] of realPairs)
+      expect([permaslug, proposedRepoMatchesModel(permaslug, repo)]).toEqual([
+        permaslug,
+        true,
+      ])
+  })
+
+  it('rejects the real-but-wrong repo that motivates the guard', () => {
+    // Solar Open2 is a genuine, public, weight-bearing Upstage repo — and a
+    // different model from Solar Pro 4. Verification alone would accept it.
+    expect(
+      proposedRepoMatchesModel(
+        'upstage/solar-pro4-20260810',
+        'upstage/Solar-Open2-250B'
+      )
+    ).toBe(false)
+  })
+
+  it('rejects a same-org repo for an unrelated model family', () => {
+    expect(
+      proposedRepoMatchesModel('x-ai/grok-4.6-20260810', 'xai-org/grok-1')
+    ).toBe(false)
+    expect(
+      proposedRepoMatchesModel(
+        'deepseek/deepseek-v4-pro-20260813',
+        'deepseek-ai/DeepSeek-R1'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('weightsRepoNameOverlap', () => {
+  it('is measured over the model tokens, so extra repo tokens are free', () => {
+    // Size and precision suffixes are normal on a weights repo and must not
+    // count against it.
+    expect(
+      weightsRepoNameOverlap(
+        'qwen/qwen3-30b-a3b-instruct-2507',
+        'Qwen/Qwen3-30B-A3B-Instruct-2507'
+      )
+    ).toBe(1)
+  })
+
+  it('scores zero when the model names something the repo lacks', () => {
+    expect(weightsRepoNameOverlap('newlab/aurora-1', 'otherlab/Zephyr-7B')).toBe(
+      0
+    )
+  })
+
+  it('never divides by zero on a degenerate identifier', () => {
+    expect(weightsRepoNameOverlap('org/', 'org/Something')).toBe(0)
+    expect(weightsRepoNameOverlap('', '')).toBe(0)
+  })
+})

--- a/common/src/perps/weights-repo-match.ts
+++ b/common/src/perps/weights-repo-match.ts
@@ -1,0 +1,112 @@
+// Does a HuggingFace repo plausibly hold THIS model's weights?
+//
+// The verifier in shared/huggingface answers "does this repo contain public
+// weight files" — ground truth, and enough to auto-classify a model open when
+// the publisher declared the repo themselves. It is NOT enough when something
+// else proposed the repo, because it answers the wrong question: it confirms
+// the repo has weights, not that the repo is *this model's* weights.
+//
+// That gap is exploitable by accident. Ask any search — a language model, a
+// web search, a fuzzy match — where Upstage Solar Pro 4's weights live, and a
+// plausible answer is `upstage/Solar-Open2-250B`: real, public, ungated, full
+// of safetensors. It verifies perfectly. It is also a completely different
+// model, and accepting it would mark a closed model open and move an
+// executable index on a false positive.
+//
+// So a proposed repo must clear a second, deterministic bar: the repo name has
+// to look like the model's name. This is a cheap guard, not a semantic one —
+// it cannot know that Solar Open and Solar Pro are different product lines. It
+// only knows that `solar-pro4` and `Solar-Open2-250B` share almost no
+// distinctive tokens, while `deepseek-v4-pro-20260813` and
+// `DeepSeek-V4-Pro-0813` share nearly all of them.
+
+/**
+ * Tokens that carry no identifying signal — they appear across unrelated
+ * models and would inflate the overlap score for free.
+ */
+const NOISE_TOKENS = new Set([
+  'ai',
+  'base',
+  'bf16',
+  'chat',
+  'fp8',
+  'gguf',
+  'instruct',
+  'it',
+  'labs',
+  'model',
+  'nvfp4',
+  'preview',
+  'v',
+])
+
+/**
+ * Split an identifier into comparable tokens: lowercase, punctuation to
+ * spaces, digits split from letters so `v4pro` and `v4-pro` agree, noise and
+ * bare-number tokens dropped.
+ *
+ * Bare numbers go because dated permaslugs (`-20260813`) and repo date
+ * suffixes (`-0813`) rarely agree on format, and a shared `2` or `70` says
+ * nothing about identity. Version numbers survive attached to their letter
+ * (`v4`, `k2`), which is where they actually discriminate.
+ */
+export const identifierTokens = (identifier: string): string[] => {
+  const withoutOrg = identifier.includes('/')
+    ? identifier.slice(identifier.indexOf('/') + 1)
+    : identifier
+  return withoutOrg
+    .toLowerCase()
+    .replace(/([a-z])(\d)/g, '$1$2 ')
+    .replace(/(\d)([a-z])/g, '$1 $2')
+    .split(/[^a-z0-9.]+/)
+    .map((token) => token.replace(/^[.]+|[.]+$/g, ''))
+    .filter(
+      (token) =>
+        token.length > 0 && !NOISE_TOKENS.has(token) && !/^\d+$/.test(token)
+    )
+}
+
+/**
+ * Fraction of the MODEL's distinctive tokens that appear in the repo name.
+ *
+ * Deliberately asymmetric — measured over the model's tokens, not the union.
+ * A weights repo routinely carries extra tokens the permaslug omits (size,
+ * precision, a base/instruct split), and penalising those would reject correct
+ * repos. What must not happen is the reverse: the model naming something the
+ * repo has no sign of.
+ */
+export const weightsRepoNameOverlap = (
+  permaslug: string,
+  repo: string
+): number => {
+  const modelTokens = identifierTokens(permaslug)
+  if (modelTokens.length === 0) return 0
+  const repoTokens = new Set(identifierTokens(repo))
+  const matched = modelTokens.filter((token) => repoTokens.has(token))
+  return matched.length / modelTokens.length
+}
+
+/**
+ * Minimum overlap for a PROPOSED repo to be accepted.
+ *
+ * 0.6 clears the real pairs seen so far (`deepseek-v4-pro-20260813` ->
+ * `DeepSeek-V4-Pro-0813` scores 1.0; `nemotron-3.5-lightning-20260807` ->
+ * `NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16` scores 1.0) while rejecting the
+ * near-miss that motivates the guard (`solar-pro4` -> `Solar-Open2-250B`
+ * scores 0.33).
+ */
+export const WEIGHTS_REPO_MATCH_THRESHOLD = 0.6
+
+/**
+ * Whether a proposed repo may back an `open` verdict for this model.
+ *
+ * Applies only to repos something GUESSED. A `hugging_face_id` the publisher
+ * declared on their own model needs no name check — the publisher is the
+ * authority on which repo is theirs, and their naming is occasionally
+ * unguessable (`z-ai/glm-4.6` -> `zai-org/GLM-4.6`).
+ */
+export const proposedRepoMatchesModel = (
+  permaslug: string,
+  repo: string
+): boolean =>
+  weightsRepoNameOverlap(permaslug, repo) >= WEIGHTS_REPO_MATCH_THRESHOLD

--- a/common/src/perps/weights-repo-match.ts
+++ b/common/src/perps/weights-repo-match.ts
@@ -93,9 +93,34 @@ export const weightsRepoNameOverlap = (
  * `DeepSeek-V4-Pro-0813` scores 1.0; `nemotron-3.5-lightning-20260807` ->
  * `NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16` scores 1.0) while rejecting the
  * near-miss that motivates the guard (`solar-pro4` -> `Solar-Open2-250B`
- * scores 0.33).
+ * scores 0.50, `grok-4.6` -> `grok-1` scores 0.50).
  */
 export const WEIGHTS_REPO_MATCH_THRESHOLD = 0.6
+
+/**
+ * Minimum number of distinctive tokens the MODEL name must contribute before a
+ * ratio over it means anything.
+ *
+ * A ratio alone is not enough, because the denominator can be 1. Bare integers
+ * are dropped as noise (see identifierTokens), so `x-ai/grok-5-20260901`
+ * reduces to exactly `["grok"]` — and then ANY repo containing "grok" scores a
+ * perfect 1.00. `xai-org/grok-1` is real, public, and full of weight files, so
+ * it clears verification too, and a closed frontier model would land on the
+ * open side of an executable index with both guards satisfied.
+ *
+ * This is not a hypothetical shape: 10 of the 243 audited seed permaslugs
+ * reduce to one token, including `openai/gpt-5-2025-08-07`,
+ * `x-ai/grok-4-07-09`, and `z-ai/glm-5-20260211` — the highest-traffic closed
+ * models on the index, and precisely the family names a successor release
+ * would reuse. Those specific slugs are safe today only because the seed list
+ * already classifies them and overrides on seeded models are refused; the
+ * exposure is the NEXT one, which is what this agent exists to catch.
+ *
+ * Two tokens is the smallest bar that makes the ratio load-bearing: a
+ * single-token model can no longer be matched by family name alone, and every
+ * real pair observed so far contributes three or more.
+ */
+export const MIN_DISTINCTIVE_MODEL_TOKENS = 2
 
 /**
  * Whether a proposed repo may back an `open` verdict for this model.
@@ -104,9 +129,16 @@ export const WEIGHTS_REPO_MATCH_THRESHOLD = 0.6
  * declared on their own model needs no name check — the publisher is the
  * authority on which repo is theirs, and their naming is occasionally
  * unguessable (`z-ai/glm-4.6` -> `zai-org/GLM-4.6`).
+ *
+ * Returns false when the model name is too generic to discriminate at all.
+ * That is a refusal to auto-apply, not a verdict of closed: the model stays
+ * pending and a human adjudicates it from the review queue, which costs a
+ * bounded sub-point of index error under the grace window rather than an
+ * unbounded one from a false positive.
  */
 export const proposedRepoMatchesModel = (
   permaslug: string,
   repo: string
 ): boolean =>
+  identifierTokens(permaslug).length >= MIN_DISTINCTIVE_MODEL_TOKENS &&
   weightsRepoNameOverlap(permaslug, repo) >= WEIGHTS_REPO_MATCH_THRESHOLD

--- a/common/src/perps/weights-repo-match.ts
+++ b/common/src/perps/weights-repo-match.ts
@@ -42,13 +42,22 @@ const NOISE_TOKENS = new Set([
 
 /**
  * Split an identifier into comparable tokens: lowercase, punctuation to
- * spaces, digits split from letters so `v4pro` and `v4-pro` agree, noise and
- * bare-number tokens dropped.
+ * spaces, a break inserted after a letter-then-digit run so `v4pro` and
+ * `v4-pro` agree, noise and bare-number tokens dropped.
  *
  * Bare numbers go because dated permaslugs (`-20260813`) and repo date
  * suffixes (`-0813`) rarely agree on format, and a shared `2` or `70` says
  * nothing about identity. Version numbers survive attached to their letter
  * (`v4`, `k2`), which is where they actually discriminate.
+ *
+ * Digit-then-letter is deliberately NOT split, and that is load-bearing rather
+ * than incidental. Splitting it turned every parameter count into the bare
+ * number (dropped as noise) plus a lone unit letter, so `480b` and `30b` both
+ * reduced to `b` — and two different-sized members of one family became
+ * token-identical. `qwen3-coder-480b-a35b` then scored a PERFECT 1.00 against
+ * `Qwen3-Coder-30B-A3B`, a real, public, weight-bearing repo for a different
+ * model. Size is often the only thing distinguishing siblings, so it has to
+ * survive tokenization: `480b` and `30b` stay whole and no longer match.
  */
 export const identifierTokens = (identifier: string): string[] => {
   const withoutOrg = identifier.includes('/')
@@ -57,7 +66,6 @@ export const identifierTokens = (identifier: string): string[] => {
   return withoutOrg
     .toLowerCase()
     .replace(/([a-z])(\d)/g, '$1$2 ')
-    .replace(/(\d)([a-z])/g, '$1 $2')
     .split(/[^a-z0-9.]+/)
     .map((token) => token.replace(/^[.]+|[.]+$/g, ''))
     .filter(
@@ -87,15 +95,31 @@ export const weightsRepoNameOverlap = (
 }
 
 /**
- * Minimum overlap for a PROPOSED repo to be accepted.
+ * Minimum overlap for a PROPOSED repo to be accepted: FULL coverage. Every
+ * distinctive token in the model's name must appear in the repo's.
  *
- * 0.6 clears the real pairs seen so far (`deepseek-v4-pro-20260813` ->
- * `DeepSeek-V4-Pro-0813` scores 1.0; `nemotron-3.5-lightning-20260807` ->
- * `NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16` scores 1.0) while rejecting the
- * near-miss that motivates the guard (`solar-pro4` -> `Solar-Open2-250B`
- * scores 0.50, `grok-4.6` -> `grok-1` scores 0.50).
+ * A partial threshold cannot separate a sibling from a match, because it is
+ * exactly the missing token that names the difference. At 0.6, every one of
+ * these cleared the bar against a real, public, weight-bearing repo for a
+ * DIFFERENT model:
+ *
+ *   deepseek-v4-pro       -> DeepSeek-V4-Flash-0731        0.67
+ *   deepseek-v4-flash     -> DeepSeek-V4-Pro-0813          0.67
+ *   nemotron-3.5-lightning-> NVIDIA-Nemotron-3.5-Ultra     0.67
+ *   qwen3-coder-480b-a35b -> Qwen3-Coder-30B-A3B-Instruct  0.60
+ *
+ * The shared tokens carry the family; the dropped one carries the identity.
+ * `pro` vs `flash` IS the model. Live HuggingFace verification cannot catch
+ * any of these, because the repo it re-fetches is genuinely public and
+ * genuinely full of weights — it is simply the wrong model's.
+ *
+ * Full coverage costs nothing on real data: every correct pair observed scores
+ * exactly 1.00, because a weights repo names its model and then ADDS to it.
+ * The asymmetry that makes extra repo tokens free (size, precision, an
+ * instruct/base split) is what lets a strict bar stay strict without
+ * rejecting correct repos.
  */
-export const WEIGHTS_REPO_MATCH_THRESHOLD = 0.6
+export const WEIGHTS_REPO_MATCH_THRESHOLD = 1
 
 /**
  * Minimum number of distinctive tokens the MODEL name must contribute before a

--- a/common/src/perps/weights-repo-match.ts
+++ b/common/src/perps/weights-repo-match.ts
@@ -147,18 +147,24 @@ export const WEIGHTS_REPO_MATCH_THRESHOLD = 1
 export const MIN_DISTINCTIVE_MODEL_TOKENS = 2
 
 /**
- * Whether a proposed repo may back an `open` verdict for this model.
+ * Whether a proposed repo is worth SHOWING an operator as this model's weights.
+ *
+ * Read the verb carefully: this gates a recommendation, not a classification.
+ * Nothing downstream auto-applies an agent-proposed repo — that decision needs
+ * a human, because verification plus a name match still cannot establish that
+ * a repo IS this model's, and this guard has been wrong twice on repos that
+ * verified cleanly. Its job is to keep obvious mismatches out of the review
+ * queue so the queue stays quick to work through; the index's correctness does
+ * not rest on it.
  *
  * Applies only to repos something GUESSED. A `hugging_face_id` the publisher
- * declared on their own model needs no name check — the publisher is the
- * authority on which repo is theirs, and their naming is occasionally
+ * declared on their own model needs no name check and IS auto-applied on
+ * verification — the publisher is the authority on which repo is theirs, so
+ * there is no identity inference to get wrong, and their naming is occasionally
  * unguessable (`z-ai/glm-4.6` -> `zai-org/GLM-4.6`).
  *
- * Returns false when the model name is too generic to discriminate at all.
- * That is a refusal to auto-apply, not a verdict of closed: the model stays
- * pending and a human adjudicates it from the review queue, which costs a
- * bounded sub-point of index error under the grace window rather than an
- * unbounded one from a false positive.
+ * Returns false when the model name is too generic to discriminate at all,
+ * which surfaces as "could not determine" rather than a verdict of closed.
  */
 export const proposedRepoMatchesModel = (
   permaslug: string,

--- a/web/pages/admin/model-classifications.tsx
+++ b/web/pages/admin/model-classifications.tsx
@@ -138,6 +138,7 @@ function PendingRow(props: {
     graceExpired: boolean
     agentRecommendation: string | null
     agentReasoning: string | null
+    agentSearches: { tool: string; input: string | null; result: string }[]
   }
   onDone: () => void
 }) {
@@ -215,6 +216,44 @@ function PendingRow(props: {
           <div className="text-ink-600 whitespace-pre-wrap">
             {model.agentReasoning}
           </div>
+
+          {/* The searches themselves, not just the summary of them. This is
+              the only checkable thing about a closed verdict — a global search
+              returning nothing is the evidence; the prose describing it is
+              not. Collapsed so the queue stays skimmable. */}
+          {model.agentSearches.length > 0 ? (
+            <details className="mt-1">
+              <summary className="text-ink-500 cursor-pointer select-none">
+                {model.agentSearches.length} search
+                {model.agentSearches.length === 1 ? '' : 'es'} it ran — check
+                these, not the summary
+              </summary>
+              <Col className="mt-1 gap-2">
+                {model.agentSearches.map((search, i) => (
+                  <Col
+                    key={i}
+                    className="border-ink-200 gap-0.5 border-l-2 pl-2"
+                  >
+                    <div className="text-ink-700 font-mono">
+                      {search.tool}
+                      {search.input && (
+                        <span className="text-ink-500"> {search.input}</span>
+                      )}
+                    </div>
+                    <div className="text-ink-600 whitespace-pre-wrap font-mono">
+                      {search.result || '(no output recorded)'}
+                    </div>
+                  </Col>
+                ))}
+              </Col>
+            </details>
+          ) : (
+            <div className="text-scarlet-600">
+              No searches recorded — this verdict rests on nothing checkable.
+              Treat it as unresearched.
+            </div>
+          )}
+
           <div className="text-ink-400">
             A recommendation, not a classification — nothing was applied. Only
             an open verdict can be machine-checked, so this one is yours.

--- a/web/pages/admin/model-classifications.tsx
+++ b/web/pages/admin/model-classifications.tsx
@@ -136,6 +136,8 @@ function PendingRow(props: {
     ageMs: number
     rankedAgeMs: number | null
     graceExpired: boolean
+    agentRecommendation: string | null
+    agentReasoning: string | null
   }
   onDone: () => void
 }) {
@@ -199,6 +201,26 @@ function PendingRow(props: {
           {model.discoveredVia ?? 'unknown'}
         </span>
       </Row>
+
+      {model.agentReasoning && (
+        <Col className="bg-canvas-50 gap-1 rounded p-2 text-xs">
+          <div className="text-ink-700 font-semibold">
+            Research says:{' '}
+            {model.agentRecommendation === 'closed' ? (
+              <span className="text-ink-900">closed — API only</span>
+            ) : (
+              <span className="text-ink-500">could not determine</span>
+            )}
+          </div>
+          <div className="text-ink-600 whitespace-pre-wrap">
+            {model.agentReasoning}
+          </div>
+          <div className="text-ink-400">
+            A recommendation, not a classification — nothing was applied. Only
+            an open verdict can be machine-checked, so this one is yours.
+          </div>
+        </Col>
+      )}
 
       <Row className="flex-wrap items-center gap-2">
         <Input

--- a/web/pages/admin/model-classifications.tsx
+++ b/web/pages/admin/model-classifications.tsx
@@ -139,6 +139,8 @@ function PendingRow(props: {
     agentRecommendation: string | null
     agentReasoning: string | null
     agentSearches: { tool: string; input: string | null; result: string }[]
+    agentProposedWeights: string | null
+    agentWeightFileCount: number | null
   }
   onDone: () => void
 }) {
@@ -147,7 +149,9 @@ function PendingRow(props: {
   // starting point, not evidence: the publisher field is routinely absent for
   // models whose weights are public, and present for repos that hold only a
   // tokenizer. Confirm it resolves and carries weight files before saving.
-  const [weights, setWeights] = useState(model.huggingFaceId ?? '')
+  const [weights, setWeights] = useState(
+    model.agentProposedWeights ?? model.huggingFaceId ?? ''
+  )
   const [saving, setSaving] = useState(false)
 
   const classify = async (open: boolean) => {
@@ -209,6 +213,23 @@ function PendingRow(props: {
             Research says:{' '}
             {model.agentRecommendation === 'closed' ? (
               <span className="text-ink-900">closed — API only</span>
+            ) : model.agentRecommendation === 'open' ? (
+              <span className="text-teal-600">
+                open — weights found
+                {model.agentProposedWeights && (
+                  <span className="text-ink-700 font-mono">
+                    {' '}
+                    {model.agentProposedWeights}
+                  </span>
+                )}
+                {model.agentWeightFileCount !== null && (
+                  <span className="text-ink-500">
+                    {' '}
+                    ({model.agentWeightFileCount} weight files, re-verified
+                    against the live API)
+                  </span>
+                )}
+              </span>
             ) : (
               <span className="text-ink-500">could not determine</span>
             )}
@@ -255,8 +276,11 @@ function PendingRow(props: {
           )}
 
           <div className="text-ink-400">
-            A recommendation, not a classification — nothing was applied. Only
-            an open verdict can be machine-checked, so this one is yours.
+            A recommendation, not a classification — nothing was applied. That
+            includes an open verdict: verification proves the repo is public and
+            carries weights, and the name check proves it looks like this model,
+            but neither proves it IS this model. A sibling in the same family
+            passes both. Check the repo, then click.
           </div>
         </Col>
       )}


### PR DESCRIPTION
**Stacked on #3993** — base is that branch, so this diff shows only the agent. Merge #3993 first.

## What this covers

#3993's watcher settles a model when the publisher declared a HuggingFace repo: fetch it, confirm weight files, done. The half that keeps freezing the feed is the other one — models with **no declared repo**, where deciding means actually searching.

| Freeze | Declared `hugging_face_id`? | Settled by |
|---|---|---|
| `nvidia/nemotron-3.5-lightning` | yes | #3993, no human |
| `deepseek/deepseek-v4-pro-0813` | yes | #3993, no human |
| `meta/muse-spark-1.1` | **no** | this PR |
| `upstage/solar-pro4` | **no** | this PR |
| `x-ai/grok-4.6` | **no** | this PR |

## Why it's tool-driven, not knowledge-driven

These models postdate any model's training data — Grok 4.6 and Solar Pro 4 were released days before they entered the index. Asking a model whether they're open-weights would be asking it to guess. So the agent gets the tools a human would use (HF search, org listing, repo fetch) and is graded on evidence it produced in-session.

## Nothing it concludes is applied automatically

Every verdict — **including `open`** — lands as a recommendation on a still-pending row. A human confirms it from the admin queue.

That is the considered position, not the cautious default. An `open` verdict looks machine-checkable: the cited repo is re-fetched from the live API and must carry public weight files, and its name must fully match the model's. Both checks are real and both run. But they establish that *a public, weight-bearing repo exists under a matching name* — not that it is **this model's**. Identity is not a string comparison.

Review found two false positives that passed verification cleanly:

| Model | Proposed repo | Why it passed | Real? |
|---|---|---|---|
| `grok-5-20260901` | `xai-org/grok-1` | normalization left only `grok`, scoring 1.00 | real, public, weight-bearing |
| `qwen3-coder-480b-a35b` | `Qwen3-Coder-30B-A3B` | sizes tokenized to a bare `b`, scoring 1.00 | real, public, weight-bearing |
| `deepseek-v4-pro` | `DeepSeek-V4-Flash-0731` | 0.67 cleared a 0.6 bar | real, public, weight-bearing |

Both guard bugs are now fixed (sizes survive tokenization; full token coverage required). But each fix closed the case we found by going looking. **Requiring a human closes the class**, and given the ranked-only gate below the queue is a handful of models a week — one click each.

What still auto-applies is #3993's deterministic path and only that: an `open` from a **publisher-declared** repo, verified to carry weight files. No identity inference is involved — the publisher is the authority on which repo is theirs, and we only verify their claim. Measured against the 243 audited seed entries, a present `hugging_face_id` agrees with the audit on 96 of 99 open models, and all three disagreements are declared-but-empty repos that verification rejects anyway.

`PERPS_AUTOCLASSIFY_CLOSED` is removed. It let the *least* checkable verdict be applied automatically while the more checkable one requires a human — an inversion that could not survive this change.

## Keeping the click a click

The recommendation is only worth having if acting on it is quick, so the row carries everything the operator needs: the proposed repo (prefilled into the weights input), the live weight-file count, and **every tool call the verdict rests on**, rendered per-call. A recommendation with no searches behind it renders as an explicit warning rather than looking clean — and a `closed` verdict submitted without running any searches is downgraded to `unresolved`, because a closed call with nothing behind it is the model answering from memory about a model released after its training data ended.

## Cost

Three things bound it:

- **Research follows ranking, not the catalog.** The index is defined over the top 50, so a model that never ranks cannot move it. `first_ranked_at` records exactly who started mattering — ~130 catalog candidates collapse to a handful, and the one-off backlog pass never runs at all.
- **A cooldown derived from the grace window** (a quarter of it), so the two cannot drift apart. Only ranked models are researched, so every model under cooldown has a grace clock running: a cooldown longer than that window would let one unreachable-API call guarantee a halt. Transient failures record their evidence without starting the clock at all.
- **`claude-haiku-4-5`** (overridable via `PERPS_CLASSIFIER_MODEL`). Since nothing it concludes reaches the index without a human, the tier cannot buy or lose correctness — a weaker model produces a worse shortlist, not a wrong classification.

Plus a hard 10-model ceiling per sweep, logged at ERROR when hit, so an upstream shape change or a HuggingFace outage cannot become an unbounded bill.

Expected steady state: **~$0.01–0.02/day.** The first sweep researches nothing at all, because nothing has ranked yet.

(No prompt caching: Haiku 4.5's minimum cacheable prefix is 4096 tokens and this system prompt plus tools is ~1.5k, so a breakpoint would silently never engage.)

## Model and SDK notes

Uses a **manual tool loop** rather than the SDK tool runner — the installed `@anthropic-ai/sdk` is 0.60.0, which predates that helper.

It also deliberately does **not** go through the shared `promptClaude` helper: that helper hardcodes `temperature: 0`, and the Opus/Sonnet 5 generation rejects sampling parameters with a 400. Worth knowing independently of this PR — any other call site pointing `promptClaude` at a 5-series model will fail the same way.

## Verification

- `common`: **458/458** across 29 suites, including 12 guard tests — the real pairs, the Solar-Open2 trap, same-org-wrong-family, the four sibling cases, single-token collapse, size-token preservation, degenerate identifiers
- `tsc -b` clean on `common`, `backend/shared`, `backend/scheduler`, `backend/api`; `web` clean
