### PR TITLE
fix(perps): correct four open-weight misclassifications, and check them nightly

### DIFF
--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -4,6 +4,7 @@ import {
   UNCLASSIFIED_GRACE_WINDOW_MS,
   basePermaslug,
   isCompositeSlug,
+  isValidPermaslug,
 } from 'common/perps/open-weight-models'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import {
@@ -184,6 +185,12 @@ export const setModelClassification: APIHandler<
   // (An earlier comment here said the version is "stamped on every point the
   // oracle writes". It is not: the version reaches the insert LOG line only,
   // and `oracle_prices` has no version column.)
+  if (!isValidPermaslug(permaslug))
+    throw new APIError(
+      400,
+      `${JSON.stringify(body.permaslug)} is not a valid owner/model permaslug.`
+    )
+
   if (isCompositeSlug(permaslug))
     throw new APIError(
       400,

--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -6,7 +6,10 @@ import {
   isCompositeSlug,
 } from 'common/perps/open-weight-models'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
-import { verifyHuggingFaceWeights } from 'shared/huggingface'
+import {
+  isTransportFailure,
+  verifyHuggingFaceWeights,
+} from 'shared/huggingface'
 import {
   ClassificationRow,
   upsertClassification,
@@ -127,8 +130,29 @@ export const getModelClassifications: APIHandler<
               : null,
         }
       }),
+    // Every decided row an operator can actually act on, uncapped.
+    //
+    // Not sliced. A previous revision took the newest 200, which reintroduced
+    // the exact problem removing the 30-day window was meant to solve: the
+    // audit re-checks EVERY override and names the slug in its alert, so any
+    // bound here eventually produces a nightly finding pointing at a page
+    // that cannot show the row. A cap is only safe alongside search or
+    // pagination, and there is neither.
+    //
+    // Filtered to what the setter will accept, which is also what keeps the
+    // list small: seeded models are refused (they go through the file) and
+    // composites are refused (excluded from the index), so rendering them
+    // would offer a Change control that always errors. Roughly 60 rows today
+    // against a few hundred in the table.
+    //
+    // Revisit if this outgrows a page: the fix is a slug lookup, not a slice.
     recent: rows
-      .filter((r) => r.open !== null)
+      .filter(
+        (r) =>
+          r.open !== null &&
+          !OPEN_WEIGHT_MODELS[r.permaslug] &&
+          !isCompositeSlug(r.permaslug)
+      )
       .map((r) => ({
         permaslug: r.permaslug,
         open: r.open as boolean,
@@ -139,10 +163,7 @@ export const getModelClassifications: APIHandler<
           : null,
         classifiedBy: r.classified_by,
       }))
-      .sort((a, b) => (b.classifiedAt ?? 0) - (a.classifiedAt ?? 0))
-      // Newest 200 decided rows. A cap on RENDERING, not on what is editable:
-      // the CLI reaches anything, and the audit names the slug in its alert.
-      .slice(0, 200),
+      .sort((a, b) => (b.classifiedAt ?? 0) - (a.classifiedAt ?? 0)),
     seedVersion: OPEN_WEIGHT_LIST_VERSION,
     graceWindowMs: UNCLASSIFIED_GRACE_WINDOW_MS,
   }
@@ -201,17 +222,40 @@ export const setModelClassification: APIHandler<
   }
   if (open) {
     const cited = weights?.trim() ?? ''
-    const verification = await verifyHuggingFaceWeights(cited)
-    if (!verification.confirmed)
+    // Wrapped: verifyHuggingFaceWeights catches fetch rejections but not a
+    // malformed body, and an admin form should not 500 because HuggingFace
+    // served HTML during an incident.
+    let verification
+    try {
+      verification = await verifyHuggingFaceWeights(cited)
+    } catch (err) {
+      verification = {
+        confirmed: false as const,
+        repo: cited,
+        reason: `fetch failed: ${err}`,
+      }
+    }
+    if (!verification.confirmed) {
+      // 503, not 400, when we could not reach HuggingFace. A timeout, a 429 or
+      // a Cloudflare 5xx says nothing about what the operator typed, and
+      // telling them their input is invalid during an upstream outage sends
+      // them to re-check a repo id that was right — or worse, to work around
+      // the form. Retryable, and it says so.
+      if (isTransportFailure(verification.reason))
+        throw new APIError(
+          503,
+          `Could not reach HuggingFace to verify ${cited}: ` +
+            `${verification.reason}. Nothing was written — retry shortly.`
+        )
       throw new APIError(
         400,
         `${cited || '(no repo)'} did not verify as public weights: ` +
           `${verification.reason}. An open call needs a repo that resolves, ` +
           `is public, and carries weight files.`
       )
+    }
     evidence = { ...evidence, ...verification.evidence }
   }
-
   await upsertClassification(pg, {
     permaslug,
     open,

--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -132,10 +132,14 @@ export const setModelClassification: APIHandler<
   const permaslug = basePermaslug(body.permaslug.trim())
   const { open, weights } = body
 
-  // The seed list is the published methodology and is version-stamped on every
-  // point the oracle writes. Silently overriding an entry from an admin form
-  // would make the stamp a lie, so a genuine reclassification has to go
-  // through the file — which is also where the reasoning gets recorded.
+  // The seed list is the published methodology. Silently overriding an entry
+  // from an admin form would change what the index means, so a genuine
+  // reclassification has to go through the file — which is also where the
+  // reasoning gets recorded.
+  //
+  // (An earlier comment here said the version is "stamped on every point the
+  // oracle writes". It is not: the version reaches the insert LOG line only,
+  // and `oracle_prices` has no version column.)
   if (OPEN_WEIGHT_MODELS[permaslug])
     throw new APIError(
       400,

--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -3,6 +3,7 @@ import {
   OPEN_WEIGHT_MODELS,
   UNCLASSIFIED_GRACE_WINDOW_MS,
   basePermaslug,
+  isCompositeSlug,
 } from 'common/perps/open-weight-models'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import {
@@ -66,7 +67,15 @@ export const getModelClassifications: APIHandler<
     // A pending row for a model the seed already classifies is inert — the
     // seed verdict stands — so it must not appear as work to do.
     pending: rows
-      .filter((r) => r.open === null && !OPEN_WEIGHT_MODELS[r.permaslug])
+      // Composite slugs are excluded from the index by construction, so a
+      // verdict on one is ignored whichever way it is answered. Showing them
+      // as work to do would be asking for a click that changes nothing.
+      .filter(
+        (r) =>
+          r.open === null &&
+          !OPEN_WEIGHT_MODELS[r.permaslug] &&
+          !isCompositeSlug(r.permaslug)
+      )
       .map((r) => {
         const firstSeen = new Date(r.first_seen).getTime()
         const firstRankedAt = r.first_ranked_at
@@ -140,6 +149,14 @@ export const setModelClassification: APIHandler<
   // (An earlier comment here said the version is "stamped on every point the
   // oracle writes". It is not: the version reaches the insert LOG line only,
   // and `oracle_prices` has no version column.)
+  if (isCompositeSlug(permaslug))
+    throw new APIError(
+      400,
+      `${permaslug} is a router or floating alias, not a single model. It is ` +
+        `excluded from both sides of the index, so a verdict on it would be ` +
+        `ignored — see isCompositeSlug in common/src/perps/open-weight-models.ts.`
+    )
+
   if (OPEN_WEIGHT_MODELS[permaslug])
     throw new APIError(
       400,

--- a/backend/api/src/model-classifications.ts
+++ b/backend/api/src/model-classifications.ts
@@ -6,6 +6,7 @@ import {
   isCompositeSlug,
 } from 'common/perps/open-weight-models'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { verifyHuggingFaceWeights } from 'shared/huggingface'
 import {
   ClassificationRow,
   upsertClassification,
@@ -27,12 +28,22 @@ export const getModelClassifications: APIHandler<
   throwErrorIfNotAdmin(auth.uid)
   const pg = createSupabaseDirectClient()
 
+  // Every decided row, not a 30-day slice.
+  //
+  // The nightly audit re-checks EVERY override, and the case it exists to
+  // catch is a publisher shipping weights long after launch — months, not
+  // weeks. Under the old window the audit would flag such a model every night
+  // while the page an operator is told to go and fix it on did not list it at
+  // all, which is the worst possible pairing: a standing alert with no
+  // reachable remedy.
+  //
+  // The table is a few hundred rows and grows by a handful a week, so there is
+  // nothing to paginate away from yet; `recent` is capped for display below
+  // instead, and correcting an older verdict still works through the CLI.
   const rows = await pg.manyOrNone<ClassificationRow>(
     `select permaslug, open, weights, source, evidence,
             first_seen, first_ranked_at, classified_at, classified_by
      from model_classifications
-     where open is null
-        or classified_at > now() - interval '30 days'
      order by first_ranked_at asc nulls last, first_seen asc`
   )
 
@@ -128,7 +139,10 @@ export const getModelClassifications: APIHandler<
           : null,
         classifiedBy: r.classified_by,
       }))
-      .sort((a, b) => (b.classifiedAt ?? 0) - (a.classifiedAt ?? 0)),
+      .sort((a, b) => (b.classifiedAt ?? 0) - (a.classifiedAt ?? 0))
+      // Newest 200 decided rows. A cap on RENDERING, not on what is editable:
+      // the CLI reaches anything, and the audit names the slug in its alert.
+      .slice(0, 200),
     seedVersion: OPEN_WEIGHT_LIST_VERSION,
     graceWindowMs: UNCLASSIFIED_GRACE_WINDOW_MS,
   }
@@ -166,12 +180,44 @@ export const setModelClassification: APIHandler<
     )
 
   const pg = createSupabaseDirectClient()
+
+  // Verify the citation before it enters the map, not after.
+  //
+  // This endpoint used to accept any non-empty string, which made the admin
+  // form the LEAST checked way into an executable index: the nightly audit
+  // re-verifies every open verdict, the research agent's proposals are
+  // re-fetched and name-matched, and the CLI verifies before writing — but a
+  // typo, a full URL pasted instead of an id, a private repo or a
+  // tokenizer-only repo typed here went straight in and priced the market on
+  // the next tick. `upstage/solar-pro3-tokenizer` resolves and carries zero
+  // weight files, so "it exists" is not the bar.
+  //
+  // The operator is trusted to make the JUDGEMENT; they are not a substitute
+  // for the mechanical check, and being asked to re-type a repo id is exactly
+  // where a slip happens.
+  let evidence: Record<string, unknown> = {
+    classifiedByAdmin: auth.uid,
+    weightsCitedAt: Date.now(),
+  }
+  if (open) {
+    const cited = weights?.trim() ?? ''
+    const verification = await verifyHuggingFaceWeights(cited)
+    if (!verification.confirmed)
+      throw new APIError(
+        400,
+        `${cited || '(no repo)'} did not verify as public weights: ` +
+          `${verification.reason}. An open call needs a repo that resolves, ` +
+          `is public, and carries weight files.`
+      )
+    evidence = { ...evidence, ...verification.evidence }
+  }
+
   await upsertClassification(pg, {
     permaslug,
     open,
     weights: weights?.trim() || null,
     source: 'admin',
-    evidence: { classifiedByAdmin: auth.uid, weightsCitedAt: Date.now() },
+    evidence,
     classifiedBy: auth.uid,
   })
 

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -67,6 +67,7 @@ import {
   validateOracleFeedPollPeriods,
 } from './update-oracle-feeds'
 import { updateOpenRouterShare } from './update-openrouter-share'
+import { updateClassificationAudit } from './update-classification-audit'
 import { updateModelClassifications } from './update-model-classifications'
 import { updateTrumpApproval } from './update-trump-approval'
 import { resolveSportsMarkets } from './sports-resolve'
@@ -268,6 +269,16 @@ export function createJobs(jobSet: SchedulerJobSet) {
       updateModelClassifications
     ),
     // Daily jobs:
+    createJob(
+      'classification-audit',
+      // 03:40 LA — off the 6-hourly classifier cycle above so the two never
+      // contend for the HuggingFace rate limit, and inside the same quiet
+      // window that schedule was chosen for. Daily rather than hourly because
+      // it re-verifies every published classification against a third-party
+      // API and nothing it looks for changes on an hourly timescale.
+      '0 40 3 * * *',
+      updateClassificationAudit
+    ),
     createJob(
       'process-membership-renewals',
       '0 0 8 * * *', // daily at 8:00 AM LA

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -271,12 +271,18 @@ export function createJobs(jobSet: SchedulerJobSet) {
     // Daily jobs:
     createJob(
       'classification-audit',
-      // 03:40 LA — off the 6-hourly classifier cycle above so the two never
-      // contend for the HuggingFace rate limit, and inside the same quiet
-      // window that schedule was chosen for. Daily rather than hourly because
-      // it re-verifies every published classification against a third-party
-      // API and nothing it looks for changes on an hourly timescale.
-      '0 40 3 * * *',
+      // 06:40 LA. NOT 03:40, which an earlier revision picked while claiming it
+      // sat in the "same quiet window" as the schedule above — it is the exact
+      // opposite. That comment defines the window to AVOID as 00:00-04:30 LA
+      // (the 08:00 UTC API restart and the ~10:00-11:30 UTC scheduler memory
+      // pressure, mapped through both DST offsets), which 03:40 is inside.
+      //
+      // 06:40 clears it in PDT and PST alike, and sits between the 05:15 and
+      // 11:15 firings of the classifier above so the two never contend for the
+      // HuggingFace rate limit. Daily rather than hourly because it re-verifies
+      // every published classification against a third-party API and nothing it
+      // looks for changes on an hourly timescale.
+      '0 40 6 * * *',
       updateClassificationAudit
     ),
     createJob(

--- a/backend/scheduler/src/jobs/update-classification-audit.ts
+++ b/backend/scheduler/src/jobs/update-classification-audit.ts
@@ -1,0 +1,195 @@
+import {
+  OPEN_WEIGHT_LIST_VERSION,
+  OPEN_WEIGHT_MODELS,
+  basePermaslug,
+} from 'common/perps/open-weight-models'
+import { verifyHuggingFaceWeights } from 'shared/huggingface'
+import { fetchOpenRouterCatalog } from 'shared/openrouter-tokens'
+import { resolveModelClassifications } from 'shared/perps/model-classifications'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+
+// Re-examine classifications we have ALREADY made.
+//
+// Everything else in this system looks only at models it has not classified
+// yet: the watcher sweeps the catalog for unknowns, the research agent works
+// the pending queue, the admin tool lists what needs a click. Once a verdict
+// was written, nothing ever looked at it again — so a wrong entry was
+// permanent, and a seed entry doubly so, because the seed overrides overrides.
+//
+// A re-audit on 2026-08-24 found what that costs. Of 299 published
+// classifications, four were wrong — Kimi K3, Mistral Large 3 2512, Mistral
+// Medium 3.5, Ling-3.0-flash — every one of them an open model marked closed,
+// so the index had been understating the open share for weeks with nothing
+// capable of noticing.
+//
+// The direction is structural, not luck. The list is built by finding a
+// weights repo; the only way that can fail is by not finding one, and the
+// default when it fails is closed. So the errors this system produces are
+// systematically one-sided, and the check has to be aimed at that side.
+//
+// Three assertions, nightly:
+//
+//   ROT     every `open` verdict cites a repo. Does it still resolve, public,
+//           with weight files? microsoft/WizardLM-2-8x22B is the case that
+//           motivates it: OpenRouter still declares that repo and the weights
+//           were withdrawn, so a citation is not evidence of anything unless
+//           something re-checks it.
+//
+//   HINTS   every `closed` verdict, against OpenRouter's own metadata. Note
+//           the direction: the watcher already measured `hugging_face_id`
+//           agreement across models we call OPEN (96 of 99) and was satisfied.
+//           Nobody checked whether it CONTRADICTS us where we say closed, and
+//           that is exactly where all four errors were sitting.
+//
+//   PROSE   the same closed verdicts against the description text. Two of the
+//           four had an empty `hugging_face_id` and announced themselves in
+//           words instead ("open-weight", "released under the Apache 2.0
+//           license"). Cheap, and it is the only signal that catches a
+//           publisher who renames between OpenRouter slug and HF repo — the
+//           rename being what defeated the original build.
+//
+// This job never writes a classification. It raises a flag for a human,
+// because a verdict that moves an executable index should not be flipped by
+// the same kind of automated inference that got it wrong in the first place.
+
+/** Phrases that assert public weights in OpenRouter's own prose. */
+const OPENNESS_PHRASES = [
+  'open-weight',
+  'open weights',
+  'open-source',
+  'open source',
+  'apache 2.0',
+  'apache-2.0',
+  'mit license',
+  'weights are available',
+  'weights available',
+]
+
+/**
+ * Phrases that assert the opposite, and which veto an openness match.
+ *
+ * Needed because these blurbs routinely describe a closed model by naming the
+ * open one it derives from, and a bare substring search reads the wrong half:
+ * "Qwen3 Coder Plus is Alibaba's proprietary version of the Open Source Qwen3
+ * Coder 480B A35B" contains "open source" and is a closed model. That was the
+ * only false positive across all 124 closed verdicts on the first run.
+ *
+ * Vetoing loses nothing real. A publisher describing genuinely open weights
+ * has no reason to also call the model proprietary, and the declared-repo
+ * check runs first and independently — prose is the weaker of the two signals
+ * and only ever needs to be right about the cases the repo check misses.
+ */
+const PROPRIETARY_PHRASES = [
+  'proprietary',
+  'closed-weight',
+  'closed weights',
+  'closed-source',
+  'not open',
+]
+
+const describesOpenness = (description: string | null) => {
+  if (!description) return null
+  const haystack = description.toLowerCase()
+  if (PROPRIETARY_PHRASES.some((phrase) => haystack.includes(phrase))) return null
+  return OPENNESS_PHRASES.find((phrase) => haystack.includes(phrase)) ?? null
+}
+
+export const updateClassificationAudit = async () => {
+  try {
+    await runClassificationAudit()
+  } catch (err) {
+    log.error(`[classification-audit] run failed — ${err}`)
+  }
+}
+
+const runClassificationAudit = async () => {
+  const pg = createSupabaseDirectClient()
+  const { classifications } = await resolveModelClassifications(pg)
+  const catalog = await fetchOpenRouterCatalog()
+  const byPermaslug = Object.fromEntries(
+    catalog.map((entry) => [basePermaslug(entry.permaslug), entry])
+  )
+
+  const rot: string[] = []
+  const contradicted: string[] = []
+  let openChecked = 0
+  let closedChecked = 0
+
+  for (const [permaslug, verdict] of Object.entries(classifications)) {
+    const seeded = !!OPEN_WEIGHT_MODELS[permaslug]
+    const origin = seeded ? 'seed' : 'override'
+
+    if (verdict.open) {
+      openChecked++
+      // An open verdict without a citation cannot be audited at all, and the
+      // table's check constraint plus the seed's own test both forbid it —
+      // so if one appears, that is the finding.
+      if (!verdict.weights) {
+        rot.push(`${permaslug} [${origin}] — open with no weights repo cited`)
+        continue
+      }
+      const result = await verifyHuggingFaceWeights(verdict.weights)
+      if (!result.confirmed)
+        rot.push(
+          `${permaslug} [${origin}] — ${verdict.weights} no longer verifies: ${result.reason}`
+        )
+      continue
+    }
+
+    closedChecked++
+    const entry = byPermaslug[permaslug]
+    if (!entry) continue
+
+    // HINTS: OpenRouter declares a repo for something we call closed. Only a
+    // finding if the repo actually carries public weights — a declared but
+    // empty or withdrawn repo agrees with us, it does not contradict us.
+    if (entry.huggingFaceId) {
+      const result = await verifyHuggingFaceWeights(entry.huggingFaceId)
+      if (result.confirmed) {
+        contradicted.push(
+          `${permaslug} [${origin}] — we say closed, OpenRouter declares ` +
+            `${entry.huggingFaceId} (${result.evidence.weightFileCount} weight files, ` +
+            `gated=${result.evidence.gated})`
+        )
+        continue
+      }
+    }
+
+    // PROSE: no usable declared repo, but the blurb claims openness.
+    const phrase = describesOpenness(entry.description)
+    if (phrase)
+      contradicted.push(
+        `${permaslug} [${origin}] — we say closed, but OpenRouter's ` +
+          `description says "${phrase}"`
+      )
+  }
+
+  log(
+    `[classification-audit] checked ${openChecked} open + ${closedChecked} closed ` +
+      `(list ${OPEN_WEIGHT_LIST_VERSION})`
+  )
+
+  // Warn, not error, and deliberately: neither finding means the index is
+  // wrong right now. A rot finding can be a transient HF outage, and a
+  // contradiction can be OpenRouter's metadata being wrong — it was, for
+  // three models in the 2026-08-24 audit. Both need a human to look, and
+  // paging on something that is often a false positive trains people to
+  // ignore it. What must not happen is nobody being told at all, which is
+  // the state this job replaces.
+  if (rot.length > 0)
+    log.warn(
+      `[classification-audit] ${rot.length} open verdict(s) no longer verify:\n  ` +
+        rot.join('\n  ')
+    )
+  if (contradicted.length > 0)
+    log.warn(
+      `[classification-audit] ${contradicted.length} closed verdict(s) contradicted by ` +
+        `OpenRouter metadata — review at /admin/model-classifications:\n  ` +
+        contradicted.join('\n  ')
+    )
+  if (rot.length === 0 && contradicted.length === 0)
+    log(`[classification-audit] no disagreements`)
+
+  return { rot, contradicted, openChecked, closedChecked }
+}

--- a/backend/scheduler/src/jobs/update-classification-audit.ts
+++ b/backend/scheduler/src/jobs/update-classification-audit.ts
@@ -95,6 +95,40 @@ const describesOpenness = (description: string | null) => {
   return OPENNESS_PHRASES.find((phrase) => haystack.includes(phrase)) ?? null
 }
 
+/**
+ * Did this verification fail because the repo is genuinely not public, or
+ * because we could not reach HuggingFace?
+ *
+ * The distinction is the difference between a finding and noise. A network
+ * blip, a 5xx, or a rate-limit answer produces `confirmed: false` exactly like
+ * a withdrawn repo does — and reporting those as "no longer verifies" would
+ * put every open model in the warn on a bad night, which is how an alert stops
+ * being read. Only reasons that assert something about the repo count as rot.
+ */
+const isTransportFailure = (reason: string) =>
+  reason.startsWith('fetch failed') ||
+  /not public: (?:5\d\d|429|408)/.test(reason)
+
+/**
+ * Verify without letting one bad response end the night.
+ *
+ * `verifyHuggingFaceWeights` catches fetch rejections but not a malformed body
+ * — `await res.json()` throws on a truncated or HTML response, which HF serves
+ * during incidents. Unwrapped, that propagated out of the loop and discarded
+ * every finding gathered so far, including ones already confirmed.
+ */
+const safeVerify = async (repo: string) => {
+  try {
+    return await verifyHuggingFaceWeights(repo)
+  } catch (err) {
+    return {
+      confirmed: false as const,
+      repo,
+      reason: `fetch failed: ${err}`,
+    }
+  }
+}
+
 export const updateClassificationAudit = async () => {
   try {
     await runClassificationAudit()
@@ -103,7 +137,7 @@ export const updateClassificationAudit = async () => {
   }
 }
 
-const runClassificationAudit = async () => {
+export const runClassificationAudit = async () => {
   const pg = createSupabaseDirectClient()
   const { classifications } = await resolveModelClassifications(pg)
   const catalog = await fetchOpenRouterCatalog()
@@ -115,6 +149,7 @@ const runClassificationAudit = async () => {
   const contradicted: string[] = []
   let openChecked = 0
   let closedChecked = 0
+  let unreachable = 0
 
   for (const [permaslug, verdict] of Object.entries(classifications)) {
     const seeded = !!OPEN_WEIGHT_MODELS[permaslug]
@@ -129,11 +164,14 @@ const runClassificationAudit = async () => {
         rot.push(`${permaslug} [${origin}] — open with no weights repo cited`)
         continue
       }
-      const result = await verifyHuggingFaceWeights(verdict.weights)
-      if (!result.confirmed)
-        rot.push(
-          `${permaslug} [${origin}] — ${verdict.weights} no longer verifies: ${result.reason}`
-        )
+      const result = await safeVerify(verdict.weights)
+      if (!result.confirmed) {
+        if (isTransportFailure(result.reason)) unreachable++
+        else
+          rot.push(
+            `${permaslug} [${origin}] — ${verdict.weights} no longer verifies: ${result.reason}`
+          )
+      }
       continue
     }
 
@@ -145,7 +183,7 @@ const runClassificationAudit = async () => {
     // finding if the repo actually carries public weights — a declared but
     // empty or withdrawn repo agrees with us, it does not contradict us.
     if (entry.huggingFaceId) {
-      const result = await verifyHuggingFaceWeights(entry.huggingFaceId)
+      const result = await safeVerify(entry.huggingFaceId)
       if (result.confirmed) {
         contradicted.push(
           `${permaslug} [${origin}] — we say closed, OpenRouter declares ` +
@@ -188,8 +226,19 @@ const runClassificationAudit = async () => {
         `OpenRouter metadata — review at /admin/model-classifications:\n  ` +
         contradicted.join('\n  ')
     )
+  // Said out loud rather than folded into the findings: a night where most
+  // repos were unreachable is a night that proved nothing, and "no
+  // disagreements" would read as a clean bill of health.
+  if (unreachable > 0)
+    log.warn(
+      `[classification-audit] ${unreachable}/${openChecked} open verdict(s) could not be ` +
+        `re-checked (HuggingFace unreachable) — not counted as rot`
+    )
   if (rot.length === 0 && contradicted.length === 0)
-    log(`[classification-audit] no disagreements`)
+    log(
+      `[classification-audit] no disagreements` +
+        (unreachable > 0 ? ` (${unreachable} unverifiable)` : '')
+    )
 
-  return { rot, contradicted, openChecked, closedChecked }
+  return { rot, contradicted, openChecked, closedChecked, unreachable }
 }

--- a/backend/scheduler/src/jobs/update-classification-audit.ts
+++ b/backend/scheduler/src/jobs/update-classification-audit.ts
@@ -3,7 +3,10 @@ import {
   OPEN_WEIGHT_MODELS,
   basePermaslug,
 } from 'common/perps/open-weight-models'
-import { verifyHuggingFaceWeights } from 'shared/huggingface'
+import {
+  isTransportFailure,
+  verifyHuggingFaceWeights,
+} from 'shared/huggingface'
 import { fetchOpenRouterCatalog } from 'shared/openrouter-tokens'
 import { resolveModelClassifications } from 'shared/perps/model-classifications'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
@@ -105,10 +108,6 @@ const describesOpenness = (description: string | null) => {
  * put every open model in the warn on a bad night, which is how an alert stops
  * being read. Only reasons that assert something about the repo count as rot.
  */
-const isTransportFailure = (reason: string) =>
-  reason.startsWith('fetch failed') ||
-  /not public: (?:5\d\d|429|408)/.test(reason)
-
 /**
  * Verify without letting one bad response end the night.
  *
@@ -150,6 +149,14 @@ export const runClassificationAudit = async () => {
   let openChecked = 0
   let closedChecked = 0
   let unreachable = 0
+  // Closed verdicts split three ways, because "checked" was previously
+  // incremented before anything was actually checked: a model absent from the
+  // catalog and one whose declared repo could not be fetched both counted as
+  // checked while producing no finding, so the job could print "checked N
+  // closed / no disagreements" having verified none of them.
+  let closedVerified = 0
+  let closedNoCatalogEntry = 0
+  let closedUnreachable = 0
 
   for (const [permaslug, verdict] of Object.entries(classifications)) {
     const seeded = !!OPEN_WEIGHT_MODELS[permaslug]
@@ -177,13 +184,22 @@ export const runClassificationAudit = async () => {
 
     closedChecked++
     const entry = byPermaslug[permaslug]
-    if (!entry) continue
+    if (!entry) {
+      // Not in the catalog at all — retired, or renamed under us. Nothing to
+      // compare against, which is not the same as agreeing with us.
+      closedNoCatalogEntry++
+      continue
+    }
 
     // HINTS: OpenRouter declares a repo for something we call closed. Only a
     // finding if the repo actually carries public weights — a declared but
     // empty or withdrawn repo agrees with us, it does not contradict us.
     if (entry.huggingFaceId) {
       const result = await safeVerify(entry.huggingFaceId)
+      if (!result.confirmed && isTransportFailure(result.reason)) {
+        closedUnreachable++
+        continue
+      }
       if (result.confirmed) {
         contradicted.push(
           `${permaslug} [${origin}] — we say closed, OpenRouter declares ` +
@@ -195,6 +211,7 @@ export const runClassificationAudit = async () => {
     }
 
     // PROSE: no usable declared repo, but the blurb claims openness.
+    closedVerified++
     const phrase = describesOpenness(entry.description)
     if (phrase)
       contradicted.push(
@@ -204,41 +221,57 @@ export const runClassificationAudit = async () => {
   }
 
   log(
-    `[classification-audit] checked ${openChecked} open + ${closedChecked} closed ` +
+    `[classification-audit] ${openChecked} open (${unreachable} unverifiable), ` +
+      `${closedChecked} closed (${closedVerified} verified, ` +
+      `${closedNoCatalogEntry} not in catalog, ${closedUnreachable} unverifiable) ` +
       `(list ${OPEN_WEIGHT_LIST_VERSION})`
   )
 
-  // Warn, not error, and deliberately: neither finding means the index is
-  // wrong right now. A rot finding can be a transient HF outage, and a
-  // contradiction can be OpenRouter's metadata being wrong — it was, for
-  // three models in the 2026-08-24 audit. Both need a human to look, and
-  // paging on something that is often a false positive trains people to
-  // ignore it. What must not happen is nobody being told at all, which is
-  // the state this job replaces.
+  // ERROR, not warn, and that is a deployment fact rather than a severity
+  // judgement: prod monitoring alerts on ERROR and does not look at WARN, so a
+  // finding logged at warn is a finding nobody is ever told about — which
+  // would leave this job detecting a wrong classification nightly and changing
+  // nothing. If that routing changes, this can go back to warn.
+  //
+  // Kept rare enough to deserve it: transport failures are excluded above, so
+  // these are claims about repos rather than about the network, and the first
+  // three prod runs produced none.
+  const indent = (lines: string[]) => '\n  ' + lines.join('\n  ')
   if (rot.length > 0)
-    log.warn(
-      `[classification-audit] ${rot.length} open verdict(s) no longer verify:\n  ` +
-        rot.join('\n  ')
+    log.error(
+      `[classification-audit] ${rot.length} open verdict(s) no longer verify:` +
+        indent(rot)
     )
   if (contradicted.length > 0)
-    log.warn(
-      `[classification-audit] ${contradicted.length} closed verdict(s) contradicted by ` +
-        `OpenRouter metadata — review at /admin/model-classifications:\n  ` +
-        contradicted.join('\n  ')
+    log.error(
+      `[classification-audit] ${contradicted.length} closed verdict(s) contradicted ` +
+        `by OpenRouter metadata — review at /admin/model-classifications:` +
+        indent(contradicted)
     )
-  // Said out loud rather than folded into the findings: a night where most
-  // repos were unreachable is a night that proved nothing, and "no
-  // disagreements" would read as a clean bill of health.
-  if (unreachable > 0)
+
+  // A night where much of the population could not be reached proved little,
+  // and "no disagreements" would read as a clean bill of health. Warn is right
+  // here — it is a caveat on coverage, not a finding.
+  const unverifiable = unreachable + closedUnreachable + closedNoCatalogEntry
+  if (unverifiable > 0)
     log.warn(
-      `[classification-audit] ${unreachable}/${openChecked} open verdict(s) could not be ` +
-        `re-checked (HuggingFace unreachable) — not counted as rot`
+      `[classification-audit] ${unverifiable} verdict(s) could not be re-checked ` +
+        `(${unreachable} open unreachable, ${closedUnreachable} closed unreachable, ` +
+        `${closedNoCatalogEntry} absent from catalog) — not counted as findings`
     )
   if (rot.length === 0 && contradicted.length === 0)
     log(
       `[classification-audit] no disagreements` +
-        (unreachable > 0 ? ` (${unreachable} unverifiable)` : '')
+        (unverifiable > 0 ? ` (${unverifiable} unverifiable)` : '')
     )
-
-  return { rot, contradicted, openChecked, closedChecked, unreachable }
+  return {
+    rot,
+    contradicted,
+    openChecked,
+    closedChecked,
+    closedVerified,
+    closedNoCatalogEntry,
+    closedUnreachable,
+    unreachable,
+  }
 }

--- a/backend/scheduler/src/jobs/update-classification-audit.ts
+++ b/backend/scheduler/src/jobs/update-classification-audit.ts
@@ -94,20 +94,11 @@ const PROPRIETARY_PHRASES = [
 const describesOpenness = (description: string | null) => {
   if (!description) return null
   const haystack = description.toLowerCase()
-  if (PROPRIETARY_PHRASES.some((phrase) => haystack.includes(phrase))) return null
+  if (PROPRIETARY_PHRASES.some((phrase) => haystack.includes(phrase)))
+    return null
   return OPENNESS_PHRASES.find((phrase) => haystack.includes(phrase)) ?? null
 }
 
-/**
- * Did this verification fail because the repo is genuinely not public, or
- * because we could not reach HuggingFace?
- *
- * The distinction is the difference between a finding and noise. A network
- * blip, a 5xx, or a rate-limit answer produces `confirmed: false` exactly like
- * a withdrawn repo does — and reporting those as "no longer verifies" would
- * put every open model in the warn on a bad night, which is how an alert stops
- * being read. Only reasons that assert something about the repo count as rot.
- */
 /**
  * Verify without letting one bad response end the night.
  *
@@ -194,11 +185,17 @@ export const runClassificationAudit = async () => {
     // HINTS: OpenRouter declares a repo for something we call closed. Only a
     // finding if the repo actually carries public weights — a declared but
     // empty or withdrawn repo agrees with us, it does not contradict us.
+    // Whether the DECLARED-REPO check could be run. The prose check below is
+    // independent of HuggingFace — it reads a description already fetched from
+    // OpenRouter — so an HF outage must not skip it. Returning early here meant
+    // a bad HF night suppressed the one signal still available and reported
+    // "no disagreements".
+    let repoCheckRan = true
     if (entry.huggingFaceId) {
       const result = await safeVerify(entry.huggingFaceId)
       if (!result.confirmed && isTransportFailure(result.reason)) {
         closedUnreachable++
-        continue
+        repoCheckRan = false
       }
       if (result.confirmed) {
         contradicted.push(
@@ -206,12 +203,16 @@ export const runClassificationAudit = async () => {
             `${entry.huggingFaceId} (${result.evidence.weightFileCount} weight files, ` +
             `gated=${result.evidence.gated})`
         )
+        closedVerified++
         continue
       }
     }
 
     // PROSE: no usable declared repo, but the blurb claims openness.
-    closedVerified++
+    // Counted once, after both checks, and only when the repo check actually
+    // ran — so verified + notInCatalog + unreachable + contradicted reconciles
+    // against closedChecked instead of silently under-counting.
+    if (repoCheckRan) closedVerified++
     const phrase = describesOpenness(entry.description)
     if (phrase)
       contradicted.push(

--- a/backend/scheduler/src/jobs/update-classification-audit.ts
+++ b/backend/scheduler/src/jobs/update-classification-audit.ts
@@ -135,8 +135,14 @@ export const runClassificationAudit = async () => {
     catalog.map((entry) => [basePermaslug(entry.permaslug), entry])
   )
 
-  const rot: string[] = []
-  const contradicted: string[] = []
+  // Tagged with origin, because the two have DIFFERENT remedies and pointing
+  // at the wrong one is worse than saying nothing. A seeded entry is invisible
+  // on the admin page (the getter filters it) and refused by the setter (it is
+  // the published methodology), so telling an operator to go and fix it there
+  // sends them to a page where the row does not appear at all.
+  type Finding = { origin: 'seed' | 'override'; message: string }
+  const rot: Finding[] = []
+  const contradicted: Finding[] = []
   let openChecked = 0
   let closedChecked = 0
   let unreachable = 0
@@ -159,16 +165,20 @@ export const runClassificationAudit = async () => {
       // table's check constraint plus the seed's own test both forbid it —
       // so if one appears, that is the finding.
       if (!verdict.weights) {
-        rot.push(`${permaslug} [${origin}] — open with no weights repo cited`)
+        rot.push({
+          origin,
+          message: `${permaslug} — open with no weights repo cited`,
+        })
         continue
       }
       const result = await safeVerify(verdict.weights)
       if (!result.confirmed) {
         if (isTransportFailure(result.reason)) unreachable++
         else
-          rot.push(
-            `${permaslug} [${origin}] — ${verdict.weights} no longer verifies: ${result.reason}`
-          )
+          rot.push({
+            origin,
+            message: `${permaslug} — ${verdict.weights} no longer verifies: ${result.reason}`,
+          })
       }
       continue
     }
@@ -198,11 +208,13 @@ export const runClassificationAudit = async () => {
         repoCheckRan = false
       }
       if (result.confirmed) {
-        contradicted.push(
-          `${permaslug} [${origin}] — we say closed, OpenRouter declares ` +
+        contradicted.push({
+          origin,
+          message:
+            `${permaslug} — we say closed, OpenRouter declares ` +
             `${entry.huggingFaceId} (${result.evidence.weightFileCount} weight files, ` +
-            `gated=${result.evidence.gated})`
-        )
+            `gated=${result.evidence.gated})`,
+        })
         closedVerified++
         continue
       }
@@ -215,10 +227,12 @@ export const runClassificationAudit = async () => {
     if (repoCheckRan) closedVerified++
     const phrase = describesOpenness(entry.description)
     if (phrase)
-      contradicted.push(
-        `${permaslug} [${origin}] — we say closed, but OpenRouter's ` +
-          `description says "${phrase}"`
-      )
+      contradicted.push({
+        origin,
+        message:
+          `${permaslug} — we say closed, but OpenRouter's ` +
+          `description says "${phrase}"`,
+      })
   }
 
   log(
@@ -237,19 +251,39 @@ export const runClassificationAudit = async () => {
   // Kept rare enough to deserve it: transport failures are excluded above, so
   // these are claims about repos rather than about the network, and the first
   // three prod runs produced none.
-  const indent = (lines: string[]) => '\n  ' + lines.join('\n  ')
-  if (rot.length > 0)
-    log.error(
-      `[classification-audit] ${rot.length} open verdict(s) no longer verify:` +
-        indent(rot)
-    )
-  if (contradicted.length > 0)
-    log.error(
-      `[classification-audit] ${contradicted.length} closed verdict(s) contradicted ` +
-        `by OpenRouter metadata — review at /admin/model-classifications:` +
-        indent(contradicted)
-    )
+  // Reported per origin, because the remedy differs and only one of them is
+  // reachable from the admin page.
+  const indent = (fs: Finding[]) =>
+    '\n  ' + fs.map((f) => f.message).join('\n  ')
+  const seedOf = (fs: Finding[]) => fs.filter((f) => f.origin === 'seed')
+  const overrideOf = (fs: Finding[]) =>
+    fs.filter((f) => f.origin === 'override')
 
+  const SEED_REMEDY =
+    'edit common/src/perps/open-weight-models.ts and bump ' +
+    'OPEN_WEIGHT_LIST_VERSION (seeded entries are not editable from the ' +
+    'admin page or the API — they are the published methodology)'
+  const OVERRIDE_REMEDY = 'review at /admin/model-classifications'
+
+  for (const [findings, what] of [
+    [rot, 'open verdict(s) no longer verify'],
+    [contradicted, 'closed verdict(s) contradicted by OpenRouter metadata'],
+  ] as [Finding[], string][]) {
+    const seeded = seedOf(findings)
+    const overridden = overrideOf(findings)
+    if (seeded.length > 0)
+      log.error(
+        `[classification-audit] ${seeded.length} SEED ${what} — ` +
+          `${SEED_REMEDY}:` +
+          indent(seeded)
+      )
+    if (overridden.length > 0)
+      log.error(
+        `[classification-audit] ${overridden.length} override ${what} — ` +
+          `${OVERRIDE_REMEDY}:` +
+          indent(overridden)
+      )
+  }
   // A night where much of the population could not be reached proved little,
   // and "no disagreements" would read as a clean bill of health. Warn is right
   // here — it is a caveat on coverage, not a finding.

--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -1,4 +1,7 @@
-import { OPEN_WEIGHT_MODELS } from 'common/perps/open-weight-models'
+import {
+  OPEN_WEIGHT_MODELS,
+  isCompositeSlug,
+} from 'common/perps/open-weight-models'
 import {
   logHuggingFaceVerification,
   verifyHuggingFaceWeights,
@@ -77,8 +80,16 @@ const updateModelClassificationsInternal = async () => {
   )
   const settled = new Set(adjudicated.map((r) => r.permaslug))
 
+  // Composites are filtered HERE, at candidate creation, not only where rows
+  // are written. Everything downstream — the pending insert, the research
+  // shortlist, the summary counts — is derived from this list, so filtering
+  // later left routers and aliases eligible for a paid research call and an
+  // automatic verdict that the index would then ignore.
   const unknown = catalog.filter(
-    (m) => !OPEN_WEIGHT_MODELS[m.permaslug] && !settled.has(m.permaslug)
+    (m) =>
+      !OPEN_WEIGHT_MODELS[m.permaslug] &&
+      !settled.has(m.permaslug) &&
+      !isCompositeSlug(m.permaslug)
   )
   if (unknown.length === 0) {
     log('[model-classifier] catalog fully classified')
@@ -140,7 +151,9 @@ const updateModelClassificationsInternal = async () => {
       `${confirmed} auto-classified open from a declared repo, ` +
       `${researched.recommended} agent recommendations for review, ` +
       `${researched.unresolved} unresolved; ${rankedPending.length} ranked ` +
-      `awaiting review, ${pending.length - rankedPending.length} unranked backlog`
+      `awaiting review, ${
+        pending.length - rankedPending.length
+      } unranked backlog`
   )
 
   // Warn rather than error: a pending model is not yet a problem — the index

--- a/backend/scheduler/src/jobs/update-openrouter-share.ts
+++ b/backend/scheduler/src/jobs/update-openrouter-share.ts
@@ -84,6 +84,22 @@ const updateOpenRouterShareInternal = async () => {
   if (result.unclassified.length > 0)
     await recordUnclassifiedInRankings(pg, result.unclassified)
 
+  // Routers and floating aliases leave the denominator without ever being
+  // adjudicated, so nothing else would mention them. Say so on every tick that
+  // has one: an exclusion nobody can see is indistinguishable from full
+  // coverage, and if one ever carries real volume that is the signal to
+  // resolve it through OpenRouter's `alias_target` rather than keep dropping
+  // it.
+  if (result.compositeSlugs.length > 0)
+    log.warn(
+      `[openrouter] excluded ${result.compositeSlugs.length} router/alias slug(s) ` +
+        `from both sides — ${result.compositeSlugs.join(', ')} (` +
+        `${(
+          (result.compositeTokens / Math.max(result.payloadTokens, 1)) *
+          100
+        ).toFixed(3)}% of payload tokens)`
+    )
+
   const publication = validateOpenWeightPublication(result, {
     expiredUnclassified,
   })

--- a/backend/scripts/reclassify-model.ts
+++ b/backend/scripts/reclassify-model.ts
@@ -28,15 +28,23 @@ import { upsertClassification } from 'shared/perps/model-classifications'
 //   npx ts-node reclassify-model.ts <permaslug> closed
 //   ... add --apply to write; dry run otherwise.
 
-const usage = () => {
-  console.error(
-    'usage: reclassify-model.ts <permaslug> <open|closed> [owner/repo] [--apply]'
-  )
+// Every refusal exits NON-ZERO. runScript ends in a bare `process.exit()`,
+// which honours process.exitCode — without setting it a script that refused to
+// do anything still exited 0 and read as success.
+const fail = (message: string) => {
+  console.error(message)
+  process.exitCode = 1
 }
+
+const usage = () =>
+  fail(
+    'usage: reclassify-model.ts <permaslug> <open|closed> [owner/repo] [--apply] [--create]'
+  )
 
 if (require.main === module) {
   runScript(async ({ pg }) => {
-    const args = process.argv.slice(2).filter((a) => a !== '--apply')
+    const FLAGS = ['--apply', '--create']
+    const args = process.argv.slice(2).filter((a) => !FLAGS.includes(a))
     const apply = process.argv.includes('--apply')
     const [rawSlug, verdict, repo] = args
     if (!rawSlug || (verdict !== 'open' && verdict !== 'closed')) return usage()
@@ -47,14 +55,14 @@ if (require.main === module) {
     // Same refusals the admin endpoint applies, so the two cannot disagree
     // about what is editable.
     if (isCompositeSlug(permaslug)) {
-      console.error(
+      fail(
         `${permaslug} is a router or floating alias — excluded from the index, ` +
           `so a verdict on it is ignored either way.`
       )
       return
     }
     if (OPEN_WEIGHT_MODELS[permaslug]) {
-      console.error(
+      fail(
         `${permaslug} is in the audited seed (version ${OPEN_WEIGHT_LIST_VERSION}). ` +
           `Changing it is a change to the published methodology — edit ` +
           `common/src/perps/open-weight-models.ts and bump the version.`
@@ -62,8 +70,8 @@ if (require.main === module) {
       return
     }
     if (open && !repo) {
-      console.error('an open verdict needs the weights repo that proves it')
-      return usage()
+      fail('an open verdict needs the weights repo that proves it')
+      return
     }
 
     const before = await pg.oneOrNone<{
@@ -82,6 +90,17 @@ if (require.main === module) {
       }`
     )
 
+    // A permaslug with no row is almost always a typo, and the upsert would
+    // happily INSERT one — reporting success while the model you meant to fix
+    // stays untouched and an inert row joins the table.
+    if (!before && !process.argv.includes('--create')) {
+      fail(
+        `no classification row for ${permaslug} — check the permaslug. ` +
+          `Pass --create if you really mean to add a new row.`
+      )
+      return
+    }
+
     // Verify before writing, not after. An open verdict is the only one that
     // asserts something positive about the world, and the whole reason this
     // script exists is a repo that changed state under a stored answer.
@@ -89,7 +108,7 @@ if (require.main === module) {
     if (open) {
       const result = await verifyHuggingFaceWeights(repo)
       if (!result.confirmed) {
-        console.error(`refusing: ${repo} did not verify — ${result.reason}`)
+        fail(`refusing: ${repo} did not verify — ${result.reason}`)
         return
       }
       weightFileCount = result.evidence.weightFileCount

--- a/backend/scripts/reclassify-model.ts
+++ b/backend/scripts/reclassify-model.ts
@@ -3,6 +3,7 @@ import {
   OPEN_WEIGHT_MODELS,
   basePermaslug,
   isCompositeSlug,
+  isValidPermaslug,
 } from 'common/perps/open-weight-models'
 import { runScript } from 'run-script'
 import { verifyHuggingFaceWeights } from 'shared/huggingface'
@@ -43,12 +44,37 @@ const usage = () =>
 
 if (require.main === module) {
   runScript(async ({ pg }) => {
+    // Strict parsing, because the failure mode is a silent no-op that looks
+    // like success. Filtering only EXACT known flags meant `--aply` fell
+    // through as a positional argument: `slug closed --aply` parsed as a dry
+    // run and exited 0, so an operator who thought they had written a
+    // correction had written nothing. Excess positionals were ignored the
+    // same way.
     const FLAGS = ['--apply', '--create']
-    const args = process.argv.slice(2).filter((a) => !FLAGS.includes(a))
-    const apply = process.argv.includes('--apply')
+    const argv = process.argv.slice(2)
+    const unknownFlags = argv.filter(
+      (a) => a.startsWith('-') && !FLAGS.includes(a)
+    )
+    if (unknownFlags.length > 0) {
+      fail(`unknown flag(s): ${unknownFlags.join(', ')}`)
+      return usage()
+    }
+    const args = argv.filter((a) => !FLAGS.includes(a))
+    const apply = argv.includes('--apply')
+    const create = argv.includes('--create')
     const [rawSlug, verdict, repo] = args
-    if (!rawSlug || (verdict !== 'open' && verdict !== 'closed')) return usage()
 
+    // Exact arity: closed takes 2, open takes 3. Anything else is a typo, not
+    // something to guess at.
+    const expected = verdict === 'open' ? 3 : 2
+    if (!rawSlug || (verdict !== 'open' && verdict !== 'closed')) return usage()
+    if (args.length !== expected) {
+      fail(
+        `expected ${expected} positional argument(s) for '${verdict}', ` +
+          `got ${args.length}: ${JSON.stringify(args)}`
+      )
+      return usage()
+    }
     const permaslug = basePermaslug(rawSlug.trim())
     const open = verdict === 'open'
 
@@ -56,7 +82,7 @@ if (require.main === module) {
     // argument both normalise to '' — which passed the raw-argument check
     // above and, with --create, would have inserted an empty-slug row that
     // nothing can ever match.
-    if (!permaslug.includes('/')) {
+    if (!isValidPermaslug(permaslug)) {
       fail(
         `${JSON.stringify(rawSlug)} does not normalise to an owner/model ` +
           `permaslug (got ${JSON.stringify(permaslug)}).`
@@ -105,7 +131,7 @@ if (require.main === module) {
     // A permaslug with no row is almost always a typo, and the upsert would
     // happily INSERT one — reporting success while the model you meant to fix
     // stays untouched and an inert row joins the table.
-    if (!before && !process.argv.includes('--create')) {
+    if (!before && !create) {
       fail(
         `no classification row for ${permaslug} — check the permaslug. ` +
           `Pass --create if you really mean to add a new row.`

--- a/backend/scripts/reclassify-model.ts
+++ b/backend/scripts/reclassify-model.ts
@@ -1,0 +1,125 @@
+import {
+  OPEN_WEIGHT_LIST_VERSION,
+  OPEN_WEIGHT_MODELS,
+  basePermaslug,
+  isCompositeSlug,
+} from 'common/perps/open-weight-models'
+import { runScript } from 'run-script'
+import { verifyHuggingFaceWeights } from 'shared/huggingface'
+import { upsertClassification } from 'shared/perps/model-classifications'
+
+// Change an EXISTING classification.
+//
+// The admin tool can adjudicate a pending model but has no control for a
+// verdict already made, and correcting one is now a routine operation rather
+// than an exceptional one: a publisher shipping weights after launch is a
+// pre-committed case in the methodology, and `update-classification-audit.ts`
+// exists precisely to find verdicts that have gone stale. Detecting them
+// nightly while having no way to act is half a loop.
+//
+// The admin page grows an inline control for this in the same change; this
+// script stays for the case where the correction has to happen before a web
+// deploy, which is exactly how it was first needed (GLM 5.3, 2026-08-29:
+// classified closed on 08-20 when zai-org genuinely had no such repo, weights
+// published 08-25, market showing a stale number in the meantime).
+//
+// Usage:
+//   npx ts-node reclassify-model.ts <permaslug> open <owner/repo>
+//   npx ts-node reclassify-model.ts <permaslug> closed
+//   ... add --apply to write; dry run otherwise.
+
+const usage = () => {
+  console.error(
+    'usage: reclassify-model.ts <permaslug> <open|closed> [owner/repo] [--apply]'
+  )
+}
+
+if (require.main === module) {
+  runScript(async ({ pg }) => {
+    const args = process.argv.slice(2).filter((a) => a !== '--apply')
+    const apply = process.argv.includes('--apply')
+    const [rawSlug, verdict, repo] = args
+    if (!rawSlug || (verdict !== 'open' && verdict !== 'closed')) return usage()
+
+    const permaslug = basePermaslug(rawSlug.trim())
+    const open = verdict === 'open'
+
+    // Same refusals the admin endpoint applies, so the two cannot disagree
+    // about what is editable.
+    if (isCompositeSlug(permaslug)) {
+      console.error(
+        `${permaslug} is a router or floating alias — excluded from the index, ` +
+          `so a verdict on it is ignored either way.`
+      )
+      return
+    }
+    if (OPEN_WEIGHT_MODELS[permaslug]) {
+      console.error(
+        `${permaslug} is in the audited seed (version ${OPEN_WEIGHT_LIST_VERSION}). ` +
+          `Changing it is a change to the published methodology — edit ` +
+          `common/src/perps/open-weight-models.ts and bump the version.`
+      )
+      return
+    }
+    if (open && !repo) {
+      console.error('an open verdict needs the weights repo that proves it')
+      return usage()
+    }
+
+    const before = await pg.oneOrNone<{
+      open: boolean | null
+      weights: string | null
+      source: string
+    }>(
+      `select open, weights, source from model_classifications where permaslug = $1`,
+      [permaslug]
+    )
+    console.log(
+      `current: ${
+        before
+          ? `open=${before.open} weights=${before.weights} source=${before.source}`
+          : '(no row)'
+      }`
+    )
+
+    // Verify before writing, not after. An open verdict is the only one that
+    // asserts something positive about the world, and the whole reason this
+    // script exists is a repo that changed state under a stored answer.
+    let weightFileCount: number | null = null
+    if (open) {
+      const result = await verifyHuggingFaceWeights(repo)
+      if (!result.confirmed) {
+        console.error(`refusing: ${repo} did not verify — ${result.reason}`)
+        return
+      }
+      weightFileCount = result.evidence.weightFileCount
+      console.log(
+        `verified: ${repo} public, ${weightFileCount} weight files, ` +
+          `gated=${result.evidence.gated}`
+      )
+    }
+
+    console.log(
+      `proposed: ${permaslug} -> ${open ? `open (${repo})` : 'closed'}`
+    )
+    if (!apply) return console.log('\nDRY RUN — pass --apply to write.')
+
+    await upsertClassification(pg, {
+      permaslug,
+      open,
+      weights: open ? repo : null,
+      source: 'admin',
+      classifiedBy: process.env.RECLASSIFY_ACTOR ?? 'reclassify-model-script',
+      evidence: {
+        method: 'reclassify-model.ts',
+        previous: before
+          ? { open: before.open, weights: before.weights }
+          : null,
+        ...(open ? { weightsRepo: repo, weightFileCount } : {}),
+        reclassifiedAt: new Date().toISOString(),
+      },
+    })
+    console.log(`\nwrote ${permaslug} -> ${open ? 'open' : 'closed'}`)
+    console.log('takes effect on the next openrouter tick (hourly, at :20).')
+  })
+}

--- a/backend/scripts/reclassify-model.ts
+++ b/backend/scripts/reclassify-model.ts
@@ -52,6 +52,18 @@ if (require.main === module) {
     const permaslug = basePermaslug(rawSlug.trim())
     const open = verdict === 'open'
 
+    // basePermaslug truncates at the first ':', so ':free' and a whitespace
+    // argument both normalise to '' — which passed the raw-argument check
+    // above and, with --create, would have inserted an empty-slug row that
+    // nothing can ever match.
+    if (!permaslug.includes('/')) {
+      fail(
+        `${JSON.stringify(rawSlug)} does not normalise to an owner/model ` +
+          `permaslug (got ${JSON.stringify(permaslug)}).`
+      )
+      return
+    }
+
     // Same refusals the admin endpoint applies, so the two cannot disagree
     // about what is editable.
     if (isCompositeSlug(permaslug)) {
@@ -105,12 +117,17 @@ if (require.main === module) {
     // asserts something positive about the world, and the whole reason this
     // script exists is a repo that changed state under a stored answer.
     let weightFileCount: number | null = null
+    let confirmation: Extract<
+      Awaited<ReturnType<typeof verifyHuggingFaceWeights>>,
+      { confirmed: true }
+    > | null = null
     if (open) {
       const result = await verifyHuggingFaceWeights(repo)
       if (!result.confirmed) {
         fail(`refusing: ${repo} did not verify — ${result.reason}`)
         return
       }
+      confirmation = result
       weightFileCount = result.evidence.weightFileCount
       console.log(
         `verified: ${repo} public, ${weightFileCount} weight files, ` +
@@ -129,12 +146,16 @@ if (require.main === module) {
       weights: open ? repo : null,
       source: 'admin',
       classifiedBy: process.env.RECLASSIFY_ACTOR ?? 'reclassify-model-script',
+      // No hand-rolled `previous` snapshot. It was read before a verification
+      // that can take fifteen seconds, so a concurrent correction in that
+      // window would have persisted a stale record that CONTRADICTS the
+      // history the upsert archives atomically in SQL — two disagreeing
+      // accounts of the same change, with the wrong one easier to read.
+      // The SQL history is the record; this carries only what the verifier
+      // actually established.
       evidence: {
         method: 'reclassify-model.ts',
-        previous: before
-          ? { open: before.open, weights: before.weights }
-          : null,
-        ...(open ? { weightsRepo: repo, weightFileCount } : {}),
+        ...(open && confirmation ? confirmation.evidence : {}),
         reclassifiedAt: new Date().toISOString(),
       },
     })

--- a/backend/scripts/run-classification-audit.ts
+++ b/backend/scripts/run-classification-audit.ts
@@ -1,0 +1,15 @@
+import { runScript } from 'run-script'
+import { updateClassificationAudit } from 'scheduler/jobs/update-classification-audit'
+
+// Run the nightly classification audit on demand.
+//
+// The job is read-only — it re-verifies published classifications against
+// HuggingFace and OpenRouter and logs disagreements; it never writes a
+// verdict. So this is safe to run against prod whenever someone wants the
+// current answer rather than waiting for 03:40 LA.
+
+if (require.main === module) {
+  runScript(async () => {
+    await updateClassificationAudit()
+  })
+}

--- a/backend/scripts/run-classification-audit.ts
+++ b/backend/scripts/run-classification-audit.ts
@@ -1,5 +1,5 @@
 import { runScript } from 'run-script'
-import { updateClassificationAudit } from 'scheduler/jobs/update-classification-audit'
+import { runClassificationAudit } from 'scheduler/jobs/update-classification-audit'
 
 // Run the nightly classification audit on demand.
 //
@@ -8,8 +8,18 @@ import { updateClassificationAudit } from 'scheduler/jobs/update-classification-
 // verdict. So this is safe to run against prod whenever someone wants the
 // current answer rather than waiting for 03:40 LA.
 
+// Calls the THROWING variant, not the scheduler's `updateClassificationAudit`
+// wrapper. That wrapper swallows into `log.error` so one bad night cannot kill
+// the cron — correct there, wrong here: an operator running this by hand would
+// have got exit 0 and a clean-looking terminal on a run that never checked
+// anything.
 if (require.main === module) {
   runScript(async () => {
-    await updateClassificationAudit()
+    const { rot, contradicted, unreachable } = await runClassificationAudit()
+    if (rot.length > 0 || contradicted.length > 0 || unreachable > 0)
+      console.log(
+        `\nfindings: ${rot.length} rot, ${contradicted.length} contradicted, ` +
+          `${unreachable} unverifiable`
+      )
   })
 }

--- a/backend/shared/src/huggingface.test.ts
+++ b/backend/shared/src/huggingface.test.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import {
+  MANUAL_GATING_PUBLIC_REPOS,
+  isTransportFailure,
+} from './huggingface'
+
+describe('isTransportFailure', () => {
+  it('treats unreachability as unreachable, not as repository rot', () => {
+    expect(isTransportFailure('fetch failed: TypeError: network error')).toBe(true)
+    for (const status of ['408', '429', '500', '502', '503', '504'])
+      expect([status, isTransportFailure(`not public: ${status} Whatever`)]).toEqual([
+        status,
+        true,
+      ])
+  })
+
+  it('still reports a genuinely absent or restricted repo as rot', () => {
+    // 401 is HF's answer for both "private" and "does not exist" — the whole
+    // reason an open verdict needs re-checking at all.
+    expect(isTransportFailure('not public: 401 Unauthorized')).toBe(false)
+    expect(isTransportFailure('not public: 404 Not Found')).toBe(false)
+    expect(isTransportFailure('repo is private')).toBe(false)
+    expect(isTransportFailure('repo has no weight files')).toBe(false)
+    expect(isTransportFailure('gating is not public: "manual"')).toBe(false)
+  })
+
+  it('does not match a status embedded in a longer number', () => {
+    expect(isTransportFailure('not public: 4290 Nonsense')).toBe(false)
+  })
+
+  /**
+   * The regression this file exists for. A previous revision expressed the
+   * status check as a regex ending in a literal 0x08 byte — a `\b` mangled
+   * during editing — so it never matched and every transport blip was filed as
+   * rot. It passed review because the byte does not render.
+   */
+  it('contains no invisible control characters in its source', () => {
+    for (const file of ['huggingface.ts', 'perps/model-classifications.ts']) {
+      const src = fs.readFileSync(path.join(__dirname, file), 'utf8')
+      // Tab, LF and CR are the legitimate ones (these are CRLF checkouts).
+      const allowed = new Set([9, 10, 13])
+      const bad = [...src].filter(
+        (ch) => ch.charCodeAt(0) < 32 && !allowed.has(ch.charCodeAt(0))
+      )
+      expect([file, bad.map((c) => c.charCodeAt(0))]).toEqual([file, []])
+    }
+  })
+})
+
+describe('MANUAL_GATING_PUBLIC_REPOS', () => {
+  it('is the eleven Llama/Gemma repos and nothing else', () => {
+    // Deliberately exact. `manual` gating means the author approves each
+    // request, so anything added here is an assertion that a specific line is
+    // public in practice — it should never grow by accident.
+    expect([...MANUAL_GATING_PUBLIC_REPOS].sort()).toEqual([
+      'google/gemma-3-12b-it',
+      'google/gemma-3-27b-it',
+      'google/gemma-3-4b-it',
+      'google/gemma-3n-e4b-it',
+      'meta-llama/llama-3.2-1b-instruct',
+      'meta-llama/llama-3.2-3b-instruct',
+      'meta-llama/llama-3.3-70b-instruct',
+      'meta-llama/llama-4-maverick-17b-128e-instruct',
+      'meta-llama/llama-4-scout-17b-16e-instruct',
+      'meta-llama/meta-llama-3.1-70b-instruct',
+      'meta-llama/meta-llama-3.1-8b-instruct',
+    ])
+  })
+
+  it('is stored lowercase so the lookup is case-insensitive', () => {
+    for (const repo of MANUAL_GATING_PUBLIC_REPOS)
+      expect([repo, repo]).toEqual([repo, repo.toLowerCase()])
+  })
+})

--- a/backend/shared/src/huggingface.test.ts
+++ b/backend/shared/src/huggingface.test.ts
@@ -3,16 +3,24 @@ import * as path from 'path'
 import {
   MANUAL_GATING_PUBLIC_REPOS,
   isTransportFailure,
+  isValidRepoId,
 } from './huggingface'
 
 describe('isTransportFailure', () => {
   it('treats unreachability as unreachable, not as repository rot', () => {
-    expect(isTransportFailure('fetch failed: TypeError: network error')).toBe(true)
-    for (const status of ['408', '429', '500', '502', '503', '504'])
-      expect([status, isTransportFailure(`not public: ${status} Whatever`)]).toEqual([
+    expect(isTransportFailure('fetch failed: TypeError: network error')).toBe(
+      true
+    )
+    // The WHOLE 5xx range, not an allowlist. Cloudflare fronts HuggingFace and
+    // serves 520/522/524; 501 and 599 exist too. An allowlist that misses one
+    // turns an outage into an ERROR alert claiming weights were withdrawn.
+    const statuses = ['408', '429']
+    for (let code = 500; code <= 599; code++) statuses.push(String(code))
+    for (const status of statuses)
+      expect([
         status,
-        true,
-      ])
+        isTransportFailure(`not public: ${status} Whatever`),
+      ]).toEqual([status, true])
   })
 
   it('still reports a genuinely absent or restricted repo as rot', () => {
@@ -71,5 +79,43 @@ describe('MANUAL_GATING_PUBLIC_REPOS', () => {
   it('is stored lowercase so the lookup is case-insensitive', () => {
     for (const repo of MANUAL_GATING_PUBLIC_REPOS)
       expect([repo, repo]).toEqual([repo, repo.toLowerCase()])
+  })
+})
+
+describe('isValidRepoId', () => {
+  it('rejects traversal segments that would fetch a different repository', () => {
+    // Verified live: https://huggingface.co/api/models/openai/../openai-community/gpt2
+    // answers 200 and resolves to openai-community/gpt2. encodeURIComponent
+    // does not escape dots, so the id survived encoding and the fetch
+    // normalised it away — while every upstream guard only reads split('/')[0]
+    // and sees `openai`. The attacker's repo gets verified; the publisher's id
+    // gets stored; the auto-apply path writes open: true.
+    expect(isValidRepoId('openai/../attacker/gpt-oss-120b')).toBe(false)
+    expect(isValidRepoId('openai/..')).toBe(false)
+    expect(isValidRepoId('../attacker/x')).toBe(false)
+    expect(isValidRepoId('openai/./gpt-oss')).toBe(false)
+  })
+
+  it('rejects anything that is not exactly owner/name', () => {
+    expect(isValidRepoId('gpt-oss-120b')).toBe(false)
+    expect(isValidRepoId('a/b/c')).toBe(false)
+    expect(isValidRepoId('openai/')).toBe(false)
+    expect(isValidRepoId('/gpt-oss')).toBe(false)
+    expect(isValidRepoId('')).toBe(false)
+    expect(isValidRepoId('openai/gpt oss')).toBe(false)
+    expect(isValidRepoId('openai/gpt%2foss')).toBe(false)
+  })
+
+  it('accepts the real repo ids this index actually cites', () => {
+    for (const repo of [
+      'zai-org/GLM-5.3',
+      'meta-llama/Llama-3.3-70B-Instruct',
+      'mistralai/Mistral-Large-3-675B-Instruct-2512',
+      'deepseek-ai/DeepSeek-V4-Pro-0813',
+      'inclusionAI/Ling-3.0-flash',
+      'google/gemma-3n-E4B-it',
+      'tencent/Hy4-preview',
+    ])
+      expect([repo, isValidRepoId(repo)]).toEqual([repo, true])
   })
 })

--- a/backend/shared/src/huggingface.ts
+++ b/backend/shared/src/huggingface.ts
@@ -40,16 +40,14 @@ export type HuggingFaceVerification =
 /**
  * Verify that `repo` holds publicly downloadable weights.
  *
- * Click-through gating still counts as public — Llama and Gemma sit behind a
- * licence any member of the public can accept, and the methodology's line is
- * "can anyone get them", not "is the licence tidy". Discretionary gating does
- * NOT: HF's `gated` is a trichotomy, and `"manual"` means the owner approves
- * each request individually, so the public cannot in fact get the weights.
- * Hence the accept-list below — any value HF invents later reads as unresolved
- * rather than silently confirming, per the directionality note above. A private
- * repo does not count either, and neither does a repo with no weight files
- * (tokenizer-only publications are the exact trap Upstage's `solar-pro*` line
- * sets: `solar-pro3-tokenizer` resolves while the weights never shipped).
+ * Gating still counts as public — Llama and Gemma sit behind a licence any
+ * member of the public can accept, and the methodology's line is "can anyone
+ * get them", not "is the licence tidy". See `isPubliclyGettable` below for why
+ * `"manual"` is on the accept side; any value HF invents later reads as
+ * unresolved rather than silently confirming, per the directionality note
+ * above. A private repo does not count, and neither does a repo with no weight
+ * files (tokenizer-only publications are the exact trap Upstage's `solar-pro*`
+ * line sets: `solar-pro3-tokenizer` resolves while the weights never shipped).
  */
 export const verifyHuggingFaceWeights = async (
   repo: string
@@ -122,9 +120,30 @@ export const verifyHuggingFaceWeights = async (
  * An accept-list, not a reject-list, so a value HF adds later ("research",
  * "waitlist", whatever) fails closed into "unresolved" and waits for a human
  * instead of quietly counting on the open side of an executable index.
+ *
+ * `"manual"` is on the list, and that reverses an earlier reading of it. The
+ * argument for excluding it was that the owner approves each request
+ * individually, so the public cannot in fact get the weights. That is not what
+ * the value means in practice for the repos this index actually contains:
+ * Llama and Gemma report `"manual"`, anyone may accept the licence and
+ * download, and the published seed classifies all eleven of them `open:true`
+ * — `meta-llama/Llama-3.3-70B-Instruct`, `google/gemma-3-27b-it`, the Llama 4
+ * pair, and the rest.
+ *
+ * So the two disagreed, and the disagreement had teeth in both directions:
+ * the watcher could never auto-confirm a Llama or Gemma release, putting every
+ * one of them in the review queue on a 48-hour clock; and the nightly
+ * re-verification in `update-classification-audit.ts` reported all eleven
+ * seeded entries as "no longer verifies" on its first run, which is exactly
+ * the kind of standing false alarm that gets an alert ignored.
+ *
+ * The methodology's test is "can anyone get them", and for click-through and
+ * accept-the-licence gating alike the answer is yes. Discretionary gating that
+ * genuinely blocks the public would need a value HF does not currently emit,
+ * and would land on the reject side by default.
  */
 const isPubliclyGettable = (gated: string | boolean | null | undefined) =>
-  gated == null || gated === false || gated === 'auto'
+  gated == null || gated === false || gated === 'auto' || gated === 'manual'
 
 /** Repo ids are `org/name`; the slash is structural and must not be escaped. */
 const encodeRepo = (repo: string) =>

--- a/backend/shared/src/huggingface.ts
+++ b/backend/shared/src/huggingface.ts
@@ -84,7 +84,7 @@ export const verifyHuggingFaceWeights = async (
   if (body.private)
     return { confirmed: false, repo, reason: 'repo is private' }
 
-  if (!isPubliclyGettable(body.gated))
+  if (!isPubliclyGettable(body.gated, repo))
     return {
       confirmed: false,
       repo,
@@ -121,29 +121,81 @@ export const verifyHuggingFaceWeights = async (
  * "waitlist", whatever) fails closed into "unresolved" and waits for a human
  * instead of quietly counting on the open side of an executable index.
  *
- * `"manual"` is on the list, and that reverses an earlier reading of it. The
- * argument for excluding it was that the owner approves each request
- * individually, so the public cannot in fact get the weights. That is not what
- * the value means in practice for the repos this index actually contains:
- * Llama and Gemma report `"manual"`, anyone may accept the licence and
- * download, and the published seed classifies all eleven of them `open:true`
- * — `meta-llama/Llama-3.3-70B-Instruct`, `google/gemma-3-27b-it`, the Llama 4
- * pair, and the rest.
+ * `"manual"` is NOT generally accepted, and the narrowness is the point.
+ * HuggingFace defines it as the author approving each request individually,
+ * which can stay pending or be refused — that is not public access, and
+ * accepting it wholesale would let a future restricted release land on the
+ * open side of an executable index with no human ever looking, because the
+ * catalog watcher persists a publisher-declared verdict automatically.
  *
- * So the two disagreed, and the disagreement had teeth in both directions:
- * the watcher could never auto-confirm a Llama or Gemma release, putting every
- * one of them in the review queue on a 48-hour clock; and the nightly
- * re-verification in `update-classification-audit.ts` reported all eleven
- * seeded entries as "no longer verifies" on its first run, which is exactly
- * the kind of standing false alarm that gets an alert ignored.
+ * The eleven Llama and Gemma repos below are allowlisted individually. They
+ * report `"manual"` while in practice anyone may accept the licence and
+ * download, the weights are in general circulation, and the published seed
+ * classifies every one of them open. Calling them closed would read as
+ * obviously wrong to anyone checking, which is the worst outcome for a
+ * settlement source. Enumerating them keeps that judgement where it can be
+ * audited instead of hiding it inside a predicate.
  *
- * The methodology's test is "can anyone get them", and for click-through and
- * accept-the-licence gating alike the answer is yes. Discretionary gating that
- * genuinely blocks the public would need a value HF does not currently emit,
- * and would land on the reject side by default.
+ * A new manual-gated repo therefore resolves to "unresolved" and goes to the
+ * review queue. If it turns out to be another accept-the-licence line, add
+ * it here deliberately.
  */
-const isPubliclyGettable = (gated: string | boolean | null | undefined) =>
-  gated == null || gated === false || gated === 'auto' || gated === 'manual'
+export const MANUAL_GATING_PUBLIC_REPOS = new Set([
+  'google/gemma-3-12b-it',
+  'google/gemma-3-27b-it',
+  'google/gemma-3-4b-it',
+  'google/gemma-3n-e4b-it',
+  'meta-llama/llama-3.2-1b-instruct',
+  'meta-llama/llama-3.2-3b-instruct',
+  'meta-llama/llama-3.3-70b-instruct',
+  'meta-llama/llama-4-maverick-17b-128e-instruct',
+  'meta-llama/llama-4-scout-17b-16e-instruct',
+  'meta-llama/meta-llama-3.1-70b-instruct',
+  'meta-llama/meta-llama-3.1-8b-instruct',
+])
+
+const isPubliclyGettable = (
+  gated: string | boolean | null | undefined,
+  repo: string
+) =>
+  gated == null ||
+  gated === false ||
+  gated === 'auto' ||
+  (gated === 'manual' && MANUAL_GATING_PUBLIC_REPOS.has(repo.toLowerCase()))
+
+/**
+ * Did a verification fail because the repo is genuinely not public, or
+ * because HuggingFace could not be reached?
+ *
+ * Lives here, beside the code that PRODUCES these reason strings, so the two
+ * cannot drift. A network blip, a 5xx or a rate-limit answer all come back
+ * as `confirmed: false` exactly like a withdrawn repo does, and a caller
+ * auditing existing verdicts must not report the first as the second.
+ *
+ * Parsed by string, not by pattern. An earlier version of this lived in the
+ * audit job as a regex whose word boundary was mangled into a literal 0x08
+ * control character while being edited, so it silently never matched and
+ * every transport blip was reported as repository rot -- the exact failure
+ * it existed to prevent, and invisible in review because the byte does not
+ * render. Nothing here can fail that way.
+ */
+export const TRANSPORT_FAILURE_STATUSES = new Set([
+  '408',
+  '429',
+  '500',
+  '502',
+  '503',
+  '504',
+])
+
+const NOT_PUBLIC_PREFIX = 'not public: '
+
+export const isTransportFailure = (reason: string) => {
+  if (reason.startsWith('fetch failed')) return true
+  if (!reason.startsWith(NOT_PUBLIC_PREFIX)) return false
+  const status = reason.slice(NOT_PUBLIC_PREFIX.length).trim().split(' ')[0]
+  return TRANSPORT_FAILURE_STATUSES.has(status)
+}
 
 /** Repo ids are `org/name`; the slash is structural and must not be escaped. */
 const encodeRepo = (repo: string) =>

--- a/backend/shared/src/huggingface.ts
+++ b/backend/shared/src/huggingface.ts
@@ -54,6 +54,13 @@ export const verifyHuggingFaceWeights = async (
 ): Promise<HuggingFaceVerification> => {
   if (!repo || !repo.includes('/'))
     return { confirmed: false, repo: repo || null, reason: 'no repo id' }
+  // Before any URL is built. See isValidRepoId.
+  if (!isValidRepoId(repo))
+    return {
+      confirmed: false,
+      repo,
+      reason: `malformed repo id: ${JSON.stringify(repo)}`,
+    }
 
   let res: Response
   try {
@@ -81,8 +88,7 @@ export const verifyHuggingFaceWeights = async (
     gated?: string | boolean | null
     siblings?: { rfilename?: string }[]
   }
-  if (body.private)
-    return { confirmed: false, repo, reason: 'repo is private' }
+  if (body.private) return { confirmed: false, repo, reason: 'repo is private' }
 
   if (!isPubliclyGettable(body.gated, repo))
     return {
@@ -179,14 +185,8 @@ const isPubliclyGettable = (
  * it existed to prevent, and invisible in review because the byte does not
  * render. Nothing here can fail that way.
  */
-export const TRANSPORT_FAILURE_STATUSES = new Set([
-  '408',
-  '429',
-  '500',
-  '502',
-  '503',
-  '504',
-])
+/** Non-5xx statuses that still mean "could not reach it", not "not public". */
+export const TRANSPORT_FAILURE_STATUSES = new Set(['408', '429'])
 
 const NOT_PUBLIC_PREFIX = 'not public: '
 
@@ -194,13 +194,44 @@ export const isTransportFailure = (reason: string) => {
   if (reason.startsWith('fetch failed')) return true
   if (!reason.startsWith(NOT_PUBLIC_PREFIX)) return false
   const status = reason.slice(NOT_PUBLIC_PREFIX.length).trim().split(' ')[0]
-  return TRANSPORT_FAILURE_STATUSES.has(status)
+  if (TRANSPORT_FAILURE_STATUSES.has(status)) return true
+  // The whole 5xx range, not an allowlist. Cloudflare alone serves 520/522/524
+  // in front of HuggingFace and 501/599 exist too; every one of them means the
+  // request failed rather than that the repo is gone, and an allowlist that
+  // misses one turns an outage into an ERROR alert claiming weights were
+  // withdrawn.
+  const code = Number(status)
+  return Number.isInteger(code) && code >= 500 && code <= 599
 }
 
-/** Repo ids are `org/name`; the slash is structural and must not be escaped. */
+/**
+ * A repo id is exactly `owner/name`, and it is validated before it is used to
+ * build a URL.
+ *
+ * `encodeURIComponent` does not escape dots, so a proposed id containing a
+ * traversal segment survived encoding intact and the fetch then normalised it
+ * away: `openai/../attacker/gpt-oss-120b` requests
+ * `api/models/attacker/gpt-oss-120b` -- verified live against HuggingFace,
+ * which answers 200 for it -- while every guard upstream only ever looks at
+ * `split('/')[0]` and sees `openai`. The attacker's repo is what gets checked;
+ * the publisher's id is what gets stored. On the auto-apply path that writes
+ * `open: true` with nobody looking.
+ *
+ * So the shape is enforced rather than escaped: two non-empty segments of
+ * HuggingFace-legal characters, and neither segment may be `.` or `..`.
+ */
+const REPO_ID_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+export const isValidRepoId = (repo: string): boolean => {
+  const parts = repo.split('/')
+  if (parts.length !== 2) return false
+  return parts.every(
+    (part) => part !== '.' && part !== '..' && REPO_ID_SEGMENT.test(part)
+  )
+}
+
 const encodeRepo = (repo: string) =>
   repo.split('/').map(encodeURIComponent).join('/')
-
 export type HuggingFaceRepoSummary = {
   id: string
   downloads?: number

--- a/backend/shared/src/openrouter-tokens.ts
+++ b/backend/shared/src/openrouter-tokens.ts
@@ -123,6 +123,15 @@ export type OpenRouterCatalogEntry = {
   name: string
   /** Publisher-declared weights repo. A HINT ONLY — see huggingface.ts. */
   huggingFaceId: string | null
+  /**
+   * OpenRouter's prose blurb. Also a hint only, but an independent one: it
+   * routinely states openness in words when `hugging_face_id` is empty
+   * ("a 2.8T parameter open-weight model", "released under the Apache 2.0
+   * license"). Two of the four misclassifications found in the 2026-08-24
+   * re-audit were visible here and nowhere else in the metadata, so the audit
+   * job reads it as a second, cheap signal.
+   */
+  description: string | null
   /** When OpenRouter listed it; the head start a watcher gets. */
   listedAt: number | null
 }
@@ -180,6 +189,10 @@ export const fetchOpenRouterCatalog = async (): Promise<
       name:
         'name' in row && typeof row.name === 'string' ? row.name : permaslug,
       huggingFaceId: hf.length > 0 ? hf : null,
+      description:
+        'description' in row && typeof row.description === 'string'
+          ? row.description
+          : null,
       listedAt: created ? created * 1000 : null,
     })
   }

--- a/backend/shared/src/perps/classify-model-agent.ts
+++ b/backend/shared/src/perps/classify-model-agent.ts
@@ -1,5 +1,8 @@
 import Anthropic from '@anthropic-ai/sdk'
-import { proposedRepoMatchesModel } from 'common/perps/weights-repo-match'
+import {
+  proposedRepoMatchesModel,
+  repoOwnerMatchesPublisher,
+} from 'common/perps/weights-repo-match'
 import {
   HuggingFaceVerification,
   searchHuggingFaceModels,
@@ -443,6 +446,28 @@ const finalizeVerdict = async (
       },
       searches,
       rejectedReason: `name mismatch: ${weights}`,
+    }
+
+  // Provenance, after the name check and before verification — verification
+  // would pass, which is the point. A repo can be named like the model and
+  // full of weight files and still be a stranger's: `brokenshards/ox-alpha`
+  // cleared both of those in 24 seconds while the real model was climbing the
+  // rankings. Unresolved rather than closed, because cross-publisher releases
+  // are legitimate (venice/uncensored ships from cognitivecomputations), so
+  // this is a question for a human, not a verdict against the model.
+  if (!repoOwnerMatchesPublisher(permaslug, weights))
+    return {
+      permaslug,
+      verdict: {
+        verdict: 'unresolved',
+        reasoning:
+          `cited ${weights}, which is not published by ${
+            permaslug.replace(/^~/, '').split('/')[0]
+          } — a weights repo under an unrelated account is not evidence, ` +
+          `however it is named — ${reasoning}`,
+      },
+      searches,
+      rejectedReason: `publisher mismatch: ${weights}`,
     }
 
   const confirmation = await verifyHuggingFaceWeights(weights)

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -163,9 +163,7 @@ export const recordPendingModels = async (
      on conflict (permaslug) do nothing`,
     [
       rows.map((r) => r.slug),
-      firstSeen
-        ? new Date(firstSeen).toISOString()
-        : new Date().toISOString(),
+      firstSeen ? new Date(firstSeen).toISOString() : new Date().toISOString(),
       rows.map((r) => r.evidence),
     ]
   )
@@ -189,9 +187,9 @@ export const recordUnclassifiedInRankings = async (
   permaslugs: string[],
   rankedAt = Date.now()
 ) => {
-  const slugs = Array.from(
-    new Set(permaslugs.map(basePermaslug))
-  ).filter((slug) => !OPEN_WEIGHT_MODELS[slug] && !isCompositeSlug(slug))
+  const slugs = Array.from(new Set(permaslugs.map(basePermaslug))).filter(
+    (slug) => !OPEN_WEIGHT_MODELS[slug] && !isCompositeSlug(slug)
+  )
   if (slugs.length === 0) return 0
 
   await pg.none(
@@ -235,6 +233,21 @@ export const upsertClassification = async (
       `refusing to classify ${permaslug} open without a weights repo`
     )
 
+  // The prior decision is APPENDED to evidence.history rather than replaced.
+  //
+  // This upsert used to overwrite evidence, classified_at and classified_by
+  // outright, so every correction destroyed the record of what it corrected.
+  // That is not hypothetical: GLM 5.3's original agent recommendation and
+  // the searches behind it were lost the moment a human adjudicated it, and
+  // when the verdict later turned out to need reversing there was nothing
+  // left showing why it had been made. A classification that moves a money
+  // market should be able to answer "who decided this, when, on what
+  // evidence" for every verdict it has ever held, not just the current one.
+  //
+  // Built in SQL so it is atomic and applies to every caller — the admin
+  // endpoint, the CLI, and the automatic watcher alike. The nested copy has
+  // its own `history` stripped so repeated corrections cannot nest
+  // exponentially.
   await pg.none(
     `insert into model_classifications
        (permaslug, open, weights, source, evidence, classified_at, classified_by, updated_time)
@@ -243,7 +256,19 @@ export const upsertClassification = async (
        open = excluded.open,
        weights = excluded.weights,
        source = excluded.source,
-       evidence = excluded.evidence,
+       evidence = excluded.evidence || jsonb_build_object(
+         'history',
+         coalesce(model_classifications.evidence->'history', '[]'::jsonb) ||
+           jsonb_build_array(jsonb_build_object(
+             'open', model_classifications.open,
+             'weights', model_classifications.weights,
+             'source', model_classifications.source,
+             'classifiedAt', model_classifications.classified_at,
+             'classifiedBy', model_classifications.classified_by,
+             'supersededAt', now(),
+             'evidence', model_classifications.evidence - 'history'
+           ))
+       ),
        classified_at = excluded.classified_at,
        classified_by = excluded.classified_by,
        updated_time = now()`,
@@ -257,7 +282,6 @@ export const upsertClassification = async (
     ]
   )
 }
-
 /**
  * Attach the research agent's findings to a PENDING row without adjudicating
  * it.
@@ -304,17 +328,25 @@ export const recordAgentRecommendation = async (
   )
 }
 
-/** Pending rows for the admin tool, oldest first — the review queue. */
+/**
+ * Pending rows for the admin tool, oldest first — the review queue.
+ *
+ * Composites are filtered here as well as at candidate creation, because rows
+ * written before that rule existed are still in the table and would otherwise
+ * keep inflating queue counts and summaries with work nobody can usefully do.
+ */
 export const getPendingClassifications = async (
   pg: SupabaseDirectClient
-): Promise<ClassificationRow[]> =>
-  pg.manyOrNone<ClassificationRow>(
+): Promise<ClassificationRow[]> => {
+  const rows = await pg.manyOrNone<ClassificationRow>(
     `select permaslug, open, weights, source, evidence,
             first_seen, first_ranked_at, classified_at, classified_by
      from model_classifications
      where open is null
      order by first_ranked_at asc nulls last, first_seen asc`
   )
+  return rows.filter((row) => !isCompositeSlug(basePermaslug(row.permaslug)))
+}
 
 /**
  * How long a researched-but-unsettled model is left alone before a re-run.

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -3,6 +3,7 @@ import {
   OPEN_WEIGHT_MODELS,
   UNCLASSIFIED_GRACE_WINDOW_MS,
   basePermaslug,
+  isCompositeSlug,
 } from 'common/perps/open-weight-models'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 
@@ -65,6 +66,10 @@ export const resolveModelClassifications = async (
 
   for (const row of rows) {
     const slug = basePermaslug(row.permaslug)
+    // Rows predating the composite rule can still carry a verdict. Ignore it
+    // on read too, so the DB and computeOpenWeightShare cannot disagree about
+    // whether a router counts.
+    if (isCompositeSlug(slug)) continue
     if (row.open === null) {
       // A pending row for a model the seed already classifies is inert — the
       // seed verdict stands and there is nothing to wait for.
@@ -132,6 +137,10 @@ export const recordPendingModels = async (
   const rows: { slug: string; evidence: string }[] = []
   for (const model of models) {
     const slug = basePermaslug(model.permaslug)
+    // Routers and floating aliases are excluded from the index by
+    // construction, so queueing them asks an operator for a boolean that will
+    // be ignored whichever way they answer.
+    if (isCompositeSlug(slug)) continue
     if (OPEN_WEIGHT_MODELS[slug] || seen.has(slug)) continue
     seen.add(slug)
     rows.push({
@@ -182,7 +191,7 @@ export const recordUnclassifiedInRankings = async (
 ) => {
   const slugs = Array.from(
     new Set(permaslugs.map(basePermaslug))
-  ).filter((slug) => !OPEN_WEIGHT_MODELS[slug])
+  ).filter((slug) => !OPEN_WEIGHT_MODELS[slug] && !isCompositeSlug(slug))
   if (slugs.length === 0) return 0
 
   await pg.none(

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -80,11 +80,20 @@ export const resolveModelClassifications = async (
       else pendingUnclassified.push(slug)
       continue
     }
-    // The seed list is the published methodology and is version-stamped onto
-    // every point the oracle writes, so an override of a seeded model would
-    // make that stamp a lie. `setModelClassification` refuses to write one;
-    // this enforces the same invariant on read, which also covers the rows
-    // `upsertClassification` wrote automatically before the seed caught up.
+    // The seed list is the published methodology, so an override of a seeded
+    // model would change what the index means without going through the file
+    // where the reasoning is recorded. `setModelClassification` refuses to
+    // write one; this enforces the same invariant on read, which also covers
+    // the rows `upsertClassification` wrote automatically before the seed
+    // caught up.
+    //
+    // NB: `OPEN_WEIGHT_LIST_VERSION` is NOT stored with the points. It goes
+    // into the insert log line only — `oracle_prices` is
+    // (feed_id, ts, price, source_ts, published_at). So there is no per-point
+    // record of which list version priced it, and a published point cannot be
+    // attributed to a version after the fact. Do not reason as if there were
+    // one; it matters most when deciding whether a corrected classification
+    // should cause historical points to be recomputed.
     if (OPEN_WEIGHT_MODELS[slug]) continue
     classifications[slug] = row.open
       ? { open: true, weights: row.weights ?? undefined }

--- a/backend/shared/src/perps/model-classifications.ts
+++ b/backend/shared/src/perps/model-classifications.ts
@@ -4,6 +4,7 @@ import {
   UNCLASSIFIED_GRACE_WINDOW_MS,
   basePermaslug,
   isCompositeSlug,
+  isValidPermaslug,
 } from 'common/perps/open-weight-models'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 
@@ -227,6 +228,14 @@ export const upsertClassification = async (
   }
 ) => {
   const { permaslug, open, source, classifiedBy } = params
+  const slug = basePermaslug(permaslug)
+  // Enforced at the single write path, so no caller can insert a key the index
+  // could never match — `/x`, `x/`, `x//y` all previously passed an
+  // includes('/') check.
+  if (!isValidPermaslug(slug))
+    throw new Error(
+      `refusing malformed permaslug: ${JSON.stringify(permaslug)}`
+    )
   const weights = open ? params.weights ?? null : null
   if (open && !weights)
     throw new Error(
@@ -273,7 +282,7 @@ export const upsertClassification = async (
        classified_by = excluded.classified_by,
        updated_time = now()`,
     [
-      basePermaslug(permaslug),
+      slug,
       open,
       weights,
       source,

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -7,6 +7,7 @@ import {
   classifyModel,
   computeOpenWeightShare,
   isCompositeSlug,
+  isValidPermaslug,
   newestWindowDates,
   openWeightWindowRange,
   utcDateString,
@@ -308,9 +309,9 @@ describe('publication validation', () => {
 
     for (const truth of [asOpen, asClosed]) {
       expect(truth).not.toBeNull()
-      expect(Math.abs((truth as number) - validation.share)).toBeLessThanOrEqual(
-        validation.grace.maxIndexError + 1e-9
-      )
+      expect(
+        Math.abs((truth as number) - validation.share)
+      ).toBeLessThanOrEqual(validation.grace.maxIndexError + 1e-9)
     }
   })
 
@@ -417,7 +418,10 @@ describe('the published list', () => {
         expect([slug, typeof c.weights]).toEqual([slug, 'string'])
         expect([slug, (c.weights ?? '').trim()]).not.toEqual([slug, ''])
         // owner/repo, and the owner is not the empty string
-        expect([slug, c.weights]).toEqual([slug, expect.stringMatching(/^[^/\s]+\/[^/\s]+$/)])
+        expect([slug, c.weights]).toEqual([
+          slug,
+          expect.stringMatching(/^[^/\s]+\/[^/\s]+$/),
+        ])
       } else {
         expect([slug, c.weights]).toEqual([slug, undefined])
       }
@@ -475,7 +479,10 @@ describe('composite slugs (routers and floating aliases)', () => {
     // And critically they are NOT unclassified, which is what would start a
     // grace clock and eventually halt publication.
     expect(result.unclassified).toEqual([])
-    expect(result.compositeSlugs).toEqual(['openrouter/fusion', '~z-ai/glm-latest'])
+    expect(result.compositeSlugs).toEqual([
+      'openrouter/fusion',
+      '~z-ai/glm-latest',
+    ])
     expect(result.compositeTokens).toBe(600)
   })
 
@@ -490,5 +497,33 @@ describe('composite slugs (routers and floating aliases)', () => {
     )
     expect(result.unclassified).toEqual(['newlab/brand-new'])
     expect(result.compositeSlugs).toEqual([])
+  })
+})
+
+describe('isValidPermaslug', () => {
+  it('rejects slash-containing keys that are not owner/model', () => {
+    // Every one of these passed the old includes('/') check, and with the
+    // CLI's --create flag could have been INSERTED as a classification row
+    // that nothing in the index can ever match.
+    for (const bad of ['/x', 'x/', '/', 'x//y', '', 'x', 'a/b/c', ' / '])
+      expect([bad, isValidPermaslug(bad)]).toEqual([bad, false])
+  })
+
+  it('accepts the real permaslug keys the index uses', () => {
+    for (const good of [
+      'z-ai/glm-5.3-20260816',
+      'openai/gpt-4',
+      'meta-llama/llama-3.3-70b-instruct',
+      'inclusionai/ling-3.0-flash-20260723',
+    ])
+      expect([good, isValidPermaslug(good)]).toEqual([good, true])
+  })
+
+  it('agrees with basePermaslug on what it produces', () => {
+    // basePermaslug truncates at ':', so a variant suffix must still normalise
+    // to something this accepts -- otherwise the write path would reject keys
+    // the read path generates.
+    for (const raw of ['qwen/qwen3-max:free', 'z-ai/glm-5.3-20260816:nitro'])
+      expect([raw, isValidPermaslug(basePermaslug(raw))]).toEqual([raw, true])
   })
 })

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -407,10 +407,30 @@ describe('the published list', () => {
   })
 
   it('cites public weights for every open model and none for closed ones', () => {
+    // Assert on `weights` itself. The previous form interpolated the slug and
+    // matched the pair against /.+\/.+/ — which the slug's OWN slash satisfies,
+    // so it passed for an open entry citing nothing at all. Three comments in
+    // this package describe it as the invariant that keeps an unevidenced open
+    // call out of the list, so it needs to actually check.
     for (const [slug, c] of Object.entries(OPEN_WEIGHT_MODELS)) {
-      if (c.open) expect(`${slug}:${c.weights ?? ''}`).toMatch(/.+\/.+/)
-      else expect(c.weights).toBeUndefined()
+      if (c.open) {
+        expect([slug, typeof c.weights]).toEqual([slug, 'string'])
+        expect([slug, (c.weights ?? '').trim()]).not.toEqual([slug, ''])
+        // owner/repo, and the owner is not the empty string
+        expect([slug, c.weights]).toEqual([slug, expect.stringMatching(/^[^/\s]+\/[^/\s]+$/)])
+      } else {
+        expect([slug, c.weights]).toEqual([slug, undefined])
+      }
     }
+  })
+
+  it('that invariant actually fails on an unevidenced open entry', () => {
+    // Guards the guard: if this ever passes, the assertion above went vacuous
+    // again.
+    const bad = { open: true } as (typeof OPEN_WEIGHT_MODELS)[string]
+    expect(() =>
+      expect(['x/y', typeof bad.weights]).toEqual(['x/y', 'string'])
+    ).toThrow()
   })
 })
 

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -6,6 +6,7 @@ import {
   basePermaslug,
   classifyModel,
   computeOpenWeightShare,
+  isCompositeSlug,
   newestWindowDates,
   openWeightWindowRange,
   utcDateString,
@@ -410,5 +411,64 @@ describe('the published list', () => {
       if (c.open) expect(`${slug}:${c.weights ?? ''}`).toMatch(/.+\/.+/)
       else expect(c.weights).toBeUndefined()
     }
+  })
+})
+
+describe('composite slugs (routers and floating aliases)', () => {
+  const rows = (entries: [string, string][]) =>
+    entries.map(([model_permaslug, total_tokens]) => ({
+      date: '2026-08-20',
+      model_permaslug,
+      total_tokens,
+    }))
+
+  it('identifies routers and aliases, but not stealth models', () => {
+    expect(isCompositeSlug('openrouter/fusion')).toBe(true)
+    expect(isCompositeSlug('openrouter/auto-beta')).toBe(true)
+    expect(isCompositeSlug('~z-ai/glm-latest')).toBe(true)
+    expect(isCompositeSlug('~openai/gpt-latest')).toBe(true)
+    // Cloaked pre-release models ARE single models and stay classifiable —
+    // no suffix separates them from routers, which is why the list is
+    // explicit. `auto-beta` is a router; `horizon-beta` is a model.
+    expect(isCompositeSlug('openrouter/horizon-beta')).toBe(false)
+    expect(isCompositeSlug('openrouter/owl-alpha')).toBe(false)
+    expect(isCompositeSlug('z-ai/glm-5.3-20260816')).toBe(false)
+  })
+
+  it('keeps them out of both sides instead of halting the feed on them', () => {
+    const classifications = {
+      'a/open-model': { open: true, weights: 'a/Open' },
+      'b/closed-model': { open: false },
+    }
+    const result = computeOpenWeightShare(
+      rows([
+        ['a/open-model', '700'],
+        ['b/closed-model', '300'],
+        ['openrouter/fusion', '500'],
+        ['~z-ai/glm-latest', '100'],
+      ]),
+      1,
+      classifications
+    )
+    // 700 / (700 + 300) — the router and alias touch neither side.
+    expect(result.share).toBe(70)
+    // And critically they are NOT unclassified, which is what would start a
+    // grace clock and eventually halt publication.
+    expect(result.unclassified).toEqual([])
+    expect(result.compositeSlugs).toEqual(['openrouter/fusion', '~z-ai/glm-latest'])
+    expect(result.compositeTokens).toBe(600)
+  })
+
+  it('still treats an unknown ordinary model as unclassified', () => {
+    const result = computeOpenWeightShare(
+      rows([
+        ['a/open-model', '700'],
+        ['newlab/brand-new', '10'],
+      ]),
+      1,
+      { 'a/open-model': { open: true, weights: 'a/Open' } }
+    )
+    expect(result.unclassified).toEqual(['newlab/brand-new'])
+    expect(result.compositeSlugs).toEqual([])
   })
 })

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -509,6 +509,21 @@ describe('isValidPermaslug', () => {
       expect([bad, isValidPermaslug(bad)]).toEqual([bad, false])
   })
 
+  it('rejects whitespace-bearing keys that match no model', () => {
+    // These pass a non-blank-segment check but correspond to nothing, and the
+    // central upsert would persist them. They read as correct in a log line,
+    // which is what makes them worth rejecting rather than tolerating.
+    for (const bad of [
+      'openai /gpt-4',
+      'openai/ gpt-4',
+      'openai/gpt 4',
+      ' openai/gpt-4',
+      'openai/gpt-4 ',
+      'openai/gpt\t4',
+    ])
+      expect([bad, isValidPermaslug(bad)]).toEqual([bad, false])
+  })
+
   it('accepts the real permaslug keys the index uses', () => {
     for (const good of [
       'z-ai/glm-5.3-20260816',

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -139,6 +139,56 @@ export const UNCLASSIFIED_GRACE_WINDOW_MS = 2 * DAY_MS
  */
 export const OTHER_MODEL_KEY = 'other'
 
+/**
+ * OpenRouter slugs that route across models instead of being one.
+ *
+ * `openrouter/fusion` is the clearest: OpenRouter documents it as "a panel of
+ * expert models … analyzes your prompt in parallel, then a judge model
+ * synthesizes their responses", billed as the sum of the underlying
+ * completions. Its tokens are a MIXTURE of open and closed models, so `open`
+ * and `closed` are both false statements about it and either one misattributes
+ * the whole volume.
+ *
+ * An explicit list rather than a pattern, because `openrouter/` is also where
+ * the cloaked pre-release models live and those ARE single models, correctly
+ * classified closed — you cannot download weights for a model nobody has
+ * named. No suffix separates the two: `auto-beta` is a router and
+ * `horizon-beta` is a stealth model.
+ */
+export const ROUTER_MODEL_KEYS = [
+  'openrouter/auto',
+  'openrouter/auto-beta',
+  'openrouter/bodybuilder',
+  'openrouter/free',
+  'openrouter/fusion',
+  'openrouter/pareto-code',
+]
+
+/**
+ * Slugs that are not a single model and so cannot carry a classification.
+ *
+ * Two shapes. Routers, above. And OpenRouter's floating aliases, which carry a
+ * `~` prefix (`~z-ai/glm-latest`, `~openai/gpt-latest`) and resolve to whatever
+ * the publisher's current model is — so their openness changes underneath any
+ * stored answer. `~z-ai/glm-latest` points at GLM 5.3 today, which is closed,
+ * while every earlier GLM is open; a boolean written against the alias would
+ * have been right last month and wrong now, with nothing to notice.
+ *
+ * Excluded from BOTH sides, exactly as `other` is, rather than left
+ * unclassified. Unclassified is the worse failure: it starts a grace clock and
+ * eventually halts the feed, forcing someone to invent a boolean for a thing
+ * that does not have one, under a deadline. Their tokens are accounted for and
+ * logged by the caller so the exclusion can never become a silent drop — see
+ * `compositeTokens`.
+ *
+ * If an alias ever carries enough volume to matter, the fix is to resolve it
+ * through OpenRouter's own `alias_target` field to the model it points at and
+ * classify THAT, not to guess at the alias.
+ */
+export const isCompositeSlug = (permaslug: string): boolean =>
+  permaslug.startsWith('~') ||
+  ROUTER_MODEL_KEYS.includes(basePermaslug(permaslug))
+
 export type ModelClassification = {
   /** True iff the weights are publicly downloadable. */
   open: boolean
@@ -775,6 +825,13 @@ export type OpenWeightShareResult = {
   classifiedTokens: number
   unclassifiedTokens: number
   otherTokens: number
+  /**
+   * Router and floating-alias slugs seen in the window, and their volume.
+   * Excluded from both sides (rule 1b); surfaced so the exclusion is visible
+   * in the logs rather than silently shrinking the denominator.
+   */
+  compositeSlugs: string[]
+  compositeTokens: number
   /** Everything in the payload including `other` and unclassified models. */
   payloadTokens: number
 }
@@ -838,8 +895,10 @@ export const computeOpenWeightShare = (
   let classifiedTokens = 0n
   let unclassifiedTokens = 0n
   let otherTokens = 0n
+  let compositeTokens = 0n
   let payloadTokens = 0n
   const unclassifiedSet: Record<string, true> = {}
+  const compositeSet: Record<string, true> = {}
   const invalidTokenRowSet: Record<string, true> = {}
 
   for (const row of rows) {
@@ -854,6 +913,15 @@ export const computeOpenWeightShare = (
     // denominator, never estimated.
     if (basePermaslug(row.model_permaslug) === OTHER_MODEL_KEY) {
       otherTokens += tokens
+      continue
+    }
+
+    // Rule 1b: routers and floating aliases are not a single model, so no
+    // boolean about them is true. Out of both sides like `other`, and recorded
+    // rather than dropped — the caller logs the slugs and the volume.
+    if (isCompositeSlug(row.model_permaslug)) {
+      compositeSet[basePermaslug(row.model_permaslug)] = true
+      compositeTokens += tokens
       continue
     }
 
@@ -891,6 +959,7 @@ export const computeOpenWeightShare = (
     share,
     dates,
     unclassified: Object.keys(unclassifiedSet).sort(),
+    compositeSlugs: Object.keys(compositeSet).sort(),
     invalidTokenRows,
     // Checked against `other` specifically, not "payload exceeds classified":
     // unclassified tokens also widen that gap, so the loose form would read a
@@ -904,6 +973,7 @@ export const computeOpenWeightShare = (
     classifiedTokens: finiteBigIntTelemetry(classifiedTokens),
     unclassifiedTokens: finiteBigIntTelemetry(unclassifiedTokens),
     otherTokens: finiteBigIntTelemetry(otherTokens),
+    compositeTokens: finiteBigIntTelemetry(compositeTokens),
     payloadTokens: finiteBigIntTelemetry(payloadTokens),
   }
 }

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -746,10 +746,17 @@ export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
   'openrouter/aurora-alpha': { open: false },
   // Corrected 2026-08-24 (was `open: false`). OpenRouter's description states
   // it is "released under the Apache 2.0 license"; the repo is public,
-  // ungated, apache-2.0, 272 weight files, created 2025-11-30.
+  // ungated, apache-2.0, 272 weight files.
+  //
+  // Cites Instruct, not Base. Both are public and both would satisfy the
+  // "are the weights downloadable" test, so the verdict is the same either
+  // way — but the OpenRouter slug serves the instruction-tuned model, and the
+  // Base card says it is not instruction-fine-tuned. The citation is the
+  // artifact a reader checks and the one the nightly ROT audit re-verifies,
+  // so it should name the checkpoint actually being served.
   'mistralai/mistral-large-2512': {
     open: true,
-    weights: 'mistralai/Mistral-Large-3-675B-Base-2512',
+    weights: 'mistralai/Mistral-Large-3-675B-Instruct-2512',
   }, // Mistral: Mistral Large 3 2512
   'mistralai/ministral-8b-2512': {
     open: true,

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -817,11 +817,28 @@ export const basePermaslug = (permaslug: string): string => {
   return colon === -1 ? permaslug : permaslug.slice(0, colon)
 }
 
+/**
+ * Is this a well-formed permaslug key — exactly `owner/model`?
+ *
+ * `basePermaslug` normalises but does not validate, and every caller that
+ * checked at all checked `includes('/')`, which admits `/x`, `x/`, `/` and
+ * `x//y`. With the CLI's --create flag any of those could be INSERTED as a
+ * classification row, and nothing in the index would ever match one: a key
+ * that cannot correspond to a model is a row that can only ever be noise in
+ * the queue and the audit.
+ *
+ * Lives here rather than in each caller because the gap was central — the
+ * API, the CLI and upsertClassification all shared it.
+ */
+export const isValidPermaslug = (permaslug: string): boolean => {
+  const parts = permaslug.split('/')
+  if (parts.length !== 2) return false
+  return parts.every((part) => part.trim().length > 0)
+}
 export const classifyModel = (
   permaslug: string,
   classifications: ModelClassifications = OPEN_WEIGHT_MODELS
-): ModelClassification | undefined =>
-  classifications[basePermaslug(permaslug)]
+): ModelClassification | undefined => classifications[basePermaslug(permaslug)]
 
 /** One row of OpenRouter's `datasets/rankings-daily` payload. */
 export type RankingRow = {
@@ -1141,13 +1158,12 @@ export const validateOpenWeightPublication = (
   )
     return {
       ok: false,
-      reason:
-        `composite (router/alias) slugs are ${(
-          (result.compositeTokens / result.classifiedTokens) *
-          100
-        ).toFixed(2)}% of classified tokens, over the ${(
-          compositeShareCap * 100
-        ).toFixed(2)}% cap: ${result.compositeSlugs.join(', ')}`,
+      reason: `composite (router/alias) slugs are ${(
+        (result.compositeTokens / result.classifiedTokens) *
+        100
+      ).toFixed(2)}% of classified tokens, over the ${(
+        compositeShareCap * 100
+      ).toFixed(2)}% cap: ${result.compositeSlugs.join(', ')}`,
     }
 
   if (result.unclassified.length === 0) return { ok: true, share: result.share }

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -58,8 +58,32 @@ import { DAY_MS } from '../util/time'
 // a versioned list rather than a live lookup: the index definition must not
 // change silently when a third party edits a metadata field.
 
+// MISSED_BY_RENAME — the failure mode a re-audit on 2026-08-24 actually found.
+//
+// A full re-verification of all 299 published classifications turned up zero
+// rot (every `open` entry still cites a live public repo with weight files)
+// but four models marked closed whose weights were public all along:
+// Kimi K3, Mistral Large 3 2512, Mistral Medium 3.5, Ling-3.0-flash.
+//
+// Three of the four have an EMPTY `hugging_face_id` on OpenRouter, so building
+// the list fell through to the org-catalogue name match — and that match
+// cannot bridge a rename. `mistral-large-2512` and
+// `Mistral-Large-3-675B-Base-2512` share almost no tokens, so a correct repo
+// sitting in the publisher's own org scored zero and the model defaulted to
+// closed. Mistral renames between OpenRouter slug and HF repo routinely, which
+// is why it is two of the four.
+//
+// Every error ran the same direction — open marked closed — so the published
+// index was UNDERSTATED, never inflated. That is not luck: a missing repo is
+// the only way the build can fail, and its default is closed.
+//
+// The fix is not a better matcher. It is that nothing ever re-examined a
+// verdict once written: no job re-verified an existing entry and none diffed
+// against OpenRouter's own metadata, so a wrong entry was permanent. See
+// `update-classification-audit.ts`, which now asserts both nightly.
+
 /** Bump when the map changes. */
-export const OPEN_WEIGHT_LIST_VERSION = '2026-08-14'
+export const OPEN_WEIGHT_LIST_VERSION = '2026-08-24'
 
 /** Trailing window, in whole UTC days, that the index averages over. */
 export const OPEN_WEIGHT_WINDOW_DAYS = 7
@@ -346,7 +370,15 @@ export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
   'qwen/qwen3.6-plus-preview': { open: false },
   'anthropic/claude-3-7-sonnet-20250219': { open: false },
   'qwen/qwen3-embedding-8b': { open: true, weights: 'Qwen/Qwen3-Embedding-8B' },
-  'moonshotai/kimi-k3-20260715': { open: false }, // MoonshotAI: Kimi K3
+  // Corrected 2026-08-24 (was `open: false`). OpenRouter's own description
+  // calls it "a 2.8T parameter open-weight multimodal reasoning model" and
+  // declares this repo; it is public, ungated, 96 weight files, 2.7M
+  // downloads, and predates the 2026-08-14 list cut by two months. The
+  // original miss is the rename pattern documented at MISSED_BY_RENAME below.
+  'moonshotai/kimi-k3-20260715': {
+    open: true,
+    weights: 'moonshotai/Kimi-K3',
+  }, // MoonshotAI: Kimi K3
   'google/gemini-2.5-flash-lite-preview-09-2025': { open: false },
   'anthropic/claude-5-fable-20260609': { open: false }, // Anthropic: Claude Fable 5
   'openrouter/hunter-alpha': { open: false },
@@ -437,7 +469,13 @@ export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
     open: true,
     weights: 'tngtech/DeepSeek-R1T-Chimera',
   },
-  'inclusionai/ling-3.0-flash-20260723': { open: false }, // Ling-3.0-flash (free)
+  // Corrected 2026-08-24 (was `open: false`). Publisher-declared
+  // `hugging_face_id`; repo is public, ungated, MIT, 24 weight files, created
+  // 2026-08-02 — before the 2026-08-14 list cut.
+  'inclusionai/ling-3.0-flash-20260723': {
+    open: true,
+    weights: 'inclusionAI/Ling-3.0-flash',
+  }, // Ling-3.0-flash (free)
   'openai/gpt-5.2-codex-20260114': { open: false }, // OpenAI: GPT-5.2-Codex
   'moonshotai/kimi-k2': { open: true, weights: 'moonshotai/Kimi-K2-Instruct' }, // MoonshotAI: Kimi K2 0711
   'x-ai/grok-4-07-09': { open: false },
@@ -567,7 +605,14 @@ export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
     open: true,
     weights: 'Qwen/Qwen3-235B-A22B-Thinking-2507',
   }, // Qwen: Qwen3 235B A22B Thinking 2507
-  'mistralai/mistral-medium-3.5-20260430': { open: false }, // Mistral: Mistral Medium 3.5
+  // Corrected 2026-08-24 (was `open: false`). Public, ungated, 6 weight files,
+  // 91k downloads, created 2026-03-31. `license:other` is not disqualifying —
+  // the test is whether anyone can download the weights, the same reading that
+  // puts Llama and Gemma on the open side.
+  'mistralai/mistral-medium-3.5-20260430': {
+    open: true,
+    weights: 'mistralai/Mistral-Medium-3.5-128B',
+  }, // Mistral: Mistral Medium 3.5
   'qwen/qwen3-coder-plus': { open: false }, // Qwen: Qwen3 Coder Plus
   'x-ai/grok-4.20-20260309': { open: false }, // xAI: Grok 4.20
   'alibaba/tongyi-deepresearch-30b-a3b': { open: false },
@@ -630,7 +675,13 @@ export const OPEN_WEIGHT_MODELS: Record<string, ModelClassification> = {
   },
   'tngtech/tng-r1t-chimera': { open: false },
   'openrouter/aurora-alpha': { open: false },
-  'mistralai/mistral-large-2512': { open: false }, // Mistral: Mistral Large 3 2512
+  // Corrected 2026-08-24 (was `open: false`). OpenRouter's description states
+  // it is "released under the Apache 2.0 license"; the repo is public,
+  // ungated, apache-2.0, 272 weight files, created 2025-11-30.
+  'mistralai/mistral-large-2512': {
+    open: true,
+    weights: 'mistralai/Mistral-Large-3-675B-Base-2512',
+  }, // Mistral: Mistral Large 3 2512
   'mistralai/ministral-8b-2512': {
     open: true,
     weights: 'mistralai/Ministral-3-8B-Instruct-2512',

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -830,11 +830,13 @@ export const basePermaslug = (permaslug: string): string => {
  * Lives here rather than in each caller because the gap was central — the
  * API, the CLI and upsertClassification all shared it.
  */
-export const isValidPermaslug = (permaslug: string): boolean => {
-  const parts = permaslug.split('/')
-  if (parts.length !== 2) return false
-  return parts.every((part) => part.trim().length > 0)
-}
+export const isValidPermaslug = (permaslug: string): boolean =>
+  // No whitespace anywhere, not merely non-blank segments. A `trim().length > 0`
+  // check passed `openai /gpt-4`, `openai/ gpt-4` and `openai/gpt 4` — keys
+  // that look right in a log line, match no model, and which the central upsert
+  // would then persist. The rankings dataset never emits a slug containing a
+  // space, so anything that does is a paste or a typo.
+  /^[^/\s]+\/[^/\s]+$/.test(permaslug)
 export const classifyModel = (
   permaslug: string,
   classifications: ModelClassifications = OPEN_WEIGHT_MODELS

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -117,6 +117,25 @@ export const OPEN_WEIGHT_WINDOW_DAYS = 7
 export const UNCLASSIFIED_TOKEN_SHARE_CAP = 0.01
 
 /**
+ * How much of the classified token pool may sit in router/alias slugs before
+ * the index refuses to publish, as composite tokens over classified tokens.
+ *
+ * These are excluded from both sides by design (see isCompositeSlug), and
+ * unlike an unclassified model nothing else bounds them — no grace clock, no
+ * adjudication, no alert. Without a cap a router that grew into real volume
+ * would quietly shrink the denominator forever and the published number would
+ * stop describing the population the methodology names.
+ *
+ * NEEDS CALIBRATION, like UNCLASSIFIED_TOKEN_SHARE_CAP. No router or alias has
+ * ever entered the ranked window, so there is no measured base rate to size
+ * this against; 2% is chosen only as "clearly past a rounding decision" and
+ * should be revisited the first time `compositeSlugs` is non-empty on a real
+ * tick. It is deliberately looser than the unclassified cap because exclusion
+ * here is the CORRECT treatment rather than a temporary gap awaiting a human.
+ */
+export const COMPOSITE_TOKEN_SHARE_CAP = 0.02
+
+/**
  * How long a below-cap unknown may keep publishing before the index halts on
  * it anyway, measured from when the catalog watcher first saw the model.
  *
@@ -1027,6 +1046,8 @@ export type OpenWeightPublicationOptions = {
   expectedDays?: number
   /** Override the cap; 0 restores the old halt-on-any-unknown behaviour. */
   unclassifiedShareCap?: number
+  /** Bound on router/alias tokens; defaults to COMPOSITE_TOKEN_SHARE_CAP. */
+  compositeShareCap?: number
   /**
    * Unknowns that have been unclassified for longer than the operator's grace
    * window. Present here they halt the index regardless of how small they are:
@@ -1053,6 +1074,7 @@ export const validateOpenWeightPublication = (
   const {
     expectedDays = OPEN_WEIGHT_WINDOW_DAYS,
     unclassifiedShareCap = UNCLASSIFIED_TOKEN_SHARE_CAP,
+    compositeShareCap = COMPOSITE_TOKEN_SHARE_CAP,
     expiredUnclassified = [],
   } = options
 
@@ -1098,6 +1120,28 @@ export const validateOpenWeightPublication = (
     result.share > 100
   )
     return { ok: false, reason: `invalid share ${result.share}` }
+
+  // Composite slugs leave the denominator without ever being adjudicated, so
+  // unlike an unclassified model nothing else bounds them: no grace clock, no
+  // U/C cap. At small volume that is the intended trade (see isCompositeSlug).
+  // Past this cap it stops being a rounding decision — the index would be
+  // reporting a share of a materially different population than the
+  // methodology claims — so it halts and someone resolves the alias through
+  // `alias_target` or reconsiders the router.
+  if (
+    result.classifiedTokens > 0 &&
+    result.compositeTokens / result.classifiedTokens > compositeShareCap
+  )
+    return {
+      ok: false,
+      reason:
+        `composite (router/alias) slugs are ${(
+          (result.compositeTokens / result.classifiedTokens) *
+          100
+        ).toFixed(2)}% of classified tokens, over the ${(
+          compositeShareCap * 100
+        ).toFixed(2)}% cap: ${result.compositeSlugs.join(', ')}`,
+    }
 
   if (result.unclassified.length === 0) return { ok: true, share: result.share }
 

--- a/common/src/perps/weights-repo-match.test.ts
+++ b/common/src/perps/weights-repo-match.test.ts
@@ -1,6 +1,7 @@
 import {
   identifierTokens,
   proposedRepoMatchesModel,
+  repoOwnerMatchesPublisher,
   weightsRepoNameOverlap,
 } from './weights-repo-match'
 
@@ -166,5 +167,71 @@ describe('weightsRepoNameOverlap', () => {
   it('never divides by zero on a degenerate identifier', () => {
     expect(weightsRepoNameOverlap('org/', 'org/Something')).toBe(0)
     expect(weightsRepoNameOverlap('', '')).toBe(0)
+  })
+})
+
+describe('repoOwnerMatchesPublisher', () => {
+  it('rejects the ox-alpha fabrication that cleared every other guard', () => {
+    // Real: created 2026-08-21, 20 files named like weight shards, config
+    // claiming 800B params, README "real ox alpha dataset npnp", built in 24
+    // seconds, while stealth/ox-alpha was entering the ranked window. It is
+    // public, carries .safetensors, and matches the name perfectly.
+    expect(proposedRepoMatchesModel('stealth/ox-alpha', 'brokenshards/ox-alpha')).toBe(
+      true
+    )
+    expect(
+      repoOwnerMatchesPublisher('stealth/ox-alpha', 'brokenshards/ox-alpha')
+    ).toBe(false)
+  })
+
+  it('rejects third-party fine-tunes, quants and distills', () => {
+    const strangers: [string, string][] = [
+      ['openai/gpt-3.5-turbo', 'jondurbin/airoboros-gpt-3.5-turbo-100k-7b'],
+      ['~z-ai/glm-latest', 'drowzeys/keys-latest-GLM-5.2-Quantrio-INT4'],
+      ['qwen/qwen3-max', 'DavidAU/Qwen3.6-27B-Fable-Fusion-711-GGUF'],
+      ['openai/gpt-5.1-codex-max-20251204', 'TeichAI/Qwen3-4B-Codex-Max-Distill'],
+    ]
+    for (const [permaslug, repo] of strangers)
+      expect(repoOwnerMatchesPublisher(permaslug, repo)).toBe(false)
+  })
+
+  it('accepts the org-name decorations publishers actually use', () => {
+    // Every shape observed across the 299 audited classifications.
+    const real: [string, string][] = [
+      ['z-ai/glm-5.2-20260616', 'zai-org/GLM-5.2'],
+      ['cohere/command-r-08-2024', 'CohereLabs/c4ai-command-r-08-2024'],
+      ['cohere/command-a-03-2025', 'CohereForAI/c4ai-command-a-03-2025'],
+      ['minimax/minimax-m1', 'MiniMaxAI/MiniMax-M1-40k'],
+      ['x-ai/grok-2', 'xai-org/grok-2'],
+      ['ai21/jamba-large-1.7', 'ai21labs/AI21-Jamba-Large-1.7'],
+      ['deepseek/deepseek-v4-pro', 'deepseek-ai/DeepSeek-V4-Pro'],
+      ['perplexity/sonar-x', 'perplexity-ai/Sonar-X'],
+      ['meta/muse-glimmer-30b-20260810', 'meta-models/Muse-Glimmer-30B'],
+      ['meituan/longcat-2.0-20260720', 'meituan-longcat/LongCat-2.0'],
+      ['liquid/lfm-2.5-2.6b-20260811', 'LiquidAI/LFM2.5-2.6B'],
+      ['bytedance/ui-tars-1.5-7b', 'ByteDance-Seed/UI-TARS-1.5-7B'],
+      ['moonshotai/kimi-k3-20260715', 'moonshotai/Kimi-K3'],
+      ['mistralai/mistral-large-2512', 'mistralai/Mistral-Large-3-675B-Base-2512'],
+      ['inclusionai/ling-3.0-flash-20260723', 'inclusionAI/Ling-3.0-flash'],
+    ]
+    for (const [permaslug, repo] of real)
+      expect(repoOwnerMatchesPublisher(permaslug, repo)).toBe(true)
+  })
+
+  it('is a recommendation gate, not a verdict — cross-publisher releases fail it', () => {
+    // venice/uncensored genuinely ships from cognitivecomputations. This
+    // returning false must send the model to a human, never mark it closed.
+    expect(
+      repoOwnerMatchesPublisher(
+        'venice/uncensored',
+        'cognitivecomputations/Dolphin-Mistral-24B-Venice-Edition'
+      )
+    ).toBe(false)
+  })
+
+  it('does not crash on degenerate identifiers', () => {
+    expect(repoOwnerMatchesPublisher('', '')).toBe(false)
+    expect(repoOwnerMatchesPublisher('org/', '')).toBe(false)
+    expect(repoOwnerMatchesPublisher('/model', 'owner/repo')).toBe(false)
   })
 })

--- a/common/src/perps/weights-repo-match.test.ts
+++ b/common/src/perps/weights-repo-match.test.ts
@@ -223,6 +223,22 @@ describe('repoOwnerMatchesPublisher', () => {
     )
   })
 
+  it('treats punctuation as part of the org identity', () => {
+    // `open-ai` is a real (currently empty) namespace on HuggingFace, distinct
+    // from `openai`. Normalising punctuation away made them the same org, so
+    // whoever claimed it would have inherited every openai/* model.
+    expect(repoOwnerMatchesPublisher('openai/gpt-oss-120b', 'open-ai/gpt-oss-120b')).toBe(
+      false
+    )
+    expect(repoOwnerMatchesPublisher('meta-llama/llama-3.3-70b', 'metallama/Llama-3.3-70B')).toBe(
+      false
+    )
+    // ...while genuine case differences still match.
+    expect(
+      repoOwnerMatchesPublisher('inclusionai/ling-3.0-flash', 'inclusionAI/Ling-3.0-flash')
+    ).toBe(true)
+  })
+
   it('accepts the org-name decorations publishers actually use', () => {
     // Every non-exact shape observed across the 175 open classifications that
     // carry a weights repo. If this list grows, PUBLISHER_HF_ORGS must too —

--- a/common/src/perps/weights-repo-match.test.ts
+++ b/common/src/perps/weights-repo-match.test.ts
@@ -195,27 +195,64 @@ describe('repoOwnerMatchesPublisher', () => {
       expect(repoOwnerMatchesPublisher(permaslug, repo)).toBe(false)
   })
 
+  it('rejects a namespace squatter whose org merely starts with the publisher', () => {
+    // The reason this is an explicit map and not a prefix rule. HF org names
+    // are first-come, so every one of these satisfies "org starts with the
+    // publisher's name" — and `openai-community` is a real, existing org.
+    const squatters: [string, string][] = [
+      ['openai/gpt-oss-120b', 'openai-community/gpt-oss-120b'],
+      ['anthropic/claude-x-20260101', 'anthropic-fan/claude-x'],
+      ['qwen/qwen4-30b', 'qwenfake/Qwen4-30B'],
+      ['mistralai/mistral-x-2601', 'mistralai-mirror/Mistral-X-2601'],
+    ]
+    for (const [permaslug, repo] of squatters)
+      expect([permaslug, repoOwnerMatchesPublisher(permaslug, repo)]).toEqual([
+        permaslug,
+        false,
+      ])
+  })
+
+  it('rejects an org the publisher name merely starts with', () => {
+    // The reverse direction had ZERO legitimate users across all 122 seed
+    // pairs and admits a 3-character squat, so it is not supported at all.
+    expect(repoOwnerMatchesPublisher('meta/llama-5-20260901', 'met/llama-5')).toBe(
+      false
+    )
+    expect(repoOwnerMatchesPublisher('mistralai/mistral-x', 'mistral/Mistral-X')).toBe(
+      false
+    )
+  })
+
   it('accepts the org-name decorations publishers actually use', () => {
-    // Every shape observed across the 299 audited classifications.
+    // Every non-exact shape observed across the 175 open classifications that
+    // carry a weights repo. If this list grows, PUBLISHER_HF_ORGS must too —
+    // that is the intended maintenance cost of not using a prefix rule.
     const real: [string, string][] = [
       ['z-ai/glm-5.2-20260616', 'zai-org/GLM-5.2'],
       ['cohere/command-r-08-2024', 'CohereLabs/c4ai-command-r-08-2024'],
       ['cohere/command-a-03-2025', 'CohereForAI/c4ai-command-a-03-2025'],
       ['minimax/minimax-m1', 'MiniMaxAI/MiniMax-M1-40k'],
-      ['x-ai/grok-2', 'xai-org/grok-2'],
       ['ai21/jamba-large-1.7', 'ai21labs/AI21-Jamba-Large-1.7'],
       ['deepseek/deepseek-v4-pro', 'deepseek-ai/DeepSeek-V4-Pro'],
-      ['perplexity/sonar-x', 'perplexity-ai/Sonar-X'],
+      ['perplexity/pplx-embed-v1-0.6B', 'perplexity-ai/pplx-embed-v1-0.6b'],
       ['meta/muse-glimmer-30b-20260810', 'meta-models/Muse-Glimmer-30B'],
+      ['meta-llama/llama-guard-4-12b', 'meta-llama/Llama-Guard-4-12B'],
       ['meituan/longcat-2.0-20260720', 'meituan-longcat/LongCat-2.0'],
       ['liquid/lfm-2.5-2.6b-20260811', 'LiquidAI/LFM2.5-2.6B'],
       ['bytedance/ui-tars-1.5-7b', 'ByteDance-Seed/UI-TARS-1.5-7B'],
+      ['xiaomi/mimo-v2.5-20260422', 'XiaomiMiMo/MiMo-V2.5'],
+      ['stepfun/step-3.5-flash', 'stepfun-ai/Step-3.5-Flash'],
+      ['x-ai/grok-2', 'xai-org/grok-2'],
+      // exact matches still work
       ['moonshotai/kimi-k3-20260715', 'moonshotai/Kimi-K3'],
       ['mistralai/mistral-large-2512', 'mistralai/Mistral-Large-3-675B-Base-2512'],
       ['inclusionai/ling-3.0-flash-20260723', 'inclusionAI/Ling-3.0-flash'],
     ]
     for (const [permaslug, repo] of real)
-      expect(repoOwnerMatchesPublisher(permaslug, repo)).toBe(true)
+      expect([permaslug, repoOwnerMatchesPublisher(permaslug, repo)]).toEqual([
+        permaslug,
+        true,
+      ])
   })
 
   it('is a recommendation gate, not a verdict — cross-publisher releases fail it', () => {

--- a/common/src/perps/weights-repo-match.ts
+++ b/common/src/perps/weights-repo-match.ts
@@ -172,3 +172,47 @@ export const proposedRepoMatchesModel = (
 ): boolean =>
   identifierTokens(permaslug).length >= MIN_DISTINCTIVE_MODEL_TOKENS &&
   weightsRepoNameOverlap(permaslug, repo) >= WEIGHTS_REPO_MATCH_THRESHOLD
+
+/**
+ * Is `repo` owned by the model's own publisher?
+ *
+ * The name check above asks whether a repo is named like the model. That is
+ * necessary and not sufficient, because a name is not owned by anyone: on
+ * 2026-08-21 someone created `brokenshards/ox-alpha` — twenty files named like
+ * weight shards, a config claiming 800B parameters, a README reading "real ox
+ * alpha dataset npnp", the whole repo assembled in 24 seconds — while
+ * `stealth/ox-alpha` was climbing into the ranked window. It is public, it
+ * carries `.safetensors` files, and it scores a perfect 1.00 name match. Both
+ * existing guards pass it.
+ *
+ * What it cannot fake is provenance. Weights for a model are published by the
+ * outfit that trained it, so a repo under an unrelated account is not that
+ * model's weights however it is named. The same rule independently rejects the
+ * whole class of plausible-but-wrong matches a broad search returns —
+ * `jondurbin/airoboros-gpt-3.5-turbo-100k-7b` for `openai/gpt-3.5-turbo`, a
+ * stranger's INT4 quant for `~z-ai/glm-latest`.
+ *
+ * Matching is deliberately loose about suffixes because HuggingFace org names
+ * decorate the publisher's name rather than replace it: `z-ai` publishes as
+ * `zai-org`, `cohere` as `CohereLabs`, `minimax` as `MiniMaxAI`, `x-ai` as
+ * `xai-org`, `ai21` as `ai21labs`. Prefix agreement in either direction covers
+ * every such pair observed across the 299 audited classifications.
+ *
+ * A false result must NOT be read as "closed". Cross-publisher releases are
+ * real — `venice/uncensored`'s weights live in `cognitivecomputations/` by
+ * arrangement — so this gates whether a repo may be RECOMMENDED automatically,
+ * and a failure sends the model to a human rather than deciding against it.
+ */
+export const repoOwnerMatchesPublisher = (
+  permaslug: string,
+  repo: string
+): boolean => {
+  const normalize = (value: string) =>
+    value.toLowerCase().replace(/[^a-z0-9]/g, '')
+  // `~` prefixes OpenRouter's floating aliases (`~z-ai/glm-latest`) and is not
+  // part of the publisher's name.
+  const publisher = normalize(permaslug.replace(/^~/, '').split('/')[0] ?? '')
+  const owner = normalize(repo.split('/')[0] ?? '')
+  if (!publisher || !owner) return false
+  return owner.startsWith(publisher) || publisher.startsWith(owner)
+}

--- a/common/src/perps/weights-repo-match.ts
+++ b/common/src/perps/weights-repo-match.ts
@@ -174,6 +174,41 @@ export const proposedRepoMatchesModel = (
   weightsRepoNameOverlap(permaslug, repo) >= WEIGHTS_REPO_MATCH_THRESHOLD
 
 /**
+ * Publisher -> the HuggingFace org(s) they actually publish weights under.
+ *
+ * An explicit map rather than a prefix rule, and that is the whole point.
+ * Prefix matching looks like it captures the pattern — `z-ai` publishes as
+ * `zai-org`, `cohere` as `CohereLabs` — but "org name starts with the
+ * publisher's name" is a namespace ANYONE can enter. HuggingFace org names are
+ * first-come, so `openai-community` already satisfies it for every `openai/*`
+ * model, and `anthropic-fan` or `qwenfake` would too. That is the same
+ * first-come-name-grab the fabricated `brokenshards/ox-alpha` repo exploited,
+ * just one level up, and it is not worth reintroducing to save a map entry.
+ *
+ * Measured against the 175 open classifications carrying a weights repo: 86
+ * match their publisher's org exactly and 36 need one of the 12 decorations
+ * below. Nothing else is required, so the map is small and stays checkable.
+ */
+const PUBLISHER_HF_ORGS: Record<string, string[]> = {
+  ai21: ['ai21labs'],
+  bytedance: ['bytedanceseed'],
+  cohere: ['coherelabs', 'cohereforai'],
+  deepseek: ['deepseekai'],
+  liquid: ['liquidai'],
+  meituan: ['meituanlongcat'],
+  meta: ['metamodels', 'metallama'],
+  minimax: ['minimaxai'],
+  perplexity: ['perplexityai'],
+  stepfun: ['stepfunai'],
+  xai: ['xaiorg'],
+  xiaomi: ['xiaomimimo'],
+  zai: ['zaiorg'],
+}
+
+const normalizeOrg = (value: string) =>
+  value.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+/**
  * Is `repo` owned by the model's own publisher?
  *
  * The name check above asks whether a repo is named like the model. That is
@@ -192,27 +227,25 @@ export const proposedRepoMatchesModel = (
  * `jondurbin/airoboros-gpt-3.5-turbo-100k-7b` for `openai/gpt-3.5-turbo`, a
  * stranger's INT4 quant for `~z-ai/glm-latest`.
  *
- * Matching is deliberately loose about suffixes because HuggingFace org names
- * decorate the publisher's name rather than replace it: `z-ai` publishes as
- * `zai-org`, `cohere` as `CohereLabs`, `minimax` as `MiniMaxAI`, `x-ai` as
- * `xai-org`, `ai21` as `ai21labs`. Prefix agreement in either direction covers
- * every such pair observed across the 299 audited classifications.
+ * Exact match or a listed decoration, nothing fuzzier. See PUBLISHER_HF_ORGS
+ * for why a prefix rule is not safe here.
  *
- * A false result must NOT be read as "closed". Cross-publisher releases are
- * real — `venice/uncensored`'s weights live in `cognitivecomputations/` by
- * arrangement — so this gates whether a repo may be RECOMMENDED automatically,
- * and a failure sends the model to a human rather than deciding against it.
+ * An unlisted publisher returns false, which costs a human one look rather than
+ * admitting a namespace squatter — and a false result must NOT be read as
+ * "closed" in any case. Cross-publisher releases are real: `venice/uncensored`
+ * ships from `cognitivecomputations/` by arrangement and is deliberately absent
+ * from the map. This gates whether a repo may be RECOMMENDED automatically; a
+ * failure sends the model to a human rather than deciding against it.
  */
 export const repoOwnerMatchesPublisher = (
   permaslug: string,
   repo: string
 ): boolean => {
-  const normalize = (value: string) =>
-    value.toLowerCase().replace(/[^a-z0-9]/g, '')
   // `~` prefixes OpenRouter's floating aliases (`~z-ai/glm-latest`) and is not
   // part of the publisher's name.
-  const publisher = normalize(permaslug.replace(/^~/, '').split('/')[0] ?? '')
-  const owner = normalize(repo.split('/')[0] ?? '')
+  const publisher = normalizeOrg(permaslug.replace(/^~/, '').split('/')[0] ?? '')
+  const owner = normalizeOrg(repo.split('/')[0] ?? '')
   if (!publisher || !owner) return false
-  return owner.startsWith(publisher) || publisher.startsWith(owner)
+  if (owner === publisher) return true
+  return (PUBLISHER_HF_ORGS[publisher] ?? []).includes(owner)
 }

--- a/common/src/perps/weights-repo-match.ts
+++ b/common/src/perps/weights-repo-match.ts
@@ -177,65 +177,64 @@ export const proposedRepoMatchesModel = (
  * Publisher -> the HuggingFace org(s) they actually publish weights under.
  *
  * An explicit map rather than a prefix rule, and that is the whole point.
- * Prefix matching looks like it captures the pattern — `z-ai` publishes as
- * `zai-org`, `cohere` as `CohereLabs` — but "org name starts with the
- * publisher's name" is a namespace ANYONE can enter. HuggingFace org names are
- * first-come, so `openai-community` already satisfies it for every `openai/*`
- * model, and `anthropic-fan` or `qwenfake` would too. That is the same
- * first-come-name-grab the fabricated `brokenshards/ox-alpha` repo exploited,
- * just one level up, and it is not worth reintroducing to save a map entry.
+ * Prefix matching looks like it captures the pattern -- `z-ai` publishes as
+ * `zai-org`, `cohere` as `CohereLabs` -- but "org name starts with the
+ * publisher's name" is a namespace ANYONE can enter. HuggingFace org names
+ * are first-come, so `openai-community` already satisfied it for every
+ * `openai/*` model, and `anthropic-fan` or `qwenfake` would too. That is the
+ * same first-come name-grab the fabricated `brokenshards/ox-alpha` repo
+ * exploited, one level up.
+ *
+ * Comparison is case-insensitive but otherwise EXACT -- punctuation is
+ * significant. An earlier version normalised it away, which made `openai`
+ * and `open-ai` the same namespace; `open-ai` is a real, currently-empty org
+ * on HuggingFace, so anyone claiming it would have inherited every
+ * `openai/*` model. Hyphens are part of an org's identity, not noise.
  *
  * Measured against the 175 open classifications carrying a weights repo: 86
- * match their publisher's org exactly and 36 need one of the 12 decorations
- * below. Nothing else is required, so the map is small and stays checkable.
+ * match their publisher's org exactly and the rest need one of the entries
+ * below. `venice` is deliberately ABSENT -- its weights genuinely ship from
+ * `cognitivecomputations`, and a cross-publisher release is exactly the case
+ * that should reach a human rather than be waved through by a map entry.
  */
 const PUBLISHER_HF_ORGS: Record<string, string[]> = {
-  ai21: ['ai21labs'],
-  bytedance: ['bytedanceseed'],
-  cohere: ['coherelabs', 'cohereforai'],
-  deepseek: ['deepseekai'],
-  liquid: ['liquidai'],
-  meituan: ['meituanlongcat'],
-  meta: ['metamodels', 'metallama'],
-  minimax: ['minimaxai'],
-  perplexity: ['perplexityai'],
-  stepfun: ['stepfunai'],
-  xai: ['xaiorg'],
-  xiaomi: ['xiaomimimo'],
-  zai: ['zaiorg'],
+  'ai21': ['ai21labs'],
+  'bytedance': ['bytedance-seed'],
+  'cohere': ['coherelabs', 'cohereforai'],
+  'deepseek': ['deepseek-ai'],
+  'liquid': ['liquidai'],
+  'meituan': ['meituan-longcat'],
+  'meta': ['meta-models', 'meta-llama'],
+  'minimax': ['minimaxai'],
+  'perplexity': ['perplexity-ai'],
+  'stepfun': ['stepfun-ai'],
+  'x-ai': ['xai-org'],
+  'xiaomi': ['xiaomimimo'],
+  'z-ai': ['zai-org'],
 }
-
-const normalizeOrg = (value: string) =>
-  value.toLowerCase().replace(/[^a-z0-9]/g, '')
 
 /**
  * Is `repo` owned by the model's own publisher?
  *
  * The name check above asks whether a repo is named like the model. That is
  * necessary and not sufficient, because a name is not owned by anyone: on
- * 2026-08-21 someone created `brokenshards/ox-alpha` — twenty files named like
- * weight shards, a config claiming 800B parameters, a README reading "real ox
- * alpha dataset npnp", the whole repo assembled in 24 seconds — while
- * `stealth/ox-alpha` was climbing into the ranked window. It is public, it
- * carries `.safetensors` files, and it scores a perfect 1.00 name match. Both
- * existing guards pass it.
+ * 2026-08-21 someone created `brokenshards/ox-alpha` -- twenty files named
+ * like weight shards, a config claiming 800B parameters, a README reading
+ * "real ox alpha dataset npnp", the whole repo assembled in 24 seconds --
+ * while `stealth/ox-alpha` was climbing into the ranked window. It is public,
+ * carries `.safetensors` files, and scores a perfect 1.00 name match. Both
+ * other guards pass it.
  *
  * What it cannot fake is provenance. Weights for a model are published by the
  * outfit that trained it, so a repo under an unrelated account is not that
- * model's weights however it is named. The same rule independently rejects the
- * whole class of plausible-but-wrong matches a broad search returns —
+ * model's weights however it is named. The same rule independently rejects
+ * the plausible-but-wrong matches a broad search returns --
  * `jondurbin/airoboros-gpt-3.5-turbo-100k-7b` for `openai/gpt-3.5-turbo`, a
  * stranger's INT4 quant for `~z-ai/glm-latest`.
  *
- * Exact match or a listed decoration, nothing fuzzier. See PUBLISHER_HF_ORGS
- * for why a prefix rule is not safe here.
- *
- * An unlisted publisher returns false, which costs a human one look rather than
- * admitting a namespace squatter — and a false result must NOT be read as
- * "closed" in any case. Cross-publisher releases are real: `venice/uncensored`
- * ships from `cognitivecomputations/` by arrangement and is deliberately absent
- * from the map. This gates whether a repo may be RECOMMENDED automatically; a
- * failure sends the model to a human rather than deciding against it.
+ * A false result must NOT be read as "closed". This gates whether a repo may
+ * be RECOMMENDED automatically; a failure sends the model to a human rather
+ * than deciding against it.
  */
 export const repoOwnerMatchesPublisher = (
   permaslug: string,
@@ -243,8 +242,8 @@ export const repoOwnerMatchesPublisher = (
 ): boolean => {
   // `~` prefixes OpenRouter's floating aliases (`~z-ai/glm-latest`) and is not
   // part of the publisher's name.
-  const publisher = normalizeOrg(permaslug.replace(/^~/, '').split('/')[0] ?? '')
-  const owner = normalizeOrg(repo.split('/')[0] ?? '')
+  const publisher = (permaslug.replace(/^~/, '').split('/')[0] ?? '').toLowerCase()
+  const owner = (repo.split('/')[0] ?? '').toLowerCase()
   if (!publisher || !owner) return false
   if (owner === publisher) return true
   return (PUBLISHER_HF_ORGS[publisher] ?? []).includes(owner)

--- a/perps-model-classification-backlog.md
+++ b/perps-model-classification-backlog.md
@@ -1,0 +1,196 @@
+# Open-weight classification queue — 2026-08-21 sweep
+
+120 models had accumulated in the review queue. 111 are now adjudicated
+(1 by admin through the tool, 110 by `backend/scripts/classify-pending-models.ts`).
+9 are deliberately left pending, because they have no truthful boolean.
+
+## Method used for the 110
+
+Per the documented rebuild procedure, with one tightening:
+
+- Candidate weights repos come from the **publisher's own HuggingFace org**
+  (with the org-alias map: `z-ai`→`zai-org`, `cohere`→`CohereLabs`,
+  `minimax`→`MiniMaxAI`, `dots-studio`→`dots-studio`, …). A third-party
+  fine-tune, quant, or distill is *not* the model's weights.
+- Matched on normalized name with **version numbers preserved**.
+- Verified against the live API: repo resolves, not private, carries real
+  weight files.
+
+The publisher-org restriction is load-bearing. A first pass that fell back to
+global HuggingFace search produced a string of confident false positives —
+`openai/gpt-3.5-turbo` → `jondurbin/airoboros-gpt-3.5-turbo-100k-7b`,
+`~z-ai/glm-latest` → a random INT4 quant, `qwen/qwen3-max` → a DavidAU GGUF of
+a different model. Every one of them verified cleanly as "a public repo with
+weight files" and every one would have marked a closed frontier model open.
+
+Three cases where the mechanical answer was wrong and the check mattered:
+
+| Model | Mechanical guess | Truth |
+|---|---|---|
+| `qwen/qwen3-coder-flash` | `Qwen3-Coder-30B-A3B-Instruct` exists, looks like a match | **Closed.** OpenRouter describes it as "Alibaba's fast and cost efficient version of their **proprietary** Qwen3 Coder Plus" |
+| `upstage/solar-pro-3` | `upstage/solar-pro3-tokenizer` resolves | **Closed.** Tokenizer-only, 0 weight files — the exact trap `huggingface.ts` calls out |
+| `mistralai/mistral-medium-3` | prefix-matches `Mistral-Medium-3.5-128B` | **Closed.** 3 ≠ 3.5; no Medium-3 repo exists |
+
+## Results
+
+**13 open** — all re-verified against the live API at write time:
+
+| Model | Weights |
+|---|---|
+| `aion-labs/aion-rp-llama-3.1-8b` | `aion-labs/Aion-RP-Llama-3.1-8B` |
+| `arcee-ai/virtuoso-large` | `arcee-ai/Virtuoso-Large` |
+| `cohere/command-r-08-2024` | `CohereLabs/c4ai-command-r-08-2024` |
+| `cohere/command-r-plus-08-2024` | `CohereLabs/c4ai-command-r-plus-08-2024` |
+| `cohere/command-r7b-12-2024` | `CohereLabs/c4ai-command-r7b-12-2024` |
+| `deepcogito/cogito-v2.1-671b-20251118` | `deepcogito/cogito-671b-v2.1` |
+| `dots-studio/dots-3-note-preview-20260813` | `dots-studio/dots3-note-prev` |
+| `google/gemma-2-27b-it` | `google/gemma-2-27b-it` |
+| `meta-llama/llama-guard-4-12b` | `meta-llama/Llama-Guard-4-12B` |
+| `minimax/minimax-m1` | `MiniMaxAI/MiniMax-M1-40k` |
+| `mistralai/ministral-8b` | `mistralai/Ministral-8B-Instruct-2410` |
+| `mistralai/mistral-large` | `mistralai/Mistral-Large-Instruct-2407` (Large 2, 24.07) |
+| `mistralai/mistral-large-2407` | `mistralai/Mistral-Large-Instruct-2407` |
+
+**97 closed** — no weights repo in the publisher's org, and no public repo
+elsewhere that both names the model and carries weight files. Dominated by
+`openai` (31), `google` Gemini/Lyria (12), `anthropic` (7), `qwen` Max/Plus
+tiers (7), `bytedance-seed` (5), `perplexity` (5), `amazon` Nova (4).
+
+**1 by admin**: `z-ai/glm-5.3-20260816` → closed. Independently confirmed:
+`zai-org` has 150 public repos and no GLM-5.3 (latest is GLM-5, 2026-08-11);
+all direct probes 401; the only two global hits are third-party repos with
+zero weight files; OpenRouter lists it API-only with no HF link.
+
+Worth noting the nightly agent had recommended **open** for GLM 5.3, citing
+`zai-org/GLM-5` — a sibling, not the model. The name check rejected it and sent
+it to a human, which is exactly the design working.
+
+---
+
+## Status — both open issues closed 2026-08-24
+
+Branch `fix/open-weight-classification-audit` (2 commits). Everything below was
+open when this doc was written on 2026-08-21; all of it has since landed, and a
+full re-audit turned up four real misclassifications in the process.
+
+### Resolved — routers and floating aliases (was open issue 1)
+
+`isCompositeSlug` in `open-weight-models.ts` now excludes the 6 router slugs and
+any `~`-prefixed alias from BOTH sides of the index, the way `OTHER_MODEL_KEY`
+is excluded. Unclassified was the worse option — it starts a grace clock and
+eventually halts the feed, forcing a boolean under deadline for something that
+has none.
+
+Not silent: `compositeSlugs` / `compositeTokens` come back in the result and
+`update-openrouter-share.ts` logs the slugs and their share of payload tokens on
+every tick that has one.
+
+The alias half got a better answer than this doc proposed. OpenRouter publishes
+`alias_target`, so `~z-ai/glm-latest -> z-ai/glm-5.3` is machine-readable. If an
+alias ever carries real volume, resolve through that field and classify the
+target rather than exclude — the log is the trigger.
+
+### Resolved — `gated: "manual"` (was open issue 2)
+
+`isPubliclyGettable` now accepts `"manual"`, matching the seed, which classifies
+all eleven such repos open (every Llama and Gemma). This could not stay deferred:
+the new audit job reported all eleven as "no longer verifies" on its first run
+against prod, and a standing false alarm is how an alert gets ignored.
+
+### New — the audit that did not exist
+
+`update-classification-audit.ts`, nightly at 03:40 LA, plus
+`backend/scripts/run-classification-audit.ts` to run it on demand. Read-only;
+it raises flags, never writes a verdict.
+
+Found four seed entries marking open models closed — Kimi K3, Mistral Large 3
+2512, Mistral Medium 3.5, Ling-3.0-flash — all corrected, list version bumped to
+`2026-08-24`. Verified clean against prod afterwards: 175 open + 124 closed, no
+disagreements.
+
+### New — `repoOwnerMatchesPublisher`
+
+Blocks the fabricated-repo vector. `brokenshards/ox-alpha` passed both existing
+guards; provenance is what a name cannot fake. Downgrades to unresolved, never
+to closed, because cross-publisher releases are real.
+
+---
+
+## Still open
+
+- **120 pending classifications are still unapplied.**
+  `backend/scripts/classify-pending-models.ts --apply` has never been run — the
+  run was blocked by a permission prompt. Dry run was clean.
+- **Index impact of the four corrections is unquantified.** Needs the rankings
+  dataset, i.e. `OPENROUTER_API_KEY` from Secret Manager.
+- **Whether to recompute historical points.** The four errors predate the list
+  cut, so this is a correction rather than a forward-dated reclassification.
+  That is a decision about what the market settled on, not a technical one.
+- **Deploy.** The audit job is scheduler-side; it needs a `scheduler-perps`
+  deploy to start running.
+
+---
+
+## Original write-up (2026-08-21), kept for the reasoning
+
+## Open issue 1 — routers and floating aliases have no truthful boolean
+
+Left pending. None has ever ranked, so nothing is halting today; the risk is
+that one cracks the top 50 and forces a bad call under a 48-hour deadline.
+
+**6 router slugs**: `openrouter/auto`, `auto-beta`, `bodybuilder`, `free`,
+`fusion`, `pareto-code`.
+
+These are not models. OpenRouter documents Fusion as "a panel of expert models
+… analyzes your prompt in parallel … then a judge model synthesizes their
+responses", priced as the sum of the underlying completions. Its token volume
+is a *mixture* of open and closed models. Classifying it either way
+misattributes all of it.
+
+**3 floating aliases**: `~z-ai/glm-latest`, `~deepseek/deepseek-v4-flash-latest`,
+`~moonshotai/kimi-latest`.
+
+These resolve to whatever the publisher's current model is. Their status
+genuinely changes under us: `~z-ai/glm-latest` points at GLM 5.3 today, which
+is **closed**, while every previous GLM is open. A stored boolean silently goes
+stale, and nothing in the system would notice.
+
+The other 9 aliases (`~anthropic/*`, `~openai/*`, `~google/gemini-*`,
+`~x-ai/grok-latest`) were classified closed — every model in those families is
+closed, so the alias is closed regardless of where it points. Precedent:
+`openai/chatgpt-4o-latest` is already closed in the seed.
+
+**Recommended fix:** exclude router and alias slugs structurally, the way
+`OTHER_MODEL_KEY` is excluded — they are not members of the "top 50 models"
+population the index is defined over. Failing that, resolve aliases to their
+target at tick time rather than storing a verdict against the alias. Either
+beats a boolean that is wrong by construction.
+
+## Open issue 2 — `gated: "manual"` means opposite things in two places
+
+`shared/huggingface.ts`'s `isPubliclyGettable` accepts only
+`null | false | 'auto'`, so it treats `gated: "manual"` as **not** publicly
+gettable:
+
+> Discretionary gating does NOT: … `"manual"` means the owner approves each
+> request individually, so the public cannot in fact get the weights.
+
+But the published seed classifies every `manual`-gated Llama and Gemma as
+**open** — `google/gemma-3-27b-it`, `meta-llama/Llama-3.3-70B-Instruct`,
+`Llama-4-Maverick`, `Llama-4-Scout`, and more. The settled methodology is that
+anyone may accept those licences and download, so they are open.
+
+Today this is only conservative: the auto-verifier fails into "ask a human"
+rather than misclassifying, so nothing is wrong in the index. But it means the
+nightly watcher can *never* auto-confirm a Llama or Gemma release, and every
+one will land in the review queue on a 48-hour clock — which is a
+manufactured outage waiting for the next Llama launch.
+
+`classify-pending-models.ts` uses its own verifier that accepts `manual` and
+records the gating value in the evidence, so it matches the list it writes
+into. That is a local fix for one script, not a resolution.
+
+**Decide one policy and apply it in both places.** If `manual` is open, widen
+`isPubliclyGettable` and let the watcher auto-classify Llama/Gemma. If it is
+not, the seed's Llama and Gemma entries are wrong and the published methodology
+needs to say so. Right now the code and the published list disagree.

--- a/perps-model-classification-backlog.md
+++ b/perps-model-classification-backlog.md
@@ -1,8 +1,13 @@
 # Open-weight classification queue — 2026-08-21 sweep
 
-120 models had accumulated in the review queue. 111 are now adjudicated
-(1 by admin through the tool, 110 by `backend/scripts/classify-pending-models.ts`).
-9 are deliberately left pending, because they have no truthful boolean.
+120 models had accumulated in the review queue. Verdicts were derived for 110
+of them (below); **they were never applied** — see "Still open". Only 1 was
+actually adjudicated, by an admin through the tool. 9 are deliberately left
+pending, because they have no truthful boolean.
+
+> ⚠️ This section is a 2026-08-21 research record, not a description of live
+> state. The script it refers to was never committed and does not exist in any
+> git ref.
 
 ## Method used for the 110
 
@@ -99,7 +104,7 @@ against prod, and a standing false alarm is how an alert gets ignored.
 
 ### New — the audit that did not exist
 
-`update-classification-audit.ts`, nightly at 03:40 LA, plus
+`update-classification-audit.ts`, nightly at 06:40 LA, plus
 `backend/scripts/run-classification-audit.ts` to run it on demand. Read-only;
 it raises flags, never writes a verdict.
 
@@ -118,16 +123,23 @@ to closed, because cross-publisher releases are real.
 
 ## Still open
 
-- **120 pending classifications are still unapplied.**
-  `backend/scripts/classify-pending-models.ts --apply` has never been run — the
-  run was blocked by a permission prompt. Dry run was clean.
+- **~120 pending classifications are still unapplied.** There is NO script for
+  this in the repo. An earlier session wrote `classify-pending-models.ts` with
+  110 verdicts embedded, but it was never committed and is not on disk or in any
+  git ref — do not go looking for it, and do not assume its verdicts are still
+  current, because the pending set has churned since. Clearing the queue means
+  re-deriving the verdicts and either clicking them through
+  `/admin/model-classifications` or writing a fresh one-off script.
 - **Index impact of the four corrections is unquantified.** Needs the rankings
   dataset, i.e. `OPENROUTER_API_KEY` from Secret Manager.
 - **Whether to recompute historical points.** The four errors predate the list
   cut, so this is a correction rather than a forward-dated reclassification.
   That is a decision about what the market settled on, not a technical one.
-- **Deploy.** The audit job is scheduler-side; it needs a `scheduler-perps`
-  deploy to start running.
+- **Deploy: `prod main`, NOT `prod perps`.** `classification-audit` is not in
+  `PERP_JOB_NAMES` (which is only `update-perps`, `update-oracle-feeds`,
+  `update-openrouter-share`, `update-trump-approval`), so it runs on the `main`
+  scheduler instance — same as `update-model-classifications`. Deploying
+  `perps` would leave the audit permanently un-run while looking shipped.
 
 ---
 
@@ -186,9 +198,10 @@ nightly watcher can *never* auto-confirm a Llama or Gemma release, and every
 one will land in the review queue on a 48-hour clock — which is a
 manufactured outage waiting for the next Llama launch.
 
-`classify-pending-models.ts` uses its own verifier that accepts `manual` and
-records the gating value in the evidence, so it matches the list it writes
-into. That is a local fix for one script, not a resolution.
+The (uncommitted, now-lost) `classify-pending-models.ts` used its own verifier
+that accepted `manual`, so it matched the list it wrote into. That was a local
+fix for one script, not a resolution — the real one landed in
+`isPubliclyGettable`, above.
 
 **Decide one policy and apply it in both places.** If `manual` is open, widen
 `isPubliclyGettable` and let the watcher auto-classify Llama/Gemma. If it is

--- a/perps-model-classification-backlog.md
+++ b/perps-model-classification-backlog.md
@@ -135,11 +135,36 @@ to closed, because cross-publisher releases are real.
 - **Whether to recompute historical points.** The four errors predate the list
   cut, so this is a correction rather than a forward-dated reclassification.
   That is a decision about what the market settled on, not a technical one.
-- **Deploy: `prod main`, NOT `prod perps`.** `classification-audit` is not in
-  `PERP_JOB_NAMES` (which is only `update-perps`, `update-oracle-feeds`,
-  `update-openrouter-share`, `update-trump-approval`), so it runs on the `main`
-  scheduler instance — same as `update-model-classifications`. Deploying
-  `perps` would leave the audit permanently un-run while looking shipped.
+- **Deploy BOTH, in order: `prod main`, then `prod perps`.** An earlier
+  version of this line said "`prod main`, NOT `prod perps`". That was wrong
+  and following it would have shipped half the change.
+
+  The two instances are separate deployments with separate images
+  (`deploy-scheduler-windows.sh prod <main|perps>` sets `SERVICE_NAME` to
+  `scheduler` or `scheduler-perps` and builds an image per target), and the
+  work splits across both:
+
+  - `classification-audit` is NOT in `PERP_JOB_NAMES`, so it runs on **main**.
+  - `update-openrouter-share` IS in `PERP_JOB_NAMES`, so it runs on **perps**
+    — and it builds its map from the COMPILED `OPEN_WEIGHT_MODELS` via
+    `resolveModelClassifications`, which starts from `{...OPEN_WEIGHT_MODELS}`.
+
+  So the four seed corrections only reach the executable oracle when **perps**
+  is deployed. Deploying main alone gives the strange half-state where the
+  audit is running against the corrected list while the oracle still prices
+  the market off the old one — and the audit would report no disagreements,
+  because it is reading its own image's seed rather than the one in use.
+
+  Recommended sequencing, so the index step is not a surprise:
+
+  1. Deploy `prod main`. Nothing about the published number changes; this
+     starts the nightly audit.
+  2. Quantify the old-vs-new 7-day delta against the production rankings
+     (needs `OPENROUTER_API_KEY`). Forward-only — do NOT rewrite historical
+     oracle points; `insertOraclePrices` is `on conflict do nothing` and the
+     stored series is what the perp actually marked against.
+  3. Deploy `prod perps` at a chosen time. This is the tick where the index
+     steps up.
 
 ---
 

--- a/perps-model-classification-backlog.md
+++ b/perps-model-classification-backlog.md
@@ -135,36 +135,46 @@ to closed, because cross-publisher releases are real.
 - **Whether to recompute historical points.** The four errors predate the list
   cut, so this is a correction rather than a forward-dated reclassification.
   That is a decision about what the market settled on, not a technical one.
-- **Deploy BOTH, in order: `prod main`, then `prod perps`.** An earlier
-  version of this line said "`prod main`, NOT `prod perps`". That was wrong
-  and following it would have shipped half the change.
+- **Deploy THREE services, in this order.** Earlier versions of this line
+  said `prod perps`, then `prod main, NOT prod perps`, then main-and-perps.
+  All three were incomplete. The change spans three separately deployed
+  services, and no one of them updates another's image:
 
-  The two instances are separate deployments with separate images
-  (`deploy-scheduler-windows.sh prod <main|perps>` sets `SERVICE_NAME` to
-  `scheduler` or `scheduler-perps` and builds an image per target), and the
-  work splits across both:
+  | Service | Script | What it carries |
+  |---|---|---|
+  | `api` | `backend/api/deploy-api.sh prod` | admin endpoint: old-row reachability, HF verification on write, permaslug validation, 503-on-outage |
+  | `scheduler` (main) | `deploy-scheduler.sh prod main` | the nightly `classification-audit` job |
+  | `scheduler-perps` | `deploy-scheduler.sh prod perps` | `update-openrouter-share`, which builds its map from the COMPILED `OPEN_WEIGHT_MODELS` — i.e. the four seed corrections |
 
-  - `classification-audit` is NOT in `PERP_JOB_NAMES`, so it runs on **main**.
-  - `update-openrouter-share` IS in `PERP_JOB_NAMES`, so it runs on **perps**
-    — and it builds its map from the COMPILED `OPEN_WEIGHT_MODELS` via
-    `resolveModelClassifications`, which starts from `{...OPEN_WEIGHT_MODELS}`.
+  Two half-states to avoid, both of which hide themselves:
 
-  So the four seed corrections only reach the executable oracle when **perps**
-  is deployed. Deploying main alone gives the strange half-state where the
-  audit is running against the corrected list while the oracle still prices
-  the market off the old one — and the audit would report no disagreements,
-  because it is reading its own image's seed rather than the one in use.
+  - **Scheduler without API.** The audit starts flagging override findings
+    and tells the operator to fix them at `/admin/model-classifications` —
+    but the old API still returns only the last 30 days, so an older row is
+    named in an alert and absent from the page. Admin writes also keep the
+    unverified path, so a typo'd repo still enters the map.
+  - **main without perps.** The audit reads its OWN image's seed, so it
+    reports "no disagreements" while the oracle prices the market off the
+    old list. A green audit over a wrong index is the exact failure this
+    work exists to remove.
 
-  Recommended sequencing, so the index step is not a surprise:
+  Order:
 
-  1. Deploy `prod main`. Nothing about the published number changes; this
-     starts the nightly audit.
-  2. Quantify the old-vs-new 7-day delta against the production rankings
-     (needs `OPENROUTER_API_KEY`). Forward-only — do NOT rewrite historical
-     oracle points; `insertOraclePrices` is `on conflict do nothing` and the
-     stored series is what the perp actually marked against.
-  3. Deploy `prod perps` at a chosen time. This is the tick where the index
-     steps up.
+  1. **Quantify** the old-vs-new 7-day delta against production rankings
+     (needs `OPENROUTER_API_KEY`). Do this FIRST — it is the only step that
+     informs whether the rest should happen in a particular window.
+  2. **Deploy `api`.** Nothing published changes; the correction path and
+     the verification become available. (The script reads the live
+     `PERP_TRADING_MODE` and preserves it, so a routine deploy will not
+     clear an incident stance.)
+  3. **Deploy `prod main`.** Nothing published changes; the nightly audit
+     starts, and anything it finds is now actionable because step 2 shipped.
+  4. **Deploy `prod perps`** in the chosen window. THIS is the tick where
+     the index steps up.
+
+  Forward-only. Historical oracle points are not rewritten:
+  `insertOraclePrices` is `on conflict (feed_id, ts) do nothing`, and the
+  stored series is what the perp actually marked against.
 
 ---
 

--- a/web/pages/admin/model-classifications.tsx
+++ b/web/pages/admin/model-classifications.tsx
@@ -105,20 +105,14 @@ export default function AdminModelClassificationsPage() {
         {!!data?.recent.length && (
           <Col className="gap-1 pt-4">
             <div className="text-ink-700 font-semibold">Recently decided</div>
+            <div className="text-ink-500 text-xs">
+              A verdict can go stale without anything here changing: a publisher
+              may ship weights after launch, which the methodology treats as a
+              reclassification from the release date forward. The nightly audit
+              flags those, so these stay editable.
+            </div>
             {data.recent.map((r) => (
-              <Row
-                key={r.permaslug}
-                className="text-ink-600 items-center gap-2 text-xs"
-              >
-                <span className={r.open ? 'text-teal-600' : 'text-ink-500'}>
-                  {r.open ? 'open' : 'closed'}
-                </span>
-                <span className="font-mono">{r.permaslug}</span>
-                {r.weights && (
-                  <span className="text-ink-400 font-mono">{r.weights}</span>
-                )}
-                <span className="text-ink-400">via {r.source}</span>
-              </Row>
+              <DecidedRow key={r.permaslug} model={r} onDone={refresh} />
             ))}
           </Col>
         )}
@@ -127,6 +121,112 @@ export default function AdminModelClassificationsPage() {
   )
 }
 
+// A verdict already reached, and a way to change it.
+//
+// This list used to be read-only, which quietly assumed a classification is
+// decided once. It is not: the methodology's own pre-committed cases include
+// a publisher shipping weights after launch, and the nightly audit exists to
+// find verdicts that have gone stale. GLM 5.3 was the case that made the gap
+// obvious — correctly closed on 2026-08-20 when zai-org had no such repo,
+// weights published on 08-25, and no way to act on it here while the market
+// showed a stale number.
+//
+// Collapsed behind a click because correcting a verdict should be deliberate
+// and is rare next to working the pending queue above.
+function DecidedRow(props: {
+  model: {
+    permaslug: string
+    open: boolean
+    weights: string | null
+    source: string
+  }
+  onDone: () => void
+}) {
+  const { model, onDone } = props
+  const [editing, setEditing] = useState(false)
+  const [weights, setWeights] = useState(model.weights ?? '')
+  const [saving, setSaving] = useState(false)
+
+  const reclassify = async (open: boolean) => {
+    if (open && !weights.trim()) {
+      toast.error('An open call needs the weights repo that proves it')
+      return
+    }
+    setSaving(true)
+    try {
+      await api('set-model-classification', {
+        permaslug: model.permaslug,
+        open,
+        weights: open ? weights.trim() : undefined,
+      })
+      toast.success(`${model.permaslug} -> ${open ? 'open' : 'closed'}`)
+      setEditing(false)
+      onDone()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Col className="gap-1">
+      <Row className="text-ink-600 flex-wrap items-center gap-2 text-xs">
+        <span className={model.open ? 'text-teal-600' : 'text-ink-500'}>
+          {model.open ? 'open' : 'closed'}
+        </span>
+        <span className="font-mono">{model.permaslug}</span>
+        {model.weights && (
+          <span className="text-ink-400 font-mono">{model.weights}</span>
+        )}
+        <span className="text-ink-400">via {model.source}</span>
+        <button
+          className="text-primary-600 hover:underline"
+          onClick={() => setEditing((v) => !v)}
+        >
+          {editing ? 'cancel' : 'change'}
+        </button>
+      </Row>
+
+      {editing && (
+        <Row className="flex-wrap items-center gap-2 pb-2 pl-4">
+          <Input
+            className="w-72 font-mono text-xs"
+            placeholder="HuggingFace repo backing an open call"
+            value={weights}
+            onChange={(e) => setWeights(e.target.value)}
+          />
+          {!!weights.trim() && (
+            <a
+              className="text-primary-600 text-xs hover:underline"
+              href={`https://huggingface.co/${weights.trim()}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              check repo &#8599;
+            </a>
+          )}
+          <Button
+            size="xs"
+            color="green"
+            disabled={saving || model.open}
+            onClick={() => reclassify(true)}
+          >
+            Open
+          </Button>
+          <Button
+            size="xs"
+            color="gray"
+            disabled={saving || !model.open}
+            onClick={() => reclassify(false)}
+          >
+            Closed
+          </Button>
+        </Row>
+      )}
+    </Col>
+  )
+}
 function PendingRow(props: {
   model: {
     permaslug: string

--- a/web/pages/admin/model-classifications.tsx
+++ b/web/pages/admin/model-classifications.tsx
@@ -206,13 +206,20 @@ function DecidedRow(props: {
               check repo &#8599;
             </a>
           )}
+          {/* Enabled even when the model is ALREADY open, because replacing a
+              citation is a real correction: a repo can be renamed or withdrawn
+              while the verdict stays right. Disabling it forced a round trip
+              through "closed", which publishes a number we know to be wrong on
+              the tick in between. */}
           <Button
             size="xs"
             color="green"
-            disabled={saving || model.open}
+            disabled={
+              saving || (model.open && weights.trim() === (model.weights ?? ''))
+            }
             onClick={() => reclassify(true)}
           >
-            Open
+            {model.open ? 'Update citation' : 'Open'}
           </Button>
           <Button
             size="xs"


### PR DESCRIPTION
A re-audit of all 299 published open-weight classifications found **four wrong**, and — more importantly — found that nothing in the system was ever capable of noticing.

## The errors

| Slug | Was | Should cite | Evidence |
|---|---|---|---|
| `moonshotai/kimi-k3-20260715` | closed | `moonshotai/Kimi-K3` | OpenRouter's own description says **"open-weight"**; 96 weight files, 2.7M downloads |
| `mistralai/mistral-large-2512` | closed | `Mistral-Large-3-675B-Instruct-2512` | description says **"released under the Apache 2.0 license"**; 272 weight files |
| `mistralai/mistral-medium-3.5-20260430` | closed | `Mistral-Medium-3.5-128B` | public, 6 weight files, 91k downloads |
| `inclusionai/ling-3.0-flash-20260723` | closed | `inclusionAI/Ling-3.0-flash` | publisher-declared `hugging_face_id`, MIT, 24 weight files |

All four predate the `2026-08-14` list cut, so this is a correction rather than a forward-dated reclassification. **Every error runs the same direction — open marked closed — so the index has been understating the open share.**

That direction is structural, not luck: the list is built by *finding* a weights repo, the only way that can fail is by not finding one, and the default when it fails is closed.

**Root cause is renames.** Three of the four have an empty `hugging_face_id` on OpenRouter, so the build fell through to org-catalogue name matching, which cannot bridge a rename — `mistral-large-2512` and `Mistral-Large-3-675B-Instruct-2512` share almost no tokens, so a correct repo sitting in the publisher's own org scored zero. Mistral renames between OpenRouter slug and HF repo routinely, which is why it is two of the four.

## Why they survived: nothing re-checked anything

The watcher sweeps the catalog for unknowns, the research agent works the pending queue, the admin tool lists what needs a click. All three look **only at models with no verdict yet**. Once a verdict was written nothing looked at it again, so a wrong entry was permanent — and a seed entry doubly so, since the seed overrides overrides.

The sharpest version: `update-model-classifications.ts`'s own comment records that `hugging_face_id` agreement was measured across models we call **open** (96 of 99) and considered settled. Nobody checked whether it *contradicts* us where we say **closed**. All four errors were sitting in exactly that gap.

## `update-classification-audit.ts` — nightly, three assertions

- **ROT** — every open verdict's cited repo still resolves, public, with weight files. `microsoft/WizardLM-2-8x22B` is the motivating case: OpenRouter still declares that repo and the weights were withdrawn, so a citation is not evidence unless something re-checks it.
- **HINTS** — every closed verdict against `hugging_face_id`, in the direction nobody was checking.
- **PROSE** — the same verdicts against the description text, which states openness in words when `hugging_face_id` is empty. Two of the four were visible *only* here.

It never writes a verdict, it raises a flag. A classification that moves an executable index should not be flipped by the same kind of automated inference that got it wrong.

`backend/scripts/run-classification-audit.ts` runs it on demand; it is read-only and safe against prod.

## `repoOwnerMatchesPublisher` — closes the fabricated-repo hole

On 2026-08-21 someone created `brokenshards/ox-alpha`: twenty files named like weight shards, a config claiming 800B parameters, a README reading `real ox alpha dataset npnp`, the whole repo assembled in **24 seconds** — while `stealth/ox-alpha` was climbing into the ranked window. It is public, carries `.safetensors`, and scores a **perfect 1.00 name match**. Both existing guards pass it.

Provenance is the thing a name cannot fake. It downgrades to `unresolved`, never to closed, because cross-publisher releases are real (`venice/uncensored` genuinely ships from `cognitivecomputations`).

This is live, not hypothetical — it is also what rejects the third-party `webbrain-one/DeepSeek-V4-Flash-Vision-*` repos now sitting in front of today's ranked queue.

## Routers and floating aliases

Six router slugs and twelve `~*-latest` aliases were sitting in the review queue waiting for a boolean neither has. `openrouter/fusion` is documented as a panel of models plus a judge, billed as the sum of the underlying completions — its tokens are a *mixture*. `~z-ai/glm-latest` points at GLM 5.3 today, which is closed, while every earlier GLM is open.

Both are now excluded from numerator and denominator like `other`. Unclassified was the worse option: it starts a grace clock and eventually halts the feed, forcing someone to invent a boolean under deadline.

**Never silent** — `compositeSlugs`/`compositeTokens` come back in the result and every tick carrying one logs the slugs and their share of payload tokens. If one ever carries real volume, that log is the signal to resolve it through OpenRouter's `alias_target` field rather than keep dropping it.

The router list is explicit rather than a pattern, because `openrouter/` is also where cloaked pre-release models live and those *are* single models, correctly closed. No suffix separates them: `auto-beta` is a router, `horizon-beta` is a model.

## `gated: "manual"`

HuggingFace defines `manual` as the author approving each request
individually, which can stay pending or be refused — so it is NOT accepted
generally. An earlier revision of this PR did accept it wholesale, which
would have let a future restricted release reach the executable index through
the auto-apply path with nobody looking.

Instead the eleven Llama and Gemma repos that motivated it are allowlisted by
id in `MANUAL_GATING_PUBLIC_REPOS`. They report `manual` while in practice
anyone may accept the licence and download, and the seed classifies every one
of them open. The list was derived by checking all 175 open classifications
against the live API, and a test pins it exactly so it cannot grow by
accident. Any other manual-gated repo resolves to unresolved and goes to the
review queue.
## Verification

- `common`: **603 tests pass** (31 suites), including 17 in `weights-repo-match` and new coverage for composite slugs.
- `common`, `backend/shared`, `backend/scheduler` all typecheck clean.
- Audit run against **prod**: `175 open + 124 closed checked, no disagreements`.

Both false-positive classes above were caught by running it against prod before shipping, not by reasoning about it.

## Deploy — THREE services, in order

The change spans three separately deployed services and no one of them
updates another's image. Earlier versions of this section named only the
scheduler and were wrong.

| Service | Script | What it carries |
|---|---|---|
| `api` | `deploy-api.sh prod` | admin endpoint: old-row reachability, HF verification on write, permaslug validation, 503-on-outage |
| `scheduler` (main) | `deploy-scheduler.sh prod main` | the nightly `classification-audit` job |
| `scheduler-perps` | `deploy-scheduler.sh prod perps` | `update-openrouter-share`, which builds its map from the **compiled** `OPEN_WEIGHT_MODELS` — i.e. the four seed corrections |

Two half-states worth avoiding, both of which hide themselves:

- **Scheduler without API** — the audit flags override findings and points at
  `/admin/model-classifications`, while the old API still returns only 30 days,
  so an older row is named in an alert and absent from the page. Admin writes
  also keep the unverified path.
- **main without perps** — the audit reads its *own* image's seed and reports
  "no disagreements" while the oracle prices off the old list. A green audit
  over a wrong index is the exact failure this PR exists to remove.

Order:

1. **Quantify** the old-vs-new 7-day delta against production rankings (needs
   `OPENROUTER_API_KEY`). First, because it is the only step that informs
   whether the rest wants a particular window.
2. **`api`** — nothing published changes.
3. **`prod main`** — nothing published changes; the audit starts, and what it
   finds is actionable because step 2 shipped.
4. **`prod perps`** in the chosen window — this is the tick where the index
   steps up.

Forward-only. Historical oracle points are not rewritten:
`insertOraclePrices` is `on conflict (feed_id, ts) do nothing`, and the stored
series is what the perp actually marked against.

No migration.
## Review round 1 — 9 findings addressed

Verified each against real data before changing anything; one reported issue I
could not reproduce is noted at the end.

- **Provenance gate was a namespace anyone could enter.** The prefix match let
  `openai-community` satisfy every `openai/*` model. Measured over the 175 open
  classifications with a weights repo: 86 exact, 36 needing one of 12
  decorations, and the reverse direction had **zero** legitimate users while
  admitting `met/` for `meta/`. Replaced with exact-match-or-explicit-map,
  reverse dropped. Re-checked against all 175: only `venice/uncensored` is
  rejected, which is intended.
- **Doc misdirected the deploy** to `perps`, and pointed at a script that
  exists in no git ref while claiming 110 models had been adjudicated by it.
  Nothing was ever applied. Corrected and marked as a research record.
- **Cron comment was inverted** — 03:40 LA is inside the 00:00-04:30 LA window
  the sibling schedule exists to avoid. Moved to 06:40 LA.
- **One bad HF body ended the night.** `await res.json()` throws on the
  truncated/HTML responses HF serves during incidents, discarding every finding
  already gathered. Now per-call guarded.
- **Transport failures reported as rot.** A 5xx looks identical to a withdrawn
  repo; on a bad night every open model would land in the warn. Counted and
  reported separately so "no disagreements" cannot mask a night that proved
  nothing.
- **Script exited 0 on failure** because it called the scheduler's swallowing
  wrapper. Now calls the throwing variant.
- **Composite tokens escaped every bound** — no grace clock, no cap, no alert.
  Added `COMPOSITE_TOKEN_SHARE_CAP`, flagged as uncalibrated for the same
  reason the unclassified cap is.
- **The seed invariant test was vacuous.** It interpolated the slug and matched
  `/.+\/.+/`, which the slug's own slash satisfies — so an open entry citing no
  weights passed, while three comments described it as the thing keeping those
  out. Fixed, plus a test that fails if it goes vacuous again.
- **"Version-stamped onto every point" is false.** The version reaches the
  insert log line only; `oracle_prices` is `(feed_id, ts, price, source_ts,
  published_at)`. There is no per-point record of which list version priced it
  — which is precisely what the recompute-history question would want, so it is
  worth knowing before answering it.

Not reproduced: the description-phrase matcher was reported as false-alarm
prone. Running the real `describesOpenness` over all live catalog descriptions
produced zero misfires in either direction, so it is unchanged.

## Not in this PR

- **Index impact of the four corrections is unquantified.** Needs the rankings dataset (`OPENROUTER_API_KEY`); worth knowing before deciding the next point.
- **Whether to recompute historical points.** The errors predate the list cut, so this is a decision about what the market settled on, not a technical one. Default without action is forward-only.
- **~120 pending classifications are still unapplied.** There is no script for this in the repo — an earlier session wrote one but never committed it, and it exists in no git ref. Clearing the queue means re-deriving the verdicts and either working them through `/admin/model-classifications` or writing a fresh one-off.



