### PR TITLE
chore(native): Android versionCode 73 for the auth-handoff fix

### DIFF
--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -94,7 +94,7 @@ android {
         applicationId 'com.markets.manifold'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 72
+        versionCode 73
         versionName "2.1.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""

--- a/native/app.config.js
+++ b/native/app.config.js
@@ -117,7 +117,7 @@ export default ({ config }) => {
           backgroundColor: '#4337C9',
         },
         package: 'com.markets.manifold',
-        versionCode: 72,
+        versionCode: 73,
         runtimeVersion: otaUpdateVersion,
       },
       ios: {


### PR DESCRIPTION
Build 72 carries the sign-in hang fixed in #4025 and is already uploaded to Play internal testing, so it can't be replaced in place — Play requires a higher versionCode.

Android only. Both files move together because `native/android/` is committed, so EAS resolves Android as a bare workflow and never runs prebuild: `build.gradle` is what actually ships and `app.config.js` alone would be inert.

**Unchanged on purpose:**
- `versionName`/`version` stay **2.1.0** — same release, one build later.
- `runtimeVersion` stays **1.1.0** — the fix is JS-only, so 72 and 73 share an OTA lane.
- iOS `buildNumber` stays **1.0.72** — that build predates #4025, is in App Store review, and never had the hang (iOS signs in through a native Apple modal, so no WebView navigation is ever abandoned). iOS picks this up in a later build, after a device test there.