### PR TITLE
chore(native): Android versionCode 74 for the widget rollover fix

### DIFF
--- a/common/src/streak-snapshot.ts
+++ b/common/src/streak-snapshot.ts
@@ -1,5 +1,15 @@
-// The Pacific streak day boundary — the "today" the backend's streak logic and
-// both widgets are defined against.
+// The Pacific streak day boundary — the "today" both widgets are defined against.
+//
+// NOTE it is NOT what the backend's reset job measures. reset-betting-streaks
+// compares lastBetTime against ts_to_millis(now() - interval '1 day'), a rolling
+// 24 hours from whenever the job runs. The two agree on the other 363 days and
+// diverge by an hour on the two DST transitions, where a Pacific day is 23 or 25
+// hours long. That makes predictOvernight (native/widgets/streak-widget.tsx)
+// disagree with the backend for a narrow cohort on those two days: in spring it
+// can predict a freeze the backend did not consume, in autumn it can stay pending
+// when one was. The prediction performs no write and the next ordinary refresh
+// corrects it, so this is left as a known, bounded divergence. A focused fix
+// would compare against todayStart - 24h, with a test for each transition.
 //
 // It lives in common/ so CI can cover it, including the two DST days a year when
 // a Pacific day is 23 or 25 hours long. The native package has no test runner,

--- a/native/android/app/build.gradle
+++ b/native/android/app/build.gradle
@@ -94,7 +94,7 @@ android {
         applicationId 'com.markets.manifold'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 73
+        versionCode 74
         versionName "2.1.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""

--- a/native/app.config.js
+++ b/native/app.config.js
@@ -117,7 +117,7 @@ export default ({ config }) => {
           backgroundColor: '#4337C9',
         },
         package: 'com.markets.manifold',
-        versionCode: 73,
+        versionCode: 74,
         runtimeVersion: otaUpdateVersion,
       },
       ios: {

--- a/native/widgets/streak-widget.tsx
+++ b/native/widgets/streak-widget.tsx
@@ -31,9 +31,9 @@ import {
 
 type StreakState = 'lit' | 'pending' | 'frozen' | 'loggedOut'
 
-// The Pacific day boundary lives in common/ so CI can test it (and the snapshot
-// acceptance rule that depends on it); re-exported here because the widget and
-// its headless task both import it from this module.
+// The Pacific day boundary lives in common/ so CI can test it — the native
+// package has no test runner. Re-exported here because the widget and its
+// headless task both import it from this module.
 export { pacificStartOfDayMs }
 
 function computeState(d: NativeStreakData | null, now: Date): StreakState {


### PR DESCRIPTION
Build 73 predates the midnight-rollover fix (#4028) and is already in Play internal testing, so it can't be replaced in place.

Android only. Both version files move together because `native/android/` is committed, so EAS resolves Android as a bare workflow and never runs prebuild — `build.gradle` is what actually ships and `app.config.js` alone would be inert.

**Unchanged on purpose:** `versionName`/`version` stay **2.1.0** (same release, one build later), `runtimeVersion` stays **1.1.0**, and iOS `buildNumber` stays **1.0.72** — that build is with Apple, predates both fixes, and isn't being rebuilt.

Also folds in the two comment corrections from the post-merge review of #4028, since this commit produces a binary anyway and neither changes behaviour:

- `streak-widget.tsx` still described the snapshot-acceptance rule removed before merge.
- `streak-snapshot.ts` claimed the Pacific day boundary is what the backend's streak logic is defined against. It isn't — `reset-betting-streaks` compares against a rolling `now() - interval '1 day'`. They agree on 363 days a year and diverge by an hour on the two DST transitions, so `predictOvernight` can disagree with the backend for a narrow cohort on those days. It writes nothing and the next refresh corrects it; the reviewer's call was to accept rather than reopen the build, so this records it where the next person will look.