### PR TITLE
fix(scheduler): materialize daily activity so update-stats stops re-reading 68 days

### DIFF
--- a/backend/scheduler/src/jobs/check-stats-freshness.ts
+++ b/backend/scheduler/src/jobs/check-stats-freshness.ts
@@ -1,0 +1,76 @@
+import * as dayjs from 'dayjs'
+import * as utc from 'dayjs/plugin/utc'
+import * as timezone from 'dayjs/plugin/timezone'
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+import { log } from 'shared/utils'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+
+// Checks the OUTPUT of update-stats rather than whether the job threw.
+//
+// The distinction matters because a failed nightly run does not reliably page
+// anyone. 'Query read timeout' — the error that killed this job every night
+// from 2026-08-04 — is in the transient-error list in helpers.ts, so the first
+// failure logs a warning and escalates to ERROR only on a second consecutive
+// one, counted in a Map that lives in process memory. The scheduler container
+// OOM-restarts most days, which resets that counter. A once-daily job can
+// therefore fail indefinitely without ever reaching the alert policy, which is
+// how the August outage ran for nine days before anyone noticed.
+//
+// Anything this finds is logged at ERROR, which is what the job-crash alert
+// policy matches on, and is deliberately not thrown: throwing would route it
+// back through the same damping that hid the original failure.
+const GAP_WINDOW_DAYS = 30
+
+export const checkStatsFreshness = async () => {
+  const pg = createSupabaseDirectClient()
+  const yesterday = dayjs()
+    .tz('America/Los_Angeles')
+    .subtract(1, 'day')
+    .format('YYYY-MM-DD')
+
+  const row = await pg.oneOrNone<{
+    missing: string[] | null
+  }>(
+    `select array_remove(array[
+      case when dau is null then 'dau' end,
+      case when dav is null then 'dav' end,
+      case when bet_count is null then 'bet_count' end,
+      case when topic_daus is null then 'topic_daus' end
+    ], null) as missing
+    from daily_stats where start_date = $1::date`,
+    [yesterday]
+  )
+
+  if (!row) {
+    log.error(`[stats-freshness] no daily_stats row for ${yesterday}`)
+  } else if (row.missing?.length) {
+    log.error(
+      `[stats-freshness] daily_stats for ${yesterday} is missing ${row.missing.join(
+        ', '
+      )}`
+    )
+  }
+
+  const { gaps } = await pg.one<{ gaps: number }>(
+    `with wanted as (
+      select generate_series($1::date - $2::int, $1::date, interval '1 day')::date as day
+    )
+    select count(*)::int as gaps
+    from wanted w
+    left join daily_stats s on s.start_date = w.day
+    where s.dau is null`,
+    [yesterday, GAP_WINDOW_DAYS]
+  )
+
+  if (gaps > 0) {
+    log.error(
+      `[stats-freshness] ${gaps} of the last ${
+        GAP_WINDOW_DAYS + 1
+      } days have no dau`
+    )
+  } else if (row && !row.missing?.length) {
+    log(`[stats-freshness] ok through ${yesterday}`)
+  }
+}

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -60,6 +60,7 @@ import { unbanUsers } from './unban-users'
 import { updateLeague } from './update-league'
 import { updateLeagueRanks } from './update-league-ranks'
 import { updateStatsCore } from './update-stats'
+import { checkStatsFreshness } from './check-stats-freshness'
 import { updatePerps } from './update-perps'
 import { updateOracleFeeds } from './update-oracle-feeds'
 import { updateOpenRouterShare } from './update-openrouter-share'
@@ -364,6 +365,11 @@ export function createJobs(jobSet: SchedulerJobSet) {
       'update-stats',
       '0 20 4 * * *', // daily at 4:20 AM LA
       () => updateStatsCore(7)
+    ),
+    createJob(
+      'check-stats-freshness',
+      '0 0 8 * * *', // daily at 8:00 AM LA, a few hours after update-stats
+      checkStatsFreshness
     ),
     createJob(
       'update-trump-approval',

--- a/backend/scheduler/src/jobs/update-stats.ts
+++ b/backend/scheduler/src/jobs/update-stats.ts
@@ -14,9 +14,11 @@ import {
 } from 'lodash'
 import { log, logMemory, revalidateStaticProps } from 'shared/utils'
 import { average, median } from 'common/util/math'
+import { MINUTE_MS, sleep } from 'common/util/time'
 import {
   createSupabaseDirectClient,
   type SupabaseDirectClient,
+  type SupabaseTransaction,
 } from 'shared/supabase/init'
 import { bulkUpsert } from 'shared/supabase/utils'
 import { saveCalibrationData } from 'shared/calculate-calibration'
@@ -58,13 +60,42 @@ type StatUser = StatEvent & {
 export const updateStatsCore = async (daysAgo: number) => {
   // We run the script at 4am, but we want data from the start of each day up until last midnight.
   const endDay = dayjs().tz('America/Los_Angeles')
-  const startDay = endDay.subtract(daysAgo, 'day')
   const end = endDay.format('YYYY-MM-DD')
-  const start = startDay.format('YYYY-MM-DD')
 
   const pg = createSupabaseDirectClient()
 
-  await updateStatsBetween(pg, start, end)
+  // Widen the window if earlier runs left holes. Only the trailing `daysAgo`
+  // days are ever written, so a failure lasting longer than that puts those
+  // days permanently out of reach of every later run: after the Aug 4-12
+  // outage, dau, retention and topic_daus for Aug 3-5 are still NULL and no
+  // nightly run would ever have filled them. Reaching back to the oldest gap
+  // lets the next run repair what the last one missed.
+  const recoveryDaysAgo = await getRecoveryDaysAgo(pg, end, daysAgo)
+  if (recoveryDaysAgo !== daysAgo) {
+    log(
+      `Widening stats window from ${daysAgo} to ${recoveryDaysAgo} days to fill gaps`
+    )
+  }
+  const recoveryStart = endDay
+    .subtract(recoveryDaysAgo, 'day')
+    .format('YYYY-MM-DD')
+
+  // Held, not thrown, for the same reason the ordering below exists: the steps
+  // after this one do not depend on it, and letting an activity failure abort
+  // the job is what left mana_supply_stats and the /stats page stale for weeks
+  // at a time. Rethrown at the end so the run still counts as failed.
+  let activityError: unknown
+  try {
+    await updateStatsBetween(pg, recoveryStart, end)
+  } catch (err) {
+    activityError = err
+    log.error(
+      'updateStatsBetween failed; continuing with the rest of the job',
+      {
+        error: err instanceof Error ? err.message : String(err),
+      }
+    )
+  }
 
   const startOfYesterday = endDay.subtract(1, 'day').startOf('day').valueOf()
   await updateTxnStats(pg, startOfYesterday, 1)
@@ -106,6 +137,8 @@ export const updateStatsCore = async (daysAgo: number) => {
     })
   }
 
+  if (activityError) throw activityError
+
   log('Done')
 }
 
@@ -120,6 +153,33 @@ export const updateCashStatsCore = async (daysAgo: number) => {
   await updateDailyCashSales(pg, start, end)
 }
 
+// How many days back this run should reach: the requested window, extended to
+// the oldest day in the last MAX_RECOVERY_DAYS whose stats never landed.
+// dau is the probe because it is written for every day the job completes and
+// for no day it does not.
+const getRecoveryDaysAgo = async (
+  pg: SupabaseDirectClient,
+  end: string,
+  requested: number
+) => {
+  const row = await pg.oneOrNone<{ oldest_gap: string | null }>(
+    `with wanted as (
+      select generate_series($1::date - $2::int, $1::date - 1, interval '1 day')::date as day
+    )
+    select min(w.day)::text as oldest_gap
+    from wanted w
+    left join daily_stats s on s.start_date = w.day
+    where s.dau is null`,
+    [end, MAX_RECOVERY_DAYS]
+  )
+  if (!row?.oldest_gap) return requested
+  // Yesterday is always "missing" before a run — that is the day this run is
+  // here to write, not a gap — and it yields a 1-day reach, well inside the
+  // requested window, so it never widens anything on its own.
+  const gapDays = dayjs(end).diff(dayjs(row.oldest_gap), 'day') + 1
+  return Math.min(Math.max(requested, gapDays), MAX_RECOVERY_DAYS)
+}
+
 // YYYY-MM-DD
 export const updateStatsBetween = async (
   pg: SupabaseDirectClient,
@@ -131,6 +191,11 @@ export const updateStatsBetween = async (
   await updateConversionScores(pg, start, end)
 }
 
+/**
+ * @deprecated CASH path only. The mana path reads the daily activity rollup;
+ * see materializeActivityDays. Kept because updateCashActivityStats still
+ * calls it, though no job registers the cash stats job any more.
+ */
 async function getDailyBets(
   pg: SupabaseDirectClient,
   start: string,
@@ -171,56 +236,6 @@ async function getDailyBets(
   )
 
   return bets as DailyBetStats[]
-}
-
-async function getDailyPerpTrades(
-  pg: SupabaseDirectClient,
-  start: string,
-  end: string
-) {
-  const trades = await pg.manyOrNone(
-    `select
-      date_trunc('day', e.ts at time zone 'america/los_angeles')::date as day,
-      json_agg(json_build_object(
-        'ts', ts_to_millis(e.ts),
-        'userId', e.user_id,
-        'id', 'perp-' || e.id
-      )) as values
-    from contract_perp_events e
-    where
-      e.ts >= date_to_midnight_pt($1)
-      and e.ts < date_to_midnight_pt($2)
-      and e.user_id is not null
-      and e.event_type in ('open', 'add', 'close')
-      and e.data->>'reason' is distinct from 'flip'
-      and e.data->>'reason' is distinct from 'resolve-market'
-    group by day
-    order by day asc`,
-    [start, end]
-  )
-
-  return trades as { day: string; values: StatEvent[] }[]
-}
-
-async function getDailyViewers(
-  pg: SupabaseDirectClient,
-  start: string,
-  end: string
-) {
-  const viewers = await pg.manyOrNone(
-    `select
-    date_trunc('day', ts at time zone 'america/los_angeles')::date as day,
-    count(distinct(data->>'deviceId')) as viewer_count
-    from user_events
-    where
-      ts >= date_to_midnight_pt($1)
-      and ts < date_to_midnight_pt($2)
-    group by day
-    order by day asc`,
-    [start, end]
-  )
-
-  return viewers as { day: string; viewer_count: number }[]
 }
 
 async function getDailyComments(
@@ -341,6 +356,262 @@ async function getDailyNewUsers(
 // this should at least be two months for monthly stats
 const bufferDays = 61
 
+// Every rollup rebuild is one day wide and carries its own server-side
+// deadline. Both properties are load-bearing. One day keeps the planner on the
+// created_time index — at ~30 days it flips to a full scan of the
+// contract_bets partial index, and it flips on ESTIMATED rows, so the margin
+// moves whenever autoanalyze runs. And a per-statement deadline means no
+// single statement can absorb the whole run's time the way the 68-day fetch
+// did: it burned the full client hour and wrote nothing.
+const CHUNK_STATEMENT_TIMEOUT = '300s'
+const CHUNK_RETRIES = 1
+const CHUNK_RETRY_DELAY_MS = 15 * 1000
+// A run that cannot get through its rebuild list inside the budget stops and
+// says so instead of grinding on into the morning. Days already rebuilt are
+// committed, so the next run resumes rather than restarting.
+const MATERIALIZE_BUDGET_MS = 25 * MINUTE_MS
+// How far back a run will reach to repair days an earlier failure left empty.
+// Bounded so one bad month cannot hand a single night an unbounded backlog.
+//
+// This is deliberately below bufferDays, and it is the automatic repair
+// horizon: an outage longer than 30 days leaves the days beyond it for the
+// backfill script plus a manual `yarn update-stats <start> <end>`. Matching
+// bufferDays instead would let one night rebuild 61 days, which is most of the
+// work this change exists to stop doing.
+const MAX_RECOVERY_DAYS = 30
+
+// [start, end) as YYYY-MM-DD. Iterating and formatting (rather than diffing)
+// keeps this correct across DST, where a local day is 23 or 25 hours long.
+const listDays = (start: string, end: string) => {
+  const days: string[] = []
+  let day = dayjs(start)
+  while (day.format('YYYY-MM-DD') < end) {
+    days.push(day.format('YYYY-MM-DD'))
+    day = day.add(1, 'day')
+  }
+  return days
+}
+
+const withChunkTimeout = <T>(
+  pg: SupabaseDirectClient,
+  fn: (tx: SupabaseTransaction) => Promise<T>
+) =>
+  pg.tx(async (tx) => {
+    // one(), not none(): set_config returns a row, and none() rejects on any
+    // returned row — the mistake that kept score-contracts down for four days
+    // (#3973, fixed in #3988). `true` scopes the setting to this transaction.
+    await tx.one(`select set_config('statement_timeout', $1, true)`, [
+      CHUNK_STATEMENT_TIMEOUT,
+    ])
+    return fn(tx)
+  })
+
+// Rebuilds one LA calendar day of the rollup. $1 is the day, $2 the next day,
+// so date_to_midnight_pt brackets exactly that day and the date_trunc grouping
+// the old per-day queries did becomes a constant.
+const REBUILD_ACTIVITY_DAY = `
+  with bets as materialized (
+    select b.user_id, count(*)::int as n,
+      sum(b.amount) filter (where c.token = 'MANA') as mana_amount
+    from contract_bets b join contracts c on b.contract_id = c.id
+    where b.created_time >= date_to_midnight_pt($1)
+      and b.created_time < date_to_midnight_pt($2)
+      and b.is_redemption = false
+    group by b.user_id
+  ),
+  created as materialized (
+    -- creator_id is nullable. The old code tolerated a null creator (it became
+    -- one more entry in the day's id list); here it would violate
+    -- daily_user_activity.user_id and make the day permanently unbuildable.
+    select creator_id as user_id, count(*)::int as n
+    from contracts
+    where created_time >= date_to_midnight_pt($1)
+      and created_time < date_to_midnight_pt($2)
+      and creator_id is not null
+    group by creator_id
+  ),
+  comments as materialized (
+    -- The contracts join looks dead here (nothing selects from c) but it is an
+    -- inner join, so it drops comments whose contract is gone. Keep it: the
+    -- query it replaces had it, and removing it would change comment_count.
+    select cc.user_id, count(*)::int as n
+    from contract_comments cc join contracts c on cc.contract_id = c.id
+    where cc.created_time >= date_to_midnight_pt($1)
+      and cc.created_time < date_to_midnight_pt($2)
+    group by cc.user_id
+  ),
+  perps as materialized (
+    select e.user_id, count(*)::int as n
+    from contract_perp_events e
+    where e.ts >= date_to_midnight_pt($1)
+      and e.ts < date_to_midnight_pt($2)
+      and e.user_id is not null
+      and e.event_type in ('open', 'add', 'close')
+      and e.data->>'reason' is distinct from 'flip'
+      and e.data->>'reason' is distinct from 'resolve-market'
+    group by e.user_id
+  ),
+  viewers as (
+    select count(distinct data->>'deviceId')::int as n
+    from user_events
+    where ts >= date_to_midnight_pt($1) and ts < date_to_midnight_pt($2)
+  ),
+  per_user as (
+    select user_id, sum(n)::int as action_count
+    from (
+      select user_id, n from bets
+      union all select user_id, n from created
+      union all select user_id, n from comments
+      union all select user_id, n from perps
+    ) actions
+    group by user_id
+  ),
+  ins_users as (
+    insert into daily_user_activity (day, user_id, action_count)
+    select $1::date, user_id, action_count from per_user
+    returning 1
+  )
+  insert into daily_activity_totals
+    (day, bet_count, mana_amount, contract_count, comment_count, viewer_count,
+     computed_at)
+  select $1::date,
+    coalesce((select sum(n) from bets), 0)::int,
+    coalesce((select sum(mana_amount) from bets), 0),
+    coalesce((select sum(n) from created), 0)::int,
+    coalesce((select sum(n) from comments), 0)::int,
+    coalesce((select n from viewers), 0),
+    now()
+  on conflict (day) do update set
+    bet_count = excluded.bet_count,
+    mana_amount = excluded.mana_amount,
+    contract_count = excluded.contract_count,
+    comment_count = excluded.comment_count,
+    viewer_count = excluded.viewer_count,
+    computed_at = excluded.computed_at`
+
+// Rebuilds the given days, one committed transaction each, serially.
+//
+// Serially on purpose. The five concurrent window-wide fetches this replaces
+// were not just individually large, they evicted each other's pages: three
+// identical chunk queries run concurrently on prod produced one success and
+// two timeouts, while the same three run one after another all succeeded.
+export const materializeActivityDays = async (
+  pg: SupabaseDirectClient,
+  days: string[],
+  budgetMs = MATERIALIZE_BUDGET_MS
+) => {
+  const deadline = Date.now() + budgetMs
+  const failed: string[] = []
+  const skipped: string[] = []
+
+  for (let i = 0; i < days.length; i++) {
+    const day = days[i]
+    if (Date.now() > deadline) {
+      skipped.push(...days.slice(i))
+      break
+    }
+    const next = dayjs(day).add(1, 'day').format('YYYY-MM-DD')
+    for (let attempt = 0; attempt <= CHUNK_RETRIES; attempt++) {
+      try {
+        await withChunkTimeout(pg, async (tx) => {
+          await tx.none(
+            `delete from daily_user_activity where day = $1::date`,
+            [day]
+          )
+          await tx.none(REBUILD_ACTIVITY_DAY, [day, next])
+        })
+        break
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        if (attempt === CHUNK_RETRIES) {
+          failed.push(day)
+          log.warn(`[update-stats] could not rebuild activity for ${day}`, {
+            error: message,
+          })
+        } else {
+          await sleep(CHUNK_RETRY_DELAY_MS)
+        }
+      }
+    }
+  }
+
+  // Throw only after the loop: every day that succeeded stays committed, which
+  // is what lets the next run pick up where this one stopped. But do not let
+  // the caller compute over a holed window — the trailing-window maths below
+  // indexes by array position, so one missing day shifts wau/mau/m1 onto the
+  // wrong dates instead of failing.
+  if (failed.length || skipped.length) {
+    throw new Error(
+      `activity rollup incomplete — failed: [${failed.join(', ')}], ` +
+        `out of time: [${skipped.join(', ')}]`
+    )
+  }
+}
+
+// The days this run must (re)build: everything it will write, plus any older
+// day in the buffer that has never been computed. A missing totals row is the
+// only way to distinguish "never computed" from "computed, nobody active".
+const getDaysToMaterialize = (
+  pg: SupabaseDirectClient,
+  startWithBuffer: string,
+  start: string,
+  end: string
+) =>
+  pg.map(
+    `with wanted as (
+      select generate_series($1::date, $3::date - 1, interval '1 day')::date as day
+    )
+    select w.day::text as day
+    from wanted w
+    left join daily_activity_totals t on t.day = w.day
+    where w.day >= $2::date or t.day is null
+    order by 1`,
+    [startWithBuffer, start, end],
+    (r: { day: string }) => r.day
+  )
+
+type DailyActivity = {
+  day: string
+  betCount: number
+  manaAmount: number
+  contractCount: number
+  commentCount: number
+  viewerCount: number
+  userCounts: { userId: string; actionCount: number }[]
+}
+
+const getDailyActivity = async (
+  pg: SupabaseDirectClient,
+  start: string,
+  end: string
+) => {
+  // day::text because pg-promise parses date (oid 1082) with the identity
+  // parser (shared/supabase/init.ts), and everything downstream keys on
+  // 'YYYY-MM-DD' strings.
+  const activity = await pg.manyOrNone(
+    `select
+      t.day::text as day,
+      t.bet_count as "betCount",
+      t.mana_amount::double precision as "manaAmount",
+      t.contract_count as "contractCount",
+      t.comment_count as "commentCount",
+      t.viewer_count as "viewerCount",
+      coalesce(a.user_counts, '[]'::json) as "userCounts"
+    from daily_activity_totals t
+    left join lateral (
+      select json_agg(json_build_object(
+        'userId', d.user_id, 'actionCount', d.action_count
+      )) as user_counts
+      from daily_user_activity d where d.day = t.day
+    ) a on true
+    where t.day >= $1::date and t.day < $2::date
+    order by t.day`,
+    [start, end]
+  )
+
+  return activity as DailyActivity[]
+}
+
 export const updateActivityStats = async (
   pg: SupabaseDirectClient,
   start: string,
@@ -351,32 +622,50 @@ export const updateActivityStats = async (
     .format('YYYY-MM-DD')
 
   log(`Fetching data for activity stats between ${startWithBuffer} and ${end}`)
-  const [
-    dailyBets,
-    dailyPerpTrades,
-    dailyContracts,
-    dailyComments,
-    dailyViewers,
-  ] = await Promise.all([
-    getDailyBets(pg, startWithBuffer, end),
-    getDailyPerpTrades(pg, startWithBuffer, end),
-    getDailyContracts(pg, startWithBuffer, end),
-    getDailyComments(pg, startWithBuffer, end),
-    getDailyViewers(pg, startWithBuffer, end),
-  ])
+  // Rebuild only the days this run writes, plus any older buffer day that has
+  // never been computed (a hole left by an earlier failure). The rest of the
+  // window is read from the rollup instead of re-derived from source tables.
+  const daysToBuild = await getDaysToMaterialize(
+    pg,
+    startWithBuffer,
+    start,
+    end
+  )
+  log(`Rebuilding ${daysToBuild.length} day(s) of activity`)
+  await materializeActivityDays(pg, daysToBuild)
+
+  const daily = await getDailyActivity(pg, startWithBuffer, end)
+  const windowDays = listDays(startWithBuffer, end)
+  if (daily.length !== windowDays.length) {
+    throw new Error(
+      `activity rollup covers ${daily.length} of ${windowDays.length} days ` +
+        `in ${startWithBuffer}..${end}; refusing to compute trailing windows ` +
+        `over a gap`
+    )
+  }
   logMemory()
 
   log('upsert viewer counts')
+  // Sliced like its three siblings below. Without the slice, the earliest days
+  // in the window get wav/mav from a slice(i-6, i+1) whose negative start wraps
+  // to the END of the array, yielding an empty range and average([]) === 0 —
+  // which is how 569 daily_stats rows came to hold wav = 0, and 621 mav = 0,
+  // while the dav beside them is intact. Each day now gets its final value
+  // while its trailing window is still complete, and is never revisited. This
+  // removes writes only; it does not repair the rows already zeroed.
+  //
+  // Filtered on dav for the same reason as the scalars below: the rollup stores
+  // a zero for a day whose events are missing, and writing that would both
+  // replace a NULL with a 0 and drag the following 7 days of wav and 30 of mav.
+  const viewerRows = daily.map((d, i) => ({
+    start_date: d.day,
+    dav: d.viewerCount,
+    wav: average(daily.slice(i - 6, i + 1).map((v) => v.viewerCount)),
+    mav: average(daily.slice(i - 29, i + 1).map((v) => v.viewerCount)),
+  }))
   await bulkUpsertStats(
     pg,
-    dailyViewers.map((viewers, i) => ({
-      start_date: viewers.day,
-      dav: viewers.viewer_count,
-      wav: average(dailyViewers.slice(i - 6, i + 1).map((v) => v.viewer_count)),
-      mav: average(
-        dailyViewers.slice(i - 29, i + 1).map((v) => v.viewer_count)
-      ),
-    }))
+    viewerRows.slice(bufferDays).filter((r) => r.dav > 0)
   )
 
   // Mirror daily DAV into the `manifold-dau` oracle feed. Each point is
@@ -392,26 +681,27 @@ export const updateActivityStats = async (
   // Unwrapped, that aborted the run before every remaining daily_stats write
   // (bets, DAU/WAU/MAU, retention, new-user), none of which have anything to
   // do with perps.
+  // Zero-viewer days are excluded rather than published as a 0: oracle_prices
+  // is append-only, so a spurious 0 is permanent, and live perps mark against
+  // the latest point.
+  const dauPoints = daily.filter((d) => d.viewerCount > 0)
   try {
     await insertOraclePrices(
       pg,
       MANIFOLD_DAU_FEED_ID,
-      dailyViewers.map((viewers) => ({
-        ts: dayjs
-          .tz(viewers.day, 'America/Los_Angeles')
-          .startOf('day')
-          .valueOf(),
-        price: viewers.viewer_count,
+      dauPoints.map((d) => ({
+        ts: dayjs.tz(d.day, 'America/Los_Angeles').startOf('day').valueOf(),
+        price: d.viewerCount,
       }))
     )
-    const latestDau = dailyViewers[dailyViewers.length - 1]
+    const latestDau = dauPoints[dauPoints.length - 1]
     if (latestDau) {
       await applyOraclePointToLivePerps(pg, MANIFOLD_DAU_FEED_ID, {
         ts: dayjs
           .tz(latestDau.day, 'America/Los_Angeles')
           .startOf('day')
           .valueOf(),
-        price: latestDau.viewer_count,
+        price: latestDau.viewerCount,
       })
     }
   } catch (error) {
@@ -421,109 +711,78 @@ export const updateActivityStats = async (
     )
   }
 
+  // The three scalar upserts below are sliced to the days this run writes.
+  // Previously they rewrote all 68 days nightly with values that only moved
+  // for one reason: contract_bets.amount is mutable, so a limit order filling
+  // later raises its day's bet_amount. That means a day now settles on the
+  // value it has seven days out rather than sixty-eight — measured at ~0.4% of
+  // a day's mana, always understating. The previous 68-day cutoff was no less
+  // arbitrary, and rewriting history nightly is what the rollup exists to stop.
+  //
+  // .filter(...) keeps the NULL-vs-zero distinction: the per-day queries these
+  // replace returned no row at all for a day with no bets, so daily_stats held
+  // NULL. The rollup has a row for every day, so an unfiltered write would turn
+  // those NULLs into zeroes.
+  const written = daily.slice(bufferDays)
+
   log('upsert bets counts and totals')
   await bulkUpsertStats(
     pg,
-    dailyBets.map((bets) => ({
-      start_date: bets.day,
-      bet_count: bets.betCount,
-      bet_amount: bets.manaAmount / 100,
-    }))
+    written
+      .filter((d) => d.betCount > 0)
+      .map((d) => ({
+        start_date: d.day,
+        bet_count: d.betCount,
+        bet_amount: d.manaAmount / 100,
+      }))
   )
 
   log('upsert contract counts')
   await bulkUpsertStats(
     pg,
-    dailyContracts.map((contracts) => ({
-      start_date: contracts.day,
-      contract_count: contracts.values.length,
-    }))
+    written
+      .filter((d) => d.contractCount > 0)
+      .map((d) => ({ start_date: d.day, contract_count: d.contractCount }))
   )
 
   log('upsert comment counts')
   await bulkUpsertStats(
     pg,
-    dailyComments.map((comments) => ({
-      start_date: comments.day,
-      comment_count: comments.values.length,
-    }))
+    written
+      .filter((d) => d.commentCount > 0)
+      .map((d) => ({ start_date: d.day, comment_count: d.commentCount }))
   )
 
-  // Unique ids across contract creation, ordinary bets, perp trades, and
-  // comments. Automated perp transitions are excluded in getDailyPerpTrades.
-  const contractUsersByDay = Object.fromEntries(
-    dailyContracts.map((contracts) => [
-      contracts.day,
-      contracts.values.map((c) => c.userId),
-    ])
-  )
-  // One entry per bet, not per user: the countBy in the median-actions calc
-  // below needs the multiset, and uniq covers the DAU-style consumers.
-  const betUsersByDay = Object.fromEntries(
-    dailyBets.map((bets) => [
-      bets.day,
-      bets.userCounts.flatMap((u) =>
-        Array.from({ length: u.betCount }, () => u.userId)
-      ),
-    ])
-  )
-  const perpTradeUsersByDay = Object.fromEntries(
-    dailyPerpTrades.map((trades) => [
-      trades.day,
-      trades.values.map((trade) => trade.userId),
-    ])
-  )
-  const commentUsersByDay = Object.fromEntries(
-    dailyComments.map((comments) => [
-      comments.day,
-      comments.values.map((c) => c.userId),
-    ])
-  )
-
-  // average actions
-  {
-    const allIds = mergeWith(
-      contractUsersByDay,
-      betUsersByDay,
-      perpTradeUsersByDay,
-      commentUsersByDay,
-      (a, b) => (a && b ? a.concat(b) : a || b)
-    )
-
-    const medianDailyUserActions = mapValues(allIds, (ids) => {
-      const userIdCounts = countBy(ids, (id) => id)
-      const countsFiltered = Object.values(userIdCounts).filter((c) => c > 1)
-      return countsFiltered.length === 0 ? 0 : median(countsFiltered)
-    })
-
-    log('upsert "average" daily user actions')
-    await bulkUpsertStats(
-      pg,
-      Object.entries(medianDailyUserActions).map(([day, median]) => ({
-        start_date: day,
-        avg_user_actions: median,
-      }))
-    )
-  }
-
-  const activeUsersByDay = mergeWith(
-    betUsersByDay,
-    perpTradeUsersByDay,
-    contractUsersByDay,
-    commentUsersByDay,
-    (a, b) => {
-      if (!a && !b) return []
-      if (!a) return b
-      if (!b) return a
-      return uniq([...a, ...b])
-    }
+  // action_count already sums the four sources the old per-day queries were
+  // merged from — bets, markets created, comments, and user-initiated perp
+  // trades — per user per day, which is exactly what the countBy over the
+  // concatenated id lists produced. median sorts internally, so order does not
+  // matter here.
+  log('upsert "average" daily user actions')
+  await bulkUpsertStats(
+    pg,
+    written
+      // Same NULL-vs-zero guard as the scalars: a day with nobody active was
+      // absent from the old per-day results and so left NULL, not zeroed.
+      .filter((d) => d.userCounts.length > 0)
+      .map((d) => {
+        const counts = d.userCounts
+          .map((u) => u.actionCount)
+          .filter((c) => c > 1)
+        return {
+          start_date: d.day,
+          avg_user_actions: counts.length === 0 ? 0 : median(counts),
+        }
+      })
   )
 
   // Stricter DAU includes market creation, comments, and user-initiated trades.
-
-  const dailyUserIds = Object.entries(activeUsersByDay)
-    .map(([day, values]) => ({ day, values }))
-    .sort((a, b) => a.day.localeCompare(b.day))
+  // One row per (day, user) in the rollup, so these are already distinct and
+  // already ordered by day.
+  const dailyUserIds = daily.map((d) => ({
+    day: d.day,
+    values: d.userCounts.map((u) => u.userId),
+  }))
 
   log('upsert dau, wau, mau, d1, w1, m1')
 
@@ -744,7 +1003,13 @@ const retention = (
   cohort2: string[] | undefined
 ) => {
   if (!cohort1 || !cohort2) return undefined
-  return average(cohort1.map((id) => (cohort2.includes(id) ? 1 : 0)))
+  // Set membership rather than Array.includes: cohorts are month-sized (~4k
+  // ids), so the nested scan is ~16M string comparisons per call on the single
+  // scheduler event loop, and gap recovery can widen the window to 30 days of
+  // them. Same value either way — retention does not care about order.
+  const cohort2Ids = new Set<string>()
+  cohort2.forEach((id) => cohort2Ids.add(id))
+  return average(cohort1.map((id) => (cohort2Ids.has(id) ? 1 : 0)))
 }
 
 // sum of distinct [start, end)
@@ -772,12 +1037,15 @@ async function calculateTopicDaus(
   start: string,
   end: string
 ) {
-  // Get daily active users per group with 50+ users filter
-  const dailyGroupUsers = await pg.manyOrNone<{
-    day: string
-    group_counts: Record<string, number>
-  }>(
-    `
+  // Get daily active users per group with 50+ users filter.
+  //
+  // Run a day at a time, under the same per-statement deadline as the rollup
+  // rebuild. This unions four sources through group_contracts and is now the
+  // largest scan left in the job, so it is the next thing that would sit on
+  // the client timeout as volume grows. Splitting by day is exact: the
+  // `having count(distinct user_id) > 50` below is already evaluated per
+  // (day, group_id), so no group's count spans a chunk boundary.
+  const topicDauSql = `
     with daily_active as (
       select 
         date_trunc('day', b.created_time at time zone 'america/los_angeles')::date as day,
@@ -830,19 +1098,29 @@ async function calculateTopicDaus(
       group by day, group_id
       having count(distinct user_id) > 50
     )
-    select 
+    select
       day,
       jsonb_object_agg(group_id, user_count) as group_counts
     from group_counts
     group by day
-  `,
-    [start, end]
-  )
+  `
 
-  // Convert to the expected format
-  return Object.fromEntries(
-    dailyGroupUsers.map(({ day, group_counts }) => [day, group_counts])
-  )
+  const topicDaus: Record<string, Record<string, number>> = {}
+  const days = listDays(start, end)
+  for (let i = 0; i < days.length; i++) {
+    const day = days[i]
+    const next = dayjs(day).add(1, 'day').format('YYYY-MM-DD')
+    const rows = await withChunkTimeout(pg, (tx) =>
+      tx.manyOrNone<{ day: string; group_counts: Record<string, number> }>(
+        topicDauSql,
+        [day, next]
+      )
+    )
+    rows.forEach((row) => {
+      topicDaus[row.day] = row.group_counts
+    })
+  }
+  return topicDaus
 }
 
 export const updateCashActivityStats = async (

--- a/backend/scripts/backfill-daily-activity.ts
+++ b/backend/scripts/backfill-daily-activity.ts
@@ -1,0 +1,69 @@
+import { runScript } from './run-script'
+import { log } from 'shared/utils'
+import { materializeActivityDays } from '../scheduler/src/jobs/update-stats'
+
+// Populates the daily activity rollup for a date range, one committed day at a
+// time. Run this once over the buffer window before deploying the scheduler
+// change, so the first nightly run has a full window to read and does not try
+// to build 100+ cold days inside the morning batch train.
+//
+// Safe to interrupt and rerun: each day is its own transaction and rebuilding a
+// day that already exists replaces it with the same values.
+//
+//   yarn ts-node backend/scripts/backfill-daily-activity.ts 2026-04-20 2026-08-16
+//
+// The range is [start, end) — the end day is not built.
+if (require.main === module)
+  runScript(async ({ pg }) => {
+    if (process.argv.length < 4) {
+      log('Usage: backfill-daily-activity <start> <end>')
+      process.exit(1)
+    }
+
+    const start = process.argv[2]
+    const end = process.argv[3]
+
+    if (!dateregex.test(start) || !dateregex.test(end)) {
+      log.error('Invalid date format, should be YYYY-MM-DD')
+      process.exit(1)
+    }
+
+    // Never build today or later. A partial day would be stored as if it were
+    // complete, and a future day would be an all-zero row that gap-filling then
+    // treats as computed.
+    const today = new Date().toISOString().slice(0, 10)
+    const cappedEnd = end > today ? today : end
+    if (cappedEnd !== end) {
+      log(`Capping end at ${cappedEnd}: only complete days can be built`)
+    }
+
+    const days = listDays(start, cappedEnd)
+    log(
+      `Backfilling ${days.length} day(s) of activity: ${start} to ${cappedEnd}`
+    )
+
+    // No budget: this is run by hand in a quiet window, and stopping halfway
+    // through a deliberate backfill would just mean running it again.
+    for (let i = 0; i < days.length; i++) {
+      await materializeActivityDays(pg, [days[i]], Number.MAX_SAFE_INTEGER)
+      if ((i + 1) % 10 === 0 || i === days.length - 1) {
+        log(`  ${i + 1}/${days.length} days`)
+      }
+    }
+
+    log('Done')
+  })
+
+const dateregex = /^\d{4}-\d{2}-\d{2}$/
+
+const listDays = (start: string, end: string) => {
+  const days: string[] = []
+  for (
+    let day = new Date(`${start}T00:00:00Z`);
+    day.toISOString().slice(0, 10) < end;
+    day.setUTCDate(day.getUTCDate() + 1)
+  ) {
+    days.push(day.toISOString().slice(0, 10))
+  }
+  return days
+}

--- a/backend/supabase/migrations/2026081501_daily_activity_rollup.sql
+++ b/backend/supabase/migrations/2026081501_daily_activity_rollup.sql
@@ -1,0 +1,82 @@
+begin;
+
+-- Per-day activity rollup for the nightly `update-stats` job.
+--
+-- WHY THIS EXISTS
+--
+-- updateActivityStats needs 68 days of history every night: 7 days that it
+-- writes, plus a 61-day read-only buffer, because m1 retention reaches 59 days
+-- back and mau 30. Until now it re-derived all 68 days from the source tables
+-- on every run — five concurrent queries scanning ~8M rows of `user_events`
+-- and ~7M rows of `contract_bets` for a second time each night.
+--
+-- That is what has been failing. The job died at exactly +60:00 (the client
+-- `query_timeout` in shared/supabase/init.ts) every night from 2026-08-04, and
+-- again on 2026-08-15 after PR #3990 had already cut the wire payload 249x —
+-- because the payload was never the constraint. The scan was. Measured on
+-- prod: the same query over the same rows takes 593 ms warm and 17,670 ms
+-- cold, and the job runs at 11:20 UTC inside a five-hour batch train whose
+-- other members (update-league re-reads every season bet every 15 minutes)
+-- evict its pages continuously. Three identical chunk queries issued
+-- concurrently: one succeeded, two timed out. Issued serially: all three
+-- succeeded. The failure is buffer-cache eviction, so the durable fix is to
+-- stop re-reading the same 68 days — not to read them faster.
+--
+-- With these tables the job rebuilds only the days it actually writes and
+-- reads the rest of the window from here: ~650 rows/day instead of ~220k.
+--
+-- WHAT IS STORED
+--
+-- Only what daily_stats cannot already answer. Counts that are stored per day
+-- (dau, bet_count, ...) are derivable, but the per-day SET of active user ids
+-- is not, and wau/mau/d1/w1/m1/engaged_users are all set operations over
+-- trailing windows. That set is the one thing that has to be materialized.
+create table if not exists daily_user_activity (
+  -- The America/Los_Angeles calendar day, matching daily_stats.start_date.
+  day date not null,
+  user_id text not null,
+  -- Bets + markets created + comments + user-initiated perp trades, summed.
+  -- The consumer takes median(counts > 1) for avg_user_actions and otherwise
+  -- only cares that the user appears, so the four sources do not need to be
+  -- kept apart. Always >= 1: a row exists only because the user did something.
+  action_count int not null,
+  primary key (day, user_id)
+);
+
+-- Per-day scalars, and the completeness marker for the rollup.
+--
+-- The marker role is load-bearing: a day with no row here has never been
+-- computed, whereas a day with a row and no daily_user_activity rows was
+-- computed and nobody was active. Gap-filling and the contiguity check both
+-- depend on being able to tell those apart, which is why this table gets a row
+-- for every processed day even when every count is zero.
+create table if not exists daily_activity_totals (
+  day date primary key,
+  bet_count int not null,
+  -- numeric, not float8: contract_bets.amount is numeric and the existing code
+  -- path sums in numeric then casts once. Storing numeric reproduces that
+  -- arithmetic exactly rather than rounding twice.
+  mana_amount numeric not null,
+  contract_count int not null,
+  comment_count int not null,
+  -- count(distinct data->>'deviceId') over user_events; feeds dav/wav/mav.
+  viewer_count int not null,
+  computed_at timestamptz not null default now()
+);
+
+comment on table daily_user_activity is
+  'Per-day active user ids with action counts; the input to dau/wau/mau/retention/engaged_users in the update-stats job';
+comment on table daily_activity_totals is
+  'Per-day scalar rollups for update-stats; presence of a row means the day has been computed';
+
+-- No index beyond the primary keys. (day, user_id) is day-leading, so the
+-- window read is a range seek, and the whole rollup is ~15 MB/year.
+
+-- RLS on with no policy: deny-all for anon and authenticated, matching every
+-- other table in the public schema. Nothing client-side reads this — the
+-- scheduler connects over createSupabaseDirectClient() as postgres and bypasses
+-- RLS, and /stats renders daily_stats, not the rollup.
+alter table daily_user_activity enable row level security;
+alter table daily_activity_totals enable row level security;
+
+commit;


### PR DESCRIPTION
Follow-up to #3990, which was necessary but not sufficient. **`update-stats` failed again on 08-15 at exactly +60:00, on the new aggregated query.**

## Why #3990 wasn't enough

#3990 cut the wire payload 249x. The payload was never the constraint — the scan was. Five concurrent queries re-derived the whole 68-day window (7 written + 61 read-only buffer, because m1 retention reaches 59 days back) from `contract_bets` and `user_events` every night: ~130 GB of page traffic, at 11:20 UTC, inside the five-hour batch train where `update-league` re-reads all 1.37M season bets every 15 minutes.

Measured on prod:

| Evidence | Result |
|---|---|
| Same query, same rows, warm vs cold cache | 593 ms vs 17,670 ms |
| Three identical chunk queries, concurrent | 1 success, 2 timeouts |
| The same three, serial | 3 successes |
| `pg_locks` during the window | 214 locks, 214 granted, 0 waiting |

The job isn't slow, it's starved. Reading the same 68 days *faster* doesn't fix that; it has to stop reading them.

Two findings shaped the design, both invisible to short-window testing:

- **The planner flips at ~30 days.** Under ~21 days `getDailyBets` uses `contract_bets_created_time_only`. At 30+ it switches to `contract_bets_historical_probs_non_redemption`, whose leading column is `contract_id` — so that "Index Cond" is a full scan of a 2,558 MB index. It flips on *estimated* rows, and estimates currently run ~6.7x under actual, so the margin moves whenever autoanalyze runs. This is why chunks are **one day**, not seven.
- **`getDailyViewers` was the biggest I/O consumer**, not bets: ~8M rows of `user_events` (334M rows / 94 GB) per run, and the only query that spilled to disk — already at 99.7% of `work_mem` at *two* days, external merge at three.

## What this does

Two rollup tables hold what `daily_stats` can't answer on its own: the per-day **set** of active user ids (wau/mau/d1/w1/m1/engaged_users are all set operations over trailing windows) and the per-day scalars.

The job now rebuilds only the days it writes, gap-fills any buffer day never computed, and reads the rest of the window from the rollup — **~650 rows/day instead of ~220k**. Rebuilds run one day at a time, serially, each in its own transaction under a 300 s server-side `statement_timeout`.

The reviewer-facing invariant: **no statement scans more than one day of event data, and every day it computes is committed before the next one starts.** A run that dies at minute 59 no longer discards 59 minutes of work.

Nightly cost: ~15.3M block accesses → ~1.5M.

## Correctness

Verified bit-exact against prod for **2026-08-09, 08-10, 08-12 and 2026-03-08** (the 23-hour DST day). `bet_count`, `mana_amount` to full numeric precision, contract/comment counts, `viewer_count`, `dau`, and an **md5 fingerprint of the entire per-user action-count distribution** all match what the replaced code produces. A full outer join per day confirmed zero divergent users. DST was checked row-by-row: 96,458 source rows over the transition, 0 dropped, 0 misfiled, 0 double-counted.

**One deliberate semantic change:** `bet_amount` now settles at day+7 instead of day+68, because `contract_bets.amount` mutates as limit orders fill. Measured at 0.08%–1.46% of a day's mana depending on the day, always understating. The old 68-day cutoff was equally arbitrary, but this does put a small one-off step in the series at the deploy date.

## Two related fixes, same window logic

- **Gap recovery.** Only the trailing 7 days were ever written, so any outage longer than a week put those days permanently out of reach of every later run. That's why `dau`, retention and `topic_daus` for **Aug 3–5 are still NULL today**. Runs now reach back to the oldest gap within 30 days. On the first run this widens to 14 days and heals Aug 3–5 and 13–15 automatically. 30 days is the automatic horizon; beyond it, the backfill script.
- **`wav`/`mav` zeroing.** These lacked the `.slice(bufferDays)` guard their three siblings carry, so the earliest days in each window took a `slice(i-6, i+1)` whose negative start wraps to the *end* of the array — empty range, `average([]) === 0`. That is how **569 `daily_stats` rows hold `wav = 0` and 621 hold `mav = 0`** next to a perfectly intact `dav`. This stops it spreading. It does not repair existing rows (separate PR — the values are recomputable from stored `dav`).

`check-stats-freshness` asserts the *output* rather than the process, because a failed run doesn't reliably alert: `Query read timeout` is on the transient list added in #3994, so the first failure only warns, and escalation is counted in process memory that the near-daily container OOM resets. That's why 08-15's failure emailed nobody.

## Deploy order — please read, both steps are load-bearing

1. **Apply migration `2026081501`.** Two empty tables, nothing reads them yet, independently revertible.
2. **Run the backfill, in the 13:00–17:00 UTC quiet window:**
   `yarn ts-node backend/scripts/backfill-daily-activity.ts <today-91> <today>`
   Interruptible and rerunnable; each day is its own committed 300s-bounded chunk. Expect ~5–10 min.
3. **Deploy scheduler `prod main`.** Main instance only — no `prod perps`, so no spurious oracle-tick alert.

Deploying the code before the migration fails with `relation "daily_activity_totals" does not exist`. Skipping the backfill means night one builds ~68–91 cold days serially against a 25-minute budget.

Rollback is `git revert` plus dropping the two tables; nothing else reads them.

## Reviewed

Five independent review passes (equivalence against prod, Postgres semantics, control flow/failure modes, scope, fresh-eyes). Five defects found and fixed before this PR:

- `materializeActivityDays` threw past `insertLatestManaStats` and `revalidateStaticProps` — reintroducing upstream exactly the failure the comment block at the top of `updateStatsCore` exists to prevent. Now held and rethrown at the end.
- `contracts.creator_id` is nullable; `daily_user_activity.user_id` is not. One such row would have made a day permanently unbuildable. Guard added.
- `dav`/`wav`/`mav` and the `manifold-dau` oracle mirror wrote unfiltered, so a zero-viewer day would store `dav = 0`, drag 7 days of `wav` and 30 of `mav`, and put a permanent `0.0` into an append-only feed live perps mark against. Now filtered like their siblings.
- The backfill script would happily build today (partial) or future days. End date now clamped.
- Two wrong numbers in the commit message and one source comment, corrected against prod.

## Explicitly out of scope

- **`update-league`** — the dominant contention source (1.37M season bets as JSON every 15 min, near-daily OOM). No branch or PR exists for it; it's the highest-value follow-up.
- **`topic_daus` missing an `is_redemption` filter** — a live correctness bug (redemption rows inflate every per-topic DAU), but fixing it changes stored values, which would break this PR's "no value changed except NULLs filling in" bar.
- Repairing the 569/621 zeroed `wav`/`mav` rows; deleting the dormant CASH path; any new index on `contract_bets`; a blanket `ANALYZE` (it would *raise* estimates and push larger chunks over the flip threshold — do not run it as part of this rollout).
