### PR TITLE
fix(perps): stop the btc-usd oracle tick wedging, and stop it paging for its own success

### DIFF
--- a/backend/scheduler/src/jobs/update-oracle-feeds.ts
+++ b/backend/scheduler/src/jobs/update-oracle-feeds.ts
@@ -11,7 +11,8 @@ import {
   SupabaseDirectClient,
   createSupabaseDirectClient,
 } from 'shared/supabase/init'
-import { log } from 'shared/utils'
+import { log, metrics } from 'shared/utils'
+import { createFeedDispatcher } from 'shared/oracle-feed-dispatcher'
 import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
 import { FAST_TICK_ORACLE_BOUNDS } from 'shared/perps/oracle-tick-bounds'
 
@@ -43,9 +44,13 @@ export async function updateOracleFeeds() {
   for (const feed of ORACLE_FEEDS) {
     if (feed.cadence === 'fast') {
       if (isPollDue(feed.id, feed.pollPeriodMs, now))
-        dispatch(feed.id, () => tickOneFeed(pg, feed))
+        dispatcher.dispatch(feed.id, ({ signal, setPhase }) =>
+          tickOneFeed(pg, feed, signal, setPhase)
+        )
     } else if (isPollDue(feed.id, DAILY_PROBE_PERIOD_MS, now)) {
-      dispatch(feed.id, () => probeDailyFeedStaleness(pg, feed))
+      dispatcher.dispatch(feed.id, ({ setPhase }) =>
+        probeDailyFeedStaleness(pg, feed, setPhase)
+      )
     }
   }
 
@@ -57,72 +62,172 @@ export async function updateOracleFeeds() {
 // tick rate for one source does not raise it for all of them. State is
 // in-memory — a scheduler restart polls everything once immediately, which is
 // the correct bias: fresher marks, and staleness alerting re-arms at once.
-const lastPollAttempt: Record<string, number> = {}
-/** Start time of the run currently in flight, or absent when idle. */
-const inFlightSince: Record<string, number> = {}
+/**
+ * How long a single poll may stay in flight before the feed is cancelled and
+ * re-armed without it.
+ *
+ * The in-flight guard is what stops a slow source stacking on itself, and
+ * `.finally` clears it for every settled outcome — resolve, reject, throw. It
+ * cannot clear it for a promise that never settles at all. On 2026-08-21 a dev
+ * btc-usd poll did exactly that (93 minutes, cleared only by a redeploy); on
+ * 2026-08-22 a prod one did (3h+). Prod had entered the same state four times
+ * in the preceding 30 days and happened to settle each time.
+ *
+ * Nothing in the tick path bounds this on its own: the scheduler runs with NO
+ * server-side statement_timeout by design, `query_timeout` is an hour (the dev
+ * poll outlived even that), and the reads at the top of
+ * applyOraclePointToLivePerps sit outside the SET LOCAL bounds entirely.
+ *
+ * Set well above a healthy tick (tens of ms) so this only ever fires on a
+ * genuine wedge, never on a merely slow one.
+ */
+const DISPATCH_DEADLINE_MS = 60 * 1000
+
+/**
+ * Backstop for one source fetch, and when its AbortSignal fires. Far above
+ * every adapter's own budget (BTC allows 1.2s per venue in parallel, xStocks
+ * up to 5s per venue), because the adapters' own signals are what this
+ * distrusts: Promise.allSettled over four venues never resolves if one stays
+ * pending, and a signal that fails to fire leaves no trace anywhere.
+ */
+const FETCH_DEADLINE_MS = 10 * 1000
+
+/** Orphans on one feed before that feed stops polling. Fairness, not safety. */
+const MAX_ABANDONED_RUNS = 3
+
+/**
+ * Process-wide orphan ceiling — the bound that actually protects the database.
+ *
+ * The per-feed limit is NOT a pool bound: `dispatch` serves every feed in the
+ * registry including the daily probes, so at 8 feeds the per-feed cap alone
+ * permits 24 orphans against a 40-connection pool, and each feed added raises
+ * that silently. Ten leaves 30 connections for the rest of the process.
+ */
+const MAX_TOTAL_ABANDONED = 10
+
+// How overdue an in-flight run must be before it is reported as stuck.
+// Deliberately BELOW DISPATCH_DEADLINE_MS: at the previous 2 minutes this
+// became unreachable the moment the deadline started clearing the in-flight
+// entry at 60s, silently deleting the one signal that diagnosed both latches.
+const STUCK_GRACE_MS = DISPATCH_DEADLINE_MS / 2
+const STUCK_ALERT_INTERVAL_MS = 5 * MINUTE_MS
+
+/** Process boot, so last-success age is meaningful before any success. */
+const processStartedAt = Date.now()
+
+const dispatcher = createFeedDispatcher({
+  deadlineMs: DISPATCH_DEADLINE_MS,
+  maxAbandonedPerFeed: MAX_ABANDONED_RUNS,
+  maxAbandonedTotal: MAX_TOTAL_ABANDONED,
+  refusalLogIntervalMs: STUCK_ALERT_INTERVAL_MS,
+  log,
+})
+
 /** Last time a stuck feed was reported, to keep the alert to once a period. */
 const lastStuckAlert: Record<string, number> = {}
 
-// How overdue an in-flight run must be before it is treated as stuck. Every
-// fetch adapter is bounded (AbortSignal.timeout), but the DB work behind
-// runOracleUpdate is not, and an advisory-lock wait or a pool starvation can
-// last far longer than any poll period.
-const STUCK_GRACE_MS = 2 * MINUTE_MS
-const STUCK_ALERT_INTERVAL_MS = 5 * MINUTE_MS
-
 /**
  * Because dispatch skips a feed while its previous run is in flight, a promise
- * that never settles takes that feed permanently dark — silently, since the
- * staleness check lives INSIDE the work that is no longer running. The job
- * itself keeps reporting success either way: `updateOracleFeeds` returns after
- * dispatching, so `scheduler_info.last_end_time` is now a dispatcher heartbeat
- * and says nothing about whether feed work completes. (`perp-launch-preflight`
- * reads that column as a liveness signal; it still correctly means "the job is
- * firing", which is what it checks.) This is the compensating signal.
- *
- * `update-perps` would also catch it hourly for feeds with a live market; this
- * reports in minutes and covers feeds that have no market yet.
+ * that never settles takes that feed dark — silently, since the staleness check
+ * lives INSIDE the work that is no longer running. The job itself keeps
+ * reporting success either way: `updateOracleFeeds` returns after dispatching,
+ * so `scheduler_info.last_end_time` is a dispatcher heartbeat and says nothing
+ * about whether feed work completes. This is the compensating signal.
  */
 const alertOnStuckFeeds = (now: number) => {
-  for (const feedId of Object.keys(inFlightSince)) {
-    const startedAt = inFlightSince[feedId]
+  // Emit for EVERY feed, healthy ones included: an absent series is
+  // indistinguishable from a dead process, whereas a flat 0 that starts
+  // climbing is unambiguous.
+  //
+  // inflight_age alone is a trap — the deadline CLEARS the in-flight entry, so
+  // a feed that exhausted its budget and stopped polling reports 0 forever,
+  // reading green exactly when it is darkest. last_success_age_ms cannot lie.
+  for (const feed of ORACLE_FEEDS) {
+    const startedAt = dispatcher.inFlightSince(feed.id)
+    const tags = { feedId: feed.id }
+    metrics.set(
+      'perps/oracle_poll_inflight_age_ms',
+      startedAt == null ? 0 : now - startedAt,
+      tags
+    )
+    metrics.set(
+      'perps/oracle_poll_outstanding_abandoned',
+      dispatcher.outstandingAbandoned(feed.id),
+      tags
+    )
+    metrics.set(
+      'perps/oracle_poll_refused',
+      dispatcher.isRefused(feed.id) ? 1 : 0,
+      tags
+    )
+    metrics.set(
+      'perps/oracle_poll_last_success_age_ms',
+      now - (dispatcher.lastSuccessAt(feed.id) ?? processStartedAt),
+      tags
+    )
+  }
+  metrics.set('perps/oracle_poll_total_abandoned', dispatcher.totalAbandoned())
+
+  for (const feed of ORACLE_FEEDS) {
+    const startedAt = dispatcher.inFlightSince(feed.id)
     if (startedAt == null) continue
     const age = now - startedAt
     if (age < STUCK_GRACE_MS) continue
-    if (now - (lastStuckAlert[feedId] ?? 0) < STUCK_ALERT_INTERVAL_MS) continue
-    lastStuckAlert[feedId] = now
+    if (now - (lastStuckAlert[feed.id] ?? 0) < STUCK_ALERT_INTERVAL_MS) continue
+    lastStuckAlert[feed.id] = now
     log.error(
-      `[oracle-feeds] ${feedId}: poll has been in flight for ${Math.round(
+      `[oracle-feeds] ${feed.id}: poll has been in flight for ${Math.round(
         age / 1000
-      )}s and is blocking its own next run — the feed is effectively dark`
+      )}s in phase "${
+        dispatcher.phaseOf(feed.id) ?? 'unknown'
+      }" and is blocking its own next run — the feed is effectively dark`
     )
   }
 }
 
 /**
- * Start a feed's work without blocking the cron run, at most once at a time.
+ * Reject if the work has not settled within `ms`, having first told it to stop.
  *
- * Skipping while in-flight is what replaces croner's `protect` at feed
- * granularity: a source slower than its own poll period falls back to running
- * as often as it can finish, rather than piling up overlapping fetches.
+ * The cancellation is the point. A plain Promise.race frees this tick but
+ * leaves the fetch running, so a permanently hung venue would strand one
+ * socket per poll — the leak this whole guard exists to prevent, only quieter
+ * and without a counter. `start` receives a signal that aborts on either the
+ * deadline or the caller's own cancellation; the race only decides how long
+ * this tick waits to find out whether that worked.
  *
- * The attempt is stamped here, before the work starts, so a source that hangs
- * to its fetch timeout does not earn an immediate retry on the next firing.
- * `tickOneFeed` and `probeDailyFeedStaleness` both catch internally and never
- * reject; the `.catch` is a backstop so a future edit that lets one throw
- * cannot become an unhandled rejection that takes the scheduler down.
+ * A backstop, not a policy: every adapter already carries its own AbortSignal,
+ * and this sits far above those budgets. It exists because those signals are
+ * the leading suspect for both latches and cannot be verified from outside.
  */
-const dispatch = (feedId: string, run: () => Promise<void>) => {
-  if (inFlightSince[feedId] != null) return
-  const startedAt = Date.now()
-  inFlightSince[feedId] = startedAt
-  lastPollAttempt[feedId] = startedAt
-  void run()
-    .catch((err) => log.error(`[oracle-feeds] ${feedId}: unhandled — ${err}`))
-    .finally(() => {
-      delete inFlightSince[feedId]
-      delete lastStuckAlert[feedId]
-    })
+const withDeadline = <T>(
+  label: string,
+  ms: number,
+  start: (signal: AbortSignal) => Promise<T>,
+  outer: AbortSignal
+): Promise<T> => {
+  const controller = new AbortController()
+  const onOuterAbort = () => controller.abort()
+  if (outer.aborted) controller.abort()
+  else outer.addEventListener('abort', onOuterAbort, { once: true })
+
+  const cancelAt = setTimeout(() => controller.abort(), ms)
+  cancelAt.unref?.()
+
+  let rejectAt: NodeJS.Timeout | undefined
+  return Promise.race([
+    start(controller.signal),
+    new Promise<never>((_, reject) => {
+      rejectAt = setTimeout(
+        () => reject(new Error(`${label} did not settle within ${ms}ms`)),
+        ms
+      )
+      rejectAt.unref?.()
+    }),
+  ]).finally(() => {
+    clearTimeout(cancelAt)
+    if (rejectAt) clearTimeout(rejectAt)
+    outer.removeEventListener('abort', onOuterAbort)
+  })
 }
 
 // The daily feeds' staleness probe is a read-only indexed lookup, but it has
@@ -159,7 +264,7 @@ const isPollDue = (
   // behavior), so a registry addition can never accidentally go silent.
   if (periodMs == null || !Number.isFinite(periodMs) || periodMs <= 0)
     return true
-  const last = lastPollAttempt[feedId]
+  const last = dispatcher.lastAttemptAt(feedId)
   if (last == null) return true
   // Cap at half the period too, so a period shorter than one tick cannot be
   // swallowed by the tolerance and turn into "poll on every firing".
@@ -214,9 +319,11 @@ const lastStaleAlert: Record<string, number> = {}
 
 const probeDailyFeedStaleness = async (
   pg: SupabaseDirectClient,
-  feed: OracleFeedDef
+  feed: OracleFeedDef,
+  setPhase: (step: string) => void
 ) => {
   try {
+    setPhase('daily-staleness-probe')
     const row = await pg.oneOrNone<{ ts: string }>(
       `select ts from oracle_prices
        where feed_id = $1 order by ts desc limit 1`,
@@ -238,8 +345,14 @@ const probeDailyFeedStaleness = async (
   }
 }
 
-const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
+const tickOneFeed = async (
+  pg: SupabaseDirectClient,
+  feed: OracleFeedDef,
+  signal: AbortSignal,
+  setPhase: (step: string) => void
+) => {
   try {
+    setPhase('read-latest-point')
     const prevRow = await pg.oneOrNone<{ ts: string; price: number | string }>(
       `select ts, price from oracle_prices
        where feed_id = $1 order by ts desc limit 1`,
@@ -257,7 +370,14 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
       // block that finalized after its successor. Row growth is bounded by
       // the source's block cadence, not the tick rate, so shouldWrite's
       // dedupe isn't needed here.
-      const points = await feed.fetchRecent()
+      setPhase('fetchRecent')
+      const fetchRecent = feed.fetchRecent
+      const points = await withDeadline(
+        `${feed.id} fetchRecent`,
+        FETCH_DEADLINE_MS,
+        (sig: AbortSignal) => fetchRecent(sig),
+        signal
+      )
       const valid: { ts: number; price: number }[] = []
       for (const point of points) {
         const rejection = validateOraclePoint(feed, null, point)
@@ -278,13 +398,21 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
             `[oracle-feeds] ${feed.id}: rejected ambiguous batch — ${normalized.reason}`
           )
         } else {
+          setPhase('insert-points')
           await insertOraclePrices(pg, feed.id, normalized.points)
           const newest = normalized.points[normalized.points.length - 1]
           if (newest && (!latest || newest.ts > latest.ts)) latest = newest
         }
       }
     } else if (feed.fetchLatest) {
-      const point = await feed.fetchLatest()
+      setPhase('fetchLatest')
+      const fetchLatest = feed.fetchLatest
+      const point = await withDeadline(
+        `${feed.id} fetchLatest`,
+        FETCH_DEADLINE_MS,
+        (sig: AbortSignal) => fetchLatest(sig),
+        signal
+      )
       if (point) {
         const rejection = validateOraclePoint(feed, prev, point)
         if (rejection) {
@@ -294,6 +422,7 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
             ).toISOString()} — ${rejection}`
           )
         } else if (shouldWrite(feed, prev, point)) {
+          setPhase('insert-point')
           await insertOraclePrices(pg, feed.id, [point])
           latest = point
         }
@@ -327,11 +456,13 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
     // tick is seconds away and carries a better price. Every other caller
     // (hourly update-perps, the daily publishers, the admin write path) must
     // wait and apply — see OracleUpdateBounds.
+    setPhase('apply-to-perps')
     await applyOraclePointToLivePerps(
       pg,
       feed.id,
       latestPoint,
-      FAST_TICK_ORACLE_BOUNDS
+      FAST_TICK_ORACLE_BOUNDS,
+      setPhase
     )
   } catch (err) {
     log.error(`[oracle-feeds] ${feed.id}: tick failed — ${err}`)

--- a/backend/shared/src/abort-signals.ts
+++ b/backend/shared/src/abort-signals.ts
@@ -1,0 +1,38 @@
+// Combining AbortSignals, without AbortSignal.any.
+//
+// Deliberately a leaf module with no imports. Node 22 has AbortSignal.any at
+// runtime, but it is absent from the lib types this project compiles against,
+// and widening `lib` to reach one static method would change type resolution
+// for every file in the repo. This is the same contract in ten lines.
+
+/**
+ * A signal that aborts as soon as ANY of its inputs does.
+ *
+ * Undefined inputs are ignored, so a caller that has no cancellation of its own
+ * can pass one through without branching. Listeners are registered `once` and
+ * the combined signal is not retained by its inputs beyond the first abort, so
+ * this is safe to call per request on a hot path.
+ */
+export const anySignal = (
+  ...signals: (AbortSignal | undefined)[]
+): AbortSignal => {
+  const controller = new AbortController()
+  const present = signals.filter((s): s is AbortSignal => s != null)
+
+  const abort = (reason: unknown) => {
+    controller.abort(reason)
+    for (const s of present) s.removeEventListener('abort', handlers.get(s)!)
+  }
+  const handlers = new Map<AbortSignal, () => void>()
+
+  for (const s of present) {
+    if (s.aborted) {
+      controller.abort(s.reason)
+      return controller.signal
+    }
+    const handler = () => abort(s.reason)
+    handlers.set(s, handler)
+    s.addEventListener('abort', handler, { once: true })
+  }
+  return controller.signal
+}

--- a/backend/shared/src/btc-price.ts
+++ b/backend/shared/src/btc-price.ts
@@ -1,6 +1,7 @@
 import { getConsensusMedian } from 'common/perps/oracle'
 
 import { log } from './utils'
+import { anySignal } from './abort-signals'
 
 // BTC/USD spot from four independent, free, no-auth, US-accessible exchanges.
 // (Binance is deliberately absent: api.binance.com geo-blocks US IPs, which
@@ -42,10 +43,27 @@ import { log } from './utils'
 const FETCH_TIMEOUT_MS = 1_200
 const MAX_SOURCE_DIVERGENCE_FRAC = 0.02
 
-const fetchJson = async (url: string): Promise<unknown> => {
+/**
+ * Combine the caller's cancellation with this adapter's own budget.
+ *
+ * The adapter timeout stays authoritative for a slow venue. The caller's
+ * signal exists so the oracle tick can actually CANCEL a fetch it has given up
+ * waiting on — without it, a racing deadline abandons the promise while the
+ * socket stays open, and a permanently hung venue leaks one orphan per poll
+ * forever.
+ */
+const withFetchTimeout = (signal: AbortSignal | undefined) =>
+  signal
+    ? anySignal(signal, AbortSignal.timeout(FETCH_TIMEOUT_MS))
+    : AbortSignal.timeout(FETCH_TIMEOUT_MS)
+
+const fetchJson = async (
+  url: string,
+  signal?: AbortSignal
+): Promise<unknown> => {
   const res = await fetch(url, {
     headers: { 'user-agent': 'Manifold/1.0 (+https://manifold.markets)' },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    signal: withFetchTimeout(signal),
   })
   if (!res.ok) throw new Error(`${url}: ${res.status} ${res.statusText}`)
   return res.json()
@@ -93,41 +111,47 @@ const readGeminiPrice = (body: unknown) => {
 
 type BtcSource = {
   name: string
-  fetchPrice: () => Promise<number>
+  fetchPrice: (signal?: AbortSignal) => Promise<number>
 }
 
 const SOURCES: BtcSource[] = [
   {
     name: 'coinbase',
-    fetchPrice: async () => {
+    fetchPrice: async (signal) => {
       const body = await fetchJson(
-        'https://api.coinbase.com/v2/prices/BTC-USD/spot'
+        'https://api.coinbase.com/v2/prices/BTC-USD/spot',
+        signal
       )
       return readCoinbasePrice(body)
     },
   },
   {
     name: 'kraken',
-    fetchPrice: async () => {
+    fetchPrice: async (signal) => {
       const body = await fetchJson(
-        'https://api.kraken.com/0/public/Ticker?pair=XBTUSD'
+        'https://api.kraken.com/0/public/Ticker?pair=XBTUSD',
+        signal
       )
       return readKrakenPrice(body)
     },
   },
   {
     name: 'bitstamp',
-    fetchPrice: async () => {
+    fetchPrice: async (signal) => {
       const body = await fetchJson(
-        'https://www.bitstamp.net/api/v2/ticker/btcusd/'
+        'https://www.bitstamp.net/api/v2/ticker/btcusd/',
+        signal
       )
       return readBitstampPrice(body)
     },
   },
   {
     name: 'gemini',
-    fetchPrice: async () => {
-      const body = await fetchJson('https://api.gemini.com/v1/pubticker/btcusd')
+    fetchPrice: async (signal) => {
+      const body = await fetchJson(
+        'https://api.gemini.com/v1/pubticker/btcusd',
+        signal
+      )
       return readGeminiPrice(body)
     },
   },
@@ -157,13 +181,15 @@ export const getBtcConsensusPrice = (
     maxDivergenceFrac
   )
 
-export const fetchBtcUsdSpot = async (): Promise<{
+export const fetchBtcUsdSpot = async (
+  signal?: AbortSignal
+): Promise<{
   ts: number
   price: number
 } | null> => {
   const results = await Promise.allSettled(
     SOURCES.map(async (s) => {
-      const price = await s.fetchPrice()
+      const price = await s.fetchPrice(signal)
       if (!Number.isFinite(price) || price <= 0)
         throw new Error(`${s.name}: bad price ${price}`)
       return price

--- a/backend/shared/src/monitoring/metrics.ts
+++ b/backend/shared/src/monitoring/metrics.ts
@@ -46,6 +46,35 @@ export const CUSTOM_METRICS = {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',
   },
+  // Oracle poll health, per feed. The dispatcher's in-flight guard is
+  // in-process state with no external view: updateOracleFeeds returns as soon
+  // as it has dispatched, so both scheduler_info.last_end_time and the
+  // perps_oracle_tick_heartbeat dead-man stay green through a feed being
+  // completely dark. These are that view.
+  //
+  // Read them together. inflight_age alone reads 0 once a wedged feed has
+  // exhausted its budget and stopped polling — green exactly when it is
+  // darkest. last_success_age_ms is the one that cannot lie.
+  'perps/oracle_poll_inflight_age_ms': {
+    metricKind: 'GAUGE',
+    valueKind: 'int64Value',
+  },
+  'perps/oracle_poll_outstanding_abandoned': {
+    metricKind: 'GAUGE',
+    valueKind: 'int64Value',
+  },
+  'perps/oracle_poll_refused': {
+    metricKind: 'GAUGE',
+    valueKind: 'int64Value',
+  },
+  'perps/oracle_poll_last_success_age_ms': {
+    metricKind: 'GAUGE',
+    valueKind: 'int64Value',
+  },
+  'perps/oracle_poll_total_abandoned': {
+    metricKind: 'GAUGE',
+    valueKind: 'int64Value',
+  },
   'ws/redis_broadcasts_published': {
     metricKind: 'CUMULATIVE',
     valueKind: 'int64Value',

--- a/backend/shared/src/oracle-feed-dispatcher.test.ts
+++ b/backend/shared/src/oracle-feed-dispatcher.test.ts
@@ -1,0 +1,245 @@
+import { createFeedDispatcher } from './oracle-feed-dispatcher'
+
+const DEADLINE_MS = 60_000
+
+const makeLog = () => {
+  const errors: string[] = []
+  const infos: string[] = []
+  const log = Object.assign((m: string) => void infos.push(m), {
+    error: (m: string) => void errors.push(m),
+  })
+  return { log, errors, infos }
+}
+
+const makeDispatcher = (
+  over: Partial<{ perFeed: number; total: number }> = {}
+) => {
+  const { log, errors, infos } = makeLog()
+  return {
+    d: createFeedDispatcher({
+      deadlineMs: DEADLINE_MS,
+      maxAbandonedPerFeed: over.perFeed ?? 3,
+      maxAbandonedTotal: over.total ?? 10,
+      refusalLogIntervalMs: 5 * 60_000,
+      log,
+    }),
+    errors,
+    infos,
+  }
+}
+
+/** A promise that never settles, plus the signal it was handed. */
+const neverSettles = () => {
+  const signals: AbortSignal[] = []
+  const setters: ((s: string) => void)[] = []
+  const run = ({
+    signal,
+    setPhase,
+  }: {
+    signal: AbortSignal
+    setPhase: (s: string) => void
+  }) => {
+    signals.push(signal)
+    setters.push(setPhase)
+    return new Promise<void>(() => {})
+  }
+  return { run, signals, setters }
+}
+
+const makeDispatcher0 = () => {
+  const { d } = makeDispatcher()
+  return { d, setters: neverSettles() }
+}
+
+/** Let queued microtasks (the .finally chains) run. */
+const flush = () => Promise.resolve().then(() => Promise.resolve())
+
+describe('createFeedDispatcher', () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => jest.useRealTimers())
+
+  it('runs one poll at a time per feed', async () => {
+    const { d } = makeDispatcher()
+    const { run } = neverSettles()
+    d.dispatch('btc-usd', run)
+    d.dispatch('btc-usd', run)
+    d.dispatch('btc-usd', run)
+    // Two of the three were skipped by the in-flight guard, not queued.
+    expect(d.outstandingAbandoned('btc-usd')).toBe(0)
+    expect(d.inFlightSince('btc-usd')).toBeDefined()
+  })
+
+  it('cancels the run it gives up on, rather than only dropping it', async () => {
+    // The regression this guards: a plain Promise.race frees the slot but
+    // leaves the work running, so the socket is stranded with nothing holding
+    // a reference to it.
+    const { d } = makeDispatcher()
+    const { run, signals } = neverSettles()
+    d.dispatch('btc-usd', run)
+    expect(signals[0].aborted).toBe(false)
+
+    jest.advanceTimersByTime(DEADLINE_MS)
+    await flush()
+
+    expect(signals[0].aborted).toBe(true)
+  })
+
+  it('re-arms the feed after the deadline so it is not dark forever', async () => {
+    const { d } = makeDispatcher()
+    const { run } = neverSettles()
+    d.dispatch('btc-usd', run)
+    expect(d.inFlightSince('btc-usd')).toBeDefined()
+
+    jest.advanceTimersByTime(DEADLINE_MS)
+    await flush()
+
+    expect(d.inFlightSince('btc-usd')).toBeUndefined()
+  })
+
+  it('keeps outstanding work BOUNDED when the source never settles', async () => {
+    // The core safety property. Before cancellation and counting, a
+    // permanently hung venue produced one orphan per poll indefinitely — the
+    // same unbounded accumulation the guard exists to prevent, only quieter.
+    const { d, errors } = makeDispatcher({ perFeed: 3 })
+    const { run, signals } = neverSettles()
+
+    for (let i = 0; i < 50; i++) {
+      d.dispatch('btc-usd', run)
+      jest.advanceTimersByTime(DEADLINE_MS)
+      await flush()
+    }
+
+    expect(d.outstandingAbandoned('btc-usd')).toBe(3)
+    expect(signals.length).toBe(3)
+    expect(d.isRefused('btc-usd')).toBe(true)
+    expect(errors.some((e) => e.includes('refusing to poll'))).toBe(true)
+  })
+
+  it('bounds the PROCESS, not just each feed', async () => {
+    // The per-feed cap is fairness. dispatch serves every feed in the registry
+    // including the daily probes, so at 8 feeds a per-feed cap of 3 alone
+    // permits 24 orphans against a 40-connection pool.
+    const { d } = makeDispatcher({ perFeed: 3, total: 5 })
+    const { run } = neverSettles()
+    const feeds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+
+    for (let round = 0; round < 5; round++) {
+      for (const f of feeds) {
+        d.dispatch(f, run)
+        jest.advanceTimersByTime(DEADLINE_MS)
+        await flush()
+      }
+    }
+
+    expect(d.totalAbandoned()).toBeLessThanOrEqual(5)
+    // and per-feed never exceeded its own cap either
+    for (const f of feeds)
+      expect(d.outstandingAbandoned(f)).toBeLessThanOrEqual(3)
+  })
+
+  it('gives the budget back when an abandoned run settles late', async () => {
+    // Otherwise a feed that recovers on its own stays refused forever.
+    const { d, infos } = makeDispatcher({ perFeed: 1 })
+    let release!: () => void
+    const run = () => new Promise<void>((res) => (release = res))
+
+    d.dispatch('btc-usd', run)
+    jest.advanceTimersByTime(DEADLINE_MS)
+    await flush()
+    expect(d.outstandingAbandoned('btc-usd')).toBe(1)
+    expect(d.isRefused('btc-usd')).toBe(false)
+
+    d.dispatch('btc-usd', run) // refused: at the per-feed cap
+    expect(d.isRefused('btc-usd')).toBe(true)
+
+    release()
+    await flush()
+
+    expect(d.outstandingAbandoned('btc-usd')).toBe(0)
+    expect(infos.some((m) => m.includes('settled late'))).toBe(true)
+    d.dispatch('btc-usd', run) // budget returned, polling resumes
+    expect(d.isRefused('btc-usd')).toBe(false)
+  })
+
+  it('does not count a run that settles normally', async () => {
+    const { d } = makeDispatcher()
+    d.dispatch('btc-usd', async () => {})
+    await flush()
+
+    expect(d.outstandingAbandoned('btc-usd')).toBe(0)
+    expect(d.inFlightSince('btc-usd')).toBeUndefined()
+    expect(d.lastSuccessAt('btc-usd')).toBeDefined()
+  })
+
+  it('does not treat a throwing run as abandoned', async () => {
+    // tickOneFeed catches internally, but a future edit that lets one throw
+    // must not consume orphan budget — it settled, it just settled badly.
+    const { d, errors } = makeDispatcher()
+    d.dispatch('btc-usd', async () => {
+      throw new Error('boom')
+    })
+    await flush()
+
+    expect(d.outstandingAbandoned('btc-usd')).toBe(0)
+    expect(d.inFlightSince('btc-usd')).toBeUndefined()
+    expect(errors.some((e) => e.includes('unhandled'))).toBe(true)
+  })
+
+  it('reports the phase the wedged run stopped on', async () => {
+    // Both latches were diagnosed to "the promise never settled" and no
+    // further, because a tick logs nothing between dispatch and completion.
+    const { d, errors } = makeDispatcher()
+    const { run, setters } = neverSettles()
+    d.dispatch('btc-usd', run)
+    setters[0]('apply:runOracleUpdate(bitcoin-price-usd)')
+
+    jest.advanceTimersByTime(DEADLINE_MS)
+    await flush()
+
+    expect(
+      errors.some((e) => e.includes('apply:runOracleUpdate(bitcoin-price-usd)'))
+    ).toBe(true)
+  })
+
+  it('ignores a phase write from a run that no longer owns the slot', async () => {
+    // An abandoned run keeps executing; it must not relabel the feed's state.
+    const { d, setters } = makeDispatcher0()
+    d.dispatch('btc-usd', setters.run)
+    jest.advanceTimersByTime(DEADLINE_MS)
+    await flush()
+
+    setters.setters[0]('stale-write-from-the-orphan')
+    expect(d.phaseOf('btc-usd')).toBeUndefined()
+  })
+
+  it('an orphan cannot relabel the phase of the run that REPLACED it', async () => {
+    // The defect this guards: setPhase gated on slot occupancy rather than run
+    // identity, so a run abandoned at the deadline that later resumed would
+    // overwrite its successor's phase — mislabelling the wedge in exactly the
+    // multi-orphan scenario the label exists to diagnose. A wrong label is
+    // worse than the "unknown" it replaced.
+    const { d, errors } = makeDispatcher()
+    const orphan = neverSettles()
+    d.dispatch('btc-usd', orphan.run)
+
+    jest.advanceTimersByTime(DEADLINE_MS)
+    await flush()
+
+    // A replacement takes the slot and reports where IT is.
+    const live = neverSettles()
+    d.dispatch('btc-usd', live.run)
+    live.setters[0]('read-latest-point')
+
+    // The orphan resumes and tries to write its own, much later, step.
+    orphan.setters[0]('apply:runOracleUpdate(bitcoin-price-usd)')
+
+    expect(d.phaseOf('btc-usd')).toBe('read-latest-point')
+
+    jest.advanceTimersByTime(DEADLINE_MS)
+    await flush()
+
+    const live_line = errors.filter((e) => e.includes('run exceeded')).pop()!
+    expect(live_line).toContain('read-latest-point')
+    expect(live_line).not.toContain('apply:runOracleUpdate')
+  })
+})

--- a/backend/shared/src/oracle-feed-dispatcher.ts
+++ b/backend/shared/src/oracle-feed-dispatcher.ts
@@ -1,0 +1,198 @@
+// Slot management and orphan accounting for the oracle tick.
+//
+// Extracted from update-oracle-feeds so it can be tested against a
+// never-settling source, which is the one failure it exists to survive and the
+// one that cannot be reproduced through the job's own entry point.
+//
+// It lives in shared rather than beside the job for the same reason
+// oracle-tick-bounds does: the scheduler package has no test runner, and this
+// is the part of the change most worth testing. Nothing here is
+// scheduler-specific — it is slot management and orphan accounting over any
+// keyed async work.
+//
+// A factory rather than module state: the whole contract is about counters
+// that persist across calls, so tests need a fresh instance and production
+// needs exactly one.
+
+export type FeedDispatcherOptions = {
+  /** How long a run may be in flight before it is cancelled and re-armed. */
+  deadlineMs: number
+  /** Orphans on ONE feed before that feed stops polling. */
+  maxAbandonedPerFeed: number
+  /**
+   * Orphans across ALL feeds before any feed stops polling. This is the bound
+   * that protects shared resources; the per-feed one is only fairness.
+   *
+   * NOTE the ceiling is soft by one dispatch round. The check reads the count
+   * before the run starts, but the count only rises when that run's deadline
+   * fires a minute later, and the cron dispatches every due feed in one
+   * synchronous pass — so a round that starts under the cap can finish over
+   * it, by at most one orphan per feed. The reachable maximum is therefore
+   * `maxAbandonedTotal + feedCount`, not `maxAbandonedTotal`. Bounded, which
+   * is the property that matters; not exact, which it does not need to be.
+   * Making it exact would mean reserving against a count of in-flight runs and
+   * refusing polls on healthy feeds, which is a worse trade.
+   */
+  maxAbandonedTotal: number
+  log: {
+    (message: string): void
+    error: (message: string) => void
+  }
+  /** Throttle for the "refusing to poll" line. */
+  refusalLogIntervalMs: number
+}
+
+export type FeedDispatcher = ReturnType<typeof createFeedDispatcher>
+
+export const createFeedDispatcher = (opts: FeedDispatcherOptions) => {
+  /** Start time of the run currently in flight, or absent when idle. */
+  const inFlightSince: Record<string, number> = {}
+  /** Stamped before work starts, so a hang does not earn an instant retry. */
+  const lastAttemptAt: Record<string, number> = {}
+  /** Last time a run finished without having been abandoned. */
+  const lastSuccessAt: Record<string, number> = {}
+  /**
+   * Runs whose promise we stopped waiting on. They may still hold a socket, a
+   * pool connection, or memory, so this — not the count of dark feeds — is what
+   * bounds the damage.
+   *
+   * Decremented ONLY when the underlying promise actually settles. A run we
+   * cancelled that then refuses to settle is precisely the pathology the
+   * deadline exists for, and it must stay counted.
+   */
+  const outstandingAbandoned: Record<string, number> = {}
+  /** Feeds currently refusing to poll because orphans hit a ceiling. */
+  const refused: Record<string, boolean> = {}
+  /** The step each in-flight poll last STARTED, so a wedge names itself. */
+  const phase: Record<string, string> = {}
+  /**
+   * Identity of the run that currently owns each slot.
+   *
+   * Slot occupancy alone is not enough to decide who may write a phase. An
+   * abandoned run keeps executing, and if it later resumes while a REPLACEMENT
+   * run holds the slot, its phase writes would land on the replacement — so a
+   * feed wedged in `read-latest-point` could be reported as wedged in
+   * `apply:runOracleUpdate`. A wrong label is worse than the "unknown" it
+   * replaced, and it would be wrong in exactly the multi-orphan scenario the
+   * label exists to diagnose.
+   */
+  const owner: Record<string, object> = {}
+  const lastRefusalLog: Record<string, number> = {}
+
+  const totalAbandoned = () =>
+    Object.values(outstandingAbandoned).reduce((a, b) => a + b, 0)
+
+  /**
+   * Start a feed's work without blocking the cron run, at most once at a time.
+   *
+   * Skipping while in-flight is what replaces croner's `protect` at feed
+   * granularity: a source slower than its own poll period runs as often as it
+   * can finish rather than piling up overlapping fetches.
+   */
+  const dispatch = (
+    feedId: string,
+    run: (ctx: {
+      signal: AbortSignal
+      /** Bound to THIS run; a write from a superseded run is dropped. */
+      setPhase: (step: string) => void
+    }) => Promise<void>
+  ) => {
+    if (inFlightSince[feedId] != null) return
+
+    const feedOrphans = outstandingAbandoned[feedId] ?? 0
+    if (
+      feedOrphans >= opts.maxAbandonedPerFeed ||
+      totalAbandoned() >= opts.maxAbandonedTotal
+    ) {
+      // Re-arming past this point adds another orphan every tick. The feed is
+      // dark either way; say so loudly rather than quietly making the process
+      // worse. Only a restart, or the orphans settling, clears this.
+      refused[feedId] = true
+      const now = Date.now()
+      if (now - (lastRefusalLog[feedId] ?? 0) >= opts.refusalLogIntervalMs) {
+        lastRefusalLog[feedId] = now
+        opts.log.error(
+          `[oracle-feeds] ${feedId}: refusing to poll — ${feedOrphans} abandoned run(s) on this feed and ${totalAbandoned()} in the process are still unsettled. This process needs a restart.`
+        )
+      }
+      return
+    }
+    refused[feedId] = false
+
+    const startedAt = Date.now()
+    inFlightSince[feedId] = startedAt
+    lastAttemptAt[feedId] = startedAt
+    const token = {}
+    owner[feedId] = token
+    // Two conditions, not one. Identity stops a superseded run relabelling its
+    // replacement; slot occupancy stops an abandoned run resurrecting a label
+    // for a feed that currently has nothing running. Either alone leaves a way
+    // to report a phase that is not where the feed actually is.
+    const setPhase = (step: string) => {
+      if (owner[feedId] === token && inFlightSince[feedId] != null)
+        phase[feedId] = step
+    }
+
+    // A deadline that CANCELS rather than merely stops waiting. Racing a
+    // promise frees the slot but leaves the work running, so a permanently
+    // hung source would leak one orphan per poll forever — the same unbounded
+    // accumulation this guard exists to prevent, only quieter. The signal
+    // gives the work a real chance to unwind; the counter covers the case
+    // where even that does not take.
+    const controller = new AbortController()
+    let abandoned = false
+
+    const timer = setTimeout(() => {
+      abandoned = true
+      controller.abort()
+      outstandingAbandoned[feedId] = (outstandingAbandoned[feedId] ?? 0) + 1
+      opts.log.error(
+        `[oracle-feeds] ${feedId}: run exceeded ${
+          opts.deadlineMs
+        }ms in phase "${
+          phase[feedId] ?? 'unknown'
+        }"; cancelled it and re-armed the feed (${
+          outstandingAbandoned[feedId]
+        } outstanding on this feed, ${totalAbandoned()} in the process)`
+      )
+      delete inFlightSince[feedId]
+      delete phase[feedId]
+    }, opts.deadlineMs)
+    // Never hold the process open for a deadline on fire-and-forget work.
+    timer.unref?.()
+
+    void run({ signal: controller.signal, setPhase })
+      .catch((err) =>
+        opts.log.error(`[oracle-feeds] ${feedId}: unhandled — ${err}`)
+      )
+      .finally(() => {
+        clearTimeout(timer)
+        if (abandoned) {
+          // It settled after all, so whatever it held is released. Give the
+          // budget back rather than leaving the feed refusing runs forever.
+          outstandingAbandoned[feedId] = Math.max(
+            0,
+            (outstandingAbandoned[feedId] ?? 1) - 1
+          )
+          opts.log(
+            `[oracle-feeds] ${feedId}: a cancelled run settled late (${outstandingAbandoned[feedId]} still outstanding on this feed)`
+          )
+          return
+        }
+        lastSuccessAt[feedId] = Date.now()
+        delete inFlightSince[feedId]
+        delete phase[feedId]
+      })
+  }
+
+  return {
+    dispatch,
+    totalAbandoned,
+    phaseOf: (feedId: string) => phase[feedId],
+    inFlightSince: (feedId: string) => inFlightSince[feedId],
+    lastAttemptAt: (feedId: string) => lastAttemptAt[feedId],
+    lastSuccessAt: (feedId: string) => lastSuccessAt[feedId],
+    outstandingAbandoned: (feedId: string) => outstandingAbandoned[feedId] ?? 0,
+    isRefused: (feedId: string) => refused[feedId] === true,
+  }
+}

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -79,12 +79,16 @@ export type OracleFeedDef = {
    * holders too). Trade it off against the source's rate limits: poll faster
    * than the source publishes and you spend quota for no new information. */
   pollPeriodMs?: number
-  fetchLatest?: () => Promise<{ ts: number; price: number } | null>
+  fetchLatest?: (
+    signal?: AbortSignal
+  ) => Promise<{ ts: number; price: number } | null>
   /** All recently-finalized points, oldest first. Takes precedence over
    * fetchLatest in the tick: sources that publish out of order (NESO batch
    * settling) permanently lose interleaved points under a latest-only
    * sampler, so the tick upserts the whole window (idempotent on ts). */
-  fetchRecent?: () => Promise<{ ts: number; price: number }[]>
+  fetchRecent?: (
+    signal?: AbortSignal
+  ) => Promise<{ ts: number; price: number }[]>
 }
 
 export const ORACLE_FEEDS: OracleFeedDef[] = [
@@ -164,7 +168,7 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     // ticks or isPollDue rounds it down (15s would run at 14s). These adapters
     // wait on up to three venues, so round AWAY from more load, not toward it.
     pollPeriodMs: 16_000,
-    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.SPYX),
+    fetchLatest: (signal) => fetchXStockUsdPrice(XSTOCK_SPECS.SPYX, signal),
   },
   {
     id: QQQX_USD_FEED_ID,
@@ -179,7 +183,7 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     // ticks or isPollDue rounds it down (15s would run at 14s). These adapters
     // wait on up to three venues, so round AWAY from more load, not toward it.
     pollPeriodMs: 16_000,
-    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.QQQX),
+    fetchLatest: (signal) => fetchXStockUsdPrice(XSTOCK_SPECS.QQQX, signal),
   },
   {
     id: GLDX_USD_FEED_ID,
@@ -194,7 +198,7 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     // ticks or isPollDue rounds it down (15s would run at 14s). These adapters
     // wait on up to three venues, so round AWAY from more load, not toward it.
     pollPeriodMs: 16_000,
-    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.GLDX),
+    fetchLatest: (signal) => fetchXStockUsdPrice(XSTOCK_SPECS.GLDX, signal),
   },
   {
     id: NVDAX_USD_FEED_ID,
@@ -209,7 +213,7 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     // ticks or isPollDue rounds it down (15s would run at 14s). These adapters
     // wait on up to three venues, so round AWAY from more load, not toward it.
     pollPeriodMs: 16_000,
-    fetchLatest: () => fetchXStockUsdPrice(XSTOCK_SPECS.NVDAX),
+    fetchLatest: (signal) => fetchXStockUsdPrice(XSTOCK_SPECS.NVDAX, signal),
   },
   // Daily feeds use a 26h threshold (one missed daily run + slack) rather
   // than a lazy 3d: the hourly update-perps job turns feed staleness into

--- a/backend/shared/src/perps/apply-oracle-point.ts
+++ b/backend/shared/src/perps/apply-oracle-point.ts
@@ -15,18 +15,23 @@ import { SupabaseDirectClient } from 'shared/supabase/init'
 import { log } from 'shared/utils'
 
 /**
- * How far a contract's executable mark may fall behind the feed before a
- * failed apply is an incident rather than a skipped slot.
+ * Contracts we have already paged for in their current stale episode.
  *
- * Expressed as a fraction of the contract's own maxOraclePriceAgeMs so the
- * alert always lands BEFORE the market freezes at that threshold, whatever it
- * is set to. This is the signal nothing else provides: feed staleness reads
- * oracle_prices, which the publisher has already written by the time apply
- * runs, and the stuck-feed detector reads inFlightSince, which is clear
- * because the poll itself completed. Both stay green while a single contract
- * silently stops tracking the price it executes against.
+ * A failing apply pages exactly ONCE — when the mark first crosses
+ * maxOraclePriceAgeMs, the point at which assertFreshOracleForTrading freezes
+ * trading — and stays silent (WARN only) thereafter until an apply succeeds and
+ * clears the flag. So a stall that spans a minute of 2s ticks is one alert, not
+ * thirty, and "nearly stale" never pages at all: the market simply freezes and
+ * unfreezes itself, and the single alert tells an operator to check. Set
+ * maxOraclePriceAgeMs (per contract, via update-perp-config) to move the
+ * freeze/alert point — this is the only staleness signal nothing else provides,
+ * since feed staleness reads oracle_prices (already written by apply time) and
+ * the stuck-feed detector reads inFlightSince (clear once the poll completes).
+ *
+ * Module-level per scheduler process; a restart may re-arm and page once more,
+ * which is acceptable.
  */
-const APPLICATION_LAG_ALERT_FRACTION = 0.5
+const staleAlerted = new Set<string>()
 
 /**
  * Apply a newly published oracle point to every live market on its feed.
@@ -151,6 +156,14 @@ export const applyOraclePointToLivePerps = async (
       )
       if (!result) continue
 
+      // The apply landed: the mark is tracking the feed again. If we paged for
+      // a stall on this contract, note the recovery and re-arm the alert.
+      if (staleAlerted.delete(contract.id)) {
+        log.info(
+          `[oracle-feeds] ${contract.slug}: executable mark recovered and tracking ${feedId} again`
+        )
+      }
+
       // Push before notifying: notification delivery does its own DB work and
       // the whole point of this path is that open pages see the new price in
       // well under a tick. Carries only what the tick authoritatively settled
@@ -193,24 +206,34 @@ export const applyOraclePointToLivePerps = async (
         contract.oraclePriceTime == null
           ? Number.POSITIVE_INFINITY
           : Date.now() - contract.oraclePriceTime
-      const lagBudget =
-        contract.maxOraclePriceAgeMs * APPLICATION_LAG_ALERT_FRACTION
+      // Frozen = the mark has aged past the point where
+      // assertFreshOracleForTrading stops accepting trades. That, not an
+      // earlier fraction of it, is the only "broken" state worth a page.
+      const frozen = markAge >= contract.maxOraclePriceAgeMs
+      // A caller that ASKED for the tick bounds may treat their own induced
+      // 55P03/57014/40001 as expected; an unbounded caller's timeout came from
+      // somewhere it did not choose and stays a real failure.
+      const expectedSkip = bounds != null && isOracleTickTimeout(err)
 
-      // A single bounded tick giving up its slot is the design working, and
-      // the next tick is already due with a better price — that should not
-      // page. But repeated failures walk the mark toward the freshness
-      // threshold with no other alarm attached to it, so escalate on the age
-      // itself rather than on the cause. Only a caller that ASKED for these
-      // bounds may treat them as expected: an unbounded caller's 57014 came
-      // from somewhere it did not choose, and stays an error.
-      if (bounds != null && isOracleTickTimeout(err) && markAge < lagBudget) {
+      if (expectedSkip && !frozen) {
+        // A bounded tick yielding its slot while the mark is still fresh is the
+        // design working — the next tick is already due with a better price.
+        // Never pages, however many ticks the stall spans.
         log.warn(message)
-      } else if (markAge >= lagBudget) {
-        log.error(
-          `${message} — executable mark is ${markAge}ms old, past ${lagBudget}ms of its ${contract.maxOraclePriceAgeMs}ms freshness budget; this market will stop trading if it keeps failing`
-        )
+      } else if (staleAlerted.has(contract.id)) {
+        // Already paged once for this episode. Keep a log trail at WARN, but do
+        // not page again until a successful apply clears the flag above.
+        log.warn(message)
       } else {
-        log.error(message)
+        // First real failure of this episode: page exactly once. Either the
+        // market just froze, or an unexpected (non-skip) error hit it while
+        // still fresh — both warrant a look.
+        staleAlerted.add(contract.id)
+        log.error(
+          frozen
+            ? `${message} — executable mark is ${markAge}ms old, past its ${contract.maxOraclePriceAgeMs}ms freshness budget; trading is frozen until an apply succeeds`
+            : message
+        )
       }
     }
   }

--- a/backend/shared/src/perps/apply-oracle-point.ts
+++ b/backend/shared/src/perps/apply-oracle-point.ts
@@ -60,8 +60,16 @@ export const applyOraclePointToLivePerps = async (
    * which must wait for the apply rather than abandon it — see
    * OracleUpdateBounds.
    */
-  bounds?: OracleUpdateBounds
+  bounds?: OracleUpdateBounds,
+  /**
+   * Optional progress callback. The fast tick passes one so a poll that never
+   * settles can still say which step it stopped on; every other caller omits
+   * it. A callback rather than a log, so the 2s tick does not emit a line per
+   * phase per feed forever.
+   */
+  onPhase?: (phase: string) => void
 ) => {
+  const phase = (p: string) => onPhase?.(p)
   const pointRejection = validateBasicOraclePoint(point)
   if (pointRejection) {
     throw new Error(
@@ -72,6 +80,7 @@ export const applyOraclePointToLivePerps = async (
   // The database row is the published source of truth. INSERT ... DO NOTHING
   // can lose a same-timestamp race, so never execute against the caller's value
   // until it matches the immutable row that actually won.
+  phase('apply:read-stored-point')
   const stored = await pg.oneOrNone<{
     ts: string
     price: number | string
@@ -111,6 +120,7 @@ export const applyOraclePointToLivePerps = async (
       }`
     )
 
+  phase('apply:read-live-contracts')
   const rows = await pg.manyOrNone<{ data: PerpContract }>(
     `select data from contracts
      where mechanism = 'perp'
@@ -157,6 +167,7 @@ export const applyOraclePointToLivePerps = async (
     }
 
     try {
+      phase(`apply:runOracleUpdate(${contract.slug})`)
       const result = await runOracleUpdate(
         contract.id,
         persistedPoint.price,
@@ -181,6 +192,7 @@ export const applyOraclePointToLivePerps = async (
       // also move on a liquidating tick, but this scope only has the pre-tick
       // contract snapshot for them, so they stay on the polled path rather
       // than pushing a stale value over a fresh one.
+      phase(`apply:publishQuote(${contract.slug})`)
       publishPerpQuote({
         contractId: contract.id,
         oraclePrice: persistedPoint.price,
@@ -193,6 +205,7 @@ export const applyOraclePointToLivePerps = async (
       })
 
       try {
+        phase(`apply:notify(${contract.slug})`)
         await notifyPerpOracleResult(pg, contract, persistedPoint.price, result)
       } catch (err) {
         // The price transition is already committed. Notification delivery

--- a/backend/shared/src/perps/apply-oracle-point.ts
+++ b/backend/shared/src/perps/apply-oracle-point.ts
@@ -6,8 +6,10 @@ import {
 } from 'common/perps/oracle'
 import { notifyPerpOracleResult } from 'shared/notifications/perps'
 import { runOracleUpdate } from 'shared/perps/engine'
+import { getOracleFeed } from 'shared/oracle-feeds'
 import {
-  isOracleTickTimeout,
+  classifyOracleApplyFailure,
+  DEFAULT_MARK_STALE_ALERT_MS,
   OracleUpdateBounds,
 } from 'shared/perps/oracle-tick-bounds'
 import { publishPerpQuote } from 'shared/perps/publish-perp-quote'
@@ -17,21 +19,29 @@ import { log } from 'shared/utils'
 /**
  * Contracts we have already paged for in their current stale episode.
  *
- * A failing apply pages exactly ONCE — when the mark first crosses
- * maxOraclePriceAgeMs, the point at which assertFreshOracleForTrading freezes
- * trading — and stays silent (WARN only) thereafter until an apply succeeds and
- * clears the flag. So a stall that spans a minute of 2s ticks is one alert, not
- * thirty, and "nearly stale" never pages at all: the market simply freezes and
- * unfreezes itself, and the single alert tells an operator to check. Set
- * maxOraclePriceAgeMs (per contract, via update-perp-config) to move the
- * freeze/alert point — this is the only staleness signal nothing else provides,
- * since feed staleness reads oracle_prices (already written by apply time) and
- * the stuck-feed detector reads inFlightSince (clear once the poll completes).
+ * A failing apply pages exactly ONCE per episode and stays silent (WARN only)
+ * thereafter, until an apply succeeds and clears the flag. So a stall spanning
+ * a minute of 2s ticks is one alert, not thirty.
+ *
+ * The page fires when the mark goes DARK — past the feed's own staleAfterMs —
+ * NOT when the market freezes at maxOraclePriceAgeMs. Those were the same
+ * threshold until the BTC gate was tightened to ~10s; see
+ * classifyOracleApplyFailure for why they must not be. A market that pauses for
+ * a few seconds is the gate working, several times an hour, and nobody needs to
+ * hear about it; a mark that has not advanced in two minutes is broken.
+ *
+ * This is the only staleness signal nothing else provides, since feed staleness
+ * reads oracle_prices (already written by apply time) and the stuck-feed
+ * detector reads inFlightSince (clear once the poll completes).
  *
  * Module-level per scheduler process; a restart may re-arm and page once more,
  * which is acceptable.
  */
 const staleAlerted = new Set<string>()
+
+/** The feed's own incident budget; see classifyOracleApplyFailure. */
+const getMarkStaleAlertMs = (feedId: string) =>
+  getOracleFeed(feedId)?.staleAfterMs ?? DEFAULT_MARK_STALE_ALERT_MS
 
 /**
  * Apply a newly published oracle point to every live market on its feed.
@@ -206,19 +216,24 @@ export const applyOraclePointToLivePerps = async (
         contract.oraclePriceTime == null
           ? Number.POSITIVE_INFINITY
           : Date.now() - contract.oraclePriceTime
-      // Frozen = the mark has aged past the point where
-      // assertFreshOracleForTrading stops accepting trades. That, not an
-      // earlier fraction of it, is the only "broken" state worth a page.
-      const frozen = markAge >= contract.maxOraclePriceAgeMs
-      // A caller that ASKED for the tick bounds may treat their own induced
-      // 55P03/57014/40001 as expected; an unbounded caller's timeout came from
-      // somewhere it did not choose and stays a real failure.
-      const expectedSkip = bounds != null && isOracleTickTimeout(err)
+      // Dark = the mark has not advanced for the FEED's whole staleness
+      // budget. Deliberately NOT maxOraclePriceAgeMs: crossing that only
+      // pauses trading, which is the gate doing its job.
+      const markStaleAlertMs = getMarkStaleAlertMs(feedId)
+      const dark = markAge >= markStaleAlertMs
 
-      if (expectedSkip && !frozen) {
-        // A bounded tick yielding its slot while the mark is still fresh is the
-        // design working — the next tick is already due with a better price.
-        // Never pages, however many ticks the stall spans.
+      if (
+        classifyOracleApplyFailure(
+          err,
+          bounds != null,
+          markAge,
+          markStaleAlertMs
+        ) === 'warn'
+      ) {
+        // A bounded tick yielding its slot is the design working — the next
+        // tick is already due with a better price. Never pages, however many
+        // ticks the stall spans, and whether or not the market paused along
+        // the way.
         log.warn(message)
       } else if (staleAlerted.has(contract.id)) {
         // Already paged once for this episode. Keep a log trail at WARN, but do
@@ -226,12 +241,12 @@ export const applyOraclePointToLivePerps = async (
         log.warn(message)
       } else {
         // First real failure of this episode: page exactly once. Either the
-        // market just froze, or an unexpected (non-skip) error hit it while
-        // still fresh — both warrant a look.
+        // mark has gone dark, or an unexpected (non-skip) error hit it — both
+        // warrant a look.
         staleAlerted.add(contract.id)
         log.error(
-          frozen
-            ? `${message} — executable mark is ${markAge}ms old, past its ${contract.maxOraclePriceAgeMs}ms freshness budget; trading is frozen until an apply succeeds`
+          dark
+            ? `${message} — executable mark is ${markAge}ms old, past this feed's ${markStaleAlertMs}ms staleness budget; ${contract.slug} stopped accepting trades once it passed ${contract.maxOraclePriceAgeMs}ms and stays frozen until an apply succeeds`
             : message
         )
       }

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -139,6 +139,35 @@ const runPerpTransaction = <T>(
   options?: TransactionRetryOptions
 ): Promise<T> => runTransactionWithRetries(fn, maxAttempts, options)
 
+/**
+ * A trade rejected for a reason the CALLER caused is not an engine fault.
+ *
+ * transactWithRetries logs every failed attempt at ERROR unless told
+ * otherwise, so a market correctly refusing a trade bills as an incident —
+ * eight lines per request, one per attempt. The 2026-08-22 feed latch produced
+ * 1,404 ERROR lines from `Oracle feed is stale`, which is the fail-closed gate
+ * doing exactly its job; it buried the real signal and inflated every
+ * error-rate dashboard for the duration.
+ *
+ * Scoped to 4xx: a 5xx from this engine (a corrupt token, a broken escrow
+ * invariant) is a genuine fault and must stay at ERROR.
+ *
+ * A wrapper rather than an argument at each call site, because passing options
+ * makes the call three-argument, which stops prettier hugging the callback and
+ * reindents both entire function bodies — a 1,600-line diff for a behavioural
+ * change worth twenty. Deliberately NOT the default for runPerpTransaction:
+ * runFunding is system-initiated, so a 4xx there is a genuine fault.
+ */
+const isClientFaultError = (err: unknown) =>
+  err instanceof APIError && err.code >= 400 && err.code < 500
+
+const runTradeTransaction = <T>(
+  fn: (pgTrans: SupabaseTransaction) => Promise<T>
+): Promise<T> =>
+  runPerpTransaction(fn, PERP_TX_MAX_ATTEMPTS, {
+    isExpectedError: isClientFaultError,
+  })
+
 const buildState = (
   contract: PerpContract,
   positions: PerpPosition[]
@@ -500,7 +529,7 @@ export const openOrAddPosition = async (
   if (maxFee !== undefined && (!Number.isFinite(maxFee) || maxFee < 0))
     throw new APIError(400, 'maxFee must be a finite non-negative number')
 
-  return runPerpTransaction(async (pgTrans) => {
+  return runTradeTransaction(async (pgTrans) => {
     if (idempotencyKey) {
       const stored = await getIdempotentEvent(
         pgTrans,
@@ -1137,7 +1166,7 @@ export const closePosition = async (
     throw new APIError(400, 'Invalid expected PERP position opening time')
   }
 
-  return runPerpTransaction(async (pgTrans) => {
+  return runTradeTransaction(async (pgTrans) => {
     if (idempotencyKey) {
       const stored = await getIdempotentEvent(
         pgTrans,

--- a/backend/shared/src/perps/oracle-tick-bounds.test.ts
+++ b/backend/shared/src/perps/oracle-tick-bounds.test.ts
@@ -1,4 +1,5 @@
 import {
+  classifyOracleApplyFailure,
   FAST_TICK_ORACLE_BOUNDS,
   isOracleTickTimeout,
   oracleTickTimeoutsQuery,
@@ -95,5 +96,60 @@ describe('oracleTickTimeoutsQuery', () => {
         FAST_TICK_ORACLE_BOUNDS.statementTimeoutMs
       )
     ).toBe('set local lock_timeout = 1000; set local statement_timeout = 4000')
+  })
+})
+
+describe('classifyOracleApplyFailure', () => {
+  const CONTENTION = { code: '55P03' } // lock_timeout
+  const BTC_STALE_AFTER_MS = 2 * 60 * 1000
+  const bounded = true
+
+  it('does not page while a tight trading gate pauses the market', () => {
+    // The regression this exists to prevent. The alert used to fire at half
+    // the contract's maxOraclePriceAgeMs, so tightening that gate from 120s
+    // to 10s would have paged on the third consecutive contended tick —
+    // measured at ~28 times an hour on the BTC feed. Pausing trading on a
+    // 4-second-old mark IS the gate working.
+    const MARK_AGE_PAST_A_10S_GATE = 12_000
+    expect(
+      classifyOracleApplyFailure(
+        CONTENTION,
+        bounded,
+        MARK_AGE_PAST_A_10S_GATE,
+        BTC_STALE_AFTER_MS
+      )
+    ).toBe('warn')
+  })
+
+  it('pages once the mark passes the feed staleness budget', () => {
+    expect(
+      classifyOracleApplyFailure(
+        CONTENTION,
+        bounded,
+        BTC_STALE_AFTER_MS,
+        BTC_STALE_AFTER_MS
+      )
+    ).toBe('error')
+  })
+
+  it('pages immediately on a failure the tick did not induce', () => {
+    // A solvency jam or a corrupt row is an incident at any mark age; only
+    // the contention codes mean "someone else is writing, try next tick".
+    expect(
+      classifyOracleApplyFailure(
+        new Error('insolvent book'),
+        bounded,
+        0,
+        BTC_STALE_AFTER_MS
+      )
+    ).toBe('error')
+  })
+
+  it('pages when an unbounded caller hits a cancellation it never asked for', () => {
+    // update-perps and the daily publishers set no timeouts, so a 55P03 there
+    // came from somewhere else and is a real failure.
+    expect(
+      classifyOracleApplyFailure(CONTENTION, false, 0, BTC_STALE_AFTER_MS)
+    ).toBe('error')
   })
 })

--- a/backend/shared/src/perps/oracle-tick-bounds.ts
+++ b/backend/shared/src/perps/oracle-tick-bounds.ts
@@ -115,3 +115,48 @@ export const oracleTickTimeoutsQuery = (
     )
   return `set local lock_timeout = ${lock}; set local statement_timeout = ${statement}`
 }
+
+/**
+ * Incident threshold used when a feed is not in the registry. Registry feeds
+ * carry their own `staleAfterMs`; this only covers the impossible case of a
+ * contract pointing at a feed that no longer exists.
+ */
+export const DEFAULT_MARK_STALE_ALERT_MS = 2 * 60 * 1000
+
+export type OracleApplySeverity = 'warn' | 'error'
+
+/**
+ * Severity for a failed apply of an oracle point to one contract.
+ *
+ * The threshold is the FEED's staleness budget, deliberately NOT a fraction of
+ * the contract's `maxOraclePriceAgeMs`. Those two numbers answer different
+ * questions and are now an order of magnitude apart:
+ *
+ *   - `maxOraclePriceAgeMs` is a trading gate. Tightening it to ~10s is the
+ *     point of the gate — the market pauses for a few seconds rather than
+ *     letting anyone execute against a mark a latency bot already knows is
+ *     wrong. That pause is the control WORKING, several times an hour, and
+ *     must not page anyone.
+ *   - `staleAfterMs` is the incident budget: silence this long means the feed
+ *     or the engine is actually broken.
+ *
+ * Deriving the alert from the trading gate coupled them, so tightening the
+ * gate to 10s would have made every third consecutive contended tick an ERROR
+ * — pages proportional to how well the gate was doing its job.
+ *
+ * A bounded tick giving up its slot is expected: the next tick is seconds away
+ * with a better price. Anything else — a genuine engine failure, or a mark
+ * that has aged past the feed's own incident budget — is not.
+ */
+export const classifyOracleApplyFailure = (
+  err: unknown,
+  /** Whether the caller passed OracleUpdateBounds, i.e. asked for the timeouts. */
+  bounded: boolean,
+  /** Wall-clock age of the mark this contract executes against. */
+  markAgeMs: number,
+  /** The feed's `staleAfterMs`. */
+  markStaleAlertMs: number
+): OracleApplySeverity => {
+  if (markAgeMs >= markStaleAlertMs) return 'error'
+  return bounded && isOracleTickTimeout(err) ? 'warn' : 'error'
+}

--- a/backend/shared/src/xstocks-price.ts
+++ b/backend/shared/src/xstocks-price.ts
@@ -7,6 +7,7 @@ import {
 } from 'common/perps/xstocks'
 
 import { log } from './utils'
+import { anySignal } from './abort-signals'
 
 // USD prices for tokenized equities (xStocks by Backed Finance), composited
 // across the free, no-auth, US-accessible venues where the tokens actually
@@ -84,10 +85,27 @@ export const XSTOCK_SPECS = {
   },
 } as const satisfies Record<string, XStockSpec>
 
-const fetchJson = async (url: string): Promise<unknown> => {
+/**
+ * Combine the caller's cancellation with this adapter's own budget.
+ *
+ * The adapter timeout stays authoritative for a slow venue. The caller's
+ * signal exists so the oracle tick can actually CANCEL a fetch it has given up
+ * waiting on — without it, a racing deadline abandons the promise while the
+ * socket stays open, and a permanently hung venue leaks one orphan per poll
+ * forever.
+ */
+const withFetchTimeout = (signal: AbortSignal | undefined) =>
+  signal
+    ? anySignal(signal, AbortSignal.timeout(FETCH_TIMEOUT_MS))
+    : AbortSignal.timeout(FETCH_TIMEOUT_MS)
+
+const fetchJson = async (
+  url: string,
+  signal?: AbortSignal
+): Promise<unknown> => {
   const res = await fetch(url, {
     headers: { 'user-agent': 'Manifold/1.0 (+https://manifold.markets)' },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    signal: withFetchTimeout(signal),
   })
   if (!res.ok) throw new Error(`${url}: ${res.status} ${res.statusText}`)
   return res.json()
@@ -95,26 +113,30 @@ const fetchJson = async (url: string): Promise<unknown> => {
 
 type XStockSource = {
   name: string
-  fetchPrice: () => Promise<number>
+  fetchPrice: (signal?: AbortSignal) => Promise<number>
 }
 
 const buildSources = (spec: XStockSpec): XStockSource[] => {
   const sources: XStockSource[] = [
     {
       name: 'jupiter',
-      fetchPrice: async () =>
+      fetchPrice: async (signal) =>
         readJupiterRawUsdPrice(
-          await fetchJson(`https://lite-api.jup.ag/price/v3?ids=${spec.mint}`),
+          await fetchJson(
+            `https://lite-api.jup.ag/price/v3?ids=${spec.mint}`,
+            signal
+          ),
           spec.mint,
           spec.unitMode
         ),
     },
     {
       name: 'gate',
-      fetchPrice: async () =>
+      fetchPrice: async (signal) =>
         readGateTickerMid(
           await fetchJson(
-            `https://api.gateio.ws/api/v4/spot/tickers?currency_pair=${spec.gatePair}`
+            `https://api.gateio.ws/api/v4/spot/tickers?currency_pair=${spec.gatePair}`,
+            signal
           )
         ),
     },
@@ -123,10 +145,11 @@ const buildSources = (spec: XStockSpec): XStockSource[] => {
     const symbol = spec.mexcSymbol
     sources.push({
       name: 'mexc',
-      fetchPrice: async () =>
+      fetchPrice: async (signal) =>
         readMexcBookTickerMid(
           await fetchJson(
-            `https://api.mexc.com/api/v3/ticker/bookTicker?symbol=${symbol}`
+            `https://api.mexc.com/api/v3/ticker/bookTicker?symbol=${symbol}`,
+            signal
           )
         ),
     })
@@ -135,12 +158,13 @@ const buildSources = (spec: XStockSpec): XStockSource[] => {
 }
 
 export const fetchXStockUsdPrice = async (
-  spec: XStockSpec
+  spec: XStockSpec,
+  signal?: AbortSignal
 ): Promise<{ ts: number; price: number } | null> => {
   const sources = buildSources(spec)
   const results = await Promise.allSettled(
     sources.map(async (s) => {
-      const price = await s.fetchPrice()
+      const price = await s.fetchPrice(signal)
       if (!Number.isFinite(price) || price <= 0)
         throw new Error(`${s.name}: bad price ${price}`)
       return price


### PR DESCRIPTION
**Superseded by [#4052](https://github.com/manifoldmarkets/manifold/pull/4052).** The replacement carries forward bounded recovery for hung feed polls, phase diagnostics, and expected trade-rejection logging on current main. It preserves the separately merged solvency and conversion-score fixes and the current Solana price sources.

---

The `btc-usd` fast tick has wedged **three different ways** in four days. Two took the prod BTC perp offline; the third made both of them harder to see. This carries the two unpushed alert commits from `fix/perp-stale-mark-pause-alert` (rebased onto current main) because they touch the same files and the fixes are interdependent.

## What happened

| | DEV 08-21 | PROD 08-21 | PROD 08-22 |
|---|---|---|---|
| Duration | 93 min | 5m33s | **3h+** |
| `oracle_prices` | **zero writes** | healthy ~2.3s | **zero writes** |
| Mechanism | poll promise never settled | 134 consecutive lost lock acquisitions | poll promise never settled |
| Trading paused | ~93 min | 158s | **~3h** |
| Recovery | redeploy | self-recovered | redeploy |

Prod had also entered the latched state **4× in the prior 30 days** (08-18 ×2, 08-19 ×2) and happened to settle each time. On 08-22 it did not.

## 1. The in-flight guard can latch forever

`dispatch()` clears `inFlightSince` in a `.finally`, which covers every *settled* outcome and cannot cover a promise that never settles. Every subsequent tick is then skipped by the guard and the feed goes silent — while the four sibling feeds on the same process keep ticking normally.

Nothing bounded it. The scheduler runs with **no server-side `statement_timeout`** by design, `connectionTimeoutMillis` is 10s, the fetch adapters carry their own `AbortSignal` — and `query_timeout` is an hour, which the dev poll **outlived** (5242s) with no rejection ever logged.

**Fix:** a 60s dispatch deadline that re-arms the feed without the hung run. Abandoning frees the *slot*, not the *work*, so abandoned runs are counted and the feed refuses to start more past 3 rather than draining the 40-connection pool one leak per tick. A late-settling run gives its budget back.

## 2. The tick yielded to the contention it exists to clear

`FAST_TICK_ORACLE_BOUNDS` gives up after 1s with `maxAttempts: 1`, on the premise that *"another tick with a fresher price is already due."* That holds only while the mark is fresh. Trade transactions take the **same** advisory lock, are rejected **inside** it (`assertFreshOracleForTrading` runs *after* `loadStateForUpdate`), and retry **8×** — so once the mark goes stale the failure *increases* contention, and the one actor that could end the episode is the only one voluntarily yielding.

**Fix:** `oracleTickBoundsForMarkAge` escalates once the mark passes half the trading gate.

## 3. A paused market paged for its own correct behaviour

The freshness gate throws `APIError(400)`; `transactWithRetries` logs every failed attempt at ERROR. The 08-22 latch produced **1,404 ERROR lines** from `Oracle feed is stale` — fail-closed working exactly as designed, billed as an incident.

Separately, the `[oracle-feeds]` alert derived its ERROR threshold from `maxOraclePriceAgeMs`, so the benign hourly `:46` contention burst (peaks ~63–68s) crossed it every hour while the policy's 7200s rate limit meant **the real 08-21 incident paged nobody** — the 08:47 noise had consumed the window 60 minutes earlier.

**Fix:** `runTradeTransaction` marks 4xx as expected (5xx stays ERROR); the alert now keys on the *feed's* `staleAfterMs` and pages **once per episode**, clearing on a successful apply.

## Diagnosability — the part that matters most

Both latches were traced to "the promise never settled" and no further, because a tick logs nothing between dispatch and completion. Ruled out from the outside: pool exhaustion and the DB (sibling feeds wrote hundreds of points throughout; `pg_locks` empty), notifications (no liquidation/ADL at either hang), and the retry backoff (capped at 5s). That leaves a shortlist and no way to choose between its entries.

- **`inFlightPhase`** records the step each poll last *started*; the stuck-feed alert and the abandon log now report it. The next occurrence reads `in flight for 6444s in phase "apply:runOracleUpdate(bitcoin-price-usd)"` and names its own culprit.
- **`withDeadline`** bounds each fetch at 10s, far above every adapter's own budget. `Promise.allSettled` over four venues in `fetchBtcUsdSpot` never resolves if one stays pending, and an `AbortSignal` that fails to fire leaves no trace — this makes that case cost one tick and one log line.
- **`perps/oracle_poll_inflight_age_ms`** is the only external view of the guard. `updateOracleFeeds` returns after dispatching, so `scheduler_info.last_end_time` and the `perps_oracle_tick_heartbeat` dead-man both stay **green** for the whole outage — that dead-man could never have fired for any of these.

## One budget, not three knobs

First draft of this branch set the escalation and the deadline independently and they contradicted each other: escalation derived a 30s lock wait from `gate/4` and took 3 attempts (up to 90s) while the deadline abandoned at 30s — three abandonments trip the ceiling and the feed stops polling. Ordinary contention would have caused the exact outage the deadline prevents. They now live in one module with `worstCaseBoundedTickMs(bounds) < DISPATCH_DEADLINE_MS` asserted across every plausible gate, plus a test that it stays under *half* so jitter cannot start abandoning healthy runs.

```
gate     10000ms -> lock 2500ms   worst tick 19500ms   (33% of deadline)
gate    120000ms -> lock 5000ms   worst tick 27000ms   (45% of deadline)
gate  21600000ms -> lock 5000ms   worst tick 27000ms   (45% of deadline)
```

## Verification

`backend/scheduler` and `backend/api` `tsc -b` clean; 30/30 perps tests. No prod changes; the 08-22 outage was cleared by a manual redeploy before this existed.

## Notes for the reviewer

- Commits 1–2 are the alert work from `fix/perp-stale-mark-pause-alert`, unmodified apart from the rebase. That branch can be deleted once this merges.
- Deploy **API and scheduler on the same SHA**, per the standing perps rule.
- Root cause is still unnamed. This makes the wedge self-heal in 60s and makes the next one identify itself; it does not claim to have found the hung `await`.

## Still open, not in this PR

- Rejected trades take the advisory lock *before* the freshness gate rejects them, so a paused market feeds its own starvation. A cheap pre-lock read would fix it; it touches the trade path and deserves its own review.
- `fix/conversion-score-contract-row-lock` removes the dominant lock holder behind the hourly bursts and is worth landing alongside.
- BTC long capacity is exhausted (`poolLong` 168k vs `openInterestLong` 761k, `maxLeverage` still 100); the resulting `Attempt 1 of 8` retry storm is a direct contributor to the contention here.
