### PR TITLE
feat(perps): page oracle price history with a `before` cursor

### DIFF
--- a/backend/api/src/get-oracle-price.ts
+++ b/backend/api/src/get-oracle-price.ts
@@ -31,11 +31,19 @@ export const getOraclePrice: APIHandler<'get-oracle-price'> = async (body) => {
 export const getOraclePriceSeries: APIHandler<
   'get-oracle-price-series'
 > = async (body) => {
-  const { feedId, since, limit = 5000, bucketSeconds } = body
+  const { feedId, since, before, limit = 5000, bucketSeconds } = body
   const pg = createSupabaseDirectClient()
-  // Return the *most recent* N points (newest first, then reversed to asc for
-  // charting). If `since` is provided we also filter to points >= since, but
-  // we still cap at `limit` most-recent rows inside the window.
+  // Return the *most recent* N points in the window (newest first, then
+  // reversed to asc for charting). `since` sets the inclusive lower bound and
+  // `before` the exclusive upper one; because the cap always keeps the newest
+  // rows, `before` is the cursor that walks a feed backwards to its start —
+  // pass the first ts of the previous page.
+  //
+  // Both bounds compare `ts` against a timestamptz rather than extracting an
+  // epoch from it, which keeps them index conditions on (feed_id, ts) instead
+  // of post-scan filters. The epoch form made a recent `since` read the feed's
+  // entire history to return a handful of rows, and would have made every
+  // `before` page do the same.
   //
   // With `bucketSeconds`, downsample to the LAST point of each bucket (its
   // real ts, not the bucket edge): the chart's gap-break and outage handling
@@ -44,27 +52,29 @@ export const getOraclePriceSeries: APIHandler<
   const rows = bucketSeconds
     ? await pg.manyOrNone<{ ts: string; price: number | string }>(
         `select ts, price from (
-           select distinct on (floor(extract(epoch from ts) / $4))
-             floor(extract(epoch from ts) / $4) as bucket, ts, price
+           select distinct on (floor(extract(epoch from ts) / $5))
+             floor(extract(epoch from ts) / $5) as bucket, ts, price
            from oracle_prices
            where feed_id = $1
-             and ($2::bigint is null or extract(epoch from ts) * 1000 >= $2::bigint)
-           order by floor(extract(epoch from ts) / $4) desc, ts desc
-           limit $3
+             and ($2::bigint is null or ts >= to_timestamp($2::bigint / 1000.0))
+             and ($3::bigint is null or ts < to_timestamp($3::bigint / 1000.0))
+           order by floor(extract(epoch from ts) / $5) desc, ts desc
+           limit $4
          ) sub
          order by ts asc`,
-        [feedId, since ?? null, limit, bucketSeconds]
+        [feedId, since ?? null, before ?? null, limit, bucketSeconds]
       )
     : await pg.manyOrNone<{ ts: string; price: number | string }>(
         `select ts, price from (
            select ts, price from oracle_prices
            where feed_id = $1
-             and ($2::bigint is null or extract(epoch from ts) * 1000 >= $2::bigint)
+             and ($2::bigint is null or ts >= to_timestamp($2::bigint / 1000.0))
+             and ($3::bigint is null or ts < to_timestamp($3::bigint / 1000.0))
            order by ts desc
-           limit $3
+           limit $4
          ) sub
          order by ts asc`,
-        [feedId, since ?? null, limit]
+        [feedId, since ?? null, before ?? null, limit]
       )
   return rows.map((r) => ({
     ts: new Date(r.ts).getTime(),

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1227,6 +1227,12 @@ export const API = (_apiTypeCheck = {
       .object({
         feedId: z.string().min(1),
         since: z.coerce.number().int().optional(),
+        // Exclusive upper bound (ms). `limit` always returns the NEWEST points
+        // in the window, so `before` is what makes the series pageable: pass
+        // the first ts of the previous response to walk backwards to the start
+        // of the feed. Without it, `since` alone can only shrink a window that
+        // is already anchored to now.
+        before: z.coerce.number().int().optional(),
         limit: z.coerce.number().int().positive().max(5000).optional(),
         // Server-side downsampling: return the last point of each
         // `bucketSeconds` bucket instead of raw rows. A 15s feed emits ~5k

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -1877,13 +1877,29 @@ Parameters:
 
 - `feedId`: Required.
 - `since`: Optional. Only return points at or after this timestamp (ms).
+- `before`: Optional. Only return points strictly before this timestamp (ms).
 - `limit`: Optional. Max `5000`.
 - `bucketSeconds`: Optional, max `86400`. Server-side downsampling: return
   the last point of each bucket instead of raw rows. Fast feeds emit a point
   every ~15 seconds, so request week-plus windows bucketed or the `limit` cap
   will truncate the window.
 
-Response is an array of `{ ts: number, price: number }`.
+Response is an array of `{ ts: number, price: number }`, ascending by `ts`.
+
+A request always returns the *newest* points in the window, so `since` alone
+cannot reach further back than `limit` points from now. To page through a full
+feed history, walk backwards with `before`: omit it on the first request, then
+pass the `ts` of the first (oldest) point you received as the next request's
+`before`, until a page comes back empty.
+
+```
+GET /v0/get-oracle-price-series?feedId=btc-usd&limit=5000
+GET /v0/get-oracle-price-series?feedId=btc-usd&limit=5000&before=<oldest ts from previous page>
+```
+
+To get the whole history in one request instead, pass `bucketSeconds` — e.g.
+`bucketSeconds=3600` returns hourly points, which covers years of a fast feed
+inside the `limit` cap.
 
 ### `POST /v0/create-perp`
 


### PR DESCRIPTION
get-oracle-price-series always returned the newest `limit` points, so `since` could only shrink a window anchored to now — there was no way to reach anything older than one page. Add an exclusive `before` upper bound so callers can walk a feed back to its first point by passing the oldest ts of the previous page.

Both bounds now compare `ts` against a timestamptz instead of extracting an epoch from it, so they are index conditions on (feed_id, ts) rather than post-scan filters. The old form made a recent `since` read a feed's entire history to return a handful of rows (prod btc-usd, since=1h ago: 75390 rows removed by filter, 6901 buffers, 72ms for 122 rows) and would have made every `before` page do the same. Same query after: index cond on both bounds, 85 buffers, 3.6ms.

The ms cursor is lossless: every write goes through insertOraclePrices, which builds ts from new Date(point.ts).toISOString(), so no row can carry sub-millisecond precision that a ms-truncated cursor would skip (confirmed: 0 of 81459 prod rows).

Verified the two-page loop against prod btc-usd — 5000 + 5000 rows, zero overlap and zero gap rows. Existing web callers pass only since / bucketSeconds and are unaffected apart from the speedup.