### PR TITLE
fix(perps): retry the trump-approval feed instead of losing a whole day

### DIFF
--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -350,7 +350,9 @@ export function createJobs(jobSet: SchedulerJobSet) {
     ),
     createJob(
       'update-trump-approval',
-      '0 30 5 * * *', // 5:30am daily
+      // 5:30am Pacific, then hourly until the day's point is published. The
+      // end hour MUST stay in sync with TRUMP_APPROVAL_LAST_ATTEMPT_HOUR.
+      '0 30 5-23 * * *',
       updateTrumpApproval
     ),
     createJob(

--- a/backend/scheduler/src/jobs/update-trump-approval.ts
+++ b/backend/scheduler/src/jobs/update-trump-approval.ts
@@ -37,17 +37,26 @@ export const updateTrumpApproval = async () => {
   if (await hasTrumpApprovalPointForDay(pg, today)) return
 
   try {
-    await publishTrumpApprovalPoint(pg)
+    const result = await publishTrumpApprovalPoint(pg)
+    // A returned failure and a thrown one are the same event to a retry
+    // loop: nothing was published, and the day is only lost if no attempt
+    // remains. Classifying only thrown errors would let `no-polls` and
+    // `rejected` page every hour and would leave the final attempt of the
+    // day without its "no attempts left" signal.
+    if (result.status !== 'published') reportFailure(today, result.reason)
   } catch (err) {
-    // Feed staleness is already alerted on by update-perps and
-    // update-oracle-feeds, so a retryable attempt logs at WARN to keep from
-    // paging once an hour for the same outage. The final attempt of the day
-    // is the one that means the day is lost, so that one is an ERROR.
-    const hour = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ).hour()
-    const lastAttempt = hour >= TRUMP_APPROVAL_LAST_ATTEMPT_HOUR
-    const message = `[trump-approval] publish failed for ${today} — ${err}`
-    if (lastAttempt)
-      log.error(`${message}; no attempts left today, feed will go stale`)
-    else log.warn(`${message}; retrying next hour`)
+    reportFailure(today, `${err}`)
   }
+}
+
+// Feed staleness is already alerted on by update-perps and
+// update-oracle-feeds, so a retryable attempt logs at WARN to keep from
+// paging once an hour for the same outage. The final attempt of the day is
+// the one that means the day is lost, so that one is an ERROR.
+const reportFailure = (day: string, reason: string) => {
+  const hour = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ).hour()
+  const message = `[trump-approval] publish failed for ${day} — ${reason}`
+  if (hour >= TRUMP_APPROVAL_LAST_ATTEMPT_HOUR)
+    log.error(`${message}; no attempts left today, feed will go stale`)
+  else log.warn(`${message}; retrying next hour`)
 }

--- a/backend/scheduler/src/jobs/update-trump-approval.ts
+++ b/backend/scheduler/src/jobs/update-trump-approval.ts
@@ -4,73 +4,50 @@ import * as utc from 'dayjs/plugin/utc'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-import { TRUMP_APPROVAL_FEED_ID, insertOraclePrices } from 'shared/oracle'
-import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
-import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
-import { createSupabaseDirectClient } from 'shared/supabase/init'
 import {
-  computeRollingAverages,
-  fetchTrumpApprovalPolls,
-  TRUMP_APPROVAL_WINDOW_DAYS,
-} from 'shared/trump-approval'
+  hasTrumpApprovalPointForDay,
+  publishTrumpApprovalPoint,
+  trumpApprovalDay,
+  TRUMP_APPROVAL_TZ,
+} from 'shared/perps/publish-trump-approval'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { log } from 'shared/utils'
 
-// Fetch enough poll history to fully cover today's trailing window, plus a
-// safety buffer for long fielding periods (some polls span 2+ weeks).
-const FETCH_LOOKBACK_DAYS = TRUMP_APPROVAL_WINDOW_DAYS + 14
+// The last Pacific hour the job is scheduled to fire. MUST match the end of
+// the hour range in this job's cron expression in ./index.ts — it is how a
+// run knows whether another attempt is coming today, which decides whether a
+// failure is a blip to retry or a lost day worth paging on.
+export const TRUMP_APPROVAL_LAST_ATTEMPT_HOUR = 23
 
-// Writes one observation of today's rolling value, stamped when it becomes
-// available to the market. Corrections append another observation instead of
-// pretending the revised value was tradable from midnight or rewriting a
-// point that liquidations/funding may already have consumed.
+// Publishes one point per Pacific day for the `trump-approval-rating` feed.
+//
+// Scheduled hourly rather than once, because a single daily firing made the
+// feed only as reliable as VoteHub's worst minute of the day: on 2026-08-14
+// the 5:30am attempt got an HTTP 500, and with no retry the feed sat frozen
+// for over 26 hours, tripped its staleness alerts, and came within ~1.5h of
+// the market's maxOraclePriceAgeMs — which pauses the engine, and with it
+// liquidations and ADL, on a market carrying leveraged positions.
+//
+// The first attempt is still 5:30am Pacific, so the normal publication time
+// is unchanged; later firings only do work when the day has no point yet.
 export const updateTrumpApproval = async () => {
   const pg = createSupabaseDirectClient()
+  const today = trumpApprovalDay()
 
-  const now = dayjs.tz(dayjs(), 'America/Los_Angeles')
-  const fetchStart = now
-    .subtract(FETCH_LOOKBACK_DAYS, 'day')
-    .format('YYYY-MM-DD')
-  const today = now.format('YYYY-MM-DD')
+  if (await hasTrumpApprovalPointForDay(pg, today)) return
 
-  const polls = await fetchTrumpApprovalPolls(fetchStart)
-  const points = computeRollingAverages(polls, today, today)
-  if (points.length === 0) {
-    log.error(
-      `[trump-approval] no polls in trailing ${TRUMP_APPROVAL_WINDOW_DAYS}-day window; skipping publication`
-    )
-    return
+  try {
+    await publishTrumpApprovalPoint(pg)
+  } catch (err) {
+    // Feed staleness is already alerted on by update-perps and
+    // update-oracle-feeds, so a retryable attempt logs at WARN to keep from
+    // paging once an hour for the same outage. The final attempt of the day
+    // is the one that means the day is lost, so that one is an ERROR.
+    const hour = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ).hour()
+    const lastAttempt = hour >= TRUMP_APPROVAL_LAST_ATTEMPT_HOUR
+    const message = `[trump-approval] publish failed for ${today} — ${err}`
+    if (lastAttempt)
+      log.error(`${message}; no attempts left today, feed will go stale`)
+    else log.warn(`${message}; retrying next hour`)
   }
-
-  const [computedPoint] = points
-  const point = { ...computedPoint, ts: Date.now() }
-  const feed = getOracleFeed(TRUMP_APPROVAL_FEED_ID)
-  const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
-    `select ts, price from oracle_prices where feed_id = $1
-     order by ts desc limit 1`,
-    [TRUMP_APPROVAL_FEED_ID]
-  )
-  const rejection = feed
-    ? validateOraclePoint(
-        feed,
-        prev
-          ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
-          : null,
-        point
-      )
-    : `missing OracleFeedDef for ${TRUMP_APPROVAL_FEED_ID}`
-  if (rejection) {
-    log.error(
-      `[trump-approval] rejected ${point.price.toFixed(2)} — ${rejection}`
-    )
-    return
-  }
-
-  log(
-    `today's ${TRUMP_APPROVAL_WINDOW_DAYS}-day rolling Trump approval average: ${point.price.toFixed(
-      2
-    )} (${new Date(point.ts).toISOString()})`
-  )
-  await insertOraclePrices(pg, TRUMP_APPROVAL_FEED_ID, [point])
-  await applyOraclePointToLivePerps(pg, TRUMP_APPROVAL_FEED_ID, point)
-  log(`inserted 1 ${TRUMP_APPROVAL_FEED_ID} oracle point for ${today}`)
 }

--- a/backend/scripts/publish-trump-approval-now.ts
+++ b/backend/scripts/publish-trump-approval-now.ts
@@ -1,4 +1,8 @@
-import { publishTrumpApprovalPoint } from 'shared/perps/publish-trump-approval'
+import {
+  hasTrumpApprovalPointForDay,
+  publishTrumpApprovalPoint,
+  trumpApprovalDay,
+} from 'shared/perps/publish-trump-approval'
 import { log } from 'shared/utils'
 import { runScript } from './run-script'
 
@@ -8,22 +12,45 @@ import { runScript } from './run-script'
 // PERP engine, and with it liquidations and ADL.
 //
 // This runs exactly what the scheduled job runs: ONE point for today's
-// trailing window, stamped at Date.now(), applied to live markets. Two
-// consequences worth knowing before you run it:
+// trailing window, stamped at Date.now(), applied to live perps. So any
+// liquidations and ADL the new price implies happen immediately, as they
+// would on a normal publication.
 //
-//   - It APPLIES the point to live perps, so any liquidations and ADL that
-//     the new price implies happen immediately, as they would on a normal
-//     publication.
-//   - It does NOT backfill missed days. A value is stamped when it became
-//     available to the market and is never backdated into a window where
-//     funding and liquidations have already run. Use
-//     backfill-trump-approval-oracle only for a feed with no live market.
+// Refuses to run when the Pacific day already has a point, because the
+// scheduled job is hourly: without the guard, an operator running this while
+// the cron fires appends two points for one day and breaks the daily cadence
+// that the market's funding period is anchored to. Pass --force to append a
+// correction deliberately.
 //
-// Running it twice in a day appends a second observation rather than
-// replacing the first; that is legal but changes the feed's daily cadence,
-// so prefer letting the scheduled retries take over once upstream recovers.
+// It does NOT backfill missed days. A value is stamped when it became
+// available to the market and is never backdated into a window where funding
+// and liquidations have already run. backfill-trump-approval-oracle is for
+// feeds with no live market: it stamps every day at midnight PT while the
+// job stamps at publication time, so on a live feed it adds a second point
+// to every day rather than filling a hole.
+//
+// Exits nonzero unless a point was actually published — during an incident
+// the one thing an operator must not be told is that the escape hatch worked
+// when nothing landed.
 if (require.main === module)
   runScript(async ({ pg }) => {
+    const force = process.argv.includes('--force')
+    const today = trumpApprovalDay()
+
+    if (!force && (await hasTrumpApprovalPointForDay(pg, today)))
+      throw new Error(
+        `${today} already has a published point; pass --force to append another`
+      )
+
     const result = await publishTrumpApprovalPoint(pg)
-    log(`publish-trump-approval-now: ${JSON.stringify(result)}`)
+    if (result.status !== 'published')
+      throw new Error(
+        `nothing published for ${today} (${result.status}): ${result.reason}`
+      )
+
+    log(
+      `published ${result.price.toFixed(2)} for ${today} at ${new Date(
+        result.ts
+      ).toISOString()}`
+    )
   })

--- a/backend/scripts/publish-trump-approval-now.ts
+++ b/backend/scripts/publish-trump-approval-now.ts
@@ -1,0 +1,29 @@
+import { publishTrumpApprovalPoint } from 'shared/perps/publish-trump-approval'
+import { log } from 'shared/utils'
+import { runScript } from './run-script'
+
+// Manually publish today's `trump-approval-rating` point, for when the daily
+// job's retries have all failed (e.g. a multi-hour VoteHub outage) and the
+// feed is about to cross the market's maxOraclePriceAgeMs — which pauses the
+// PERP engine, and with it liquidations and ADL.
+//
+// This runs exactly what the scheduled job runs: ONE point for today's
+// trailing window, stamped at Date.now(), applied to live markets. Two
+// consequences worth knowing before you run it:
+//
+//   - It APPLIES the point to live perps, so any liquidations and ADL that
+//     the new price implies happen immediately, as they would on a normal
+//     publication.
+//   - It does NOT backfill missed days. A value is stamped when it became
+//     available to the market and is never backdated into a window where
+//     funding and liquidations have already run. Use
+//     backfill-trump-approval-oracle only for a feed with no live market.
+//
+// Running it twice in a day appends a second observation rather than
+// replacing the first; that is legal but changes the feed's daily cadence,
+// so prefer letting the scheduled retries take over once upstream recovers.
+if (require.main === module)
+  runScript(async ({ pg }) => {
+    const result = await publishTrumpApprovalPoint(pg)
+    log(`publish-trump-approval-now: ${JSON.stringify(result)}`)
+  })

--- a/backend/shared/src/perps/publish-trump-approval.ts
+++ b/backend/shared/src/perps/publish-trump-approval.ts
@@ -1,0 +1,122 @@
+import * as dayjs from 'dayjs'
+import * as timezone from 'dayjs/plugin/timezone'
+import * as utc from 'dayjs/plugin/utc'
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+import { TRUMP_APPROVAL_FEED_ID, insertOraclePrices } from 'shared/oracle'
+import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
+import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import {
+  computeRollingAverages,
+  fetchTrumpApprovalPolls,
+  TRUMP_APPROVAL_WINDOW_DAYS,
+} from 'shared/trump-approval'
+import { log } from 'shared/utils'
+
+// Fetch enough poll history to fully cover today's trailing window, plus a
+// safety buffer for long fielding periods (some polls span 2+ weeks).
+const FETCH_LOOKBACK_DAYS = TRUMP_APPROVAL_WINDOW_DAYS + 14
+
+export const TRUMP_APPROVAL_TZ = 'America/Los_Angeles'
+
+export const trumpApprovalDay = (now: number = Date.now()) =>
+  dayjs.tz(dayjs(now), TRUMP_APPROVAL_TZ).format('YYYY-MM-DD')
+
+/**
+ * Has a point already been published during the given Pacific calendar day?
+ *
+ * This is what makes the job idempotent across its retry window: the first
+ * run of the day that gets a usable response from VoteHub publishes, and
+ * every later run that day is a single indexed query and a return.
+ */
+export const hasTrumpApprovalPointForDay = async (
+  pg: SupabaseDirectClient,
+  day: string
+) => {
+  // Derive the end of the window from the NEXT calendar date rather than
+  // dayStart.add(1, 'day'): adding a day adds 24 UTC hours, which is off by
+  // an hour on both DST transition days and would either miss a published
+  // point or double-count one from the adjacent day.
+  const dayStart = dayjs.tz(day, TRUMP_APPROVAL_TZ)
+  const dayEnd = dayjs.tz(
+    dayjs.utc(day).add(1, 'day').format('YYYY-MM-DD'),
+    TRUMP_APPROVAL_TZ
+  )
+  const row = await pg.oneOrNone<{ published: boolean }>(
+    `select exists (
+       select 1 from oracle_prices
+       where feed_id = $1 and ts >= $2 and ts < $3
+     ) as published`,
+    [TRUMP_APPROVAL_FEED_ID, dayStart.toISOString(), dayEnd.toISOString()]
+  )
+  return row?.published === true
+}
+
+export type TrumpApprovalPublishResult =
+  | { status: 'published'; price: number; ts: number }
+  | { status: 'no-polls' }
+  | { status: 'rejected'; reason: string }
+
+/**
+ * Compute and publish ONE observation of today's rolling value, stamped when
+ * it becomes available to the market. Corrections append another observation
+ * instead of pretending the revised value was tradable from midnight or
+ * rewriting a point that liquidations/funding may already have consumed.
+ *
+ * Throws if the upstream fetch fails — callers decide whether that is a
+ * retryable blip or a lost day.
+ */
+export const publishTrumpApprovalPoint = async (
+  pg: SupabaseDirectClient
+): Promise<TrumpApprovalPublishResult> => {
+  const now = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ)
+  const fetchStart = now
+    .subtract(FETCH_LOOKBACK_DAYS, 'day')
+    .format('YYYY-MM-DD')
+  const today = now.format('YYYY-MM-DD')
+
+  const polls = await fetchTrumpApprovalPolls(fetchStart)
+  const points = computeRollingAverages(polls, today, today)
+  if (points.length === 0) {
+    log.error(
+      `[trump-approval] no polls in trailing ${TRUMP_APPROVAL_WINDOW_DAYS}-day window; skipping publication`
+    )
+    return { status: 'no-polls' }
+  }
+
+  const [computedPoint] = points
+  const point = { ...computedPoint, ts: Date.now() }
+  const feed = getOracleFeed(TRUMP_APPROVAL_FEED_ID)
+  const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
+    `select ts, price from oracle_prices where feed_id = $1
+     order by ts desc limit 1`,
+    [TRUMP_APPROVAL_FEED_ID]
+  )
+  const rejection = feed
+    ? validateOraclePoint(
+        feed,
+        prev
+          ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
+          : null,
+        point
+      )
+    : `missing OracleFeedDef for ${TRUMP_APPROVAL_FEED_ID}`
+  if (rejection) {
+    log.error(
+      `[trump-approval] rejected ${point.price.toFixed(2)} — ${rejection}`
+    )
+    return { status: 'rejected', reason: rejection }
+  }
+
+  log(
+    `today's ${TRUMP_APPROVAL_WINDOW_DAYS}-day rolling Trump approval average: ${point.price.toFixed(
+      2
+    )} (${new Date(point.ts).toISOString()})`
+  )
+  await insertOraclePrices(pg, TRUMP_APPROVAL_FEED_ID, [point])
+  await applyOraclePointToLivePerps(pg, TRUMP_APPROVAL_FEED_ID, point)
+  log(`inserted 1 ${TRUMP_APPROVAL_FEED_ID} oracle point for ${today}`)
+  return { status: 'published', price: point.price, ts: point.ts }
+}

--- a/backend/shared/src/perps/publish-trump-approval.ts
+++ b/backend/shared/src/perps/publish-trump-approval.ts
@@ -56,7 +56,7 @@ export const hasTrumpApprovalPointForDay = async (
 
 export type TrumpApprovalPublishResult =
   | { status: 'published'; price: number; ts: number }
-  | { status: 'no-polls' }
+  | { status: 'no-polls'; reason: string }
   | { status: 'rejected'; reason: string }
 
 /**
@@ -65,8 +65,11 @@ export type TrumpApprovalPublishResult =
  * instead of pretending the revised value was tradable from midnight or
  * rewriting a point that liquidations/funding may already have consumed.
  *
- * Throws if the upstream fetch fails — callers decide whether that is a
- * retryable blip or a lost day.
+ * Every unsuccessful outcome is REPORTED, never logged here: a thrown fetch
+ * error and a returned `no-polls` are the same kind of event to a caller
+ * that retries, and only the caller knows whether another attempt is coming.
+ * Logging failures at this level is what made an hourly retry loop page
+ * hourly for a single outage.
  */
 export const publishTrumpApprovalPoint = async (
   pg: SupabaseDirectClient
@@ -79,12 +82,11 @@ export const publishTrumpApprovalPoint = async (
 
   const polls = await fetchTrumpApprovalPolls(fetchStart)
   const points = computeRollingAverages(polls, today, today)
-  if (points.length === 0) {
-    log.error(
-      `[trump-approval] no polls in trailing ${TRUMP_APPROVAL_WINDOW_DAYS}-day window; skipping publication`
-    )
-    return { status: 'no-polls' }
-  }
+  if (points.length === 0)
+    return {
+      status: 'no-polls',
+      reason: `no polls in trailing ${TRUMP_APPROVAL_WINDOW_DAYS}-day window`,
+    }
 
   const [computedPoint] = points
   const point = { ...computedPoint, ts: Date.now() }
@@ -103,12 +105,11 @@ export const publishTrumpApprovalPoint = async (
         point
       )
     : `missing OracleFeedDef for ${TRUMP_APPROVAL_FEED_ID}`
-  if (rejection) {
-    log.error(
-      `[trump-approval] rejected ${point.price.toFixed(2)} — ${rejection}`
-    )
-    return { status: 'rejected', reason: rejection }
-  }
+  if (rejection)
+    return {
+      status: 'rejected',
+      reason: `computed ${point.price.toFixed(2)} but ${rejection}`,
+    }
 
   log(
     `today's ${TRUMP_APPROVAL_WINDOW_DAYS}-day rolling Trump approval average: ${point.price.toFixed(


### PR DESCRIPTION
## What happened

`update-trump-approval` fired once a day, so the feed was only as reliable as VoteHub's worst minute of the day. On 2026-08-14 the 5:30am attempt got an HTTP 500:

```
2026-08-14T12:30:00.281Z  ERROR  klt-scheduler-perps-fvsn
[update-trump-approval] Error during job execution.
Error: VoteHub request failed: 500 Internal Server Error
    at fetchTrumpApprovalPolls (backend/shared/lib/trump-approval.js:37:15)
```

With no retry, the next attempt was 24h later. Observed fallout in prod:

- Feed frozen at the 08-13 print (`39.7875`) for **40+ hours**.
- `[oracle-feeds]` and hourly `[update-perps]` staleness alerts firing from 16:00Z onward.
- Age crossed the contract's `maxOraclePriceAgeMs` (30h) at 08-14 18:30Z, so `getOracleFreshness` went non-`fresh` and [update-perps](backend/scheduler/src/jobs/update-perps.ts#L96-L100) **skipped the engine**.
- The 08-15 04:00Z funding event is **absent** — skipped entirely. Funding is charged per event rather than accrued, so that period's carry was never collected. Liquidations and ADL also stopped applying, on 74 open leveraged positions (21 long / 53 short).

The outage was upstream and total: every parameterized request to `polling.votehub.com/polls` returned 500 for hours, while bare `/polls` stayed 200. Nothing on our side could have made that particular call succeed — but a retry an hour later would have.

## The fix

Schedule hourly from 5:30am through 11:30pm Pacific (`0 30 5-23 * * *`) and make the job idempotent on the Pacific day. The first run that gets a usable response publishes; every later run that day is one indexed query and a return. The first attempt is still 5:30am, so the normal publication time is unchanged.

Failures log `WARN` while retries remain and `ERROR` only on the last attempt of the day — `update-perps` and `update-oracle-feeds` already alert on staleness, so an hourly `ERROR` would just re-page for a single outage.

The publish core moves to `shared/perps/publish-trump-approval` so the job and the new manual script share one code path. The day-bounds query derives its end from the next calendar date rather than `add(1, 'day')`, which adds 24 UTC hours and would be an hour off on both DST transition days.

## Manual escape hatch

`backend/scripts/publish-trump-approval-now.ts`, for when a multi-hour outage exhausts the day's retries. It publishes exactly what the cron does: one point for today's window, stamped `Date.now()`, applied to live perps.

It deliberately does **not** backfill missed days, and `backfill-trump-approval-oracle` is not the tool for a live feed — that script stamps every day at midnight PT while the daily job stamps at 12:30 UTC, and since `insertOraclePrices` dedupes on exact `(feed_id, ts)`, running it would add a second point to every day since 08-06 rather than filling the hole.

## What this does not change

One point per Pacific day. `updatePeriodMs: DAY_MS` drives the live contract's frozen `fundingPeriodMs` (86400000) and the slow-period oracle funding anchor, so moving to OpenRouter-style hourly appends — which would also remove the fixed, readable-off-a-clock publication time — is a deliberate cadence change, not something to fold into an outage fix.

## Testing

- `tsc -b` clean for `backend/shared` and `backend/scheduler`.
- `backend/scripts` reports 191 errors, all pre-existing breakage in unrelated legacy scripts (`writeAsync`, `common/love/*`); none in the files touched here.
- Neither `backend/shared` nor `backend/scheduler` has test infrastructure, so the new path has no unit tests.

## Deploy note

Deploying unsticks the current incident on its own: Pacific day 08-14 still has no point, so the first firing after deploy publishes immediately. Needs a `scheduler-perps` deploy.