### PR TITLE
Quiet bot comments: notification level + comment-section filter

### DIFF
--- a/backend/api/src/create-comment.ts
+++ b/backend/api/src/create-comment.ts
@@ -129,6 +129,7 @@ export const createCommentOnContractInternal = async (
     ...denormalizeBet(bet, contract),
 
     isApi,
+    ...(creator.isBot ? { isBot: true } : {}),
     isRepost,
   } as ContractComment)
   await pg

--- a/backend/api/src/get-comment-threads.ts
+++ b/backend/api/src/get-comment-threads.ts
@@ -8,12 +8,13 @@ import { type APIHandler } from './helpers/endpoint'
 export const getContractCommentThreads: APIHandler<'comment-threads'> = async (
   props
 ) => {
-  const { contractId, limit, page } = props
+  const { contractId, limit, page, excludeBots } = props
   const pg = createSupabaseDirectClient()
   return await getCommentThreads(pg, {
     contractId,
     limit: limit ?? 50,
     page: page ?? 0,
+    excludeBots,
   })
 }
 

--- a/backend/shared/src/notifications/create-new-contract-comment-notif.ts
+++ b/backend/shared/src/notifications/create-new-contract-comment-notif.ts
@@ -15,6 +15,7 @@ import {
   EmailAndTemplateEntry,
 } from '../emails'
 import {
+  botNotificationAllowed,
   getNotificationDestinationsForUser,
   notification_destination_types,
   userIsBlocked,
@@ -136,6 +137,7 @@ export const createCommentOnContractNotification = async (
       !privateUser ||
       sourceUser.id == userId ||
       userIsBlocked(privateUser, sourceUser.id) ||
+      (sourceUser.isBot && !botNotificationAllowed(privateUser, reason)) ||
       (!followerIds.some((id) => id === userId) &&
         !needNotFollowContractReasons.includes(reason))
     )
@@ -401,6 +403,9 @@ export const createCommentOnPostNotification = async (
   for (const { userId, reason } of uniqueUsersToNotify) {
     const privateUser = privateUserMap.get(userId)
     if (!privateUser || userIsBlocked(privateUser, commentCreator.id)) {
+      continue
+    }
+    if (commentCreator.isBot && !botNotificationAllowed(privateUser, reason)) {
       continue
     }
 

--- a/backend/shared/src/supabase/contract-comments.ts
+++ b/backend/shared/src/supabase/contract-comments.ts
@@ -33,17 +33,24 @@ export async function getCommentThreads(
     contractId: string
     limit: number
     page: number
+    excludeBots?: boolean
   }
 ) {
-  const { contractId, limit, page } = filters
+  const { contractId, limit, page, excludeBots } = filters
 
+  // users.is_bot rather than the comment's denormalized isBot: it stays right
+  // for comments written before an account was flagged as a bot. A bot's
+  // top-level comment takes its replies with it — the thread has no root to
+  // hang them off once it's gone.
   const allComments = await pg.map(
     `
     with parent_comments as (
       select cc.data, cc.likes, cc.comment_id from contract_comments cc
+      join users u on u.id = cc.user_id
       where cc.contract_id = $1
       and (cc.data->>'replyToCommentId' is null)
       and (cc.data->>'deleted' is null or cc.data->>'deleted' = 'false')
+      and ($4::boolean is not true or not u.is_bot)
       order by cc.created_time desc
       limit $2
       offset $3
@@ -51,11 +58,13 @@ export async function getCommentThreads(
     select * from parent_comments
     union all
     select cc.data, cc.likes, cc.comment_id from contract_comments cc
+    join users u on u.id = cc.user_id
     where cc.contract_id = $1
     and (cc.data->>'replyToCommentId' in (select comment_id from parent_comments))
     and (cc.data->>'deleted' is null or cc.data->>'deleted' = 'false')
+    and ($4::boolean is not true or not u.is_bot)
     `,
-    [contractId, limit, page * limit],
+    [contractId, limit, page * limit, excludeBots ?? false],
     convertContractComment
   )
 

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1502,6 +1502,10 @@ export const API = (_apiTypeCheck = {
         contractId: z.string(),
         limit: z.coerce.number().gte(0).lte(100).default(10),
         page: z.coerce.number().gte(0).default(0),
+        // Drops comments by users flagged `isBot`, including whole threads
+        // rooted at one. Filtered server-side because pagination counts rows
+        // before the filter, so client-side dropping leaves ragged pages.
+        excludeBots: z.coerce.boolean().optional(),
       })
       .strict(),
     cache: DEFAULT_CACHE_STRATEGY,
@@ -1593,6 +1597,9 @@ export const API = (_apiTypeCheck = {
         paymentInfo: z.string().optional(),
         lastAppReviewTime: z.number().optional(),
         optOutAppReviewPrompts: z.boolean().optional(),
+        botNotificationLevel: z
+          .enum(['never', 'mentions', 'always'])
+          .optional(),
       })
       .strict(),
   },

--- a/common/src/comment.ts
+++ b/common/src/comment.ts
@@ -36,6 +36,11 @@ export type Comment<T extends AnyCommentType = AnyCommentType> = {
   visibility: Visibility
   editedTime?: number
   isApi?: boolean
+  // Author was flagged `isBot` when they posted. Denormalized so comments
+  // arriving over the websocket or in static props can be filtered client-side
+  // without a second lookup; the server-side filter reads users.is_bot, which
+  // stays correct when someone is flagged a bot after the fact.
+  isBot?: boolean
 } & T
 
 export type OnContract = {

--- a/common/src/user-notification-preferences.test.ts
+++ b/common/src/user-notification-preferences.test.ts
@@ -1,0 +1,69 @@
+import { PrivateUser } from './user'
+import {
+  bot_notification_level,
+  botNotificationAllowed,
+  DEFAULT_BOT_NOTIFICATION_LEVEL,
+  getDefaultNotificationPreferences,
+} from './user-notification-preferences'
+
+const privateUserWith = (level?: bot_notification_level) =>
+  ({
+    id: 'u1',
+    notificationPreferences: getDefaultNotificationPreferences(),
+    blockedUserIds: [],
+    blockedByUserIds: [],
+    blockedContractIds: [],
+    blockedGroupSlugs: [],
+    ...(level ? { botNotificationLevel: level } : {}),
+  } as PrivateUser)
+
+// Reasons a bot can generate on a comment, split by whether the bot was
+// addressing this user or just commenting where they happened to be attached.
+const DIRECT = [
+  'tagged_user',
+  'reply_to_users_comment',
+  'reply_to_users_answer',
+] as const
+const AMBIENT = [
+  'all_comments_on_my_markets',
+  'comment_on_contract_with_users_shares_in',
+  'comment_on_contract_you_follow',
+  'all_comments_on_followed_posts',
+] as const
+
+describe('botNotificationAllowed', () => {
+  it('defaults to mentions when the user has never set a level', () => {
+    const user = privateUserWith()
+    expect(DEFAULT_BOT_NOTIFICATION_LEVEL).toEqual('mentions')
+    for (const reason of DIRECT) {
+      expect(botNotificationAllowed(user, reason)).toBe(true)
+    }
+    for (const reason of AMBIENT) {
+      expect(botNotificationAllowed(user, reason)).toBe(false)
+    }
+  })
+
+  it("lets nothing through at 'never'", () => {
+    const user = privateUserWith('never')
+    for (const reason of [...DIRECT, ...AMBIENT]) {
+      expect(botNotificationAllowed(user, reason)).toBe(false)
+    }
+  })
+
+  it("lets everything through at 'always'", () => {
+    const user = privateUserWith('always')
+    for (const reason of [...DIRECT, ...AMBIENT]) {
+      expect(botNotificationAllowed(user, reason)).toBe(true)
+    }
+  })
+
+  it("passes direct interactions but not the firehose at 'mentions'", () => {
+    const user = privateUserWith('mentions')
+    for (const reason of DIRECT) {
+      expect(botNotificationAllowed(user, reason)).toBe(true)
+    }
+    for (const reason of AMBIENT) {
+      expect(botNotificationAllowed(user, reason)).toBe(false)
+    }
+  })
+})

--- a/common/src/user-notification-preferences.ts
+++ b/common/src/user-notification-preferences.ts
@@ -5,6 +5,41 @@ import { DOMAIN } from './envs/constants'
 import { PrivateUser } from './user'
 
 export type notification_destination_types = 'email' | 'browser' | 'mobile'
+
+// How much users flagged `isBot` are allowed to notify you. This is a scalar
+// rather than another notification_preferences key because it cuts across
+// every comment reason instead of being one of them: a bot reply to your
+// comment and a bot comment on a market you follow differ in whether you
+// asked for them, not in which preference row they belong to.
+export type bot_notification_level = 'never' | 'mentions' | 'always'
+
+// 'mentions' rather than 'never': bots that reply to you are usually bots you
+// invoked (a randomness draw, a question you asked), and dropping those
+// notifications makes the bot look broken. The firehose — every bot comment on
+// a market you follow or hold shares in — is what's worth muting by default.
+export const DEFAULT_BOT_NOTIFICATION_LEVEL: bot_notification_level = 'mentions'
+
+// Reasons that mean the bot was addressing this user specifically, rather than
+// the user happening to be attached to the market it commented on.
+const DIRECT_BOT_INTERACTION_REASONS: NotificationReason[] = [
+  'tagged_user',
+  'reply_to_users_comment',
+  'reply_to_users_answer',
+]
+
+/** Whether a comment authored by a bot may notify this user at all. Applied on
+ * top of the usual per-reason destination settings, never instead of them. */
+export const botNotificationAllowed = (
+  privateUser: PrivateUser,
+  reason: NotificationReason
+) => {
+  const level =
+    privateUser.botNotificationLevel ?? DEFAULT_BOT_NOTIFICATION_LEVEL
+  if (level === 'always') return true
+  if (level === 'never') return false
+  return DIRECT_BOT_INTERACTION_REASONS.includes(reason)
+}
+
 export type notification_preference = keyof notification_preferences
 export type notification_preferences = {
   // Watched Markets

--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -1,5 +1,8 @@
 import { ENV_CONFIG } from './envs/constants'
-import { notification_preferences } from './user-notification-preferences'
+import {
+  bot_notification_level,
+  notification_preferences,
+} from './user-notification-preferences'
 import { UserEntitlement } from './shop/types'
 import { DAY_MS, HOUR_MS } from './util/time'
 import {
@@ -186,6 +189,10 @@ export type PrivateUser = {
   initialIpAddress?: string
   apiKey?: string
   notificationPreferences: notification_preferences
+  // How much a user flagged `isBot` is allowed to notify this user. Undefined
+  // reads as DEFAULT_BOT_NOTIFICATION_LEVEL rather than 'always' — see
+  // botNotificationAllowed in common/user-notification-preferences.
+  botNotificationLevel?: bot_notification_level
   twitchInfo?: {
     twitchName: string
     controlToken: string

--- a/web/components/contract/comments-tab-content.tsx
+++ b/web/components/contract/comments-tab-content.tsx
@@ -60,10 +60,16 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
   } = props
   const user = useUser()
 
+  const [hideBotComments, setHideBotComments] = usePersistentInMemoryState(
+    false,
+    `hide-bot-comments-${staticContract.id}`
+  )
+
   const { threads, loadMore, loading, page } = useCommentThreads(
     staticContract.id,
     10,
-    !!highlightCommentId
+    !!highlightCommentId,
+    hideBotComments
   )
   const [highlightedThreads, setHighlightedThreads] = useState<
     { parent: ContractComment; replies: ContractComment[] }[]
@@ -122,6 +128,22 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
       'id'
     )
   }, [newComments, staticComments, threads, highlightedThreads, page])
+
+  // The API already drops bot comments from paginated pages; this catches the
+  // ones it never saw — static props rendered before the toggle was flipped,
+  // and comments arriving live over the websocket. A deep link wins over the
+  // filter: landing on a blank page after following a permalink to a bot
+  // comment is worse than being shown the comment you asked for.
+  const shownComments = useMemo(() => {
+    if (!hideBotComments) return allComments
+    const highlightedIds = new Set(
+      highlightedThreads.flatMap((t) => [
+        t.parent.id,
+        ...t.replies.map((r) => r.id),
+      ])
+    )
+    return allComments.filter((c) => !c.isBot || highlightedIds.has(c.id))
+  }, [allComments, hideBotComments, highlightedThreads])
 
   const commentExistsLocally = useMemo(
     () => allComments.some((c) => c.id === highlightCommentId),
@@ -201,7 +223,7 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
   // replied to answers/comments are NOT newest, otherwise newest first
   const isReply = (c: ContractComment) => c.replyToCommentId !== undefined
 
-  const strictlySortedComments = sortBy(allComments, [
+  const strictlySortedComments = sortBy(shownComments, [
     sort === 'Best'
       ? (c) =>
           isReply(c)
@@ -230,7 +252,7 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
     (c) => c.replyToCommentId ?? '_'
   )
 
-  const commentById = keyBy(allComments, 'id')
+  const commentById = keyBy(shownComments, 'id')
 
   // lump comments on load/sort to prevent jumping
   const [frozenCommentIds, refreezeIds] = useReducer(
@@ -271,9 +293,9 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
   }, [allComments.length, totalComments])
 
   const pinnedComments = uniqBy(
-    staticPinnedComments.concat(
-      allComments.filter((comment) => comment.pinned)
-    ),
+    staticPinnedComments
+      .concat(allComments.filter((comment) => comment.pinned))
+      .filter((comment) => !hideBotComments || !comment.isBot),
     'id'
   )
 
@@ -315,6 +337,7 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
     <Col className={clsx(className, scrollToEnd && 'flex-col-reverse')}>
       <div ref={endOfMessagesRef} />
       <ContractCommentInput
+        // eslint-disable-next-line jsx-a11y/no-autofocus -- explicitly off
         autoFocus={false}
         replyTo={replyTo}
         className="mb-4 mr-px mt-px"
@@ -354,7 +377,39 @@ export const CommentsTabContent = memo(function CommentsTabContent(props: {
       )}
 
       {allComments.length > 0 && (
-        <Row className="justify-end">
+        <Row className="items-center justify-between">
+          <Row className="items-center gap-1">
+            <span className="text-ink-400 text-sm">Bot comments:</span>
+            <DropdownMenu
+              items={generateFilterDropdownItems(
+                [
+                  { label: 'Show', value: 'show' },
+                  { label: 'Hide', value: 'hide' },
+                ],
+                (value: string) => {
+                  const hide = value === 'hide'
+                  setHideBotComments(hide)
+                  refreezeIds()
+                  track('change-comments-bot-filter', {
+                    contractSlug: staticContract.slug,
+                    contractName: staticContract.question,
+                    hideBotComments: hide,
+                  })
+                }
+              )}
+              buttonContent={
+                <Row className="text-ink-600 items-center text-sm">
+                  <span className="whitespace-nowrap">
+                    {hideBotComments ? 'Hide' : 'Show'}
+                  </span>
+                  <ChevronDownIcon className="h-4 w-4" />
+                </Row>
+              }
+              menuWidth={'w-24'}
+              selectedItemName={hideBotComments ? 'Hide' : 'Show'}
+              closeOnClick
+            />
+          </Row>
           <Tooltip text={sortTooltip}>
             <Row className="items-center gap-1">
               <span className="text-ink-400 text-sm">Sort by:</span>

--- a/web/components/notification-settings.tsx
+++ b/web/components/notification-settings.tsx
@@ -18,6 +18,8 @@ import clsx from 'clsx'
 import { NOTIFICATION_DESCRIPTIONS } from 'common/notification'
 import { PrivateUser } from 'common/user'
 import {
+  bot_notification_level,
+  DEFAULT_BOT_NOTIFICATION_LEVEL,
   getDefaultNotificationPreferences,
   notification_destination_types,
   notification_preference,
@@ -36,6 +38,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { UserWatchedContractsButton } from 'web/components/notifications/watched-markets'
 import { SwitchSetting } from 'web/components/switch-setting'
+import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
 import ShortToggle from 'web/components/widgets/short-toggle'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { api } from 'web/lib/api/api'
@@ -279,6 +282,7 @@ export function NotificationSettings(props: {
           icon={<InboxInIcon className={'h-6 w-6'} />}
           data={generalOther}
         />
+        <BotNotificationSetting privateUser={privateUser} />
         <NotificationSection
           icon={<ExclamationIcon className={'h-6 w-6'} />}
           data={optOutAll}
@@ -287,6 +291,63 @@ export function NotificationSettings(props: {
         <FollowMarketModal open={showWatchModal} setOpen={setShowWatchModal} />
       </Col>
     </SectionRoutingContext.Provider>
+  )
+}
+
+const BOT_LEVEL_DESCRIPTIONS: Record<bot_notification_level, string> = {
+  never: 'Bots never notify you, even when they reply to you directly.',
+  mentions:
+    'Only when a bot replies to you or @mentions you. Their other comments stay silent.',
+  always: 'Treat bot comments like anyone else’s.',
+}
+
+function BotNotificationSetting(props: { privateUser: PrivateUser }) {
+  const { privateUser } = props
+  const serverLevel =
+    privateUser.botNotificationLevel ?? DEFAULT_BOT_NOTIFICATION_LEVEL
+  const [level, setLevel] = useState<bot_notification_level>(serverLevel)
+  const [saving, setSaving] = useState(false)
+
+  // Re-sync if the prop updates from a websocket push (e.g. changed in another
+  // tab) and we're not mid-save.
+  useEffect(() => {
+    if (!saving) setLevel(serverLevel)
+  }, [serverLevel, saving])
+
+  const handleChange = async (newLevel: bot_notification_level) => {
+    const previous = level
+    setLevel(newLevel)
+    setSaving(true)
+    try {
+      await api('me/private/update', { botNotificationLevel: newLevel })
+    } catch (e) {
+      setLevel(previous)
+      toast.error('Failed to update preference')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Col className="gap-2">
+      <Row className={'text-ink-700 gap-2 text-xl'}>
+        <span>Bots</span>
+      </Row>
+      <Col className="ml-3 gap-2 text-sm">
+        <ChoicesToggleGroup
+          currentChoice={level}
+          choicesMap={{
+            Never: 'never',
+            Mentions: 'mentions',
+            Always: 'always',
+          }}
+          setChoice={(choice) => handleChange(choice as bot_notification_level)}
+          disabled={saving}
+          className="w-fit"
+        />
+        <span className="text-ink-500">{BOT_LEVEL_DESCRIPTIONS[level]}</span>
+      </Col>
+    </Col>
   )
 }
 

--- a/web/hooks/use-comments.ts
+++ b/web/hooks/use-comments.ts
@@ -3,7 +3,7 @@ import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-i
 import { ContractComment } from 'common/comment'
 import { convertContractComment } from 'common/supabase/comments'
 import { groupBy, sortBy, uniqBy } from 'lodash'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { api } from 'web/lib/api/api'
 import {
   getAllCommentRows,
@@ -103,36 +103,60 @@ export const useGlobalComments = (limit: number) => {
 export const useCommentThreads = (
   contractId: string,
   limit: number,
-  disabled: boolean
+  disabled: boolean,
+  excludeBots?: boolean
 ) => {
   const [threads, setThreads] = useState<
     { parent: ContractComment; replies: ContractComment[] }[]
   >([])
   const [page, setPage] = useState(0)
   const [loading, setLoading] = useState(false)
+  // Changing the filter has to restart at page 0, and state set in the same
+  // tick isn't readable by the fetch that follows it, so the page and the
+  // in-flight guard live in refs. requestId discards a response whose request
+  // has since been superseded by a filter change.
+  const pageRef = useRef(0)
+  const loadingRef = useRef(false)
+  const requestId = useRef(0)
 
-  const loadMore = async () => {
-    if (loading) return
+  const fetchPage = async (restart: boolean) => {
+    if (loadingRef.current && !restart) return
+    const thisRequest = ++requestId.current
+    const pageToLoad = restart ? 0 : pageRef.current
+    loadingRef.current = true
     setLoading(true)
-    const { parentComments, replyComments } = await api('comment-threads', {
-      contractId,
-      limit,
-      page,
-    })
-    const repliesByParent = groupBy(replyComments, 'replyToCommentId')
-    const newThreads = parentComments.map((p) => ({
-      parent: p,
-      replies: repliesByParent[p.id] ?? [],
-    }))
-    setThreads((t) => [...t, ...newThreads])
-    setPage((p) => p + 1)
-    setLoading(false)
+    try {
+      const { parentComments, replyComments } = await api('comment-threads', {
+        contractId,
+        limit,
+        page: pageToLoad,
+        // Only sent when on: props are strict and web deploys ahead of the
+        // API, so the default view must work against an API without the param.
+        ...(excludeBots ? { excludeBots: true } : {}),
+      })
+      if (thisRequest !== requestId.current) return
+      const repliesByParent = groupBy(replyComments, 'replyToCommentId')
+      const newThreads = parentComments.map((p) => ({
+        parent: p,
+        replies: repliesByParent[p.id] ?? [],
+      }))
+      setThreads((t) => (pageToLoad === 0 ? newThreads : [...t, ...newThreads]))
+      pageRef.current = pageToLoad + 1
+      setPage(pageToLoad + 1)
+    } finally {
+      if (thisRequest === requestId.current) {
+        loadingRef.current = false
+        setLoading(false)
+      }
+    }
   }
+
+  const loadMore = () => fetchPage(false)
 
   useEffect(() => {
     if (disabled) return
-    loadMore()
-  }, [contractId, disabled])
+    fetchPage(true)
+  }, [contractId, disabled, excludeBots])
 
   return { threads, loadMore, loading, page }
 }


### PR DESCRIPTION
## Why

Bots are already **21.8% of comment volume** — 1,877 of 8,617 comments in the last 30 days — and that's before the wave we're expecting. Nothing distinguished a bot comment from a human one in either the notification fan-out or the comment section.

The volume is concentrated but not only in the obvious places: FairlyRandom (1,254) and Claudius Maximus (588) dominate, but there are other flagged accounts posting into markets people own.

## What

**Notifications** — `botNotificationLevel` on `PrivateUser`: `never` / `mentions` / `always`, defaulting to **`mentions`**.

The gate is one clause in `sendNotificationsIfSettingsPermit`, the single funnel every recipient already passes through, so it covers browser, push and email at once and layers on top of the per-reason destination settings rather than replacing them. The same gate is applied to the post-comment path.

It's a scalar rather than another `notification_preferences` key because it cuts across every comment reason instead of being one of them — and because that type is `Record<key, ('email'|'browser'|'mobile')[]>`, which can't express a three-way choice. Persisted via `me/private/update`; the control is a three-way toggle under a new "Bots" heading in notification settings.

**Why `mentions` and not `never`:** 1,254 of those 1,877 comments are FairlyRandom, whose replies are randomness draws people explicitly requested. Silencing the reply to your own request makes the bot look broken. What's worth muting by default is the ambient fan-out — every bot comment on a market you follow, created, or hold shares in.

**Comment section** — a "Bot comments: show / hide" dropdown on the left of the sort row, defaulting to **show**.

Filtering is server-side (`excludeBots` on `comment-threads`) because pagination counts parent threads *before* the filter, so dropping rows client-side leaves ragged pages — same reasoning as the API-trade filter on the trades tab (079f7c976). A client-side pass on top catches what the query never saw: static props and websocket arrivals. The query joins `users.is_bot` rather than reading the comment's flag, so it stays correct for comments written before an account was flagged; comments also carry a denormalized `isBot` next to `isApi` for the client pass.

**Why show-by-default:** 1,349 of 1,877 bot comments are replies nested under human parents. Hiding by default would leave visible gaps in threads.

## Deliberate edges

- **Hiding a bot's top-level comment hides its replies too** — the thread has no root left to render under. 528 of the last month's bot comments are top-level and some carry human replies. Worth revisiting with a collapsed stub if it bites.
- **A deep link to a specific comment overrides the filter** rather than landing you on a blank page.
- **Scope is comments only.** A bot liking your comment (`reaction.ts`) or a bot's trades still notify normally. If "never" should mean *all* bot-sourced notifications, that's the other call site.
- House accounts (`ManifoldSports`, `ManifoldPolitics`, `ManifoldAI`) are **not** flagged `is_bot`, so auto-posted resolution score comments are unaffected.

## ⚠️ Deploy order: API before web

`excludeBots` on a `.strict()` schema 400s against an older API. The client only sends the param when the toggle is on, so the default view survives either order — but a user who flips the toggle against an un-deployed API gets an error.

No migration. `contract_comments.user_id` already exists, so the filter needs no schema change and no backfill.

## Testing

- `common` suite: 428 pass, including 4 new cases covering the gate at each level (`common/src/user-notification-preferences.test.ts`)
- `common`, `backend/api`, `web` all typecheck clean
- Filter SQL run against prod on a real contract: page 0 returned 24 rows, 7 bot-authored; with the filter, 21 rows, 0 bot-authored
- **Not runtime-tested:** the two UI pieces (settings toggle, comment dropdown) haven't been exercised in a running app

## Note

The `eslint-disable jsx-a11y/no-autofocus` in `comments-tab-content.tsx` is a pre-existing violation on a line that explicitly *disables* autofocus — it only surfaced because this PR stages that file and pre-commit lints it.
