### PR TITLE
fix(notifications): deliver bot comments silently

### DIFF
--- a/backend/shared/src/notifications/create-new-contract-comment-notif.ts
+++ b/backend/shared/src/notifications/create-new-contract-comment-notif.ts
@@ -49,6 +49,11 @@ export const createCommentOnContractNotification = async (
   taggedUserIds: string[],
   requiresResponse: boolean
 ) => {
+  // Bots deliver silently. Temporary blanket mute until the per-user bot
+  // notification level ships; see PR #4001. isBot is the users.is_bot column
+  // (convertUser maps it), so mod changes via set-bot-status apply at once.
+  if (sourceUser.isBot) return
+
   const pg = createSupabaseDirectClient()
 
   const usersToReceivedNotifications: Record<
@@ -253,6 +258,9 @@ export const createCommentOnPostNotification = async (
   repliedUserId: string | undefined,
   mentionedUserIds: string[]
 ) => {
+  // Same blanket mute as the contract-comment path above.
+  if (commentCreator.isBot) return
+
   const usersToNotify: { userId: string; reason: NotificationReason }[] = []
 
   // Fetch post followers


### PR DESCRIPTION
Bot-authored comments no longer notify anyone. Two guards, one file:

```ts
// createCommentOnContractNotification
if (sourceUser.isBot) return

// createCommentOnPostNotification
if (commentCreator.isBot) return
```

### Why this shape

Temporary stand-in for the per-user bot notification level in #4001, which is parked. This is the blunt version of that feature's `never` setting, applied to everyone: silent delivery, which is what we've publicly committed to.

The guard sits at the top of both creators, above the fan-out — so it also skips the `contract_follows` query, `getUniqueBettorIds`, and the per-recipient `private_users join users` fetch. It's a load shed as well as a mute.

`isBot` is trustworthy at this seam: `convertUser` maps it from the `users.is_bot` **column**, not `data` JSONB (`updateUser` deliberately routes `isBot` to the column, so a JSONB read would be silently `undefined`). All three call sites — `on-create-comment-on-contract.ts:217`, `sports-markets.ts:499`, `create-post-comment.ts:126` — pass a `User` from `getUser` (`select *`), so the flag is populated, and mod changes via `set-bot-status` apply immediately with no deploy.

### Scope

- **Covers:** every notification arising from a bot comment on a contract or a post — browser, push, and email.
- **Does not cover:** bot likes, bet fills, new-market `@mentions`, answer notifications. Those live in other creators that don't gate on the source user. Deliberate — comments are the volume problem (~21.8% of comment traffic).
- **Does not touch the comment section.** Bot comments still render; this is notifications only.

### Known tradeoffs

1. Blunter than #4001 intends. This also silences bot→you replies and `@mentions` — the case that PR keeps alive on the reasoning that a bot you invoked (a randomness draw, a question you `@`-asked) looks broken when it goes quiet. Accepted for now; the per-user level restores it.
2. Won't catch a bot whose `is_bot` column is unset. The canonical resolver elsewhere is `user.isBot ?? BOT_USERNAMES.includes(user.username)` (`common/src/api/user-types.ts:39`); migration `2026040101` seeded the column from that same list, so this only bites if a username changed afterward.
3. As a side effect it closes a hole #4001 leaves open — that PR's `mentions` default still lets a creator/admin/mod bot blast every trader via `@Traders`, because those recipients carry reason `tagged_user`, which its allowlist treats as a direct interaction. A blanket return blocks it.

### Testing

`npx tsc -b` from `backend/api` (builds `common` → `shared` → `api`) exits 0. Neither function returns a value elsewhere and all three callers `await` without consuming a result, so the bare `return` is type-safe.

Deploy: API only, no migration, no web change.

Note: the pre-commit hook reported "No staged files match any configured task" for a `.ts` file under `backend/shared/` — lint-staged's globs appear not to cover that path. Unrelated to this change, but worth a separate look.
