### PR TITLE
fix(perps): price Trump approval off VoteHub's published average

### DIFF
--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -367,10 +367,13 @@ export function createJobs(jobSet: SchedulerJobSet) {
     ),
     createJob(
       'update-trump-approval',
-      // Hourly, around the clock. The feed publishes whenever VoteHub's
-      // average moves, so a fixed daily slot would leave every intraday move
-      // sitting in public view as the next morning's mark.
-      '0 30 * * * *',
+      // Every 5 minutes, which is VoteHub's OWN freshness bound: their
+      // averages endpoint serves `Cache-Control: max-age=300`, so polling
+      // faster returns cached bytes rather than a newer number — and it
+      // bounds what any other observer can see too, since they read through
+      // the same cache. Hourly left a 59-minute window in which a move was
+      // publicly visible while the market still traded on the old mark.
+      '0 */5 * * * *',
       updateTrumpApproval
     ),
     createJob(

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -367,9 +367,10 @@ export function createJobs(jobSet: SchedulerJobSet) {
     ),
     createJob(
       'update-trump-approval',
-      // 5:30am Pacific, then hourly until the day's point is published. The
-      // end hour MUST stay in sync with TRUMP_APPROVAL_LAST_ATTEMPT_HOUR.
-      '0 30 5-23 * * *',
+      // Hourly, around the clock. The feed publishes whenever VoteHub's
+      // average moves, so a fixed daily slot would leave every intraday move
+      // sitting in public view as the next morning's mark.
+      '0 30 * * * *',
       updateTrumpApproval
     ),
     createJob(

--- a/backend/scheduler/src/jobs/update-trump-approval.ts
+++ b/backend/scheduler/src/jobs/update-trump-approval.ts
@@ -1,62 +1,88 @@
-import * as dayjs from 'dayjs'
-import * as timezone from 'dayjs/plugin/timezone'
-import * as utc from 'dayjs/plugin/utc'
-dayjs.extend(utc)
-dayjs.extend(timezone)
+import { HOUR_MS } from 'common/util/time'
 
+import { TRUMP_APPROVAL_FEED_ID } from 'shared/oracle'
 import {
-  hasTrumpApprovalPointForDay,
   publishTrumpApprovalPoint,
   trumpApprovalDay,
-  TRUMP_APPROVAL_TZ,
 } from 'shared/perps/publish-trump-approval'
-import { createSupabaseDirectClient } from 'shared/supabase/init'
+import {
+  createSupabaseDirectClient,
+  SupabaseDirectClient,
+} from 'shared/supabase/init'
 import { log } from 'shared/utils'
 
-// The last Pacific hour the job is scheduled to fire. MUST match the end of
-// the hour range in this job's cron expression in ./index.ts — it is how a
-// run knows whether another attempt is coming today, which decides whether a
-// failure is a blip to retry or a lost day worth paging on.
-export const TRUMP_APPROVAL_LAST_ATTEMPT_HOUR = 23
+/**
+ * How long the feed may go without a published point before a failed attempt
+ * is an ERROR rather than a retryable blip.
+ *
+ * Replaces the old "is this the last firing of the day?" test, which only
+ * made sense when the job published once daily. With hourly publication the
+ * question that matters is not what time it is, it is how long the market has
+ * been marking against an ageing price. Set below the feed's 26h staleAfterMs
+ * so the page arrives before the staleness alert, not after it.
+ */
+export const TRUMP_APPROVAL_STALE_ERROR_MS = 20 * HOUR_MS
 
-// Publishes one point per Pacific day for the `trump-approval-rating` feed.
+// Publishes points for the `trump-approval-rating` feed from VoteHub's
+// published average.
 //
-// Scheduled hourly rather than once, because a single daily firing made the
-// feed only as reliable as VoteHub's worst minute of the day: on 2026-08-14
-// the 5:30am attempt got an HTTP 500, and with no retry the feed sat frozen
-// for over 26 hours, tripped its staleness alerts, and came within ~1.5h of
-// the market's maxOraclePriceAgeMs — which pauses the engine, and with it
-// liquidations and ADL, on a market carrying leveraged positions.
+// Runs HOURLY, around the clock, and publishes whenever the source value
+// moves — see decideApprovalPublish. Publishing once a day, as this job did
+// originally, left every intraday move by the source sitting in public view
+// as the exact next morning's mark: the same timing edge the feed was rebuilt
+// to remove, relocated from the averaging window to the publication schedule.
 //
-// The first attempt is still 5:30am Pacific, so the normal publication time
-// is unchanged; later firings only do work when the day has no point yet.
+// The hourly cadence originally existed only as a retry: on 2026-08-14 a
+// single 5:30am HTTP 500 froze the feed for over 26 hours, tripped its
+// staleness alerts, and came within ~1.5h of the market's
+// maxOraclePriceAgeMs, which pauses the engine and with it liquidations and
+// ADL. That retry behaviour is preserved — a failed hour is simply followed
+// by another hour — it is just no longer the only reason to run.
 export const updateTrumpApproval = async () => {
   const pg = createSupabaseDirectClient()
   const today = trumpApprovalDay()
 
-  if (await hasTrumpApprovalPointForDay(pg, today)) return
-
   try {
     const result = await publishTrumpApprovalPoint(pg)
-    // A returned failure and a thrown one are the same event to a retry
-    // loop: nothing was published, and the day is only lost if no attempt
-    // remains. Classifying only thrown errors would let `no-polls` and
-    // `rejected` page every hour and would leave the final attempt of the
-    // day without its "no attempts left" signal.
-    if (result.status !== 'published') reportFailure(today, result.reason)
+    // `unchanged` is the ordinary outcome most hours and is deliberately
+    // silent: the source moves roughly once every couple of days, so logging
+    // every no-op would bury the hours that matter.
+    if (result.status === 'published' || result.status === 'unchanged') return
+    await reportFailure(pg, today, result.reason)
   } catch (err) {
-    reportFailure(today, `${err}`)
+    await reportFailure(pg, today, `${err}`)
   }
 }
 
-// Feed staleness is already alerted on by update-perps and
-// update-oracle-feeds, so a retryable attempt logs at WARN to keep from
-// paging once an hour for the same outage. The final attempt of the day is
-// the one that means the day is lost, so that one is an ERROR.
-const reportFailure = (day: string, reason: string) => {
-  const hour = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ).hour()
+/** How long since the feed last got a point, or null if it never has. */
+const getAgeOfLatestPoint = async (
+  pg: SupabaseDirectClient
+): Promise<number | null> => {
+  const row = await pg.oneOrNone<{ ts: string }>(
+    `select ts from oracle_prices where feed_id = $1 order by ts desc limit 1`,
+    [TRUMP_APPROVAL_FEED_ID]
+  )
+  if (!row) return null
+  const ts = new Date(row.ts).getTime()
+  return Number.isFinite(ts) ? Date.now() - ts : null
+}
+
+const reportFailure = async (
+  pg: SupabaseDirectClient,
+  day: string,
+  reason: string
+) => {
   const message = `[trump-approval] publish failed for ${day} — ${reason}`
-  if (hour >= TRUMP_APPROVAL_LAST_ATTEMPT_HOUR)
-    log.error(`${message}; no attempts left today, feed will go stale`)
+  // Feed staleness is alerted on separately by update-perps and
+  // update-oracle-feeds, so a retryable attempt stays at WARN to avoid paging
+  // once an hour for one outage. Escalate only once the feed itself has gone
+  // long enough without a point that the next retry is no longer the fix.
+  const ageMs = await getAgeOfLatestPoint(pg)
+  if (ageMs == null || ageMs >= TRUMP_APPROVAL_STALE_ERROR_MS)
+    log.error(
+      `${message}; last point ${
+        ageMs == null ? 'never' : `${Math.round(ageMs / HOUR_MS)}h ago`
+      }, feed is going stale`
+    )
   else log.warn(`${message}; retrying next hour`)
 }

--- a/backend/scheduler/src/jobs/update-trump-approval.ts
+++ b/backend/scheduler/src/jobs/update-trump-approval.ts
@@ -12,6 +12,17 @@ import {
 import { log } from 'shared/utils'
 
 /**
+ * Failures are logged at most this often.
+ *
+ * At a 5-minute cadence an outage that used to produce one line an hour would
+ * produce 288 a day. The feed's own staleness alerting is the durable signal;
+ * these lines exist to say why, so one an hour is plenty. In-memory, so a
+ * scheduler restart re-logs immediately — which is the behaviour you want.
+ */
+const FAILURE_LOG_INTERVAL_MS = HOUR_MS
+let lastFailureLog = 0
+
+/**
  * How long the feed may go without a published point before a failed attempt
  * is an ERROR rather than a retryable blip.
  *
@@ -26,11 +37,17 @@ export const TRUMP_APPROVAL_STALE_ERROR_MS = 20 * HOUR_MS
 // Publishes points for the `trump-approval-rating` feed from VoteHub's
 // published average.
 //
-// Runs HOURLY, around the clock, and publishes whenever the source value
-// moves — see decideApprovalPublish. Publishing once a day, as this job did
-// originally, left every intraday move by the source sitting in public view
-// as the exact next morning's mark: the same timing edge the feed was rebuilt
-// to remove, relocated from the averaging window to the publication schedule.
+// Runs EVERY 5 MINUTES and publishes whenever the source value moves — see
+// decideApprovalPublish. Publishing once a day, as this job did originally,
+// left every intraday move by the source sitting in public view as the exact
+// next morning's mark: the same timing edge the feed was rebuilt to remove,
+// relocated from the averaging window to the publication schedule. Hourly
+// shortened that window without closing it.
+//
+// 5 minutes is VoteHub's own bound, not a guess: their averages endpoint
+// serves `Cache-Control: max-age=300`. Polling faster returns cached bytes
+// rather than a fresher number, and it is the same cache any other observer
+// reads through.
 //
 // The hourly cadence originally existed only as a retry: on 2026-08-14 a
 // single 5:30am HTTP 500 froze the feed for over 26 hours, tripped its
@@ -78,11 +95,16 @@ const reportFailure = async (
   // once an hour for one outage. Escalate only once the feed itself has gone
   // long enough without a point that the next retry is no longer the fix.
   const ageMs = await getAgeOfLatestPoint(pg)
-  if (ageMs == null || ageMs >= TRUMP_APPROVAL_STALE_ERROR_MS)
+  const stale = ageMs == null || ageMs >= TRUMP_APPROVAL_STALE_ERROR_MS
+  // Throttle, but never throttle away the escalation: a feed that has gone
+  // stale is the one thing here worth paging on every time it is observed.
+  if (!stale && Date.now() - lastFailureLog < FAILURE_LOG_INTERVAL_MS) return
+  lastFailureLog = Date.now()
+  if (stale)
     log.error(
       `${message}; last point ${
         ageMs == null ? 'never' : `${Math.round(ageMs / HOUR_MS)}h ago`
       }, feed is going stale`
     )
-  else log.warn(`${message}; retrying next hour`)
+  else log.warn(`${message}; retrying in 5 minutes`)
 }

--- a/backend/scripts/backfill-trump-approval-oracle.ts
+++ b/backend/scripts/backfill-trump-approval-oracle.ts
@@ -4,37 +4,41 @@ import * as timezone from 'dayjs/plugin/timezone'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
+import { readPublishedApprovalSeries } from 'common/perps/trump-approval'
+
 import { log } from 'shared/utils'
 import { TRUMP_APPROVAL_FEED_ID, insertOraclePrices } from 'shared/oracle'
-import {
-  computeRollingAverages,
-  fetchTrumpApprovalPolls,
-  TRUMP_APPROVAL_WINDOW_DAYS,
-  TRUMP_INAUGURATION_DATE,
-} from 'shared/trump-approval'
+import { fetchTrumpApprovalAverage } from 'shared/trump-approval'
 import { runScript } from './run-script'
 
-// Backfill `trump-approval-rating` oracle feed from the VoteHub API.
-// Strategy:
-//   1. Fetch every poll since inauguration (Jan 21, 2025) — the first day
-//      Trump's approval as president is defined.
-//   2. For each day from (inauguration + windowDays - 1) through today,
-//      compute the unweighted 14-day trailing mean of Approve pct.
-//   3. Upsert as one oracle_prices row per day (idempotent on (feed_id, ts)).
+// Backfill `trump-approval-rating` from VoteHub's published, time-weighted
+// approval average — the same series the daily job publishes, so a backfill
+// and the live feed can never disagree about what the index means.
+//
+// ⚠️ NOT for a live feed. Points already published are immutable and may have
+// been consumed by funding and liquidations; this writes history under
+// whatever the methodology is TODAY, so running it against a feed with open
+// positions rewrites the basis those positions were priced against. It exists
+// for standing up a NEW feed, and `insertOraclePrices` is on-conflict-do-
+// nothing, so existing rows are left alone even if it is run by accident.
 if (require.main === module)
   runScript(async ({ pg }) => {
-    const polls = await fetchTrumpApprovalPolls(TRUMP_INAUGURATION_DATE)
-
-    // First day with a full trailing window available.
-    const fromDay = dayjs
-      .tz(TRUMP_INAUGURATION_DATE, 'America/Los_Angeles')
-      .add(TRUMP_APPROVAL_WINDOW_DAYS - 1, 'day')
-      .format('YYYY-MM-DD')
-    const toDay = dayjs.tz(dayjs(), 'America/Los_Angeles').format('YYYY-MM-DD')
-
-    const points = computeRollingAverages(polls, fromDay, toDay)
+    // Stamp each day's point from its own calendar date rather than adding a
+    // day to a running instant: dayjs.tz(...).add(1,'day') adds 24 UTC hours,
+    // so a loop started in PST drifts to 1 AM once PDT begins, and every
+    // summer stamp lands an hour off midnight — colliding with the correctly
+    // stamped rows the daily job writes.
+    const series = readPublishedApprovalSeries(
+      await fetchTrumpApprovalAverage()
+    )
+    const points = series.map((entry) => ({
+      ts: dayjs.tz(entry.day, 'America/Los_Angeles').valueOf(),
+      price: entry.price,
+    }))
+    const fromDay = series[0]?.day ?? 'n/a'
+    const toDay = series[series.length - 1]?.day ?? 'n/a'
     log(
-      `computed ${points.length} daily rolling averages from ${fromDay} to ${toDay}`
+      `read ${points.length} published daily averages from ${fromDay} to ${toDay}`
     )
     if (points.length > 0) {
       log(

--- a/backend/scripts/publish-trump-approval-now.ts
+++ b/backend/scripts/publish-trump-approval-now.ts
@@ -1,5 +1,4 @@
 import {
-  hasTrumpApprovalPointForDay,
   publishTrumpApprovalPoint,
   trumpApprovalDay,
 } from 'shared/perps/publish-trump-approval'
@@ -16,11 +15,16 @@ import { runScript } from './run-script'
 // liquidations and ADL the new price implies happen immediately, as they
 // would on a normal publication.
 //
-// Refuses to run when the Pacific day already has a point, because the
-// scheduled job is hourly: without the guard, an operator running this while
-// the cron fires appends two points for one day and breaks the daily cadence
-// that the market's funding period is anchored to. Pass --force to append a
-// correction deliberately.
+// Without --force this respects the same gate the scheduled job uses, so it
+// declines when VoteHub's value has not moved and the feed already carries a
+// recent point — there is nothing to publish and saying so is more useful
+// than appending a duplicate. Pass --force during an incident to stamp the
+// current value regardless, which is the whole point of the escape hatch.
+//
+// Multiple points in one Pacific day are expected now that the job publishes
+// on change rather than once daily. Funding is gated on elapsed time since
+// the last funding event, not on one point per day, so extra points do not
+// disturb its cadence.
 //
 // It does NOT backfill missed days. A value is stamped when it became
 // available to the market and is never backdated into a window where funding
@@ -37,12 +41,7 @@ if (require.main === module)
     const force = process.argv.includes('--force')
     const today = trumpApprovalDay()
 
-    if (!force && (await hasTrumpApprovalPointForDay(pg, today)))
-      throw new Error(
-        `${today} already has a published point; pass --force to append another`
-      )
-
-    const result = await publishTrumpApprovalPoint(pg)
+    const result = await publishTrumpApprovalPoint(pg, { force })
     if (result.status !== 'published')
       throw new Error(
         `nothing published for ${today} (${result.status}): ${result.reason}`

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -104,17 +104,29 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
   // trading tolerance and alerting are separate thresholds.)
   {
     id: TRUMP_APPROVAL_FEED_ID,
-    description: '14-day rolling Trump approval average (VoteHub polls)',
+    description: "VoteHub's published time-weighted Trump approval average",
     marketCreationEnabled: true,
+    // 'daily' means "own scheduler job, health-checked here only" — it does
+    // NOT mean daily cadence. update-trump-approval polls every 5 minutes
+    // (VoteHub serves Cache-Control: max-age=300) and writes a point only
+    // when the value moves, plus a heartbeat so a flat stretch cannot look
+    // like a dead feed.
     cadence: 'daily',
     minPrice: 10,
     maxPrice: 90,
-    // Corruption is caught at the source: getApprovePct drops any poll
-    // reporting a percentage outside [0,100], which is what would otherwise
-    // drag the unweighted mean far enough to matter while still landing
-    // inside these bounds. A genuine multi-point shift in the average is
-    // news, and the market should trade on it.
+    // Corruption is caught at the source in two places, neither of which is
+    // on the price path any more: readPublishedApprovalAverage rejects a
+    // published average outside (0,100) or staler than
+    // TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS, and the independent cross-check
+    // refuses to publish a value our own computation disagrees with by more
+    // than TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP. getApprovePct now only
+    // screens polls feeding that cross-check.
     staleAfterMs: 26 * HOUR_MS,
+    // The value changes about once a day even though it is polled every 5
+    // minutes, and this drives the funding period of any NEW market on the
+    // feed (max(1h, updatePeriodMs)). Holding it at a day keeps funding
+    // matched to how often the number actually moves rather than to how
+    // often we look at it. The live market carries its own frozen 24h value.
     updatePeriodMs: DAY_MS,
   },
   {

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -121,9 +121,9 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
     oracleBehavior: 'scheduled-step',
     requiresSourceAsOf: false,
     gameDesign:
-      'Two-sided political exposure, but the 14-day average is slow and often unchanged between poll releases.',
+      "Two-sided political exposure, but VoteHub's time-weighted average is slow and often unchanged between poll releases.",
     latencyArbitrageRisk:
-      'The daily source update is public and the ingestion schedule is known, allowing a trader to open against the old cached value and close after the step without crossing a funding event.',
+      "The source value is public, so ingestion latency is the whole exposure: the feed is polled every 5 minutes against VoteHub's own max-age=300 cache, which bounds the window in which a move is visible to a trader but not yet to the market. Recommended leverage assumes that bound holds.",
     recommended: {
       maxLeverage: 3,
       annualMaxFundingRate: 1,
@@ -205,8 +205,10 @@ export const PERP_LAUNCH_SCHEDULER_EXPECTATIONS = [
   },
   {
     jobName: 'update-trump-approval',
-    maxEndAgeMs: 26 * HOUR_MS,
-    maxRunMs: 30 * MINUTE_MS,
+    // Polls every 5 minutes, so a 26h last-success age would have described
+    // a job that had been dead for over 300 consecutive runs.
+    maxEndAgeMs: 30 * MINUTE_MS,
+    maxRunMs: 2 * MINUTE_MS,
   },
 ] as const
 

--- a/backend/shared/src/perps/publish-trump-approval.ts
+++ b/backend/shared/src/perps/publish-trump-approval.ts
@@ -8,6 +8,7 @@ import {
   TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP,
   TRUMP_APPROVAL_MAX_WINDOW_DAYS,
   computeApprovalPoint,
+  decideApprovalPublish,
   getApprovalCrossCheckGap,
   readPublishedApprovalAverage,
 } from 'common/perps/trump-approval'
@@ -36,36 +37,6 @@ export const TRUMP_APPROVAL_TZ = 'America/Los_Angeles'
 export const trumpApprovalDay = (now: number = Date.now()) =>
   dayjs.tz(dayjs(now), TRUMP_APPROVAL_TZ).format('YYYY-MM-DD')
 
-/**
- * Has a point already been published during the given Pacific calendar day?
- *
- * This is what makes the job idempotent across its retry window: the first
- * run of the day that gets a usable response from VoteHub publishes, and
- * every later run that day is a single indexed query and a return.
- */
-export const hasTrumpApprovalPointForDay = async (
-  pg: SupabaseDirectClient,
-  day: string
-) => {
-  // Derive the end of the window from the NEXT calendar date rather than
-  // dayStart.add(1, 'day'): adding a day adds 24 UTC hours, which is off by
-  // an hour on both DST transition days and would either miss a published
-  // point or double-count one from the adjacent day.
-  const dayStart = dayjs.tz(day, TRUMP_APPROVAL_TZ)
-  const dayEnd = dayjs.tz(
-    dayjs.utc(day).add(1, 'day').format('YYYY-MM-DD'),
-    TRUMP_APPROVAL_TZ
-  )
-  const row = await pg.oneOrNone<{ published: boolean }>(
-    `select exists (
-       select 1 from oracle_prices
-       where feed_id = $1 and ts >= $2 and ts < $3
-     ) as published`,
-    [TRUMP_APPROVAL_FEED_ID, dayStart.toISOString(), dayEnd.toISOString()]
-  )
-  return row?.published === true
-}
-
 export type TrumpApprovalPublishResult =
   | {
       status: 'published'
@@ -80,6 +51,7 @@ export type TrumpApprovalPublishResult =
        * produce one. Null is "unchecked", never "agrees". */
       crossCheckGap: number | null
     }
+  | { status: 'unchanged'; price: number; reason: string }
   | { status: 'no-polls'; reason: string }
   | { status: 'rejected'; reason: string }
 
@@ -96,7 +68,8 @@ export type TrumpApprovalPublishResult =
  * hourly for a single outage.
  */
 export const publishTrumpApprovalPoint = async (
-  pg: SupabaseDirectClient
+  pg: SupabaseDirectClient,
+  options: { force?: boolean } = {}
 ): Promise<TrumpApprovalPublishResult> => {
   const now = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ)
   const fetchStart = now
@@ -111,21 +84,81 @@ export const publishTrumpApprovalPoint = async (
   )
   if (!published.ok) return { status: 'no-polls', reason: published.reason }
 
-  // The canary. Computed from the raw polls, never used as the price. A
-  // failure to produce it is NOT a reason to withhold a good published value —
-  // our estimator gives up in droughts that their time-weighted one handles
-  // fine — so an unavailable reference downgrades to "unchecked" and says so.
-  const polls = await fetchTrumpApprovalPolls(fetchStart)
-  const reference = computeApprovalPoint(toApprovalPolls(polls), today)
-  const crossCheckGap = reference.ok
-    ? getApprovalCrossCheckGap(published.price, reference.price)
+  const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
+    `select ts, price from oracle_prices where feed_id = $1
+     order by ts desc limit 1`,
+    [TRUMP_APPROVAL_FEED_ID]
+  )
+  const last = prev
+    ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
     : null
+
+  // Decide BEFORE running the cross-check: an unchanged reading is the common
+  // case now that this runs hourly, and it costs a second HTTP request and a
+  // full window computation to conclude nothing happened.
+  // `force` is the operator escape hatch: during an incident the point of
+  // running this by hand is to put a fresh stamp on the feed before it
+  // crosses maxOraclePriceAgeMs and pauses the engine, which is exactly the
+  // case the unchanged-value gate would otherwise refuse.
+  const decision = options.force
+    ? ({ publish: true, reason: 'forced' } as const)
+    : decideApprovalPublish({
+        price: published.price,
+        last,
+        now: Date.now(),
+      })
+  if (!decision.publish)
+    return {
+      status: 'unchanged',
+      price: published.price,
+      reason: decision.reason,
+    }
+
+  // The canary. Computed from the raw polls, never used as the price.
+  //
+  // Its whole contract is that failing to produce it must not withhold a good
+  // published value, so the fetch and the computation are both inside the
+  // try: a timeout or an HTTP error here previously threw straight past the
+  // "unchecked" path and blocked publication, which is the opposite of what
+  // the surrounding comments promised.
+  //
+  // Computed for `published.asOfDay`, NOT for today. The published value can
+  // be a day or two behind, and comparing it against a reference built from
+  // polls it had not seen manufactures a divergence out of nothing but the
+  // date mismatch. Residual: a poll whose end_date precedes asOfDay but which
+  // VoteHub ingested afterwards still lands in our reference and not in
+  // theirs. Filtering on the provider's `created_at` would be a guess at when
+  // they folded it in rather than a fact, and the drift it leaves is bounded
+  // by our own ~0.17/day movement against a tolerance of 3.
+  let reference: ReturnType<typeof computeApprovalPoint> | null = null
+  try {
+    const polls = await fetchTrumpApprovalPolls(fetchStart)
+    reference = computeApprovalPoint(toApprovalPolls(polls), published.asOfDay)
+  } catch (err) {
+    reference = null
+    log.warn(
+      `[trump-approval] cross-check reference unavailable: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
+  const referencePrice = reference?.ok === true ? reference.price : null
+  const referenceLabel =
+    referencePrice == null ? '?' : referencePrice.toFixed(2)
+  const crossCheckGap =
+    referencePrice == null
+      ? null
+      : getApprovalCrossCheckGap(published.price, referencePrice)
 
   if (crossCheckGap == null)
     log.warn(
       `[trump-approval] publishing ${published.price.toFixed(2)} unchecked — ` +
         `no independent reference (${
-          reference.ok ? 'gap not computable' : reference.reason
+          reference == null
+            ? 'fetch failed'
+            : reference.ok
+            ? 'gap not computable'
+            : reference.reason
         })`
     )
   else if (crossCheckGap > TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP)
@@ -134,26 +167,15 @@ export const publishTrumpApprovalPoint = async (
       reason:
         `published average ${published.price.toFixed(2)} (as of ` +
         `${published.asOfDay}) is ${crossCheckGap.toFixed(2)} from our own ` +
-        `${reference.ok ? reference.price.toFixed(2) : '?'}, over the ` +
+        `${referenceLabel}, over the ` +
         `${TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP} tolerance — not publishing a ` +
         `value two independent computations disagree about`,
     }
 
   const point = { price: published.price, ts: Date.now() }
   const feed = getOracleFeed(TRUMP_APPROVAL_FEED_ID)
-  const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
-    `select ts, price from oracle_prices where feed_id = $1
-     order by ts desc limit 1`,
-    [TRUMP_APPROVAL_FEED_ID]
-  )
   const rejection = feed
-    ? validateOraclePoint(
-        feed,
-        prev
-          ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
-          : null,
-        point
-      )
+    ? validateOraclePoint(feed, last, point)
     : `missing OracleFeedDef for ${TRUMP_APPROVAL_FEED_ID}`
   if (rejection)
     return {
@@ -163,13 +185,14 @@ export const publishTrumpApprovalPoint = async (
 
   log(
     `VoteHub published Trump approval average: ${point.price.toFixed(2)} ` +
-      `(as of ${published.asOfDay}, ${published.ageDays}d old); ` +
+      `(as of ${published.asOfDay}, ${published.ageDays}d old, ` +
+      `${decision.reason}); ` +
       `${
         crossCheckGap == null
           ? 'cross-check unavailable'
-          : `cross-check gap ${crossCheckGap.toFixed(2)} vs our own ${
-              reference.ok ? reference.price.toFixed(2) : '?'
-            }`
+          : `cross-check gap ${crossCheckGap.toFixed(
+              2
+            )} vs our own ${referenceLabel}`
       } at ${new Date(point.ts).toISOString()}`
   )
   await insertOraclePrices(pg, TRUMP_APPROVAL_FEED_ID, [point])

--- a/backend/shared/src/perps/publish-trump-approval.ts
+++ b/backend/shared/src/perps/publish-trump-approval.ts
@@ -4,20 +4,32 @@ import * as utc from 'dayjs/plugin/utc'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
+import {
+  TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP,
+  TRUMP_APPROVAL_MAX_WINDOW_DAYS,
+  computeApprovalPoint,
+  getApprovalCrossCheckGap,
+  readPublishedApprovalAverage,
+} from 'common/perps/trump-approval'
+
 import { TRUMP_APPROVAL_FEED_ID, insertOraclePrices } from 'shared/oracle'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
 import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 import {
-  computeRollingAverages,
+  fetchTrumpApprovalAverage,
   fetchTrumpApprovalPolls,
-  TRUMP_APPROVAL_WINDOW_DAYS,
+  toApprovalPolls,
 } from 'shared/trump-approval'
 import { log } from 'shared/utils'
 
-// Fetch enough poll history to fully cover today's trailing window, plus a
-// safety buffer for long fielding periods (some polls span 2+ weeks).
-const FETCH_LOOKBACK_DAYS = TRUMP_APPROVAL_WINDOW_DAYS + 14
+// Fetch enough poll history to cover the WIDEST window the methodology can
+// ask for, not just the nominal 14 days: when polling goes quiet the window
+// extends to satisfy TRUMP_APPROVAL_MIN_POLLS, and a lookback that stopped at
+// the nominal width would starve exactly the case the floor exists to handle.
+// The extra 21 days is buffer for long fielding periods (some polls span 2+
+// weeks, so their end_date can trail their start_date well past the bound).
+const FETCH_LOOKBACK_DAYS = TRUMP_APPROVAL_MAX_WINDOW_DAYS + 21
 
 export const TRUMP_APPROVAL_TZ = 'America/Los_Angeles'
 
@@ -55,12 +67,24 @@ export const hasTrumpApprovalPointForDay = async (
 }
 
 export type TrumpApprovalPublishResult =
-  | { status: 'published'; price: number; ts: number }
+  | {
+      status: 'published'
+      price: number
+      ts: number
+      /** The day VoteHub stamped the value we published, and how far behind
+       * `today` that is. Surfaced so a published point can be reconciled
+       * against their site without re-deriving it. */
+      asOfDay: string
+      ageDays: number
+      /** Distance from our independent computation, or null when we could not
+       * produce one. Null is "unchecked", never "agrees". */
+      crossCheckGap: number | null
+    }
   | { status: 'no-polls'; reason: string }
   | { status: 'rejected'; reason: string }
 
 /**
- * Compute and publish ONE observation of today's rolling value, stamped when
+ * Publish ONE observation of VoteHub's current approval average, stamped when
  * it becomes available to the market. Corrections append another observation
  * instead of pretending the revised value was tradable from midnight or
  * rewriting a point that liquidations/funding may already have consumed.
@@ -80,16 +104,42 @@ export const publishTrumpApprovalPoint = async (
     .format('YYYY-MM-DD')
   const today = now.format('YYYY-MM-DD')
 
+  // The price. Fetched first so a failure here costs one request, not two.
+  const published = readPublishedApprovalAverage(
+    await fetchTrumpApprovalAverage(),
+    today
+  )
+  if (!published.ok) return { status: 'no-polls', reason: published.reason }
+
+  // The canary. Computed from the raw polls, never used as the price. A
+  // failure to produce it is NOT a reason to withhold a good published value —
+  // our estimator gives up in droughts that their time-weighted one handles
+  // fine — so an unavailable reference downgrades to "unchecked" and says so.
   const polls = await fetchTrumpApprovalPolls(fetchStart)
-  const points = computeRollingAverages(polls, today, today)
-  if (points.length === 0)
+  const reference = computeApprovalPoint(toApprovalPolls(polls), today)
+  const crossCheckGap = reference.ok
+    ? getApprovalCrossCheckGap(published.price, reference.price)
+    : null
+
+  if (crossCheckGap == null)
+    log.warn(
+      `[trump-approval] publishing ${published.price.toFixed(2)} unchecked — ` +
+        `no independent reference (${
+          reference.ok ? 'gap not computable' : reference.reason
+        })`
+    )
+  else if (crossCheckGap > TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP)
     return {
-      status: 'no-polls',
-      reason: `no polls in trailing ${TRUMP_APPROVAL_WINDOW_DAYS}-day window`,
+      status: 'rejected',
+      reason:
+        `published average ${published.price.toFixed(2)} (as of ` +
+        `${published.asOfDay}) is ${crossCheckGap.toFixed(2)} from our own ` +
+        `${reference.ok ? reference.price.toFixed(2) : '?'}, over the ` +
+        `${TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP} tolerance — not publishing a ` +
+        `value two independent computations disagree about`,
     }
 
-  const [computedPoint] = points
-  const point = { ...computedPoint, ts: Date.now() }
+  const point = { price: published.price, ts: Date.now() }
   const feed = getOracleFeed(TRUMP_APPROVAL_FEED_ID)
   const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
     `select ts, price from oracle_prices where feed_id = $1
@@ -108,16 +158,29 @@ export const publishTrumpApprovalPoint = async (
   if (rejection)
     return {
       status: 'rejected',
-      reason: `computed ${point.price.toFixed(2)} but ${rejection}`,
+      reason: `published average ${point.price.toFixed(2)} but ${rejection}`,
     }
 
   log(
-    `today's ${TRUMP_APPROVAL_WINDOW_DAYS}-day rolling Trump approval average: ${point.price.toFixed(
-      2
-    )} (${new Date(point.ts).toISOString()})`
+    `VoteHub published Trump approval average: ${point.price.toFixed(2)} ` +
+      `(as of ${published.asOfDay}, ${published.ageDays}d old); ` +
+      `${
+        crossCheckGap == null
+          ? 'cross-check unavailable'
+          : `cross-check gap ${crossCheckGap.toFixed(2)} vs our own ${
+              reference.ok ? reference.price.toFixed(2) : '?'
+            }`
+      } at ${new Date(point.ts).toISOString()}`
   )
   await insertOraclePrices(pg, TRUMP_APPROVAL_FEED_ID, [point])
   await applyOraclePointToLivePerps(pg, TRUMP_APPROVAL_FEED_ID, point)
   log(`inserted 1 ${TRUMP_APPROVAL_FEED_ID} oracle point for ${today}`)
-  return { status: 'published', price: point.price, ts: point.ts }
+  return {
+    status: 'published',
+    price: point.price,
+    ts: point.ts,
+    asOfDay: published.asOfDay,
+    ageDays: published.ageDays,
+    crossCheckGap,
+  }
 }

--- a/backend/shared/src/perps/publish-trump-approval.ts
+++ b/backend/shared/src/perps/publish-trump-approval.ts
@@ -6,6 +6,7 @@ dayjs.extend(timezone)
 
 import {
   TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP,
+  TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS,
   TRUMP_APPROVAL_MAX_WINDOW_DAYS,
   computeApprovalPoint,
   decideApprovalPublish,
@@ -16,6 +17,7 @@ import {
 import { TRUMP_APPROVAL_FEED_ID, insertOraclePrices } from 'shared/oracle'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
 import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
+import { advisoryLockQuery } from 'shared/perps/queries'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 import {
   fetchTrumpApprovalAverage,
@@ -30,7 +32,12 @@ import { log } from 'shared/utils'
 // the nominal width would starve exactly the case the floor exists to handle.
 // The extra 21 days is buffer for long fielding periods (some polls span 2+
 // weeks, so their end_date can trail their start_date well past the bound).
-const FETCH_LOOKBACK_DAYS = TRUMP_APPROVAL_MAX_WINDOW_DAYS + 21
+// ...and reach back from the OLDEST day we might value, not from today: the
+// published value can be up to TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS behind, and
+// the cross-check is computed for that day. Measuring the lookback from today
+// silently delivered a window three days short of what these comments claim.
+const FETCH_LOOKBACK_DAYS =
+  TRUMP_APPROVAL_MAX_WINDOW_DAYS + TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS + 21
 
 export const TRUMP_APPROVAL_TZ = 'America/Los_Angeles'
 
@@ -72,46 +79,57 @@ export const publishTrumpApprovalPoint = async (
   options: { force?: boolean } = {}
 ): Promise<TrumpApprovalPublishResult> => {
   const now = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ)
-  const fetchStart = now
-    .subtract(FETCH_LOOKBACK_DAYS, 'day')
-    .format('YYYY-MM-DD')
   const today = now.format('YYYY-MM-DD')
 
   // The price. Fetched first so a failure here costs one request, not two.
-  const published = readPublishedApprovalAverage(
-    await fetchTrumpApprovalAverage(),
-    today
-  )
+  const averages = await fetchTrumpApprovalAverage()
+  // Stamp the observation the moment it arrives, NOT after the cross-check
+  // below. With the timestamp taken later, a publisher that stalled in the
+  // canary fetch could write its stale reading with a timestamp newer than a
+  // concurrent publisher's fresher one, and the older observation would
+  // become the executable mark. The point is when we saw the value.
+  const observedAt = Date.now()
+  const published = readPublishedApprovalAverage(averages, today)
   if (!published.ok) return { status: 'no-polls', reason: published.reason }
 
-  const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
-    `select ts, price from oracle_prices where feed_id = $1
-     order by ts desc limit 1`,
-    [TRUMP_APPROVAL_FEED_ID]
-  )
-  const last = prev
-    ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
-    : null
+  const fetchStart = dayjs
+    .utc(published.asOfDay)
+    .subtract(FETCH_LOOKBACK_DAYS, 'day')
+    .format('YYYY-MM-DD')
 
-  // Decide BEFORE running the cross-check: an unchanged reading is the common
-  // case now that this runs hourly, and it costs a second HTTP request and a
-  // full window computation to conclude nothing happened.
+  const readLast = async (
+    db: SupabaseDirectClient
+  ): Promise<{ ts: number; price: number } | null> => {
+    const row = await db.oneOrNone<{ ts: string; price: number | string }>(
+      `select ts, price from oracle_prices where feed_id = $1
+       order by ts desc limit 1`,
+      [TRUMP_APPROVAL_FEED_ID]
+    )
+    if (!row) return null
+    return { ts: new Date(row.ts).getTime(), price: Number(row.price) }
+  }
+
   // `force` is the operator escape hatch: during an incident the point of
   // running this by hand is to put a fresh stamp on the feed before it
   // crosses maxOraclePriceAgeMs and pauses the engine, which is exactly the
   // case the unchanged-value gate would otherwise refuse.
-  const decision = options.force
-    ? ({ publish: true, reason: 'forced' } as const)
-    : decideApprovalPublish({
-        price: published.price,
-        last,
-        now: Date.now(),
-      })
-  if (!decision.publish)
+  const decide = (last: { ts: number; price: number } | null) =>
+    options.force
+      ? ({ publish: true, reason: 'forced' } as const)
+      : decideApprovalPublish({ price: published.price, last, now: observedAt })
+
+  // Cheap early-out OUTSIDE the lock. An unchanged reading is the overwhelming
+  // common case at a 5-minute cadence — the value moves about once a day — and
+  // concluding that costs one indexed read rather than a second HTTP request,
+  // a full window computation, and a lock. The authoritative re-check happens
+  // under the lock below; this one is only an optimisation and is allowed to
+  // race.
+  const earlyDecision = decide(await readLast(pg))
+  if (!earlyDecision.publish)
     return {
       status: 'unchanged',
       price: published.price,
-      reason: decision.reason,
+      reason: earlyDecision.reason,
     }
 
   // The canary. Computed from the raw polls, never used as the price.
@@ -128,8 +146,10 @@ export const publishTrumpApprovalPoint = async (
   // date mismatch. Residual: a poll whose end_date precedes asOfDay but which
   // VoteHub ingested afterwards still lands in our reference and not in
   // theirs. Filtering on the provider's `created_at` would be a guess at when
-  // they folded it in rather than a fact, and the drift it leaves is bounded
-  // by our own ~0.17/day movement against a tolerance of 3.
+  // they folded it in rather than a fact. The drift it leaves is small — our
+  // own computation moves ~0.17/day on average against a tolerance of 3 —
+  // though that is a mean and not a bound, so an unusually eventful few days
+  // could narrow the margin.
   let reference: ReturnType<typeof computeApprovalPoint> | null = null
   try {
     const polls = await fetchTrumpApprovalPolls(fetchStart)
@@ -172,30 +192,67 @@ export const publishTrumpApprovalPoint = async (
         `value two independent computations disagree about`,
     }
 
-  const point = { price: published.price, ts: Date.now() }
+  const point = { price: published.price, ts: observedAt }
   const feed = getOracleFeed(TRUMP_APPROVAL_FEED_ID)
-  const rejection = feed
-    ? validateOraclePoint(feed, last, point)
-    : `missing OracleFeedDef for ${TRUMP_APPROVAL_FEED_ID}`
-  if (rejection)
+  if (!feed)
     return {
       status: 'rejected',
-      reason: `published average ${point.price.toFixed(2)} but ${rejection}`,
+      reason: `missing OracleFeedDef for ${TRUMP_APPROVAL_FEED_ID}`,
     }
 
-  log(
-    `VoteHub published Trump approval average: ${point.price.toFixed(2)} ` +
-      `(as of ${published.asOfDay}, ${published.ageDays}d old, ` +
-      `${decision.reason}); ` +
-      `${
-        crossCheckGap == null
-          ? 'cross-check unavailable'
-          : `cross-check gap ${crossCheckGap.toFixed(
-              2
-            )} vs our own ${referenceLabel}`
-      } at ${new Date(point.ts).toISOString()}`
-  )
-  await insertOraclePrices(pg, TRUMP_APPROVAL_FEED_ID, [point])
+  // Serialize the decide-and-write against every other publisher on this
+  // feed. Croner's `protect` only covers one Cron object inside one process,
+  // so it does nothing about the standalone publish script, a second
+  // scheduler instance during a rolling deploy, or a manual run. Without this
+  // the read of the previous point and the insert are two unrelated
+  // statements, and two publishers can both decide to write.
+  //
+  // The decision is re-made INSIDE the lock against a fresh read, because the
+  // early-out above ran before the cross-check's HTTP call and its answer may
+  // be seconds stale by now.
+  const outcome = await pg.tx(async (tx) => {
+    await tx.one(advisoryLockQuery(`oracle-publish:${TRUMP_APPROVAL_FEED_ID}`))
+    const last = await readLast(tx)
+
+    const decision = decide(last)
+    if (!decision.publish)
+      return {
+        status: 'unchanged' as const,
+        price: published.price,
+        reason: decision.reason,
+      }
+
+    // validateOraclePoint rejects `point.ts <= prev.ts`, which under the lock
+    // is what stops a stalled publisher from rolling the mark backwards onto
+    // an older observation.
+    const rejection = validateOraclePoint(feed, last, point)
+    if (rejection)
+      return {
+        status: 'rejected' as const,
+        reason: `published average ${point.price.toFixed(2)} but ${rejection}`,
+      }
+
+    log(
+      `VoteHub published Trump approval average: ${point.price.toFixed(2)} ` +
+        `(as of ${published.asOfDay}, ${published.ageDays}d old, ` +
+        `${decision.reason}); ` +
+        `${
+          crossCheckGap == null
+            ? 'cross-check unavailable'
+            : `cross-check gap ${crossCheckGap.toFixed(
+                2
+              )} vs our own ${referenceLabel}`
+        } at ${new Date(point.ts).toISOString()}`
+    )
+    await insertOraclePrices(tx, TRUMP_APPROVAL_FEED_ID, [point])
+    return { status: 'published' as const }
+  })
+
+  if (outcome.status !== 'published') return outcome
+
+  // Applied OUTSIDE the publishing transaction, exactly as the fast oracle
+  // path does it: runOracleUpdate takes its own per-contract advisory lock,
+  // and nesting that inside this one would hold both across engine work.
   await applyOraclePointToLivePerps(pg, TRUMP_APPROVAL_FEED_ID, point)
   log(`inserted 1 ${TRUMP_APPROVAL_FEED_ID} oracle point for ${today}`)
   return {

--- a/backend/shared/src/trump-approval.ts
+++ b/backend/shared/src/trump-approval.ts
@@ -1,8 +1,9 @@
-import * as dayjs from 'dayjs'
-import * as utc from 'dayjs/plugin/utc'
-import * as timezone from 'dayjs/plugin/timezone'
-dayjs.extend(utc)
-dayjs.extend(timezone)
+import {
+  ApprovalPoll,
+  PublishedAverageSeries,
+  hasApproveAnswer,
+  readApprovePct,
+} from 'common/perps/trump-approval'
 
 import { log } from './utils'
 
@@ -14,9 +15,10 @@ import { log } from './utils'
 // is its `end_date` (last day of fielding) — not `created_at`, which is
 // when the poll was published.
 //
-// We compute a daily average as the *unweighted* mean of Approve pct across
-// all polls whose end_date falls within a trailing window ending on the day
-// in question. 14 days is standard for political polling aggregators.
+// This module is the ADAPTER only: it fetches and shapes. How the polls are
+// then windowed and averaged is the published methodology and lives in
+// common/perps/trump-approval.ts, where a UI can read the same rule the
+// oracle prices against.
 
 export type VoteHubPoll = {
   id: string
@@ -28,12 +30,56 @@ export type VoteHubPoll = {
   answers: { choice: string; pct: number }[]
 }
 
-export const TRUMP_APPROVAL_WINDOW_DAYS = 14
 export const TRUMP_INAUGURATION_DATE = '2025-01-21'
 
-// Fetch all Trump approval polls from VoteHub since `startDate` (YYYY-MM-DD).
-// The API returns the full list in one payload (no pagination observed in
-// practice; `total` is included but all items come back).
+const getApprovePct = (poll: VoteHubPoll): number | null => {
+  const pct = readApprovePct(poll?.answers)
+  // Distinguish "no Approve answer" (structural, not newsworthy) from a
+  // percentage that cannot be a percentage. The latter is a provider
+  // data-entry error and worth an ERROR: one pct of 460 against ~20 polls
+  // near 45 moves the unweighted mean ~20 points, which lands inside the
+  // feed's [10,90] plausibility bounds and would price live positions.
+  if (pct == null && hasApproveAnswer(poll?.answers))
+    log.error(
+      `[trump-approval] dropping poll ${poll?.id} with unusable approve pct`
+    )
+  return pct
+}
+
+/**
+ * Fetch every Trump approval poll from VoteHub since `startDate`.
+ *
+ * ONE REQUEST, DELIBERATELY. An earlier revision of this function paged by
+ * `offset`, on the belief that the endpoint truncated silently — the giveaway
+ * being that `items.length` comes back well under the reported `total` (26 of
+ * 37 over 28 days, 57 of 69 over 56, 807 of 995 over the full history). That
+ * was a misreading, and the paging it motivated made things worse rather than
+ * better. What the response body actually does:
+ *
+ *   - `items` is COMPLETE. Verified across six range sizes from 2 polls to
+ *     807: `items.length` always equals the distinct-id count, and the entire
+ *     history since inauguration arrives in a single response.
+ *   - `total` counts a different and larger population than `items` — it does
+ *     not match the item count under any combination of the filters we send,
+ *     including with `in_averages_only=false`. It is not a completeness
+ *     signal, and any check comparing the two fires on every single request.
+ *   - `offset` past the end of `items` does NOT return further rows. It
+ *     returns byte-identical copies of rows already delivered, then empties.
+ *     The "unstable sort producing duplicates" the paging loop deduplicated
+ *     against was an artifact the loop itself created by requesting offsets
+ *     that only existed in `total`'s larger population.
+ *
+ * So there is nothing to page and nothing to reconcile. Do not reintroduce a
+ * loop here on the strength of `items.length < total` alone; confirm first
+ * that distinct ids are actually missing, which so far they never are.
+ *
+ * The real backstop against a future truncation lives in the methodology
+ * rather than here: selectApprovalWindow refuses to publish unless it finds
+ * TRUMP_APPROVAL_MIN_POLLS within TRUMP_APPROVAL_MAX_WINDOW_DAYS. Truncation
+ * would drop the OLDEST polls (responses arrive newest-first), which is
+ * exactly what a widened window reaches for, so a short read surfaces as a
+ * refusal to publish rather than as a quietly wrong average.
+ */
 export const fetchTrumpApprovalPolls = async (
   startDate: string
 ): Promise<VoteHubPoll[]> => {
@@ -67,71 +113,77 @@ export const fetchTrumpApprovalPolls = async (
     items: VoteHubPoll[]
     total: number
   }
+  const items = Array.isArray(body.items) ? body.items : []
+  const distinct = new Set(items.map((poll) => poll?.id)).size
+
+  // Log the oldest date reached, not `total`: coverage of the window we are
+  // about to price is the property that matters, and it is the one a future
+  // truncation would visibly break.
+  const oldest = items.reduce<string | null>(
+    (acc, poll) => (acc == null || poll?.end_date < acc ? poll?.end_date : acc),
+    null
+  )
   log(
-    `fetched ${body.items.length}/${body.total} Trump approval polls from VoteHub (start_date=${startDate})`
+    `fetched ${items.length} Trump approval polls from VoteHub ` +
+      `(start_date=${startDate}, oldest end_date ${oldest ?? 'n/a'})`
   )
-  return body.items
-}
-
-const getApprovePct = (poll: VoteHubPoll): number | null => {
-  const approve = poll.answers.find(
-    (a) => a.choice.toLowerCase() === 'approve'
-  )
-  if (!approve || typeof approve.pct !== 'number') return null
-  // The response is cast, not schema-validated, so a provider data-entry
-  // error arrives as a plain number. Drop implausible percentages rather
-  // than letting one bad row drag the unweighted mean: a single pct of 460
-  // against ~20 polls near 45 moves the average by ~20 points, which lands
-  // inside the feed's [10,90] sanity bounds and would be applied to live
-  // positions as a real price.
-  if (!Number.isFinite(approve.pct) || approve.pct < 0 || approve.pct > 100) {
+  // Distinct ids have always equalled the item count. If that ever changes,
+  // the response really is repeating rows and the assumptions above need
+  // revisiting — so say so loudly rather than silently deduplicating.
+  if (distinct !== items.length)
     log.error(
-      `[trump-approval] dropping poll ${poll.id} with out-of-range approve pct ${approve.pct}`
+      `[trump-approval] VoteHub returned ${items.length} rows but only ${distinct} distinct ids`
     )
-    return null
-  }
-  return approve.pct
+  return items
 }
 
-// Compute a rolling (trailing, unweighted) average of Approve pct for each
-// day in [fromDay, toDay] (inclusive). A poll contributes to day D if its
-// end_date is in (D - windowDays, D] (i.e. the windowDays days ending on D).
-// Days with no polls in the window are omitted.
-export const computeRollingAverages = (
-  polls: VoteHubPoll[],
-  fromDay: string, // YYYY-MM-DD, in America/Los_Angeles
-  toDay: string, // YYYY-MM-DD
-  windowDays: number = TRUMP_APPROVAL_WINDOW_DAYS
-): { ts: number; price: number }[] => {
-  const pollsWithPct = polls
-    .map((p) => ({ endDate: p.end_date, pct: getApprovePct(p) }))
-    .filter((p): p is { endDate: string; pct: number } => p.pct != null)
+/** VoteHub's key for the Trump approval average. */
+export const VOTEHUB_TRUMP_APPROVAL_KEY = 'trump_approval'
 
-  // Iterate CALENDAR dates and derive each day's timestamp fresh:
-  // dayjs.tz(...).add(1, 'day') adds 24 UTC hours, so a loop started in PST
-  // drifts to 1 AM once PDT begins — every summer stamp landed an hour off
-  // midnight and collided with the correctly-stamped daily-job rows.
-  // Window membership compares ISO date strings, which is DST-proof.
-  const points: { ts: number; price: number }[] = []
-  for (
-    let d = dayjs.utc(fromDay);
-    !d.isAfter(dayjs.utc(toDay));
-    d = d.add(1, 'day')
-  ) {
-    const dateStr = d.format('YYYY-MM-DD')
-    const windowStartStr = d
-      .subtract(windowDays - 1, 'day')
-      .format('YYYY-MM-DD')
-    const inWindow = pollsWithPct.filter(
-      (p) => p.endDate >= windowStartStr && p.endDate <= dateStr
-    )
-    if (inWindow.length === 0) continue
-    const avg = inWindow.reduce((sum, p) => sum + p.pct, 0) / inWindow.length
-    points.push({
-      ts: dayjs.tz(dateStr, 'America/Los_Angeles').valueOf(),
-      price: avg,
+/**
+ * Fetch VoteHub's published, time-weighted approval average.
+ *
+ * This is the oracle price. The raw `/polls` feed above is still read, but
+ * only to compute the independent cross-check described in
+ * common/perps/trump-approval.ts — it no longer sets the price.
+ *
+ * Returns the whole series (one entry per day back to inauguration, ~50KB).
+ * There is no "latest only" parameter, and the full payload is small enough
+ * that adding one would be optimising the wrong thing: having the history in
+ * hand is what lets readPublishedApprovalAverage tell "posted late today" from
+ * "stopped updating three days ago".
+ */
+export const fetchTrumpApprovalAverage =
+  async (): Promise<PublishedAverageSeries> => {
+    const url = `https://polling.votehub.com/averages/${VOTEHUB_TRUMP_APPROVAL_KEY}/values`
+
+    const response = await fetch(url, {
+      headers: {
+        accept: '*/*',
+        'user-agent': 'Manifold/1.0 (+https://manifold.markets)',
+      },
+      // Same reasoning as the polls fetch: without an explicit timeout a
+      // slow-trickling body never resolves, the job never finishes, and
+      // croner's `protect` silently skips later firings at WARN severity.
+      signal: AbortSignal.timeout(30_000),
     })
+    if (!response.ok) {
+      throw new Error(
+        `VoteHub averages request failed: ${response.status} ${response.statusText}`
+      )
+    }
+    const body = (await response.json()) as PublishedAverageSeries
+    log(
+      `fetched VoteHub published approval average ` +
+        `(${Object.keys(body ?? {}).length} daily points)`
+    )
+    return body
   }
 
-  return points
-}
+/** Shape VoteHub rows into the methodology's input, dropping unusable ones. */
+export const toApprovalPolls = (polls: VoteHubPoll[]): ApprovalPoll[] =>
+  polls.flatMap((poll) => {
+    const pct = getApprovePct(poll)
+    if (pct == null) return []
+    return [{ endDate: poll.end_date, pct, pollster: poll.pollster }]
+  })

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -15,9 +15,12 @@
 // haven't read is its own problem:
 //   - OpenRouter — their dataset terms specify the exact credit line,
 //     including the data's as-of time. Hence `showAsOf`.
-//   - NESO / VoteHub — both publish under an open licence requiring
-//     attribution, but the exact current licence text was NOT read directly.
-//     So they get a credit and a link, and no licence label we can't back up.
+//   - VoteHub — their API documentation states "This API is licensed under
+//     Creative Commons Attribution 4.0 International". Read directly, so it
+//     carries a licence label and a link to the licence deed.
+//   - NESO — publishes under an open licence requiring attribution, but the
+//     exact current licence text was NOT read directly. So it gets a credit
+//     and a link, and no licence label we can't back up.
 //   - BTC — we compute the median ourselves from three public tickers, so
 //     nothing is being republished. Credited for transparency, not obligation.
 
@@ -28,6 +31,14 @@ export type OracleAttribution = {
   url?: string
   /** Only set where the licence has actually been verified. */
   licence?: string
+  /**
+   * Canonical URI for that licence, rendered as a link.
+   *
+   * CC BY 4.0 s3(a)(1)(C) asks for a URI or hyperlink to the licence itself
+   * when sharing licensed material, not merely its name — so a bare "CC BY
+   * 4.0" label is an incomplete credit. Set this wherever `licence` is set.
+   */
+  licenceUrl?: string
   /**
    * Render the data's as-of timestamp in the credit line. Set only where the
    * provider's terms ask for it — elsewhere it is noise, and the oracle
@@ -50,12 +61,13 @@ export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
     source: 'VoteHub',
     url: 'https://votehub.com',
     // Stated on VoteHub's API documentation: "This API is licensed under
-    // Creative Commons Attribution 4.0 International." Read directly, hence
-    // the label — CC BY 4.0 permits reuse and redistribution, including
-    // commercially, on the single condition that the source is credited.
-    // The oracle mirrors their published average, so this credit IS the
-    // compliance, not decoration.
+    // Creative Commons Attribution 4.0 International." CC BY 4.0 permits
+    // reuse and redistribution, including commercially, on the single
+    // condition that the source is credited. The oracle mirrors their
+    // published average, so this credit IS the compliance, not decoration —
+    // which is why the licence link is required rather than ornamental.
     licence: 'CC BY 4.0',
+    licenceUrl: 'https://creativecommons.org/licenses/by/4.0/',
   },
   'btc-usd': {
     source: 'Coinbase, Kraken & Bitstamp',

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -49,6 +49,13 @@ export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
   'trump-approval-rating': {
     source: 'VoteHub',
     url: 'https://votehub.com',
+    // Stated on VoteHub's API documentation: "This API is licensed under
+    // Creative Commons Attribution 4.0 International." Read directly, hence
+    // the label — CC BY 4.0 permits reuse and redistribution, including
+    // commercially, on the single condition that the source is credited.
+    // The oracle mirrors their published average, so this credit IS the
+    // compliance, not decoration.
+    licence: 'CC BY 4.0',
   },
   'btc-usd': {
     source: 'Coinbase, Kraken & Bitstamp',

--- a/common/src/perps/trump-approval.test.ts
+++ b/common/src/perps/trump-approval.test.ts
@@ -584,3 +584,45 @@ describe('decideApprovalPublish', () => {
     ).toBe(false)
   })
 })
+
+describe('decideApprovalPublish — concurrency guards', () => {
+  const now = Date.parse('2026-08-23T12:00:00Z')
+
+  it('declines when a concurrent publisher already wrote the same value', () => {
+    // The locked re-check re-runs this against a fresh read. A publisher that
+    // stalled in the cross-check fetch must not append a duplicate behind the
+    // one that got there first.
+    const last = { price: 38.4, ts: now - 1000 }
+    expect(decideApprovalPublish({ price: 38.4, last, now }).publish).toBe(
+      false
+    )
+  })
+
+  it('still publishes a genuinely newer value behind a concurrent write', () => {
+    const last = { price: 38.4, ts: now - 1000 }
+    expect(decideApprovalPublish({ price: 38.5, last, now }).publish).toBe(true)
+  })
+})
+
+describe('lookback covers the day actually valued', () => {
+  it('reaches the max window measured from the oldest valuable as-of day', () => {
+    // The cross-check is computed for published.asOfDay, which can trail today
+    // by TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS. A lookback measured from today
+    // would deliver a window that many days short of the documented span.
+    const polls = Array.from({ length: TRUMP_APPROVAL_MIN_POLLS }, (_, i) =>
+      poll(shift('2026-08-20', -i - 20), 38)
+    )
+    const asOfDay = '2026-08-20'
+    const result = selectApprovalWindow(polls, asOfDay)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    // Everything selected must sit inside the fetched span.
+    const oldest = result.window.startDate
+    const spanFromAsOf = Math.round(
+      (Date.parse(`${asOfDay}T00:00:00Z`) - Date.parse(`${oldest}T00:00:00Z`)) /
+        86_400_000
+    )
+    expect(spanFromAsOf).toBeLessThanOrEqual(TRUMP_APPROVAL_MAX_WINDOW_DAYS)
+  })
+})

--- a/common/src/perps/trump-approval.test.ts
+++ b/common/src/perps/trump-approval.test.ts
@@ -1,11 +1,13 @@
 import {
   ApprovalPoll,
   PublishedAverageSeries,
+  TRUMP_APPROVAL_HEARTBEAT_MS,
   TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP,
   TRUMP_APPROVAL_MAX_WINDOW_DAYS,
   TRUMP_APPROVAL_MIN_POLLS,
   averageApprovalPct,
   computeApprovalPoint,
+  decideApprovalPublish,
   getApprovalCrossCheckGap,
   hasApproveAnswer,
   isUsableApprovalPoll,
@@ -494,5 +496,91 @@ describe('averageApprovalPct', () => {
   it('returns null rather than NaN on an empty set', () => {
     expect(averageApprovalPct([])).toBeNull()
     expect(averageApprovalPct([poll('2026-08-10', NaN)])).toBeNull()
+  })
+})
+
+describe('decideApprovalPublish', () => {
+  const now = Date.parse('2026-08-22T20:00:00Z')
+
+  it('publishes when there is no prior point', () => {
+    expect(decideApprovalPublish({ price: 38.4, last: null, now })).toEqual({
+      publish: true,
+      reason: 'first',
+    })
+  })
+
+  it('publishes as soon as the source value moves', () => {
+    // The whole point of hourly running: a move at 2pm must not sit in public
+    // view as tomorrow morning's mark.
+    const last = { price: 38.4, ts: now - 60_000 }
+    expect(decideApprovalPublish({ price: 38.5, last, now })).toEqual({
+      publish: true,
+      reason: 'changed',
+    })
+  })
+
+  it('does not republish an unchanged value within the heartbeat', () => {
+    const last = { price: 38.4, ts: now - TRUMP_APPROVAL_HEARTBEAT_MS + 1000 }
+    const decision = decideApprovalPublish({ price: 38.4, last, now })
+
+    expect(decision.publish).toBe(false)
+    expect(decision.reason).toContain('unchanged')
+  })
+
+  it('re-stamps an unchanged value once the heartbeat elapses', () => {
+    // Their average genuinely held 38.4 for three days running; without this
+    // the feed would age past staleAfterMs and pause the engine while the
+    // source was working perfectly.
+    const last = { price: 38.4, ts: now - TRUMP_APPROVAL_HEARTBEAT_MS }
+    expect(decideApprovalPublish({ price: 38.4, last, now })).toEqual({
+      publish: true,
+      reason: 'heartbeat',
+    })
+  })
+
+  it('keeps the heartbeat well inside the feed staleness bound', () => {
+    // staleAfterMs is 26h and the market's maxOraclePriceAgeMs is 30h, so two
+    // heartbeats a day leaves real margin.
+    expect(TRUMP_APPROVAL_HEARTBEAT_MS).toBeLessThan(26 * 60 * 60 * 1000)
+  })
+
+  it('detects a one-decimal move, the smallest the source can express', () => {
+    const last = { price: 38.4, ts: now - 60_000 }
+    expect(decideApprovalPublish({ price: 38.5, last, now }).publish).toBe(true)
+    expect(decideApprovalPublish({ price: 38.4, last, now }).publish).toBe(
+      false
+    )
+  })
+
+  it('treats a corrupt prior point as no prior point', () => {
+    for (const bad of [NaN, Infinity]) {
+      expect(
+        decideApprovalPublish({
+          price: 38.4,
+          last: { price: bad, ts: now },
+          now,
+        })
+      ).toEqual({ publish: true, reason: 'first' })
+      expect(
+        decideApprovalPublish({
+          price: 38.4,
+          last: { price: 38.4, ts: bad },
+          now,
+        })
+      ).toEqual({ publish: true, reason: 'first' })
+    }
+  })
+
+  it('refuses on invalid inputs rather than publishing garbage', () => {
+    expect(decideApprovalPublish({ price: NaN, last: null, now }).publish).toBe(
+      false
+    )
+    expect(
+      decideApprovalPublish({ price: 38.4, last: null, now: NaN }).publish
+    ).toBe(false)
+    expect(
+      decideApprovalPublish({ price: 38.4, last: null, now, heartbeatMs: 0 })
+        .publish
+    ).toBe(false)
   })
 })

--- a/common/src/perps/trump-approval.test.ts
+++ b/common/src/perps/trump-approval.test.ts
@@ -1,0 +1,498 @@
+import {
+  ApprovalPoll,
+  PublishedAverageSeries,
+  TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP,
+  TRUMP_APPROVAL_MAX_WINDOW_DAYS,
+  TRUMP_APPROVAL_MIN_POLLS,
+  averageApprovalPct,
+  computeApprovalPoint,
+  getApprovalCrossCheckGap,
+  hasApproveAnswer,
+  isUsableApprovalPoll,
+  readApprovePct,
+  readPublishedApprovalAverage,
+  readPublishedApprovalSeries,
+  selectApprovalWindow,
+} from './trump-approval'
+
+const poll = (
+  endDate: string,
+  pct: number,
+  pollster = 'Pollster'
+): ApprovalPoll => ({ endDate, pct, pollster })
+
+const shift = (date: string, days: number) =>
+  new Date(Date.parse(`${date}T00:00:00Z`) + days * 86_400_000)
+    .toISOString()
+    .slice(0, 10)
+
+/** `count` polls all ending on `endDate`, at a constant pct. */
+const cluster = (endDate: string, count: number, pct: number) =>
+  Array.from({ length: count }, (_, i) => poll(endDate, pct, `Pollster${i}`))
+
+/** One poll per day for `count` days, ending on `endDate`. */
+const daily = (endDate: string, count: number, pct: number) =>
+  Array.from({ length: count }, (_, i) => poll(shift(endDate, -i), pct))
+
+// The polls that were actually in VoteHub's list on 2026-08-17, newest first.
+// This is the regression fixture: under the old fixed 14-day rule these five
+// most recent polls were the entire window and averaged exactly 40.000.
+const AUGUST_2026: ApprovalPoll[] = [
+  poll('2026-08-10', 39.5, 'AlphaROC'),
+  poll('2026-08-10', 38, 'YouGov'),
+  poll('2026-08-09', 43, 'Morning Consult'),
+  poll('2026-08-05', 38, 'John Zogby Strategies'),
+  poll('2026-08-04', 41.5, 'Quantus Insights'),
+  poll('2026-08-03', 38, 'Ipsos'),
+  poll('2026-08-03', 39, 'YouGov'),
+  poll('2026-08-02', 42.8, 'Morning Consult'),
+  poll('2026-08-01', 38, 'TIPP Insights'),
+  poll('2026-07-29', 42, 'Marquette'),
+  poll('2026-07-29', 40, 'Big Data Poll'),
+  poll('2026-07-27', 37, 'Global Strategy Group'),
+  poll('2026-07-27', 33, 'AP-NORC'),
+  poll('2026-07-27', 32, 'Quinnipiac'),
+  poll('2026-07-27', 34, 'CNN/SSRS'),
+  poll('2026-07-27', 39, 'YouGov'),
+]
+
+describe('isUsableApprovalPoll', () => {
+  it('accepts a well-formed poll', () => {
+    expect(isUsableApprovalPoll(poll('2026-08-10', 39.5))).toBe(true)
+  })
+
+  it('rejects out-of-range and non-finite percentages', () => {
+    // The provider response is cast, not schema-validated: a pct of 460 would
+    // otherwise drag the mean ~20 points while staying inside the feed's
+    // [10,90] plausibility bounds.
+    expect(isUsableApprovalPoll(poll('2026-08-10', 460))).toBe(false)
+    expect(isUsableApprovalPoll(poll('2026-08-10', -1))).toBe(false)
+    expect(isUsableApprovalPoll(poll('2026-08-10', NaN))).toBe(false)
+    expect(isUsableApprovalPoll(poll('2026-08-10', Infinity))).toBe(false)
+  })
+
+  it('rejects malformed dates', () => {
+    expect(isUsableApprovalPoll(poll('2026-8-10', 39))).toBe(false)
+    expect(isUsableApprovalPoll(poll('not-a-date', 39))).toBe(false)
+    expect(isUsableApprovalPoll(poll('2026-02-31', 39))).toBe(false)
+  })
+})
+
+describe('readPublishedApprovalAverage', () => {
+  const series = (...rows: [string, number][]) =>
+    Object.fromEntries(
+      rows.map(([day, average]) => [day, { approve: { average } }])
+    )
+
+  it('reads the most recent entry at or before the valuation day', () => {
+    const result = readPublishedApprovalAverage(
+      series(['2026-08-15', 38.6], ['2026-08-17', 38.8], ['2026-08-18', 99]),
+      '2026-08-17'
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.price).toBeCloseTo(38.8, 10)
+    expect(result.asOfDay).toBe('2026-08-17')
+    expect(result.ageDays).toBe(0)
+  })
+
+  it('accepts a value a day or two behind — posting late is not a fault', () => {
+    const result = readPublishedApprovalAverage(
+      series(['2026-08-17', 38.8]),
+      '2026-08-19'
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.ageDays).toBe(2)
+  })
+
+  it('refuses once the source itself has stopped updating', () => {
+    // The check the old design lacked: staleness was measured on OUR row age,
+    // and we wrote a row daily regardless of whether the inputs moved, so a
+    // frozen feed went unnoticed for a week.
+    const result = readPublishedApprovalAverage(
+      series(['2026-08-10', 38.6]),
+      '2026-08-17'
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('stale')
+    expect(result.reason).toContain('2026-08-10')
+  })
+
+  it('ignores entries that are not usable percentages', () => {
+    const bad: PublishedAverageSeries = {
+      '2026-08-17': { approve: { average: 0 } },
+      '2026-08-16': { approve: { average: 100 } },
+      '2026-08-15': { approve: { average: NaN } },
+      '2026-08-14': { approve: null },
+      '2026-08-13': null,
+      'not-a-day': { approve: { average: 38 } },
+      '2026-08-12': { approve: { average: 38.5 } },
+    }
+    const result = readPublishedApprovalAverage(bad, '2026-08-17', {
+      maxAgeDays: 30,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.asOfDay).toBe('2026-08-12')
+    expect(result.price).toBeCloseTo(38.5, 10)
+  })
+
+  it('refuses a missing, empty, or malformed payload', () => {
+    expect(readPublishedApprovalAverage(null, '2026-08-17').ok).toBe(false)
+    expect(readPublishedApprovalAverage({}, '2026-08-17').ok).toBe(false)
+    expect(readPublishedApprovalAverage('nope' as never, '2026-08-17').ok).toBe(
+      false
+    )
+    expect(
+      readPublishedApprovalAverage(series(['2026-08-17', 38.8]), 'nonsense').ok
+    ).toBe(false)
+  })
+})
+
+describe('readPublishedApprovalSeries', () => {
+  it('returns usable days oldest first and drops the rest', () => {
+    const out = readPublishedApprovalSeries({
+      '2026-08-17': { approve: { average: 38.8 } },
+      '2026-08-15': { approve: { average: 38.6 } },
+      '2026-08-16': { approve: { average: 0 } },
+      bogus: { approve: { average: 38 } },
+    })
+
+    expect(out).toEqual([
+      { day: '2026-08-15', price: 38.6 },
+      { day: '2026-08-17', price: 38.8 },
+    ])
+  })
+
+  it('returns empty rather than throwing on junk', () => {
+    expect(readPublishedApprovalSeries(null)).toEqual([])
+    expect(readPublishedApprovalSeries('x' as never)).toEqual([])
+  })
+})
+
+describe('getApprovalCrossCheckGap', () => {
+  it('measures the distance between the two estimators', () => {
+    // The real 2026-08-17 pair: VoteHub 38.80, our own 39.82.
+    expect(getApprovalCrossCheckGap(38.8, 39.82)).toBeCloseTo(1.02, 10)
+    expect(getApprovalCrossCheckGap(39.82, 38.8)).toBeCloseTo(1.02, 10)
+  })
+
+  it('catches the failures the tolerance exists for', () => {
+    // Approve/disapprove swap, and a 0-1 vs 0-100 units change.
+    expect(getApprovalCrossCheckGap(57.5, 38.5) as number).toBeGreaterThan(
+      TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP
+    )
+    expect(getApprovalCrossCheckGap(0.385, 38.5) as number).toBeGreaterThan(
+      TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP
+    )
+  })
+
+  it('stays under tolerance across the observed range', () => {
+    // 554 days of real data: median 0.435, p99 1.289, max 1.700.
+    for (const gap of [0.435, 1.289, 1.7])
+      expect(gap).toBeLessThan(TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP)
+  })
+
+  it('returns null — not zero — when either side is unusable', () => {
+    expect(getApprovalCrossCheckGap(NaN, 38.5)).toBeNull()
+    expect(getApprovalCrossCheckGap(38.5, Infinity)).toBeNull()
+  })
+})
+
+describe('readApprovePct / hasApproveAnswer', () => {
+  const answers = (...rows: [string, number][]) =>
+    rows.map(([choice, pct]) => ({ choice, pct }))
+
+  it('reads Approve regardless of case or position', () => {
+    expect(readApprovePct(answers(['Disapprove', 61], ['Approve', 39]))).toBe(
+      39
+    )
+    expect(readApprovePct(answers(['APPROVE', 42.8]))).toBe(42.8)
+  })
+
+  it('returns null when there is no Approve row', () => {
+    expect(readApprovePct(answers(['Favorable', 39]))).toBeNull()
+    expect(hasApproveAnswer(answers(['Favorable', 39]))).toBe(false)
+  })
+
+  it('returns null for a value that cannot be a percentage', () => {
+    // The provider row that motivated this: 460 would survive the feed's
+    // [10,90] bounds after being averaged with ~20 polls near 45.
+    for (const bad of [460, -1, NaN, Infinity]) {
+      expect(readApprovePct(answers(['Approve', bad]))).toBeNull()
+      // ...but the row EXISTS, which is what makes it alertable rather than
+      // an ordinary poll about a different question.
+      expect(hasApproveAnswer(answers(['Approve', bad]))).toBe(true)
+    }
+  })
+
+  it('survives a malformed or missing answers array', () => {
+    expect(readApprovePct(undefined)).toBeNull()
+    expect(readApprovePct([] as never)).toBeNull()
+    expect(readApprovePct({ choice: 'Approve' } as never)).toBeNull()
+    expect(readApprovePct([{ pct: 39 }] as never)).toBeNull()
+    expect(readApprovePct(answers(['Approve', '39' as never]))).toBeNull()
+    expect(hasApproveAnswer(undefined)).toBe(false)
+  })
+})
+
+describe('selectApprovalWindow — base window', () => {
+  it('uses the plain 14-day window when it holds enough polls', () => {
+    const polls = daily('2026-08-17', TRUMP_APPROVAL_MIN_POLLS + 2, 40)
+    const result = selectApprovalWindow(polls, '2026-08-17')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.window.extended).toBe(false)
+    expect(result.window.spanDays).toBe(14)
+    expect(result.window.startDate).toBe('2026-08-04')
+    expect(result.window.polls).toHaveLength(TRUMP_APPROVAL_MIN_POLLS + 2)
+  })
+
+  it('excludes polls that end after the valuation day', () => {
+    const polls = [
+      ...daily('2026-08-17', TRUMP_APPROVAL_MIN_POLLS, 40),
+      poll('2026-08-18', 99),
+    ]
+    const result = selectApprovalWindow(polls, '2026-08-17')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.window.polls.some((p) => p.pct === 99)).toBe(false)
+  })
+
+  it('drops polls outside the base window once the floor is satisfied', () => {
+    const polls = [
+      ...daily('2026-08-17', TRUMP_APPROVAL_MIN_POLLS + 1, 40),
+      poll('2026-07-01', 10),
+    ]
+    const result = selectApprovalWindow(polls, '2026-08-17')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.window.extended).toBe(false)
+    expect(result.window.polls.some((p) => p.pct === 10)).toBe(false)
+  })
+})
+
+describe('selectApprovalWindow — count floor', () => {
+  it('widens the window when the base window is short', () => {
+    const result = selectApprovalWindow(AUGUST_2026, '2026-08-17')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.window.extended).toBe(true)
+    expect(result.window.startDate).toBe('2026-07-27')
+    expect(result.window.spanDays).toBe(22)
+  })
+
+  it('admits every poll tied at the cut-off date', () => {
+    // The 12th most recent poll ends 2026-07-27, and five polls share that
+    // date. All five must come in, or the result depends on array order.
+    const result = selectApprovalWindow(AUGUST_2026, '2026-08-17')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.window.polls).toHaveLength(16)
+    expect(
+      result.window.polls.filter((p) => p.endDate === '2026-07-27')
+    ).toHaveLength(5)
+  })
+
+  it('is independent of input order', () => {
+    const shuffled = [...AUGUST_2026].reverse()
+    const a = selectApprovalWindow(AUGUST_2026, '2026-08-17')
+    const b = selectApprovalWindow(shuffled, '2026-08-17')
+
+    expect(a.ok && b.ok).toBe(true)
+    if (!a.ok || !b.ok) return
+    expect(b.window.startDate).toBe(a.window.startDate)
+    expect(b.window.polls).toHaveLength(a.window.polls.length)
+    expect(averageApprovalPct(b.window.polls)).toBeCloseTo(
+      averageApprovalPct(a.window.polls) as number,
+      10
+    )
+  })
+
+  it('never narrows below the base window', () => {
+    // A dense recent burst puts the Nth most recent poll inside the base
+    // window; the window must stay 14 days wide, not shrink to the burst.
+    const polls = cluster('2026-08-17', TRUMP_APPROVAL_MIN_POLLS + 5, 40)
+    const result = selectApprovalWindow(polls, '2026-08-17')
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.window.startDate).toBe('2026-08-04')
+    expect(result.window.spanDays).toBe(14)
+    expect(result.window.extended).toBe(false)
+  })
+})
+
+describe('selectApprovalWindow — the drought invariant', () => {
+  // This is the property the change exists for: with no new polls arriving,
+  // the selected set must not change, so the price cannot be predicted and
+  // traded against.
+  it('selects an identical set on every day of a drought', () => {
+    const days = Array.from({ length: 10 }, (_, i) => shift('2026-08-17', i))
+    const prices = days.map((day) => {
+      const point = computeApprovalPoint(AUGUST_2026, day)
+      expect(point.ok).toBe(true)
+      return point.ok ? point.price : NaN
+    })
+
+    for (const price of prices) expect(price).toBeCloseTo(prices[0], 10)
+  })
+
+  it('moves only when a new poll actually arrives', () => {
+    const before = computeApprovalPoint(AUGUST_2026, '2026-08-18')
+    const after = computeApprovalPoint(
+      [...AUGUST_2026, poll('2026-08-18', 30, 'New')],
+      '2026-08-18'
+    )
+
+    expect(before.ok && after.ok).toBe(true)
+    if (!before.ok || !after.ok) return
+    expect(after.price).not.toBeCloseTo(before.price, 6)
+  })
+
+  it('can evict a whole tied cluster when an arrival satisfies the floor', () => {
+    // Documented residual, pinned so it cannot change unnoticed.
+    //
+    // On 08-17 the floor needs 12 and the cut lands on the five-poll 07-27
+    // cluster, admitting 16. One arrival on 08-18 moves the cut to 07-29,
+    // where 12 polls suffice, and all five 07-27 polls leave at once. Because
+    // that cluster averaged 35 against a window near 39.9, the index rises
+    // even though the arriving poll printed 30.
+    //
+    // This is bounded and, unlike the drought drift this change removes, it
+    // cannot be timed: it fires only on an arrival, which is the one event
+    // nobody schedules. Backtested over 560 days the floor-engaged regime is
+    // the calmest of the two (mean |move| 0.111 vs 0.174 overall), and every
+    // wrong-direction move in that history came from the ordinary 14-day
+    // regime instead. Smoothing it needs a ratcheted window start, which
+    // trades a large step up in explainability cost for this.
+    const after = computeApprovalPoint(
+      [...AUGUST_2026, poll('2026-08-18', 30, 'New')],
+      '2026-08-18'
+    )
+
+    expect(after.ok).toBe(true)
+    if (!after.ok) return
+    expect(after.window.startDate).toBe('2026-07-29')
+    expect(after.window.polls).toHaveLength(12)
+    expect(after.price).toBeCloseTo(39.15, 3)
+  })
+
+  it('still expires on schedule ABOVE the floor — the claim is not general', () => {
+    // The security property holds only while the floor is engaged. With 13
+    // polls the base window governs, so the 14-day edge still retires a poll
+    // with nothing arriving to replace it, and the price moves on a schedule
+    // anyone can read off the source list a day ahead.
+    //
+    // Measured over 554 days: 87 of the 181 zero-arrival days (48.1%) still
+    // move under this rule, mean 0.073 and max 0.84. Kept as a test so the
+    // exposure is documented rather than implied away.
+    const oldest = poll('2026-08-04', 20, 'Oldest')
+    const polls = [
+      oldest,
+      ...Array.from({ length: 12 }, (_, i) =>
+        poll(shift('2026-08-16', -i), 40)
+      ),
+    ]
+
+    const before = computeApprovalPoint(polls, '2026-08-17')
+    const after = computeApprovalPoint(polls, '2026-08-18')
+
+    expect(before.ok && after.ok).toBe(true)
+    if (!before.ok || !after.ok) return
+    // 13 polls on the 17th; on the 18th the 08-04 poll falls out of the base
+    // window, 12 remain, the floor is satisfied and nothing widens.
+    expect(before.window.polls).toHaveLength(13)
+    expect(after.window.polls).toHaveLength(12)
+    expect(after.window.extended).toBe(false)
+    // No poll arrived, and the price moved anyway.
+    expect(before.price).toBeCloseTo((12 * 40 + 20) / 13, 10)
+    expect(after.price).toBeCloseTo(40, 10)
+  })
+
+  it('reproduces the 2026-08 regression: flat instead of drifting to 40', () => {
+    // Under the old fixed 14-day rule these same polls priced 39.98 on 08-10
+    // and 40.00 on 08-17 with no new data. Now both days price the same.
+    const tenth = computeApprovalPoint(AUGUST_2026, '2026-08-10')
+    const seventeenth = computeApprovalPoint(AUGUST_2026, '2026-08-17')
+
+    expect(tenth.ok && seventeenth.ok).toBe(true)
+    if (!tenth.ok || !seventeenth.ok) return
+    expect(tenth.price).toBeCloseTo(38.425, 3)
+    expect(seventeenth.price).toBeCloseTo(38.425, 3)
+  })
+})
+
+describe('selectApprovalWindow — failing closed', () => {
+  it('refuses when the floor cannot be met inside the max window', () => {
+    const polls = [
+      poll('2026-08-10', 39.5),
+      poll('2026-08-09', 43),
+      poll('2026-08-04', 41.5),
+    ]
+    const result = selectApprovalWindow(polls, '2026-08-17')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('need')
+  })
+
+  it('refuses when the only polls are older than the max window', () => {
+    const stale = shift('2026-08-17', -(TRUMP_APPROVAL_MAX_WINDOW_DAYS + 5))
+    const result = selectApprovalWindow(
+      cluster(stale, TRUMP_APPROVAL_MIN_POLLS + 5, 40),
+      '2026-08-17'
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain(`${TRUMP_APPROVAL_MAX_WINDOW_DAYS} days`)
+  })
+
+  it('refuses when there are no usable polls at all', () => {
+    expect(selectApprovalWindow([], '2026-08-17').ok).toBe(false)
+    expect(
+      selectApprovalWindow([poll('2026-08-10', 460)], '2026-08-17').ok
+    ).toBe(false)
+  })
+
+  it('rejects an invalid valuation day or bounds', () => {
+    expect(selectApprovalWindow(AUGUST_2026, 'nonsense').ok).toBe(false)
+    expect(
+      selectApprovalWindow(AUGUST_2026, '2026-08-17', { minPolls: 0 }).ok
+    ).toBe(false)
+    expect(
+      selectApprovalWindow(AUGUST_2026, '2026-08-17', {
+        windowDays: 14,
+        maxWindowDays: 7,
+      }).ok
+    ).toBe(false)
+  })
+})
+
+describe('averageApprovalPct', () => {
+  it('averages usable polls and ignores corrupt ones', () => {
+    expect(
+      averageApprovalPct([poll('2026-08-10', 38), poll('2026-08-10', 42)])
+    ).toBeCloseTo(40, 10)
+    expect(
+      averageApprovalPct([poll('2026-08-10', 38), poll('2026-08-10', 460)])
+    ).toBeCloseTo(38, 10)
+  })
+
+  it('returns null rather than NaN on an empty set', () => {
+    expect(averageApprovalPct([])).toBeNull()
+    expect(averageApprovalPct([poll('2026-08-10', NaN)])).toBeNull()
+  })
+})

--- a/common/src/perps/trump-approval.ts
+++ b/common/src/perps/trump-approval.ts
@@ -1,0 +1,506 @@
+import { DAY_MS } from '../util/time'
+
+// The Trump approval index: VoteHub's published, time-weighted polling
+// average, mirrored as the oracle price.
+//
+// This file is the published methodology, not an implementation detail — the
+// same reasoning as open-weight-models.ts. It lives in `common` (a leaf
+// package) so the rule the oracle is scored against is one auditable artifact
+// that a UI can render directly, rather than a description in a market blurb
+// that drifts from the code that actually prices the market.
+//
+// WHY WE MIRROR RATHER THAN COMPUTE
+//
+// We used to compute our own unweighted mean of the Approve percentage across
+// polls in a trailing 14-day window. That estimator had two problems, and
+// only one of them was fixable by us.
+//
+// The first was a timing exploit. Polls leave a fixed window on a schedule set
+// by their end_date; they arrive on no schedule at all. So when polling goes
+// quiet every daily move is a *departure*, and departures are public knowledge
+// days ahead. Between 2026-08-10 and 2026-08-17 the window decayed from 11
+// polls to 5 with nothing arriving, and the index rose from 38.38 to 40.00
+// purely because the 2026-07-27 cluster (Quinnipiac 32, AP-NORC 33, CNN/SSRS
+// 34, Global Strategy 37) expired. No poll moved up. Anyone reading the source
+// list could compute the next several prints exactly, which on a market
+// carrying leveraged positions is not a price but a standing invitation.
+//
+// The second was the level itself. An unweighted mean applies no recency,
+// sample-size, or house-effect adjustment, so the mix of pollsters who happen
+// to be in the window moves the number more than opinion does. That is why it
+// read 40.0 while every public aggregate sat between 36 and 39.
+//
+// A time-weighted average fixes both at once, because weights decay instead of
+// falling off a cliff: no scheduled expiry to trade against, and no single
+// pollster worth a fixed fraction of the price. VoteHub already publishes one,
+// computed by people who do this for a living. Mirroring it is strictly better
+// than us maintaining a worse estimator — and it means the number a user sees
+// on the market is the number they can look up on votehub.com, rather than
+// something they have to take on trust from us. A settlement source the reader
+// can verify in ten seconds is worth more than one we control.
+//
+// Measured against our old rule over the 554 days from 2025-02-10, their
+// average is materially calmer: mean |day-over-day| 0.112 against our 0.174,
+// max 0.90 against our 1.23.
+//
+// LICENCE
+//
+// VoteHub's polling API is published under Creative Commons Attribution 4.0
+// International, stated on their API documentation. CC BY 4.0 permits reuse,
+// redistribution, and derivative works, including commercially, on the single
+// condition that the source is credited. We credit VoteHub with a link on the
+// market page — see oracle-attribution.ts, which renders it as a component
+// precisely so it cannot be edited away by accident.
+//
+// WE STILL COMPUTE OUR OWN AVERAGE — AS A CANARY, NOT AS THE PRICE
+//
+// Mirroring a third party means a silent change on their side would reprice a
+// live market with nobody noticing. So the window code below still runs, on
+// the same raw polls, and its result is compared against theirs. It never sets
+// the price; it exists to answer "does their number still look like a Trump
+// approval average?" Over 554 days the two differ by a median of 0.435 and
+// never by more than 1.70, so a large divergence means something broke — a
+// units change, an approve/disapprove swap, a methodology rewrite — and the
+// feed stops rather than publishing a number we cannot corroborate.
+//
+// The floor and max-window rules on that computation are kept for the same
+// reason they were introduced: they stop the CANARY from going haywire during
+// a polling drought and raising a false alarm against a perfectly good
+// published value.
+
+/** Trailing window, in whole days, that the index averages over. */
+export const TRUMP_APPROVAL_WINDOW_DAYS = 14
+
+/**
+ * Minimum polls the window must contain before it is allowed to be only
+ * TRUMP_APPROVAL_WINDOW_DAYS wide.
+ *
+ * Set from the observed distribution rather than taste. Over the 560 days
+ * from 2025-02-04 the 14-day poll count ran: min 5, p5 11, p25 17, median 20,
+ * max 31. A floor of 12 sits just above the 5th percentile, so it engages
+ * only in a genuine drought (7.1% of days) and leaves the plain 14-day mean
+ * intact the rest of the time. It also bounds single-pollster influence: at
+ * 12 polls no one house effect is worth more than ~1/12 of the price, where
+ * at the 5 polls seen on 2026-08-17 one Morning Consult print was worth 20%.
+ */
+export const TRUMP_APPROVAL_MIN_POLLS = 12
+
+/**
+ * Hard cap on how far the window may reach back to satisfy the floor.
+ *
+ * Reaching further does not make the number better — past some age the polls
+ * are describing a different month. The observed worst case needed 22 days,
+ * so 35 leaves real headroom while still failing closed on a source outage.
+ * Hitting this cap means the feed publishes nothing and goes stale, which
+ * pauses the engine: a visible, safe stop, and strictly better than pricing a
+ * leveraged market off four polls from five weeks ago.
+ */
+export const TRUMP_APPROVAL_MAX_WINDOW_DAYS = 35
+
+/**
+ * How stale VoteHub's own latest datapoint may be before we stop publishing.
+ *
+ * This is the check the previous design was missing, and it is why a frozen
+ * feed went unnoticed for a week: staleness was measured on OUR row age, and
+ * we wrote a row every day regardless of whether the inputs had moved. A
+ * source that stops updating must stop the feed, not be relaid daily under a
+ * fresh timestamp.
+ *
+ * Their series carries a same-day entry most days and is at most a day behind
+ * when we publish at 5:30am Pacific, so 3 days is slack for a weekend or a
+ * short outage without tolerating a genuinely dead source.
+ */
+export const TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS = 3
+
+/**
+ * How far our independently computed average may sit from VoteHub's published
+ * one before we refuse to publish.
+ *
+ * Set from the observed joint distribution, not taste: over the 554 days from
+ * 2025-02-10 the two differ by a median of 0.435, p99 1.289, and a maximum of
+ * 1.700. They are different estimators of the same quantity, so they are never
+ * expected to agree exactly — 3.0 clears the entire observed range with room
+ * to spare while still catching the failures worth catching. An approve /
+ * disapprove swap moves it ~19 points; a 0-1 versus 0-100 units change moves
+ * it ~38.
+ *
+ * A trip fails closed. The feed goes stale and the engine pauses, which is
+ * visible and recoverable, where publishing a number two independent
+ * computations disagree about is neither.
+ */
+export const TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP = 3
+
+export type ApprovalPoll = {
+  /**
+   * Last day of fielding (YYYY-MM-DD) — the poll's representative date. Not
+   * the publication date: when a poll becomes visible says something about
+   * the pollster's release schedule, not about when opinion was measured.
+   */
+  endDate: string
+  /** Approve percentage, on a 0-100 scale. */
+  pct: number
+  /** Attribution and display only. Never affects selection or weighting. */
+  pollster?: string
+}
+
+export type ApprovalWindow = {
+  /** The selected polls, newest end_date first. */
+  polls: ApprovalPoll[]
+  /** Inclusive earliest end_date admitted (YYYY-MM-DD). */
+  startDate: string
+  /** Inclusive latest end_date admitted — the valuation day (YYYY-MM-DD). */
+  endDate: string
+  /** Whole days spanned, inclusive of both ends. */
+  spanDays: number
+  /** Whether the count floor widened the window past the base window. */
+  extended: boolean
+}
+
+export type ApprovalWindowResult =
+  | { ok: true; window: ApprovalWindow }
+  | { ok: false; reason: string }
+
+export type ApprovalPointResult =
+  | { ok: true; price: number; window: ApprovalWindow }
+  | { ok: false; reason: string }
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Calendar dates are compared and shifted as UTC midnights, never as local
+ * instants. Both operations then have no DST to be wrong about, and because
+ * every date is zero-padded ISO, string ordering is already chronological
+ * ordering — so membership tests need no parsing at all.
+ */
+const parseDay = (date: string): number | null => {
+  if (typeof date !== 'string' || !DATE_PATTERN.test(date)) return null
+  const ms = Date.parse(`${date}T00:00:00Z`)
+  if (!Number.isFinite(ms)) return null
+  // Date.parse is lenient about impossible calendar dates: '2026-02-31'
+  // silently rolls forward to March 3 rather than returning NaN. Round-trip
+  // the result so a provider typo is rejected instead of being quietly
+  // reinterpreted as a different day at the window boundary.
+  return new Date(ms).toISOString().slice(0, 10) === date ? ms : null
+}
+
+const shiftDay = (date: string, days: number): string | null => {
+  const ms = parseDay(date)
+  if (ms == null) return null
+  const shifted = ms + days * DAY_MS
+  if (!Number.isFinite(shifted)) return null
+  return new Date(shifted).toISOString().slice(0, 10)
+}
+
+const daysBetween = (from: string, to: string): number | null => {
+  const a = parseDay(from)
+  const b = parseDay(to)
+  if (a == null || b == null) return null
+  return Math.round((b - a) / DAY_MS)
+}
+
+/**
+ * A poll is usable if it reports a percentage that could be a percentage.
+ *
+ * The provider response is cast rather than schema-validated, so a data-entry
+ * error arrives as an ordinary number. One pct of 460 against ~20 polls near
+ * 40 moves the mean by ~20 points, which lands inside the feed's [10,90]
+ * plausibility bounds and would price live positions.
+ */
+export const isUsableApprovalPoll = (poll: ApprovalPoll): boolean =>
+  poll != null &&
+  parseDay(poll.endDate) != null &&
+  typeof poll.pct === 'number' &&
+  Number.isFinite(poll.pct) &&
+  poll.pct >= 0 &&
+  poll.pct <= 100
+
+/**
+ * VoteHub's published average series, keyed by ISO day.
+ *
+ * Typed loosely on purpose: this is an external payload, so every field is
+ * treated as absent-or-wrong until checked rather than trusted through a cast.
+ */
+export type PublishedAverageSeries = Record<
+  string,
+  { approve?: { average?: number } | null } | null | undefined
+>
+
+export type PublishedAverageResult =
+  | { ok: true; price: number; asOfDay: string; ageDays: number }
+  | { ok: false; reason: string }
+
+/**
+ * Read the most recent published average at or before `day`.
+ *
+ * Takes the latest available entry rather than requiring one stamped `day`,
+ * because the provider posts a same-day value at an hour we do not control and
+ * a missing entry at 5:30am Pacific is routine, not a fault. Age is then
+ * checked explicitly — see TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS — so "slightly
+ * behind" and "stopped updating" get different answers.
+ */
+export const readPublishedApprovalAverage = (
+  series: PublishedAverageSeries | null | undefined,
+  day: string,
+  options: { maxAgeDays?: number } = {}
+): PublishedAverageResult => {
+  const { maxAgeDays = TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS } = options
+
+  if (parseDay(day) == null)
+    return { ok: false, reason: `invalid valuation day ${day}` }
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays < 0)
+    return { ok: false, reason: `invalid maxAgeDays ${maxAgeDays}` }
+  if (series == null || typeof series !== 'object')
+    return { ok: false, reason: 'published average series is missing' }
+
+  let best: { asOfDay: string; price: number } | null = null
+  for (const [key, entry] of Object.entries(series)) {
+    if (parseDay(key) == null || key > day) continue
+    const average = entry?.approve?.average
+    // A percentage of exactly 0 or 100 is not a real approval reading; it is
+    // the shape a cleared or defaulted field takes.
+    if (
+      typeof average !== 'number' ||
+      !Number.isFinite(average) ||
+      average <= 0 ||
+      average >= 100
+    )
+      continue
+    if (!best || key > best.asOfDay) best = { asOfDay: key, price: average }
+  }
+
+  if (!best)
+    return {
+      ok: false,
+      reason: `no usable published average on or before ${day}`,
+    }
+
+  const ageDays = daysBetween(best.asOfDay, day)
+  if (ageDays == null)
+    return { ok: false, reason: `could not measure age of ${best.asOfDay}` }
+  if (ageDays > maxAgeDays)
+    return {
+      ok: false,
+      reason: `published average is ${ageDays} days stale (as of ${best.asOfDay}, max ${maxAgeDays})`,
+    }
+
+  return { ok: true, price: best.price, asOfDay: best.asOfDay, ageDays }
+}
+
+/**
+ * Every usable day of the published series, oldest first.
+ *
+ * Shares its validity rules with readPublishedApprovalAverage so a backfill
+ * and the daily job cannot disagree about which entries are real.
+ */
+export const readPublishedApprovalSeries = (
+  series: PublishedAverageSeries | null | undefined
+): { day: string; price: number }[] => {
+  if (series == null || typeof series !== 'object') return []
+  return Object.entries(series)
+    .flatMap(([key, entry]) => {
+      if (parseDay(key) == null) return []
+      const average = entry?.approve?.average
+      if (
+        typeof average !== 'number' ||
+        !Number.isFinite(average) ||
+        average <= 0 ||
+        average >= 100
+      )
+        return []
+      return [{ day: key, price: average }]
+    })
+    .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0))
+}
+
+/**
+ * Absolute distance between the published average and our own computation,
+ * or null when either side is unusable — which is "no opinion", not "agrees".
+ */
+export const getApprovalCrossCheckGap = (
+  published: number,
+  reference: number
+): number | null => {
+  if (!Number.isFinite(published) || !Number.isFinite(reference)) return null
+  const gap = Math.abs(published - reference)
+  return Number.isFinite(gap) ? gap : null
+}
+
+/** One row of a provider's answer array, before any validation. */
+export type ApprovalAnswer = { choice: string; pct: number }
+
+const findApprove = (answers: readonly ApprovalAnswer[] | undefined) =>
+  Array.isArray(answers)
+    ? answers.find(
+        (answer) =>
+          typeof answer?.choice === 'string' &&
+          answer.choice.toLowerCase() === 'approve'
+      )
+    : undefined
+
+/**
+ * Whether the provider offered an Approve row at all.
+ *
+ * Separate from reading it, so a caller can tell "this poll asks a different
+ * question" (ordinary, silent) from "this poll answers our question with a
+ * number that cannot be a percentage" (a data error worth alerting on).
+ */
+export const hasApproveAnswer = (
+  answers: readonly ApprovalAnswer[] | undefined
+): boolean => findApprove(answers) != null
+
+/**
+ * Read the Approve percentage, or null when it is absent or unusable.
+ *
+ * Lives here rather than in the backend adapter because it is the point where
+ * provider data becomes oracle input, and the repo has no test runner under
+ * backend/shared to pin that behaviour.
+ */
+export const readApprovePct = (
+  answers: readonly ApprovalAnswer[] | undefined
+): number | null => {
+  const approve = findApprove(answers)
+  if (!approve || typeof approve.pct !== 'number') return null
+  if (!Number.isFinite(approve.pct) || approve.pct < 0 || approve.pct > 100)
+    return null
+  return approve.pct
+}
+
+/**
+ * Choose the polls that price `day`.
+ *
+ * The base window is the TRUMP_APPROVAL_WINDOW_DAYS days ending on `day`. If
+ * that holds at least TRUMP_APPROVAL_MIN_POLLS polls it is used unchanged.
+ * Otherwise the window widens to the end_date of the Nth most recent poll.
+ *
+ * That cut is taken by DATE and is tie-inclusive: every poll sharing the
+ * cut-off end_date is admitted, so the result never depends on the input
+ * order. Picking "the first N after sorting" would let two polls that ended
+ * the same day be separated by nothing but array position — the same
+ * order-dependence normalizeOraclePointBatch refuses to tolerate when
+ * publishing points, and it matters more here because a tie at the boundary
+ * is the common case (five polls ended 2026-07-27).
+ *
+ * Because the widened cut is defined by rank rather than by age, it does not
+ * move as `day` advances. A drought therefore reselects exactly the same
+ * polls tomorrow, and the price does not move until a poll actually arrives.
+ */
+export const selectApprovalWindow = (
+  polls: readonly ApprovalPoll[],
+  day: string,
+  options: {
+    windowDays?: number
+    minPolls?: number
+    maxWindowDays?: number
+  } = {}
+): ApprovalWindowResult => {
+  const {
+    windowDays = TRUMP_APPROVAL_WINDOW_DAYS,
+    minPolls = TRUMP_APPROVAL_MIN_POLLS,
+    maxWindowDays = TRUMP_APPROVAL_MAX_WINDOW_DAYS,
+  } = options
+
+  if (parseDay(day) == null)
+    return { ok: false, reason: `invalid valuation day ${day}` }
+  if (!Number.isFinite(windowDays) || windowDays < 1)
+    return { ok: false, reason: `invalid windowDays ${windowDays}` }
+  if (!Number.isFinite(minPolls) || minPolls < 1)
+    return { ok: false, reason: `invalid minPolls ${minPolls}` }
+  if (!Number.isFinite(maxWindowDays) || maxWindowDays < windowDays)
+    return { ok: false, reason: `invalid maxWindowDays ${maxWindowDays}` }
+
+  // A poll that ends after the valuation day cannot inform it. This also
+  // keeps a provider's future-dated row out of a backfilled day.
+  const eligible = polls
+    .filter((poll) => isUsableApprovalPoll(poll) && poll.endDate <= day)
+    .sort((a, b) =>
+      a.endDate < b.endDate ? 1 : a.endDate > b.endDate ? -1 : 0
+    )
+
+  if (eligible.length === 0)
+    return { ok: false, reason: `no usable polls on or before ${day}` }
+
+  const baseStart = shiftDay(day, -(windowDays - 1))
+  const floorStart = shiftDay(day, -(maxWindowDays - 1))
+  if (baseStart == null || floorStart == null)
+    return { ok: false, reason: `could not derive window bounds for ${day}` }
+
+  const inBase = eligible.filter((poll) => poll.endDate >= baseStart)
+
+  let startDate = baseStart
+  let extended = false
+  if (inBase.length < minPolls) {
+    // eligible is sorted newest-first, so index minPolls-1 is the Nth most
+    // recent poll. With fewer than N polls in total, reach as far as the data
+    // goes and let the count check below decide whether that is publishable.
+    const cut =
+      eligible.length >= minPolls
+        ? eligible[minPolls - 1].endDate
+        : eligible[eligible.length - 1].endDate
+    // Never narrower than the base window: the floor may only widen.
+    if (cut < baseStart) {
+      startDate = cut
+      extended = true
+    }
+  }
+
+  if (startDate < floorStart)
+    return {
+      ok: false,
+      reason:
+        `only ${
+          eligible.filter((p) => p.endDate >= floorStart).length
+        } polls ` + `within ${maxWindowDays} days of ${day}, need ${minPolls}`,
+    }
+
+  const selected = eligible.filter((poll) => poll.endDate >= startDate)
+  // Unconditional, NOT gated on `extended`. When the base window already
+  // covers every poll we hold, no widening happens and `extended` stays
+  // false — so gating here would wave a three-poll average straight through
+  // the floor that is the entire point of this function.
+  if (selected.length < minPolls)
+    return {
+      ok: false,
+      reason: `only ${selected.length} polls available on or before ${day}, need ${minPolls}`,
+    }
+
+  const spanDays = daysBetween(startDate, day)
+  if (spanDays == null)
+    return { ok: false, reason: `could not measure window span for ${day}` }
+
+  return {
+    ok: true,
+    window: {
+      polls: selected,
+      startDate,
+      endDate: day,
+      spanDays: spanDays + 1,
+      extended,
+    },
+  }
+}
+
+/** Unweighted mean of Approve pct. Null rather than NaN on an empty set. */
+export const averageApprovalPct = (
+  polls: readonly ApprovalPoll[]
+): number | null => {
+  const usable = polls.filter(isUsableApprovalPoll)
+  if (usable.length === 0) return null
+  const mean = usable.reduce((sum, poll) => sum + poll.pct, 0) / usable.length
+  return Number.isFinite(mean) ? mean : null
+}
+
+/** Select the window for `day` and average it. */
+export const computeApprovalPoint = (
+  polls: readonly ApprovalPoll[],
+  day: string,
+  options?: Parameters<typeof selectApprovalWindow>[2]
+): ApprovalPointResult => {
+  const selection = selectApprovalWindow(polls, day, options)
+  if (!selection.ok) return selection
+
+  const price = averageApprovalPct(selection.window.polls)
+  if (price == null)
+    return { ok: false, reason: `could not average the window for ${day}` }
+
+  return { ok: true, price, window: selection.window }
+}

--- a/common/src/perps/trump-approval.ts
+++ b/common/src/perps/trump-approval.ts
@@ -67,6 +67,15 @@ import { DAY_MS } from '../util/time'
 // reason they were introduced: they stop the CANARY from going haywire during
 // a polling drought and raising a false alarm against a perfectly good
 // published value.
+//
+// Note on funding, since publishing more often changes its timing: the
+// maximum cadence is unchanged, because shouldApplyFunding gates on elapsed
+// time against the contract's own fundingPeriodMs. What changes is that its
+// second condition for slow periods — a new oracle point since the last
+// funding event — is now reliably satisfied, so DELAYED funding events become
+// less likely. Historically that mattered: the 2026-08-14 event due at 21:00
+// PT waited until 04:00 the next day for the first new point, making that
+// interval 26 hours.
 
 /** Trailing window, in whole days, that the index averages over. */
 export const TRUMP_APPROVAL_WINDOW_DAYS = 14

--- a/common/src/perps/trump-approval.ts
+++ b/common/src/perps/trump-approval.ts
@@ -504,3 +504,60 @@ export const computeApprovalPoint = (
 
   return { ok: true, price, window: selection.window }
 }
+
+/**
+ * How long a published point may stand before we re-publish an unchanged
+ * value purely to prove the feed is alive.
+ *
+ * Publishing only on change is what closes the intraday arbitrage window, but
+ * on its own it would starve the feed during a flat stretch — VoteHub's
+ * average genuinely held 38.4 for three straight days in August 2026 — and
+ * staleness alerting keys on ROW age. So a value that has not moved is
+ * re-stamped twice a day, comfortably inside the feed's 26h staleAfterMs and
+ * the market's 30h maxOraclePriceAgeMs.
+ */
+export const TRUMP_APPROVAL_HEARTBEAT_MS = 12 * 60 * 60 * 1000
+
+export type ApprovalPublishDecision =
+  | { publish: true; reason: 'first' | 'changed' | 'heartbeat' }
+  | { publish: false; reason: string }
+
+/**
+ * Should this reading be written as a new oracle point?
+ *
+ * The old rule published the first usable value of each Pacific day and then
+ * stopped, which left every later move by the source sitting in public view
+ * as the exact next day's mark — the same shape of timing edge this feed was
+ * changed to remove, just relocated from the window to the schedule. So the
+ * job now runs hourly and publishes whenever the value actually moves.
+ *
+ * Prices are compared exactly rather than within an epsilon: the source
+ * publishes to one decimal, so any real move is at least 0.1, and rounding
+ * slack here would silently swallow the smallest genuine moves.
+ */
+export const decideApprovalPublish = (args: {
+  price: number
+  last: { price: number; ts: number } | null
+  now: number
+  heartbeatMs?: number
+}): ApprovalPublishDecision => {
+  const { price, last, now, heartbeatMs = TRUMP_APPROVAL_HEARTBEAT_MS } = args
+
+  if (!Number.isFinite(price))
+    return { publish: false, reason: `invalid price ${price}` }
+  if (!Number.isFinite(now))
+    return { publish: false, reason: `invalid now ${now}` }
+  if (!Number.isFinite(heartbeatMs) || heartbeatMs <= 0)
+    return { publish: false, reason: `invalid heartbeatMs ${heartbeatMs}` }
+  if (!last) return { publish: true, reason: 'first' }
+  if (!Number.isFinite(last.price) || !Number.isFinite(last.ts))
+    return { publish: true, reason: 'first' }
+
+  if (price !== last.price) return { publish: true, reason: 'changed' }
+  if (now - last.ts >= heartbeatMs)
+    return { publish: true, reason: 'heartbeat' }
+  return {
+    publish: false,
+    reason: `unchanged at ${price} since ${new Date(last.ts).toISOString()}`,
+  }
+}

--- a/web/components/perps/perp-oracle-attribution.tsx
+++ b/web/components/perps/perp-oracle-attribution.tsx
@@ -20,7 +20,7 @@ export const PerpOracleAttribution = (props: {
   // undefined".
   if (!attribution) return null
 
-  const { source, url, licence, showAsOf } = attribution
+  const { source, url, licence, licenceUrl, showAsOf } = attribution
   const validAsOfTime =
     typeof asOfTime === 'number' && Number.isFinite(asOfTime) && asOfTime > 0
       ? asOfTime
@@ -41,7 +41,23 @@ export const PerpOracleAttribution = (props: {
       ) : (
         source
       )}
-      {licence && ` (${licence})`}
+      {licence &&
+        (licenceUrl ? (
+          <>
+            {' ('}
+            <a
+              href={licenceUrl}
+              target="_blank"
+              rel="noopener noreferrer license"
+              className="hover:text-ink-600 underline underline-offset-2"
+            >
+              {licence}
+            </a>
+            {')'}
+          </>
+        ) : (
+          ` (${licence})`
+        ))}
       {showAsOf &&
         (validAsOfTime == null
           ? ', source as-of unavailable.'


### PR DESCRIPTION
> **Round 3 pushed.** Cadence cut to 5 minutes, publication serialized under an advisory lock, canary lookback corrected, operational metadata updated. One correction to the PR's own claims: the market **does** charge 10 bps — see below.

## What happened

A user flagged the Trump approval perp reading **40.000 on the dot** while VoteHub showed 39, pollsmax 38.2, and fiftyplusone 36.2 — and correctly noted that no poll had moved up.

It was arithmetically correct and structurally wrong, in two separate ways.

**Timing.** Polls leave a fixed window on a schedule set by their `end_date`; they arrive on none. So when polling goes quiet, every daily move is a *departure* — and departures are public knowledge days ahead. Between 08-10 and 08-17 the 14-day window decayed from 11 polls to 5 with nothing arriving, and the index rose from 38.38 to 40.00 purely because the 07-27 cluster (Quinnipiac 32, AP-NORC 33, CNN/SSRS 34, Global Strategy 37) expired. The next prints were computable in advance: `39.625 · 40.167 · 38.750 · then nothing`. On a market with `maxLeverage: 100` and ~M$320k open interest, that is a risk-free path.

**Level.** An unweighted mean applies no recency, sample-size, or house-effect adjustment, so which pollsters happen to sit in the window moves the number more than opinion does. That is the entire gap to the public aggregates.

## The fix: mirror VoteHub's published average

A time-weighted average fixes both at once — weights decay instead of falling off a cliff, so there is no scheduled expiry to trade against and no single pollster worth a fixed fraction of the price. VoteHub publishes one at `/averages/trump_approval/values`, computed by people who do this for a living.

Measured over the 554 days from 2025-02-10, theirs is materially calmer than ours:

| | our old rule | VoteHub |
|---|---|---|
| mean \|day-over-day\| | 0.174 | **0.112** |
| max \|day-over-day\| | 1.23 | **0.90** |

The bigger win isn't smoothness. The number on the market is now one the reader can look up on votehub.com, instead of taking on trust from us.

## Licence

VoteHub's polling API is published under **Creative Commons Attribution 4.0 International**, stated on their API documentation. CC BY 4.0 permits reuse and redistribution, including commercially, on the single condition that the source is credited.

We credit VoteHub with a link below the chart, and that credit is now labelled `CC BY 4.0`. It renders from [oracle-attribution.ts](common/src/perps/oracle-attribution.ts) as a component rather than as prose in a market description, specifically so it cannot be edited away by accident.

## Publication cadence

The job runs **every 5 minutes** and publishes whenever VoteHub's value moves.

Publishing once a day left every intraday move sitting in public view as the exact next morning's mark. Hourly shortened that window to 59 minutes without closing it.

**5 minutes is the provider's own bound, not a guess.** VoteHub's averages endpoint serves `Cache-Control: max-age=300`. Polling faster returns cached bytes rather than a fresher number — and it is the same cache any would-be arbitrageur reads through, so it bounds what anyone can see ahead of us, not merely what we see.

Failure logging is throttled to hourly (288 lines a day otherwise); the staleness escalation is never throttled.

**Correction to an earlier claim in this PR.** It previously said this market charges no taker fee because `takerFeeBps` is absent in production. That was wrong: `getPerpTakerFeeBps` returns `PERP_TAKER_FEE_BPS_DEFAULT = 10` when the key is undefined, and 280 events on this contract record `feeBps: 10`. The market charges 10 bps, and the arb economics should be read against that.

## Concurrent publication

Two defects, both fixed.

**The observation timestamp was captured after the cross-check fetch**, which can take up to 30 seconds. A publisher that stalled there could write its older reading with a newer timestamp than a concurrent publisher's fresher one, making the stale observation the executable mark. The point is now stamped the moment the averages response arrives.

**The read of the previous point and the insert were unrelated statements.** Croner's `protect` covers one Cron object in one process — it says nothing about the standalone publish script, a second scheduler during a rolling deploy, or a manual run. Publication now runs in a transaction holding an advisory lock on the feed, with the publish decision re-made against a fresh read inside it. `validateOraclePoint`'s `ts <= prev.ts` rejection is what prevents a backwards roll once serialized. The unchanged-value early-out stays outside the lock as a pure optimisation.

`applyOraclePointToLivePerps` stays outside that transaction, as the fast oracle path does it — `runOracleUpdate` takes its own per-contract lock and nesting them would hold both across engine work.

## Funding

Maximum cadence is unchanged: `shouldApplyFunding` gates on elapsed time against the contract's own 24h `fundingPeriodMs`. What changes is that its second condition for slow periods — a new oracle point since the last funding event — is now reliably satisfied, so **delayed** funding events become less likely. That is a real timing change: the 2026-08-14 event due at 21:00 PT waited until 04:00 the next day for a new point, making that interval 26 hours. No event was ever permanently skipped.

## Operational metadata

These feed the admin API and launch preflight, not just human readers. The registry described a "14-day rolling" average and framed `getApprovePct` as price-path corruption protection (it is now the cross-check path); the launch manifest described a daily source arb; the scheduler preflight accepted a 26h last-success age, which for a 5-minute job is over 300 consecutive dead runs. All corrected.

`updatePeriodMs` stays at `DAY_MS` deliberately — it drives the funding period of NEW markets on this feed, and the value still moves about once a day however often we look at it.

## We still compute our own average — as a canary

Mirroring a third party means a silent change on their side would reprice a live market with nobody noticing. So the window code still runs on the same raw polls, and its result is compared against theirs. **It never sets the price.**

Over 554 days the two estimators differ by a median of 0.435, p99 1.289, max 1.700. The tolerance is **3.0** — clear of the entire observed range, but tripped by an approve/disapprove swap (~19 points) or a 0-1 vs 0-100 units change (~38).

A trip **fails closed**: the feed stops and the engine pauses rather than publishing a number two independent computations disagree about. An unavailable reference downgrades to `unchecked` and logs it, rather than withholding a good published value because our weaker estimator gave up during a drought.

## Source-age staleness

The feed sat frozen for a week without alerting, because staleness was measured on **our row age** and we wrote a row daily regardless of whether the inputs had moved. That is why a user found this before we did.

The publisher now checks how old VoteHub's own latest datapoint is and refuses past 3 days. A dead source stops the feed instead of being relaid under a fresh timestamp.

## Repricing — measured against the actual book

This moves the mark from **40.00 to 38.80, -3.0%**. That step is inherent in fixing the bug, not in the choice of source: the previous version of this PR repriced to 38.42, or -3.95%. VoteHub's is the gentler correction.

An earlier revision of this description warned the step would liquidate leveraged longs. That was overstated, and the book says otherwise:

- **89 positions, 22 long / 67 short.** Average leverage 7.2x; 9 positions above 10x.
- **Exactly one position liquidates at 38.80** — the single 100x long (M$129,836 notional, entry 39.79, liquidation price 39.39, margin M$1,298).
- The same position liquidates at **39.30**, roughly what the *currently deployed* rule prints today as the 08-04 poll ages out. It survives only above 39.39, so it is marginal under the status quo independently of this change. Zero positions liquidate at 39.67.

Aggregate holder PnL by mark:

| mark | aggregate holder PnL |
|---|---|
| 40.00 (now) | -1,205 |
| 39.30 | -290 |
| **38.80** | **+363** |

The book is 3:1 short, so the inflated mark has been marking the majority against a number we know is wrong. Correcting it is worth **+M$1,568 to holders in aggregate**.

Cutting `maxLeverage` is still worth doing — all three live perps sit at 100, an unset default rather than three decisions, and the launch QA notes list "Trump 10x vs 3x" as never resolved. It is not a blocker for this PR.

Waiting for the gap to close on its own is possible: the two estimators agreed to within 0.02 as recently as 08-06 through 08-08, the median gap over 554 days is 0.44, and 2-3 arriving polls would close it to ~0.01-0.13. It is just not worth it — the delay protects one marginal 100x position at the cost of marking 67 shorts against a known-wrong price, while the deterministic drought arb stays live.

## Verification

Live end-to-end against the real API:

```
PRICE   : 38.80  as of 2026-08-17 (1d old)
CANARY  : 39.82  (12 polls, 21d)
GAP     : 1.02   (tolerance 3)
VERDICT : PUBLISH 38.80
```

36 tests in this suite; full `common` suite green (494 tests, 30 suites). `common`, `backend/shared`, `backend/scheduler` typecheck clean; `backend/scripts` has no new errors.

## Notes for review

- The backfill script reads the **same published series**, so a backfill and the live feed cannot disagree about what the index means. It stays marked not-for-a-live-feed, and `insertOraclePrices` is on-conflict-do-nothing.
- Our own daily-series computation (`computeApprovalSeries`) lost its last consumer when the backfill switched, and is deleted rather than left unused in a pricing path.
- The fetch is a **single request**, deliberately. An earlier revision added `offset` paging on the theory that `items.length < total` meant silent truncation. That was wrong: `items` is complete at every range size (verified from 2 polls to 807, where the item count always equals the distinct-id count), `total` counts a larger population matching no filter we send, and `offset` past the end returns byte-identical copies of rows already delivered. Documented in place so it is not "re-fixed."

## Follow-ups (not in this PR)

- **Publish the constituent polls on the market page** — the user's original transparency ask.
- **Publish more often than once daily.** Their average updates live; ours is a single daily reveal at a known time, which is its own arb surface. This becomes a `fast` feed rather than `daily`, and the funding period has to move with it.

## Deploy

Scheduler-only (`scheduler-perps`). No migration, no API change. Cut leverage first.




