### PR TITLE
perf(perps): record the oracle-feed index (already applied to dev + prod)

### DIFF
--- a/backend/supabase/migrations/2026082001_contracts_perp_oracle_feed.sql
+++ b/backend/supabase/migrations/2026082001_contracts_perp_oracle_feed.sql
@@ -14,10 +14,15 @@
 -- The predicate is byte-identical to the query's WHERE clause; the planner
 -- will not use a partial index it cannot prove covers the query.
 --
--- On prod create this CONCURRENTLY by hand, BEFORE deploying the faster tick,
--- to avoid locking the live table:
+-- ALREADY APPLIED on dev and prod (2026-08-20), created CONCURRENTLY by hand to
+-- avoid locking the live table. Verified there: indisvalid = true, and the tick
+-- query went from a 28,499-buffer bitmap heap scan at 185 ms to a 30-buffer
+-- index scan at 0.5 ms. The name below MUST stay byte-identical to what was
+-- created by hand — IF NOT EXISTS matches on name, so a differently-named copy
+-- of the same index would be silently created a second time, doubling write
+-- cost on contracts for nothing. The command used was:
 --
---   create index concurrently if not exists contracts_perp_oracle_feed_idx
+--   create index concurrently if not exists contracts_perp_oracle_feed
 --     on contracts ((data->>'oracleFeedId'))
 --     where mechanism = 'perp' and resolution_time is null;
 --   analyze contracts;
@@ -28,11 +33,11 @@
 -- silently ignores, so verify afterwards:
 --
 --   select indisvalid from pg_index
---    where indexrelid = 'contracts_perp_oracle_feed_idx'::regclass;
+--    where indexrelid = 'contracts_perp_oracle_feed'::regclass;
 --
 -- This file uses the plain (transaction-safe) form for fresh / CI databases,
 -- where the contracts table is small so a brief lock is fine. IF NOT EXISTS
 -- makes it a no-op wherever the index already exists (incl. prod).
-create index if not exists contracts_perp_oracle_feed_idx
+create index if not exists contracts_perp_oracle_feed
   on contracts ((data->>'oracleFeedId'))
   where mechanism = 'perp' and resolution_time is null;

--- a/backend/supabase/migrations/2026082001_contracts_perp_oracle_feed_idx.sql
+++ b/backend/supabase/migrations/2026082001_contracts_perp_oracle_feed_idx.sql
@@ -1,0 +1,38 @@
+-- Expression index on contracts ((data->>'oracleFeedId')), partial to live perp
+-- markets. Powers the per-tick lookup in apply-oracle-point.ts, which resolves
+-- "which markets does this feed back?" on EVERY oracle tick.
+--
+-- Without it that query is a bitmap heap scan: prod EXPLAIN ANALYZE measured
+-- 28,499 shared buffers (~223 MB) and 185 ms per execution, discarding 46,344
+-- rows to return 1. The BTC feed alone runs it every 5 seconds today and every
+-- 2 seconds once the faster tick ships, so the churn lands continuously on the
+-- shared buffer cache of the table every bet also writes — the same cache the
+-- nightly stall incident traced its eviction pressure to. 185 ms is also ~9%
+-- of a 2,000 ms tick budget, and it sits OUTSIDE the tick's lock/statement
+-- timeouts, which only bound the transaction that follows.
+--
+-- The predicate is byte-identical to the query's WHERE clause; the planner
+-- will not use a partial index it cannot prove covers the query.
+--
+-- On prod create this CONCURRENTLY by hand, BEFORE deploying the faster tick,
+-- to avoid locking the live table:
+--
+--   create index concurrently if not exists contracts_perp_oracle_feed_idx
+--     on contracts ((data->>'oracleFeedId'))
+--     where mechanism = 'perp' and resolution_time is null;
+--   analyze contracts;
+--
+-- Run it as a bare statement (NOT inside a transaction — CONCURRENTLY cannot
+-- run in one) and in a quiet window, away from update-league and update-stats.
+-- An aborted CONCURRENTLY build leaves an INVALID index that the planner
+-- silently ignores, so verify afterwards:
+--
+--   select indisvalid from pg_index
+--    where indexrelid = 'contracts_perp_oracle_feed_idx'::regclass;
+--
+-- This file uses the plain (transaction-safe) form for fresh / CI databases,
+-- where the contracts table is small so a brief lock is fine. IF NOT EXISTS
+-- makes it a no-op wherever the index already exists (incl. prod).
+create index if not exists contracts_perp_oracle_feed_idx
+  on contracts ((data->>'oracleFeedId'))
+  where mechanism = 'perp' and resolution_time is null;


### PR DESCRIPTION
One migration file, no code. Records an index that is **already live on dev and prod**, created by hand with `CONCURRENTLY` — so this has no deploy coupling and blocks nothing. It exists so fresh and CI databases get the index too.

`apply-oracle-point` resolves "which markets does this feed back?" on every oracle tick. Before the index, prod EXPLAIN ANALYZE showed that query doing a bitmap heap scan — **28,499 shared buffers (~223 MB), 185 ms**, discarding 46,344 rows to return 1 — every 5 seconds. After: an **Index Scan, 30 buffers, 0.5 ms**.

That churn landed continuously on the shared buffer cache of the table every bet also writes, which is the cache the nightly stall incident traced its eviction pressure to. It was also ~9% of a 2,000 ms tick budget at the faster tick, and it sits outside that tick's lock/statement timeouts, which only bound the transaction that follows.

Deliberately separate from #4011: it pays for itself at the current 5s tick, so it need not wait, and folding it in would add deploy-order coupling for no benefit.

Follows the `contracts_sports_league_idx` precedent, which fixed the same failure mode for the 10s sports cron — plain transaction-safe form here for fresh/CI, `CONCURRENTLY` by hand on prod, with the `indisvalid` verification query in the file because an aborted concurrent build leaves an INVALID index the planner ignores silently.

The index name is byte-identical to the hand-created one (`contracts_perp_oracle_feed`). `IF NOT EXISTS` matches on name, not definition, so a mismatch here would have silently created a second identical index on both environments.