### PR TITLE
perf(scheduler): stop calculate-conversion-scores locking contract rows for minutes

### DIFF
--- a/backend/shared/src/conversion-score.test.ts
+++ b/backend/shared/src/conversion-score.test.ts
@@ -1,0 +1,136 @@
+import {
+  ConversionScoreDb,
+  ConversionScoreTx,
+  rescoreConversionScores,
+} from './conversion-score'
+
+jest.mock('shared/supabase/init', () => ({
+  createSupabaseDirectClient: () => {
+    throw new Error('the tests drive the client explicitly')
+  },
+}))
+jest.mock('shared/utils', () => ({ log: () => undefined }))
+
+type Write = { ids: string[]; scores: string[] }
+
+// A database in which `for update skip locked` returns only the unlocked ids,
+// which is the whole behaviour under test. Scores are kept as the strings
+// postgres would return for an unconstrained numeric.
+const fakeDb = (opts: {
+  viewedIds: string[]
+  scores: Record<string, string>
+  lockedIds?: string[]
+}) => {
+  const locked = new Set(opts.lockedIds ?? [])
+  const writes: Write[] = []
+  const db: ConversionScoreDb = {
+    map: async <T>(
+      _query: string,
+      _values: unknown[],
+      cb: (row: Record<string, any>) => T
+    ) => opts.viewedIds.map((id) => cb({ contract_id: id })),
+    manyOrNone: async <T>(_query: string, values: unknown[]) =>
+      (values[0] as string[])
+        .filter((id) => id in opts.scores)
+        .map((id) => ({ id, score: opts.scores[id] })) as T[],
+    tx: async <T>(cb: (tx: ConversionScoreTx) => Promise<T>) => {
+      const tx: ConversionScoreTx = {
+        map: async <U>(
+          _query: string,
+          values: unknown[],
+          rowCb: (row: Record<string, any>) => U
+        ) =>
+          (values[0] as string[])
+            .filter((id) => !locked.has(id))
+            .map((id) => rowCb({ id })),
+        none: async (_query: string, values: unknown[]) => {
+          writes.push({
+            ids: values[0] as string[],
+            scores: values[1] as string[],
+          })
+          return null
+        },
+      }
+      return cb(tx)
+    },
+  }
+  return { db, writes }
+}
+
+const writtenIds = (writes: Write[]) => writes.flatMap((w) => w.ids)
+
+describe('rescoreConversionScores', () => {
+  it('retries a locked contract that is never viewed again', async () => {
+    // The regression: the candidate query only sees contracts viewed in the
+    // last hour, so a contract skipped while locked and then never viewed
+    // again would silently keep a stale score forever.
+    const scores = { locked1: '0.5632098085888197', free1: '0.25' }
+
+    const run1 = fakeDb({
+      viewedIds: ['locked1', 'free1'],
+      scores,
+      lockedIds: ['locked1'],
+    })
+    const pending = await rescoreConversionScores(run1.db)
+
+    // While locked it keeps its existing score: no write mentions it.
+    expect(writtenIds(run1.writes)).toEqual(['free1'])
+    expect(pending).toEqual(['locked1'])
+
+    // Second run: nobody has viewed it since, so the activity window is empty
+    // and only the carry-forward can bring it back. The lock has cleared.
+    const run2 = fakeDb({ viewedIds: [], scores })
+    const stillPending = await rescoreConversionScores(run2.db, pending)
+
+    expect(writtenIds(run2.writes)).toEqual(['locked1'])
+    expect(stillPending).toEqual([])
+  })
+
+  it('keeps carrying a contract that stays locked', async () => {
+    const scores = { locked1: '0.25' }
+    let pending = ['locked1']
+    for (let run = 0; run < 3; run++) {
+      const { db, writes } = fakeDb({
+        viewedIds: [],
+        scores,
+        lockedIds: ['locked1'],
+      })
+      pending = await rescoreConversionScores(db, pending)
+      expect(writes).toEqual([])
+      expect(pending).toEqual(['locked1'])
+    }
+  })
+
+  it('does not duplicate an id that is both pending and freshly viewed', async () => {
+    const { db, writes } = fakeDb({
+      viewedIds: ['a'],
+      scores: { a: '0.25' },
+    })
+    const pending = await rescoreConversionScores(db, ['a'])
+    expect(writtenIds(writes)).toEqual(['a'])
+    expect(pending).toEqual([])
+  })
+
+  it('writes the score postgres returned, without rounding it through a double', async () => {
+    // conversion_score is an unconstrained numeric; the value below has more
+    // precision than an IEEE-754 double can carry.
+    const exact = '0.56320980858881971516496'
+    const { db, writes } = fakeDb({ viewedIds: ['a'], scores: { a: exact } })
+
+    await rescoreConversionScores(db)
+
+    expect(writes[0].scores).toEqual([exact])
+    expect(String(Number(exact))).not.toEqual(exact) // the rounding it avoids
+  })
+
+  it('retries a chunk whose score computation failed', async () => {
+    const { db } = fakeDb({ viewedIds: ['a'], scores: { a: '0.25' } })
+    const failing: ConversionScoreDb = {
+      ...db,
+      manyOrNone: async () => {
+        throw new Error('statement timeout')
+      },
+    }
+    expect(await rescoreConversionScores(failing)).toEqual(['a'])
+  })
+})

--- a/backend/shared/src/conversion-score.ts
+++ b/backend/shared/src/conversion-score.ts
@@ -23,6 +23,14 @@ import { chunk } from 'lodash'
 // Computing first and writing second keeps the semantics identical and holds
 // the row lock for the length of a keyed update instead of the length of the
 // aggregation.
+//
+// The write takes its row locks in id order and skips rows someone else holds
+// (score-contracts pre-locks in id order for the same reason — an unordered
+// batch write deadlocked against other multi-row contracts writers). Skipping
+// means the write never waits, so it can neither deadlock nor sit on a lock it
+// already holds — a perp's included — while a bet or oracle tick finishes on
+// another row. A skipped contract keeps last hour's score and is rescored on
+// the next run.
 export async function calculateConversionScore() {
   const pg = createSupabaseDirectClient()
   log('Loading contract data...')
@@ -39,7 +47,7 @@ export async function calculateConversionScore() {
   let processed = 0
   for (const chunk of chunks) {
     const scores = await pg
-      .manyOrNone<{ id: string; score: number | string }>(
+      .manyOrNone<{ id: string; score: string }>(
         `
         with card_viewers as (
           select contract_id, coalesce(count(distinct user_id), 0) as uniques
@@ -115,7 +123,7 @@ export async function calculateConversionScore() {
                   *
               (($2+coalesce(pe.uniques, 0) * 1.0) / (coalesce(nullif(pv.uniques,0), pe.uniques,0)+$3)),
               1.0 / 4
-            ) end as score
+            ) end::text as score
         from contracts c
            left join recent_card_enjoyers rce on c.id = rce.contract_id
            left join recent_card_viewers rcv on c.id = rcv.contract_id
@@ -138,25 +146,49 @@ export async function calculateConversionScore() {
         return null
       })
 
-    // A null score would blank a column the feed ranks on. The expression
-    // above coalesces every input, so this only ever drops a row that a future
-    // edit broke — and dropping it leaves the previous score in place.
+    // The score travels as text: conversion_score is an unconstrained numeric,
+    // and the default numeric parser (parseFloat) would round the server-side
+    // value through a double on the way back. Number() is only used to check
+    // it — a non-finite score would blank a column the feed ranks on. The
+    // expression above coalesces every input, so this only ever drops a row
+    // that a future edit broke, and dropping it leaves the previous score.
     const writable = (scores ?? []).filter((row) =>
       Number.isFinite(Number(row.score))
     )
-    if (writable.length > 0)
-      await pg
-        .none(
-          `update contracts c
-           set conversion_score = v.score
-           from (select unnest($1::text[]) as id, unnest($2::numeric[]) as score) v
-           where c.id = v.id`,
-          [writable.map((row) => row.id), writable.map((row) => row.score)]
-        )
+    if (writable.length > 0) {
+      const written = await pg
+        .tx(async (tx) => {
+          const lockedIds = new Set(
+            await tx.map(
+              `select id from contracts
+               where id = any ($1)
+               order by id
+               for update skip locked`,
+              [writable.map((row) => row.id)],
+              (row) => row.id as string
+            )
+          )
+          const rows = writable.filter((row) => lockedIds.has(row.id))
+          if (rows.length > 0)
+            await tx.none(
+              `update contracts c
+               set conversion_score = v.score
+               from (select unnest($1::text[]) as id, unnest($2::numeric[]) as score) v
+               where c.id = v.id`,
+              [rows.map((row) => row.id), rows.map((row) => row.score)]
+            )
+          return rows.length
+        })
         .catch((e) => {
           log('Error on set conversion scores', e)
-          return null
+          return 0
         })
+      const skipped = writable.length - written
+      if (skipped > 0)
+        log(
+          `Skipped ${skipped} contracts whose rows were locked; they keep their previous conversion score until the next run.`
+        )
+    }
 
     processed += chunk.length
     log(`Finished processing conversion scores for ${processed} contracts.`)

--- a/backend/shared/src/conversion-score.ts
+++ b/backend/shared/src/conversion-score.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_CONVERSION_SCORE_DENOMINATOR,
   DEFAULT_CONVERSION_SCORE_NUMERATOR,
 } from 'common/new-contract'
-import { chunk } from 'lodash'
+import { chunk, uniq } from 'lodash'
 
 // The aggregates below are the expensive part — count(distinct user_id) over
 // user_contract_views, user_contract_interactions and user_view_events for a
@@ -29,22 +29,72 @@ import { chunk } from 'lodash'
 // batch write deadlocked against other multi-row contracts writers). Skipping
 // means the write never waits, so it can neither deadlock nor sit on a lock it
 // already holds — a perp's included — while a bet or oracle tick finishes on
-// another row. A skipped contract keeps last hour's score and is rescored on
-// the next run.
+// another row.
+//
+// A skipped contract cannot simply be left for "the next run": the candidate
+// query below only sees contracts VIEWED IN THE LAST HOUR, so one that is
+// locked now and gets no further views would never be reconsidered and its
+// score would freeze indefinitely. Skipped ids are therefore carried forward
+// in `pendingRescoreIds` and unioned into the next run's candidates,
+// independently of that rolling activity window.
+
+// Ids whose write we intended but did not land, carried between runs. The
+// scheduler is long-lived, so this survives from one hourly firing to the
+// next; a process restart drops it, after which a contract is rescored the
+// next time it is viewed — the same exposure the job had before this change,
+// and this is a discovery ranking, not money.
+let pendingRescoreIds: string[] = []
+
+// Bounds the carry-forward if something keeps a row locked indefinitely.
+// Ids are ~12 chars, so this is tens of KB at worst.
+const MAX_PENDING_RESCORE_IDS = 10_000
+
+type RowMapper<T> = (row: Record<string, any>) => T
+
+// The slice of the pg client this job uses, so the retry behaviour below can
+// be tested without a live database (the repo has no DB test harness).
+export type ConversionScoreDb = {
+  map<T>(query: string, values: unknown[], cb: RowMapper<T>): Promise<T[]>
+  manyOrNone<T>(query: string, values: unknown[]): Promise<T[]>
+  tx<T>(cb: (tx: ConversionScoreTx) => Promise<T>): Promise<T>
+}
+export type ConversionScoreTx = {
+  map<T>(query: string, values: unknown[], cb: RowMapper<T>): Promise<T[]>
+  none(query: string, values: unknown[]): Promise<null>
+}
+
 export async function calculateConversionScore() {
-  const pg = createSupabaseDirectClient()
+  pendingRescoreIds = await rescoreConversionScores(
+    createSupabaseDirectClient(),
+    pendingRescoreIds
+  )
+}
+
+// Returns the ids that still need writing, for the next run to retry.
+export async function rescoreConversionScores(
+  pg: ConversionScoreDb,
+  carriedOverIds: string[] = []
+): Promise<string[]> {
   log('Loading contract data...')
-  const contractIds = await pg.map(
+  const viewedIds = await pg.map(
     `select distinct contract_id from user_view_events
         where created_time > now() - interval '1 hour'`,
     [],
-    (c) => c.contract_id
+    (c) => c.contract_id as string
   )
+  // Retries first: a contract that has been waiting since an earlier run is
+  // the one at risk of never being rescored at all.
+  const contractIds = uniq([...carriedOverIds, ...viewedIds])
+  if (carriedOverIds.length > 0)
+    log(
+      `Retrying ${carriedOverIds.length} contracts skipped by an earlier run.`
+    )
   const chunks = chunk(contractIds, 100)
   log(
     `Processing conversion scores for ${contractIds.length} contracts in ${chunks.length} chunks...`
   )
   let processed = 0
+  const stillPending: string[] = []
   for (const chunk of chunks) {
     const scores = await pg
       .manyOrNone<{ id: string; score: string }>(
@@ -146,6 +196,11 @@ export async function calculateConversionScore() {
         return null
       })
 
+    // A failed compute is the same defect class as a skipped write — a
+    // rescore we intended and did not do — so the chunk is retried too
+    // rather than waiting on the contracts happening to be viewed again.
+    if (scores === null) stillPending.push(...chunk)
+
     // The score travels as text: conversion_score is an unconstrained numeric,
     // and the default numeric parser (parseFloat) would round the server-side
     // value through a double on the way back. Number() is only used to check
@@ -156,7 +211,7 @@ export async function calculateConversionScore() {
       Number.isFinite(Number(row.score))
     )
     if (writable.length > 0) {
-      const written = await pg
+      const writtenIds = await pg
         .tx(async (tx) => {
           const lockedIds = new Set(
             await tx.map(
@@ -177,21 +232,33 @@ export async function calculateConversionScore() {
                where c.id = v.id`,
               [rows.map((row) => row.id), rows.map((row) => row.score)]
             )
-          return rows.length
+          return rows.map((row) => row.id)
         })
         .catch((e) => {
           log('Error on set conversion scores', e)
-          return 0
+          return [] as string[]
         })
-      const skipped = writable.length - written
-      if (skipped > 0)
+      const written = new Set(writtenIds)
+      const skipped = writable
+        .map((row) => row.id)
+        .filter((id) => !written.has(id))
+      if (skipped.length > 0) {
+        stillPending.push(...skipped)
         log(
-          `Skipped ${skipped} contracts whose rows were locked; they keep their previous conversion score until the next run.`
+          `Skipped ${skipped.length} contracts whose rows were locked; they keep their previous score and are retried next run.`
         )
+      }
     }
 
     processed += chunk.length
     log(`Finished processing conversion scores for ${processed} contracts.`)
   }
+
+  // Newest retries win if something is persistently locked, so a permanently
+  // stuck id cannot crowd out fresher ones forever.
+  const pending = uniq(stillPending).slice(-MAX_PENDING_RESCORE_IDS)
+  if (pending.length > 0)
+    log(`Carrying ${pending.length} contracts forward to the next run.`)
   log('Done.')
+  return pending
 }

--- a/backend/shared/src/conversion-score.ts
+++ b/backend/shared/src/conversion-score.ts
@@ -6,6 +6,23 @@ import {
 } from 'common/new-contract'
 import { chunk } from 'lodash'
 
+// The aggregates below are the expensive part — count(distinct user_id) over
+// user_contract_views, user_contract_interactions and user_view_events for a
+// whole chunk of contracts. Measured on prod, one 100-contract chunk takes
+// 8-160 seconds.
+//
+// It used to be a single `update contracts set conversion_score = (<those
+// aggregates>)`, which meant every contract in the chunk held a ROW LOCK for
+// that entire duration. That is fine for a market whose row is only written
+// when someone bets on it, and not at all fine for a perp: the oracle tick
+// writes the BTC perp's row every 2 seconds and bounds its lock wait to 1s
+// (FAST_TICK_ORACLE_BOUNDS), so every tick inside the chunk's statement lost
+// its slot to a 55P03. That was 86% of all oracle-tick apply failures — a
+// 40-70 second freeze of the executable mark, once an hour, at :46.
+//
+// Computing first and writing second keeps the semantics identical and holds
+// the row lock for the length of a keyed update instead of the length of the
+// aggregation.
 export async function calculateConversionScore() {
   const pg = createSupabaseDirectClient()
   log('Loading contract data...')
@@ -21,8 +38,8 @@ export async function calculateConversionScore() {
   )
   let processed = 0
   for (const chunk of chunks) {
-    await pg
-      .none(
+    const scores = await pg
+      .manyOrNone<{ id: string; score: number | string }>(
         `
         with card_viewers as (
           select contract_id, coalesce(count(distinct user_id), 0) as uniques
@@ -82,36 +99,32 @@ export async function calculateConversionScore() {
              and contract_id= any ($1)
              and created_time > now() - interval '1 week'
            group by contract_id)
-        update contracts c
-        set conversion_score = (
-          select 
-            case when 
-                -- If our data is sus, return default conversion score
-              (coalesce(pe.uniques,0) > coalesce(pv.uniques,0) or
-              coalesce(ce.uniques,0) > coalesce(cv.uniques,0))
-              then ($2 * 1.0) / $3
-            else
-              power(
-                (($2+coalesce(rce.uniques, 0) * 1.0) / (coalesce(nullif(rcv.uniques,0),rce.uniques,0)+$3))
-                    *
-                (($2+coalesce(rpe.uniques, 0) * 1.0) / (coalesce(nullif(rpv.uniques,0),rpe.uniques,0)+$3))
-                    *
-                (($2+coalesce(ce.uniques, 0) * 1.0) / (coalesce(nullif(cv.uniques,0),ce.uniques,0)+$3))
-                    *
-                (($2+coalesce(pe.uniques, 0) * 1.0) / (coalesce(nullif(pv.uniques,0), pe.uniques,0)+$3)),
-                1.0 / 4
-              ) end
-          from contracts c2
-             left join recent_card_enjoyers rce on c.id = rce.contract_id
-             left join recent_card_viewers rcv on c.id = rcv.contract_id
-             left join recent_page_enjoyers rpe on c.id = rpe.contract_id
-             left join recent_page_viewers rpv on c.id = rpv.contract_id
-             left join card_viewers cv on c2.id = cv.contract_id
-             left join card_enjoyers ce on c2.id = ce.contract_id
-             left join page_viewers pv on c2.id = pv.contract_id
-             left join page_enjoyers pe on c2.id = pe.contract_id
-          where c2.id = c.id
-        )
+        select c.id,
+          case when
+              -- If our data is sus, return default conversion score
+            (coalesce(pe.uniques,0) > coalesce(pv.uniques,0) or
+            coalesce(ce.uniques,0) > coalesce(cv.uniques,0))
+            then ($2 * 1.0) / $3
+          else
+            power(
+              (($2+coalesce(rce.uniques, 0) * 1.0) / (coalesce(nullif(rcv.uniques,0),rce.uniques,0)+$3))
+                  *
+              (($2+coalesce(rpe.uniques, 0) * 1.0) / (coalesce(nullif(rpv.uniques,0),rpe.uniques,0)+$3))
+                  *
+              (($2+coalesce(ce.uniques, 0) * 1.0) / (coalesce(nullif(cv.uniques,0),ce.uniques,0)+$3))
+                  *
+              (($2+coalesce(pe.uniques, 0) * 1.0) / (coalesce(nullif(pv.uniques,0), pe.uniques,0)+$3)),
+              1.0 / 4
+            ) end as score
+        from contracts c
+           left join recent_card_enjoyers rce on c.id = rce.contract_id
+           left join recent_card_viewers rcv on c.id = rcv.contract_id
+           left join recent_page_enjoyers rpe on c.id = rpe.contract_id
+           left join recent_page_viewers rpv on c.id = rpv.contract_id
+           left join card_viewers cv on c.id = cv.contract_id
+           left join card_enjoyers ce on c.id = ce.contract_id
+           left join page_viewers pv on c.id = pv.contract_id
+           left join page_enjoyers pe on c.id = pe.contract_id
         where c.id = any ($1)
         `,
         [
@@ -121,9 +134,30 @@ export async function calculateConversionScore() {
         ]
       )
       .catch((e) => {
-        log('Error on set conversion scores', e)
+        log('Error on compute conversion scores', e)
         return null
       })
+
+    // A null score would blank a column the feed ranks on. The expression
+    // above coalesces every input, so this only ever drops a row that a future
+    // edit broke — and dropping it leaves the previous score in place.
+    const writable = (scores ?? []).filter((row) =>
+      Number.isFinite(Number(row.score))
+    )
+    if (writable.length > 0)
+      await pg
+        .none(
+          `update contracts c
+           set conversion_score = v.score
+           from (select unnest($1::text[]) as id, unnest($2::numeric[]) as score) v
+           where c.id = v.id`,
+          [writable.map((row) => row.id), writable.map((row) => row.score)]
+        )
+        .catch((e) => {
+          log('Error on set conversion scores', e)
+          return null
+        })
+
     processed += chunk.length
     log(`Finished processing conversion scores for ${processed} contracts.`)
   }


### PR DESCRIPTION
## Problem

`calculate-conversion-scores` (main scheduler, hourly at :46) ran

```sql
update contracts set conversion_score = (<eight count(distinct) CTEs>) where id = any($1)
```

in 100-contract chunks. Postgres takes each row lock as the UPDATE reaches it and holds it until commit, so every contract in the chunk is locked for the whole aggregation. Measured on prod: one chunk = 8–160 s (2026-08-21: 121 s; 2026-08-25: 00:47:11→00:49:35 = 144 s, 01:47:48→01:49:41 = 113 s).

Harmless for a market whose row only changes when someone bets. Not harmless for a perp: the oracle tick rewrites the BTC perp's row every 2 s with a 1 s `lock_timeout` (`FAST_TICK_ORACLE_BOUNDS`), so every tick inside the chunk statement dies with 55P03 and the executable mark freezes while the underlying keeps moving.

Over 24 h on prod: 667 oracle-tick apply failures, 575 (86%) inside the :46–:48 window this job occupies. Concretely, a 40–87 s freeze of the BTC mark once an hour, from a discovery-ranking job — and the `PROD perps: [oracle-feeds] feed error` alert pages on every one of them (last two bursts today: 00:48:39–00:49:01 and 01:49:15–01:49:41, each ending within 600 ms of the chunk commit).

## Fix

Compute the scores with a SELECT, then write them with a keyed UPDATE (`unnest` VALUES join). The row lock now lasts a keyed update instead of an aggregation.

- Same arithmetic. The old form's `from contracts c2 … where c2.id = c.id` made the c2-keyed joins identical to the c-keyed ones; the SELECT is that expression with a single `contracts c` source. Verified against the old correlated-subquery form on prod data — 0 mismatches.
- Rows whose score comes back non-finite are skipped rather than written, so a future edit that breaks the expression leaves the previous score in place instead of blanking a column the feed ranks on. The expression coalesces every input, so today this never triggers.
- Log line for the compute failure renamed (`Error on compute conversion scores`) so it's distinguishable from the write.

One file: `backend/shared/src/conversion-score.ts`. No schema change, no perps-engine change.

## Alert-volume estimate

A 7-day replay of prod `[oracle-feeds]` logs through the policy's 2h notification rate limit puts this at **32 emails/week -> 8**, i.e. ~75% fewer. 98.5% of the 926 error lines fall inside an actual `calculate-conversion-scores` run (interval-joined against 168 runs; median 126s, p90 361s, max 533s). Treat it as an estimate from log replay, not a production measurement -- worth re-checking once this is deployed.

## Review round 1 (`0c2741e76`)

- **Lock order (P2):** the write is one short transaction — `select id … order by id for update skip locked`, then the keyed update over exactly those rows. Same ordering as `score-contracts`' pre-lock; never waits, so no deadlock and no prolonging a held lock (perp included). Skipped rows keep last hour's score, are rescored next run, and the count is logged.
- **Numeric precision (P3):** `conversion_score` is unconstrained `numeric` and the default parser is `parseFloat`; 143,302 stored scores carry >17 decimals (the expression yields 23). Score is now selected as `::text`, checked with `Number.isFinite(Number(s))`, and the original string goes to `numeric[]`.

## Review round 2 (`27e5eab39`)

- **Skipped ids were discarded.** The candidate query only selects markets viewed in the last hour, so a market skipped while locked and then never viewed again was never reconsidered -- its score froze indefinitely, contrary to what this description previously claimed. Skipped ids (and chunks whose computation failed) now carry between runs and are unioned into the next run's candidates ahead of the viewed ids, independently of that window. Capped at 10k, newest kept, logged on both ends; dropped on process restart, after which a market is rescored next time it is viewed.
- **Unchanged:** SELECT-then-write, short id-ordered `for update skip locked` transaction that never waits, and `::text` -> `numeric[]` precision passthrough.
- **Regression test** (`backend/shared/src/conversion-score.test.ts`): a locked market with **no subsequent views** keeps its score while locked, then updates once the lock clears -- plus stays-pending-while-locked, no duplicate when pending and freshly viewed, exact-string passthrough, and retry after failed computation. Verified to fail 3/5 against the previous behaviour. Full `backend/shared` suite green (9 suites, 56 tests).

## Deploy

Main scheduler only (`prod main`). Keep it out of the perps deploy — it does not touch the perp engine or `scheduler-perps`.

## Verify after deploy

The `[oracle-feeds] bitcoin-price-usd: failed to apply … lock timeout` burst at :47–:49 should stop. Residual ~4 apply failures/hr from ordinary trader contention stay under the 60 s log threshold and do not page.

```
gcloud logging read 'resource.type="gce_instance" AND severity>=ERROR AND jsonPayload.message:"[oracle-feeds] bitcoin-price-usd: failed to apply"' --project=mantic-markets --freshness=6h --format="value(timestamp)" | cut -c1-16 | sort | uniq -c
```

Related: #4017 (oracle tick latch) is the other half of the tick-reliability work; independent of this.

