### PR TITLE
Clarify invalid open-weight window dates

### DIFF
--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -189,6 +189,16 @@ describe('publication validation', () => {
     if (!otherValidation.ok)
       expect(otherValidation.reason).toContain('no excluded `other`')
   })
+
+  it('reports an invalid window date separately from a date gap', () => {
+    const result = computeOpenWeightShare(completeWindow())
+    result.dates[3] = 'not-a-date'
+
+    expect(validateOpenWeightPublication(result)).toEqual({
+      ok: false,
+      reason: 'invalid window date: not-a-date',
+    })
+  })
 })
 
 describe('window dates', () => {

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -814,11 +814,16 @@ export const validateOpenWeightPublication = (
   for (let i = 1; i < result.dates.length; i++) {
     const previous = Date.parse(result.dates[i - 1])
     const current = Date.parse(result.dates[i])
-    if (
-      !Number.isFinite(previous) ||
-      !Number.isFinite(current) ||
-      current - previous !== DAY_MS
-    )
+    if (!Number.isFinite(previous) || !Number.isFinite(current)) {
+      const invalidDate = !Number.isFinite(previous)
+        ? result.dates[i - 1]
+        : result.dates[i]
+      return {
+        ok: false,
+        reason: `invalid window date: ${invalidDate}`,
+      }
+    }
+    if (current - previous !== DAY_MS)
       return {
         ok: false,
         reason: `non-consecutive window dates: ${result.dates.join(', ')}`,


### PR DESCRIPTION
Was reading the code and your error message was messed up: if something failed to parse (the `!Number.isFinite()` branch), the error message `non-consecutive window dates` was nonsensical lol 
https://github.com/manifoldmarkets/manifold/blob/acf6da0ea653431ddc48594fe6574ba41fda8295/common/src/perps/open-weight-models.ts#L815-L826
Fixed it and added a unit test.