### PR TITLE
fix(perps): run model research agent only in prod

### DIFF
--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -19,7 +19,7 @@ import {
   createSupabaseDirectClient,
   SupabaseDirectClient,
 } from 'shared/supabase/init'
-import { log } from 'shared/utils'
+import { isProd, log } from 'shared/utils'
 
 // Classify new OpenRouter models BEFORE they reach the top 50.
 //
@@ -193,6 +193,11 @@ const researchRemainingModels = async (
   pg: SupabaseDirectClient,
   candidates: OpenRouterCatalogEntry[]
 ) => {
+  if (!isProd()) {
+    log('[model-classifier] skipping paid agent research outside prod')
+    return { recommended: 0, unresolved: candidates.length }
+  }
+
   let recommended = 0
   let unresolved = 0
 


### PR DESCRIPTION
## What changed

- Skip the paid model-research agent outside production.
- Keep deterministic OpenRouter catalog ingestion and Hugging Face verification running in dev.

## Why

Dev runs its own scheduler with the `all` job set and has the relevant API secrets. Without an environment guard, a future dev deploy of the merged classifier would duplicate paid research against a dev-only review queue.

Production still runs this job once on the `main` scheduler; the existing job-set split excludes it from the `perps` scheduler.

## Validation

- `git diff --check`
- Confirmed `isProd()` is the existing scheduler environment gate and returns a boolean.
- Attempted the TypeScript project build for `common`, `backend/shared`, and `backend/scheduler`. The local checkout is blocked in unchanged `backend/shared/src/helpers/openai-utils.ts` because the installed OpenAI SDK lacks `responses`; the changed scheduler file did not introduce that failure.