### PR TITLE
feat(charity): retire the LTFF, add TAIF, AISTOF, and Sentinel Bio

### DIFF
--- a/common/src/charity.ts
+++ b/common/src/charity.ts
@@ -68,21 +68,62 @@ At Topos, we pioneer emerging mathematical sciences of connection and integratio
     photo: 'https://i.imgur.com/6akJg2p.png',
     description: `An independent, non-profit organization dedicated to broadening the adoption of Haskell, by supporting its ecosystem of tools, libraries, education, and research.`,
   },
+  // Closed by EA Funds in 2026 and succeeded by the Transformative AI Fund
+  // below. Kept in the list so historical donations and giveaway entries still
+  // resolve to a name; excluded from the giveaway picker in web/pages/charity.tsx.
   {
-    name: 'Long-Term Future Fund',
+    name: 'Long-Term Future Fund (closed)',
     id: 'long-term-future-fund',
     website: 'https://funds.effectivealtruism.org/funds/far-future',
     photo: 'https://i.imgur.com/C2qka9g.png',
     preview:
-      'The Long-Term Future Fund aims to improve the long-term trajectory of civilization by making grants that address global catastrophic risks.',
-    description: `The Long-Term Future Fund aims to positively influence the long-term trajectory of civilization by making grants that address global catastrophic risks, especially potential risks from advanced artificial intelligence and pandemics. In addition, we seek to promote, implement, and advocate for longtermist ideas, and to otherwise increase the likelihood that future generations will flourish.
+      'The Long-Term Future Fund has closed. EA Funds now runs the Transformative AI Fund in its stead.',
+    description: `The Long-Term Future Fund aimed to positively influence the long-term trajectory of civilization by making grants that address global catastrophic risks, especially potential risks from advanced artificial intelligence and pandemics.
 
-    The Fund has a broad remit to make grants that promote, implement and advocate for longtermist ideas. Many of our grants aim to address potential risks from advanced artificial intelligence and to build infrastructure and advocate for longtermist projects. However, we welcome applications related to long-term institutional reform or other global catastrophic risks (e.g., pandemics or nuclear conflict).
+    EA Funds has since closed the fund and launched the Transformative AI Fund in its stead. If you want to support this work, donate to the Transformative AI Fund instead.`,
+  },
+  {
+    name: 'Transformative AI Fund',
+    id: 'transformative-ai-fund',
+    website: 'https://funds.effectivealtruism.org/funds/transformative-ai',
+    // Generic EA Funds wordmark — the same asset the LTFF entry uses. EA Funds
+    // does not publish a per-fund logo.
+    photo: 'https://i.imgur.com/C2qka9g.png',
+    preview:
+      'EA Funds’ successor to the Long-Term Future Fund, making early-stage grants that reduce global catastrophic risks from advanced AI.',
+    description: `The Transformative AI Fund makes early-stage grants to individuals, new organizations, and existing organizations with new projects addressing transformative AI, with a primary focus on reducing global catastrophic risks from advanced AI systems.
 
-    We intend to support:
-    - Projects that directly contribute to reducing existential risks through technical research, policy analysis, advocacy, and/or demonstration projects
-    - Training for researchers or practitioners who work to mitigate existential risks, or help with relevant recruitment efforts, or infrastructure for people working on longtermist projects
-    - Promoting long-term thinking`,
+    The fund backs technical AI safety research, policy analysis, forecasting, advocacy, and demonstration projects, as well as the field-building infrastructure that supports them. A minority of grants go to other neglected implications of transformative AI, such as flourishing futures and digital sentience.
+
+    Grants are typically $10k–$150k and rarely exceed $300k, aimed at the early stage where a small amount of funding can be decisive. It is led by Head of Fund Lowe Lundin, with fund advisors Caleb Parikh and Catherine Low.
+
+    EA Funds launched the Transformative AI Fund in 2026 after closing the Long-Term Future Fund.`,
+  },
+  {
+    name: 'AI Safety Tactical Opportunities Fund',
+    id: 'ai-safety-tactical-opportunities-fund',
+    website: 'https://manifund.org/JueYan',
+    preview:
+      'AISTOF moves fast to fund emerging opportunities in AI governance, technical alignment, and evaluations.',
+    description: `The AI Safety Tactical Opportunities Fund (AISTOF) is a pooled, multi-donor fund working to reduce catastrophic risks from advanced AI. It is run by JueYan Zhang and regrants through Manifund.
+
+    AISTOF aims to be fast and to capture emerging opportunities in a rapidly changing landscape, including in governance, technical alignment, and evaluations / audit. Its grants span technical safety research (interpretability, alignment, evaluations), AI governance and policy, safety infrastructure and tooling, international safety initiatives, talent development and education, and safety-focused startups and accelerators.
+
+    The fund has raised over $30 million and committed more than 150 grants.`,
+  },
+  {
+    name: 'Sentinel Bio',
+    id: 'sentinel-bio',
+    website: 'https://sentinelbio.org/',
+    photo:
+      'https://sentinelbio.org/wp-content/themes/theme/assets/img/android-chrome-512x512.png',
+    preview:
+      'Sentinel Bio is working to make pandemics history within our lifetimes.',
+    description: `Sentinel Bio is an independent 501(c)(3) research and philanthropic organization working to make pandemics history within our lifetimes.
+
+    It funds and supports strategic solutions across three areas: understanding the drivers of catastrophic pandemics, strengthening safeguards for advanced biotechnologies, and improving global pandemic preparedness. In the near term its work concentrates on guardrails for safely advancing biotechnology, including nucleic acid synthesis governance, with grantees such as the Johns Hopkins Center for Health Security and RAND.
+
+    Sentinel Bio's staff and advisors work in global health and pandemic prevention and are based in the U.S., the Netherlands, and Singapore.`,
   },
   // Temporarily disabled as New Science isn't accepting donations
   // {

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -33,6 +33,10 @@ module.exports = {
       { hostname: 'storage.googleapis.com' },
       { hostname: 'picsum.photos' },
       { hostname: '*.giphy.com' },
+      // Sentinel Bio charity logo (common/charity.ts). next/image throws at
+      // runtime on an unlisted hostname, so this is required for the legacy
+      // /old-charity pages, which render every charity's photo.
+      { hostname: 'sentinelbio.org' },
     ],
   },
   turbopack: {

--- a/web/pages/charity.tsx
+++ b/web/pages/charity.tsx
@@ -52,8 +52,11 @@ function formatEntries(entries: number): string {
   }
 }
 
-// Horse charities to exclude from the giveaway
+// Charities to exclude from the giveaway: the horse charities, plus any fund
+// that has shut down and can no longer receive the prize.
 const EXCLUDED_CHARITY_IDS = [
+  // Closed by EA Funds; succeeded by the Transformative AI Fund.
+  'long-term-future-fund',
   'new-vocations',
   'stable-recovery',
   'thoroughbred-retirement-foundation',


### PR DESCRIPTION
EA Funds [closed the Long-Term Future Fund](https://forum.effectivealtruism.org/posts/dtZ9wbKWjtvGWDRJx/closing-the-ltff-spending-down-funds-and-a-new-ai-fund-at-ea) and [launched the Transformative AI Fund](https://forum.effectivealtruism.org/posts/dYuNi5Rh68o9YKstg/ea-funds-is-launching-the-transformative-ai-fund) in its stead, so the LTFF can no longer receive a giveaway prize. This removes it from the giveaway and adds three funds in its place.

## Changes

**Retires the LTFF from the giveaway picker** by adding it to `EXCLUDED_CHARITY_IDS` in `web/pages/charity.tsx`, rather than deleting the entry from `common/src/charity.ts`. Prod has **99 giveaway tickets and 296 charity txns** against `long-term-future-fund`, and three call sites resolve its display name from that array — `get-balance-changes.ts:221`, `spinning-wheel.tsx:69`, and the past-results panel in `charity.tsx:1384`. Deleting the entry would render the raw slug on all 395 historical records. The entry is renamed `Long-Term Future Fund (closed)` and its copy now points at the successor fund.

**Adds three funds:**

| Fund | id | Link |
|---|---|---|
| Transformative AI Fund | `transformative-ai-fund` | [funds.effectivealtruism.org](https://funds.effectivealtruism.org/funds/transformative-ai) |
| AI Safety Tactical Opportunities Fund (AISTOF) | `ai-safety-tactical-opportunities-fund` | [manifund.org/JueYan](https://manifund.org/JueYan) |
| Sentinel Bio | `sentinel-bio` | [sentinelbio.org](https://sentinelbio.org/) |

## Logos

- **TAIF** reuses `i.imgur.com/C2qka9g.png`, the generic EA Funds wordmark already used by the LTFF entry. EA Funds publishes no per-fund logo.
- **Sentinel Bio** hotlinks its square 512px site icon. Their OG sharecard is 5001×2626, and all three render sites draw the photo at 48×48 `object-cover`, so the banner would have been cropped to nothing. This is the only reason `next.config.js` changes: `next/image` throws at runtime on an unlisted hostname and the legacy `/old-charity` index renders every charity's photo. Re-hosting on imgur later lets us drop that entry.
- **AISTOF** ships without a photo, deliberately — the only image on its Manifund profile is a personal headshot of JueYan Zhang, which seemed wrong as a charity logo. Every render site guards on `photo &&`, so it shows name + preview with no broken image.

## Deploy

⚠️ **API before web.** `buy-charity-giveaway-tickets.ts:25-27` validates the submitted `charityId` against the `charities` array, which is compiled into the API bundle. Web auto-deploys on merge to main; the API is a manual deploy. Merging without deploying the API first means the picker lists all three new funds and every purchase 404s `Charity not found`.

- No migration. `charity_giveaway_tickets.charity_id` is plain `text`, no FK or check constraint.
- No scheduler deploy. Only `buy-charity-giveaway-tickets.ts`, `donate.ts`, and `get-balance-changes.ts` import `common/charity`.

## Verification

- `common` typechecks clean (`tsc --noEmit`); no duplicate charity ids.
- **The live giveaway is unaffected.** Giveaway #4 (open until 2026-10-15) has 14 charities holding entries and **none is the LTFF**, so excluding it mid-giveaway strands no ticket holders and creates no prize owed to a closed fund.

## Out of scope

`/old-charity` still lists the closed LTFF as a sweepcash donation target and `donate.ts` would accept it. The `(closed)` name makes it visible but it isn't blocked. Flagged and deliberately left alone — this PR is giveaway-only. A `closed?: boolean` on the `Charity` type would be the clean fix if we want it.
