### PR TITLE
fix(native): don't strand the auth handoff when a navigation is abandoned

### DIFF
--- a/common/src/native-app-url.test.ts
+++ b/common/src/native-app-url.test.ts
@@ -6,10 +6,56 @@ import {
   parseSwitchableAppUrl,
 } from './native-app-url'
 
+// Every url this module accepts, so the browser-oracle invariant below can be
+// asserted over all of them in one place. Add here when adding an accept case.
+const ACCEPTED = [
+  'https://manifold.markets/',
+  'https://dev.manifold.markets/',
+  'https://PREVIEW.VERCEL.APP',
+  'HTTPS://Manifold.Markets/Home',
+  'https://manifold.markets:443/x',
+  'https://manifold.markets:8443/',
+  'https://manifold.markets/home?nativePlatform=android',
+  'https://manifold.markets/#/deep',
+  'https://xn--mnifold-5wa.markets/',
+  'https://prod-git-abc-manifold.vercel.app',
+  'http://localhost:3000/',
+  'HTTP://LOCALHOST:3000',
+  'http://localhost:80/',
+  'http://127.0.0.1:3001',
+  'http://192.168.1.229:3000/',
+  'http://10.0.0.5:3000',
+  'http://172.16.4.4:3000',
+  'http://[::1]:3000/',
+  'https://1.2.3.4/',
+]
+
+describe('browser-origin invariant', () => {
+  // The whole point of the module: an accepted origin must be exactly what a
+  // browser reports for that document, or the credential hand-off compares two
+  // different strings forever. Node's WHATWG URL stands in for the browser here
+  // — it is NOT a valid oracle for the app's runtime parser
+  // (whatwg-url-without-unicode preserves host case), but it is the right oracle
+  // for what a WebView document's location.origin will say.
+  it.each(ACCEPTED)('%s round-trips through a real URL parser', (raw) => {
+    const parsed = parseHttpOrigin(raw)
+    expect(parsed).not.toBeNull()
+    const href = parsed!.origin + (parsed!.rest || '/')
+    expect(new URL(href).origin).toBe(parsed!.origin)
+  })
+
+  it.each(ACCEPTED)('%s produces a switchable base a browser agrees with', (raw) => {
+    const parsed = parseSwitchableAppUrl(raw)
+    if (!parsed) return // http on a public host is rejected by design
+    expect(new URL(parsed.base).origin).toBe(parsed.origin)
+    expect(new URL(parsed.href).origin).toBe(parsed.origin)
+  })
+})
+
 describe('parseHttpOrigin', () => {
   it('canonicalizes scheme and host case', () => {
-    // React Native's URL polyfill does not lowercase, so an uppercase host would
-    // never match the lowercase origin a document reports for itself.
+    // The app's runtime URL does not lowercase, so an uppercase host would never
+    // match the lowercase origin a document reports for itself.
     expect(originOf('https://PREVIEW.VERCEL.APP')).toBe(
       'https://preview.vercel.app'
     )
@@ -28,15 +74,15 @@ describe('parseHttpOrigin', () => {
   })
 
   it('ignores path, query and fragment', () => {
-    expect(originOf('https://manifold.markets/home?nativePlatform=android')).toBe(
-      'https://manifold.markets'
-    )
+    expect(
+      originOf('https://manifold.markets/home?nativePlatform=android')
+    ).toBe('https://manifold.markets')
     expect(originOf('https://manifold.markets/#/deep')).toBe(
       'https://manifold.markets'
     )
   })
 
-  it('rejects userinfo, which RN URL.origin would keep', () => {
+  it('rejects userinfo', () => {
     expect(originOf('https://manifold.markets@evil.com/')).toBeNull()
     expect(originOf('https://user:pass@evil.com/')).toBeNull()
   })
@@ -54,9 +100,7 @@ describe('parseHttpOrigin', () => {
       expect(originOf(raw)).toBeNull()
   })
 
-  it('rejects malformed input rather than coercing it', () => {
-    // RN's single-argument URL constructor never throws, so these all "parse"
-    // there; a try/catch is not a filter.
+  it('rejects malformed input', () => {
     for (const raw of [
       'not a url',
       '',
@@ -75,6 +119,8 @@ describe('parseHttpOrigin', () => {
   })
 
   it('rejects non-ASCII hosts but accepts their punycode form', () => {
+    // The runtime URL skips IDNA entirely, so a unicode host would be stored
+    // verbatim while the browser reports the punycoded origin.
     expect(originOf('https://mänifold.markets/')).toBeNull()
     expect(originOf('https://манифолд.рф/')).toBeNull()
     expect(originOf('https://xn--mnifold-5wa.markets/')).toBe(
@@ -82,14 +128,42 @@ describe('parseHttpOrigin', () => {
     )
   })
 
+  it('rejects non-canonical IPv4, which a browser would rewrite', () => {
+    // Each of these parses in a browser but serializes to something else, so
+    // storing our reading of it would strand the hand-off. Asserted against the
+    // oracle so the comment cannot rot.
+    for (const [raw, browserOrigin] of [
+      ['https://127.1/', 'https://127.0.0.1'],
+      ['https://010.000.000.001/', 'https://8.0.0.1'],
+      ['https://2130706433/', 'https://127.0.0.1'],
+      ['https://0x7f.0.0.1/', 'https://127.0.0.1'],
+    ]) {
+      expect(new URL(raw).origin).toBe(browserOrigin)
+      expect(originOf(raw)).toBeNull()
+    }
+  })
+
+  it('accepts only already-canonical IPv6 loopback', () => {
+    expect(originOf('http://[::1]:3000/')).toBe('http://[::1]:3000')
+    // A browser compresses this to [::1]; we reject rather than reimplement
+    // RFC 5952.
+    expect(new URL('http://[0:0:0:0:0:0:0:1]:3000/').origin).toBe(
+      'http://[::1]:3000'
+    )
+    expect(originOf('http://[0:0:0:0:0:0:0:1]:3000/')).toBeNull()
+    // Malformed: a browser throws, and so must we — the old parser accepted
+    // these and threw later, after trust had already been cleared.
+    for (const raw of ['http://[:::]/', 'http://[1::2::3]/', 'http://[::1/']) {
+      expect(() => new URL(raw)).toThrow()
+      expect(originOf(raw)).toBeNull()
+    }
+    // Any other IPv6 is refused, canonical or not.
+    expect(originOf('http://[2001:db8::1]/')).toBeNull()
+  })
+
   it('rejects non-strings', () => {
     for (const raw of [null, undefined, 42, {}, [], { toString: () => 'x' }])
       expect(originOf(raw)).toBeNull()
-  })
-
-  it('handles bracketed IPv6', () => {
-    expect(originOf('http://[::1]:3000/')).toBe('http://[::1]:3000')
-    expect(originOf('http://[::1/')).toBeNull()
   })
 
   it('exposes the remainder after the authority', () => {
@@ -103,22 +177,28 @@ describe('parseHttpOrigin', () => {
 describe('isSameOrigin', () => {
   it('matches regardless of path or case', () => {
     expect(
-      isSameOrigin('https://manifold.markets/home?x=1', 'https://manifold.markets/')
+      isSameOrigin(
+        'https://manifold.markets/home?x=1',
+        'https://manifold.markets/'
+      )
     ).toBe(true)
-    expect(isSameOrigin('https://MANIFOLD.markets/', 'https://manifold.markets/')).toBe(
-      true
-    )
+    expect(
+      isSameOrigin('https://MANIFOLD.markets/', 'https://manifold.markets/')
+    ).toBe(true)
   })
 
   it('separates scheme, host and port', () => {
-    expect(isSameOrigin('http://manifold.markets/', 'https://manifold.markets/')).toBe(
-      false
-    )
+    expect(
+      isSameOrigin('http://manifold.markets/', 'https://manifold.markets/')
+    ).toBe(false)
     expect(
       isSameOrigin('https://www.manifold.markets/', 'https://manifold.markets/')
     ).toBe(false)
     expect(
-      isSameOrigin('https://manifold.markets.evil.com/', 'https://manifold.markets/')
+      isSameOrigin(
+        'https://manifold.markets.evil.com/',
+        'https://manifold.markets/'
+      )
     ).toBe(false)
     expect(
       isSameOrigin('https://manifold.markets:8443/', 'https://manifold.markets/')
@@ -176,6 +256,7 @@ describe('isLocalHostname', () => {
       '010.0.0.1',
       '10.0.0.01',
       '10.-1.0.1',
+      '127.1',
     ])
       expect(isLocalHostname(host)).toBe(false)
   })
@@ -183,13 +264,13 @@ describe('isLocalHostname', () => {
 
 describe('parseSwitchableAppUrl', () => {
   it('accepts the deploy previews and LAN dev servers the workflow needs', () => {
-    expect(parseSwitchableAppUrl('https://prod-git-abc-manifold.vercel.app')).toEqual(
-      {
-        origin: 'https://prod-git-abc-manifold.vercel.app',
-        base: 'https://prod-git-abc-manifold.vercel.app/',
-        href: 'https://prod-git-abc-manifold.vercel.app/',
-      }
-    )
+    expect(
+      parseSwitchableAppUrl('https://prod-git-abc-manifold.vercel.app')
+    ).toEqual({
+      origin: 'https://prod-git-abc-manifold.vercel.app',
+      base: 'https://prod-git-abc-manifold.vercel.app/',
+      href: 'https://prod-git-abc-manifold.vercel.app/',
+    })
     expect(parseSwitchableAppUrl('http://192.168.1.229:3000/')?.base).toBe(
       'http://192.168.1.229:3000/'
     )
@@ -222,6 +303,8 @@ describe('parseSwitchableAppUrl', () => {
       'about:blank',
       'blob:https://evil.com/1',
       'https://user@evil.com/',
+      'https://127.1/',
+      'http://[0:0:0:0:0:0:0:1]/',
       'not a url',
       '',
       null,
@@ -229,61 +312,5 @@ describe('parseSwitchableAppUrl', () => {
       42,
     ])
       expect(parseSwitchableAppUrl(raw)).toBeNull()
-  })
-})
-
-// Transcribed VERBATIM from react-native@0.81.4
-// Libraries/Blob/URL.js (the module polyfillGlobal installs as the global URL in
-// setUpXHR.js). Not the live module — common's jest cannot load a Flow file — so
-// this pins the behaviour that motivated parsing urls by hand. If a React Native
-// upgrade makes these fail, the global URL may have become spec-compliant and
-// this module could be reconsidered.
-describe('react-native 0.81 URL semantics this module exists to avoid', () => {
-  class RnUrl {
-    _url: string
-    constructor(url: string) {
-      this._url = url
-      if (this._url.includes('#')) {
-        const split = this._url.split('#')
-        const beforeHash = split[0]
-        const website = beforeHash.split('://')[1]
-        if (!website.includes('/')) this._url = split.join('/#')
-      }
-      if (
-        !this._url.endsWith('/') &&
-        !(this._url.includes('?') || this._url.includes('#'))
-      )
-        this._url += '/'
-    }
-    get origin(): string {
-      const matches = this._url.match(/^(https?:\/\/[^/]+)/)
-      return matches ? matches[1] : ''
-    }
-    get hostname(): string {
-      const m = this._url.match(/^https?:\/\/(?:[^@]+@)?([^:/?#]+)/)
-      return m ? m[1] : ''
-    }
-  }
-
-  it('never throws on garbage, so try/catch is not a filter', () => {
-    expect(() => new RnUrl('not a url')).not.toThrow()
-    expect(() => new RnUrl('javascript:alert(1)')).not.toThrow()
-    expect(originOf('not a url')).toBeNull()
-  })
-
-  it('keeps userinfo in origin while hostname strips it', () => {
-    const url = new RnUrl('https://manifold.markets@evil.com/')
-    expect(url.origin).toBe('https://manifold.markets@evil.com')
-    expect(url.hostname).toBe('evil.com')
-    expect(originOf('https://manifold.markets@evil.com/')).toBeNull()
-  })
-
-  it('does not lowercase the host', () => {
-    expect(new RnUrl('https://PREVIEW.VERCEL.APP/').origin).toBe(
-      'https://PREVIEW.VERCEL.APP'
-    )
-    expect(originOf('https://PREVIEW.VERCEL.APP/')).toBe(
-      'https://preview.vercel.app'
-    )
   })
 })

--- a/common/src/native-app-url.test.ts
+++ b/common/src/native-app-url.test.ts
@@ -28,6 +28,8 @@ const ACCEPTED = [
   'http://172.16.4.4:3000',
   'http://[::1]:3000/',
   'https://1.2.3.4/',
+  'http://100.64.0.1:3000/',
+  'https://manifold.markets:080/',
 ]
 
 describe('browser-origin invariant', () => {
@@ -44,12 +46,15 @@ describe('browser-origin invariant', () => {
     expect(new URL(href).origin).toBe(parsed!.origin)
   })
 
-  it.each(ACCEPTED)('%s produces a switchable base a browser agrees with', (raw) => {
-    const parsed = parseSwitchableAppUrl(raw)
-    if (!parsed) return // http on a public host is rejected by design
-    expect(new URL(parsed.base).origin).toBe(parsed.origin)
-    expect(new URL(parsed.href).origin).toBe(parsed.origin)
-  })
+  it.each(ACCEPTED)(
+    '%s produces a switchable base a browser agrees with',
+    (raw) => {
+      const parsed = parseSwitchableAppUrl(raw)
+      if (!parsed) return // http on a public host is rejected by design
+      expect(new URL(parsed.base).origin).toBe(parsed.origin)
+      expect(new URL(parsed.href).origin).toBe(parsed.origin)
+    }
+  )
 })
 
 describe('parseHttpOrigin', () => {
@@ -137,8 +142,26 @@ describe('parseHttpOrigin', () => {
       ['https://010.000.000.001/', 'https://8.0.0.1'],
       ['https://2130706433/', 'https://127.0.0.1'],
       ['https://0x7f.0.0.1/', 'https://127.0.0.1'],
+      // The spec's "ends in a number" test also covers a 0x-prefixed last
+      // label, which an all-digits check misses.
+      ['https://0x7f/', 'https://0.0.0.127'],
+      ['https://1.0x1/', 'https://1.0.0.1'],
+      ['https://0x/', 'https://0.0.0.0'],
     ]) {
       expect(new URL(raw).origin).toBe(browserOrigin)
+      expect(originOf(raw)).toBeNull()
+    }
+  })
+
+  it('rejects hosts a browser refuses outright', () => {
+    // 'ends in a number' with a non-numeric earlier label is a parse failure,
+    // not a domain.
+    for (const raw of [
+      'https://a.0x1/',
+      'https://a.1/',
+      'https://1.2.3.4.5/',
+    ]) {
+      expect(() => new URL(raw)).toThrow()
       expect(originOf(raw)).toBeNull()
     }
   })
@@ -201,7 +224,10 @@ describe('isSameOrigin', () => {
       )
     ).toBe(false)
     expect(
-      isSameOrigin('https://manifold.markets:8443/', 'https://manifold.markets/')
+      isSameOrigin(
+        'https://manifold.markets:8443/',
+        'https://manifold.markets/'
+      )
     ).toBe(false)
   })
 
@@ -225,6 +251,9 @@ describe('isLocalHostname', () => {
       '192.168.1.229',
       '172.16.0.1',
       '172.31.255.255',
+      // RFC 6598 / Tailscale
+      '100.64.0.1',
+      '100.127.255.255',
     ])
       expect(isLocalHostname(host)).toBe(true)
   })
@@ -250,6 +279,8 @@ describe('isLocalHostname', () => {
       '172.32.0.1',
       '192.169.0.1',
       '9.255.255.255',
+      '100.63.255.255',
+      '100.128.0.1',
       '10.0.0',
       '10.0.0.0.1',
       '10.0.0.256',

--- a/common/src/native-app-url.test.ts
+++ b/common/src/native-app-url.test.ts
@@ -1,0 +1,289 @@
+import {
+  isLocalHostname,
+  isSameOrigin,
+  originOf,
+  parseHttpOrigin,
+  parseSwitchableAppUrl,
+} from './native-app-url'
+
+describe('parseHttpOrigin', () => {
+  it('canonicalizes scheme and host case', () => {
+    // React Native's URL polyfill does not lowercase, so an uppercase host would
+    // never match the lowercase origin a document reports for itself.
+    expect(originOf('https://PREVIEW.VERCEL.APP')).toBe(
+      'https://preview.vercel.app'
+    )
+    expect(originOf('HTTPS://Manifold.Markets/Home')).toBe(
+      'https://manifold.markets'
+    )
+    expect(originOf('HTTP://LOCALHOST:3000')).toBe('http://localhost:3000')
+  })
+
+  it('drops the default port, keeps a non-default one', () => {
+    expect(originOf('https://manifold.markets:443/x')).toBe(
+      'https://manifold.markets'
+    )
+    expect(originOf('http://localhost:80/')).toBe('http://localhost')
+    expect(originOf('http://localhost:3000/')).toBe('http://localhost:3000')
+  })
+
+  it('ignores path, query and fragment', () => {
+    expect(originOf('https://manifold.markets/home?nativePlatform=android')).toBe(
+      'https://manifold.markets'
+    )
+    expect(originOf('https://manifold.markets/#/deep')).toBe(
+      'https://manifold.markets'
+    )
+  })
+
+  it('rejects userinfo, which RN URL.origin would keep', () => {
+    expect(originOf('https://manifold.markets@evil.com/')).toBeNull()
+    expect(originOf('https://user:pass@evil.com/')).toBeNull()
+  })
+
+  it('rejects non-http(s) schemes', () => {
+    for (const raw of [
+      'javascript:alert(1)',
+      'data:text/html,<script>x</script>',
+      'file:///sdcard/evil.html',
+      'about:blank',
+      'blob:https://evil.com/1234',
+      'ftp://manifold.markets/',
+      'manifold://home',
+    ])
+      expect(originOf(raw)).toBeNull()
+  })
+
+  it('rejects malformed input rather than coercing it', () => {
+    // RN's single-argument URL constructor never throws, so these all "parse"
+    // there; a try/catch is not a filter.
+    for (const raw of [
+      'not a url',
+      '',
+      '   ',
+      '//manifold.markets/',
+      'https://',
+      'https:///path',
+      'https://manifold.markets:0/',
+      'https://manifold.markets:99999/',
+      'https://manifold.markets:8o80/',
+      'https://manifold.markets:+80/',
+      'https://mani fold.markets/',
+      'https://man\tifold.markets/',
+    ])
+      expect(originOf(raw)).toBeNull()
+  })
+
+  it('rejects non-ASCII hosts but accepts their punycode form', () => {
+    expect(originOf('https://mänifold.markets/')).toBeNull()
+    expect(originOf('https://манифолд.рф/')).toBeNull()
+    expect(originOf('https://xn--mnifold-5wa.markets/')).toBe(
+      'https://xn--mnifold-5wa.markets'
+    )
+  })
+
+  it('rejects non-strings', () => {
+    for (const raw of [null, undefined, 42, {}, [], { toString: () => 'x' }])
+      expect(originOf(raw)).toBeNull()
+  })
+
+  it('handles bracketed IPv6', () => {
+    expect(originOf('http://[::1]:3000/')).toBe('http://[::1]:3000')
+    expect(originOf('http://[::1/')).toBeNull()
+  })
+
+  it('exposes the remainder after the authority', () => {
+    expect(parseHttpOrigin('https://x.dev/foo/bar?q=1#h')?.rest).toBe(
+      '/foo/bar?q=1#h'
+    )
+    expect(parseHttpOrigin('https://x.dev')?.rest).toBe('')
+  })
+})
+
+describe('isSameOrigin', () => {
+  it('matches regardless of path or case', () => {
+    expect(
+      isSameOrigin('https://manifold.markets/home?x=1', 'https://manifold.markets/')
+    ).toBe(true)
+    expect(isSameOrigin('https://MANIFOLD.markets/', 'https://manifold.markets/')).toBe(
+      true
+    )
+  })
+
+  it('separates scheme, host and port', () => {
+    expect(isSameOrigin('http://manifold.markets/', 'https://manifold.markets/')).toBe(
+      false
+    )
+    expect(
+      isSameOrigin('https://www.manifold.markets/', 'https://manifold.markets/')
+    ).toBe(false)
+    expect(
+      isSameOrigin('https://manifold.markets.evil.com/', 'https://manifold.markets/')
+    ).toBe(false)
+    expect(
+      isSameOrigin('https://manifold.markets:8443/', 'https://manifold.markets/')
+    ).toBe(false)
+  })
+
+  it('never treats two unparseable urls as the same origin', () => {
+    // The empty string is what the app holds while it distrusts the WebView.
+    expect(isSameOrigin('', '')).toBe(false)
+    expect(isSameOrigin('', 'https://manifold.markets/')).toBe(false)
+    expect(isSameOrigin('null', 'null')).toBe(false)
+    expect(isSameOrigin(undefined, undefined)).toBe(false)
+  })
+})
+
+describe('isLocalHostname', () => {
+  it('accepts loopback and RFC1918', () => {
+    for (const host of [
+      'localhost',
+      '[::1]',
+      '127.0.0.1',
+      '127.1.2.3',
+      '10.0.0.5',
+      '192.168.1.229',
+      '172.16.0.1',
+      '172.31.255.255',
+    ])
+      expect(isLocalHostname(host)).toBe(true)
+  })
+
+  it('requires a complete numeric IPv4, not a prefix', () => {
+    // The bug this replaced: /^10\./ matches a public hostname.
+    for (const host of [
+      '10.attacker.example',
+      '192.168.attacker.example',
+      '127.evil.com',
+      '172.16.evil.com',
+      '10.0.0.5.evil.com',
+      'localhost.evil.com',
+      'notlocalhost',
+    ])
+      expect(isLocalHostname(host)).toBe(false)
+  })
+
+  it('rejects neighbouring ranges and malformed octets', () => {
+    for (const host of [
+      '11.0.0.1',
+      '172.15.0.1',
+      '172.32.0.1',
+      '192.169.0.1',
+      '9.255.255.255',
+      '10.0.0',
+      '10.0.0.0.1',
+      '10.0.0.256',
+      '010.0.0.1',
+      '10.0.0.01',
+      '10.-1.0.1',
+    ])
+      expect(isLocalHostname(host)).toBe(false)
+  })
+})
+
+describe('parseSwitchableAppUrl', () => {
+  it('accepts the deploy previews and LAN dev servers the workflow needs', () => {
+    expect(parseSwitchableAppUrl('https://prod-git-abc-manifold.vercel.app')).toEqual(
+      {
+        origin: 'https://prod-git-abc-manifold.vercel.app',
+        base: 'https://prod-git-abc-manifold.vercel.app/',
+        href: 'https://prod-git-abc-manifold.vercel.app/',
+      }
+    )
+    expect(parseSwitchableAppUrl('http://192.168.1.229:3000/')?.base).toBe(
+      'http://192.168.1.229:3000/'
+    )
+    expect(parseSwitchableAppUrl('http://localhost:3000')?.base).toBe(
+      'http://localhost:3000/'
+    )
+  })
+
+  it('keeps a typed path for the first navigation but never in the base', () => {
+    // baseUri is concatenated with an endpoint, so a path in it yields '/foohome'.
+    const parsed = parseSwitchableAppUrl('https://preview.vercel.app/foo')
+    expect(parsed?.base).toBe('https://preview.vercel.app/')
+    expect(parsed?.href).toBe('https://preview.vercel.app/foo')
+    expect(parsed?.base + 'home').toBe('https://preview.vercel.app/home')
+  })
+
+  it('allows plain http only for loopback and RFC1918', () => {
+    expect(parseSwitchableAppUrl('http://evil.com/')).toBeNull()
+    expect(parseSwitchableAppUrl('http://10.attacker.example/')).toBeNull()
+    expect(parseSwitchableAppUrl('http://192.168.attacker.example/')).toBeNull()
+    expect(parseSwitchableAppUrl('http://172.32.0.1:3000/')).toBeNull()
+    expect(parseSwitchableAppUrl('https://evil.com/')).not.toBeNull()
+  })
+
+  it('rejects everything parseHttpOrigin rejects', () => {
+    for (const raw of [
+      'javascript:alert(1)',
+      'data:text/html,x',
+      'file:///x',
+      'about:blank',
+      'blob:https://evil.com/1',
+      'https://user@evil.com/',
+      'not a url',
+      '',
+      null,
+      undefined,
+      42,
+    ])
+      expect(parseSwitchableAppUrl(raw)).toBeNull()
+  })
+})
+
+// Transcribed VERBATIM from react-native@0.81.4
+// Libraries/Blob/URL.js (the module polyfillGlobal installs as the global URL in
+// setUpXHR.js). Not the live module — common's jest cannot load a Flow file — so
+// this pins the behaviour that motivated parsing urls by hand. If a React Native
+// upgrade makes these fail, the global URL may have become spec-compliant and
+// this module could be reconsidered.
+describe('react-native 0.81 URL semantics this module exists to avoid', () => {
+  class RnUrl {
+    _url: string
+    constructor(url: string) {
+      this._url = url
+      if (this._url.includes('#')) {
+        const split = this._url.split('#')
+        const beforeHash = split[0]
+        const website = beforeHash.split('://')[1]
+        if (!website.includes('/')) this._url = split.join('/#')
+      }
+      if (
+        !this._url.endsWith('/') &&
+        !(this._url.includes('?') || this._url.includes('#'))
+      )
+        this._url += '/'
+    }
+    get origin(): string {
+      const matches = this._url.match(/^(https?:\/\/[^/]+)/)
+      return matches ? matches[1] : ''
+    }
+    get hostname(): string {
+      const m = this._url.match(/^https?:\/\/(?:[^@]+@)?([^:/?#]+)/)
+      return m ? m[1] : ''
+    }
+  }
+
+  it('never throws on garbage, so try/catch is not a filter', () => {
+    expect(() => new RnUrl('not a url')).not.toThrow()
+    expect(() => new RnUrl('javascript:alert(1)')).not.toThrow()
+    expect(originOf('not a url')).toBeNull()
+  })
+
+  it('keeps userinfo in origin while hostname strips it', () => {
+    const url = new RnUrl('https://manifold.markets@evil.com/')
+    expect(url.origin).toBe('https://manifold.markets@evil.com')
+    expect(url.hostname).toBe('evil.com')
+    expect(originOf('https://manifold.markets@evil.com/')).toBeNull()
+  })
+
+  it('does not lowercase the host', () => {
+    expect(new RnUrl('https://PREVIEW.VERCEL.APP/').origin).toBe(
+      'https://PREVIEW.VERCEL.APP'
+    )
+    expect(originOf('https://PREVIEW.VERCEL.APP/')).toBe(
+      'https://preview.vercel.app'
+    )
+  })
+})

--- a/common/src/native-app-url.ts
+++ b/common/src/native-app-url.ts
@@ -1,0 +1,186 @@
+// Origin parsing for the native app's credential hand-off.
+//
+// This deliberately does NOT use the global URL. React Native 0.81 polyfills URL
+// from Libraries/Blob/URL.js, which is a set of regexes rather than a WHATWG
+// parser, and three of its behaviours are actively unsafe to base a trust
+// decision on:
+//   - the single-argument constructor NEVER throws, so `new URL('not a url')`
+//     succeeds and a try/catch around it is dead code;
+//   - `origin` is `_url.match(/^(https?:\/\/[^/]+)/)`, so it keeps any userinfo:
+//     'https://manifold.markets@evil.com/' yields origin
+//     'https://manifold.markets@evil.com';
+//   - nothing is lowercased, so 'https://PREVIEW.VERCEL.APP' compares unequal to
+//     the lowercase origin the WebView document reports for itself.
+// Everything here is pure and string-only so it can be tested in CI, which the
+// native package has no runner for.
+
+const DEFAULT_PORTS: Record<string, string> = { 'http:': '80', 'https:': '443' }
+
+// A single ASCII DNS label: alphanumeric, inner hyphens allowed.
+const LABEL = '[a-z0-9](?:[a-z0-9-]*[a-z0-9])?'
+const HOSTNAME_RE = new RegExp(`^${LABEL}(?:\\.${LABEL})*$`)
+// Bracketed IPv6, e.g. [::1]. Only hex, colons and a dotted IPv4 tail.
+const IPV6_RE = /^\[[0-9a-f:.]+\]$/
+
+// Splits scheme + authority off the front. Authority runs to the first /, ? or #.
+const SCHEME_AUTHORITY_RE = /^([a-z][a-z0-9+.-]*):\/\/([^/?#]*)([\s\S]*)$/i
+
+type ParsedOrigin = {
+  /** Canonical, comparable against a browser's location.origin. */
+  origin: string
+  /** Lowercased host with no port. '[::1]' keeps its brackets. */
+  hostname: string
+  /** 'http:' or 'https:'. */
+  protocol: string
+  /** Everything after the authority: path + query + fragment. */
+  rest: string
+}
+
+const parsePort = (raw: string, protocol: string): string | null => {
+  if (raw === '') return ''
+  // No leading zeros, no '+', no whitespace — Number() is far too forgiving.
+  if (!/^[0-9]{1,5}$/.test(raw)) return null
+  const port = Number(raw)
+  if (port < 1 || port > 65535) return null
+  // A browser's origin omits the scheme's default port; match that or the
+  // comparison against location.origin fails for an explicit :443.
+  return String(port) === DEFAULT_PORTS[protocol] ? '' : String(port)
+}
+
+/**
+ * Strictly parses an absolute http(s) URL into a canonical origin, or returns
+ * null. Rejects userinfo, non-ASCII hosts, malformed ports and every non-http(s)
+ * scheme (javascript:, data:, file:, blob:, about:).
+ */
+export const parseHttpOrigin = (raw: unknown): ParsedOrigin | null => {
+  if (typeof raw !== 'string') return null
+  // Leading/trailing whitespace and C0 controls are stripped by real parsers;
+  // anything else non-printable means it isn't a URL a human typed.
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  for (let i = 0; i < trimmed.length; i++) {
+    const code = trimmed.charCodeAt(i)
+    // C0 controls and DEL. Written as a scan because a control-character
+    // class in a regex literal trips no-control-regex.
+    if (code <= 0x1f || code === 0x7f) return null
+  }
+
+  const match = SCHEME_AUTHORITY_RE.exec(trimmed)
+  if (!match) return null
+  const [, rawScheme, authority, rest] = match
+
+  const protocol = rawScheme.toLowerCase() + ':'
+  if (protocol !== 'http:' && protocol !== 'https:') return null
+
+  // Userinfo is never acceptable here: RN's URL.origin keeps it while its
+  // hostname getter strips it, so the two disagree about who the host is.
+  if (authority.includes('@')) return null
+
+  let hostPart = authority
+  let portPart = ''
+  if (authority.startsWith('[')) {
+    const close = authority.indexOf(']')
+    if (close === -1) return null
+    hostPart = authority.slice(0, close + 1)
+    const tail = authority.slice(close + 1)
+    if (tail !== '') {
+      if (!tail.startsWith(':')) return null
+      portPart = tail.slice(1)
+    }
+  } else {
+    const colon = authority.indexOf(':')
+    if (colon !== -1) {
+      hostPart = authority.slice(0, colon)
+      portPart = authority.slice(colon + 1)
+    }
+  }
+
+  const hostname = hostPart.toLowerCase()
+  if (hostname === '') return null
+  // ASCII only. A non-ASCII host would need IDNA to canonicalize, which nothing
+  // in this path can do — a punycoded 'xn--' host is already ASCII and passes.
+  if (!HOSTNAME_RE.test(hostname) && !IPV6_RE.test(hostname)) return null
+
+  const port = parsePort(portPart, protocol)
+  if (port === null) return null
+
+  return {
+    origin: `${protocol}//${hostname}${port ? `:${port}` : ''}`,
+    hostname,
+    protocol,
+    rest,
+  }
+}
+
+/** Canonical origin string, or null. */
+export const originOf = (raw: unknown): string | null =>
+  parseHttpOrigin(raw)?.origin ?? null
+
+/** True when both parse and share an origin. Two unparseable urls are NOT equal. */
+export const isSameOrigin = (a: unknown, b: unknown): boolean => {
+  const originA = originOf(a)
+  return originA !== null && originA === originOf(b)
+}
+
+const ipv4Octets = (hostname: string): number[] | null => {
+  const parts = hostname.split('.')
+  if (parts.length !== 4) return null
+  const octets: number[] = []
+  for (const part of parts) {
+    // No leading zeros: '010.0.0.1' is octal to some resolvers and decimal to
+    // others, so it has no single correct reading.
+    if (!/^(?:0|[1-9][0-9]{0,2})$/.test(part)) return null
+    const value = Number(part)
+    if (value > 255) return null
+    octets.push(value)
+  }
+  return octets
+}
+
+/**
+ * Loopback or RFC1918 only — the sole hosts allowed to hold credentials over
+ * plain http. Requires a COMPLETE numeric IPv4 address: a prefix test alone
+ * would accept public names like '10.attacker.example'.
+ */
+export const isLocalHostname = (hostname: string): boolean => {
+  if (hostname === 'localhost' || hostname === '[::1]') return true
+  const octets = ipv4Octets(hostname)
+  if (!octets) return false
+  const [a, b] = octets
+  if (a === 127) return true
+  if (a === 10) return true
+  if (a === 192 && b === 168) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  return false
+}
+
+export type SwitchableAppUrl = {
+  /** Canonical origin, shown to the admin for confirmation. */
+  origin: string
+  /** What baseUri becomes. Always origin + '/', because callers concatenate. */
+  base: string
+  /** Where to navigate first, preserving any path the admin typed. */
+  href: string
+}
+
+/**
+ * Validates a 'Native url' before it may become the app's base — and therefore
+ * the origin the credential hand-off trusts. https anywhere; plain http only for
+ * localhost / RFC1918.
+ */
+export const parseSwitchableAppUrl = (
+  raw: unknown
+): SwitchableAppUrl | null => {
+  const parsed = parseHttpOrigin(raw)
+  if (!parsed) return null
+  if (parsed.protocol === 'http:' && !isLocalHostname(parsed.hostname))
+    return null
+  // baseUri is concatenated with an endpoint ('home', 'notifications', ...), so
+  // it has to be the bare origin with a trailing slash. Keeping a typed path
+  // here is what produced urls like '/foohome'.
+  return {
+    origin: parsed.origin,
+    base: `${parsed.origin}/`,
+    href: parsed.origin + (parsed.rest || '/'),
+  }
+}

--- a/common/src/native-app-url.ts
+++ b/common/src/native-app-url.ts
@@ -26,6 +26,11 @@
 // rejects the input rather than store an origin no document will ever report.
 // native-app-url.test.ts asserts that invariant for every accepted case, using
 // Node's WHATWG URL as the browser oracle.
+//
+// Known gap, low impact: an 'xn--' label that isn't decodable punycode
+// ('https://xn--abc/') is accepted here while a browser throws. That fails
+// loudly at navigation rather than silently stranding auth, and validating it
+// would mean carrying a punycode decoder.
 
 const DEFAULT_PORTS: Record<string, string> = { 'http:': '80', 'https:': '443' }
 
@@ -62,15 +67,20 @@ const ipv4Octets = (hostname: string): number[] | null => {
   return octets
 }
 
-// Per the URL spec a domain whose last label is all digits must parse as an IPv4
-// address, so anything that looks numeric has to already BE the canonical dotted
-// quad. This rejects '127.1' (browser: 127.0.0.1), '2130706433' (127.0.0.1),
-// '0x7f.0.0.1' (127.0.0.1) and '010.000.000.001' (8.0.0.1).
-const looksNumeric = (hostname: string) => /(?:^|\.)[0-9]+$/.test(hostname)
+// Per the URL spec a domain "ends in a number" - and so must parse as IPv4 - when
+// its last label is all digits OR starts with '0x'. Anything matching therefore
+// has to already BE the canonical dotted quad. This rejects '127.1' (browser:
+// 127.0.0.1), '2130706433' (127.0.0.1), '010.000.000.001' (8.0.0.1, octal),
+// '0x7f' (0.0.0.127), '1.0x1' (1.0.0.1), '0x' (0.0.0.0) and 'a.0x1' (a browser
+// throws). The hostname is already lowercased, so '0X' is covered.
+const looksNumeric = (hostname: string) =>
+  /(?:^|\.)(?:[0-9]+|0x[0-9a-f]*)$/.test(hostname)
 
 const parsePort = (raw: string, protocol: string): string | null => {
   if (raw === '') return ''
-  // No leading zeros, no '+', no whitespace — Number() is far too forgiving.
+  // Digits only — no '+', no whitespace, no hex; Number() is far too forgiving.
+  // Leading zeros are fine because the value is re-serialized below, exactly as
+  // a browser does ('https://x:080' -> origin 'https://x:80').
   if (!/^[0-9]{1,5}$/.test(raw)) return null
   const port = Number(raw)
   if (port < 1 || port > 65535) return null
@@ -166,9 +176,13 @@ export const isSameOrigin = (a: unknown, b: unknown): boolean => {
 }
 
 /**
- * Loopback or RFC1918 only — the sole hosts allowed to hold credentials over
- * plain http. Requires a COMPLETE numeric IPv4 address: a prefix test alone
+ * Loopback, RFC1918 or CGNAT only — the sole hosts allowed to hold credentials
+ * over plain http. Requires a COMPLETE numeric IPv4 address: a prefix test alone
  * would accept public names like '10.attacker.example'.
+ *
+ * Deliberately NOT accepted, so a dev hitting one of these knows it is a policy
+ * choice and not a bug: mDNS '.local' names (they resolve off-link in ways this
+ * cannot see), and IPv6 other than [::1]. Use https, or tunnel to localhost.
  */
 export const isLocalHostname = (hostname: string): boolean => {
   if (hostname === 'localhost' || hostname === '[::1]') return true
@@ -179,6 +193,9 @@ export const isLocalHostname = (hostname: string): boolean => {
   if (a === 10) return true
   if (a === 192 && b === 168) return true
   if (a === 172 && b >= 16 && b <= 31) return true
+  // 100.64.0.0/10, RFC 6598 shared address space — what Tailscale hands out,
+  // and a common way to reach a dev server from a test device.
+  if (a === 100 && b >= 64 && b <= 127) return true
   return false
 }
 

--- a/common/src/native-app-url.ts
+++ b/common/src/native-app-url.ts
@@ -1,26 +1,37 @@
 // Origin parsing for the native app's credential hand-off.
 //
-// This deliberately does NOT use the global URL. React Native 0.81 polyfills URL
-// from Libraries/Blob/URL.js, which is a set of regexes rather than a WHATWG
-// parser, and three of its behaviours are actively unsafe to base a trust
-// decision on:
-//   - the single-argument constructor NEVER throws, so `new URL('not a url')`
-//     succeeds and a try/catch around it is dead code;
-//   - `origin` is `_url.match(/^(https?:\/\/[^/]+)/)`, so it keeps any userinfo:
-//     'https://manifold.markets@evil.com/' yields origin
-//     'https://manifold.markets@evil.com';
-//   - nothing is lowercased, so 'https://PREVIEW.VERCEL.APP' compares unequal to
-//     the lowercase origin the WebView document reports for itself.
-// Everything here is pure and string-only so it can be tested in CI, which the
-// native package has no runner for.
+// WHY NOT THE GLOBAL URL. The native app's index.js imports 'expo' before
+// './App', and expo/src/winter/runtime.native.ts installs URL from
+// whatwg-url-without-unicode over React Native's own polyfill — so the runtime
+// URL is spec-compliant in almost every respect. It throws on garbage, strips
+// userinfo from origin, and drops a default port. Two things it does NOT do,
+// because that package exists to omit the IDNA tables:
+//
+//   new URL('https://PREVIEW.VERCEL.APP/').origin -> 'https://PREVIEW.VERCEL.APP'
+//   new URL('https://mänifold.markets/').origin   -> 'https://mänifold.markets'
+//
+// (Verified against whatwg-url-without-unicode@8.0.0-3; Node's WHATWG URL gives
+// 'https://preview.vercel.app' and 'https://xn--mnifold-5wa.markets'.)
+//
+// A WebView document is a real browser, so the location.origin it reports is
+// always lowercase ASCII. Comparing that against an origin the runtime URL left
+// mixed-case would never match, and the hand-off would be stranded for good —
+// silently and permanently. So origins are parsed and canonicalized here
+// instead. Everything is pure and string-only, because CI has no way to run
+// anything in the native package.
+//
+// The bar for accepting an origin is therefore: it must serialize exactly the
+// way a browser would. Where matching a browser takes real work — compressing an
+// IPv6 address per RFC 5952, or expanding shorthand IPv4 like '127.1' — this
+// rejects the input rather than store an origin no document will ever report.
+// native-app-url.test.ts asserts that invariant for every accepted case, using
+// Node's WHATWG URL as the browser oracle.
 
 const DEFAULT_PORTS: Record<string, string> = { 'http:': '80', 'https:': '443' }
 
 // A single ASCII DNS label: alphanumeric, inner hyphens allowed.
 const LABEL = '[a-z0-9](?:[a-z0-9-]*[a-z0-9])?'
 const HOSTNAME_RE = new RegExp(`^${LABEL}(?:\\.${LABEL})*$`)
-// Bracketed IPv6, e.g. [::1]. Only hex, colons and a dotted IPv4 tail.
-const IPV6_RE = /^\[[0-9a-f:.]+\]$/
 
 // Splits scheme + authority off the front. Authority runs to the first /, ? or #.
 const SCHEME_AUTHORITY_RE = /^([a-z][a-z0-9+.-]*):\/\/([^/?#]*)([\s\S]*)$/i
@@ -36,6 +47,27 @@ type ParsedOrigin = {
   rest: string
 }
 
+const ipv4Octets = (hostname: string): number[] | null => {
+  const parts = hostname.split('.')
+  if (parts.length !== 4) return null
+  const octets: number[] = []
+  for (const part of parts) {
+    // No leading zeros: a browser reads '010' as octal, so '010.000.000.001'
+    // serializes to 8.0.0.1. Refuse the ambiguity rather than reimplement it.
+    if (!/^(?:0|[1-9][0-9]{0,2})$/.test(part)) return null
+    const value = Number(part)
+    if (value > 255) return null
+    octets.push(value)
+  }
+  return octets
+}
+
+// Per the URL spec a domain whose last label is all digits must parse as an IPv4
+// address, so anything that looks numeric has to already BE the canonical dotted
+// quad. This rejects '127.1' (browser: 127.0.0.1), '2130706433' (127.0.0.1),
+// '0x7f.0.0.1' (127.0.0.1) and '010.000.000.001' (8.0.0.1).
+const looksNumeric = (hostname: string) => /(?:^|\.)[0-9]+$/.test(hostname)
+
 const parsePort = (raw: string, protocol: string): string | null => {
   if (raw === '') return ''
   // No leading zeros, no '+', no whitespace — Number() is far too forgiving.
@@ -49,13 +81,12 @@ const parsePort = (raw: string, protocol: string): string | null => {
 
 /**
  * Strictly parses an absolute http(s) URL into a canonical origin, or returns
- * null. Rejects userinfo, non-ASCII hosts, malformed ports and every non-http(s)
- * scheme (javascript:, data:, file:, blob:, about:).
+ * null. Accepts only what serializes identically in a browser: ASCII hostnames,
+ * canonical dotted-quad IPv4, and '[::1]'. Rejects userinfo, non-ASCII hosts,
+ * malformed ports and every non-http(s) scheme.
  */
 export const parseHttpOrigin = (raw: unknown): ParsedOrigin | null => {
   if (typeof raw !== 'string') return null
-  // Leading/trailing whitespace and C0 controls are stripped by real parsers;
-  // anything else non-printable means it isn't a URL a human typed.
   const trimmed = raw.trim()
   if (trimmed === '') return null
   for (let i = 0; i < trimmed.length; i++) {
@@ -72,8 +103,8 @@ export const parseHttpOrigin = (raw: unknown): ParsedOrigin | null => {
   const protocol = rawScheme.toLowerCase() + ':'
   if (protocol !== 'http:' && protocol !== 'https:') return null
 
-  // Userinfo is never acceptable here: RN's URL.origin keeps it while its
-  // hostname getter strips it, so the two disagree about who the host is.
+  // Userinfo before the host is never acceptable here — it is exactly how a
+  // hostile url is dressed to read as ours: 'https://manifold.markets@evil.com'.
   if (authority.includes('@')) return null
 
   let hostPart = authority
@@ -97,9 +128,21 @@ export const parseHttpOrigin = (raw: unknown): ParsedOrigin | null => {
 
   const hostname = hostPart.toLowerCase()
   if (hostname === '') return null
-  // ASCII only. A non-ASCII host would need IDNA to canonicalize, which nothing
-  // in this path can do — a punycoded 'xn--' host is already ASCII and passes.
-  if (!HOSTNAME_RE.test(hostname) && !IPV6_RE.test(hostname)) return null
+
+  if (hostname.startsWith('[')) {
+    // Loopback only. A browser compresses IPv6 per RFC 5952, so
+    // '[0:0:0:0:0:0:0:1]' comes back as '[::1]' and a stored expanded form would
+    // never match, while '[:::]' and '[1::2::3]' are rejected outright there.
+    // Rather than reimplement either behaviour for an address nothing needs,
+    // take the one form that is already canonical.
+    if (hostname !== '[::1]') return null
+  } else {
+    // ASCII only. A non-ASCII host needs IDNA to canonicalize, which the app's
+    // runtime URL deliberately cannot do — a punycoded 'xn--' host is already
+    // ASCII and passes.
+    if (!HOSTNAME_RE.test(hostname)) return null
+    if (looksNumeric(hostname) && ipv4Octets(hostname) === null) return null
+  }
 
   const port = parsePort(portPart, protocol)
   if (port === null) return null
@@ -120,21 +163,6 @@ export const originOf = (raw: unknown): string | null =>
 export const isSameOrigin = (a: unknown, b: unknown): boolean => {
   const originA = originOf(a)
   return originA !== null && originA === originOf(b)
-}
-
-const ipv4Octets = (hostname: string): number[] | null => {
-  const parts = hostname.split('.')
-  if (parts.length !== 4) return null
-  const octets: number[] = []
-  for (const part of parts) {
-    // No leading zeros: '010.0.0.1' is octal to some resolvers and decimal to
-    // others, so it has no single correct reading.
-    if (!/^(?:0|[1-9][0-9]{0,2})$/.test(part)) return null
-    const value = Number(part)
-    if (value > 255) return null
-    octets.push(value)
-  }
-  return octets
 }
 
 /**

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -202,10 +202,10 @@ const App = () => {
     pendingAuthPosts.current = []
   }
   // Whether a wanted handoff post was dropped because the WebView was on an
-  // untrusted URL at fire time. Trust is cleared for the whole document load,
-  // so on a slow connection every timer below can fire inside that window —
-  // this flag lets the next committed Manifold page re-arm the handoff (see
-  // onNavigate) instead of silently stranding the web client logged out.
+  // untrusted URL at fire time — the whole retry ladder can fire while a
+  // third-party page (iDenfy, Stripe) is up. This flag lets the next committed
+  // Manifold page re-arm the handoff (see onNavigate) instead of silently
+  // stranding the web client logged out.
   const authPostDropped = useRef(false)
 
   // Sends the saved user to the web client to make the log in process faster
@@ -752,9 +752,17 @@ const App = () => {
           setHasLoadedWebView={setHasLoadedWebView}
           handleMessageFromWebview={handleMessageFromWebview}
           handleExternalLink={handleExternalLink}
-          onNavigate={(url) => {
-            // null (navigation start) leaves an empty string, which isManifoldUrl
-            // treats as untrusted until the next load commits.
+          onNavigate={(url, phase) => {
+            if (phase === 'start') {
+              // Distrust ONLY a navigation heading somewhere foreign. Clearing
+              // on every start is what stranded sign-in: the OAuth hand-off
+              // abandons an in-flight load, so onLoad never fires, trust stays
+              // empty forever, and every queued credential post is dropped with
+              // no path back. A start we can't identify is still treated as
+              // hostile.
+              if (!url || !isManifoldUrl(url)) webviewUrl.current = ''
+              return
+            }
             webviewUrl.current = url ?? ''
             // A slow initial load can outlast the whole retry ladder while
             // trust is cleared; if that dropped a wanted post, re-arm the

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -38,6 +38,7 @@ import {
 import { useIsConnected } from 'lib/use-is-connected'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
+  Alert,
   AppState,
   BackHandler,
   NativeModules,
@@ -66,6 +67,36 @@ SplashScreen.preventAutoHideAsync()
 
 const BASE_URI =
   ENV === 'DEV' ? 'https://dev.manifold.markets/' : 'https://manifold.markets/'
+
+// Hosts we'll accept over plain http, for a dev server on the machine or LAN.
+// Everything else must be https before it can ever hold credentials.
+const isLocalHost = (hostname: string) =>
+  hostname === 'localhost' ||
+  hostname === '::1' ||
+  hostname === '[::1]' ||
+  /^127\./.test(hostname) ||
+  /^10\./.test(hostname) ||
+  /^192\.168\./.test(hostname) ||
+  /^172\.(1[6-9]|2\d|3[01])\./.test(hostname)
+
+// Validates a 'Native url' the admin typed into the web app before it is allowed
+// to become the app's base — and therefore the origin the credential hand-off
+// trusts. Returns null for anything that must not be switched to.
+const parseAppUrl = (raw: unknown) => {
+  if (typeof raw !== 'string') return null
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    return null
+  }
+  // An opaque origin serializes to the string "null", which would also be what a
+  // sandboxed hostile document reports for itself — never let that be the match.
+  if (!url.origin || url.origin === 'null') return null
+  if (url.protocol === 'https:') return url
+  if (url.protocol === 'http:' && isLocalHost(url.hostname)) return url
+  return null
+}
 
 // Set up notification handler before component
 Notifications.setNotificationHandler({
@@ -623,10 +654,59 @@ const App = () => {
       const version = Constants.expoConfig?.version
       communicateWithWebview('version', { version })
     } else if (type === 'setAppUrl') {
+      // This points the app at another deployment (the admin 'Native url' box —
+      // a Vercel preview, or a laptop on the LAN) and that URL BECOMES the
+      // origin the credential hand-off trusts. So it cannot be driven by the
+      // WebView alone: an admin check says who is signed in, not who sent the
+      // message, and any document in the WebView can reach the bridge —
+      // react-native-webview registers the Android message listener for origin
+      // '*' (RNCWebView.createRNCWebViewBridge), and on the older
+      // addJavascriptInterface fallback the reported url is the TOP document's,
+      // so an iframe's message is indistinguishable from the page's own.
+      // Without this, a third-party page could repoint the app at itself and
+      // then collect an admin's Firebase credentials from the hand-off.
       if (!fbUser?.uid || !isAdminId(fbUser.uid)) return
-      log('Setting app url to: ', payload.appUrl)
-      setBaseUri(payload.appUrl)
-      setUrlWithNativeQuery(payload.appUrl)
+      // Cheap first cut: on the modern bridge (and on iOS) this really is the
+      // sending frame's url, so a foreign sender is rejected before we prompt.
+      if (messageUrl && !isManifoldUrl(messageUrl)) {
+        log('Rejected setAppUrl from untrusted sender:', messageUrl)
+        return
+      }
+      const appUrl = parseAppUrl(payload?.appUrl)
+      if (!appUrl) {
+        log('Rejected setAppUrl, not a switchable url:', payload?.appUrl)
+        return
+      }
+      if (appUrl.origin === new URL(baseUri).origin) {
+        setUrlWithNativeQuery(appUrl.href)
+        return
+      }
+      // The one check content cannot forge or race, because it isn't in the
+      // WebView: the admin has to okay the new origin by name.
+      log('Confirming app url switch to: ', appUrl.href)
+      Alert.alert(
+        'Switch Manifold to another server?',
+        appUrl.origin +
+          '\n\n' +
+          'You will be signed in there with this account, so only ' +
+          'continue if you entered this URL yourself.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Switch',
+            style: 'destructive',
+            onPress: () => {
+              // Don't let a hand-off queued for the old origin land on the new one.
+              cancelPendingAuthPosts()
+              authPostDropped.current = false
+              webviewUrl.current = ''
+              setBaseUri(appUrl.href)
+              setUrlWithNativeQuery(appUrl.href)
+            },
+          },
+        ],
+        { cancelable: true }
+      )
     } else {
       log('Unhandled message from web type: ', type)
       log('Unhandled message from web data: ', data)

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -2,6 +2,11 @@ import { ReadexPro_400Regular, useFonts } from '@expo-google-fonts/readex-pro'
 import Clipboard from '@react-native-clipboard/clipboard'
 import * as Sentry from '@sentry/react-native'
 import { CONFIGS, EXTERNAL_REDIRECTS, isAdminId } from 'common/envs/constants'
+import {
+  isSameOrigin,
+  originOf,
+  parseSwitchableAppUrl,
+} from 'common/native-app-url'
 import { setFirebaseUserViaJson } from 'common/firebase-auth'
 import {
   MesageTypeMap,
@@ -68,36 +73,6 @@ SplashScreen.preventAutoHideAsync()
 const BASE_URI =
   ENV === 'DEV' ? 'https://dev.manifold.markets/' : 'https://manifold.markets/'
 
-// Hosts we'll accept over plain http, for a dev server on the machine or LAN.
-// Everything else must be https before it can ever hold credentials.
-const isLocalHost = (hostname: string) =>
-  hostname === 'localhost' ||
-  hostname === '::1' ||
-  hostname === '[::1]' ||
-  /^127\./.test(hostname) ||
-  /^10\./.test(hostname) ||
-  /^192\.168\./.test(hostname) ||
-  /^172\.(1[6-9]|2\d|3[01])\./.test(hostname)
-
-// Validates a 'Native url' the admin typed into the web app before it is allowed
-// to become the app's base — and therefore the origin the credential hand-off
-// trusts. Returns null for anything that must not be switched to.
-const parseAppUrl = (raw: unknown) => {
-  if (typeof raw !== 'string') return null
-  let url: URL
-  try {
-    url = new URL(raw)
-  } catch {
-    return null
-  }
-  // An opaque origin serializes to the string "null", which would also be what a
-  // sandboxed hostile document reports for itself — never let that be the match.
-  if (!url.origin || url.origin === 'null') return null
-  if (url.protocol === 'https:') return url
-  if (url.protocol === 'http:' && isLocalHost(url.hostname)) return url
-  return null
-}
-
 // Set up notification handler before component
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -127,6 +102,8 @@ const App = () => {
     destination: string
   } | null>(null)
   const [baseUri, setBaseUri] = useState(BASE_URI)
+  // Origin of the one outstanding 'switch server?' prompt, or null. See setAppUrl.
+  const appUrlPrompt = useRef<string | null>(null)
 
   // Auth
   const [fbUser, setFbUser] = useState<FirebaseUser | null>(auth.currentUser)
@@ -214,13 +191,10 @@ const App = () => {
   const webviewUrl = useRef(baseUri)
   // Full-origin match (scheme + host + port), not just host: a page served over
   // http://manifold.markets or a look-alike subdomain must not read as ours.
-  const isManifoldUrl = (url: string) => {
-    try {
-      return new URL(url).origin === new URL(baseUri).origin
-    } catch {
-      return false
-    }
-  }
+  // Parsed by hand rather than with the global URL — React Native's polyfill
+  // never throws, keeps userinfo in origin, and doesn't lowercase the host, so
+  // 'https://manifold.markets@evil.com/' and case tricks both misread there.
+  const isManifoldUrl = (url: string) => isSameOrigin(url, baseUri)
 
   // Pending 'nativeFbUser' posts, kept so a sign-out (or a switch to another
   // account) can cancel them. A late post would otherwise hand the OLD user back
@@ -672,17 +646,30 @@ const App = () => {
         log('Rejected setAppUrl from untrusted sender:', messageUrl)
         return
       }
-      const appUrl = parseAppUrl(payload?.appUrl)
+      const appUrl = parseSwitchableAppUrl(payload?.appUrl)
       if (!appUrl) {
         log('Rejected setAppUrl, not a switchable url:', payload?.appUrl)
         return
       }
-      if (appUrl.origin === new URL(baseUri).origin) {
+      if (appUrl.origin === originOf(baseUri)) {
         setUrlWithNativeQuery(appUrl.href)
         return
       }
-      // The one check content cannot forge or race, because it isn't in the
-      // WebView: the admin has to okay the new origin by name.
+      // Alert.alert is not single-flight: React Native dismisses the visible
+      // dialog to show the next one. Without this, a page that spams setAppUrl
+      // could swap the origin under the admin's finger between reading and
+      // tapping, or just wedge the app behind an endless stack of dialogs.
+      if (appUrlPrompt.current) {
+        log('Ignoring setAppUrl, a switch prompt is already open')
+        return
+      }
+      const promptedUid = fbUser.uid
+      appUrlPrompt.current = appUrl.origin
+      const closePrompt = () => {
+        appUrlPrompt.current = null
+      }
+      // The one check WebView content can neither forge nor race, because it
+      // isn't in the WebView: the admin okays the new origin by name.
       log('Confirming app url switch to: ', appUrl.href)
       Alert.alert(
         'Switch Manifold to another server?',
@@ -691,21 +678,35 @@ const App = () => {
           'You will be signed in there with this account, so only ' +
           'continue if you entered this URL yourself.',
         [
-          { text: 'Cancel', style: 'cancel' },
+          { text: 'Cancel', style: 'cancel', onPress: closePrompt },
           {
             text: 'Switch',
             style: 'destructive',
             onPress: () => {
+              closePrompt()
+              // Re-check on confirm: the dialog may have sat there across a
+              // sign-out or an account switch.
+              const signedIn = fbUserRef.current
+              if (
+                !signedIn?.uid ||
+                signedIn.uid !== promptedUid ||
+                !isAdminId(signedIn.uid)
+              ) {
+                log('Dropping confirmed app url switch, signed-in user changed')
+                return
+              }
               // Don't let a hand-off queued for the old origin land on the new one.
               cancelPendingAuthPosts()
               authPostDropped.current = false
               webviewUrl.current = ''
-              setBaseUri(appUrl.href)
+              // The base must be the bare origin: callers concatenate an
+              // endpoint onto it, so a path here yields urls like '/foohome'.
+              setBaseUri(appUrl.base)
               setUrlWithNativeQuery(appUrl.href)
             },
           },
         ],
-        { cancelable: true }
+        { cancelable: true, onDismiss: closePrompt }
       )
     } else {
       log('Unhandled message from web type: ', type)
@@ -779,13 +780,15 @@ const App = () => {
   // RNCWebView's postMessage injects — a 'message' MessageEvent dispatched on
   // document; web listens on both document and window (use-native-messages.ts).
   const postAuthToWebview = (user: FirebaseUser) => {
+    const trustedOrigin = originOf(baseUri)
+    if (!trustedOrigin) return
     const message = JSON.stringify({
       type: 'nativeFbUser',
       data: user,
     } as nativeToWebMessage)
     webview.current?.injectJavaScript(
       `(function () {
-        if (window.location.origin !== ${jsString(new URL(baseUri).origin)}) return;
+        if (window.location.origin !== ${jsString(trustedOrigin)}) return;
         var data = { data: ${jsString(message)} };
         var event;
         try {

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -219,12 +219,14 @@ const App = () => {
       setTimeout(() => {
         // Stale: native signed out or switched accounts since this was queued.
         if (fbUserRef.current?.uid !== user.uid) return
-        // Never post credentials into a third-party page.
+        // Never post credentials into a third-party page. Best-effort only —
+        // the enforcing check is inside postAuthToWebview; this one exists so a
+        // skipped post sets authPostDropped and gets re-armed.
         if (!isManifoldUrl(webviewUrl.current)) {
           authPostDropped.current = true
           return
         }
-        communicateWithWebview('nativeFbUser', user)
+        postAuthToWebview(user)
       }, timeout)
     )
   }
@@ -664,6 +666,57 @@ const App = () => {
         type,
         data,
       } as nativeToWebMessage)
+    )
+  }
+
+  // Escapes a string for embedding in injected JS. JSON.stringify covers quotes
+  // and backslashes but emits raw U+2028/U+2029, which are legal in JSON yet were
+  // illegal in JS string literals before ES2019 — a display name containing one
+  // would otherwise be a syntax error that silently kills the whole injection.
+  const jsString = (value: string) =>
+    JSON.stringify(value)
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029')
+
+  // The credential hand-off — the ONE message that must never reach a document
+  // that isn't ours — so it does not go through communicateWithWebview's plain
+  // postMessage.
+  //
+  // Checking a React-side URL ref cannot enforce that, because no navigation
+  // event we receive is reliably pre-navigation. On Android react-native-webview
+  // dispatches topLoadingStart from doUpdateVisitedHistory, which Chromium calls
+  // only AFTER the navigation commits, so between a foreign page committing and
+  // that event reaching JS the ref still holds the old Manifold url.
+  // onShouldStartLoadWithRequest is genuinely pre-navigation but unusable here:
+  // RNCWebViewClient forwards the WebResourceRequest overload without
+  // isForMainFrame, so every third-party IFRAME on one of our own pages would
+  // look like a foreign navigation and strand the hand-off — the exact bug class
+  // above.
+  //
+  // So the check is made inside the target document instead, where it cannot be
+  // raced: location.origin is [LegacyUnforgeable], so a hostile page cannot
+  // shadow it, and a foreign document just drops the payload. This mirrors what
+  // RNCWebView's postMessage injects — a 'message' MessageEvent dispatched on
+  // document; web listens on both document and window (use-native-messages.ts).
+  const postAuthToWebview = (user: FirebaseUser) => {
+    const message = JSON.stringify({
+      type: 'nativeFbUser',
+      data: user,
+    } as nativeToWebMessage)
+    webview.current?.injectJavaScript(
+      `(function () {
+        if (window.location.origin !== ${jsString(new URL(baseUri).origin)}) return;
+        var data = { data: ${jsString(message)} };
+        var event;
+        try {
+          event = new MessageEvent('message', data);
+        } catch (e) {
+          event = document.createEvent('MessageEvent');
+          event.initMessageEvent('message', true, true, data.data, data.origin, data.lastEventId, data.source);
+        }
+        document.dispatchEvent(event);
+      })();
+      true;`
     )
   }
 

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -84,6 +84,8 @@ const App = () => {
 
   // This tracks if the webview has loaded its first page
   const [hasLoadedWebView, setHasLoadedWebView] = useState(false)
+  // Bumped to force a brand-new WebView instance. See resetWebView.
+  const [webviewKey, setWebviewKey] = useState(0)
   // This tracks if the app has its nativeMessageListener set up
   // NOTE: After the webview is killed on android due to OOM, this will always be false, see: https://github.com/react-native-webview/react-native-webview/issues/2680
   const listeningToNative = useRef(false)
@@ -669,8 +671,18 @@ const App = () => {
     setHasLoadedWebView(false)
     listeningToNative.current = false
     setEndpointWithNativeQuery()
-    log('Reloading webview, webview.current:', webview.current)
-    webview.current?.reload()
+    log('Recreating webview')
+    // Remount, don't reload. This runs from onError and - the case that matters -
+    // from onRenderProcessGone / onContentProcessDidTerminate. A WebView whose
+    // renderer process the OS killed is a dead object, and .reload() on it
+    // silently does nothing (react-native-webview#2680, already noted next to
+    // listeningToNative above). onLoadEnd then never fires again, so
+    // hasLoadedWebView stays false and SplashAuth is stuck on the splash until
+    // the app is force-closed. Android reclaims that renderer while we're
+    // backgrounded for the OAuth round-trip, which made every first sign-in on a
+    // low-memory device hang on the crane. A new key gives a fresh instance,
+    // which loads urlToLoad from scratch.
+    setWebviewKey((k) => k + 1)
   }
 
   const isConnected = useIsConnected()
@@ -732,6 +744,7 @@ const App = () => {
           isConnected={isConnected}
         />
         <CustomWebview
+          webviewKey={webviewKey}
           display={!!fullyLoaded}
           urlToLoad={urlToLoad}
           webview={webview}

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -90,7 +90,7 @@ const App = () => {
 
   // This tracks if the webview has loaded its first page
   const [hasLoadedWebView, setHasLoadedWebView] = useState(false)
-  // Bumped to force a brand-new WebView instance. See resetWebView.
+  // Bumped to force a brand-new WebView instance. See recreateWebView.
   const [webviewKey, setWebviewKey] = useState(0)
   // This tracks if the app has its nativeMessageListener set up
   // NOTE: After the webview is killed on android due to OOM, this will always be false, see: https://github.com/react-native-webview/react-native-webview/issues/2680
@@ -102,9 +102,11 @@ const App = () => {
     destination: string
   } | null>(null)
   const [baseUri, setBaseUri] = useState(BASE_URI)
-  // State of the 'switch server?' prompt: one per app run, and a refusal is
-  // final. See setAppUrl.
+  // State of the 'switch server?' prompt. See setAppUrl.
   const appUrlPrompt = useRef<'idle' | 'open' | 'rejected'>('idle')
+  // Set when the prompt goes away without the admin choosing anything, so a
+  // page in a tight loop can't immediately put it back.
+  const appUrlPromptCooldownUntil = useRef(0)
 
   // Auth
   const [fbUser, setFbUser] = useState<FirebaseUser | null>(auth.currentUser)
@@ -209,17 +211,10 @@ const App = () => {
     pendingAuthPosts.current.forEach((timer) => clearTimeout(timer))
     pendingAuthPosts.current = []
   }
-  // Whether a wanted handoff post was dropped because the WebView was on an
-  // untrusted URL at fire time — the whole retry ladder can fire while a
-  // third-party page (iDenfy, Stripe) is up. This flag lets the next committed
-  // Manifold page re-arm the handoff (see onNavigate) instead of silently
-  // stranding the web client logged out.
-  const authPostDropped = useRef(false)
 
   // Sends the saved user to the web client to make the log in process faster
   const sendWebviewAuthInfo = (user: FirebaseUser) => {
     cancelPendingAuthPosts()
-    authPostDropped.current = false
     // We use a timeout because sometimes the auth persistence manager is still undefined on the client side
     // Seems my iPhone 12 mini can regularly handle a shorter timeout
     const timeouts = [100, 500, 1000, 3000]
@@ -227,13 +222,10 @@ const App = () => {
       setTimeout(() => {
         // Stale: native signed out or switched accounts since this was queued.
         if (fbUserRef.current?.uid !== user.uid) return
-        // Never post credentials into a third-party page. Best-effort only —
-        // the enforcing check is inside postAuthToWebview; this one exists so a
-        // skipped post sets authPostDropped and gets re-armed.
-        if (!isManifoldUrl(webviewUrl.current)) {
-          authPostDropped.current = true
-          return
-        }
+        // Cheap first cut so we don't inject into a page we already know isn't
+        // ours. It is NOT the guarantee — postAuthToWebview checks the origin
+        // inside the receiving document, which is the check that can't be raced.
+        if (!isManifoldUrl(webviewUrl.current)) return
         postAuthToWebview(user)
       }, timeout)
     )
@@ -659,21 +651,38 @@ const App = () => {
         return
       }
       // Alert.alert is not single-flight: React Native dismisses the visible
-      // dialog to show the next one. Tracking only whether one is OPEN is not
-      // enough either — a page in a setInterval would just reopen it the instant
-      // it was cancelled, which is a modal DoS the admin cannot tap their way
-      // out of. So a refusal latches: 'rejected' is terminal for the life of the
-      // app process, and restarting the app is the reset, which is the one thing
-      // the WebView cannot do for itself. If neither button ever fires we stay
-      // 'open', which fails closed.
+      // dialog to show the next one, so tracking that one is OPEN is what stops
+      // a page swapping the origin under the admin's finger. That alone still
+      // leaves a modal DoS — a setInterval would put the dialog straight back —
+      // so Cancel latches to 'rejected' for the rest of the app run.
+      //
+      // Only the Cancel BUTTON latches. Android routes every other kind of
+      // dismissal through onDismiss too: an outside tap, hardware back, and
+      // notably any other Alert.alert in the app, because DialogModule dismisses
+      // the existing dialog before showing a new one. Latching on those would
+      // silently kill the admin's own switcher until a force-quit. Those take a
+      // cooldown instead.
+      const now = Date.now()
       if (appUrlPrompt.current !== 'idle') {
         log('Ignoring setAppUrl, switch prompt is', appUrlPrompt.current)
         return
       }
+      if (now < appUrlPromptCooldownUntil.current) {
+        log('Ignoring setAppUrl, prompt is cooling down')
+        return
+      }
       const promptedUid = fbUser.uid
       appUrlPrompt.current = 'open'
+      // The admin said no. Nothing the WebView can do reopens this; signing out
+      // or restarting the app does.
       const rejectPrompt = () => {
         appUrlPrompt.current = 'rejected'
+      }
+      // Went away on its own. Allow another, but not immediately.
+      const dismissPrompt = () => {
+        if (appUrlPrompt.current !== 'open') return
+        appUrlPrompt.current = 'idle'
+        appUrlPromptCooldownUntil.current = Date.now() + 30_000
       }
       // The one check WebView content can neither forge nor race, because it
       // isn't in the WebView: the admin okays the new origin by name.
@@ -707,7 +716,6 @@ const App = () => {
               }
               // Don't let a hand-off queued for the old origin land on the new one.
               cancelPendingAuthPosts()
-              authPostDropped.current = false
               webviewUrl.current = ''
               // The base must be the bare origin: callers concatenate an
               // endpoint onto it, so a path here yields urls like '/foohome'.
@@ -716,7 +724,7 @@ const App = () => {
             },
           },
         ],
-        { cancelable: true, onDismiss: rejectPrompt }
+        { cancelable: true, onDismiss: dismissPrompt }
       )
     } else {
       log('Unhandled message from web type: ', type)
@@ -726,8 +734,10 @@ const App = () => {
 
   const signOutUsers = async (errorMessage: string) => {
     authGeneration.current += 1
+    // A refusal was this user's decision, not a permanent property of the app.
+    appUrlPrompt.current = 'idle'
+    appUrlPromptCooldownUntil.current = 0
     cancelPendingAuthPosts()
-    authPostDropped.current = false
     try {
       await auth.signOut()
     } catch (err) {
@@ -787,8 +797,10 @@ const App = () => {
   // So the check is made inside the target document instead, where it cannot be
   // raced: location.origin is [LegacyUnforgeable], so a hostile page cannot
   // shadow it, and a foreign document just drops the payload. This mirrors what
-  // RNCWebView's postMessage injects — a 'message' MessageEvent dispatched on
-  // document; web listens on both document and window (use-native-messages.ts).
+  // RNCWebView's postMessage injects on ANDROID - a 'message' MessageEvent
+  // dispatched on document. (iOS RNW dispatches on window instead; web registers
+  // a listener on both, see use-native-messages.ts, and the event doesn't bubble,
+  // so dispatching on document reaches exactly one of them on either platform.)
   const postAuthToWebview = (user: FirebaseUser) => {
     const trustedOrigin = originOf(baseUri)
     if (!trustedOrigin) return
@@ -813,21 +825,32 @@ const App = () => {
     )
   }
 
-  const resetWebView = () => {
+  // A load failed - offline, TLS, an unknown scheme from a mailto:/tel: tap.
+  // The WebView object is alive, so reload it. Deliberately NOT a remount: that
+  // would throw away the back stack and the current route for an offline blip,
+  // and repeated errors would churn instances instead of retrying one.
+  const reloadWebView = () => {
     setHasLoadedWebView(false)
     listeningToNative.current = false
+    webviewUrl.current = ''
+    setEndpointWithNativeQuery()
+    log('Reloading webview')
+    webview.current?.reload()
+  }
+
+  // The OS killed the renderer / content process. THIS one cannot be reloaded:
+  // that WebView is a dead object and .reload() on it silently does nothing
+  // (react-native-webview#2680, already noted next to listeningToNative above).
+  // onLoadEnd then never fires again, so hasLoadedWebView stays false and
+  // SplashAuth is stuck on the splash until the app is force-closed. A new key
+  // gives a fresh instance, which loads urlToLoad from scratch - at the cost of
+  // the back stack, which is why only process death gets this treatment.
+  const recreateWebView = () => {
+    setHasLoadedWebView(false)
+    listeningToNative.current = false
+    webviewUrl.current = ''
     setEndpointWithNativeQuery()
     log('Recreating webview')
-    // Remount, don't reload. This runs from onError and - the case that matters -
-    // from onRenderProcessGone / onContentProcessDidTerminate. A WebView whose
-    // renderer process the OS killed is a dead object, and .reload() on it
-    // silently does nothing (react-native-webview#2680, already noted next to
-    // listeningToNative above). onLoadEnd then never fires again, so
-    // hasLoadedWebView stays false and SplashAuth is stuck on the splash until
-    // the app is force-closed. Android reclaims that renderer while we're
-    // backgrounded for the OAuth round-trip, which made every first sign-in on a
-    // low-memory device hang on the crane. A new key gives a fresh instance,
-    // which loads urlToLoad from scratch.
     setWebviewKey((k) => k + 1)
   }
 
@@ -894,7 +917,8 @@ const App = () => {
           display={!!fullyLoaded}
           urlToLoad={urlToLoad}
           webview={webview}
-          resetWebView={resetWebView}
+          reloadWebView={reloadWebView}
+          recreateWebView={recreateWebView}
           setHasLoadedWebView={setHasLoadedWebView}
           handleMessageFromWebview={handleMessageFromWebview}
           handleExternalLink={handleExternalLink}
@@ -910,16 +934,16 @@ const App = () => {
               return
             }
             webviewUrl.current = url ?? ''
-            // A slow initial load can outlast the whole retry ladder while
-            // trust is cleared; if that dropped a wanted post, re-arm the
-            // handoff now that one of our pages has committed. The web side
-            // no-ops when the user already matches, so re-sends are idempotent.
-            if (
-              url &&
-              authPostDropped.current &&
-              fbUserRef.current &&
-              isManifoldUrl(url)
-            ) {
+            // Re-hand credentials to every one of our pages that commits, not
+            // just when an earlier post was recorded as dropped. The enforcing
+            // check now lives inside the target document, so a post fired into
+            // a page that hasn't hydrated yet is dropped there and leaves no
+            // trace here — the whole 100/500/1000/3000ms ladder can expire that
+            // way on a cold start or after a remount. The web side no-ops when
+            // the user already matches, so re-sends are idempotent and cheap:
+            // an in-app route change doesn't commit a document, so this is once
+            // per real page load.
+            if (url && fbUserRef.current && isManifoldUrl(url)) {
               sendWebviewAuthInfo(fbUserRef.current)
             }
           }}

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -102,8 +102,9 @@ const App = () => {
     destination: string
   } | null>(null)
   const [baseUri, setBaseUri] = useState(BASE_URI)
-  // Origin of the one outstanding 'switch server?' prompt, or null. See setAppUrl.
-  const appUrlPrompt = useRef<string | null>(null)
+  // State of the 'switch server?' prompt: one per app run, and a refusal is
+  // final. See setAppUrl.
+  const appUrlPrompt = useRef<'idle' | 'open' | 'rejected'>('idle')
 
   // Auth
   const [fbUser, setFbUser] = useState<FirebaseUser | null>(auth.currentUser)
@@ -191,9 +192,11 @@ const App = () => {
   const webviewUrl = useRef(baseUri)
   // Full-origin match (scheme + host + port), not just host: a page served over
   // http://manifold.markets or a look-alike subdomain must not read as ours.
-  // Parsed by hand rather than with the global URL — React Native's polyfill
-  // never throws, keeps userinfo in origin, and doesn't lowercase the host, so
-  // 'https://manifold.markets@evil.com/' and case tricks both misread there.
+  // Parsed by hand rather than with the global URL. Expo's winter runtime
+  // installs whatwg-url-without-unicode as URL before App loads, and that
+  // package omits the IDNA tables — so it neither lowercases a host nor
+  // punycodes one, while the document we compare against always reports a
+  // lowercase ASCII location.origin. See common/src/native-app-url.ts.
   const isManifoldUrl = (url: string) => isSameOrigin(url, baseUri)
 
   // Pending 'nativeFbUser' posts, kept so a sign-out (or a switch to another
@@ -656,17 +659,21 @@ const App = () => {
         return
       }
       // Alert.alert is not single-flight: React Native dismisses the visible
-      // dialog to show the next one. Without this, a page that spams setAppUrl
-      // could swap the origin under the admin's finger between reading and
-      // tapping, or just wedge the app behind an endless stack of dialogs.
-      if (appUrlPrompt.current) {
-        log('Ignoring setAppUrl, a switch prompt is already open')
+      // dialog to show the next one. Tracking only whether one is OPEN is not
+      // enough either — a page in a setInterval would just reopen it the instant
+      // it was cancelled, which is a modal DoS the admin cannot tap their way
+      // out of. So a refusal latches: 'rejected' is terminal for the life of the
+      // app process, and restarting the app is the reset, which is the one thing
+      // the WebView cannot do for itself. If neither button ever fires we stay
+      // 'open', which fails closed.
+      if (appUrlPrompt.current !== 'idle') {
+        log('Ignoring setAppUrl, switch prompt is', appUrlPrompt.current)
         return
       }
       const promptedUid = fbUser.uid
-      appUrlPrompt.current = appUrl.origin
-      const closePrompt = () => {
-        appUrlPrompt.current = null
+      appUrlPrompt.current = 'open'
+      const rejectPrompt = () => {
+        appUrlPrompt.current = 'rejected'
       }
       // The one check WebView content can neither forge nor race, because it
       // isn't in the WebView: the admin okays the new origin by name.
@@ -678,12 +685,15 @@ const App = () => {
           'You will be signed in there with this account, so only ' +
           'continue if you entered this URL yourself.',
         [
-          { text: 'Cancel', style: 'cancel', onPress: closePrompt },
+          { text: 'Cancel', style: 'cancel', onPress: rejectPrompt },
           {
             text: 'Switch',
             style: 'destructive',
             onPress: () => {
-              closePrompt()
+              // A confirmed switch goes back to idle rather than latching: the
+              // admin may well want to switch back, and a page that got a
+              // confirmation out of them has already won.
+              appUrlPrompt.current = 'idle'
               // Re-check on confirm: the dialog may have sat there across a
               // sign-out or an account switch.
               const signedIn = fbUserRef.current
@@ -706,7 +716,7 @@ const App = () => {
             },
           },
         ],
-        { cancelable: true, onDismiss: closePrompt }
+        { cancelable: true, onDismiss: rejectPrompt }
       )
     } else {
       log('Unhandled message from web type: ', type)

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -940,9 +940,18 @@ const App = () => {
             // a page that hasn't hydrated yet is dropped there and leaves no
             // trace here — the whole 100/500/1000/3000ms ladder can expire that
             // way on a cold start or after a remount. The web side no-ops when
-            // the user already matches, so re-sends are idempotent and cheap:
-            // an in-app route change doesn't commit a document, so this is once
-            // per real page load.
+            // the user already matches, so re-sends are idempotent.
+            //
+            // How often this fires differs by platform, and it is worth knowing
+            // on a path that ships a token. On Android it is once per real page
+            // load. On iOS it is once per CLIENT-SIDE route change too: RNW
+            // installs a history shim at document start that posts every
+            // pushState / replaceState / popstate, and RNCWebViewImpl routes
+            // that straight to onLoadingFinish, i.e. to this handler. So every
+            // in-app tap re-runs the ladder there. Harmless — only one ladder is
+            // ever live, since sendWebviewAuthInfo cancels the previous — but if
+            // the chatter ever matters, the 'users' echo is the ack needed to
+            // cancel the remaining rungs early.
             if (url && fbUserRef.current && isManifoldUrl(url)) {
               sendWebviewAuthInfo(fbUserRef.current)
             }

--- a/native/App.tsx
+++ b/native/App.tsx
@@ -107,6 +107,12 @@ const App = () => {
   // Set when the prompt goes away without the admin choosing anything, so a
   // page in a tight loop can't immediately put it back.
   const appUrlPromptCooldownUntil = useRef(0)
+  // Bumped for every prompt, and on sign-out. An Alert's callbacks outlive the
+  // Alert — signing out clears the latch but does NOT take a dialog off the
+  // screen — so each callback carries the generation it was created with and
+  // does nothing once that generation is stale. Without this, tapping a
+  // leftover dialog rewrites the state of the prompt that replaced it.
+  const appUrlPromptGeneration = useRef(0)
 
   // Auth
   const [fbUser, setFbUser] = useState<FirebaseUser | null>(auth.currentUser)
@@ -271,10 +277,12 @@ const App = () => {
     const [baseUrl, fragment] = urlString.split('#')
     const url = new URL(baseUrl)
 
-    const params = new URLSearchParams()
-    params.set('nativePlatform', Platform.OS)
-    params.set('rand', Math.random().toString())
-    url.search = params.toString()
+    // Add ours ON TOP of whatever the caller already had. This used to build a
+    // fresh URLSearchParams and overwrite url.search, which silently dropped the
+    // query off any url that carried one — a preview link's ?token=… being the
+    // case that matters, since the admin switcher navigates to exactly that.
+    url.searchParams.set('nativePlatform', Platform.OS)
+    url.searchParams.set('rand', Math.random().toString())
 
     const newUrl = url.toString() + (fragment ? `#${fragment}` : '')
     log('Setting new url:', newUrl)
@@ -672,15 +680,18 @@ const App = () => {
         return
       }
       const promptedUid = fbUser.uid
+      const generation = ++appUrlPromptGeneration.current
+      const isCurrent = () => appUrlPromptGeneration.current === generation
       appUrlPrompt.current = 'open'
       // The admin said no. Nothing the WebView can do reopens this; signing out
       // or restarting the app does.
       const rejectPrompt = () => {
+        if (!isCurrent()) return
         appUrlPrompt.current = 'rejected'
       }
       // Went away on its own. Allow another, but not immediately.
       const dismissPrompt = () => {
-        if (appUrlPrompt.current !== 'open') return
+        if (!isCurrent() || appUrlPrompt.current !== 'open') return
         appUrlPrompt.current = 'idle'
         appUrlPromptCooldownUntil.current = Date.now() + 30_000
       }
@@ -699,6 +710,7 @@ const App = () => {
             text: 'Switch',
             style: 'destructive',
             onPress: () => {
+              if (!isCurrent()) return
               // A confirmed switch goes back to idle rather than latching: the
               // admin may well want to switch back, and a page that got a
               // confirmation out of them has already won.
@@ -735,6 +747,9 @@ const App = () => {
   const signOutUsers = async (errorMessage: string) => {
     authGeneration.current += 1
     // A refusal was this user's decision, not a permanent property of the app.
+    // Bump the generation too: any dialog still on screen belongs to the session
+    // being ended, and its buttons must not touch what comes next.
+    appUrlPromptGeneration.current += 1
     appUrlPrompt.current = 'idle'
     appUrlPromptCooldownUntil.current = 0
     cancelPendingAuthPosts()

--- a/native/components/custom-webview.tsx
+++ b/native/components/custom-webview.tsx
@@ -37,10 +37,12 @@ export const CustomWebview = (props: {
   setHasLoadedWebView: (loaded: boolean) => void
   handleMessageFromWebview: (m: any) => Promise<void>
   handleExternalLink: (url: string) => void
-  // Reports the WebView's committed URL (including third-party pages such as
-  // iDenfy), so the app can avoid posting credentials into them. Called with
-  // null at navigation start to clear trust until the next load commits.
-  onNavigate: (url: string | null) => void
+  // Reports where the WebView is going ('start') and what actually committed
+  // ('commit'), so the app can avoid posting credentials into third-party pages
+  // such as iDenfy. The start URL matters: clearing trust for EVERY navigation
+  // start strands us when a navigation is abandoned (the user leaving for the
+  // OAuth flow), because onLoad then never fires to restore it.
+  onNavigate: (url: string | null, phase: 'start' | 'commit') => void
   display: boolean
 }) => {
   const {
@@ -92,13 +94,13 @@ export const CustomWebview = (props: {
             key={webviewKey}
             {...sharedWebViewProps}
             style={styles.webView}
-            onLoadStart={() => onNavigate(null)}
+            onLoadStart={(e) => onNavigate(e.nativeEvent.url, 'start')}
             // Restore trust only from a SUCCESSFUL, committed load. onLoad fires
             // only from onLoadingFinish; onNavigationStateChange also fires for
             // the provisional navigation-START event (on iOS with loading still
             // false), which would restore a Manifold URL while the external
             // document is still active, and onLoadEnd also fires on errors.
-            onLoad={(e) => onNavigate(e.nativeEvent.url)}
+            onLoad={(e) => onNavigate(e.nativeEvent.url, 'commit')}
             onLoadEnd={() => {
               console.log('WebView onLoadEnd for url:', urlToLoad)
               setHasLoadedWebView(true)
@@ -129,13 +131,13 @@ export const CustomWebview = (props: {
             key={webviewKey}
             {...sharedWebViewProps}
             style={styles.webView}
-            onLoadStart={() => onNavigate(null)}
+            onLoadStart={(e) => onNavigate(e.nativeEvent.url, 'start')}
             // Restore trust only from a SUCCESSFUL, committed load. onLoad fires
             // only from onLoadingFinish; onNavigationStateChange also fires for
             // the provisional navigation-START event (on iOS with loading still
             // false), which would restore a Manifold URL while the external
             // document is still active, and onLoadEnd also fires on errors.
-            onLoad={(e) => onNavigate(e.nativeEvent.url)}
+            onLoad={(e) => onNavigate(e.nativeEvent.url, 'commit')}
             onLoadEnd={() => {
               console.log('WebView onLoadEnd for url:', urlToLoad)
               setHasLoadedWebView(true)

--- a/native/components/custom-webview.tsx
+++ b/native/components/custom-webview.tsx
@@ -28,6 +28,9 @@ const PREVENT_ZOOM_SET_NATIVE = `(function() {
 const isIOS = Platform.OS === 'ios'
 
 export const CustomWebview = (props: {
+  // Changing this remounts the WebView. resetWebView bumps it, because a
+  // renderer-killed WebView cannot be revived with .reload().
+  webviewKey: number
   urlToLoad: string
   webview: RefObject<WebView>
   resetWebView: () => void
@@ -41,6 +44,7 @@ export const CustomWebview = (props: {
   display: boolean
 }) => {
   const {
+    webviewKey,
     urlToLoad,
     webview,
     resetWebView,
@@ -85,6 +89,7 @@ export const CustomWebview = (props: {
           }
         >
           <WebView
+            key={webviewKey}
             {...sharedWebViewProps}
             style={styles.webView}
             onLoadStart={() => onNavigate(null)}
@@ -121,6 +126,7 @@ export const CustomWebview = (props: {
       ) : (
         <View style={[styles.container, { position: 'relative' }]}>
           <WebView
+            key={webviewKey}
             {...sharedWebViewProps}
             style={styles.webView}
             onLoadStart={() => onNavigate(null)}

--- a/native/components/custom-webview.tsx
+++ b/native/components/custom-webview.tsx
@@ -28,12 +28,15 @@ const PREVENT_ZOOM_SET_NATIVE = `(function() {
 const isIOS = Platform.OS === 'ios'
 
 export const CustomWebview = (props: {
-  // Changing this remounts the WebView. resetWebView bumps it, because a
+  // Changing this remounts the WebView. recreateWebView bumps it, because a
   // renderer-killed WebView cannot be revived with .reload().
   webviewKey: number
   urlToLoad: string
   webview: RefObject<WebView>
-  resetWebView: () => void
+  // A load error: reload the live instance, keeping the back stack.
+  reloadWebView: () => void
+  // The OS killed the renderer / content process: only a fresh instance helps.
+  recreateWebView: () => void
   setHasLoadedWebView: (loaded: boolean) => void
   handleMessageFromWebview: (m: any) => Promise<void>
   handleExternalLink: (url: string) => void
@@ -49,7 +52,8 @@ export const CustomWebview = (props: {
     webviewKey,
     urlToLoad,
     webview,
-    resetWebView,
+    reloadWebView,
+    recreateWebView,
     setHasLoadedWebView,
     handleMessageFromWebview,
     handleExternalLink,
@@ -95,11 +99,15 @@ export const CustomWebview = (props: {
             {...sharedWebViewProps}
             style={styles.webView}
             onLoadStart={(e) => onNavigate(e.nativeEvent.url, 'start')}
-            // Restore trust only from a SUCCESSFUL, committed load. onLoad fires
-            // only from onLoadingFinish; onNavigationStateChange also fires for
-            // the provisional navigation-START event (on iOS with loading still
-            // false), which would restore a Manifold URL while the external
-            // document is still active, and onLoadEnd also fires on errors.
+            // Restore trust from a committed load. onNavigationStateChange is
+            // not usable here: it also fires for the provisional navigation
+            // START (on iOS with loading still false), which would mark a
+            // Manifold URL trusted while an external document is still active.
+            // Note onLoad is not strictly success-only — Android's
+            // onReceivedError deliberately emits the finish event before the
+            // error (RNCWebViewClient.java) — so 'commit' can carry a URL that
+            // failed to load. Harmless: this gate is a first cut, and the
+            // enforcing origin check runs inside the receiving document.
             onLoad={(e) => onNavigate(e.nativeEvent.url, 'commit')}
             onLoadEnd={() => {
               console.log('WebView onLoadEnd for url:', urlToLoad)
@@ -108,12 +116,12 @@ export const CustomWebview = (props: {
             }}
             source={{ uri: urlToLoad }}
             ref={webview}
-            onError={(e) => handleWebviewError(e, resetWebView)}
+            onError={(e) => handleWebviewError(e, reloadWebView)}
             renderError={(e) => handleRenderError(e)}
             onOpenWindow={(e) => handleExternalLink(e.nativeEvent.targetUrl)}
-            onRenderProcessGone={(e) => handleWebviewKilled(e, resetWebView)}
+            onRenderProcessGone={(e) => handleWebviewKilled(e, recreateWebView)}
             onContentProcessDidTerminate={(e) =>
-              handleWebviewKilled(e, resetWebView)
+              handleWebviewKilled(e, recreateWebView)
             }
             onScroll={handleScroll}
             onMessage={async (m) => {
@@ -132,11 +140,15 @@ export const CustomWebview = (props: {
             {...sharedWebViewProps}
             style={styles.webView}
             onLoadStart={(e) => onNavigate(e.nativeEvent.url, 'start')}
-            // Restore trust only from a SUCCESSFUL, committed load. onLoad fires
-            // only from onLoadingFinish; onNavigationStateChange also fires for
-            // the provisional navigation-START event (on iOS with loading still
-            // false), which would restore a Manifold URL while the external
-            // document is still active, and onLoadEnd also fires on errors.
+            // Restore trust from a committed load. onNavigationStateChange is
+            // not usable here: it also fires for the provisional navigation
+            // START (on iOS with loading still false), which would mark a
+            // Manifold URL trusted while an external document is still active.
+            // Note onLoad is not strictly success-only — Android's
+            // onReceivedError deliberately emits the finish event before the
+            // error (RNCWebViewClient.java) — so 'commit' can carry a URL that
+            // failed to load. Harmless: this gate is a first cut, and the
+            // enforcing origin check runs inside the receiving document.
             onLoad={(e) => onNavigate(e.nativeEvent.url, 'commit')}
             onLoadEnd={() => {
               console.log('WebView onLoadEnd for url:', urlToLoad)
@@ -145,12 +157,12 @@ export const CustomWebview = (props: {
             }}
             source={{ uri: urlToLoad }}
             ref={webview}
-            onError={(e) => handleWebviewError(e, resetWebView)}
+            onError={(e) => handleWebviewError(e, reloadWebView)}
             renderError={(e) => handleRenderError(e)}
             onOpenWindow={(e) => handleExternalLink(e.nativeEvent.targetUrl)}
-            onRenderProcessGone={(e) => handleWebviewKilled(e, resetWebView)}
+            onRenderProcessGone={(e) => handleWebviewKilled(e, recreateWebView)}
             onContentProcessDidTerminate={(e) =>
-              handleWebviewKilled(e, resetWebView)
+              handleWebviewKilled(e, recreateWebView)
             }
             onMessage={async (m) => {
               try {


### PR DESCRIPTION
Signing in on Android left the app stuck on the web loading crane forever. Force-closing and reopening worked, and so did every later sign-in — until the next log out. Found while device-testing the 2.1.0 internal-testing build (versionCode 72).

**This is a regression from #4020, which is already merged and live in production web.** Android build 72 should not be promoted to production until this lands.

### The bug

`sendWebviewAuthInfo` posts the Firebase credential to the web client on a 100/500/1000/3000ms retry ladder. Each post is gated on `isManifoldUrl(webviewUrl.current)` so credentials never land in a third-party document (iDenfy, Stripe — both load *inside* the webview). `onLoadStart` cleared that trust unconditionally, and only a committed `onLoad` restored it.

The OAuth hand-off abandons the in-flight WebView navigation when the user leaves for the browser. `onLoad` therefore never fires, trust stays `''` permanently, and all four posts are dropped. The `authPostDropped` re-arm can't rescue it either — that path is driven by `onNavigate`, which also never fires again. The web client sits waiting for a credential the native side already earned.

Confirmed on device (Moto g play 2024), the failing trace:

```
18:57:07.045  onNavigate url=null                  ← trust cleared, never restored
18:57:29.795  uid effect fired, uid=5dGB…          ← sign-in completed 23s later
18:57:29.911  DROP untrusted t=100    webviewUrl=""
18:57:30.313  DROP untrusted t=500    webviewUrl=""
18:57:30.815  DROP untrusted t=1000   webviewUrl=""
18:57:32.803  DROP untrusted t=3000   webviewUrl=""
```

### The fix

`onNavigate` now takes a `phase`. A `'start'` distrusts only a navigation heading to a **foreign origin** (or one it can't identify); a `'commit'` behaves exactly as before.

### Why this keeps #4020's security property

Credentials still must never post into a third-party document — and after review, that property is now enforced somewhere it can't be raced.

**Correction to this PR's original claim.** I wrote that `onLoadStart` is pre-navigation on Android because it comes from `onPageStarted`. That is wrong, and Codex's review caught it. `RNCWebViewClient` dispatches `topLoadingStart` from [`doUpdateVisitedHistory`](https://github.com/react-native-webview/react-native-webview/blob/v13.15.0/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java#L78-L88), which Chromium invokes only *after* a navigation commits. So there is a window — between a foreign page committing and that event reaching JS — where `webviewUrl.current` still holds the old Manifold url. **This window exists identically in #4020's code and is not widened by this PR**, but the invariant I claimed did not hold.

**Why not `onShouldStartLoadWithRequest`** (the suggested remedy): it is genuinely pre-navigation, but `RNCWebViewClient` forwards the `WebResourceRequest` overload to the string overload and [drops `isForMainFrame`](https://github.com/react-native-webview/react-native-webview/blob/v13.15.0/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java#L147-L151); the Android event carries no `isTopFrame` (iOS does). Revoking trust from it would treat **every third-party iframe on one of our own pages** as a foreign navigation and strand the hand-off — reintroducing this PR's exact bug for any page with an embed.

**What commit 3 does instead:** the credential post no longer uses `postMessage`. It is injected with an origin check that runs *inside the document that would receive it*. `location.origin` is `[LegacyUnforgeable]`, so a hostile page cannot shadow it, and a foreign document simply drops the payload. This holds regardless of what any navigation event reports or when, on either platform, and relies on no react-native-webview internals.

The snippet mirrors what `RNCWebView.postMessage` injects (a `message` `MessageEvent` on `document`, with the legacy `createEvent` fallback); web listens on both `document` and `window`, so it reaches the same handler on both platforms. The `webviewUrl` gate stays as the cheap first check and is what sets `authPostDropped` for the re-arm — it is simply no longer load-bearing for the security property.

### The mutable trust root (second review find)

`setAppUrl` — the admin "Native url" switcher — took the new base uri straight from a WebView message, gated only on `isAdminId(fbUser.uid)`. That checks who is **signed in**, not who **sent the message**, and `baseUri` is the root of trust for both `isManifoldUrl` and the in-document check above. A third-party page could repoint the app at itself, reload, send `startedListening`, and collect an admin's credentials.

A sender check alone can't carry this: react-native-webview registers the Android message listener for origin `*` and discards `isMainFrame`, and on the older `addJavascriptInterface` fallback the url reported with a message is `webView.getUrl()` — the **top** document's — so an iframe's message is indistinguishable from the page's own.

Commit 4 uses three layers, keeping the switcher usable (it's how the web half gets tested against a Vercel preview with no native rebuild):

- **Sender** — reject when `messageUrl` is present and untrusted. Real on iOS (`frameInfo.request.URL`) and on the modern Android bridge (`sourceOrigin`).
- **Value** — `parseAppUrl` requires a parseable url with a non-opaque origin, and https (or http only for `localhost` / RFC1918). Drops `javascript:`, `data:`, `file:`, `blob:`, `about:blank`, plain http to a public host, and the literal `"null"` origin a sandboxed hostile document reports for itself.
- **Confirmation** — switching origin needs the admin to approve the new origin **by name** in a native `Alert`. That's the check WebView content can neither forge nor race, because it isn't in the WebView — and it's what still holds on the old bridge where the sender check can't see an iframe.

On confirm, pending posts queued for the old origin are cancelled. A switch that only changes the path on the current origin skips the prompt.

### Which `URL` actually runs, and what it does (third and fourth review finds)

**Correction to what this PR said in round 3.** I justified the manual parser by pointing at React Native's `Libraries/Blob/URL.js`. **That module does not run.** `index.js` imports `expo` before `./App`, and `expo/src/winter/runtime.native.ts` installs `URL` from `whatwg-url-without-unicode` over RN's. Loading the package that actually runs:

```
new URL('not a url')                    -> THROWS                       (RN's did not)
new URL('https://a.markets@evil.com/')  -> origin https://evil.com      (RN kept userinfo)
new URL('https://x.markets:443/')       -> origin https://x.markets     (RN kept :443)
new URL('https://PREVIEW.VERCEL.APP/')  -> origin https://PREVIEW.VERCEL.APP
new URL('https://mänifold.markets/')    -> origin https://mänifold.markets
```

So three of the four defects cited in round 3 were real only of a module the app never loads. The runtime `URL` is spec-compliant **except** that it omits the IDNA tables, so it neither lowercases a host nor punycodes one. That single gap still justifies the parser — a WebView document always reports a lowercase ASCII `location.origin`, so a mixed-case stored origin strands the hand-off permanently — but the stated reasons were wrong and are corrected in the module, the tests and here.

**The bug round 4 fixes** is that same permanent-stranding failure from the other side: the parser accepted hosts a browser *rewrites*.

```
https://127.1/            browser: https://127.0.0.1
https://010.000.000.001/  browser: https://8.0.0.1     (octal)
https://2130706433/       browser: https://127.0.0.1
https://0x7f.0.0.1/       browser: https://127.0.0.1
http://[0:0:0:0:0:0:0:1]/ browser: http://[::1]        (RFC 5952)
```

Plus two a browser rejects outright — `http://[:::]/` and `http://[1::2::3]/` — which were accepted and would have thrown later during navigation, *after* `webviewUrl` had been cleared.

Rather than reimplement IPv4 shorthand expansion and IPv6 compression, the rule is now: **an origin is accepted only if it is already what a browser would serialize.** A host whose last label is all digits must be a canonical dotted quad (the URL spec requires such a host to parse as IPv4 at all), and the only accepted IPv6 is `[::1]`.

The tests assert that as an invariant — `new URL(href).origin === parsed.origin` over every accepted url, with Node's WHATWG URL as the browser oracle. Node is the right oracle for what a *document* reports, even though it was the wrong one for the app's runtime parser. Rejection cases assert the browser's differing serialization too, so the comments can't rot. 59 tests, up from 23.

**The confirmation latch** also had a hole: cancelling returned it to idle, so a page in a `setInterval` could reopen the dialog forever. Replacement-under-tap was fixed in round 3; modal DoS was not. It is now `idle | open | rejected`, a refusal is terminal for the app process, and only restarting the app — which the WebView cannot do — resets it. A confirmed switch returns to idle, since the admin may want to switch back and a page that obtained a confirmation has already won.

The round-3 tests included a transcription of RN's `URL` getters, claiming it would catch an upgrade. It could not — it imported nothing — and it described a module that isn't in the runtime. Removed.

### Round 5

**P1 — the parser still accepted hosts a browser rewrites.** My "ends in a number" check only looked for an all-digits last label; the URL spec also counts one starting with `0x`.

```
https://0x7f/   parser: https://0x7f   browser: https://0.0.0.127
https://1.0x1/  parser: https://1.0x1  browser: https://1.0.0.1
https://0x/     parser: https://0x     browser: https://0.0.0.0
https://a.0x1/  parser: https://a.0x1  browser: THROWS
```

`looksNumeric` now matches `/(?:^|\.)(?:[0-9]+|0x[0-9a-f]*)$/`, and all four are in the rejection tests with their browser serialization asserted alongside.

**`onError` no longer destroys the WebView.** Remounting is only correct for a renderer the OS killed, which cannot be reloaded. Wiring it to `onError` too meant every main-frame failure — offline blip, TLS error, a `mailto:`/`tel:` tap reported as `ERR_UNKNOWN_URL_SCHEME` — threw away the instance, the back stack and the route, and offline it churned instances instead of retrying one. Split into `reloadWebView` (`onError`, the pre-PR behaviour) and `recreateWebView` (process death only). This is the narrowing offered on commit 1 rather than dropping it outright — the `#2680` fix is real, it was just wired too broadly.

**The credential re-arm had become unreachable.** It was gated on a flag only the React-side check could set, but the enforcing check now lives inside the target document, where a drop leaves no trace. On a cold start or after a remount the whole ladder could fire into an unhydrated document, be dropped there, and never retry — leaving the web's `startedListening` as the only rescue, which a fresh install's first page can miss. Every committed Manifold page now re-hands credentials when signed in (web no-ops on a matching user; an in-app route change doesn't commit a document, so it's once per real page load). The dead flag is removed rather than left overstating its coverage, and both reset paths now clear `webviewUrl.current`.

**The switch prompt latched on dismissals the admin never made.** Android routes an outside tap, hardware back, *and any other `Alert.alert`* through `onDismiss`, because `DialogModule` dismisses the existing dialog before showing a new one — so an unrelated alert could silently kill the switcher until a force-quit. Only the Cancel **button** latches now; a bare dismissal returns to idle behind a 30s cooldown, which still denies the tight-loop DoS. Signing out clears both.

**Nits:** prettier run on the two `common` files (content only — the CRLF-vs-LF disagreement between prettier's default and `common`'s eslint `linebreak-style` is repo-wide and predates this). Two comments corrected: the injection mirrors RNW's **Android** dispatch target (iOS dispatches on `window`; web listens on both and the event doesn't bubble), and `onLoad` is not success-only, since Android's `onReceivedError` emits finish before the error. Added `100.64.0.0/10` so a Tailscale/CGNAT dev server works, and documented what's still excluded (`.local`, IPv6 beyond `[::1]`) plus the known `xn--` gap, which fails loudly at navigation rather than silently.

### Round 6

**Alert callbacks outlived their Alert.** Signing out cleared the switch-prompt latch but did not take a dialog off the screen, so a stale dialog's Cancel could write `rejected` over the state of the prompt that replaced it — and on Android, showing a new Alert dismisses the old one and fires *its* `onDismiss`, flipping the new prompt to idle while it was still visible. Every callback now carries the generation it was created with and no-ops when stale; sign-out bumps the generation. Not a bypass (the confirm path already revalidates the admin uid), but the latch wasn't reliably saying what it meant.

**`setUrlWithNativeQuery` was discarding the caller's query.** It built a fresh `URLSearchParams` and assigned over `url.search`. Two victims: a preview url's `?token=…` (which `parseSwitchableAppUrl` deliberately preserves), and — not previously noticed — the deep-link handler at `App.tsx:376`, which builds query params onto the path only to have them overwritten. That code was dead, so a shared link like `/market?tab=comments` has been silently losing `tab=comments`. Both params are now set on top of the existing ones, verified against the URL implementation that actually ships (`whatwg-url-without-unicode`): `searchParams` is live-bound, an existing `?token=x` survives, and our keys still win.

*Not fixed, pre-existing and left alone deliberately:* `setEndpointWithNativeQuery` concatenates a leading-slash path onto a base ending in a slash, so deep links produce `//home`. Harmless — deep links have always worked — and changing it touches every navigation in the app.

### Commits

1. **`recreate the WebView when its renderer is killed`** — a *separate, latent* bug found while chasing this one: `.reload()` is a silent no-op on a WebView whose renderer the OS killed (react-native-webview#2680, already cited in `App.tsx`). Renderer death is hard to trigger on demand, so this half is reasoned rather than reproduced. Commit 7 narrows it to the process-death handlers only, so `onError` keeps its pre-PR reload behaviour.
2. **`don't strand the auth handoff when a navigation is abandoned`** — the hang fix.
3. **`enforce the credential-post origin check inside the target document`** — review fix 1.
4. **`don't let WebView content redefine the credential origin`** — review fix 2.
5. **`parse trust origins strictly instead of via React Native's URL`** — review fix 3.
6. **`only accept origins a browser serializes identically`** — review fix 4.
7. **`narrow the remount, restore the re-arm, unlatch benign dismissals`** — review fix 5.
8. **`the re-arm fires per route change on iOS`** — comment correction, no code change.
9. **`scope switch-prompt callbacks, and stop dropping the caller's query`** — review fix 6.

### Testing

**Device-tested on a Moto g play 2024 at head `0df753fdc`**, dev build over Metro against production:

| Test | Result |
|---|---|
| logout → login (no cold start) | pass — `successfully set user via json`, same pid throughout, i.e. the exact case that used to hang |
| cold-start login | pass |
| offline / `onError` recovery | pass — 325 × `Reloading webview`, **0** × `Recreating webview`, confirming the commit-7 narrowing |
| switch prompt: confirm dialog | pass — `Confirming app url switch to: 'https://example.com/'` |
| switch prompt: Cancel latches | pass — second Send logged `Ignoring setAppUrl, switch prompt is 'rejected'` |

**Not tested: iOS.** Nothing on this branch reaches an iPhone until an iOS build is cut — iOS is shipping 1.0.72, which predates this branch and never exhibited the hang (iOS signs in through a native Apple modal, so no WebView navigation is ever abandoned; and its history shim restores trust on any in-app navigation anyway). An iOS logout→login should gate the **iOS build**, not this merge. The thing to watch there is the fix rather than the bug: credential delivery moves from `postMessage` (which dispatches on `window` on iOS) to `injectJavaScript` dispatching on `document`. Web registers both listeners, so it should be fine — but that is reasoning, not evidence.

Unit coverage: 64 tests for the origin parser in `common/`, run by CI.

### Release notes

JS-only — no native module or manifest change, so this is OTA-able to runtime 1.1.0 binaries via `eas update`.

- **iOS 2.1.0 (1.0.72)** is in App Store review with "Manually release" set. No resubmission needed; this can go out as an OTA after release.
- **Android** needs a rebuild as versionCode 73 before production promotion.
