### PR TITLE
fix(perps): fee-aware trade panel affordability + profit ladder, and fractional perp displays

### DIFF
--- a/backend/api/src/get-balance-changes.ts
+++ b/backend/api/src/get-balance-changes.ts
@@ -9,7 +9,7 @@ import {
   BET_BALANCE_CHANGE_TYPES,
 } from 'common/balance-change'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
-import { formatMoney } from 'common/util/format'
+import { formatMoney, formatMoneyPrecise } from 'common/util/format'
 import { Txn } from 'common/txn'
 import { filterDefined } from 'common/util/array'
 import { charities } from 'common/charity'
@@ -77,11 +77,13 @@ const perpTxnDescription = (txn: Txn): string | undefined => {
   if (txn.category === 'PERP_CLOSE_PAYOUT') {
     const pnlNumber = Number(d.pnl ?? 0)
     const pnl = Number.isFinite(pnlNumber) ? pnlNumber : 0
-    const pnlText = `${pnl >= 0 ? '+' : ''}${formatMoney(pnl)}`
+    // Realised PnL and settlement payouts are fractional; formatMoney would
+    // floor a +M$0.60 close to "+M$0" while the position history shows it.
+    const pnlText = `${pnl >= 0 ? '+' : ''}${formatMoneyPrecise(pnl)}`
     if (d.reason === 'adl') {
       return `Auto-deleveraged ${d.direction} at ${px(
         d.closePrice
-      )} — ${formatMoney(txn.amount)} margin returned, profit ${pnlText}`
+      )} — ${formatMoneyPrecise(txn.amount)} margin returned, profit ${pnlText}`
     }
     const verb =
       d.reason === 'flip'

--- a/backend/shared/src/notifications/perps.ts
+++ b/backend/shared/src/notifications/perps.ts
@@ -4,7 +4,7 @@ import { formatPrice, inferPriceDecimals } from 'common/perps/format'
 import { getPrivateUser } from 'shared/utils'
 import { getNotificationDestinationsForUser } from 'common/user-notification-preferences'
 import { MANIFOLD_AVATAR_URL } from 'common/user'
-import { formatMoney } from 'common/util/format'
+import { formatMoney, formatMoneyPrecise } from 'common/util/format'
 import { nanoid } from 'common/util/random'
 import type {
   AdlNotificationResult,
@@ -183,7 +183,7 @@ export const createPerpAdlNotification = async (
     data.settlementPayout != null
       ? `Your ${data.direction} on ${
           contract.question
-        } was fully auto-deleveraged${sizes} to stay payable. The position is closed and its ${formatMoney(
+        } was fully auto-deleveraged${sizes} to stay payable. The position is closed and its ${formatMoneyPrecise(
           data.settlementPayout
         )} remaining margin was returned to your balance.`
       : `Your ${data.direction} on ${contract.question} was reduced ${cutPct}%${sizes} to stay payable: your unrealized profit exceeded what the other side's pool can pay. Your cost basis is unchanged.`

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -180,11 +180,22 @@ user → contract) alongside the margin debit, so the cash-backing invariant
 above is preserved. The position tracks its cumulative opening fees in
 `takerFeeCostBasis` (kept separate from margin so leverage/liquidation math
 is untouched), and every user-facing PnL number — the position card, close
-receipts, portfolio metrics, period metrics — subtracts it: a fresh position
-starts at PnL = −fee. Admins tune both knobs live per market via
-`update-perp-config` (base 0 disables the flat part, impact 0 the size
-part); contracts created before the fields existed default to base 10 /
-impact 0 at trade time.
+receipts, portfolio metrics, period metrics, and the trade panel's profit
+ladder (`getPerpPriceForUserFacingPnl` solves for the price at which that
+PnL reaches a target, so each tier is net of the fee and agrees with the
+card) — subtracts it: a fresh position starts at PnL = −fee. Admins tune
+both knobs live per market via `update-perp-config` (base 0 disables the
+flat part, impact 0 the size part); contracts created before the fields
+existed default to base 10 / impact 0 at trade time.
+
+The fee also changes what a trade COSTS to place: the debit is margin plus
+fee, and on a flip the closed leg's free payout may fund it. Both the engine's
+`Insufficient balance` reject and the trade panel's client-side check go
+through `calculatePerpOpenCashFlow` in `common/src/perps/fees.ts` with the
+quoted fee as an input (never recomputed from bps), so the preview cannot
+disagree with the charge. The panel therefore opts out of `BuyAmountInput`'s
+margin-only balance check (`disregardUserBalance`) — that check both passed a
+max-balance open the fee makes unaffordable and blocked a payout-funded flip.
 
 **Two channels, two rates.** `takerFeeBps` is the WEB base. Opens
 authenticated with an API key instead pay `max(takerFeeBps, takerFeeApiBps)`

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -45,6 +45,7 @@ import {
 import {
   accruePerpPositionTakerFee,
   assertPerpTakerFeeConfig,
+  calculatePerpOpenCashFlow,
   creditPerpPoolFee,
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeImpact,
@@ -845,9 +846,22 @@ export const openOrAddPosition = async (
           2
         )} margin. Reduce your position size or leverage.`
       )
-    const totalDebit = mana + openFee
-    const spendableBalance = trader.balance + closePayout
-    if (spendableBalance < totalDebit)
+    // Shared with the bet panel's preview (calculatePerpOpenCashFlow), so the
+    // client's affordability check is exactly this one: margin plus the fee
+    // as priced above, funded by balance plus a flip's free close payout.
+    const cashFlow = calculatePerpOpenCashFlow({
+      balance: trader.balance,
+      margin: mana,
+      openFee,
+      closePayout,
+    })
+    if (!cashFlow)
+      throw new APIError(
+        500,
+        'Perp trade cash flow is invalid; refusing to debit the trader'
+      )
+    const { totalDebit, spendableBalance } = cashFlow
+    if (!cashFlow.isAffordable)
       throw new APIError(
         403,
         `Insufficient balance: needed ${totalDebit.toFixed(2)} (${mana} margin${

--- a/common/src/perps/fees.test.ts
+++ b/common/src/perps/fees.test.ts
@@ -3,6 +3,7 @@ import {
   accruePerpPositionTakerFee,
   calcPerpSizeFee,
   calcPerpTakerFee,
+  calculatePerpOpenCashFlow,
   creditPerpPoolFee,
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeImpact,
@@ -744,6 +745,105 @@ describe('perpOpenFeeQuote (net-of-own-contribution depth)', () => {
       impact,
     })
     expect(q.fee).toBeCloseTo(oneShotQuote(10_000).fee, 10)
+  })
+})
+
+describe('calculatePerpOpenCashFlow', () => {
+  const base = { balance: 100, margin: 100, openFee: 10 }
+
+  it('includes the opening fee in the required debit', () => {
+    expect(calculatePerpOpenCashFlow(base)).toEqual({
+      totalDebit: 110,
+      spendableBalance: 100,
+      isAffordable: false,
+    })
+  })
+
+  it('rejects a raw-balance maximum when a fractional fee is still due', () => {
+    // margin == balance used to pass the client check and 403 server-side.
+    expect(
+      calculatePerpOpenCashFlow({ balance: 10, margin: 10, openFee: 0.02 })
+    ).toEqual({
+      totalDebit: 10.02,
+      spendableBalance: 10,
+      isAffordable: false,
+    })
+  })
+
+  it('takes the fee as priced rather than recomputing it', () => {
+    // A size-dependent or API-channel fee is whatever perpOpenFeeQuote
+    // produced — the helper must not assume notional × bps.
+    const quoted = perpOpenFeeQuote({
+      grossPoolDepth: 1_000,
+      existingSize: 0,
+      existingCostBasis: 0,
+      existingPositionValue: 0,
+      existingTakerFeeCostBasis: 0,
+      addedNotional: 2_000,
+      baseBps: 10,
+      impact: 10,
+    }).fee
+    expect(quoted).toBeGreaterThan(calcPerpTakerFee(2_000, 10))
+    expect(
+      calculatePerpOpenCashFlow({ balance: 200, margin: 200, openFee: quoted })
+    ).toMatchObject({ totalDebit: 200 + quoted })
+  })
+
+  it('lets a free flip payout fund the new margin and fee', () => {
+    expect(
+      calculatePerpOpenCashFlow({ ...base, balance: 0, closePayout: 110 })
+    ).toMatchObject({ spendableBalance: 110, isAffordable: true })
+    expect(
+      calculatePerpOpenCashFlow({ ...base, balance: 0, closePayout: 109.99 })
+        ?.isAffordable
+    ).toBe(false)
+  })
+
+  it('accepts the exact boundary and preserves zero-fee behavior', () => {
+    expect(
+      calculatePerpOpenCashFlow({ ...base, balance: 109.999 })?.isAffordable
+    ).toBe(false)
+    expect(
+      calculatePerpOpenCashFlow({ ...base, balance: 110 })?.isAffordable
+    ).toBe(true)
+    expect(calculatePerpOpenCashFlow({ ...base, openFee: 0 })).toMatchObject({
+      totalDebit: 100,
+      isAffordable: true,
+    })
+  })
+
+  it('fails closed on invalid or overflowing inputs', () => {
+    expect(
+      calculatePerpOpenCashFlow({ ...base, balance: Number.NaN })
+    ).toBeUndefined()
+    expect(calculatePerpOpenCashFlow({ ...base, margin: 0 })).toBeUndefined()
+    expect(calculatePerpOpenCashFlow({ ...base, margin: -1 })).toBeUndefined()
+    expect(
+      calculatePerpOpenCashFlow({ ...base, openFee: -0.01 })
+    ).toBeUndefined()
+    expect(
+      calculatePerpOpenCashFlow({ ...base, openFee: Number.POSITIVE_INFINITY })
+    ).toBeUndefined()
+    expect(
+      calculatePerpOpenCashFlow({ ...base, closePayout: -1 })
+    ).toBeUndefined()
+    expect(
+      calculatePerpOpenCashFlow({ ...base, closePayout: Number.NaN })
+    ).toBeUndefined()
+    expect(
+      calculatePerpOpenCashFlow({
+        ...base,
+        margin: Number.MAX_VALUE,
+        openFee: Number.MAX_VALUE,
+      })
+    ).toBeUndefined()
+    expect(
+      calculatePerpOpenCashFlow({
+        ...base,
+        balance: Number.MAX_VALUE,
+        closePayout: Number.MAX_VALUE,
+      })
+    ).toBeUndefined()
   })
 })
 

--- a/common/src/perps/fees.ts
+++ b/common/src/perps/fees.ts
@@ -527,6 +527,61 @@ export const perpOwnContributionInputs = (
   existingTakerFeeCostBasis: standingSame?.takerFeeCostBasis ?? 0,
 })
 
+export type PerpOpenCashFlow = {
+  /** Margin plus opening fee: the mana that leaves the trader's balance. */
+  totalDebit: number
+  /** Balance plus a flip's free close payout — what can fund the debit. */
+  spendableBalance: number
+  isAffordable: boolean
+}
+
+/**
+ * Cash required to open/add a position and whether the trader can fund it.
+ * Shared by the engine's authoritative check and the bet panel's preview so
+ * the two cannot disagree — the panel used to validate margin against raw
+ * balance alone, which let a max-balance open through to a server 403 once
+ * the fee was added, and blocked a payout-funded flip the engine accepts.
+ *
+ * The fee is an INPUT, not recomputed here: it is whatever perpOpenFeeQuote
+ * priced for this trade (size-dependent, channel-dependent), so this helper
+ * stays correct however the fee schedule evolves. `closePayout` is the free
+ * close of an opposite-side position on a flip — the engine credits it
+ * before debiting the new leg, so it may fund the new margin and fee (a
+ * trader whose mana is all in the position they are flipping out of).
+ *
+ * Fails closed (undefined) on any non-finite or negative input so a corrupt
+ * balance or fee can never read as affordable.
+ */
+export const calculatePerpOpenCashFlow = (params: {
+  balance: number
+  margin: number
+  openFee: number
+  closePayout?: number
+}): PerpOpenCashFlow | undefined => {
+  const { balance, margin, openFee, closePayout = 0 } = params
+  if (
+    !Number.isFinite(balance) ||
+    !Number.isFinite(margin) ||
+    margin <= 0 ||
+    !Number.isFinite(openFee) ||
+    openFee < 0 ||
+    !Number.isFinite(closePayout) ||
+    closePayout < 0
+  )
+    return undefined
+
+  const totalDebit = margin + openFee
+  const spendableBalance = balance + closePayout
+  if (!Number.isFinite(totalDebit) || !Number.isFinite(spendableBalance))
+    return undefined
+
+  return {
+    totalDebit,
+    spendableBalance,
+    isAffordable: spendableBalance >= totalDebit,
+  }
+}
+
 /**
  * Credit a collected fee to one side's backing pool. Pure, like the amm.ts
  * transitions: the caller persists the new pool. The fee mana enters

--- a/common/src/perps/pnl.test.ts
+++ b/common/src/perps/pnl.test.ts
@@ -2,6 +2,7 @@ import { applyFunding, computeFundingRate, getPositionValue } from './amm'
 import {
   fundingPerPeriod,
   getPerpPositionTotalCost,
+  getPerpPriceForUserFacingPnl,
   getUserFacingPnl,
   getUserFacingPnlFromPayout,
   getUserFacingPnlPercent,
@@ -81,7 +82,7 @@ describe('getUserFacingPnlFromPayout', () => {
     const position = makePosition('long', { takerFeeCostBasis: 0.5 })
     expect(getPerpPositionTotalCost(position)).toBe(100.5)
     expect(getUserFacingPnl(position, 50)).toBe(-0.5)
-    // Gross close value is 100; a 0.5 close fee leaves a 99.5 payout.
+    // A 99.5 payout after a 0.5 opening fee is a total loss of 1.
     expect(getUserFacingPnlFromPayout(99.5, 100, 0.5)).toBe(-1)
     expect(getUserFacingPnlFromPayout(0, 100, 0.5)).toBe(-100.5)
   })
@@ -102,5 +103,71 @@ describe('getUserFacingPnlFromPayout', () => {
     expect(getPerpPositionTotalCost(position)).toBe(0)
     expect(getUserFacingPnl(position, 60)).toBe(0)
     expect(getUserFacingPnlPercent(position, 60)).toBe(0)
+  })
+})
+
+describe('getPerpPriceForUserFacingPnl', () => {
+  const position = makePosition('long', {
+    size: 10_000,
+    costBasis: 100,
+    originalCostBasis: 100,
+    takerFeeCostBasis: 10,
+    entryPrice: 100,
+    leverage: 100,
+  })
+
+  it('recoups the opening fee before reaching the displayed profit', () => {
+    const longPrice = getPerpPriceForUserFacingPnl(position, 25)
+    const shortPosition = { ...position, direction: 'short' as const }
+    const shortPrice = getPerpPriceForUserFacingPnl(shortPosition, 25)
+
+    expect(longPrice).toBeCloseTo(100.35, 10)
+    expect(shortPrice).toBeCloseTo(99.65, 10)
+    expect(getUserFacingPnl(position, longPrice!)).toBeCloseTo(25, 10)
+    expect(getUserFacingPnl(shortPosition, shortPrice!)).toBeCloseTo(25, 10)
+  })
+
+  it('reduces to the original leverage target when fees are zero', () => {
+    const noFee = { ...position, takerFeeCostBasis: 0 }
+    expect(getPerpPriceForUserFacingPnl(noFee, 25)).toBeCloseTo(100.25, 10)
+    expect(
+      getPerpPriceForUserFacingPnl(
+        { ...noFee, direction: 'short' as const },
+        25
+      )
+    ).toBeCloseTo(99.75, 10)
+  })
+
+  it('accounts for funding-adjusted cost basis', () => {
+    const funded = makePosition('long', {
+      size: 1_000,
+      costBasis: 95,
+      originalCostBasis: 100,
+      takerFeeCostBasis: 1,
+      entryPrice: 100,
+    })
+    const targetPrice = getPerpPriceForUserFacingPnl(funded, 20)
+    expect(targetPrice).toBeCloseTo(102.6, 10)
+    expect(getUserFacingPnl(funded, targetPrice!)).toBeCloseTo(20, 10)
+  })
+
+  it('fails closed on invalid or impossible targets', () => {
+    expect(getPerpPriceForUserFacingPnl(position, Number.NaN)).toBeUndefined()
+    expect(getPerpPriceForUserFacingPnl(position, -1)).toBeUndefined()
+    expect(
+      getPerpPriceForUserFacingPnl({ ...position, size: 0 }, 25)
+    ).toBeUndefined()
+    expect(
+      getPerpPriceForUserFacingPnl(
+        { ...position, takerFeeCostBasis: Number.NaN },
+        25
+      )
+    ).toBeUndefined()
+    expect(
+      getPerpPriceForUserFacingPnl(
+        { ...position, direction: 'short', size: 10 },
+        1_000
+      )
+    ).toBeUndefined()
   })
 })

--- a/common/src/perps/pnl.ts
+++ b/common/src/perps/pnl.ts
@@ -79,6 +79,50 @@ export const getPerpPositionTotalCost = (
 ) => getValidatedPerpPositionTotalCost(position) ?? 0
 
 /**
+ * Oracle/close price required to reach a user-facing PnL target. The target
+ * is net of all opening/add fees already paid; future funding is necessarily
+ * excluded. Returns undefined when the inputs cannot describe a valid target.
+ */
+export const getPerpPriceForUserFacingPnl = (
+  position: Pick<
+    PerpPosition,
+    | 'direction'
+    | 'size'
+    | 'costBasis'
+    | 'originalCostBasis'
+    | 'takerFeeCostBasis'
+    | 'entryPrice'
+  >,
+  targetPnl: number
+): number | undefined => {
+  const { direction, size, costBasis, entryPrice } = position
+  const totalCost = getValidatedPerpPositionTotalCost(position)
+  if (
+    (direction !== 'long' && direction !== 'short') ||
+    !Number.isFinite(size) ||
+    size <= 0 ||
+    !Number.isFinite(costBasis) ||
+    costBasis < 0 ||
+    !Number.isFinite(entryPrice) ||
+    entryPrice <= 0 ||
+    totalCost === undefined ||
+    totalCost <= 0 ||
+    !Number.isFinite(targetPnl) ||
+    targetPnl < 0
+  )
+    return undefined
+
+  const targetValue = totalCost + targetPnl
+  const pricePnlNeeded = targetValue - costBasis
+  const relativeMove = pricePnlNeeded / size
+  const directionSign = direction === 'long' ? 1 : -1
+  const targetPrice = entryPrice * (1 + directionSign * relativeMove)
+  return Number.isFinite(targetPrice) && targetPrice > 0
+    ? targetPrice
+    : undefined
+}
+
+/**
  * Realized PnL shown on close receipts, history, and ledger rows. Settlement
  * payout already contains every funding transfer, so compare it with the
  * margin the user actually deposited rather than the funding-scaled basis.

--- a/common/src/util/format.test.ts
+++ b/common/src/util/format.test.ts
@@ -1,0 +1,58 @@
+import { ENV_CONFIG } from '../envs/constants'
+import { formatMoneyPrecise } from './format'
+
+describe('formatMoneyPrecise', () => {
+  const mana = ENV_CONFIG.moneyMoniker
+  // Grouping and the decimal separator follow the runtime locale (as
+  // formatMoney does), so pin expectations to the same Intl call with the
+  // digit count we expect, rather than to en-US punctuation — the suite must
+  // pass on a de-DE or es-ES runner too.
+  const fixed = (n: number, digits: number) =>
+    n.toLocaleString(undefined, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    })
+
+  it('keeps cents and groups larger values', () => {
+    expect(formatMoneyPrecise(0)).toBe(`${mana}0`)
+    expect(formatMoneyPrecise(0.01)).toBe(`${mana}${fixed(0.01, 2)}`)
+    expect(formatMoneyPrecise(0.02)).toBe(`${mana}${fixed(0.02, 2)}`)
+    expect(formatMoneyPrecise(12.345)).toBe(`${mana}${fixed(12.35, 2)}`)
+    expect(formatMoneyPrecise(1_234.5)).toBe(`${mana}${fixed(1_234.5, 2)}`)
+    // Sanity on the digits themselves, separator-agnostic.
+    expect(formatMoneyPrecise(1_234.5).replace(/\D/g, '')).toBe('123450')
+    expect(formatMoneyPrecise(12.345).replace(/\D/g, '')).toBe('1235')
+  })
+
+  it('preserves non-zero sub-cent values at two significant digits', () => {
+    expect(formatMoneyPrecise(0.009)).toBe(`${mana}${fixed(0.009, 3)}`)
+    expect(formatMoneyPrecise(0.001234)).toBe(`${mana}${fixed(0.0012, 4)}`)
+    expect(formatMoneyPrecise(0.001234).replace(/\D/g, '')).toBe('00012')
+    // Two significant digits round up across the cent boundary cleanly.
+    expect(formatMoneyPrecise(0.0099999)).toBe(`${mana}${fixed(0.01, 2)}`)
+    // The smallest real fee (M$1 at 1x, 10 bps) survives.
+    expect(formatMoneyPrecise(0.001)).toBe(`${mana}${fixed(0.001, 3)}`)
+    expect(formatMoneyPrecise(0.001).replace(/\D/g, '')).toBe('0001')
+  })
+
+  it('reads float dust below a micro-mana as zero, never as exponent notation', () => {
+    expect(formatMoneyPrecise(1e-9)).toBe(`${mana}0`)
+    expect(formatMoneyPrecise(-5e-8)).toBe(`${mana}0`)
+    expect(formatMoneyPrecise(9.9e-7)).toBe(`${mana}0`)
+    expect(formatMoneyPrecise(1e-6)).toBe(`${mana}${fixed(1e-6, 6)}`)
+    expect(formatMoneyPrecise(1e-6)).not.toMatch(/e/)
+  })
+
+  it('places the sign before the moniker', () => {
+    expect(formatMoneyPrecise(-0.02)).toBe(`-${mana}${fixed(0.02, 2)}`)
+    expect(formatMoneyPrecise(-0.001)).toBe(`-${mana}${fixed(0.001, 3)}`)
+    expect(formatMoneyPrecise(-1_234.5)).toBe(`-${mana}${fixed(1_234.5, 2)}`)
+    expect(formatMoneyPrecise(-0)).toBe(`${mana}0`)
+  })
+
+  it('fails closed on non-finite values', () => {
+    expect(formatMoneyPrecise(Number.NaN)).toBe(`${mana}0`)
+    expect(formatMoneyPrecise(Number.POSITIVE_INFINITY)).toBe(`${mana}0`)
+    expect(formatMoneyPrecise(Number.NEGATIVE_INFINITY)).toBe(`${mana}0`)
+  })
+})

--- a/common/src/util/format.ts
+++ b/common/src/util/format.ts
@@ -134,6 +134,40 @@ export function formatMoneyWithDecimals(amount: number) {
   return ENV_CONFIG.moneyMoniker + amount.toFixed(2)
 }
 
+/** Below this, a non-zero amount is float dust (no fee or payout is that
+ * small: the smallest possible fee is M$0.001). formatMoneyPrecise reads it
+ * as zero rather than as JavaScript's exponent notation, and callers that
+ * word a sign ("Paying …") should treat it as nothing rather than as a
+ * direction with a zero amount. */
+export const MONEY_PRECISE_DUST = 1e-6
+
+/**
+ * Mana formatting for exact fractional financial values such as perp fees,
+ * PnL, payouts and per-period funding. Values of at least 0.01 use cents;
+ * smaller non-zero values use two significant digits so a real debit never
+ * collapses to zero. Both go through formatNumber, so grouping and the
+ * decimal separator follow the viewer's locale like formatMoney. The sign
+ * goes before the moniker; non-finite input reads as zero.
+ */
+export function formatMoneyPrecise(amount: number) {
+  if (!Number.isFinite(amount)) return ENV_CONFIG.moneyMoniker + '0'
+  const absoluteAmount = Math.abs(amount)
+  if (absoluteAmount < MONEY_PRECISE_DUST) return ENV_CONFIG.moneyMoniker + '0'
+
+  const fractionDigits =
+    absoluteAmount >= 0.01
+      ? 2
+      : // Two significant digits: count the decimals they occupy. The value
+        // is ≥ 1e-6, so its string form is never in exponent notation.
+        (String(Number(absoluteAmount.toPrecision(2))).split('.')[1] ?? '')
+          .length
+  const numberText = formatNumber(absoluteAmount, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })
+  return `${amount < 0 ? '-' : ''}${ENV_CONFIG.moneyMoniker}${numberText}`
+}
+
 // Like formatMoney, but avoids collapsing tiny non-zero spends to "Ṁ0".
 // Any positive amount below 1 is shown as Ṁ1 (and any negative amount above
 // -1 as -Ṁ1) so the UI always reflects that mana was actually spent.

--- a/web/components/bet/user-bets-table.tsx
+++ b/web/components/bet/user-bets-table.tsx
@@ -27,7 +27,11 @@ import {
 import { getUserFacingPnl } from 'common/perps/pnl'
 import { PerpPosition } from 'common/perps/position'
 import { buildArray } from 'common/util/array'
-import { formatMoney, formatWithToken } from 'common/util/format'
+import {
+  formatMoney,
+  formatMoneyPrecise,
+  formatWithToken,
+} from 'common/util/format'
 import { floatingEqual } from 'common/util/math'
 import { searchInAny } from 'common/util/parse'
 import { Dictionary, mapValues, sortBy, sum, uniqBy } from 'lodash'
@@ -1297,18 +1301,18 @@ const ExpandedPerpRow = (props: {
       <Row className="flex-wrap gap-x-8 gap-y-2 text-sm">
         <Col>
           <span className="text-ink-500 text-xs">Position value</span>
-          <span className="font-semibold">{formatMoney(m.payout)}</span>
+          <span className="font-semibold">{formatMoneyPrecise(m.payout)}</span>
         </Col>
         <Col>
           <span className="text-ink-500 text-xs">Amount invested</span>
           <span className="font-semibold">
-            {formatMoney(m.totalAmountInvested)}
+            {formatMoneyPrecise(m.totalAmountInvested)}
           </span>
         </Col>
         <Col>
           <span className="text-ink-500 text-xs">Returned on closes</span>
           <span className="font-semibold">
-            {formatMoney(m.totalAmountSold ?? 0)}
+            {formatMoneyPrecise(m.totalAmountSold ?? 0)}
           </span>
         </Col>
         <Col>
@@ -1320,7 +1324,7 @@ const ExpandedPerpRow = (props: {
             )}
           >
             {m.profit >= 0 ? '+' : ''}
-            {formatMoney(m.profit)}
+            {formatMoneyPrecise(m.profit)}
           </span>
         </Col>
       </Row>
@@ -1370,7 +1374,7 @@ const ExpandedPerpRow = (props: {
                     )}
                   >
                     {pnl >= 0 ? '+' : ''}
-                    {formatMoney(pnl)}
+                    {formatMoneyPrecise(pnl)}
                   </span>
                 )}
               </Row>
@@ -1402,7 +1406,7 @@ const ExpandedPerpRow = (props: {
               </span>
               {e.payout != null && (
                 <span className="text-ink-500">
-                  payout {formatMoney(e.payout)}
+                  payout {formatMoneyPrecise(e.payout)}
                 </span>
               )}
               <span className="text-ink-400 text-xs">

--- a/web/components/perps/perp-bet-panel.tsx
+++ b/web/components/perps/perp-bet-panel.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { PerpContract } from 'common/contract'
-import { ENV_CONFIG } from 'common/envs/constants'
 import {
   assertPerpPositionNumbers,
   getPerpBackingPool,
@@ -21,6 +20,7 @@ import {
 } from 'common/perps/amm'
 import {
   assertPerpTakerFeeConfig,
+  calculatePerpOpenCashFlow,
   getPerpTakerFeeBps,
   getPerpTakerFeeImpact,
   perpMaxFeeFor,
@@ -34,9 +34,16 @@ import {
   getFundingPeriodMs,
   getPerpFundingRate,
 } from 'common/perps/funding'
-import { fundingPerPeriod } from 'common/perps/pnl'
+import {
+  fundingPerPeriod,
+  getPerpPriceForUserFacingPnl,
+} from 'common/perps/pnl'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
-import { formatMoney, formatMoneyWithDecimals } from 'common/util/format'
+import {
+  formatMoney,
+  formatMoneyPrecise,
+  MONEY_PRECISE_DUST,
+} from 'common/util/format'
 import { randomString } from 'common/util/random'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
@@ -308,6 +315,38 @@ export const PerpBetPanel = (props: {
   // fee plus PERP_FEE_SLIPPAGE_BPS of notional — see perpMaxFeeFor for why it
   // is sized in bps of size rather than as a percentage of the fee.
   const maxFee = perpMaxFeeFor(openFee, notional)
+
+  // Affordability, through the same helper the engine's 403 runs: the debit
+  // is margin PLUS the fee quoted above, and a flip's free close payout —
+  // myPositionValue, the same amount that leaves the pool — may fund it.
+  // BuyAmountInput's own check (margin ≤ raw balance) is switched off via
+  // disregardUserBalance because it is wrong in both directions here: it
+  // passes a max-balance open the fee makes unaffordable (server 403), and
+  // blocks a payout-funded flip the engine accepts.
+  const flipPayout = isFlip && myPosition ? myPositionValue : 0
+  const cashFlow =
+    marginAmount > 0
+      ? calculatePerpOpenCashFlow({
+          balance: user?.balance ?? 0,
+          margin: marginAmount,
+          openFee,
+          closePayout: flipPayout,
+        })
+      : undefined
+  // Judged only once positions are loaded — before that a flip previews as a
+  // fresh open with no payout to fund it, which would flash "Insufficient
+  // balance" at exactly the trader it should not (submit is separately gated
+  // on positions == null). An unpriceable fee already blocks submit with its
+  // own message, so it is not double-reported here.
+  const affordabilityError =
+    user && positions != null && marginAmount > 0 && !feePreviewInvalid
+      ? !cashFlow
+        ? 'Unable to calculate trade cost'
+        : !cashFlow.isAffordable
+        ? 'Insufficient balance'
+        : undefined
+      : undefined
+  const displayedAmountError = amountError ?? affordabilityError
   const capacity = useMemo(() => {
     if (positions == null) return null
     try {
@@ -397,6 +436,22 @@ export const PerpBetPanel = (props: {
       // depth to price against, so adding is blocked.
       toast.error(
         'Market backing is exhausted relative to your position — close or reduce instead'
+      )
+      return
+    }
+    if (!cashFlow || !cashFlow.isAffordable) {
+      // Mirrors the engine's 403 (same helper, same inputs), itemised the
+      // same way so the two messages can never tell different stories.
+      toast.error(
+        cashFlow
+          ? `Insufficient balance: need ${formatMoneyPrecise(
+              cashFlow.totalDebit
+            )} (${formatMoney(marginAmount)} margin${
+              openFee > 0 ? ` + ${formatMoneyPrecise(openFee)} fee` : ''
+            }), have ${formatMoneyPrecise(cashFlow.spendableBalance)}${
+              flipPayout > 0 ? ' including the flipped position' : ''
+            }`
+          : 'Unable to calculate trade cost'
       )
       return
     }
@@ -544,8 +599,11 @@ export const PerpBetPanel = (props: {
           parentClassName="max-w-full"
           amount={margin}
           onChange={setMargin}
-          error={amountError}
+          error={displayedAmountError}
           setError={setAmountError}
+          // Balance is validated against margin + fee (and a flip's payout)
+          // above, not against margin alone.
+          disregardUserBalance
           disabled={submitting}
           showSlider
           showSliderMarks
@@ -575,7 +633,6 @@ export const PerpBetPanel = (props: {
         direction={direction}
         notional={notional}
         margin={marginAmount}
-        leverage={preview.leverage}
         entryPrice={preview.entryPrice}
         liqPrice={liqPrice}
         priceDecimals={priceDecimals}
@@ -626,7 +683,7 @@ export const PerpBetPanel = (props: {
           // Positions must be loaded before the previewed fee (and add/flip
           // detection) can be trusted — see the onSubmit gate.
           positions == null ||
-          !!amountError ||
+          !!displayedAmountError ||
           !margin ||
           margin <= 0 ||
           exceedsCapacity ||
@@ -741,20 +798,10 @@ const LeverageSlider = (props: {
   )
 }
 
-// Profit tiers shown in the scenario ladder: each is a +r return on margin.
+// Profit tiers shown in the scenario ladder: each is a +r NET return on the
+// cash committed to this new position (margin + opening fee) — the same base
+// the position card's percentage uses, so the two agree at the target price.
 const RETURN_TIERS = [0.25, 0.5, 1] as const
-
-// Adaptive precision so sub-cent per-period funding amounts don't collapse
-// to "0.00". Shared with the position card's funding row.
-export const formatFundingMana = (absAmount: number) => {
-  const m = ENV_CONFIG.moneyMoniker
-  if (!(absAmount > 0)) return `${m}0`
-  const body =
-    absAmount >= 0.01
-      ? absAmount.toFixed(2)
-      : `${Number(absAmount.toPrecision(2))}`
-  return `${m}${body}`
-}
 
 // Fees display as PERCENTAGES — traders don't think in bps. Two decimals
 // below 1% keep the base (0.10%) and a small size term legible; larger fees
@@ -787,7 +834,6 @@ const StatsGrid = (props: {
   direction: 'long' | 'short'
   notional: number
   margin: number
-  leverage: number
   entryPrice: number
   liqPrice: number
   priceDecimals: number
@@ -823,7 +869,6 @@ const StatsGrid = (props: {
     direction,
     notional,
     margin,
-    leverage,
     entryPrice,
     liqPrice,
     priceDecimals,
@@ -852,28 +897,51 @@ const StatsGrid = (props: {
   const feeExceedsMargin =
     margin > 0 && fee >= margin * PERP_MAX_FEE_SHARE_OF_MARGIN
 
+  // Add previews are hidden on purpose: `margin` is the new tranche but
+  // entryPrice describes the merged position, so a "+25% on margin" target
+  // would mix two bases. Defining return for an add is a product decision.
   const canShowScenarios =
-    Number.isFinite(entryPrice) && margin > 0 && leverage > 0
+    !isAddPreview &&
+    !feePreviewInvalid &&
+    Number.isFinite(entryPrice) &&
+    entryPrice > 0 &&
+    margin > 0 &&
+    notional > 0
 
-  // At leverage ℓ a +r return on margin needs a price move of r/ℓ, so the
-  // target price is entry·(1 ± r/ℓ) and the mana P&L is just r·margin.
+  // Solve for the price at which the position's user-facing PnL — the number
+  // the position card will show, net of the opening fee — reaches +r of the
+  // cash committed. The base is margin + fee, the same denominator the card's
+  // percentage uses (getUserFacingPnlPercent), so at the solved price the
+  // card reads exactly "+r%" and exactly this mana profit. Without the fee
+  // this is the familiar entry·(1 ± r/ℓ); with it the target sits further
+  // out, so the ladder no longer promises a profit the card would then
+  // report as smaller. Closing is free; future funding remains unknowable
+  // here (and is called out below).
   const scenarios = canShowScenarios
-    ? RETURN_TIERS.map((ret) => ({
-        ret,
-        price:
-          direction === 'long'
-            ? entryPrice * (1 + ret / leverage)
-            : entryPrice * (1 - ret / leverage),
-        pnl: ret * margin,
-      })).filter((s) => Number.isFinite(s.price) && s.price > 0)
+    ? RETURN_TIERS.flatMap((ret) => {
+        const pnl = ret * (margin + fee)
+        const price = getPerpPriceForUserFacingPnl(
+          {
+            direction,
+            size: notional,
+            costBasis: margin,
+            originalCostBasis: margin,
+            takerFeeCostBasis: fee,
+            entryPrice,
+          },
+          pnl
+        )
+        return price === undefined ? [] : [{ ret, price, pnl }]
+      })
     : []
 
   const periodPct = marketFundingRate * 100
-  const paysFunding = fundingManaPerPeriod < 0
-  const earnsFunding = fundingManaPerPeriod > 0
+  // Dust from a near-balanced pool would otherwise read "-Ṁ0/hr".
+  const paysFunding = fundingManaPerPeriod <= -MONEY_PRECISE_DUST
+  const earnsFunding = fundingManaPerPeriod >= MONEY_PRECISE_DUST
   const fundingValue = `${
     paysFunding ? '-' : earnsFunding ? '+' : ''
-  }${formatFundingMana(Math.abs(fundingManaPerPeriod))}/${fundingPeriodUnit(
+  }${formatMoneyPrecise(Math.abs(fundingManaPerPeriod))}/${fundingPeriodUnit(
     fundingPeriodMs
   )} · ${periodPct >= 0 ? '+' : ''}${periodPct.toFixed(3)}%`
 
@@ -915,7 +983,7 @@ const StatsGrid = (props: {
             value={
               feePreviewInvalid
                 ? '—'
-                : `${formatMoneyWithDecimals(fee)} (${formatFeePct(
+                : `${formatMoneyPrecise(fee)} (${formatFeePct(
                     notional > 0 ? feeEffectiveBps : feeBaseBps
                   )})`
             }
@@ -990,7 +1058,7 @@ const StatsGrid = (props: {
           {scenariosOpen && (
             <>
               <Row className="text-ink-400 items-baseline text-xs">
-                <span className="flex-1">gain</span>
+                <span className="flex-1">return</span>
                 <span className="w-20 text-right">at price</span>
                 <span className="w-20 text-right">profit</span>
               </Row>
@@ -1003,7 +1071,7 @@ const StatsGrid = (props: {
                     {formatPrice(s.price, priceDecimals)}
                   </span>
                   <span className="w-20 text-right font-medium text-teal-600">
-                    +{formatMoneyWithDecimals(s.pnl)}
+                    +{formatMoneyPrecise(s.pnl)}
                   </span>
                 </Row>
               ))}

--- a/web/components/perps/perp-holders-tab.tsx
+++ b/web/components/perps/perp-holders-tab.tsx
@@ -12,7 +12,11 @@ import {
   getFundingPeriodMs,
   getPerpFundingRate,
 } from 'common/perps/funding'
-import { formatMoney, formatMoneyShort } from 'common/util/format'
+import {
+  formatMoney,
+  formatMoneyPrecise,
+  formatMoneyShort,
+} from 'common/util/format'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import generateFilterDropdownItems from 'web/components/search/search-dropdown-helpers'
@@ -351,7 +355,7 @@ const HolderRow = (props: {
         </div>
         <Col className="items-end">
           <span className={pnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'}>
-            {formatMoney(pnl)}
+            {formatMoneyPrecise(pnl)}
           </span>
           <span className="text-ink-500 text-xs">
             {formatMoney(holder.size)} notional · {holder.leverage.toFixed(2)}×

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -20,7 +20,11 @@ import {
   formatPrice,
   inferPriceDecimals,
 } from 'common/perps/format'
-import { formatMoney } from 'common/util/format'
+import {
+  formatMoney,
+  formatMoneyPrecise,
+  MONEY_PRECISE_DUST,
+} from 'common/util/format'
 import { randomString } from 'common/util/random'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
@@ -28,7 +32,6 @@ import { Row } from 'web/components/layout/row'
 import { api } from 'web/lib/api/api'
 import { useUser } from 'web/hooks/use-user'
 import { track } from 'web/lib/service/analytics'
-import { formatFundingMana } from './perp-bet-panel'
 import { PerpPositionRow, scheduleFreshBurst } from './use-perp-positions'
 
 type Position = {
@@ -150,9 +153,9 @@ export const PerpPositionPanel = (props: {
         expectedOpenedTime: position.openedTime,
       })
       toast.success(
-        `Closed ${direction} — payout ${formatMoney(
+        `Closed ${direction} — payout ${formatMoneyPrecise(
           res.payout
-        )} (profit ${formatMoney(res.pnl)})`
+        )} (profit ${formatMoneyPrecise(res.pnl)})`
       )
       track('sell shares', {
         outcomeType: contract.outcomeType,
@@ -257,7 +260,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
                 💥 Liquidated {e.direction}
               </span>
               <span className="text-scarlet-600 font-semibold tabular-nums">
-                −{formatMoney(lost)} margin
+                −{formatMoneyPrecise(lost)} margin
               </span>
               <span className="text-ink-500 tabular-nums">
                 at {formatPrice(e.oraclePrice, decimals)}
@@ -277,7 +280,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
                 Auto-deleveraged {e.direction}
               </span>
               <span className="text-ink-700 tabular-nums">
-                {formatMoney(e.payout ?? 0)} margin returned
+                {formatMoneyPrecise(e.payout ?? 0)} margin returned
               </span>
               <span
                 className={clsx(
@@ -286,7 +289,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
                 )}
               >
                 Profit {pnl >= 0 ? '+' : ''}
-                {formatMoney(pnl)}
+                {formatMoneyPrecise(pnl)}
               </span>
               <span className="text-ink-500 tabular-nums">
                 at {formatPrice(e.oraclePrice, decimals)}
@@ -307,7 +310,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
               Closed {e.direction}
             </span>
             <span className="text-ink-700 tabular-nums">
-              payout {formatMoney(e.payout ?? 0)}
+              payout {formatMoneyPrecise(e.payout ?? 0)}
             </span>
             <span
               className={clsx(
@@ -316,7 +319,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
               )}
             >
               {pnl >= 0 ? '+' : ''}
-              {formatMoney(pnl)}
+              {formatMoneyPrecise(pnl)}
             </span>
             <span className="text-ink-500 tabular-nums">
               at {formatPrice(e.oraclePrice, decimals)}
@@ -455,7 +458,7 @@ const PositionCard = (props: {
             <div className="text-ink-400 text-xs">Unrealized profit</div>
             <div className={clsx('text-xl font-bold tabular-nums', pnlColor)}>
               {pnl >= 0 ? '+' : ''}
-              {formatMoney(pnl)}
+              {formatMoneyPrecise(pnl)}
             </div>
             <div className={clsx('text-xs tabular-nums', pnlColor)}>
               {pnl >= 0 ? '+' : ''}
@@ -489,7 +492,7 @@ const PositionCard = (props: {
         {/* One left-aligned sentence — a lone "Funding" label with a
             paragraph-length value right-aligned across the card read as two
             disconnected columns. */}
-        {fundingMana !== 0 && (
+        {Math.abs(fundingMana) >= MONEY_PRECISE_DUST && (
           <div className="-mt-1 text-sm">
             <span
               className={clsx(
@@ -498,7 +501,7 @@ const PositionCard = (props: {
               )}
             >
               {fundingMana > 0 ? 'Earning ' : 'Paying '}
-              {formatFundingMana(Math.abs(fundingMana))}/
+              {formatMoneyPrecise(Math.abs(fundingMana))}/
               {fundingPeriodUnit(fundingPeriodMs)}{' '}
               {fundingMana > 0 ? 'from funding' : 'in funding'}
             </span>

--- a/web/components/perps/perp-trades-tab.tsx
+++ b/web/components/perps/perp-trades-tab.tsx
@@ -3,7 +3,7 @@ import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-i
 import { useEffect, useRef, useState } from 'react'
 import { PerpContract } from 'common/contract'
 import { formatPrice, inferPriceDecimals } from 'common/perps/format'
-import { formatMoney } from 'common/util/format'
+import { formatMoney, formatMoneyPrecise } from 'common/util/format'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { RelativeTimestamp } from 'web/components/relative-timestamp'
@@ -278,21 +278,27 @@ const EventRow = (props: {
           <span className="text-scarlet-600 font-medium">
             {liquidationMarginLost == null
               ? 'Margin lost'
-              : `${formatMoney(liquidationMarginLost)} margin lost`}
+              : `${formatMoneyPrecise(liquidationMarginLost)} margin lost`}
           </span>
         ) : partialAdlReduction != null ? (
           <span className="font-medium text-amber-600">
             {(partialAdlReduction * 100).toFixed(1)}% position reduced
           </span>
         ) : marginOrPayout != null ? (
-          <span className="text-ink-900">{formatMoney(marginOrPayout)}</span>
+          // Payouts and PnL are fractional and match the position history
+          // rows; posted margin stays whole-mana like everywhere else.
+          <span className="text-ink-900">
+            {isExit
+              ? formatMoneyPrecise(marginOrPayout)
+              : formatMoney(marginOrPayout)}
+          </span>
         ) : null}
         {isExit && event.pnl != null && (
           <span
             className={event.pnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'}
           >
             {event.pnl >= 0 ? '+' : ''}
-            {formatMoney(event.pnl)}
+            {formatMoneyPrecise(event.pnl)}
           </span>
         )}
       </Col>

--- a/web/components/portfolio/balance-change-table.tsx
+++ b/web/components/portfolio/balance-change-table.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import { Col } from 'web/components/layout/col'
 import {
   formatMoney,
+  formatMoneyPrecise,
   formatMoneyUSD,
   formatSpice,
   formatSweepies,
@@ -793,6 +794,8 @@ const TxnBalanceChangeRow = (props: {
               ? formatSpice(amount).replace('-', '')
               : token === 'CASH'
               ? formatSweepies(amount).replace('-', '')
+              : type === 'PERP_TAKER_FEE'
+              ? formatMoneyPrecise(Math.abs(amount))
               : formatMoney(amount).replace('-', '')}
           </span>
         </Row>


### PR DESCRIPTION
## Summary

Reworked on top of #4014/#4015 — the original branch predated the size-dependent fee and no longer merged (its shared helper recomputed the fee as `notional × bps`, which would have disagreed with what the engine now charges).

- **Fee-aware affordability, shared with the engine.** New `calculatePerpOpenCashFlow({ balance, margin, openFee, closePayout })` in `common/perps/fees.ts`. The engine's 403 runs through it, and the trade panel now runs the *same* check on the same inputs — its previewed `perpOpenFeeQuote` fee and `getPositionValue` of the flipped leg (exactly the engine's close payout). The fee is an **input**, never recomputed from bps, so the helper is correct for the size-dependent and API-channel fees and stays correct as the schedule evolves.
- **Profit ladder net of the opening fee.** New `getPerpPriceForUserFacingPnl` inverts `getUserFacingPnl` for the price at which the position card's PnL reaches a target. Each tier is a return on the cash committed (margin + fee) — the same denominator the card's percentage uses — so at the solved price the card shows exactly the ladder's `+r%` and mana profit. Add previews stay hidden (tranche margin vs merged entry are different bases; a separate product call).
- **Fractional displays.** New `formatMoneyPrecise` (cents at ≥ 0.01 grouped in the viewer's locale like `formatMoney`; two significant digits below that; float dust < 1e-6 reads as zero; sign before the moniker; fails closed on non-finite). Used wherever a perp fee, payout or PnL is shown: bet-panel fee row and ladder, position card + history, close toast, trades and holders tabs, portfolio perp expansion, ledger `PERP_TAKER_FEE` row and close/ADL subtitles, ADL notification, and the funding rows (replacing the panel's private `formatFundingMana`). Posted margin and notional stay whole-mana.

## Root cause

The opening fee was added after the panel's balance validation and scenario ladder were built. `BuyAmountInput` validated *margin* against *raw balance*, so a max-balance open passed the client and 403'd on the server once the fee was added, while a flip whose new margin exceeds raw balance was blocked even though the engine funds it from the closed leg's free payout. The ladder solved `entry·(1 ± r/ℓ)`, gross of the fee. And `formatMoney` floors to whole mana, so a M$0.05 fee or a +M$0.60 profit rendered as "Ṁ0" — and differently across surfaces for the same event.

## Behaviour

- The panel shows "Insufficient balance" (with the usual buy-more UI) exactly when the engine would 403; submit is disabled in that state and, if reached, rejects with the engine's itemised message (`need Ṁ110.00 (Ṁ100 margin + Ṁ10.00 fee), have Ṁ100.00`) before any request.
- Payout-funded flips are no longer blocked client-side.
- Affordability is judged only once positions have loaded, so a flip never flashes a spurious error while it still previews as a fresh open.
- Server behaviour is unchanged (pure refactor of the existing check into the shared helper; a non-finite input now fails closed with a 500 instead of being compared).

## Validation (from the worktree root)

- `yarn --cwd common test --runInBand` — 32 suites / 602 tests (new: `calculatePerpOpenCashFlow`, `getPerpPriceForUserFacingPnl`, `formatMoneyPrecise`)
- `yarn test:shared` — 20 tests
- `yarn build:common && yarn build:shared`
- `yarn typecheck:web && yarn typecheck:api`
- `yarn lint:common && yarn lint:api && yarn lint:shared`
- `yarn --cwd web eslint --max-warnings=0` on the six touched web files
- Prettier `--check` on the committed (LF) content of every touched file
- Multi-agent adversarial review (5 lenses, 2 refuters per finding): 7 findings, all addressed in this revision.
