### PR TITLE
feat(perps): explain the fee schedule to every reader, not just admins

### DIFF
--- a/common/src/perps/fees.test.ts
+++ b/common/src/perps/fees.test.ts
@@ -11,6 +11,7 @@ import {
   perpMaxFeeFor,
   perpOpenFeeQuote,
   perpOwnContributionInputs,
+  perpFreshPositionFeeBps,
   perpSizeFeeDetails,
   PERP_FEE_SLIPPAGE_BPS,
   PERP_MAX_FEE_SHARE_OF_MARGIN,
@@ -1770,5 +1771,46 @@ describe('PERP_MAX_FEE_SHARE_OF_MARGIN', () => {
     // And the pre-fix charge it replaced, which the old bound let through.
     expect(19_488.679541 / margin).toBeLessThan(1)
     expect(19_488.679541 / margin).toBeGreaterThan(PERP_MAX_FEE_SHARE_OF_MARGIN)
+  })
+})
+
+describe('perpFreshPositionFeeBps', () => {
+  it('is base + (impact/3)·S² for a fresh position of pool-share S', () => {
+    expect(
+      perpFreshPositionFeeBps({ baseBps: 10, impact: 10, poolShare: 1 })
+    ).toBeCloseTo(10 + 10 / 3, 10)
+    expect(
+      perpFreshPositionFeeBps({ baseBps: 10, impact: 10, poolShare: 4 })
+    ).toBeCloseTo(10 + (10 / 3) * 16, 10)
+  })
+
+  it('matches the charged effective rate for the same trade at any pool depth', () => {
+    const P = 466_000
+    const S = 1.42
+    const charged = perpSizeFeeDetails({
+      notionalBefore: 0,
+      notionalAfter: S * P,
+      poolDepth: P,
+      baseBps: 10,
+      impact: 90,
+    })
+    expect(
+      perpFreshPositionFeeBps({ baseBps: 10, impact: 90, poolShare: S })
+    ).toBeCloseTo(charged.effectiveBps, 8)
+  })
+
+  it('reads as the base with no impact or a degenerate share', () => {
+    expect(
+      perpFreshPositionFeeBps({ baseBps: 10, impact: 0, poolShare: 3 })
+    ).toBeCloseTo(10, 10)
+    expect(
+      perpFreshPositionFeeBps({ baseBps: 10, impact: 10, poolShare: 0 })
+    ).toBe(10)
+    expect(
+      perpFreshPositionFeeBps({ baseBps: 10, impact: 10, poolShare: NaN })
+    ).toBe(10)
+    expect(
+      perpFreshPositionFeeBps({ baseBps: NaN, impact: 10, poolShare: 1 })
+    ).toBeCloseTo(10 / 3, 10)
   })
 })

--- a/common/src/perps/fees.test.ts
+++ b/common/src/perps/fees.test.ts
@@ -11,7 +11,6 @@ import {
   perpMaxFeeFor,
   perpOpenFeeQuote,
   perpOwnContributionInputs,
-  perpFeeScheduleSummary,
   perpFreshPositionFeeBps,
   perpSizeFeeDetails,
   PERP_FEE_SLIPPAGE_BPS,
@@ -19,7 +18,6 @@ import {
   PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_IMPACT_DEFAULT,
   PERP_TAKER_FEE_IMPACT_MAX,
-  PERP_FEE_EXAMPLE_POOL_SHARES,
   PERP_TAKER_FEE_BPS_DEFAULT,
   PERP_TAKER_FEE_BPS_MAX,
 } from './fees'
@@ -1814,88 +1812,5 @@ describe('perpFreshPositionFeeBps', () => {
     expect(
       perpFreshPositionFeeBps({ baseBps: NaN, impact: 10, poolShare: 1 })
     ).toBeCloseTo(10 / 3, 10)
-  })
-})
-
-describe('perpFeeScheduleSummary', () => {
-  // The regression this suite exists for: the size term stacks on whichever
-  // base the CHANNEL selected (engine.ts picks the base, then scales), so the
-  // web figures are simply wrong for an API-key open. The reader-facing
-  // surfaces quoted the web numbers to API traders.
-  it('stacks the size term on the API base, not the web base', () => {
-    // Live BTC / Trump-approval config at time of writing.
-    const s = perpFeeScheduleSummary({
-      takerFeeBps: 10,
-      takerFeeApiBps: 30,
-      takerFeeImpact: 10,
-    })
-    expect(s.baseBps).toBe(10)
-    expect(s.apiBps).toBe(30)
-    expect(s.apiDiffers).toBe(true)
-    expect(s.poolSizedBps).toBeCloseTo(10 + 10 / 3, 10)
-    expect(s.fourTimesPoolBps).toBeCloseTo(10 + (10 / 3) * 16, 10)
-    expect(s.apiPoolSizedBps).toBeCloseTo(30 + 10 / 3, 10)
-    expect(s.apiFourTimesPoolBps).toBeCloseTo(30 + (10 / 3) * 16, 10)
-    // The API figures must not silently equal the web ones.
-    expect(s.apiPoolSizedBps).toBeGreaterThan(s.poolSizedBps)
-    expect(s.apiFourTimesPoolBps).toBeGreaterThan(s.fourTimesPoolBps)
-  })
-
-  it('agrees with the rate the engine would charge on each channel', () => {
-    const contract = { takerFeeBps: 10, takerFeeApiBps: 30, takerFeeImpact: 90 }
-    const s = perpFeeScheduleSummary(contract)
-    for (const [isApi, expected] of [
-      [false, s.poolSizedBps],
-      [true, s.apiPoolSizedBps],
-    ] as const) {
-      const P = 466_000
-      const charged = perpSizeFeeDetails({
-        notionalBefore: 0,
-        notionalAfter: P,
-        poolDepth: P,
-        baseBps: getPerpEffectiveTakerFeeBps(contract, isApi),
-        impact: getPerpTakerFeeImpact(contract),
-      })
-      expect(expected).toBeCloseTo(charged.effectiveBps, 8)
-    }
-  })
-
-  it('reports no separate API rate when one is not configured', () => {
-    // Announcing an API rate identical to the base reads as a bug, so the
-    // surfaces gate on this rather than on "is takerFeeApiBps present".
-    const s = perpFeeScheduleSummary({ takerFeeBps: 10, takerFeeImpact: 10 })
-    expect(s.apiBps).toBe(10)
-    expect(s.apiDiffers).toBe(false)
-    expect(s.apiPoolSizedBps).toBeCloseTo(s.poolSizedBps, 10)
-    // max(base, api) — a misconfigured API rate below base never discounts.
-    const low = perpFeeScheduleSummary({ takerFeeBps: 10, takerFeeApiBps: 4 })
-    expect(low.apiBps).toBe(10)
-    expect(low.apiDiffers).toBe(false)
-  })
-
-  it('reads defaults for an unstamped contract and flags a flat schedule', () => {
-    const s = perpFeeScheduleSummary({})
-    expect(s.baseBps).toBe(PERP_TAKER_FEE_BPS_DEFAULT)
-    expect(s.impact).toBe(PERP_TAKER_FEE_IMPACT_DEFAULT)
-    expect(s.hasSizeTerm).toBe(false)
-    // With no size term every example collapses to the base.
-    expect(s.poolSizedBps).toBe(s.baseBps)
-    expect(s.fourTimesPoolBps).toBe(s.baseBps)
-  })
-
-  it('is total: corrupt config reads as the defaults rather than throwing', () => {
-    const s = perpFeeScheduleSummary({
-      takerFeeBps: NaN,
-      takerFeeApiBps: -1,
-      takerFeeImpact: 1e9,
-    })
-    expect(s.baseBps).toBe(PERP_TAKER_FEE_BPS_DEFAULT)
-    expect(s.impact).toBe(PERP_TAKER_FEE_IMPACT_DEFAULT)
-    expect(Number.isFinite(s.poolSizedBps)).toBe(true)
-    expect(Number.isFinite(s.apiFourTimesPoolBps)).toBe(true)
-  })
-
-  it('works the examples at the shares the copy actually names', () => {
-    expect(PERP_FEE_EXAMPLE_POOL_SHARES).toEqual([1, 4])
   })
 })

--- a/common/src/perps/fees.test.ts
+++ b/common/src/perps/fees.test.ts
@@ -11,6 +11,7 @@ import {
   perpMaxFeeFor,
   perpOpenFeeQuote,
   perpOwnContributionInputs,
+  perpFeeScheduleSummary,
   perpFreshPositionFeeBps,
   perpSizeFeeDetails,
   PERP_FEE_SLIPPAGE_BPS,
@@ -18,6 +19,7 @@ import {
   PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_IMPACT_DEFAULT,
   PERP_TAKER_FEE_IMPACT_MAX,
+  PERP_FEE_EXAMPLE_POOL_SHARES,
   PERP_TAKER_FEE_BPS_DEFAULT,
   PERP_TAKER_FEE_BPS_MAX,
 } from './fees'
@@ -1812,5 +1814,88 @@ describe('perpFreshPositionFeeBps', () => {
     expect(
       perpFreshPositionFeeBps({ baseBps: NaN, impact: 10, poolShare: 1 })
     ).toBeCloseTo(10 / 3, 10)
+  })
+})
+
+describe('perpFeeScheduleSummary', () => {
+  // The regression this suite exists for: the size term stacks on whichever
+  // base the CHANNEL selected (engine.ts picks the base, then scales), so the
+  // web figures are simply wrong for an API-key open. The reader-facing
+  // surfaces quoted the web numbers to API traders.
+  it('stacks the size term on the API base, not the web base', () => {
+    // Live BTC / Trump-approval config at time of writing.
+    const s = perpFeeScheduleSummary({
+      takerFeeBps: 10,
+      takerFeeApiBps: 30,
+      takerFeeImpact: 10,
+    })
+    expect(s.baseBps).toBe(10)
+    expect(s.apiBps).toBe(30)
+    expect(s.apiDiffers).toBe(true)
+    expect(s.poolSizedBps).toBeCloseTo(10 + 10 / 3, 10)
+    expect(s.fourTimesPoolBps).toBeCloseTo(10 + (10 / 3) * 16, 10)
+    expect(s.apiPoolSizedBps).toBeCloseTo(30 + 10 / 3, 10)
+    expect(s.apiFourTimesPoolBps).toBeCloseTo(30 + (10 / 3) * 16, 10)
+    // The API figures must not silently equal the web ones.
+    expect(s.apiPoolSizedBps).toBeGreaterThan(s.poolSizedBps)
+    expect(s.apiFourTimesPoolBps).toBeGreaterThan(s.fourTimesPoolBps)
+  })
+
+  it('agrees with the rate the engine would charge on each channel', () => {
+    const contract = { takerFeeBps: 10, takerFeeApiBps: 30, takerFeeImpact: 90 }
+    const s = perpFeeScheduleSummary(contract)
+    for (const [isApi, expected] of [
+      [false, s.poolSizedBps],
+      [true, s.apiPoolSizedBps],
+    ] as const) {
+      const P = 466_000
+      const charged = perpSizeFeeDetails({
+        notionalBefore: 0,
+        notionalAfter: P,
+        poolDepth: P,
+        baseBps: getPerpEffectiveTakerFeeBps(contract, isApi),
+        impact: getPerpTakerFeeImpact(contract),
+      })
+      expect(expected).toBeCloseTo(charged.effectiveBps, 8)
+    }
+  })
+
+  it('reports no separate API rate when one is not configured', () => {
+    // Announcing an API rate identical to the base reads as a bug, so the
+    // surfaces gate on this rather than on "is takerFeeApiBps present".
+    const s = perpFeeScheduleSummary({ takerFeeBps: 10, takerFeeImpact: 10 })
+    expect(s.apiBps).toBe(10)
+    expect(s.apiDiffers).toBe(false)
+    expect(s.apiPoolSizedBps).toBeCloseTo(s.poolSizedBps, 10)
+    // max(base, api) — a misconfigured API rate below base never discounts.
+    const low = perpFeeScheduleSummary({ takerFeeBps: 10, takerFeeApiBps: 4 })
+    expect(low.apiBps).toBe(10)
+    expect(low.apiDiffers).toBe(false)
+  })
+
+  it('reads defaults for an unstamped contract and flags a flat schedule', () => {
+    const s = perpFeeScheduleSummary({})
+    expect(s.baseBps).toBe(PERP_TAKER_FEE_BPS_DEFAULT)
+    expect(s.impact).toBe(PERP_TAKER_FEE_IMPACT_DEFAULT)
+    expect(s.hasSizeTerm).toBe(false)
+    // With no size term every example collapses to the base.
+    expect(s.poolSizedBps).toBe(s.baseBps)
+    expect(s.fourTimesPoolBps).toBe(s.baseBps)
+  })
+
+  it('is total: corrupt config reads as the defaults rather than throwing', () => {
+    const s = perpFeeScheduleSummary({
+      takerFeeBps: NaN,
+      takerFeeApiBps: -1,
+      takerFeeImpact: 1e9,
+    })
+    expect(s.baseBps).toBe(PERP_TAKER_FEE_BPS_DEFAULT)
+    expect(s.impact).toBe(PERP_TAKER_FEE_IMPACT_DEFAULT)
+    expect(Number.isFinite(s.poolSizedBps)).toBe(true)
+    expect(Number.isFinite(s.apiFourTimesPoolBps)).toBe(true)
+  })
+
+  it('works the examples at the shares the copy actually names', () => {
+    expect(PERP_FEE_EXAMPLE_POOL_SHARES).toEqual([1, 4])
   })
 })

--- a/common/src/perps/fees.ts
+++ b/common/src/perps/fees.ts
@@ -293,6 +293,65 @@ export const perpFreshPositionFeeBps = (args: {
   }).effectiveBps
 }
 
+/** Pool shares the reader-facing fee examples are worked at. A pool-sized
+ * entry is the intuitive unit ("as big as the market backing it"); 4x is the
+ * calibration reference the impact default was chosen against (see
+ * PERP_TAKER_FEE_IMPACT_DEFAULT). Named so the explainer, the info dialog and
+ * that comment cannot drift to different examples. */
+export const PERP_FEE_EXAMPLE_POOL_SHARES = [1, 4] as const
+
+export type PerpFeeScheduleSummary = {
+  baseBps: number // web open rate
+  apiBps: number // API-key open rate (>= base; equals base when unset)
+  /** True when the API channel actually costs more. When false, quoting the
+   * API rate separately tells the reader nothing and reads as a bug. */
+  apiDiffers: boolean
+  impact: number
+  hasSizeTerm: boolean
+  /** Effective rates for a FRESH position at each example pool share, per
+   * channel. The size term stacks on whichever base the CHANNEL selected —
+   * the engine picks the base first and then scales — so the web figures are
+   * simply wrong for an API open and both must be available to render. */
+  poolSizedBps: number
+  fourTimesPoolBps: number
+  apiPoolSizedBps: number
+  apiFourTimesPoolBps: number
+}
+
+/**
+ * A market's fee schedule reduced to the numbers a reader needs, derived in
+ * ONE place so the perp explainer and the market info dialog cannot quote the
+ * same market two different ways. Every figure routes through
+ * perpFreshPositionFeeBps -> perpSizeFeeDetails, i.e. the math the engine
+ * charges from.
+ *
+ * Total, like the getters it composes: corrupt legacy config reads as the
+ * defaults rather than throwing inside a React render.
+ */
+export const perpFeeScheduleSummary = (contract: {
+  takerFeeBps?: number
+  takerFeeApiBps?: number
+  takerFeeImpact?: number
+}): PerpFeeScheduleSummary => {
+  const baseBps = getPerpTakerFeeBps(contract)
+  const apiBps = getPerpEffectiveTakerFeeBps(contract, true)
+  const impact = getPerpTakerFeeImpact(contract)
+  const [poolShare, bigShare] = PERP_FEE_EXAMPLE_POOL_SHARES
+  const at = (b: number, share: number) =>
+    perpFreshPositionFeeBps({ baseBps: b, impact, poolShare: share })
+  return {
+    baseBps,
+    apiBps,
+    apiDiffers: apiBps > baseBps,
+    impact,
+    hasSizeTerm: impact > 0,
+    poolSizedBps: at(baseBps, poolShare),
+    fourTimesPoolBps: at(baseBps, bigShare),
+    apiPoolSizedBps: at(apiBps, poolShare),
+    apiFourTimesPoolBps: at(apiBps, bigShare),
+  }
+}
+
 /**
  * The one fee-input assembly for an exposure increase — the engine charges
  * from it and the bet panel previews from it, so the state selection can

--- a/common/src/perps/fees.ts
+++ b/common/src/perps/fees.ts
@@ -268,6 +268,32 @@ export const perpSizeFeeDetails = (args: {
 }
 
 /**
+ * Effective open-side rate, in bps of notional, for a FRESH position whose
+ * notional is `poolShare` × the external pool depth: base + (impact/3)·S².
+ * Display helper for turning the bare `takerFeeImpact` coefficient into a
+ * number a trader can read ("a pool-sized entry pays ~0.13%"). Delegates to
+ * perpSizeFeeDetails (share space is depth-invariant, so P = 1) rather than
+ * restating the formula, so the explanation can never drift from the fee
+ * actually charged. Total: degenerate inputs read as the base.
+ */
+export const perpFreshPositionFeeBps = (args: {
+  baseBps: number
+  impact: number
+  poolShare: number
+}): number => {
+  const { baseBps, impact, poolShare } = args
+  const base = Number.isFinite(baseBps) && baseBps > 0 ? baseBps : 0
+  if (!Number.isFinite(poolShare) || poolShare <= 0) return base
+  return perpSizeFeeDetails({
+    notionalBefore: 0,
+    notionalAfter: poolShare,
+    poolDepth: 1,
+    baseBps: base,
+    impact,
+  }).effectiveBps
+}
+
+/**
  * The one fee-input assembly for an exposure increase — the engine charges
  * from it and the bet panel previews from it, so the state selection can
  * never drift between them.

--- a/common/src/perps/fees.ts
+++ b/common/src/perps/fees.ts
@@ -293,65 +293,6 @@ export const perpFreshPositionFeeBps = (args: {
   }).effectiveBps
 }
 
-/** Pool shares the reader-facing fee examples are worked at. A pool-sized
- * entry is the intuitive unit ("as big as the market backing it"); 4x is the
- * calibration reference the impact default was chosen against (see
- * PERP_TAKER_FEE_IMPACT_DEFAULT). Named so the explainer, the info dialog and
- * that comment cannot drift to different examples. */
-export const PERP_FEE_EXAMPLE_POOL_SHARES = [1, 4] as const
-
-export type PerpFeeScheduleSummary = {
-  baseBps: number // web open rate
-  apiBps: number // API-key open rate (>= base; equals base when unset)
-  /** True when the API channel actually costs more. When false, quoting the
-   * API rate separately tells the reader nothing and reads as a bug. */
-  apiDiffers: boolean
-  impact: number
-  hasSizeTerm: boolean
-  /** Effective rates for a FRESH position at each example pool share, per
-   * channel. The size term stacks on whichever base the CHANNEL selected —
-   * the engine picks the base first and then scales — so the web figures are
-   * simply wrong for an API open and both must be available to render. */
-  poolSizedBps: number
-  fourTimesPoolBps: number
-  apiPoolSizedBps: number
-  apiFourTimesPoolBps: number
-}
-
-/**
- * A market's fee schedule reduced to the numbers a reader needs, derived in
- * ONE place so the perp explainer and the market info dialog cannot quote the
- * same market two different ways. Every figure routes through
- * perpFreshPositionFeeBps -> perpSizeFeeDetails, i.e. the math the engine
- * charges from.
- *
- * Total, like the getters it composes: corrupt legacy config reads as the
- * defaults rather than throwing inside a React render.
- */
-export const perpFeeScheduleSummary = (contract: {
-  takerFeeBps?: number
-  takerFeeApiBps?: number
-  takerFeeImpact?: number
-}): PerpFeeScheduleSummary => {
-  const baseBps = getPerpTakerFeeBps(contract)
-  const apiBps = getPerpEffectiveTakerFeeBps(contract, true)
-  const impact = getPerpTakerFeeImpact(contract)
-  const [poolShare, bigShare] = PERP_FEE_EXAMPLE_POOL_SHARES
-  const at = (b: number, share: number) =>
-    perpFreshPositionFeeBps({ baseBps: b, impact, poolShare: share })
-  return {
-    baseBps,
-    apiBps,
-    apiDiffers: apiBps > baseBps,
-    impact,
-    hasSizeTerm: impact > 0,
-    poolSizedBps: at(baseBps, poolShare),
-    fourTimesPoolBps: at(baseBps, bigShare),
-    apiPoolSizedBps: at(apiBps, poolShare),
-    apiFourTimesPoolBps: at(apiBps, bigShare),
-  }
-}
-
 /**
  * The one fee-input assembly for an exposure increase — the engine charges
  * from it and the bet panel previews from it, so the state selection can

--- a/common/src/perps/format.test.ts
+++ b/common/src/perps/format.test.ts
@@ -1,4 +1,15 @@
-import { formatFeePct } from './format'
+import {
+  formatFeePct,
+  perpFeeScheduleSummary,
+  PERP_FEE_EXAMPLE_POOL_SHARES,
+} from './format'
+import {
+  getPerpEffectiveTakerFeeBps,
+  getPerpTakerFeeImpact,
+  perpSizeFeeDetails,
+  PERP_TAKER_FEE_BPS_DEFAULT,
+  PERP_TAKER_FEE_IMPACT_DEFAULT,
+} from './fees'
 
 describe('formatFeePct', () => {
   it('shows two decimals below 1% and one above, so the base rate stays legible', () => {
@@ -36,5 +47,118 @@ describe('formatFeePct', () => {
   it('keeps large rates whole', () => {
     expect(formatFeePct(1500)).toBe('15%')
     expect(formatFeePct(10_000)).toBe('100%')
+  })
+})
+
+describe('perpFeeScheduleSummary', () => {
+  // The regression this suite exists for: the size term stacks on whichever
+  // base the CHANNEL selected (engine.ts picks the base, then scales), so the
+  // web figures are simply wrong for an API-key open. The reader-facing
+  // surfaces quoted the web numbers to API traders.
+  it('stacks the size term on the API base, not the web base', () => {
+    // Live BTC / Trump-approval config at time of writing.
+    const s = perpFeeScheduleSummary({
+      takerFeeBps: 10,
+      takerFeeApiBps: 30,
+      takerFeeImpact: 10,
+    })
+    expect(s.baseBps).toBe(10)
+    expect(s.apiBps).toBe(30)
+    expect(s.apiDiffers).toBe(true)
+    expect(s.poolSizedBps).toBeCloseTo(10 + 10 / 3, 10)
+    expect(s.fourTimesPoolBps).toBeCloseTo(10 + (10 / 3) * 16, 10)
+    expect(s.apiPoolSizedBps).toBeCloseTo(30 + 10 / 3, 10)
+    expect(s.apiFourTimesPoolBps).toBeCloseTo(30 + (10 / 3) * 16, 10)
+    // The API figures must not silently equal the web ones.
+    expect(s.apiPoolSizedBps).toBeGreaterThan(s.poolSizedBps)
+    expect(s.apiFourTimesPoolBps).toBeGreaterThan(s.fourTimesPoolBps)
+  })
+
+  it('agrees with the rate the engine would charge on each channel', () => {
+    const contract = { takerFeeBps: 10, takerFeeApiBps: 30, takerFeeImpact: 90 }
+    const s = perpFeeScheduleSummary(contract)
+    for (const [isApi, expected] of [
+      [false, s.poolSizedBps],
+      [true, s.apiPoolSizedBps],
+    ] as const) {
+      const P = 466_000
+      const charged = perpSizeFeeDetails({
+        notionalBefore: 0,
+        notionalAfter: P,
+        poolDepth: P,
+        baseBps: getPerpEffectiveTakerFeeBps(contract, isApi),
+        impact: getPerpTakerFeeImpact(contract),
+      })
+      expect(expected).toBeCloseTo(charged.effectiveBps, 8)
+    }
+  })
+
+  it('reports no separate API rate when one is not configured', () => {
+    // Announcing an API rate identical to the base reads as a bug, so the
+    // surfaces gate on this rather than on "is takerFeeApiBps present".
+    const s = perpFeeScheduleSummary({ takerFeeBps: 10, takerFeeImpact: 10 })
+    expect(s.apiBps).toBe(10)
+    expect(s.apiDiffers).toBe(false)
+    expect(s.apiPoolSizedBps).toBeCloseTo(s.poolSizedBps, 10)
+    // max(base, api) — a misconfigured API rate below base never discounts.
+    const low = perpFeeScheduleSummary({ takerFeeBps: 10, takerFeeApiBps: 4 })
+    expect(low.apiBps).toBe(10)
+    expect(low.apiDiffers).toBe(false)
+  })
+
+  it('reads defaults for an unstamped contract and flags a flat schedule', () => {
+    const s = perpFeeScheduleSummary({})
+    expect(s.baseBps).toBe(PERP_TAKER_FEE_BPS_DEFAULT)
+    expect(s.impact).toBe(PERP_TAKER_FEE_IMPACT_DEFAULT)
+    expect(s.hasSizeTerm).toBe(false)
+    // With no size term every example collapses to the base.
+    expect(s.poolSizedBps).toBe(s.baseBps)
+    expect(s.fourTimesPoolBps).toBe(s.baseBps)
+  })
+
+  it('is total: corrupt config reads as the defaults rather than throwing', () => {
+    const s = perpFeeScheduleSummary({
+      takerFeeBps: NaN,
+      takerFeeApiBps: -1,
+      takerFeeImpact: 1e9,
+    })
+    expect(s.baseBps).toBe(PERP_TAKER_FEE_BPS_DEFAULT)
+    expect(s.impact).toBe(PERP_TAKER_FEE_IMPACT_DEFAULT)
+    expect(Number.isFinite(s.poolSizedBps)).toBe(true)
+    expect(Number.isFinite(s.apiFourTimesPoolBps)).toBe(true)
+  })
+
+  it('works the examples at the shares the copy actually names', () => {
+    expect(PERP_FEE_EXAMPLE_POOL_SHARES).toEqual([1, 4])
+  })
+
+  it('stays silent about the API channel when the gap vanishes in formatting', () => {
+    // The regression this guards: apiDiffers compared raw bps, so base 10 vs
+    // API 10.1 — a real difference the engine charges — turned on a second
+    // sentence in which EVERY figure rendered identically to the first.
+    const s = perpFeeScheduleSummary({
+      takerFeeBps: 10,
+      takerFeeApiBps: 10.1,
+      takerFeeImpact: 10,
+    })
+    expect(s.apiBps).toBeGreaterThan(s.baseBps) // the raw gap is real
+    expect(formatFeePct(s.apiBps)).toBe(formatFeePct(s.baseBps))
+    expect(formatFeePct(s.apiPoolSizedBps)).toBe(formatFeePct(s.poolSizedBps))
+    expect(formatFeePct(s.apiFourTimesPoolBps)).toBe(
+      formatFeePct(s.fourTimesPoolBps)
+    )
+    expect(s.apiDiffers).toBe(false) // ...but there is nothing to SAY
+  })
+
+  it('speaks up as soon as one rendered figure separates', () => {
+    const s = perpFeeScheduleSummary({
+      takerFeeBps: 10,
+      takerFeeApiBps: 30,
+      takerFeeImpact: 10,
+    })
+    expect(s.apiDiffers).toBe(true)
+    expect(formatFeePct(s.apiPoolSizedBps)).not.toBe(
+      formatFeePct(s.poolSizedBps)
+    )
   })
 })

--- a/common/src/perps/format.test.ts
+++ b/common/src/perps/format.test.ts
@@ -1,0 +1,40 @@
+import { formatFeePct } from './format'
+
+describe('formatFeePct', () => {
+  it('shows two decimals below 1% and one above, so the base rate stays legible', () => {
+    expect(formatFeePct(10)).toBe('0.10%')
+    expect(formatFeePct(13.333333333333332)).toBe('0.13%')
+    expect(formatFeePct(63.33333333333333)).toBe('0.63%')
+    expect(formatFeePct(100)).toBe('1.0%')
+    expect(formatFeePct(490)).toBe('4.9%')
+  })
+
+  it('never renders a POSITIVE rate as free', () => {
+    // Reachable: takerFeeBps is z.number().min(0).max(100) with no .int(), and
+    // base 0 with impact 1 prices a pool-sized entry at 1/3 bps.
+    expect(formatFeePct(0.4)).toBe('<0.01%')
+    expect(formatFeePct(1 / 3)).toBe('<0.01%')
+    expect(formatFeePct(1e-9)).toBe('<0.01%')
+    // Only a genuinely absent fee reads as zero.
+    expect(formatFeePct(0)).toBe('0%')
+    expect(formatFeePct(-1)).toBe('0%')
+    expect(formatFeePct(NaN)).toBe('0%')
+    expect(formatFeePct(Infinity)).toBe('0%')
+  })
+
+  it('takes its cutovers on the rounded value, so the bands cannot overlap', () => {
+    // 999 bps must not print "10.0%" while 1000 bps prints "10%".
+    expect(formatFeePct(999)).toBe('10%')
+    expect(formatFeePct(1000)).toBe('10%')
+    expect(formatFeePct(994)).toBe('9.9%')
+    // Same at the 1% boundary: 99.9 bps rounds to 1.00, so it takes the
+    // one-decimal band rather than printing "1.00%" next to "1.0%".
+    expect(formatFeePct(99.9)).toBe('1.0%')
+    expect(formatFeePct(99)).toBe('0.99%')
+  })
+
+  it('keeps large rates whole', () => {
+    expect(formatFeePct(1500)).toBe('15%')
+    expect(formatFeePct(10_000)).toBe('100%')
+  })
+})

--- a/common/src/perps/format.test.ts
+++ b/common/src/perps/format.test.ts
@@ -165,6 +165,30 @@ describe('perpFeeScheduleSummary', () => {
       formatFeePct(s.fourTimesPoolBps)
     )
     expect(s.apiDiffers).toBe(false) // ...but there is nothing to SAY
+    expect(s.apiBaseDiffers).toBe(false)
+    expect(s.apiPoolSizedDiffers).toBe(false)
+    expect(s.apiSizeExamplesDiffer).toBe(false)
+  })
+
+  it('gates each slot on the pair that slot actually prints', () => {
+    // base 100 / API 101 / impact 27 separates ONLY at 4x. A surface showing
+    // just the base, or just the pool-sized pair, would repeat itself while
+    // apiDiffers is legitimately true — which is how the info dialog's
+    // compact row shipped "~1.1% web / ~1.1% API".
+    const s = perpFeeScheduleSummary({
+      takerFeeBps: 100,
+      takerFeeApiBps: 101,
+      takerFeeImpact: 27,
+    })
+    expect(formatFeePct(s.baseBps)).toBe(formatFeePct(s.apiBps))
+    expect(formatFeePct(s.poolSizedBps)).toBe(formatFeePct(s.apiPoolSizedBps))
+    expect(formatFeePct(s.fourTimesPoolBps)).not.toBe(
+      formatFeePct(s.apiFourTimesPoolBps)
+    )
+    expect(s.apiBaseDiffers).toBe(false)
+    expect(s.apiPoolSizedDiffers).toBe(false)
+    expect(s.apiSizeExamplesDiffer).toBe(true) // the 4x pair carries it
+    expect(s.apiDiffers).toBe(true)
   })
 
   it('speaks up as soon as one rendered figure separates', () => {
@@ -174,8 +198,30 @@ describe('perpFeeScheduleSummary', () => {
       takerFeeImpact: 10,
     })
     expect(s.apiDiffers).toBe(true)
+    expect(s.apiBaseDiffers).toBe(true)
+    expect(s.apiPoolSizedDiffers).toBe(true)
+    expect(s.apiSizeExamplesDiffer).toBe(true)
     expect(formatFeePct(s.apiPoolSizedBps)).not.toBe(
       formatFeePct(s.poolSizedBps)
     )
+  })
+
+  it('carries the API rate into a summary built from a save response', () => {
+    // The impact-save toast built its summary WITHOUT takerFeeApiBps, so the
+    // helper read apiBps = base and the toast quoted the web figure as if it
+    // applied to everyone.
+    const withApi = perpFeeScheduleSummary({
+      takerFeeBps: 10,
+      takerFeeApiBps: 30,
+      takerFeeImpact: 10,
+    })
+    const withoutApi = perpFeeScheduleSummary({
+      takerFeeBps: 10,
+      takerFeeImpact: 10,
+    })
+    expect(formatFeePct(withApi.apiPoolSizedBps)).toBe('0.33%')
+    expect(formatFeePct(withoutApi.apiPoolSizedBps)).toBe('0.13%')
+    expect(withApi.apiPoolSizedDiffers).toBe(true)
+    expect(withoutApi.apiPoolSizedDiffers).toBe(false)
   })
 })

--- a/common/src/perps/format.test.ts
+++ b/common/src/perps/format.test.ts
@@ -1,5 +1,6 @@
 import {
   formatFeePct,
+  formatFeePctApprox,
   perpFeeScheduleSummary,
   PERP_FEE_EXAMPLE_POOL_SHARES,
 } from './format'
@@ -47,6 +48,22 @@ describe('formatFeePct', () => {
   it('keeps large rates whole', () => {
     expect(formatFeePct(1500)).toBe('15%')
     expect(formatFeePct(10_000)).toBe('100%')
+  })
+})
+
+describe('formatFeePctApprox', () => {
+  it('marks a normal figure as approximate', () => {
+    expect(formatFeePctApprox(13.333333333333332)).toBe('~0.13%')
+    expect(formatFeePctApprox(490)).toBe('~4.9%')
+    expect(formatFeePctApprox(0)).toBe('~0%')
+  })
+
+  it('never doubles the hedge on an inequality', () => {
+    // The bug: callers wrote `~${formatFeePct(x)}` and got "~<0.01%".
+    expect(formatFeePct(1 / 3)).toBe('<0.01%')
+    expect(formatFeePctApprox(1 / 3)).toBe('<0.01%')
+    expect(formatFeePctApprox(0.4)).toBe('<0.01%')
+    expect(formatFeePctApprox(1 / 3)).not.toContain('~')
   })
 })
 

--- a/common/src/perps/format.ts
+++ b/common/src/perps/format.ts
@@ -40,3 +40,15 @@ export const formatCountdown = (ms: number): string => {
   if (ms < 2 * HOUR) return `${Math.max(1, Math.ceil(ms / MINUTE))}m`
   return `${Math.round(ms / HOUR)}h`
 }
+
+// Fees display as PERCENTAGES — traders don't think in bps. Two decimals
+// below 1% keep the base (0.10%) and a small size term legible; larger fees
+// don't need the precision. Shared by the bet panel's quote, the market info
+// dialog, and the perp explainer so one fee never reads two ways.
+export const formatFeePct = (bps: number) => {
+  if (!Number.isFinite(bps) || bps <= 0) return '0%'
+  const pct = bps / 100
+  return `${
+    pct < 1 ? pct.toFixed(2) : pct < 10 ? pct.toFixed(1) : Math.round(pct)
+  }%`
+}

--- a/common/src/perps/format.ts
+++ b/common/src/perps/format.ts
@@ -45,10 +45,20 @@ export const formatCountdown = (ms: number): string => {
 // below 1% keep the base (0.10%) and a small size term legible; larger fees
 // don't need the precision. Shared by the bet panel's quote, the market info
 // dialog, and the perp explainer so one fee never reads two ways.
+//
+// A positive rate NEVER renders as "0%". Two decimals bottom out at 0.5 bps,
+// and a fee schedule is exactly the place a reader must not be told that
+// something costing money is free — sub-0.01% reads as "<0.01%" instead.
+// (Reachable: takerFeeBps is z.number().min(0).max(100) with no .int(), and
+// a base of 0 with a small impact term prices a pool-sized entry at 0.33 bps.)
+//
+// The 1%/10% cutovers are taken on the ROUNDED value, so 9.99% cannot print
+// as "10.0%" while 10.05% prints as "10%".
 export const formatFeePct = (bps: number) => {
   if (!Number.isFinite(bps) || bps <= 0) return '0%'
   const pct = bps / 100
-  return `${
-    pct < 1 ? pct.toFixed(2) : pct < 10 ? pct.toFixed(1) : Math.round(pct)
-  }%`
+  if (pct < 0.005) return '<0.01%'
+  if (Number(pct.toFixed(2)) < 1) return `${pct.toFixed(2)}%`
+  if (Number(pct.toFixed(1)) < 10) return `${pct.toFixed(1)}%`
+  return `${Math.round(pct)}%`
 }

--- a/common/src/perps/format.ts
+++ b/common/src/perps/format.ts
@@ -1,3 +1,10 @@
+import {
+  getPerpEffectiveTakerFeeBps,
+  getPerpTakerFeeBps,
+  getPerpTakerFeeImpact,
+  perpFreshPositionFeeBps,
+} from './fees'
+
 // Infer how many decimal places to show for an oracle-price-style value.
 // Heuristic: if every sample is integer-valued, show 0 decimals; otherwise
 // scale decimals to the value's magnitude so big prices don't look like
@@ -61,4 +68,80 @@ export const formatFeePct = (bps: number) => {
   if (Number(pct.toFixed(2)) < 1) return `${pct.toFixed(2)}%`
   if (Number(pct.toFixed(1)) < 10) return `${pct.toFixed(1)}%`
   return `${Math.round(pct)}%`
+}
+
+/** Pool shares the reader-facing fee examples are worked at. A pool-sized
+ * entry is the intuitive unit ("as big as the market backing it"); 4x is the
+ * calibration reference the impact default was chosen against (see
+ * PERP_TAKER_FEE_IMPACT_DEFAULT). Named so the explainer, the info dialog and
+ * that comment cannot drift to different examples. */
+export const PERP_FEE_EXAMPLE_POOL_SHARES = [1, 4] as const
+
+export type PerpFeeScheduleSummary = {
+  baseBps: number // web open rate
+  apiBps: number // API-key open rate (>= base; equals base when unset)
+  /** Whether the API channel is worth a sentence of its own — true only when
+   * it costs more AND that difference SURVIVES formatting. Comparing raw bps
+   * is not enough: base 10 vs API 10.1 is a real difference the engine
+   * charges, but every figure it produces renders identically at display
+   * precision, so saying it twice reads as a bug rather than as information.
+   * Gated here, not at each call site, so all surfaces agree on when to
+   * speak. */
+  apiDiffers: boolean
+  impact: number
+  hasSizeTerm: boolean
+  /** Effective rates for a FRESH position at each example pool share, per
+   * channel. The size term stacks on whichever base the CHANNEL selected —
+   * the engine picks the base first and then scales — so the web figures are
+   * simply wrong for an API open and both must be available to render. */
+  poolSizedBps: number
+  fourTimesPoolBps: number
+  apiPoolSizedBps: number
+  apiFourTimesPoolBps: number
+}
+
+/**
+ * A market's fee schedule reduced to the numbers a reader needs, derived in
+ * ONE place so the perp explainer and the market info dialog cannot quote the
+ * same market two different ways. Every figure routes through
+ * perpFreshPositionFeeBps -> perpSizeFeeDetails, i.e. the math the engine
+ * charges from.
+ *
+ * Lives here rather than in fees.ts because it is a DISPLAY reduction — it
+ * has to know how its numbers will be rendered (see apiDiffers) — and fees.ts
+ * is on the engine's import path, which should not pull in a formatter.
+ *
+ * Total, like the getters it composes: corrupt legacy config reads as the
+ * defaults rather than throwing inside a React render.
+ */
+export const perpFeeScheduleSummary = (contract: {
+  takerFeeBps?: number
+  takerFeeApiBps?: number
+  takerFeeImpact?: number
+}): PerpFeeScheduleSummary => {
+  const baseBps = getPerpTakerFeeBps(contract)
+  const apiBps = getPerpEffectiveTakerFeeBps(contract, true)
+  const impact = getPerpTakerFeeImpact(contract)
+  const [poolShare, bigShare] = PERP_FEE_EXAMPLE_POOL_SHARES
+  const at = (b: number, share: number) =>
+    perpFreshPositionFeeBps({ baseBps: b, impact, poolShare: share })
+  const poolSizedBps = at(baseBps, poolShare)
+  const fourTimesPoolBps = at(baseBps, bigShare)
+  const apiPoolSizedBps = at(apiBps, poolShare)
+  const apiFourTimesPoolBps = at(apiBps, bigShare)
+  const rendersIdentically =
+    formatFeePct(baseBps) === formatFeePct(apiBps) &&
+    formatFeePct(poolSizedBps) === formatFeePct(apiPoolSizedBps) &&
+    formatFeePct(fourTimesPoolBps) === formatFeePct(apiFourTimesPoolBps)
+  return {
+    baseBps,
+    apiBps,
+    apiDiffers: apiBps > baseBps && !rendersIdentically,
+    impact,
+    hasSizeTerm: impact > 0,
+    poolSizedBps,
+    fourTimesPoolBps,
+    apiPoolSizedBps,
+    apiFourTimesPoolBps,
+  }
 }

--- a/common/src/perps/format.ts
+++ b/common/src/perps/format.ts
@@ -92,14 +92,19 @@ export const PERP_FEE_EXAMPLE_POOL_SHARES = [1, 4] as const
 export type PerpFeeScheduleSummary = {
   baseBps: number // web open rate
   apiBps: number // API-key open rate (>= base; equals base when unset)
-  /** Whether the API channel is worth a sentence of its own — true only when
-   * it costs more AND that difference SURVIVES formatting. Comparing raw bps
-   * is not enough: base 10 vs API 10.1 is a real difference the engine
-   * charges, but every figure it produces renders identically at display
-   * precision, so saying it twice reads as a bug rather than as information.
-   * Gated here, not at each call site, so all surfaces agree on when to
-   * speak. */
+  /** Is the API channel worth mentioning AT ALL — it costs more AND that
+   * shows up somewhere once formatted. Comparing raw bps is not enough: base
+   * 10 vs API 10.1 is a real difference the engine charges, but every figure
+   * it produces renders identically, so saying it twice reads as a bug. */
   apiDiffers: boolean
+  /** Per-SLOT versions of the same question. A surface must gate on the pair
+   * it actually prints, not on `apiDiffers`: base 100 / API 101 / impact 27
+   * separates only at 4x, so a row showing just the base ("1.0% vs 1.0%") or
+   * just the pool-sized pair ("~1.1% vs ~1.1%") would repeat itself while
+   * `apiDiffers` is legitimately true. */
+  apiBaseDiffers: boolean
+  apiPoolSizedDiffers: boolean
+  apiSizeExamplesDiffer: boolean
   impact: number
   hasSizeTerm: boolean
   /** Effective rates for a FRESH position at each example pool share, per
@@ -141,14 +146,20 @@ export const perpFeeScheduleSummary = (contract: {
   const fourTimesPoolBps = at(baseBps, bigShare)
   const apiPoolSizedBps = at(apiBps, poolShare)
   const apiFourTimesPoolBps = at(apiBps, bigShare)
-  const rendersIdentically =
-    formatFeePct(baseBps) === formatFeePct(apiBps) &&
-    formatFeePct(poolSizedBps) === formatFeePct(apiPoolSizedBps) &&
-    formatFeePct(fourTimesPoolBps) === formatFeePct(apiFourTimesPoolBps)
+  const costsMore = apiBps > baseBps
+  const separates = (a: number, b: number) =>
+    costsMore && formatFeePct(a) !== formatFeePct(b)
+  const apiBaseDiffers = separates(baseBps, apiBps)
+  const apiPoolSizedDiffers = separates(poolSizedBps, apiPoolSizedBps)
+  const apiFourTimesDiffers = separates(fourTimesPoolBps, apiFourTimesPoolBps)
+  const apiSizeExamplesDiffer = apiPoolSizedDiffers || apiFourTimesDiffers
   return {
     baseBps,
     apiBps,
-    apiDiffers: apiBps > baseBps && !rendersIdentically,
+    apiDiffers: apiBaseDiffers || apiSizeExamplesDiffer,
+    apiBaseDiffers,
+    apiPoolSizedDiffers,
+    apiSizeExamplesDiffer,
     impact,
     hasSizeTerm: impact > 0,
     poolSizedBps,

--- a/common/src/perps/format.ts
+++ b/common/src/perps/format.ts
@@ -70,6 +70,18 @@ export const formatFeePct = (bps: number) => {
   return `${Math.round(pct)}%`
 }
 
+/**
+ * formatFeePct for a slot that wants to mark the figure as approximate.
+ * formatFeePct already returns an INEQUALITY below display precision
+ * ("<0.01%"), which states its own imprecision — prefixing "~" there produced
+ * the malformed "~<0.01%". Callers use this instead of writing the tilde (or
+ * the word "about") themselves, so no surface has to remember the case.
+ */
+export const formatFeePctApprox = (bps: number) => {
+  const pct = formatFeePct(bps)
+  return pct.startsWith('<') ? pct : `~${pct}`
+}
+
 /** Pool shares the reader-facing fee examples are worked at. A pool-sized
  * entry is the intuitive unit ("as big as the market backing it"); 4x is the
  * calibration reference the impact default was chosen against (see

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -14,6 +14,7 @@ import {
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeBps,
   getPerpTakerFeeImpact,
+  perpFreshPositionFeeBps,
   PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_IMPACT_MAX,
 } from 'common/perps/fees'
@@ -23,7 +24,11 @@ import {
   getFundingPeriodMs,
   getPerpFundingRate,
 } from 'common/perps/funding'
-import { formatPrice, inferPriceDecimals } from 'common/perps/format'
+import {
+  formatFeePct,
+  formatPrice,
+  inferPriceDecimals,
+} from 'common/perps/format'
 import { UNRANKED_GROUP_ID } from 'common/supabase/groups'
 import { BETTORS, User } from 'common/user'
 import { formatWithCommas } from 'common/util/format'
@@ -596,6 +601,25 @@ function PerpStatsRows(props: { contract: PerpContract }) {
   const { contract } = props
   const isAdmin = useAdmin()
   const canEdit = isAdmin && !contract.isResolved
+  // Fee settings are admin-edited but reader-visible: every row below renders
+  // read-only for non-admins, and the size-impact coefficient is translated
+  // into what a pool-sized entry actually pays so the number means something.
+  const takerFeeBps = getPerpTakerFeeBps(contract)
+  const takerFeeImpact = getPerpTakerFeeImpact(contract)
+  const poolSizedFee = formatFeePct(
+    perpFreshPositionFeeBps({
+      baseBps: takerFeeBps,
+      impact: takerFeeImpact,
+      poolShare: 1,
+    })
+  )
+  const fourTimesPoolFee = formatFeePct(
+    perpFreshPositionFeeBps({
+      baseBps: takerFeeBps,
+      impact: takerFeeImpact,
+      poolShare: 4,
+    })
+  )
   const price =
     contract.resolution === 'MKT'
       ? Number(contract.resolvedOraclePrice ?? contract.oraclePrice)
@@ -669,14 +693,14 @@ function PerpStatsRows(props: { contract: PerpContract }) {
       <tr className={clsx(canEdit && 'bg-purple-500/30')}>
         <td>
           Taker fee{' '}
-          <InfoTooltip text="Fee on notional charged when opening a position (closing is free), paid into this market's backing pool. Prices out oracle-tick sniping." />
+          <InfoTooltip text="Charged on a position's notional (margin × leverage) when it is opened or added to; closing is free, so this is the whole round-trip cost. Paid into this market's backing pool, not to Manifold. Exists to price out oracle-tick sniping." />
         </td>
         <td>
           {canEdit ? (
             <TakerFeeBpsInput contract={contract} />
           ) : (
             <span className="tabular-nums">
-              {(getPerpTakerFeeBps(contract) / 100).toFixed(2)}% to open
+              {formatFeePct(takerFeeBps)} to open
             </span>
           )}
         </td>
@@ -684,15 +708,15 @@ function PerpStatsRows(props: { contract: PerpContract }) {
       <tr className={clsx(canEdit && 'bg-purple-500/30')}>
         <td>
           API taker fee{' '}
-          <InfoTooltip text="Opens authenticated with an API key pay the higher of this and the web taker fee. Prices bot flow without taxing the web majority. Closing is free on both channels." />
+          <InfoTooltip text="Rate for positions opened through the API (bots). API opens pay the higher of this and the web taker fee, so automated flow is priced without taxing manual traders. Closing is free on both channels." />
         </td>
         <td>
           {canEdit ? (
             <TakerFeeApiBpsInput contract={contract} />
           ) : (
             <span className="tabular-nums">
-              {(getPerpEffectiveTakerFeeBps(contract, true) / 100).toFixed(2)}%
-              to open
+              {formatFeePct(getPerpEffectiveTakerFeeBps(contract, true))} to
+              open
             </span>
           )}
         </td>
@@ -700,14 +724,27 @@ function PerpStatsRows(props: { contract: PerpContract }) {
       <tr className={clsx(canEdit && 'bg-purple-500/30')}>
         <td>
           Fee size impact{' '}
-          <InfoTooltip text="Size coefficient of the taker fee: the marginal rate at pool-share s is base + impact·s² bps, so a fresh position that is share S of the pool pays base + (impact/3)·S² bps on average. 0 = flat base fee only. Small trades pay ~base regardless of the impact." />
+          <InfoTooltip
+            text={
+              takerFeeImpact > 0
+                ? `Positions that are large relative to this market's backing pool pay a higher opening fee, like price impact on an exchange. Small positions pay just the base taker fee; a position the size of the whole pool pays about ${poolSizedFee}, and one four times the pool about ${fourTimesPoolFee}. The exact fee is quoted before you confirm. (Marginal rate at pool-share s is base + impact·s² bps; a fresh position of share S averages base + impact/3·S².)`
+                : 'Size coefficient of the taker fee. At 0 the fee is flat: every position pays the base taker fee regardless of how large it is relative to the backing pool. When set above 0, positions large relative to the pool pay more (marginal rate at pool-share s is base + impact·s² bps).'
+            }
+          />
         </td>
         <td>
           {canEdit ? (
             <TakerFeeImpactInput contract={contract} />
           ) : (
             <span className="tabular-nums">
-              {formatWithCommas(getPerpTakerFeeImpact(contract))}
+              {formatWithCommas(takerFeeImpact)}
+              <span className="text-ink-500 text-xs">
+                {' '}
+                ·{' '}
+                {takerFeeImpact > 0
+                  ? `pool-sized entry pays ~${poolSizedFee}`
+                  : 'flat fee, size does not matter'}
+              </span>
             </span>
           )}
         </td>

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -620,15 +620,16 @@ function PerpStatsRows(props: { contract: PerpContract }) {
   const fees = perpFeeScheduleSummary(contract)
   const takerFeeBps = fees.baseBps
   const takerFeeImpact = fees.impact
-  const poolSizedFee = formatFeePct(fees.poolSizedBps)
-  const fourTimesPoolFee = formatFeePct(fees.fourTimesPoolBps)
   const apiPoolSizedFee = formatFeePct(fees.apiPoolSizedBps)
   const apiFourTimesPoolFee = formatFeePct(fees.apiFourTimesPoolBps)
+  // Approx forms wherever the copy hedges: formatFeePct returns "<0.01%"
+  // below display precision, and "about <0.01%" / "~<0.01%" doubles it.
   const poolSizedApprox = formatFeePctApprox(fees.poolSizedBps)
+  const fourTimesPoolApprox = formatFeePctApprox(fees.fourTimesPoolBps)
   const apiPoolSizedApprox = formatFeePctApprox(fees.apiPoolSizedBps)
   // The size term stacks on whichever base the CHANNEL selected, so the web
   // figures understate an API-key open whenever the API rate is higher.
-  const apiSizeNote = fees.apiDiffers
+  const apiSizeNote = fees.apiSizeExamplesDiffer
     ? ` Through the API those are ${apiPoolSizedFee} and ${apiFourTimesPoolFee}.`
     : ''
   const price =
@@ -737,7 +738,7 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           <InfoTooltip
             text={
               takerFeeImpact > 0
-                ? `Positions that are large relative to this market's backing pool pay a higher opening fee, like price impact on an exchange. Small positions pay just the base taker fee; a position the size of the whole pool pays about ${poolSizedFee}, and one four times the pool about ${fourTimesPoolFee}.${apiSizeNote} The exact fee is quoted before you confirm. (Marginal rate at pool-share s is base + impact·s² bps; a fresh position of share S averages base + impact/3·S².)`
+                ? `Positions that are large relative to this market's backing pool pay a higher opening fee, like price impact on an exchange. Small positions pay just the base taker fee; a position the size of the whole pool pays ${poolSizedApprox}, and one four times the pool ${fourTimesPoolApprox}.${apiSizeNote} The exact fee is quoted before you confirm. (Marginal rate at pool-share s is base + impact·s² bps; a fresh position of share S averages base + impact/3·S².)`
                 : 'Size coefficient of the taker fee. At 0 the fee is flat: every position pays the base taker fee regardless of how large it is relative to the backing pool. When set above 0, positions large relative to the pool pay more (marginal rate at pool-share s is base + impact·s² bps).'
             }
           />
@@ -755,7 +756,7 @@ function PerpStatsRows(props: { contract: PerpContract }) {
                 {' '}
                 ·{' '}
                 {takerFeeImpact > 0
-                  ? fees.apiDiffers
+                  ? fees.apiPoolSizedDiffers
                     ? `pool-sized: ${poolSizedApprox} web / ${apiPoolSizedApprox} API`
                     : `pool-sized entry pays ${poolSizedApprox}`
                   : 'flat fee, size does not matter'}
@@ -1164,17 +1165,26 @@ function TakerFeeImpactInput(props: { contract: PerpContract }) {
       // have just been edited in the sibling input.
       // Read the shared summary rather than restating base + impact/3 here:
       // duplicated market math is exactly how the two reader surfaces drifted.
-      const { poolSizedBps } = perpFeeScheduleSummary({
+      const saved = perpFeeScheduleSummary({
         takerFeeBps: res.takerFeeBps,
+        // Without this the summary reads apiBps = base and the toast quotes
+        // the WEB figure as if it applied to everyone — at base 10 / API 30 /
+        // impact 10 it said 0.13% when an API open pays 0.33%.
+        takerFeeApiBps: res.takerFeeApiBps ?? undefined,
         takerFeeImpact: res.takerFeeImpact,
       })
+      // Gated on the pool-sized pair specifically: that is the only pair this
+      // sentence shows.
+      const apiPart = saved.apiPoolSizedDiffers
+        ? ` on the web, ${formatFeePct(saved.apiPoolSizedBps)} via API`
+        : ''
       toast.success(
         res.takerFeeImpact > 0
           ? `Fee size impact is now ${
               res.takerFeeImpact
             } — a pool-sized position pays ${formatFeePct(
-              poolSizedBps
-            )} effective`
+              saved.poolSizedBps
+            )} effective${apiPart}`
           : 'Fee size impact is off — the taker fee is flat at the base'
       )
     } catch (err) {

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -25,6 +25,7 @@ import {
 } from 'common/perps/funding'
 import {
   formatFeePct,
+  formatFeePctApprox,
   formatPrice,
   inferPriceDecimals,
   perpFeeScheduleSummary,
@@ -623,6 +624,8 @@ function PerpStatsRows(props: { contract: PerpContract }) {
   const fourTimesPoolFee = formatFeePct(fees.fourTimesPoolBps)
   const apiPoolSizedFee = formatFeePct(fees.apiPoolSizedBps)
   const apiFourTimesPoolFee = formatFeePct(fees.apiFourTimesPoolBps)
+  const poolSizedApprox = formatFeePctApprox(fees.poolSizedBps)
+  const apiPoolSizedApprox = formatFeePctApprox(fees.apiPoolSizedBps)
   // The size term stacks on whichever base the CHANNEL selected, so the web
   // figures understate an API-key open whenever the API rate is higher.
   const apiSizeNote = fees.apiDiffers
@@ -753,8 +756,8 @@ function PerpStatsRows(props: { contract: PerpContract }) {
                 ·{' '}
                 {takerFeeImpact > 0
                   ? fees.apiDiffers
-                    ? `pool-sized: ~${poolSizedFee} web / ~${apiPoolSizedFee} API`
-                    : `pool-sized entry pays ~${poolSizedFee}`
+                    ? `pool-sized: ${poolSizedApprox} web / ${apiPoolSizedApprox} API`
+                    : `pool-sized entry pays ${poolSizedApprox}`
                   : 'flat fee, size does not matter'}
               </span>
             </span>
@@ -986,9 +989,9 @@ function TakerFeeBpsInput(props: { contract: PerpContract }) {
       setJustSaved(res.takerFeeBps)
       setInput('')
       toast.success(
-        `Taker fee is now ${res.takerFeeBps} bps (${(
-          res.takerFeeBps / 100
-        ).toFixed(2)}%) to open`
+        `Taker fee is now ${res.takerFeeBps} bps (${formatFeePct(
+          res.takerFeeBps
+        )}) to open`
       )
     } catch (err) {
       toast.error(
@@ -1002,7 +1005,7 @@ function TakerFeeBpsInput(props: { contract: PerpContract }) {
   return (
     <Row className="flex-wrap items-center gap-1.5">
       <span className="tabular-nums">
-        {current} bps ({(current / 100).toFixed(2)}%)
+        {current} bps ({formatFeePct(current)})
       </span>
       <input
         type="number"
@@ -1065,9 +1068,9 @@ function TakerFeeApiBpsInput(props: { contract: PerpContract }) {
       setInput('')
       toast.success(
         res.effectiveTakerFeeApiBps === parsed
-          ? `API taker fee is now ${parsed} bps (${(parsed / 100).toFixed(
-              2
-            )}%) to open`
+          ? `API taker fee is now ${parsed} bps (${formatFeePct(
+              parsed
+            )}) to open`
           : `Set to ${parsed} bps, but the ${base} bps web base is higher — API opens still pay ${res.effectiveTakerFeeApiBps} bps`
       )
     } catch (err) {
@@ -1082,7 +1085,7 @@ function TakerFeeApiBpsInput(props: { contract: PerpContract }) {
   return (
     <Row className="flex-wrap items-center gap-1.5">
       <span className="tabular-nums">
-        {current} bps ({(current / 100).toFixed(2)}%)
+        {current} bps ({formatFeePct(current)})
       </span>
       {contract.takerFeeApiBps === undefined && (
         <span className="text-ink-500 text-xs">(unset — pays web base)</span>
@@ -1159,14 +1162,19 @@ function TakerFeeImpactInput(props: { contract: PerpContract }) {
       setInput('')
       // The response's base, not the possibly-stale prop's — the base may
       // have just been edited in the sibling input.
-      const poolSizedPct = (res.takerFeeBps + res.takerFeeImpact / 3) / 100
+      // Read the shared summary rather than restating base + impact/3 here:
+      // duplicated market math is exactly how the two reader surfaces drifted.
+      const { poolSizedBps } = perpFeeScheduleSummary({
+        takerFeeBps: res.takerFeeBps,
+        takerFeeImpact: res.takerFeeImpact,
+      })
       toast.success(
         res.takerFeeImpact > 0
           ? `Fee size impact is now ${
               res.takerFeeImpact
-            } — a pool-sized position pays ${poolSizedPct.toFixed(
-              2
-            )}% effective`
+            } — a pool-sized position pays ${formatFeePct(
+              poolSizedBps
+            )} effective`
           : 'Fee size impact is off — the taker fee is flat at the base'
       )
     } catch (err) {

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -14,7 +14,7 @@ import {
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeBps,
   getPerpTakerFeeImpact,
-  perpFreshPositionFeeBps,
+  perpFeeScheduleSummary,
   PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_IMPACT_MAX,
 } from 'common/perps/fees'
@@ -604,22 +604,20 @@ function PerpStatsRows(props: { contract: PerpContract }) {
   // Fee settings are admin-edited but reader-visible: every row below renders
   // read-only for non-admins, and the size-impact coefficient is translated
   // into what a pool-sized entry actually pays so the number means something.
-  const takerFeeBps = getPerpTakerFeeBps(contract)
-  const takerFeeImpact = getPerpTakerFeeImpact(contract)
-  const poolSizedFee = formatFeePct(
-    perpFreshPositionFeeBps({
-      baseBps: takerFeeBps,
-      impact: takerFeeImpact,
-      poolShare: 1,
-    })
-  )
-  const fourTimesPoolFee = formatFeePct(
-    perpFreshPositionFeeBps({
-      baseBps: takerFeeBps,
-      impact: takerFeeImpact,
-      poolShare: 4,
-    })
-  )
+  // Derived by the same shared helper the perp explainer uses, so the two
+  // surfaces cannot quote this market two different ways.
+  const fees = perpFeeScheduleSummary(contract)
+  const takerFeeBps = fees.baseBps
+  const takerFeeImpact = fees.impact
+  const poolSizedFee = formatFeePct(fees.poolSizedBps)
+  const fourTimesPoolFee = formatFeePct(fees.fourTimesPoolBps)
+  const apiPoolSizedFee = formatFeePct(fees.apiPoolSizedBps)
+  const apiFourTimesPoolFee = formatFeePct(fees.apiFourTimesPoolBps)
+  // The size term stacks on whichever base the CHANNEL selected, so the web
+  // figures understate an API-key open whenever the API rate is higher.
+  const apiSizeNote = fees.apiDiffers
+    ? ` Through the API those are ${apiPoolSizedFee} and ${apiFourTimesPoolFee}.`
+    : ''
   const price =
     contract.resolution === 'MKT'
       ? Number(contract.resolvedOraclePrice ?? contract.oraclePrice)
@@ -708,15 +706,14 @@ function PerpStatsRows(props: { contract: PerpContract }) {
       <tr className={clsx(canEdit && 'bg-purple-500/30')}>
         <td>
           API taker fee{' '}
-          <InfoTooltip text="Rate for positions opened through the API (bots). API opens pay the higher of this and the web taker fee, so automated flow is priced without taxing manual traders. Closing is free on both channels." />
+          <InfoTooltip text="Rate for opens authenticated with an API key — the server selects it from the credential, not from whether the caller looks like a bot, so session-authenticated automation still pays the web rate. API opens pay the higher of this and the web taker fee, and the size term (if any) stacks on top of it. Closing is free on both channels." />
         </td>
         <td>
           {canEdit ? (
             <TakerFeeApiBpsInput contract={contract} />
           ) : (
             <span className="tabular-nums">
-              {formatFeePct(getPerpEffectiveTakerFeeBps(contract, true))} to
-              open
+              {formatFeePct(fees.apiBps)} to open
             </span>
           )}
         </td>
@@ -727,7 +724,7 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           <InfoTooltip
             text={
               takerFeeImpact > 0
-                ? `Positions that are large relative to this market's backing pool pay a higher opening fee, like price impact on an exchange. Small positions pay just the base taker fee; a position the size of the whole pool pays about ${poolSizedFee}, and one four times the pool about ${fourTimesPoolFee}. The exact fee is quoted before you confirm. (Marginal rate at pool-share s is base + impact·s² bps; a fresh position of share S averages base + impact/3·S².)`
+                ? `Positions that are large relative to this market's backing pool pay a higher opening fee, like price impact on an exchange. Small positions pay just the base taker fee; a position the size of the whole pool pays about ${poolSizedFee}, and one four times the pool about ${fourTimesPoolFee}.${apiSizeNote} The exact fee is quoted before you confirm. (Marginal rate at pool-share s is base + impact·s² bps; a fresh position of share S averages base + impact/3·S².)`
                 : 'Size coefficient of the taker fee. At 0 the fee is flat: every position pays the base taker fee regardless of how large it is relative to the backing pool. When set above 0, positions large relative to the pool pay more (marginal rate at pool-share s is base + impact·s² bps).'
             }
           />
@@ -742,7 +739,9 @@ function PerpStatsRows(props: { contract: PerpContract }) {
                 {' '}
                 ·{' '}
                 {takerFeeImpact > 0
-                  ? `pool-sized entry pays ~${poolSizedFee}`
+                  ? fees.apiDiffers
+                    ? `pool-sized entry pays ~${poolSizedFee} on the web, ~${apiPoolSizedFee} via API`
+                    : `pool-sized entry pays ~${poolSizedFee}`
                   : 'flat fee, size does not matter'}
               </span>
             </span>

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -14,7 +14,6 @@ import {
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeBps,
   getPerpTakerFeeImpact,
-  perpFeeScheduleSummary,
   PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_IMPACT_MAX,
 } from 'common/perps/fees'
@@ -28,10 +27,11 @@ import {
   formatFeePct,
   formatPrice,
   inferPriceDecimals,
+  perpFeeScheduleSummary,
 } from 'common/perps/format'
 import { UNRANKED_GROUP_ID } from 'common/supabase/groups'
 import { BETTORS, User } from 'common/user'
-import { formatWithCommas } from 'common/util/format'
+import { formatNumber, formatWithCommas } from 'common/util/format'
 import { YEAR_MS } from 'common/util/time'
 import dayjs from 'dayjs'
 import { capitalize, sumBy } from 'lodash'
@@ -597,6 +597,16 @@ export const Stats = (props: {
   )
 }
 
+// formatWithCommas floors, and both of these settings are validated as plain
+// numbers (maxLeverage is z.number().gt(1).lte(100), takerFeeImpact
+// z.number().min(0).max(100) — neither is .int(), and the leverage input ships
+// step={0.5}). Flooring turned a 2.5x cap into "2x" and an active 0.5 impact
+// into "0", i.e. "size does not matter" on a market where it does.
+const formatLeverage = (value: number) =>
+  formatNumber(value, { maximumFractionDigits: 2 })
+const formatImpact = (value: number) =>
+  formatNumber(value, { maximumFractionDigits: 2 })
+
 function PerpStatsRows(props: { contract: PerpContract }) {
   const { contract } = props
   const isAdmin = useAdmin()
@@ -666,7 +676,7 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           {canEdit ? (
             <MaxLeverageInput contract={contract} />
           ) : Number.isFinite(contract.maxLeverage) ? (
-            `${formatWithCommas(contract.maxLeverage)}×`
+            `${formatLeverage(contract.maxLeverage)}×`
           ) : (
             '—'
           )}
@@ -733,14 +743,17 @@ function PerpStatsRows(props: { contract: PerpContract }) {
           {canEdit ? (
             <TakerFeeImpactInput contract={contract} />
           ) : (
-            <span className="tabular-nums">
-              {formatWithCommas(takerFeeImpact)}
+            // The Table is `table-fixed ... sm:whitespace-nowrap`, so this
+            // cell must opt back into wrapping (`!` beats the sm: variant) or
+            // the two-channel hint runs outside the modal.
+            <span className="!whitespace-normal tabular-nums">
+              {formatImpact(takerFeeImpact)}
               <span className="text-ink-500 text-xs">
                 {' '}
                 ·{' '}
                 {takerFeeImpact > 0
                   ? fees.apiDiffers
-                    ? `pool-sized entry pays ~${poolSizedFee} on the web, ~${apiPoolSizedFee} via API`
+                    ? `pool-sized: ~${poolSizedFee} web / ~${apiPoolSizedFee} API`
                     : `pool-sized entry pays ~${poolSizedFee}`
                   : 'flat fee, size does not matter'}
               </span>
@@ -919,7 +932,7 @@ function MaxLeverageInput(props: { contract: PerpContract }) {
   return (
     <Row className="items-center gap-2">
       <span className="tabular-nums">
-        {Number.isFinite(current) ? `${formatWithCommas(current)}×` : '—'}
+        {Number.isFinite(current) ? `${formatLeverage(current)}×` : '—'}
       </span>
       <input
         type="number"
@@ -1167,7 +1180,7 @@ function TakerFeeImpactInput(props: { contract: PerpContract }) {
 
   return (
     <Row className="flex-wrap items-center gap-1.5">
-      <span className="tabular-nums">{formatWithCommas(current)}</span>
+      <span className="tabular-nums">{formatImpact(current)}</span>
       <input
         type="number"
         min={0}

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -15,6 +15,7 @@ import {
   tradingAllowed,
   type Contract,
   type ContractParams,
+  type PerpContract,
 } from 'common/contract'
 import { shouldHideGraph } from 'common/contract-params'
 import { base64toPoints } from 'common/edge/og'
@@ -368,7 +369,13 @@ export function ContractPageContent(props: ContractParams) {
                   <EditableQuestionTitle
                     contract={liveContract}
                     canEdit={isAdmin || isCreator || isMod}
-                    prefix={isPerp ? <PerpMarketExplainer /> : undefined}
+                    prefix={
+                      isPerp ? (
+                        <PerpMarketExplainer
+                          contract={liveContract as PerpContract}
+                        />
+                      ) : undefined
+                    }
                   />
                 </div>
               </Col>

--- a/web/components/perps/perp-bet-panel.tsx
+++ b/web/components/perps/perp-bet-panel.tsx
@@ -38,7 +38,11 @@ import {
   fundingPerPeriod,
   getPerpPriceForUserFacingPnl,
 } from 'common/perps/pnl'
-import { formatPrice, inferPriceDecimals } from 'common/perps/format'
+import {
+  formatFeePct,
+  formatPrice,
+  inferPriceDecimals,
+} from 'common/perps/format'
 import {
   formatMoney,
   formatMoneyPrecise,
@@ -802,17 +806,6 @@ const LeverageSlider = (props: {
 // cash committed to this new position (margin + opening fee) — the same base
 // the position card's percentage uses, so the two agree at the target price.
 const RETURN_TIERS = [0.25, 0.5, 1] as const
-
-// Fees display as PERCENTAGES — traders don't think in bps. Two decimals
-// below 1% keep the base (0.10%) and a small size term legible; larger fees
-// don't need the precision.
-const formatFeePct = (bps: number) => {
-  if (!Number.isFinite(bps) || bps <= 0) return '0%'
-  const pct = bps / 100
-  return `${
-    pct < 1 ? pct.toFixed(2) : pct < 10 ? pct.toFixed(1) : Math.round(pct)
-  }%`
-}
 
 const formatPoolShare = (share: number) => {
   if (!Number.isFinite(share) || share <= 0) return '0%'

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -146,7 +146,8 @@ function PerpFeesItem(props: { contract: PerpContract }) {
   const {
     baseBps,
     apiBps,
-    apiDiffers,
+    apiBaseDiffers,
+    apiSizeExamplesDiffer,
     hasSizeTerm,
     poolSizedBps,
     fourTimesPoolBps,
@@ -165,7 +166,7 @@ function PerpFeesItem(props: { contract: PerpContract }) {
           caller pays this one. Say what is actually true of the reader.
           Suppressed entirely when the two rates are equal: announcing a
           separate rate identical to the one just quoted reads as a bug. */}
-      {apiDiffers && (
+      {apiBaseDiffers && (
         <>Positions opened with an API key pay {formatFeePct(apiBps)}. </>
       )}
       {hasSizeTerm ? (
@@ -177,7 +178,7 @@ function PerpFeesItem(props: { contract: PerpContract }) {
           {/* The size term stacks on whichever base the CHANNEL selected, so
               the web figures understate an API open — on BTC at base 10 / API
               30 / impact 10 a pool-sized API entry pays 0.33%, not 0.13%. */}
-          {apiDiffers && (
+          {apiSizeExamplesDiffer && (
             <>
               Through the API those are {formatFeePctApprox(apiPoolSizedBps)}{' '}
               and {formatFeePctApprox(apiFourTimesPoolBps)}.{' '}

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -1,7 +1,11 @@
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import { PerpContract } from 'common/contract'
-import { formatFeePct, perpFeeScheduleSummary } from 'common/perps/format'
+import {
+  formatFeePct,
+  formatFeePctApprox,
+  perpFeeScheduleSummary,
+} from 'common/perps/format'
 import { formatNumber } from 'common/util/format'
 import { ReactNode, useState } from 'react'
 import { useUser } from 'web/hooks/use-user'
@@ -167,16 +171,16 @@ function PerpFeesItem(props: { contract: PerpContract }) {
       {hasSizeTerm ? (
         <>
           Large positions pay more, like price impact on an exchange: one the
-          size of this market's whole backing pool pays about{' '}
-          {formatFeePct(poolSizedBps)}, and one four times the pool about{' '}
-          {formatFeePct(fourTimesPoolBps)}.{' '}
+          size of this market's whole backing pool pays{' '}
+          {formatFeePctApprox(poolSizedBps)}, and one four times the pool{' '}
+          {formatFeePctApprox(fourTimesPoolBps)}.{' '}
           {/* The size term stacks on whichever base the CHANNEL selected, so
               the web figures understate an API open — on BTC at base 10 / API
               30 / impact 10 a pool-sized API entry pays 0.33%, not 0.13%. */}
           {apiDiffers && (
             <>
-              Through the API those are {formatFeePct(apiPoolSizedBps)} and{' '}
-              {formatFeePct(apiFourTimesPoolBps)}.{' '}
+              Through the API those are {formatFeePctApprox(apiPoolSizedBps)}{' '}
+              and {formatFeePctApprox(apiFourTimesPoolBps)}.{' '}
             </>
           )}
           Small positions pay just the base rate.{' '}

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -1,8 +1,7 @@
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import { PerpContract } from 'common/contract'
-import { perpFeeScheduleSummary } from 'common/perps/fees'
-import { formatFeePct } from 'common/perps/format'
+import { formatFeePct, perpFeeScheduleSummary } from 'common/perps/format'
 import { formatNumber } from 'common/util/format'
 import { ReactNode, useState } from 'react'
 import { useUser } from 'web/hooks/use-user'
@@ -110,15 +109,17 @@ export function PerpMarketExplainer(props: {
 
           <p className="text-ink-500 text-xs">
             Every setting for this market — leverage cap, funding cap, and fees
-            — is listed in the market info panel
-            {/* HeaderActions (the only route to that panel) is `!user &&
-                'hidden md:flex'` on both of its containers, so a signed-out
-                reader on a phone has no ··· menu to point at. Mirror that
-                exact condition rather than naming a route they cannot see. */}
+            — is set per market, and only Manifold admins can change them.
+            {/* ContractInfoDialog is reachable ONLY through HeaderActions, and
+                both of its containers are `!user && 'hidden md:flex'` — so a
+                signed-out reader on a phone has no route to that panel at all.
+                Point at it only under the exact condition that renders it;
+                the sentence above is complete and true without this. */}
             <span className={clsx(!user && 'hidden md:inline')}>
-              , under the ··· menu → See info
+              {' '}
+              The full list is in the market info panel, under the ··· menu →
+              See info.
             </span>
-            . Only Manifold admins can change them.
           </p>
 
           <div className="border-primary-200 bg-primary-50 text-ink-700 dark:border-primary-800 dark:bg-primary-900/20 rounded-md border p-3 text-sm">

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -1,13 +1,28 @@
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
+import { PerpContract } from 'common/contract'
+import {
+  getPerpEffectiveTakerFeeBps,
+  getPerpTakerFeeBps,
+  getPerpTakerFeeImpact,
+  perpFreshPositionFeeBps,
+} from 'common/perps/fees'
+import { formatFeePct } from 'common/perps/format'
+import { formatWithCommas } from 'common/util/format'
 import { ReactNode, useState } from 'react'
 
 import { Col } from '../layout/col'
 import { Modal, MODAL_CLASS, SCROLLABLE_MODAL_CLASS } from '../layout/modal'
 import { PERP_MARKET_BADGE_CLASS } from './perp-market-badge'
 
-export function PerpMarketExplainer(props: { className?: string }) {
-  const { className } = props
+export function PerpMarketExplainer(props: {
+  // When given, the explainer quotes THIS market's live settings (fees,
+  // leverage cap) instead of only describing the mechanism — only admins can
+  // change them, but every trader needs to be able to read them.
+  contract?: PerpContract
+  className?: string
+}) {
+  const { contract, className } = props
   const [open, setOpen] = useState(false)
 
   return (
@@ -64,7 +79,16 @@ export function PerpMarketExplainer(props: { className?: string }) {
             price, your position closes and you can lose all the margin you
             posted. Profitable positions may also be auto-deleveraged if market
             backing becomes insufficient.
+            {contract && Number.isFinite(contract.maxLeverage) && (
+              <>
+                {' '}
+                This market allows up to{' '}
+                {formatWithCommas(contract.maxLeverage)}× leverage.
+              </>
+            )}
           </ExplainerItem>
+
+          {contract && <PerpFeesItem contract={contract} />}
 
           <ExplainerItem title="Funding while you hold">
             At each funding interval, the more crowded side pays the other side.
@@ -82,6 +106,14 @@ export function PerpMarketExplainer(props: { className?: string }) {
             until a fresh, valid update arrives.
           </ExplainerItem>
 
+          {contract && (
+            <p className="text-ink-500 text-xs">
+              Every setting for this market — leverage cap, funding cap, and
+              fees — is listed under the ··· menu → See info. Only Manifold
+              admins can change them.
+            </p>
+          )}
+
           <div className="border-primary-200 bg-primary-50 text-ink-700 dark:border-primary-800 dark:bg-primary-900/20 rounded-md border p-3 text-sm">
             <span className="font-semibold">League scoring:</span> For now,
             perpetual-market profit and loss appear in your portfolio but do not
@@ -90,6 +122,44 @@ export function PerpMarketExplainer(props: { className?: string }) {
         </Col>
       </Modal>
     </>
+  )
+}
+
+// The fee schedule in a trader's terms: what opening costs on the web and via
+// the API, that closing is free, and — when the size term is on — what a
+// pool-sized entry actually pays, so `takerFeeImpact` is never just a bare
+// coefficient. Worked numbers come from perpFreshPositionFeeBps, which reads
+// the same math the engine charges.
+function PerpFeesItem(props: { contract: PerpContract }) {
+  const { contract } = props
+  const baseBps = getPerpTakerFeeBps(contract)
+  const apiBps = getPerpEffectiveTakerFeeBps(contract, true)
+  const impact = getPerpTakerFeeImpact(contract)
+  const poolSizedFee = formatFeePct(
+    perpFreshPositionFeeBps({ baseBps, impact, poolShare: 1 })
+  )
+  const fourTimesPoolFee = formatFeePct(
+    perpFreshPositionFeeBps({ baseBps, impact, poolShare: 4 })
+  )
+
+  return (
+    <ExplainerItem title="Fees">
+      Opening a position costs {formatFeePct(baseBps)} of its notional (margin ×
+      leverage), paid into this market's backing pool rather than to Manifold.
+      Closing is free. Positions opened through the API — bots — pay{' '}
+      {formatFeePct(apiBps)} to open.{' '}
+      {impact > 0 ? (
+        <>
+          Large positions pay more, like price impact on an exchange: one the
+          size of this market's whole backing pool pays about {poolSizedFee},
+          and one four times the pool about {fourTimesPoolFee}. Small positions
+          pay just the base rate.{' '}
+        </>
+      ) : (
+        <>The rate is flat — position size does not change it. </>
+      )}
+      The exact fee is quoted before you confirm a trade.
+    </ExplainerItem>
   )
 }
 

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -1,29 +1,28 @@
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import { PerpContract } from 'common/contract'
-import {
-  getPerpEffectiveTakerFeeBps,
-  getPerpTakerFeeBps,
-  getPerpTakerFeeImpact,
-  perpFreshPositionFeeBps,
-} from 'common/perps/fees'
+import { perpFeeScheduleSummary } from 'common/perps/fees'
 import { formatFeePct } from 'common/perps/format'
-import { formatWithCommas } from 'common/util/format'
+import { formatNumber } from 'common/util/format'
 import { ReactNode, useState } from 'react'
+import { useUser } from 'web/hooks/use-user'
 
 import { Col } from '../layout/col'
 import { Modal, MODAL_CLASS, SCROLLABLE_MODAL_CLASS } from '../layout/modal'
 import { PERP_MARKET_BADGE_CLASS } from './perp-market-badge'
 
 export function PerpMarketExplainer(props: {
-  // When given, the explainer quotes THIS market's live settings (fees,
-  // leverage cap) instead of only describing the mechanism — only admins can
-  // change them, but every trader needs to be able to read them.
-  contract?: PerpContract
+  // The explainer quotes THIS market's live settings (fees, leverage cap)
+  // rather than only describing the mechanism — only admins can change them,
+  // but every trader needs to be able to read them. Required: there is one
+  // call site and it always has the contract, so an optional prop would only
+  // buy an unreachable, fee-less rendering of the modal.
+  contract: PerpContract
   className?: string
 }) {
   const { contract, className } = props
   const [open, setOpen] = useState(false)
+  const user = useUser()
 
   return (
     <>
@@ -79,16 +78,19 @@ export function PerpMarketExplainer(props: {
             price, your position closes and you can lose all the margin you
             posted. Profitable positions may also be auto-deleveraged if market
             backing becomes insufficient.
-            {contract && Number.isFinite(contract.maxLeverage) && (
+            {Number.isFinite(contract.maxLeverage) && (
               <>
                 {' '}
                 This market allows up to{' '}
-                {formatWithCommas(contract.maxLeverage)}× leverage.
+                {formatNumber(contract.maxLeverage, {
+                  maximumFractionDigits: 2,
+                })}
+                × leverage.
               </>
             )}
           </ExplainerItem>
 
-          {contract && <PerpFeesItem contract={contract} />}
+          <PerpFeesItem contract={contract} />
 
           <ExplainerItem title="Funding while you hold">
             At each funding interval, the more crowded side pays the other side.
@@ -106,13 +108,18 @@ export function PerpMarketExplainer(props: {
             until a fresh, valid update arrives.
           </ExplainerItem>
 
-          {contract && (
-            <p className="text-ink-500 text-xs">
-              Every setting for this market — leverage cap, funding cap, and
-              fees — is listed under the ··· menu → See info. Only Manifold
-              admins can change them.
-            </p>
-          )}
+          <p className="text-ink-500 text-xs">
+            Every setting for this market — leverage cap, funding cap, and fees
+            — is listed in the market info panel
+            {/* HeaderActions (the only route to that panel) is `!user &&
+                'hidden md:flex'` on both of its containers, so a signed-out
+                reader on a phone has no ··· menu to point at. Mirror that
+                exact condition rather than naming a route they cannot see. */}
+            <span className={clsx(!user && 'hidden md:inline')}>
+              , under the ··· menu → See info
+            </span>
+            . Only Manifold admins can change them.
+          </p>
 
           <div className="border-primary-200 bg-primary-50 text-ink-700 dark:border-primary-800 dark:bg-primary-900/20 rounded-md border p-3 text-sm">
             <span className="font-semibold">League scoring:</span> For now,
@@ -128,32 +135,50 @@ export function PerpMarketExplainer(props: {
 // The fee schedule in a trader's terms: what opening costs on the web and via
 // the API, that closing is free, and — when the size term is on — what a
 // pool-sized entry actually pays, so `takerFeeImpact` is never just a bare
-// coefficient. Worked numbers come from perpFreshPositionFeeBps, which reads
-// the same math the engine charges.
+// coefficient. Every figure comes from perpFeeScheduleSummary, which reads the
+// same math the engine charges and is shared with the market info dialog.
 function PerpFeesItem(props: { contract: PerpContract }) {
-  const { contract } = props
-  const baseBps = getPerpTakerFeeBps(contract)
-  const apiBps = getPerpEffectiveTakerFeeBps(contract, true)
-  const impact = getPerpTakerFeeImpact(contract)
-  const poolSizedFee = formatFeePct(
-    perpFreshPositionFeeBps({ baseBps, impact, poolShare: 1 })
-  )
-  const fourTimesPoolFee = formatFeePct(
-    perpFreshPositionFeeBps({ baseBps, impact, poolShare: 4 })
-  )
+  const {
+    baseBps,
+    apiBps,
+    apiDiffers,
+    hasSizeTerm,
+    poolSizedBps,
+    fourTimesPoolBps,
+    apiPoolSizedBps,
+    apiFourTimesPoolBps,
+  } = perpFeeScheduleSummary(props.contract)
 
   return (
     <ExplainerItem title="Fees" scope="this market only">
       In this market, opening a position costs {formatFeePct(baseBps)} of its
       notional (margin × leverage), paid into the market's backing pool rather
-      than to Manifold. Closing is free. Positions opened through the API — bots
-      — pay {formatFeePct(apiBps)} to open.{' '}
-      {impact > 0 ? (
+      than to Manifold. Closing is free.{' '}
+      {/* The surcharge is selected by auth channel — the server checks
+          `auth.creds.kind === 'key'`, not whether the caller is a bot — so
+          session-authenticated automation pays the web rate and any API-key
+          caller pays this one. Say what is actually true of the reader.
+          Suppressed entirely when the two rates are equal: announcing a
+          separate rate identical to the one just quoted reads as a bug. */}
+      {apiDiffers && (
+        <>Positions opened with an API key pay {formatFeePct(apiBps)}. </>
+      )}
+      {hasSizeTerm ? (
         <>
           Large positions pay more, like price impact on an exchange: one the
-          size of this market's whole backing pool pays about {poolSizedFee},
-          and one four times the pool about {fourTimesPoolFee}. Small positions
-          pay just the base rate.{' '}
+          size of this market's whole backing pool pays about{' '}
+          {formatFeePct(poolSizedBps)}, and one four times the pool about{' '}
+          {formatFeePct(fourTimesPoolBps)}.{' '}
+          {/* The size term stacks on whichever base the CHANNEL selected, so
+              the web figures understate an API open — on BTC at base 10 / API
+              30 / impact 10 a pool-sized API entry pays 0.33%, not 0.13%. */}
+          {apiDiffers && (
+            <>
+              Through the API those are {formatFeePct(apiPoolSizedBps)} and{' '}
+              {formatFeePct(apiFourTimesPoolBps)}.{' '}
+            </>
+          )}
+          Small positions pay just the base rate.{' '}
         </>
       ) : (
         <>The rate is flat — position size does not change it. </>

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -143,11 +143,11 @@ function PerpFeesItem(props: { contract: PerpContract }) {
   )
 
   return (
-    <ExplainerItem title="Fees">
-      Opening a position costs {formatFeePct(baseBps)} of its notional (margin ×
-      leverage), paid into this market's backing pool rather than to Manifold.
-      Closing is free. Positions opened through the API — bots — pay{' '}
-      {formatFeePct(apiBps)} to open.{' '}
+    <ExplainerItem title="Fees" scope="this market only">
+      In this market, opening a position costs {formatFeePct(baseBps)} of its
+      notional (margin × leverage), paid into the market's backing pool rather
+      than to Manifold. Closing is free. Positions opened through the API — bots
+      — pay {formatFeePct(apiBps)} to open.{' '}
       {impact > 0 ? (
         <>
           Large positions pay more, like price impact on an exchange: one the
@@ -158,16 +158,31 @@ function PerpFeesItem(props: { contract: PerpContract }) {
       ) : (
         <>The rate is flat — position size does not change it. </>
       )}
-      The exact fee is quoted before you confirm a trade.
+      The exact fee is quoted before you confirm a trade. Fees are set per
+      market, so other perpetuals may differ.
     </ExplainerItem>
   )
 }
 
-function ExplainerItem(props: { title: string; children: ReactNode }) {
-  const { title, children } = props
+function ExplainerItem(props: {
+  title: string
+  // Always-visible qualifier beside the heading (e.g. "this market only") for
+  // sections whose figures are per-market, not platform rules. Inline rather
+  // than a hover tooltip so it cannot be missed and exists on touch devices.
+  scope?: string
+  children: ReactNode
+}) {
+  const { title, scope, children } = props
   return (
     <div>
-      <h3 className="text-ink-800 font-semibold">{title}</h3>
+      <h3 className="text-ink-800 font-semibold">
+        {title}
+        {scope && (
+          <span className="text-ink-500 ml-2 text-xs font-normal italic">
+            — {scope}
+          </span>
+        )}
+      </h3>
       <p className="text-ink-600 mt-0.5 text-sm">{children}</p>
     </div>
   )


### PR DESCRIPTION
The market info dialog already rendered every perp setting read-only for non-admins, but "Fee size impact: 10" meant nothing to a trader, and the fee schedule was only reachable via the ··· menu. Now:

- The "Perpetual (i)" explainer takes the contract and quotes THIS market's fees in trader terms: web open rate, API/bot open rate, free close, and (when the size term is on) what a pool-sized and a 4×-pool entry actually pay. Also states the leverage cap and points at ··· → See info for the full settings, noting only admins edit them.
- The info dialog's "Fee size impact" row shows the coefficient plus a worked "pool-sized entry pays ~0.13%" hint, with a plain-English tooltip; the taker-fee and API-fee tooltips now say what they charge and who pays (bots), not just why they exist.
- New common helper perpFreshPositionFeeBps(base, impact, poolShare) delegates to perpSizeFeeDetails in share space so the worked numbers can never drift from the engine's charged fee; tested against the charged rate at a real pool depth and the closed form.
- formatFeePct moves from the bet panel into common/perps/format so the quote, the dialog, and the explainer format one fee one way.

No engine, schema, or admin-editing changes.