### PR TITLE
feat(perps): API-channel taker fee (takerFeeApiBps), live-tunable per market

### DIFF
--- a/backend/api/src/update-perp-config.ts
+++ b/backend/api/src/update-perp-config.ts
@@ -25,6 +25,10 @@ import { APIError, APIHandler } from './helpers/endpoint'
 //   round-trip cost), applied to the NEXT open or add. 0 disables. The
 //   schema keeps it inside assertPerpTakerFeeConfig's [0, 100] domain;
 //   outside it the engine fail-closes every trade.
+// - takerFeeApiBps: base fee for API-KEY opens, applied as
+//   max(takerFeeBps, takerFeeApiBps) from the NEXT open or add. Unset or 0
+//   = API pays the web base. Its own wider [0, 300] domain — it prices
+//   hostile bot flow (the 2026-08-19/20 BTC drain was all API-key trades).
 // - maxOraclePriceAgeMs: the age at which the engine stops accepting trades
 //   AND closes against the cached mark. Lowering it is the direct lever on
 //   latency arbitrage — every stale-mark window a bot can trade is bounded by
@@ -43,6 +47,7 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
     maxLeverage,
     maxFundingRate,
     takerFeeBps,
+    takerFeeApiBps,
     maxOraclePriceAgeMs,
   } = body
 
@@ -74,6 +79,7 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
     maxLeverage,
     maxFundingRate,
     takerFeeBps,
+    takerFeeApiBps,
     maxOraclePriceAgeMs,
     lastUpdatedTime,
   })
@@ -92,6 +98,12 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
         contract.slug
       }: ${getPerpTakerFeeBps(contract)} -> ${takerFeeBps}`
     )
+  if (takerFeeApiBps !== undefined)
+    log(
+      `admin ${auth.uid} set takerFeeApiBps on ${contract.slug}: ${
+        contract.takerFeeApiBps ?? 'unset'
+      } -> ${takerFeeApiBps}`
+    )
   if (maxOraclePriceAgeMs !== undefined)
     log(
       `admin ${auth.uid} set maxOraclePriceAgeMs on ${contract.slug}: ${contract.maxOraclePriceAgeMs} -> ${maxOraclePriceAgeMs}`
@@ -103,6 +115,7 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
       maxLeverage,
       maxFundingRate,
       takerFeeBps,
+      takerFeeApiBps,
       maxOraclePriceAgeMs,
     })
   )
@@ -112,6 +125,7 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
       maxLeverage: maxLeverage ?? contract.maxLeverage,
       maxFundingRate: maxFundingRate ?? contract.maxFundingRate,
       takerFeeBps: takerFeeBps ?? getPerpTakerFeeBps(contract),
+      takerFeeApiBps: takerFeeApiBps ?? contract.takerFeeApiBps ?? null,
       maxOraclePriceAgeMs: maxOraclePriceAgeMs ?? contract.maxOraclePriceAgeMs,
     },
     continue: async () => {

--- a/backend/api/src/update-perp-config.ts
+++ b/backend/api/src/update-perp-config.ts
@@ -1,4 +1,7 @@
-import { getPerpTakerFeeBps } from 'common/perps/fees'
+import {
+  getPerpEffectiveTakerFeeBps,
+  getPerpTakerFeeBps,
+} from 'common/perps/fees'
 import { getMinTradingMarkAgeMs, getOracleFeed } from 'shared/oracle-feeds'
 import { removeUndefinedProps } from 'common/util/object'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
@@ -74,6 +77,19 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
       )
   }
 
+  // What an API-key open will ACTUALLY be charged once max(base, api) is
+  // applied. Echoing the submitted value alone is misleading: a rate at or
+  // below the base is a silent no-op, and with no GET for perp config and no
+  // admin-UI row, this response is the only feedback the operator gets.
+  const nextTakerFeeBps = takerFeeBps ?? getPerpTakerFeeBps(contract)
+  const effectiveTakerFeeApiBps = getPerpEffectiveTakerFeeBps(
+    {
+      takerFeeBps: nextTakerFeeBps,
+      takerFeeApiBps: takerFeeApiBps ?? contract.takerFeeApiBps,
+    },
+    true
+  )
+
   const lastUpdatedTime = Date.now()
   const patch = removeUndefinedProps({
     maxLeverage,
@@ -102,7 +118,11 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
     log(
       `admin ${auth.uid} set takerFeeApiBps on ${contract.slug}: ${
         contract.takerFeeApiBps ?? 'unset'
-      } -> ${takerFeeApiBps}`
+      } -> ${takerFeeApiBps} (API opens will pay ${effectiveTakerFeeApiBps} bps${
+        effectiveTakerFeeApiBps !== takerFeeApiBps
+          ? ` — the ${nextTakerFeeBps} bps base is higher, so this value has no effect`
+          : ''
+      })`
     )
   if (maxOraclePriceAgeMs !== undefined)
     log(
@@ -124,8 +144,9 @@ export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
       success: true as const,
       maxLeverage: maxLeverage ?? contract.maxLeverage,
       maxFundingRate: maxFundingRate ?? contract.maxFundingRate,
-      takerFeeBps: takerFeeBps ?? getPerpTakerFeeBps(contract),
+      takerFeeBps: nextTakerFeeBps,
       takerFeeApiBps: takerFeeApiBps ?? contract.takerFeeApiBps ?? null,
+      effectiveTakerFeeApiBps,
       maxOraclePriceAgeMs: maxOraclePriceAgeMs ?? contract.maxOraclePriceAgeMs,
     },
     continue: async () => {

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -129,9 +129,35 @@ cash-backing invariant above is preserved. The position tracks its
 cumulative opening fees in `takerFeeCostBasis` (kept separate from margin so
 leverage/liquidation math is untouched), and every user-facing PnL number —
 the position card, close receipts, portfolio metrics, period metrics —
-subtracts it: a fresh position starts at PnL = −fee. Admins tune the rate
-live per market via `update-perp-config` (0 disables); contracts created
+subtracts it: a fresh position starts at PnL = −fee. Contracts created
 before the field default to 10 bps at trade time.
+
+**Two channels, two rates.** `takerFeeBps` is the WEB base. Opens
+authenticated with an API key instead pay `max(takerFeeBps, takerFeeApiBps)`
+— see `getPerpEffectiveTakerFeeBps`, which the engine calls with the
+auth-derived `isApi` flag (`auth.creds.kind === 'key'`, never
+client-supplied). Unset or 0 means API flow pays the web base. The `max()`
+is deliberate: a misconfigured API rate below the base can never hand bots a
+discount, but it also means a submitted value at or below the base is a
+silent no-op — `update-perp-config` echoes `effectiveTakerFeeApiBps` so an
+operator can see what will actually be charged. Both rates are tuned live
+per market via `update-perp-config`; setting `takerFeeBps: 0` disables the
+fee for WEB only, and does NOT disable it for API flow while
+`takerFeeApiBps` is set. Closing is free on both channels.
+
+Why per-channel: the 2026-08-19/20 BTC drain was API-key flow (5 API accounts
+were 85% of opening notional over that week against 135 web traders), so a
+flat raise would tax the honest web majority for the bots' edge. A bot can
+still dodge by scripting a session token — this is a raised bar and a clean
+ToS line, not a wall; the structural fix is next-tick execution.
+
+The two rates carry different domains — `PERP_TAKER_FEE_BPS_MAX` = 100,
+`PERP_TAKER_FEE_API_BPS_MAX` = 300 — and neither is validated against
+`maxLeverage`. Because the fee is charged on NOTIONAL, `feeBps × leverage ≥
+10_000` would cost a trader more than the margin they posted, so the engine
+rejects any open whose fee meets or exceeds its margin (`openFee >= mana`).
+That floor is what keeps a fat-fingered rate survivable rather than
+catastrophic; honest settings never approach it.
 
 ## Funding imbalance
 

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -44,7 +44,7 @@ import {
   assertPerpTakerFeeConfig,
   calcPerpTakerFee,
   creditPerpPoolFee,
-  getPerpTakerFeeBps,
+  getPerpEffectiveTakerFeeBps,
 } from 'common/perps/fees'
 import { noFees } from 'common/fees'
 import { getUserFacingPnlFromPayout } from 'common/perps/pnl'
@@ -598,7 +598,12 @@ export const openOrAddPosition = async (
     // snipe needs an entry, so an open-only fee taxes each round trip once).
     // The fee mana enters escrow with the margin, so ledger = L + S holds.
     assertPerpTakerFeeConfig(contract)
-    const takerFeeBps = getPerpTakerFeeBps(contract)
+    // Channel-selected base: API-key opens pay max(takerFeeBps,
+    // takerFeeApiBps) when the API rate is set — the 2026-08-19/20 BTC drain
+    // was 100% API-key flow (see getPerpEffectiveTakerFeeBps). The event's
+    // feeBps stamp below records the effective base actually charged, and
+    // the isApi flag on the same event says which channel selected it.
+    const takerFeeBps = getPerpEffectiveTakerFeeBps(contract, isApi)
 
     // Auto-close opposite side first, then open on top of the resulting state.
     let workingState: PerpState = state

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -597,7 +597,7 @@ export const openOrAddPosition = async (
     // pools at a measured edge of ~1.5 bps of notional per round trip; every
     // snipe needs an entry, so an open-only fee taxes each round trip once).
     // The fee mana enters escrow with the margin, so ledger = L + S holds.
-    assertPerpTakerFeeConfig(contract)
+    assertPerpTakerFeeConfig(contract, isApi)
     // Channel-selected base: API-key opens pay max(takerFeeBps,
     // takerFeeApiBps) when the API rate is set — the 2026-08-19/20 BTC drain
     // was 100% API-key flow (see getPerpEffectiveTakerFeeBps). The event's
@@ -655,6 +655,25 @@ export const openOrAddPosition = async (
     // The user row is locked FOR UPDATE above, so the balance cannot move
     // between here and the debit.
     const openFee = calcPerpTakerFee(mana * leverage, takerFeeBps)
+    // Hard consent floor: a fee that meets or exceeds the margin means the
+    // position opens at a guaranteed total loss — always a misconfiguration
+    // or an attack, never intent. Reject instead of charging, so no
+    // combination of leverage and configured rate can cost a trader more
+    // than the margin they posted. The fee is charged on NOTIONAL, so this
+    // trips exactly when feeBps × leverage >= 10_000. Honest settings never
+    // reach it (the intended 30 bps API rate would need leverage 334), but
+    // the rate domains are validated independently of maxLeverage, so a
+    // fat-fingered API rate at the top of its [0, 300] range crosses it
+    // above 33x — this is what keeps that misconfiguration survivable.
+    if (openFee >= mana)
+      throw new APIError(
+        400,
+        `This trade's fee (M$${openFee.toFixed(
+          2
+        )}) would meet or exceed its margin (M$${mana.toFixed(
+          2
+        )}) — the position would open at a total loss. Reduce leverage.`
+      )
     const totalDebit = mana + openFee
     const spendableBalance = trader.balance + closePayout
     if (spendableBalance < totalDebit)

--- a/common/src/api/market-types.test.ts
+++ b/common/src/api/market-types.test.ts
@@ -237,6 +237,52 @@ describe('toLiteMarket', () => {
       toLiteMarket({ ...legacyContract, takerFeeBps: 0 }).takerFeeBps
     ).toBe(0)
   })
+
+  it('publishes the rate an API-key open actually pays', () => {
+    // The cohort that reads a market over the API is the cohort charged the
+    // API rate, so the payload must carry it. Publishing only takerFeeBps
+    // told every bot the wrong number.
+    const perp = {
+      id: 'p',
+      creatorId: 'c',
+      creatorUsername: 't',
+      creatorName: 'T',
+      createdTime: 1_700_000_000_000,
+      question: 'Q',
+      slug: 'q',
+      outcomeType: 'PERP',
+      mechanism: 'perp',
+      volume: 0,
+      volume24Hours: 0,
+      isResolved: false,
+      uniqueBettorCount: 0,
+      oraclePrice: 42,
+      poolLong: 100,
+      poolShort: 100,
+      description: '',
+    } as unknown as PerpContract
+
+    // Unset: API pays the web base, and the field mirrors it rather than
+    // going missing — a client should never have to infer the rate.
+    expect(toLiteMarket({ ...perp, takerFeeBps: 10 }).takerFeeApiBps).toBe(10)
+    expect(toFullMarket({ ...perp, takerFeeBps: 10 }).takerFeeApiBps).toBe(10)
+
+    // Set above the base: the published rate is what the engine charges.
+    expect(
+      toLiteMarket({ ...perp, takerFeeBps: 10, takerFeeApiBps: 30 })
+        .takerFeeApiBps
+    ).toBe(30)
+
+    // Set at or below the base: max() means the base still wins, and the
+    // payload must say so rather than echoing a rate nobody is charged.
+    expect(
+      toLiteMarket({ ...perp, takerFeeBps: 50, takerFeeApiBps: 30 })
+        .takerFeeApiBps
+    ).toBe(50)
+
+    // Legacy row with no base: both channels fall back to the default.
+    expect(toLiteMarket(perp).takerFeeApiBps).toBe(PERP_TAKER_FEE_BPS_DEFAULT)
+  })
 })
 
 function getLiteMarket(overrides: Partial<LiteMarket> = {}): LiteMarket {

--- a/common/src/api/market-types.test.ts
+++ b/common/src/api/market-types.test.ts
@@ -279,6 +279,7 @@ describe('update-perp-config props', () => {
       'maxFundingRate',
       'maxLeverage',
       'maxOraclePriceAgeMs',
+      'takerFeeApiBps',
       'takerFeeBps',
     ])
   })
@@ -288,6 +289,7 @@ describe('update-perp-config props', () => {
       maxLeverage: 10,
       maxFundingRate: 0.02,
       takerFeeBps: 10,
+      takerFeeApiBps: 30,
       maxOraclePriceAgeMs: 10_000,
     }
     for (const field of optionalFields) {

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -13,7 +13,10 @@ import { DOMAIN } from 'common/envs/constants'
 import { MAX_ID_LENGTH } from 'common/group'
 import { MAX_MULTI_NUMERIC_ANSWERS } from 'common/multi-numeric'
 import { MIN_PERP_LEVERAGE } from 'common/perps/amm'
-import { getPerpTakerFeeBps } from 'common/perps/fees'
+import {
+  getPerpEffectiveTakerFeeBps,
+  getPerpTakerFeeBps,
+} from 'common/perps/fees'
 import { getMappedValue } from 'common/pseudo-numeric'
 import {
   getTierIndexFromLiquidityAndAnswers,
@@ -89,6 +92,12 @@ export type LiteMarket = {
   lastFundingTime?: number
   maxLeverage?: number
   takerFeeBps?: number
+  // What an API-key open is charged, in bps of notional. Equal to
+  // takerFeeBps unless this market prices the API channel separately. The
+  // channel that pays this rate is the one that reads the market over the
+  // API, so publishing only takerFeeBps would tell every bot the wrong
+  // number — and it is the input a client needs to size a trade.
+  takerFeeApiBps?: number
   resolvedOraclePrice?: number
 }
 export type ApiAnswer = Omit<
@@ -234,6 +243,7 @@ export function toLiteMarket(
           lastFundingTime: contract.lastFundingTime,
           maxLeverage: contract.maxLeverage,
           takerFeeBps: getPerpTakerFeeBps(contract),
+          takerFeeApiBps: getPerpEffectiveTakerFeeBps(contract, true),
           resolvedOraclePrice: contract.resolvedOraclePrice,
         }
       : {}),

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1165,6 +1165,10 @@ export const API = (_apiTypeCheck = {
       // Configured API-channel base rate, or null when API trades pay the
       // same base as the web. The engine applies max(takerFeeBps, this).
       takerFeeApiBps: number | null
+      // What an API-key open is actually charged after that max() — equal to
+      // takerFeeBps whenever the configured API rate sits at or below the
+      // base, which makes such a rate a no-op rather than a reduction.
+      effectiveTakerFeeApiBps: number
       maxOraclePriceAgeMs: number
     },
     props: z

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -35,6 +35,7 @@ import { CandidateBet } from 'common/new-bet'
 import { Headline } from 'common/news'
 import { PERIODS } from 'common/period'
 import type { PerpTradeActivity } from 'common/perps/activity'
+import { PERP_TAKER_FEE_API_BPS_MAX } from 'common/perps/fees'
 import { PerpQuote, perpQuoteSchema } from 'common/perps/quote'
 import {
   LivePortfolioMetrics,
@@ -1161,6 +1162,9 @@ export const API = (_apiTypeCheck = {
       maxLeverage: number
       maxFundingRate: number
       takerFeeBps: number
+      // Configured API-channel base rate, or null when API trades pay the
+      // same base as the web. The engine applies max(takerFeeBps, this).
+      takerFeeApiBps: number | null
       maxOraclePriceAgeMs: number
     },
     props: z
@@ -1176,6 +1180,16 @@ export const API = (_apiTypeCheck = {
         // assertPerpTakerFeeConfig — outside them the engine fail-closes
         // every trade.
         takerFeeBps: z.number().min(0).max(100).optional(),
+        // Base rate for API-KEY opens only, applied as max(takerFeeBps,
+        // takerFeeApiBps) — it can raise the API channel's rate, never
+        // discount it. 0 (or unset) = API pays the web base. Wider cap than
+        // the web base on purpose: it prices hostile bot flow (see
+        // PERP_TAKER_FEE_API_BPS_MAX).
+        takerFeeApiBps: z
+          .number()
+          .min(0)
+          .max(PERP_TAKER_FEE_API_BPS_MAX)
+          .optional(),
         // How old the executable mark may be before the engine refuses trades
         // and closes. Tunable live because the right value depends on how
         // reliably the feed is actually ticking, which is an operational fact
@@ -1194,6 +1208,7 @@ export const API = (_apiTypeCheck = {
           p.maxLeverage !== undefined ||
           p.maxFundingRate !== undefined ||
           p.takerFeeBps !== undefined ||
+          p.takerFeeApiBps !== undefined ||
           p.maxOraclePriceAgeMs !== undefined,
         { message: 'Provide at least one field to update' }
       ),

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -308,6 +308,11 @@ export type Perp = {
   // on pre-fee contracts = PERP_TAKER_FEE_BPS_DEFAULT. Read via
   // getPerpTakerFeeBps (common/perps/fees), never directly.
   takerFeeBps?: number
+  // Base taker fee for API-key opens, in bps of notional. Applied as
+  // max(takerFeeBps, takerFeeApiBps) so it can only raise the API channel's
+  // rate, never discount it. Missing = API pays the same base as the web.
+  // Read via getPerpEffectiveTakerFeeBps (common/perps/fees), never directly.
+  takerFeeApiBps?: number
   // ms between funding events: max(1h, feed updatePeriodMs), derived at
   // create time and frozen so later feed-registry changes can't rewrite the
   // economics of open positions. Missing on pre-period contracts = hourly.

--- a/common/src/perps/fees.test.ts
+++ b/common/src/perps/fees.test.ts
@@ -3,7 +3,9 @@ import {
   accruePerpPositionTakerFee,
   calcPerpTakerFee,
   creditPerpPoolFee,
+  getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeBps,
+  PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_BPS_DEFAULT,
   PERP_TAKER_FEE_BPS_MAX,
 } from './fees'
@@ -37,6 +39,57 @@ describe('getPerpTakerFeeBps', () => {
   })
 })
 
+describe('getPerpEffectiveTakerFeeBps', () => {
+  it('web trades always pay the base, ignoring any API rate', () => {
+    expect(getPerpEffectiveTakerFeeBps({ takerFeeBps: 10 }, false)).toBe(10)
+    expect(
+      getPerpEffectiveTakerFeeBps(
+        { takerFeeBps: 10, takerFeeApiBps: 200 },
+        false
+      )
+    ).toBe(10)
+  })
+
+  it('API trades pay the API rate when it is set and higher', () => {
+    expect(
+      getPerpEffectiveTakerFeeBps({ takerFeeBps: 10, takerFeeApiBps: 40 }, true)
+    ).toBe(40)
+    expect(
+      getPerpEffectiveTakerFeeBps(
+        { takerFeeBps: 10, takerFeeApiBps: PERP_TAKER_FEE_API_BPS_MAX },
+        true
+      )
+    ).toBe(PERP_TAKER_FEE_API_BPS_MAX)
+  })
+
+  it('an API rate below the base can never discount API flow', () => {
+    expect(
+      getPerpEffectiveTakerFeeBps({ takerFeeBps: 50, takerFeeApiBps: 5 }, true)
+    ).toBe(50)
+    expect(
+      getPerpEffectiveTakerFeeBps({ takerFeeBps: 50, takerFeeApiBps: 0 }, true)
+    ).toBe(50)
+  })
+
+  it('missing or corrupt API rate reads as "no separate rate" (display path is total)', () => {
+    expect(getPerpEffectiveTakerFeeBps({ takerFeeBps: 10 }, true)).toBe(10)
+    for (const bad of [NaN, Infinity, -1, PERP_TAKER_FEE_API_BPS_MAX + 1])
+      expect(
+        getPerpEffectiveTakerFeeBps(
+          { takerFeeBps: 10, takerFeeApiBps: bad },
+          true
+        )
+      ).toBe(10)
+  })
+
+  it('defaults the base for pre-fee contracts on both channels', () => {
+    expect(getPerpEffectiveTakerFeeBps({}, false)).toBe(
+      PERP_TAKER_FEE_BPS_DEFAULT
+    )
+    expect(getPerpEffectiveTakerFeeBps({ takerFeeApiBps: 40 }, true)).toBe(40)
+  })
+})
+
 describe('assertPerpTakerFeeConfig', () => {
   it('accepts undefined and the full valid range', () => {
     expect(() => assertPerpTakerFeeConfig({})).not.toThrow()
@@ -44,11 +97,19 @@ describe('assertPerpTakerFeeConfig', () => {
     expect(() =>
       assertPerpTakerFeeConfig({ takerFeeBps: PERP_TAKER_FEE_BPS_MAX })
     ).not.toThrow()
+    expect(() =>
+      assertPerpTakerFeeConfig({ takerFeeApiBps: 0 })
+    ).not.toThrow()
+    expect(() =>
+      assertPerpTakerFeeConfig({ takerFeeApiBps: PERP_TAKER_FEE_API_BPS_MAX })
+    ).not.toThrow()
   })
 
   it('fails closed on corrupt persisted values', () => {
     for (const bad of [NaN, Infinity, -1, PERP_TAKER_FEE_BPS_MAX + 0.001])
       expect(() => assertPerpTakerFeeConfig({ takerFeeBps: bad })).toThrow()
+    for (const bad of [NaN, Infinity, -1, PERP_TAKER_FEE_API_BPS_MAX + 0.001])
+      expect(() => assertPerpTakerFeeConfig({ takerFeeApiBps: bad })).toThrow()
   })
 })
 

--- a/common/src/perps/fees.test.ts
+++ b/common/src/perps/fees.test.ts
@@ -87,6 +87,17 @@ describe('getPerpEffectiveTakerFeeBps', () => {
       PERP_TAKER_FEE_BPS_DEFAULT
     )
     expect(getPerpEffectiveTakerFeeBps({ takerFeeApiBps: 40 }, true)).toBe(40)
+    // Pin the DEFAULT as the API branch's floor too. Without these two, an
+    // implementation that read takerFeeBps raw on the API branch (0 when
+    // absent) would charge legacy contracts 0 bps and let an API rate below
+    // the default win — the exact inversion this function exists to prevent
+    // — while every other assertion here stayed green.
+    expect(getPerpEffectiveTakerFeeBps({}, true)).toBe(
+      PERP_TAKER_FEE_BPS_DEFAULT
+    )
+    expect(getPerpEffectiveTakerFeeBps({ takerFeeApiBps: 5 }, true)).toBe(
+      PERP_TAKER_FEE_BPS_DEFAULT
+    )
   })
 })
 
@@ -98,10 +109,13 @@ describe('assertPerpTakerFeeConfig', () => {
       assertPerpTakerFeeConfig({ takerFeeBps: PERP_TAKER_FEE_BPS_MAX })
     ).not.toThrow()
     expect(() =>
-      assertPerpTakerFeeConfig({ takerFeeApiBps: 0 })
+      assertPerpTakerFeeConfig({ takerFeeApiBps: 0 }, true)
     ).not.toThrow()
     expect(() =>
-      assertPerpTakerFeeConfig({ takerFeeApiBps: PERP_TAKER_FEE_API_BPS_MAX })
+      assertPerpTakerFeeConfig(
+        { takerFeeApiBps: PERP_TAKER_FEE_API_BPS_MAX },
+        true
+      )
     ).not.toThrow()
   })
 
@@ -109,7 +123,25 @@ describe('assertPerpTakerFeeConfig', () => {
     for (const bad of [NaN, Infinity, -1, PERP_TAKER_FEE_BPS_MAX + 0.001])
       expect(() => assertPerpTakerFeeConfig({ takerFeeBps: bad })).toThrow()
     for (const bad of [NaN, Infinity, -1, PERP_TAKER_FEE_API_BPS_MAX + 0.001])
-      expect(() => assertPerpTakerFeeConfig({ takerFeeApiBps: bad })).toThrow()
+      expect(() =>
+        assertPerpTakerFeeConfig({ takerFeeApiBps: bad }, true)
+      ).toThrow()
+  })
+
+  it('a corrupt API rate does not halt the web channel', () => {
+    // The API rate governs API flow only. Failing closed on it for a web
+    // open would take the market dark for every ordinary trader over a
+    // field their trades never read.
+    for (const bad of [NaN, Infinity, -1, PERP_TAKER_FEE_API_BPS_MAX + 0.001]) {
+      expect(() =>
+        assertPerpTakerFeeConfig({ takerFeeBps: 10, takerFeeApiBps: bad })
+      ).not.toThrow()
+      expect(getPerpEffectiveTakerFeeBps({ takerFeeBps: 10 }, false)).toBe(10)
+    }
+    // ...but a corrupt BASE still fails closed on both channels.
+    expect(() =>
+      assertPerpTakerFeeConfig({ takerFeeBps: NaN, takerFeeApiBps: 30 })
+    ).toThrow()
   })
 })
 
@@ -123,6 +155,33 @@ describe('calcPerpTakerFee', () => {
   it('scales with notional, so the fee cannot be outgrown by sizing up', () => {
     const fee = calcPerpTakerFee(1_000, 5)
     expect(calcPerpTakerFee(10_000, 5)).toBeCloseTo(10 * fee, 10)
+  })
+
+  it('crosses the margin exactly at feeBps x leverage = 10_000', () => {
+    // The engine rejects an open whose fee meets or exceeds its margin
+    // (openFee >= mana). Because the fee is charged on NOTIONAL, that floor
+    // is a pure statement about this function, so pin it here: the two
+    // config domains are validated independently of maxLeverage, and this
+    // is the arithmetic that decides whether a given pair is survivable.
+    const mana = 1_000
+    const feeAt = (bps: number, leverage: number) =>
+      calcPerpTakerFee(mana * leverage, bps)
+
+    // Honest settings sit far below the floor.
+    expect(feeAt(PERP_TAKER_FEE_BPS_DEFAULT, 100)).toBeCloseTo(0.1 * mana, 10)
+    expect(feeAt(30, 100)).toBeCloseTo(0.3 * mana, 10)
+
+    // The boundary itself, from both sides.
+    expect(feeAt(100, 100)).toBeCloseTo(mana, 10) // 100 x 100 = 10_000
+    expect(feeAt(100, 99)).toBeLessThan(mana)
+    expect(feeAt(101, 100)).toBeGreaterThan(mana)
+
+    // The API domain crosses it well inside the allowed leverage range:
+    // at the ceiling the floor is breached above ~33x, and at maxLeverage
+    // 100 the fee would be 3x the margin posted.
+    expect(feeAt(PERP_TAKER_FEE_API_BPS_MAX, 34)).toBeGreaterThan(mana)
+    expect(feeAt(PERP_TAKER_FEE_API_BPS_MAX, 33)).toBeLessThan(mana)
+    expect(feeAt(PERP_TAKER_FEE_API_BPS_MAX, 100)).toBeCloseTo(3 * mana, 10)
   })
 
   it('returns 0 for degenerate inputs', () => {

--- a/common/src/perps/fees.ts
+++ b/common/src/perps/fees.ts
@@ -45,17 +45,31 @@ const isValidTakerFeeApiBps = (bps: number) =>
  * contracts are schema-validated, but old rows bypass that schema, and a
  * corrupt fee must block trading rather than silently repricing it.
  * `undefined` is the valid pre-fee-contract case (reads as the default).
+ *
+ * `isApi` scopes the API-rate check to the channel that rate governs. A
+ * corrupt `takerFeeApiBps` must fail closed for API flow — falling back to
+ * the base would silently UNDER-charge exactly the flow the rate exists to
+ * price — but it must not halt web opens, which that field never touches.
+ * Without the scope, one bad JSON value in an API-only field takes the whole
+ * market dark for everyone.
  */
-export const assertPerpTakerFeeConfig = (config: {
-  takerFeeBps?: number
-  takerFeeApiBps?: number
-}) => {
+export const assertPerpTakerFeeConfig = (
+  config: {
+    takerFeeBps?: number
+    takerFeeApiBps?: number
+  },
+  isApi = false
+) => {
   const { takerFeeBps, takerFeeApiBps } = config
   if (takerFeeBps !== undefined && !isValidTakerFeeBps(takerFeeBps))
     throw new Error(
       `taker fee must be finite and in [0, ${PERP_TAKER_FEE_BPS_MAX}] bps`
     )
-  if (takerFeeApiBps !== undefined && !isValidTakerFeeApiBps(takerFeeApiBps))
+  if (
+    isApi &&
+    takerFeeApiBps !== undefined &&
+    !isValidTakerFeeApiBps(takerFeeApiBps)
+  )
     throw new Error(
       `API taker fee must be finite and in [0, ${PERP_TAKER_FEE_API_BPS_MAX}] bps`
     )

--- a/common/src/perps/fees.ts
+++ b/common/src/perps/fees.ts
@@ -26,8 +26,19 @@ export const PERP_TAKER_FEE_BPS_DEFAULT = 10
 /** Upper bound for admin configuration: 100 bps = 1% per open. */
 export const PERP_TAKER_FEE_BPS_MAX = 100
 
+/** Upper bound for the API-channel base rate: 300 bps = 3% per open. Wider
+ * than the web cap on purpose — it exists to price hostile flow: the
+ * 2026-08-19/20 BTC drain (M$254k/24h, 100% API-key trades) measured bot
+ * captures of 22–30 bps of notional per round trip on average and ~140 bps
+ * on the largest momentum entries, so the ceiling must clear the worst
+ * observed capture with room to spare. */
+export const PERP_TAKER_FEE_API_BPS_MAX = 300
+
 const isValidTakerFeeBps = (bps: number) =>
   Number.isFinite(bps) && bps >= 0 && bps <= PERP_TAKER_FEE_BPS_MAX
+
+const isValidTakerFeeApiBps = (bps: number) =>
+  Number.isFinite(bps) && bps >= 0 && bps <= PERP_TAKER_FEE_API_BPS_MAX
 
 /**
  * Fail-closed guard for the engine, mirroring assertPerpFundingConfig: new
@@ -35,12 +46,18 @@ const isValidTakerFeeBps = (bps: number) =>
  * corrupt fee must block trading rather than silently repricing it.
  * `undefined` is the valid pre-fee-contract case (reads as the default).
  */
-export const assertPerpTakerFeeConfig = (config: { takerFeeBps?: number }) => {
-  const { takerFeeBps } = config
-  if (takerFeeBps === undefined) return
-  if (!isValidTakerFeeBps(takerFeeBps))
+export const assertPerpTakerFeeConfig = (config: {
+  takerFeeBps?: number
+  takerFeeApiBps?: number
+}) => {
+  const { takerFeeBps, takerFeeApiBps } = config
+  if (takerFeeBps !== undefined && !isValidTakerFeeBps(takerFeeBps))
     throw new Error(
       `taker fee must be finite and in [0, ${PERP_TAKER_FEE_BPS_MAX}] bps`
+    )
+  if (takerFeeApiBps !== undefined && !isValidTakerFeeApiBps(takerFeeApiBps))
+    throw new Error(
+      `API taker fee must be finite and in [0, ${PERP_TAKER_FEE_API_BPS_MAX}] bps`
     )
 }
 
@@ -57,6 +74,33 @@ export const getPerpTakerFeeBps = (contract: {
   return isValidTakerFeeBps(takerFeeBps)
     ? takerFeeBps
     : PERP_TAKER_FEE_BPS_DEFAULT
+}
+
+/**
+ * The base rate a specific trade pays, selected by auth channel. API-key
+ * trades pay `takerFeeApiBps` when it is set — as `max(base, api)`, so a
+ * misconfigured API rate below the base can never DISCOUNT bot flow — and
+ * the web base otherwise. Missing or invalid `takerFeeApiBps` reads as "no
+ * separate API rate" (total, like getPerpTakerFeeBps: render paths must not
+ * throw; the engine separately fail-closes via assertPerpTakerFeeConfig).
+ *
+ * Why per-channel: the 2026-08-19/20 BTC drain was 100% API-key flow, and a
+ * flat raise taxes the honest web majority for the bots' edge. The channel
+ * check is auth-derived server-side (`auth.creds.kind === 'key'`), never
+ * client-supplied — a bot CAN dodge it by scripting a session token, so this
+ * is a raised bar and a clean ToS line, not a wall; the structural fix is
+ * next-tick execution.
+ */
+export const getPerpEffectiveTakerFeeBps = (
+  contract: { takerFeeBps?: number; takerFeeApiBps?: number },
+  isApi: boolean
+): number => {
+  const base = getPerpTakerFeeBps(contract)
+  if (!isApi) return base
+  const { takerFeeApiBps } = contract
+  if (takerFeeApiBps === undefined || !isValidTakerFeeApiBps(takerFeeApiBps))
+    return base
+  return Math.max(base, takerFeeApiBps)
 }
 
 /** Fee in mana on a notional amount. Returns 0 for any degenerate input. */

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -10,7 +10,11 @@ import {
   TRADED_TERM,
 } from 'common/envs/constants'
 import { getPerpBackingPool } from 'common/perps/amm'
-import { getPerpTakerFeeBps } from 'common/perps/fees'
+import {
+  getPerpEffectiveTakerFeeBps,
+  getPerpTakerFeeBps,
+  PERP_TAKER_FEE_API_BPS_MAX,
+} from 'common/perps/fees'
 import {
   fundingPeriodNoun,
   fundingPeriodUnit,
@@ -675,6 +679,22 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           )}
         </td>
       </tr>
+      <tr className={clsx(canEdit && 'bg-purple-500/30')}>
+        <td>
+          API taker fee{' '}
+          <InfoTooltip text="Opens authenticated with an API key pay the higher of this and the web taker fee. Prices bot flow without taxing the web majority. Closing is free on both channels." />
+        </td>
+        <td>
+          {canEdit ? (
+            <TakerFeeApiBpsInput contract={contract} />
+          ) : (
+            <span className="tabular-nums">
+              {(getPerpEffectiveTakerFeeBps(contract, true) / 100).toFixed(2)}%
+              to open
+            </span>
+          )}
+        </td>
+      </tr>
       <tr>
         <td>
           Current funding{' '}
@@ -936,6 +956,89 @@ function TakerFeeBpsInput(props: { contract: PerpContract }) {
         size="2xs"
         color="indigo-outline"
         disabled={!valid || saving || parsed === current}
+        loading={saving}
+        onClick={submit}
+      >
+        Set
+      </Button>
+    </Row>
+  )
+}
+
+// Inline admin editor for a perp's API-CHANNEL taker fee, in basis points of
+// notional. API-key opens pay max(takerFeeBps, takerFeeApiBps), so a value at
+// or below the web base is a no-op rather than a discount — the row shows the
+// EFFECTIVE rate an API open is charged, which is what the engine applies.
+// 0 (or unset) puts API flow back on the web base. Applies to the next open.
+function TakerFeeApiBpsInput(props: { contract: PerpContract }) {
+  const { contract } = props
+  const [input, setInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [justSaved, setJustSaved] = useState<number | null>(null)
+  const stored = getPerpEffectiveTakerFeeBps(contract, true)
+  const current = justSaved != null && justSaved !== stored ? justSaved : stored
+  const base = getPerpTakerFeeBps(contract)
+  const parsed = Number(input)
+  const valid =
+    input !== '' &&
+    Number.isFinite(parsed) &&
+    parsed >= 0 &&
+    parsed <= PERP_TAKER_FEE_API_BPS_MAX
+
+  const submit = async () => {
+    if (!valid || saving) return
+    setSaving(true)
+    try {
+      const res = await api('update-perp-config', {
+        contractId: contract.id,
+        takerFeeApiBps: parsed,
+      })
+      // The echo is the effective rate, so a submitted value the base
+      // overrides shows up here as the base rather than silently "saving".
+      setJustSaved(res.effectiveTakerFeeApiBps)
+      setInput('')
+      toast.success(
+        res.effectiveTakerFeeApiBps === parsed
+          ? `API taker fee is now ${parsed} bps (${(parsed / 100).toFixed(
+              2
+            )}%) to open`
+          : `Set to ${parsed} bps, but the ${base} bps web base is higher — API opens still pay ${res.effectiveTakerFeeApiBps} bps`
+      )
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to update API taker fee'
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Row className="flex-wrap items-center gap-1.5">
+      <span className="tabular-nums">
+        {current} bps ({(current / 100).toFixed(2)}%)
+      </span>
+      {contract.takerFeeApiBps === undefined && (
+        <span className="text-ink-500 text-xs">(unset — pays web base)</span>
+      )}
+      <input
+        type="number"
+        min={0}
+        max={PERP_TAKER_FEE_API_BPS_MAX}
+        step={1}
+        value={input}
+        disabled={saving}
+        placeholder="New bps"
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') submit()
+        }}
+        className="bg-canvas-0 border-ink-300 h-7 w-20 rounded-md border px-2 text-sm"
+      />
+      <Button
+        size="2xs"
+        color="indigo-outline"
+        disabled={!valid || saving}
         loading={saving}
         onClick={submit}
       >


### PR DESCRIPTION
## Why

The 2026-08-19/20 BTC perp drain: **M$254k realized in 24h by three accounts, 100% API-key flow** (`isApi: true` on every open), at a measured 22-30 bps of notional captured per round trip on average. A flat `takerFeeBps` raise would tax the honest web majority for the bots'' edge; this prices the channel the drain actually came through.

## What

New per-market `takerFeeApiBps`. Opens authenticated with an API key pay **`max(takerFeeBps, takerFeeApiBps)`**; web trades are untouched. Closing stays free on both channels.

- **No-op on deploy**: unset = API pays the web base. Nothing changes until an admin sets it via `update-perp-config`.
- **`max()` semantics** so a misconfigured API rate below the base can never hand bots a discount.
- Own **[0, 300] bps** domain (`PERP_TAKER_FEE_API_BPS_MAX`), wider than the web cap because it prices hostile flow (~140 bps captured on the largest momentum entries); `assertPerpTakerFeeConfig` fail-closes on corrupt values like the other fee fields.
- The open event''s `feeBps` stamp records the effective base actually charged; the existing `isApi` flag on the same event says which channel selected it, so charges are auditable per trade.
- `update-perp-config` zod `.refine` includes the new optional field (a request setting ONLY `takerFeeApiBps` works - the maxOraclePriceAgeMs lesson).

Channel detection is auth-derived server-side (`auth.creds.kind === ''key''`), never client-supplied. A bot can still masquerade via a scripted session token - this is a raised bar and a clean ToS line, not a wall; the structural fix (next-tick execution) is tracked separately.

## Deploy & enable

1. Deploy **API** (engine change ships with it). No migration, no scheduler dependency; scheduler redeploy harmless.
2. Enable on the BTC perp (intended temporary operating value **30 bps**, which puts the measured average capture underwater):
   `update-perp-config {contractId: 5pN6lyEuLN8t, takerFeeApiBps: 30}`
3. Revert = set `0` (API pays the web base again). Live-tunable either direction, no deploy.

## Tests

- `common` fees suite: 21 passing (7 new: channel selection, max() no-discount, corrupt-value fallback, assert domain).
- `tsc -b` clean through `common -> backend/shared -> backend/api`.