### PR TITLE
fix(perps): make the oracle tick un-wedgeable, and let a short-heavy book take a long

### DIFF
--- a/backend/scheduler/src/jobs/update-perps.ts
+++ b/backend/scheduler/src/jobs/update-perps.ts
@@ -107,6 +107,16 @@ const updateOnePerp = async (contract: PerpContract) => {
       latest.ts,
       latest.sourceTs
     )
+    if (oracleResult?.solvencyHalt) {
+      // Price committed, state did not, trading halted. Funding would only
+      // re-derive the same failure (applyFundingWithSolvency asserts solvency
+      // on its INPUT), so stop here and page once rather than twice.
+      log.error(
+        `[update-perps] ${contract.slug}: oracle price applied but state is not solvent, trading halted and funding skipped: ${oracleResult.solvencyHalt.reason}`
+      )
+      return
+    }
+
     if (oracleResult) {
       // Best-effort, like apply-oracle-point does. This only touches the DB
       // when liquidations or ADL occurred, i.e. exactly the runs whose

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -261,13 +261,18 @@ from somewhere other than the absent side.
 
 ## Exposure capacity
 
-Opening, adding, or flipping into a side is limited so aggregate open notional
-on that side cannot exceed 10× its unreserved opposing-pool cover. Unreserved
-cover is the opposing pool minus each opposite-side position's currently
-refundable value (capped at its cost basis), matching the reserve definition
-used by ADL solvency:
+Opening, adding, or flipping into a side is limited by what the opposing side
+can back. That is two things: its unreserved pool cover, plus the notional it
+already has at risk and funds out of its own losses. Unreserved cover is the
+opposing pool minus each opposite-side position's currently refundable value
+(capped at its cost basis), matching the reserve definition used by ADL
+solvency:
 
-`side open interest <= 10 × max(opposing pool - opposing reserves, 0)`
+```
+matched credit = min(opposing OI, 10 × opposing reserves)
+side OI       <= min(10 × max(opposing pool - opposing reserves, 0) + matched credit,
+                     10 × opposing pool)
+```
 
 This is a launch guardrail in addition to the ManiPerp paper. It preserves high
 leverage for small positions while preventing a new, initially flat position
@@ -275,6 +280,77 @@ from creating unlimited future claims against finite backing. The cap applies
 only to exposure-increasing actions; users can always reduce or close existing
 positions. Funding, oracle movement, or legacy state can move a side above the
 limit, in which case further opens are blocked until capacity recovers.
+
+Read the multiple as an adverse move of 1/10. Over such a move this side's
+profit is `OI/10`, and the opposing side funds it twice over: from the pool it
+has already lost into (`availableCover`), and from the margin it is about to
+lose (`matched credit`), which is forfeited into that same pool. Crediting only
+the first term compares a NOTIONAL quantity against a MARGIN one and ignores
+opposing notional entirely, so a market could refuse the trade that would
+balance it while still accepting the trade that worsened it — on 2026-08-31 the
+BTC market held 734,349 long against 928,994 short of notional, a short-heavy
+book, and had 1,129 of long headroom against 544,752 of short. The two terms
+telescope to at most `10 × opposing pool`, which the final `min` also enforces
+directly for books whose cover has gone negative.
+
+## Cross-side deficit transfer
+
+A side's pool can end up below that side's own refundable margin: short profits
+are paid out of `L` (see `closePosition`), and while the longs are underwater
+their reserve `Σ min(costBasis, value)` is small, so those payouts pass the
+solvency check — but the reserve grows back toward `Σ costBasis` if the price
+mean-reverts, and the mana has already left. Twice in production: UK carbon
+2026-08-07 and the OpenRouter open-weight share market 2026-08-29.
+
+ADL cannot repair it. ADL scales profits and never cost bases, so the factor
+clamps to 0, the winners are settled and removed, and the deficit remains with
+no profit left to scale — `assertPerpStateSolvent` then sees `-Infinity`.
+
+`applyADL` therefore moves the deficit across from the other pool first, when
+that pool holds at least that much above its own reserve. `assertPerpEscrowBalance`
+checks `L + S` against one contract balance, so the split is an accounting
+convention, not a custody boundary; the transfer conserves total escrow and
+moves no user balance. It is all-or-nothing: a partial transfer cannot make the
+book representable but would change the ADL factors on the way to the same
+throw, so it can only ever turn a failure into a success.
+
+This does NOT stop principal being spent against an opposing side's unrealized
+loss in the first place — it lets the pot honour the resulting claim out of its
+own surplus. Reserving at full cost basis would prevent the spend, at the cost
+of much lower profit capacity on every market. That is a separate decision.
+
+## Solvency halt (tick liveness)
+
+`runOracleUpdate` always commits the new price. If the post-transition state
+cannot be made solvent even after liquidations, ADL, and the transfer above,
+the tick writes the price and `solvencyHaltTime`/`solvencyHaltReason`, and
+writes nothing else — no pools, positions, events, or metrics.
+
+Before this, that state threw and rolled the whole transaction back, so the
+cached mark never advanced and every later tick re-derived the same failure
+from the same state: a permanent wedge (12h in both incidents). A frozen mark
+is strictly worse than the state it refuses to write — it is wrong on the
+screen, it leaves trading OPEN against a dead price for a full
+`maxOraclePriceAgeMs`, and it grows the deficit it is failing on. On 2026-08-29
+a trader added to a position against a mark that had been frozen for four
+hours.
+
+Because the mark now stays fresh, the implicit staleness protection is gone, so
+`assertPerpNotSolvencyHalted` gates opens AND closes explicitly. Scheduler
+exits (liquidation, ADL, resolution) call the internal paths and are
+unaffected. `add-perp-subsidy` is deliberately not gated: it is the rescue
+tool. The first tick that applies cleanly clears the halt, so topping up the
+deficit side is the whole runbook.
+
+Pending liquidations and ADL stay pending across a halt and are re-derived by
+the next tick at the newer price. A position whose liquidation is deferred that
+way can escape it if the price rebounds — a real but bounded transfer, accepted
+against a market that is otherwise dark for hours, and trading is halted
+throughout so nobody can act on the gap.
+
+Both callers log the halt with their own prefix (`[oracle-feeds]` /
+`[update-perps]`), so the existing GCP alert policies page exactly as they did
+when this threw.
 
 ## Oracle feeds
 

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -352,6 +352,35 @@ Both callers log the halt with their own prefix (`[oracle-feeds]` /
 `[update-perps]`), so the existing GCP alert policies page exactly as they did
 when this threw.
 
+Two consequences of committing the price that are easy to miss:
+
+- **`runFunding` refuses a persisted halt, read under the contract lock.** Once
+  a tick halts it has committed its price, so replaying that same point returns
+  `ignore`/null and a caller checking only its own oracle result sees nothing to
+  skip on. Funding would then run against positions whose liquidation and ADL
+  are still pending — and unlike the tick that refused to write them, funding
+  persists pools, positions, and events. Before the halt existed this was
+  covered incidentally, by the throw taking funding down with it.
+- **A halted contract re-applies the SAME oracle point.** Otherwise the halt is
+  terminal: the committed price makes every retry a duplicate, so the pending
+  transition is never applied and the halt never clears no matter how much
+  subsidy is added. Restricted to an exact duplicate; a stale (older) point
+  stays ignored.
+
+### Deploy order
+
+**API first, fully rolled out and drained, THEN the perps scheduler.** Not
+"same SHA" — that is not sufficient during a rolling deploy. A new scheduler
+writes a fresh mark alongside `solvencyHaltTime`; an old API instance does not
+know the field, sees a fresh mark, passes the freshness gate, and will happily
+persist trades against the inconsistent book. The open path does not
+independently verify global solvency, so nothing else catches it. The new API
+is inert until a scheduler writes the first halt, so leading with it is free.
+
+The same asymmetry applies in reverse: **do not roll the API back while halt
+rows exist.** Clear them first (top up the deficit side, let a tick apply, or
+clear the field directly) or roll the scheduler back with it.
+
 ## Oracle feeds
 
 `backend/shared/src/oracle-feeds.ts` is the registry of known feeds: cadence

--- a/backend/shared/src/perps/apply-oracle-point.ts
+++ b/backend/shared/src/perps/apply-oracle-point.ts
@@ -151,6 +151,27 @@ export const applyOraclePointToLivePerps = async (
       )
       if (!result) continue
 
+      if (result.solvencyHalt) {
+        // The tick committed its PRICE but not its state, and halted trading.
+        // Same `[oracle-feeds]` prefix as the catch below, so the existing
+        // alert policy pages exactly as it did when this threw — the market is
+        // no longer dark while it waits, but it still needs an operator.
+        log.error(
+          `[oracle-feeds] ${contract.slug}: ${feedId} @ ${persistedPoint.ts} applied as PRICE ONLY, trading halted — post-tick state is not solvent: ${result.solvencyHalt.reason}`
+        )
+        publishPerpQuote({
+          contractId: contract.id,
+          oraclePrice: persistedPoint.price,
+          oraclePriceTime: persistedPoint.ts,
+          poolLong: result.poolLongAfter,
+          poolShort: result.poolShortAfter,
+          ...(persistedPoint.sourceTs == null
+            ? {}
+            : { oracleSourceTime: persistedPoint.sourceTs }),
+        })
+        continue
+      }
+
       // Push before notifying: notification delivery does its own DB work and
       // the whole point of this path is that open pages see the new price in
       // well under a tick. Carries only what the tick authoritatively settled

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -126,6 +126,31 @@ const assertFreshOracleForTrading = (contract: PerpContract, now: number) => {
   )
 }
 
+/**
+ * Explicit trading halt set by a tick that could not represent its own result.
+ *
+ * Normally a book that cannot take a price update is protected implicitly: the
+ * mark stops advancing and `assertFreshOracleForTrading` closes the market at
+ * `maxOraclePriceAgeMs`. That protection is an accident of the failure, not a
+ * decision, and it is a bad one — it leaves the market OPEN at a dead price for
+ * a whole freshness budget (5 hours of it on 2026-08-29, during which a trader
+ * added to a position at a mark that had been frozen for four).
+ *
+ * `runOracleUpdate` now always commits the price, so that implicit protection
+ * is gone by construction and this takes its place. Closes are gated too: the
+ * book is known-inconsistent, and letting one side exit against it at a price
+ * the engine could not validate is exactly the drain the halt exists to stop.
+ * Scheduler-driven exits (liquidation, ADL, resolution) call the internal paths
+ * and are unaffected, so positions still settle.
+ */
+const assertPerpNotSolvencyHalted = (contract: PerpContract) => {
+  if (contract.solvencyHaltTime == null) return
+  throw new APIError(
+    503,
+    `Trading is paused on this market: a risk update could not be applied, and an operator has been alerted. Open positions are unaffected and still settle.`
+  )
+}
+
 // All engine writers on one contract serialize on the advisory lock, but each
 // waiter's SERIALIZABLE snapshot predates the winner's commit, so contended
 // transactions abort with 40001 on wake-up and must retry. Under a burst
@@ -625,6 +650,7 @@ export const openOrAddPosition = async (
       )
 
     assertFreshOracleForTrading(contract, now)
+    assertPerpNotSolvencyHalted(contract)
 
     await assertPerpEscrowBalance(pgTrans, contractId, state.pool)
 
@@ -903,9 +929,10 @@ export const openOrAddPosition = async (
     // over-cap positions can always close, but cannot add further exposure.
     const capacity = getPerpOpenInterestCapacity(direction, open.state, price)
     if (!capacity.isWithinLimit) {
-      // The limit depends only on the opposing pool, which an open never
-      // touches, so pre-trade headroom is exact — tell the user the largest
-      // trade that fits instead of making them reverse-engineer the cap.
+      // The limit depends only on the opposing SIDE (its pool and its own
+      // exposure), which an open on this side never touches, so pre-trade
+      // headroom is exact — tell the user the largest trade that fits instead
+      // of making them reverse-engineer the cap.
       const headroom = Math.max(
         capacity.limit - (capacity.openInterest - open.deltaSize),
         0
@@ -917,7 +944,7 @@ export const openOrAddPosition = async (
           2
         )} more ${direction} exposure right now, but this trade adds M$${open.deltaSize.toFixed(
           2
-        )} (margin × leverage). Reduce your margin or leverage so their product fits, or wait for more ${opposite} interest to raise the cap (${direction} exposure is limited to ${PERP_OPEN_INTEREST_COVER_MULTIPLE}× the unreserved ${opposite}-side pool).`
+        )} (margin × leverage). Reduce your margin or leverage so their product fits, or wait for more ${opposite} interest to raise the cap (${direction} exposure is limited to ${PERP_OPEN_INTEREST_COVER_MULTIPLE}× the unreserved ${opposite}-side pool, plus the notional the ${opposite} side already has at risk).`
       )
     }
 
@@ -1288,6 +1315,7 @@ export const closePosition = async (
     // watching the real market move. Opens and closes share one predicate.
     const now = Date.now()
     assertFreshOracleForTrading(contract, now)
+    assertPerpNotSolvencyHalted(contract)
 
     await assertPerpEscrowBalance(pgTrans, contractId, state.pool)
 
@@ -1496,6 +1524,12 @@ export type OracleUpdateResult = {
   poolLongAfter: number
   poolShortBefore: number
   poolShortAfter: number
+  /**
+   * Present only when the tick committed its price but NOT its state, because
+   * the post-transition book could not be made solvent. Callers log this with
+   * their own prefix so the existing alert policies still fire.
+   */
+  solvencyHalt?: { reason: string }
 }
 
 const collectAdlAdjusted = (
@@ -1779,13 +1813,54 @@ export const runOracleUpdate = async (
       const poolShortBefore = state.pool.S
 
       const appliedTime = Date.now()
-      const applied = applyOracleUpdate(
-        contract,
-        state,
-        newPrice,
-        ts,
-        appliedTime
-      )
+      let applied: ReturnType<typeof applyOracleUpdate>
+      try {
+        applied = applyOracleUpdate(contract, state, newPrice, ts, appliedTime)
+      } catch (error) {
+        // LIVENESS. An accounting assert must never be able to take out price
+        // discovery. Before this, a post-transition state that failed
+        // assertPerpStateSolvent rolled the whole transaction back, so the
+        // cached mark never moved again and EVERY subsequent tick re-derived
+        // the same failure from the same state — a permanent wedge that only
+        // an operator could clear (UK carbon 2026-08-07, 12h; OpenRouter
+        // open-weight share 2026-08-29, 12h).
+        //
+        // A frozen mark is strictly worse than the state it refuses to write:
+        // it is wrong on the screen, it keeps trading open against a dead
+        // price until the freshness budget expires, and it grows the very
+        // deficit it is failing on. So commit the price and halt trading
+        // explicitly instead.
+        //
+        // Deliberately NOT written: pools, positions, metrics, events. The
+        // pending liquidations and ADL stay pending and are re-derived by the
+        // next tick against the newer price — a position whose liquidation is
+        // deferred this way can escape it if the price rebounds, which is a
+        // real but small transfer, and the alternative on the table is a
+        // market that is dark for hours. Trading is halted throughout, so
+        // nobody can act on the gap.
+        const reason = error instanceof Error ? error.message : String(error)
+        await pgTrans.one(
+          mergeContractDataQuery(contractId, {
+            oraclePrice: newPrice,
+            oraclePriceTime: ts,
+            oracleSourceTime: sourceTs ?? null,
+            solvencyHaltTime: appliedTime,
+            solvencyHaltReason: reason,
+          })
+        )
+        return {
+          liquidated: [],
+          adlAdjusted: [],
+          adlSettled: [],
+          adlFactorLong: 1,
+          adlFactorShort: 1,
+          poolLongBefore,
+          poolLongAfter: poolLongBefore,
+          poolShortBefore,
+          poolShortAfter: poolShortBefore,
+          solvencyHalt: { reason },
+        }
+      }
 
       const { upserts, deletes } = diffForWrite(
         state.positions,
@@ -1804,6 +1879,13 @@ export const runOracleUpdate = async (
         // Price polling is infrastructure activity, not user activity. Only a
         // liquidation/ADL transition should refresh discovery freshness.
         lastUpdatedTime: applied.events.length > 0 ? ts : undefined,
+        // This tick represented its own result, so whatever wedged the book is
+        // gone (typically an add-perp-subsidy top-up). Self-heal rather than
+        // needing a second operator action. `undefined` when not halted so the
+        // common path writes nothing extra.
+        ...(contract.solvencyHaltTime == null
+          ? {}
+          : { solvencyHaltTime: null, solvencyHaltReason: null }),
       })
 
       // Fast path: no liquidations and no ADL means no position changed, so

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -1804,10 +1804,23 @@ export const runOracleUpdate = async (
       const decision = decideOracleTransition(currentPoint, incomingPoint)
       if (decision.action === 'reject')
         throw new APIError(400, `Invalid oracle transition: ${decision.reason}`)
+
+      // A halted contract MUST be allowed to re-run the same point. The halt
+      // committed the price without the transition, so from here on that point
+      // reads as a duplicate and is ignored — which would strand the contract
+      // permanently: the pending liquidations/ADL would never be applied and
+      // the halt would never clear, no matter how much subsidy an operator
+      // added. This retry is what makes recovery converge. Restricted to an
+      // exact duplicate; a genuinely stale (older) point stays ignored.
+      const retryingHalt =
+        decision.action === 'ignore' &&
+        decision.reason === 'duplicate' &&
+        contract.solvencyHaltTime != null
+
       // Delivery can race even though state writes cannot. Once the contract
       // lock is held, an older point or exact retry must not touch price, pools,
       // positions, metrics, or event history.
-      if (decision.action === 'ignore') return null
+      if (decision.action === 'ignore' && !retryingHalt) return null
 
       const poolLongBefore = state.pool.L
       const poolShortBefore = state.pool.S
@@ -1844,7 +1857,10 @@ export const runOracleUpdate = async (
             oraclePrice: newPrice,
             oraclePriceTime: ts,
             oracleSourceTime: sourceTs ?? null,
-            solvencyHaltTime: appliedTime,
+            // Keep the ORIGINAL halt time across retries so an operator can
+            // see how long this book has been wedged, not how long ago the
+            // last retry ran.
+            solvencyHaltTime: contract.solvencyHaltTime ?? appliedTime,
             solvencyHaltReason: reason,
           })
         )
@@ -1994,6 +2010,27 @@ export const runFunding = async (
   return runPerpTransaction(async (pgTrans) => {
     const { contract, state } = await loadStateForUpdate(pgTrans, contractId)
     const appliedTime = Date.now()
+
+    // Halt gate, read from the PERSISTED contract under the lock rather than
+    // from the caller's oracle result.
+    //
+    // Once a tick has halted, it has already committed its price, so replaying
+    // that same point returns `ignore`/null and the scheduler's per-run check
+    // sees nothing to skip on. Funding would then run against positions whose
+    // liquidation and ADL are still pending — and unlike the tick that refused
+    // to write them, funding DOES persist pools, positions, and events. Before
+    // the halt existed this was covered incidentally: the tick threw, and the
+    // throw took funding down with it.
+    //
+    // Subsidy recovery is not blocked by this. The retried oracle tick applies
+    // the pending transition and clears the halt; funding resumes on the next
+    // pass, against a book that has caught up.
+    if (contract.solvencyHaltTime != null) {
+      log(
+        `[perps] skipping funding for ${contract.slug}: solvency halt in effect since ${contract.solvencyHaltTime}`
+      )
+      return null
+    }
 
     // Cadence gate lives INSIDE the advisory lock: the scheduler's own check
     // runs unlocked, so two overlapping ticks (fine hourly, likely at fast

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -353,6 +353,13 @@ export type PerpMechanism = {
   lastFundingTime?: number
   fundingRate?: number // last applied rate; +ve = longs pay
   resolvedOraclePrice?: number
+  // Set when an oracle tick's post-transition state could not be made solvent
+  // even after ADL and the cross-side deficit transfer. The tick still commits
+  // the new price (a frozen mark is its own exploit surface), so the freshness
+  // gate no longer protects the book — this halts trading explicitly instead.
+  // Cleared by the first tick that applies cleanly, e.g. after add-perp-subsidy.
+  solvencyHaltTime?: number | null
+  solvencyHaltReason?: string | null
 }
 export type PerpContract = Contract & Perp & PerpMechanism
 

--- a/common/src/perps/amm.test.ts
+++ b/common/src/perps/amm.test.ts
@@ -11,6 +11,7 @@ import {
   getPerpBackingPool,
   getPerpOpenInterest,
   getPerpOpenInterestCapacity,
+  getPerpOpenInterestCapacityForOpen,
   getPositionValue,
   getUnrealizedEquity,
   imbalance,
@@ -1109,6 +1110,38 @@ describe('open interest capacity', () => {
     expect(long.matchedCredit).toBe(1500)
     expect(long.limit).toBe(2000)
     expect(long.isWithinLimit).toBe(true)
+  })
+
+  it('previews a flip against the book after closing the opposite position', () => {
+    const shortToClose = makePosition({
+      userId: 'flipper',
+      direction: 'short',
+      size: 1000,
+      costBasis: 500,
+      entryPrice: 100,
+    })
+    const state: PerpState = {
+      pool: { L: 1000, S: 1500 },
+      positions: [
+        makePosition({
+          userId: 'other',
+          direction: 'long',
+          size: 8000,
+          costBasis: 100,
+          entryPrice: 100,
+        }),
+        shortToClose,
+      ],
+    }
+
+    // Against the current book the short supplies 1000 of matched credit,
+    // making 3000 appear available. A flat close pays its M$500 basis out of
+    // pool S and removes that credit, so the opening leg can use only 2000.
+    expect(getPerpOpenInterestCapacity('long', state, 100).headroom).toBe(3000)
+    expect(
+      getPerpOpenInterestCapacityForOpen('long', state, 100, shortToClose)
+        .headroom
+    ).toBe(2000)
   })
 
   it('credits nothing for an opposing side that is in profit', () => {

--- a/common/src/perps/amm.test.ts
+++ b/common/src/perps/amm.test.ts
@@ -977,6 +977,9 @@ describe('open interest capacity', () => {
     expect(capacity).toEqual({
       openInterest: 9999,
       availableCover: 1000,
+      // No short positions exist, so there is nothing to credit and the cap
+      // is exactly the pre-netting one.
+      matchedCredit: 0,
       limit: 10_000,
       headroom: 1,
       isWithinLimit: true,
@@ -1006,8 +1009,12 @@ describe('open interest capacity', () => {
     const capacity = getPerpOpenInterestCapacity('long', state, 100)
     expect(capacity.openInterest).toBe(0)
     expect(capacity.availableCover).toBe(1000)
-    expect(capacity.limit).toBe(10_000)
-    expect(capacity.headroom).toBe(10_000)
+    // The short's own M$1000 of notional is credited on top: over an adverse
+    // move it is the shorts who fund the longs, up to their M$500 of margin
+    // (10 x 500 = 5000 of notional headroom, so their own 1000 binds).
+    expect(capacity.matchedCredit).toBe(1000)
+    expect(capacity.limit).toBe(11_000)
+    expect(capacity.headroom).toBe(11_000)
   })
 
   it('releases an opposite-side unrealized loss into available cover', () => {
@@ -1025,7 +1032,108 @@ describe('open interest capacity', () => {
     // At 140 the short has lost M$400, so only M$100 remains refundable.
     const capacity = getPerpOpenInterestCapacity('long', state, 140)
     expect(capacity.availableCover).toBeCloseTo(1400, 10)
-    expect(capacity.limit).toBeCloseTo(14_000, 10)
+    expect(capacity.matchedCredit).toBe(1000)
+    expect(capacity.limit).toBeCloseTo(15_000, 10)
+  })
+
+  it('credits the opposing side notional it funds from its own losses', () => {
+    const base: PerpState = {
+      pool: { L: 1000, S: 1000 },
+      positions: [
+        makePosition({
+          direction: 'short',
+          size: 4000,
+          costBasis: 1000,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    // Opposing pool 1000, all of it reserved as the short's own refundable
+    // basis: zero unreserved cover, so the old rule granted zero long capacity
+    // despite 4000 of short notional standing in front of it.
+    const capacity = getPerpOpenInterestCapacity('long', base, 100)
+    expect(capacity.availableCover).toBe(0)
+    expect(capacity.matchedCredit).toBe(4000)
+    expect(capacity.limit).toBe(4000)
+    expect(capacity.headroom).toBe(4000)
+  })
+
+  it('caps the credit by the opposing side margin, not its notional', () => {
+    // 100x shorts: 10_000 of notional standing on 100 of margin. They can fund
+    // only 100 of losses before liquidating, so credit 10 x 100, not 10_000.
+    const state: PerpState = {
+      pool: { L: 1000, S: 100 },
+      positions: [
+        makePosition({
+          direction: 'short',
+          size: 10_000,
+          costBasis: 100,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    const capacity = getPerpOpenInterestCapacity('long', state, 100)
+    expect(capacity.availableCover).toBe(0)
+    expect(capacity.matchedCredit).toBe(1000)
+    expect(capacity.limit).toBe(1000)
+  })
+
+  it('lets a short-heavy book take the long trade that balances it', () => {
+    // Shape of the BTC market on 2026-08-31: more short notional than long,
+    // yet the long side was the one being refused.
+    const state: PerpState = {
+      pool: { L: 1000, S: 200 },
+      positions: [
+        makePosition({
+          direction: 'long',
+          size: 2000,
+          costBasis: 100,
+          entryPrice: 100,
+        }),
+        makePosition({
+          direction: 'short',
+          size: 3000,
+          costBasis: 150,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    const long = getPerpOpenInterestCapacity('long', state, 100)
+    expect(long.openInterest).toBe(2000)
+    // Old rule: 10 x (200 - 150) = 500, under the 2000 of long OI already
+    // open, so the book could not take another M$1 of long.
+    expect(long.availableCover).toBe(50)
+    expect(long.matchedCredit).toBe(1500)
+    expect(long.limit).toBe(2000)
+    expect(long.isWithinLimit).toBe(true)
+  })
+
+  it('never promises more than the whole opposing pool', () => {
+    // A book whose long side is already short of its own reserve: cover floors
+    // at 0 and the reserved value exceeds pool.L, so the raw credit would hand
+    // the shorts more notional than the long pool could ever fund.
+    const wedged: PerpState = {
+      pool: { L: 100, S: 1000 },
+      positions: [
+        makePosition({
+          direction: 'long',
+          size: 1000,
+          costBasis: 200,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    const short = getPerpOpenInterestCapacity('short', wedged, 100)
+    expect(short.availableCover).toBe(-100)
+    expect(short.matchedCredit).toBe(1000)
+    expect(short.limit).toBe(1000)
+    expect(short.limit).toBeLessThanOrEqual(
+      wedged.pool.L * PERP_OPEN_INTEREST_COVER_MULTIPLE
+    )
   })
 
   it('fails closed on non-finite aggregate exposure', () => {
@@ -1248,5 +1356,163 @@ describe('assertPerpStateNumbers ordering vs the risk transitions', () => {
     expect(() => assertPerpStateSolvent(insolvent, 150)).toThrow()
     const repaired = applyADL(insolvent, 150)
     expect(() => assertPerpStateSolvent(repaired.state, 150)).not.toThrow()
+  })
+})
+
+describe('applyADL cross-side deficit transfer', () => {
+  // pool.L cannot cover the long book's own refundable margin, because short
+  // profits were paid out of L against long paper losses that then recovered.
+  // pool.S is fat. This is the shape of both production wedges.
+  const wedged = (): PerpState => ({
+    pool: { L: 100, S: 1000 },
+    positions: [
+      makePosition({
+        direction: 'long',
+        size: 1000,
+        costBasis: 200,
+        entryPrice: 100,
+      }),
+      makePosition({
+        direction: 'short',
+        size: 100,
+        costBasis: 10,
+        entryPrice: 100,
+      }),
+    ],
+  })
+
+  it('is load-bearing: the book is unrepresentable without it', () => {
+    // Guards the premise. If this stops throwing, the rest of the block is
+    // asserting nothing.
+    expect(() => assertPerpStateSolvent(wedged(), 110)).toThrow(
+      'short solvency factor must be finite or +Infinity'
+    )
+  })
+
+  it('moves exactly the deficit and leaves the state solvent', () => {
+    const result = applyADL(wedged(), 110)
+
+    expect(result.crossSideTransfer).toBeCloseTo(100, 10)
+    expect(result.state.pool.L).toBeCloseTo(200, 10)
+    expect(result.state.pool.S).toBeCloseTo(900, 10)
+    expect(() => assertPerpStateSolvent(result.state, 110)).not.toThrow()
+  })
+
+  it('conserves total escrow', () => {
+    const before = wedged()
+    const result = applyADL(before, 110)
+
+    expect(result.state.pool.L + result.state.pool.S).toBeCloseTo(
+      before.pool.L + before.pool.S,
+      10
+    )
+  })
+
+  it('does nothing at all to a book that is already covered', () => {
+    const healthy: PerpState = {
+      pool: { L: 1000, S: 1000 },
+      positions: [
+        makePosition({
+          direction: 'long',
+          size: 1000,
+          costBasis: 200,
+          entryPrice: 100,
+        }),
+        makePosition({
+          direction: 'short',
+          size: 500,
+          costBasis: 100,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    const result = applyADL(healthy, 110)
+    expect(result.crossSideTransfer).toBe(0)
+    expect(result.state.pool).toEqual(healthy.pool)
+    expect(result.adlFactorLong).toBe(1)
+    expect(result.adlFactorShort).toBe(1)
+  })
+
+  it('transfers in the other direction too', () => {
+    const shortSideWedged: PerpState = {
+      pool: { L: 1000, S: 100 },
+      positions: [
+        makePosition({
+          direction: 'short',
+          size: 1000,
+          costBasis: 200,
+          entryPrice: 100,
+        }),
+        makePosition({
+          direction: 'long',
+          size: 100,
+          costBasis: 10,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    const result = applyADL(shortSideWedged, 90)
+    expect(result.crossSideTransfer).toBeCloseTo(-100, 10)
+    expect(result.state.pool.S).toBeCloseTo(200, 10)
+    expect(result.state.pool.L).toBeCloseTo(900, 10)
+    expect(() => assertPerpStateSolvent(result.state, 90)).not.toThrow()
+  })
+
+  it('still fails closed when the whole pot cannot cover the book', () => {
+    // Nothing to donate: the deficit is real at the contract level, not an
+    // artifact of the partition. The engine's liveness path handles this one.
+    const globallyInsolvent: PerpState = {
+      pool: { L: 100, S: 0 },
+      positions: [
+        makePosition({
+          direction: 'long',
+          size: 1000,
+          costBasis: 200,
+          entryPrice: 100,
+        }),
+        makePosition({
+          direction: 'short',
+          size: 100,
+          costBasis: 10,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    const result = applyADL(globallyInsolvent, 110)
+    expect(result.crossSideTransfer).toBe(0)
+    expect(() => assertPerpStateSolvent(result.state, 110)).toThrow()
+  })
+
+  it('declines to donate at all when it cannot cover the whole deficit', () => {
+    const thinDonor: PerpState = {
+      pool: { L: 100, S: 40 },
+      positions: [
+        makePosition({
+          direction: 'long',
+          size: 1000,
+          costBasis: 200,
+          entryPrice: 100,
+        }),
+        makePosition({
+          direction: 'short',
+          size: 100,
+          costBasis: 10,
+          entryPrice: 100,
+        }),
+      ],
+    }
+
+    // The deficit is 100 and S holds only 40 spare. Moving those 40 would
+    // leave the book just as unrepresentable while draining the donor to zero,
+    // which drives the opposing ADL factor to 0 and settles a position against
+    // a pool that cannot pay it. Leave the state exactly as it was and let the
+    // engine's liveness path deal with it.
+    const result = applyADL(thinDonor, 110)
+    expect(result.crossSideTransfer).toBe(0)
+    expect(result.state.pool).toEqual(thinDonor.pool)
+    expect(() => assertPerpStateSolvent(result.state, 110)).toThrow()
   })
 })

--- a/common/src/perps/amm.test.ts
+++ b/common/src/perps/amm.test.ts
@@ -1111,6 +1111,44 @@ describe('open interest capacity', () => {
     expect(long.isWithinLimit).toBe(true)
   })
 
+  it('credits nothing for an opposing side that is in profit', () => {
+    // Review counterexample. The short is 500 up at the mark, so its reserve is
+    // clamped at its 100 of cost basis and STAYS there across the whole move
+    // this cap is sized for — an adverse tick frees none of the pool. Crediting
+    // its reserve outright would admit 1000 of long notional whose cover is
+    // zero, and factor-zero ADL would take it out on its first profitable tick.
+    const profitableOpponent: PerpState = {
+      pool: { L: 500, S: 100 },
+      positions: [
+        makePosition({
+          direction: 'short',
+          size: 1000,
+          costBasis: 100,
+          entryPrice: 200,
+        }),
+      ],
+    }
+
+    const capacity = getPerpOpenInterestCapacity(
+      'long',
+      profitableOpponent,
+      100
+    )
+    expect(capacity.availableCover).toBe(0)
+    expect(capacity.matchedCredit).toBe(0)
+    expect(capacity.limit).toBe(0)
+    expect(capacity.headroom).toBe(0)
+
+    // The same short, now at a mark where it is underwater, does release its
+    // margin over the move and is credited for it.
+    const underwater = getPerpOpenInterestCapacity(
+      'long',
+      profitableOpponent,
+      210
+    )
+    expect(underwater.matchedCredit).toBeGreaterThan(0)
+  })
+
   it('never promises more than the whole opposing pool', () => {
     // A book whose long side is already short of its own reserve: cover floors
     // at 0 and the reserved value exceeds pool.L, so the raw credit would hand

--- a/common/src/perps/amm.ts
+++ b/common/src/perps/amm.ts
@@ -410,8 +410,15 @@ export const applyADL = (state: PerpState, price: number) => {
   const transferToS = surplusS < 0 && surplusL >= -surplusS ? -surplusS : 0
   /** Positive = moved S -> L, negative = moved L -> S. */
   const crossSideTransfer = transferToL - transferToS
-  const adjustedL = L + crossSideTransfer
-  const adjustedS = S - crossSideTransfer
+  // Assign the RECIPIENT its reserve exactly rather than computing
+  // `L + (CL - L)`, which is not exactly CL in float and can leave cover one
+  // ULP negative. That is not a rounding nuisance here: the -Infinity branch of
+  // solvencyFactor has no tolerance, so a single ULP of negative cover on a
+  // side with no profit left is the difference between unwedging and staying
+  // wedged. The donor absorbs the same value, so escrow moves by at most one
+  // ULP, which assertPerpEscrowBalance tolerates.
+  const adjustedL = transferToL > 0 ? CL : L - transferToS
+  const adjustedS = transferToS > 0 ? CS : S - transferToL
 
   const sL = EL > 0 ? (adjustedS - CS) / EL : 1
   const sS = ES > 0 ? (adjustedL - CL) / ES : 1
@@ -717,33 +724,41 @@ const calculateAvailableCover = (
  * profits over an adverse move of x = 1 / PERP_OPEN_INTEREST_COVER_MULTIPLE.
  * Over such a move:
  *
- *   this side's profit   ≈ x · OI(side)
- *   opposing side's loss ≈ x · OI(opposite), but they liquidate once their
- *                          remaining margin is gone, so at most R(opposite),
- *                          the same reserved value `availableCover` deducts
- *                          — and it is forfeited INTO the very pool that pays
- *                          this side.
- *   net drain            ≈ x · OI(side) − min(x · OI(opp), R(opp))
+ *   this side's profit ≈ x · OI(side)
+ *   released           = R(opp, P) − R(opp, P'), the opposing reserve that
+ *                        actually stops being reserved as the move goes
+ *                        against them — and it is released INTO the very pool
+ *                        that pays this side.
+ *   net drain          ≈ x · OI(side) − released
  *
  * Requiring `net drain ≤ availableCover` and multiplying through by the
  * multiple M = 1/x gives
  *
- *   OI(side) ≤ M · availableCover + min(OI(opp), M · R(opp))
+ *   OI(side) ≤ M · availableCover + M · released
  *
  * and the second term is this credit.
  *
- * Using R — `min(costBasis, positionValue)`, exactly what `availableCover`
- * reserves — rather than raw cost basis is what makes the two terms compose
- * into something bounded. Where cover is non-negative they telescope:
+ * ⚠️ `released` must be evaluated at BOTH prices. R is
+ * `min(costBasis, positionValue)`, which is FLAT in price wherever the
+ * opposing position is in profit — value exceeds cost basis, the `min` clamps
+ * to cost basis, and an adverse move releases nothing at all. Crediting
+ * `M · R(opp, P)` instead (the first version of this) hands out capacity
+ * against margin that the move never frees: mark 100, a short of size 1000 at
+ * entry 200 with 100 of basis against a 100 short pool reserves its whole 100,
+ * so the naive form credits 1000 of long notional — and at mark 110 that short
+ * is still deeply profitable, still reserves the entire pool, and the new long
+ * has zero cover and is factor-zero ADL'd on its first profitable tick.
  *
- *   M · (pool − R) + min(OI(opp), M · R)  ≤  M · pool
+ * Because R is non-increasing over an adverse move and can fall by at most the
+ * position's own loss, `released ≤ x · OI(opp)`, so `M · released ≤ OI(opp)`;
+ * the explicit `min` against opposing OI below is therefore belt-and-braces
+ * against float, not the binding constraint. And since `released ≤ R(opp, P)`,
+ * the two terms telescope wherever cover is non-negative:
  *
- * so the cap can never promise more than the whole opposing pool over the
- * move it is sized for. (Raw cost basis has no such bound — on a wedged book
- * Σ cb exceeds the pool, which is the entire failure mode this PR is about.)
- * The `min` is what stops a thin-margin, high-leverage opposing book from
- * granting unbounded capacity: 929k of short notional standing on 34k of
- * reserved margin credits 335k, not 929k.
+ *   M · (pool − R) + M · released  ≤  M · pool
+ *
+ * so the cap can never promise more than the whole opposing pool over the move
+ * it is sized for.
  *
  * Without this term the cap compares a NOTIONAL quantity against a MARGIN one
  * and never looks at opposing notional at all, so a market can refuse the
@@ -761,15 +776,25 @@ const calculateMatchedCredit = (
   const opposing = state.positions.filter(
     (p) => p.direction === oppositeDirection && p.size > 0
   )
+  // The move this cap is sized for, in the direction that hurts the opposing
+  // side: up for a long book, down for a short one.
+  const x = 1 / PERP_OPEN_INTEREST_COVER_MULTIPLE
+  const movedPrice = side === 'long' ? price * (1 + x) : price * (1 - x)
+
   const openInterest = opposing.reduce((sum, p) => sum + p.size, 0)
-  const reserved = opposing.reduce(
-    (sum, p) => sum + Math.min(p.costBasis, getPositionValue(p, price)),
+  // Per position, and floored at zero: one holder whose reserve does not move
+  // must not have another's release netted away against it.
+  const released = opposing.reduce(
+    (sum, p) =>
+      sum +
+      Math.max(
+        Math.min(p.costBasis, getPositionValue(p, price)) -
+          Math.min(p.costBasis, getPositionValue(p, movedPrice)),
+        0
+      ),
     0
   )
-  return Math.min(
-    openInterest,
-    Math.max(reserved, 0) * PERP_OPEN_INTEREST_COVER_MULTIPLE
-  )
+  return Math.min(openInterest, released * PERP_OPEN_INTEREST_COVER_MULTIPLE)
 }
 
 /**

--- a/common/src/perps/amm.ts
+++ b/common/src/perps/amm.ts
@@ -376,8 +376,45 @@ export const applyADL = (state: PerpState, price: number) => {
     0
   )
 
-  const sL = EL > 0 ? (S - CS) / EL : 1
-  const sS = ES > 0 ? (L - CL) / ES : 1
+  // Cross-side deficit transfer. Margin refunds are senior to unrealized
+  // profits, and the two pools sit behind ONE escrow balance.
+  //
+  // A side's pool can fall below that side's own refundable margin when
+  // realized profits were paid to the opposing side against unrealized
+  // losses that later recovered (UK carbon 2026-08-07, and the OpenRouter
+  // open-weight share market 2026-08-29). ADL alone cannot repair that
+  // state: it scales profits and never cost bases, so the factor clamps to
+  // 0, every winner is settled and removed, and the deficit is still there
+  // with no profit left to scale against. assertPerpStateSolvent then sees
+  // -Infinity and the oracle apply fail-closes — forever, at a stale price.
+  //
+  // assertPerpEscrowBalance checks L + S against one contract balance, so
+  // the L/S split is an accounting convention rather than a custody
+  // boundary. Before pricing ADL, if one side is short of its own reserve and
+  // the other holds at least that much above its reserve, move the deficit
+  // across. At most one direction is non-zero — a side in deficit has no
+  // surplus by construction. Total escrow is unchanged and no user balance
+  // moves. A book that was already covered transfers exactly zero, so this is
+  // inert on every market that was not wedged.
+  //
+  // All-or-nothing on purpose. A partial transfer cannot make the book
+  // representable — the recipient's cover is still negative afterwards, so the
+  // assert throws either way — but it DOES change the ADL factors on the way
+  // there, and a donor drained to exactly zero pushes the opposing factor to 0,
+  // which settles that side and overdraws its pool. Transferring only when the
+  // donor fully covers the deficit means this can turn a throw into a success
+  // and can never reshape a path that was going to throw regardless.
+  const surplusL = L - CL
+  const surplusS = S - CS
+  const transferToL = surplusL < 0 && surplusS >= -surplusL ? -surplusL : 0
+  const transferToS = surplusS < 0 && surplusL >= -surplusS ? -surplusS : 0
+  /** Positive = moved S -> L, negative = moved L -> S. */
+  const crossSideTransfer = transferToL - transferToS
+  const adjustedL = L + crossSideTransfer
+  const adjustedS = S - crossSideTransfer
+
+  const sL = EL > 0 ? (adjustedS - CS) / EL : 1
+  const sS = ES > 0 ? (adjustedL - CL) / ES : 1
 
   const adlFactorLong = sL < 1 ? Math.max(sL, 0) : 1
   const adlFactorShort = sS < 1 ? Math.max(sS, 0) : 1
@@ -432,14 +469,15 @@ export const applyADL = (state: PerpState, price: number) => {
   return {
     state: {
       pool: {
-        L: poolAfterDebit(L, longSettlementPayout),
-        S: poolAfterDebit(S, shortSettlementPayout),
+        L: poolAfterDebit(adjustedL, longSettlementPayout),
+        S: poolAfterDebit(adjustedS, shortSettlementPayout),
       },
       positions,
     },
     adlFactorLong,
     adlFactorShort,
     settled,
+    crossSideTransfer,
   }
 }
 
@@ -616,17 +654,23 @@ export const closePosition = (
 
 /**
  * Launch guardrail beyond the ManiPerp paper: aggregate exposure on either
- * side may not exceed this multiple of unreserved opposing-pool cover.
+ * side may not exceed this multiple of the backing the opposing side provides.
  *
  * This still permits high leverage for small positions, while preventing a
  * freshly opened position (which has no unrealized profit yet) from creating
  * effectively unlimited future claims against a finite pool.
+ *
+ * Read it as an adverse move of 1/M where M is this multiple: the cap is sized
+ * so this side's profit over a 10% move still fits the backing available for
+ * it. See `calculateMatchedCredit` for the derivation.
  */
 export const PERP_OPEN_INTEREST_COVER_MULTIPLE = 10
 
 export type PerpOpenInterestCapacity = {
   openInterest: number
   availableCover: number
+  /** Notional the opposing book funds out of its own losses. */
+  matchedCredit: number
   limit: number
   headroom: number
   isWithinLimit: boolean
@@ -667,12 +711,75 @@ const calculateAvailableCover = (
 }
 
 /**
+ * Notional the OPPOSING book can fund out of its own losses.
+ *
+ * The cap exists to bound the drain on the opposing pool from this side's
+ * profits over an adverse move of x = 1 / PERP_OPEN_INTEREST_COVER_MULTIPLE.
+ * Over such a move:
+ *
+ *   this side's profit   ≈ x · OI(side)
+ *   opposing side's loss ≈ x · OI(opposite), but they liquidate once their
+ *                          remaining margin is gone, so at most R(opposite),
+ *                          the same reserved value `availableCover` deducts
+ *                          — and it is forfeited INTO the very pool that pays
+ *                          this side.
+ *   net drain            ≈ x · OI(side) − min(x · OI(opp), R(opp))
+ *
+ * Requiring `net drain ≤ availableCover` and multiplying through by the
+ * multiple M = 1/x gives
+ *
+ *   OI(side) ≤ M · availableCover + min(OI(opp), M · R(opp))
+ *
+ * and the second term is this credit.
+ *
+ * Using R — `min(costBasis, positionValue)`, exactly what `availableCover`
+ * reserves — rather than raw cost basis is what makes the two terms compose
+ * into something bounded. Where cover is non-negative they telescope:
+ *
+ *   M · (pool − R) + min(OI(opp), M · R)  ≤  M · pool
+ *
+ * so the cap can never promise more than the whole opposing pool over the
+ * move it is sized for. (Raw cost basis has no such bound — on a wedged book
+ * Σ cb exceeds the pool, which is the entire failure mode this PR is about.)
+ * The `min` is what stops a thin-margin, high-leverage opposing book from
+ * granting unbounded capacity: 929k of short notional standing on 34k of
+ * reserved margin credits 335k, not 929k.
+ *
+ * Without this term the cap compares a NOTIONAL quantity against a MARGIN one
+ * and never looks at opposing notional at all, so a market can refuse the
+ * trade that would balance it while still accepting the trade that worsens
+ * the imbalance. Measured on prod 2026-08-31: the BTC market held 734,349
+ * long vs 928,994 short of notional — a short-heavy book — with 1,129 of long
+ * headroom against 544,752 of short headroom, and was rejecting M$110 longs.
+ */
+const calculateMatchedCredit = (
+  side: PerpDirection,
+  state: PerpState,
+  price: number
+) => {
+  const oppositeDirection = side === 'long' ? 'short' : 'long'
+  const opposing = state.positions.filter(
+    (p) => p.direction === oppositeDirection && p.size > 0
+  )
+  const openInterest = opposing.reduce((sum, p) => sum + p.size, 0)
+  const reserved = opposing.reduce(
+    (sum, p) => sum + Math.min(p.costBasis, getPositionValue(p, price)),
+    0
+  )
+  return Math.min(
+    openInterest,
+    Math.max(reserved, 0) * PERP_OPEN_INTEREST_COVER_MULTIPLE
+  )
+}
+
+/**
  * Aggregate side capacity at the current oracle price.
  *
  * `availableCover` deliberately deducts each opposite-side position's current
  * refundable value, capped at its cost basis. This is the same reserve used by
  * the ADL solvency calculation, so committed trader margin is not counted as
- * free backing for new exposure.
+ * free backing for new exposure. `matchedCredit` then adds back the exposure
+ * the opposing book funds out of its own losses — see above.
  */
 export const getPerpOpenInterestCapacity = (
   side: PerpDirection,
@@ -689,12 +796,27 @@ export const getPerpOpenInterestCapacity = (
   const availableCover = calculateAvailableCover(side, state, price)
   assertFiniteNumber(`${side} available cover`, availableCover)
 
-  const limit = Math.max(availableCover, 0) * PERP_OPEN_INTEREST_COVER_MULTIPLE
+  const matchedCredit = calculateMatchedCredit(side, state, price)
+  assertFiniteNumber(`${side} matched credit`, matchedCredit)
+
+  // The telescoping above holds only where cover is non-negative. On a book
+  // that is already short of its own reserve, cover floors at 0 while the
+  // credit keeps counting reserved value the pool does not actually hold, so
+  // bound the result explicitly: over a 1/M move this side's profit is OI/M,
+  // and the most the opposing side can ever fund is its entire pool. This is a
+  // no-op on every healthy book.
+  const opposingPool = side === 'long' ? state.pool.S : state.pool.L
+  const limit = Math.min(
+    Math.max(availableCover, 0) * PERP_OPEN_INTEREST_COVER_MULTIPLE +
+      matchedCredit,
+    Math.max(opposingPool, 0) * PERP_OPEN_INTEREST_COVER_MULTIPLE
+  )
   assertFiniteNumber(`${side} open interest limit`, limit)
 
   return {
     openInterest,
     availableCover,
+    matchedCredit,
     limit,
     headroom: Math.max(limit - openInterest, 0),
     isWithinLimit: isPerpOpenInterestWithinLimit(openInterest, limit),

--- a/common/src/perps/amm.ts
+++ b/common/src/perps/amm.ts
@@ -849,6 +849,31 @@ export const getPerpOpenInterestCapacity = (
 }
 
 /**
+ * Capacity seen by the opening leg of a trade.
+ *
+ * A flip closes the trader's opposite-side position first. That close changes
+ * both the opposing pool and the opposing open interest used by the cap, so a
+ * client preview against the unmodified book can promise headroom that the
+ * atomic engine correctly rejects after performing the close.
+ */
+export const getPerpOpenInterestCapacityForOpen = (
+  side: PerpDirection,
+  state: PerpState,
+  price: number,
+  positionToClose?: PerpPosition
+): PerpOpenInterestCapacity => {
+  // Validate before closing so a malformed row cannot disappear during the
+  // simulated transition and turn into a plausible-looking preview.
+  assertPerpStateNumbers(state, price)
+  if (positionToClose?.direction === side)
+    throw new Error('capacity preview may only close the opposite side')
+  const stateBeforeOpen = positionToClose
+    ? closePosition(state, positionToClose, price).state
+    : state
+  return getPerpOpenInterestCapacity(side, stateBeforeOpen, price)
+}
+
+/**
  * Solvency factor for a side (>= 1 means fully solvent). Used to refuse opens
  * that would immediately require ADL.
  */

--- a/web/components/perps/perp-bet-panel.tsx
+++ b/web/components/perps/perp-bet-panel.tsx
@@ -11,7 +11,7 @@ import { PerpContract } from 'common/contract'
 import {
   assertPerpPositionNumbers,
   getPerpBackingPool,
-  getPerpOpenInterestCapacity,
+  getPerpOpenInterestCapacityForOpen,
   getPositionValue,
   isPerpOpenInterestWithinLimit,
   liquidationPrice as computeLiquidationPrice,
@@ -353,16 +353,20 @@ export const PerpBetPanel = (props: {
   const capacity = useMemo(() => {
     if (positions == null) return null
     try {
-      return getPerpOpenInterestCapacity(
+      const state = {
+        pool: { L: contract.poolLong, S: contract.poolShort },
+        positions: positions.map((position) => ({
+          ...position,
+          contractId: contract.id,
+        })),
+      }
+      return getPerpOpenInterestCapacityForOpen(
         direction,
-        {
-          pool: { L: contract.poolLong, S: contract.poolShort },
-          positions: positions.map((position) => ({
-            ...position,
-            contractId: contract.id,
-          })),
-        },
-        price
+        state,
+        price,
+        isFlip && myPosition
+          ? { ...myPosition, contractId: contract.id }
+          : undefined
       )
     } catch {
       // The engine remains authoritative. Avoid turning corrupt or transiently
@@ -374,6 +378,8 @@ export const PerpBetPanel = (props: {
     contract.poolLong,
     contract.poolShort,
     direction,
+    isFlip,
+    myPosition,
     positions,
     price,
   ])

--- a/web/components/perps/perp-bet-panel.tsx
+++ b/web/components/perps/perp-bet-panel.tsx
@@ -16,7 +16,6 @@ import {
   isPerpOpenInterestWithinLimit,
   liquidationPrice as computeLiquidationPrice,
   mergedEntryPrice,
-  PERP_OPEN_INTEREST_COVER_MULTIPLE,
 } from 'common/perps/amm'
 import {
   assertPerpTakerFeeConfig,
@@ -670,8 +669,7 @@ export const PerpBetPanel = (props: {
           ) : (
             <>
               {formatMoney(capacity.headroom)} additional {direction} notional
-              capacity at the {PERP_OPEN_INTEREST_COVER_MULTIPLE}× backing
-              limit.
+              capacity at the backing limit.
             </>
           )}
         </div>

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -107,10 +107,16 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
   // sign — until the next funding tick, which reads as "backwards".
   const liveFundingRate = getPerpFundingRate(contract)
   const oracleFreshness = useOracleFreshness(contract)
+  // A solvency halt keeps the mark FRESH on purpose (see runOracleUpdate), so
+  // freshness alone no longer tells you whether the engine will accept a trade.
+  // Fold it into the same flag the panels already gate on, or the controls stay
+  // live until the API answers 503.
+  const solvencyHalted = contract.solvencyHaltTime != null
   const oracleTradingPaused =
-    !PERPS_SKIP_ORACLE_FRESHNESS &&
-    oracleFreshness != null &&
-    oracleFreshness.status !== 'fresh'
+    solvencyHalted ||
+    (!PERPS_SKIP_ORACLE_FRESHNESS &&
+      oracleFreshness != null &&
+      oracleFreshness.status !== 'fresh')
 
   return (
     <Col className="gap-4">
@@ -175,17 +181,32 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
           className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-100"
         >
           <div className="font-semibold">
-            {oracleFreshness.status === 'stale'
+            {solvencyHalted
+              ? 'Trading paused for a risk check'
+              : oracleFreshness?.status === 'stale'
               ? 'Oracle update delayed'
               : 'Oracle update unavailable'}
           </div>
-          Trading and position closes are paused to prevent execution at an
-          outdated price.{' '}
-          {oracleFreshness.ageMs != null &&
-          typeof contract.oraclePriceTime === 'number'
-            ? `The last update arrived ${fromNow(contract.oraclePriceTime)}. `
-            : 'No valid update timestamp is available. '}
-          They resume automatically after the next valid update.
+          {solvencyHalted ? (
+            <>
+              A risk update could not be applied to this market, so trading and
+              position closes are paused while it is looked at. Open positions
+              are unaffected and still settle. Trading resumes automatically
+              once the market processes its next update.
+            </>
+          ) : (
+            <>
+              Trading and position closes are paused to prevent execution at an
+              outdated price.{' '}
+              {oracleFreshness?.ageMs != null &&
+              typeof contract.oraclePriceTime === 'number'
+                ? `The last update arrived ${fromNow(
+                    contract.oraclePriceTime
+                  )}. `
+                : 'No valid update timestamp is available. '}
+              They resume automatically after the next valid update.
+            </>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Two independent perp failures. One PR because they share a root cause: **both rules compare a NOTIONAL quantity against a MARGIN one.** `pool` is margin, `OI` is notional, and each rule bridged the gap with a constant and lost information doing it.

## 1. The oracle tick can no longer wedge

**What happened.** Short profits are paid out of `pool.L` (`closePosition`: short close with π>0 → `poolLongDelta = -π`). While the longs are underwater their reserve `Σ min(costBasis, value)` is depressed, so those payouts pass the solvency check — but the reserve grows back toward `Σ costBasis` when the price mean-reverts, and the mana has already left. `pool.L` is then below the long book's own refundable margin.

ADL cannot repair that. It scales profits and never cost bases, so the factor clamps to 0, the winners are settled and removed, and the deficit is still there with no profit left to scale. `assertPerpStateSolvent` sees `-Infinity`, the whole transaction rolls back, and the cached mark never advances — so every subsequent tick re-derives the identical failure from the identical state. Permanent, until an operator intervenes.

Twice in production, 12 hours dark each:

| | market | pools | deficit |
|---|---|---|---|
| 2026-08-07 | `uk-grid-carbon-intensity-gcokwh` | S below Σ short cb | −442 |
| 2026-08-29 | `openweight-ai-token-share-on-openro` | L 22,357 vs Σ long cb 28,485 | −6,128 |

On the second one, 36,344 of short profit had been paid out of `L` over the market's life against only 8,953 of *realized* long losses. The other 27,391 was funded by paper.

**Two changes, in order of how much they carry:**

**(a) Cross-side deficit transfer, in `applyADL`.** `assertPerpEscrowBalance` checks `L + S` against one contract balance, so the split is an accounting convention, not a custody boundary. Before pricing ADL, if one side is short of its own reserve and the other holds at least that much spare, move the deficit across. Total escrow conserved, no user balance moves. On the OpenRouter book `S` was carrying 29,068 of unreserved surplus while `L` was 6,128 short — the mana to fix it was already inside the contract.

All-or-nothing on purpose: a partial transfer can't make the book representable (the recipient's cover is still negative, the assert still throws) but it *would* change the ADL factors on the way to that throw, and a donor drained to exactly zero pushes the opposing factor to 0, settling a position against a pool that can't pay it. Restricting to full coverage means this can only ever turn a throw into a success, never reshape a path that was going to fail anyway. The tests caught this — the first version had the partial behaviour.

A covered book transfers exactly zero, so this is inert on every market that wasn't already wedged.

**(b) Liveness: `runOracleUpdate` always commits the price.** If the state still can't be represented, the tick writes the price plus `solvencyHaltTime`/`solvencyHaltReason` and nothing else — no pools, positions, events, or metrics.

A frozen mark is strictly worse than the state it refuses to write. It's wrong on the screen, it grows the deficit it's failing on, and it leaves trading **open** against a dead price for a full `maxOraclePriceAgeMs` — on 2026-08-29 a trader added to a position at 03:59Z against a mark that died at 00:50Z. The staleness "protection" was an accident of the failure, not a decision.

Since the mark now stays fresh, that implicit protection is gone by construction, so `assertPerpNotSolvencyHalted` gates opens **and** closes explicitly. Scheduler exits (liquidation, ADL, resolution) use the internal paths and are unaffected, so positions still settle. `add-perp-subsidy` is deliberately not gated — it's the rescue tool, and the first tick that applies cleanly clears the halt, so topping up the deficit side is the whole runbook.

Both callers log the halt with their own prefix (`[oracle-feeds]` / `[update-perps]`), so the existing GCP alert policies page exactly as they did when this threw.

*Accepted tradeoff:* pending liquidations and ADL stay pending across a halt and are re-derived at the next tick's price. A position whose liquidation is deferred that way can escape it on a rebound — a real but bounded transfer, against the alternative of a market dark for hours, with trading halted throughout so nobody can act on the gap.

## 2. A short-heavy book can take a long

The cap rationed a side's notional against the opposing **pool** and never looked at opposing **notional** at all. Measured on prod 2026-08-31:

```
long OI   734,348.81      short OI   928,994.19    ← short-heavy by 194,645
pool.L    181,363.42      pool.S     107,092.07

long headroom     1,128.63
short headroom  544,752.23
```

It refused the trade that would balance the book and freely accepted 545k more of the trade that worsened it. Live rejections: a **M$110** notional long on 8/30, M$6,900 on 8/28 — with an error telling the user to *"wait for more short interest to raise the cap"* while short interest was already 195k larger. Pool ratio read 1.69 long-heavy; OI ratio read 0.79 long-heavy. The cap was reading the wrong one.

**Fix — credit the opposing side what it funds out of its own losses.** Over an adverse move of `x = 1/M`:

```
this side's profit   ≈ x · OI(side)
opposing side's loss ≈ x · OI(opp), capped at R(opp) — they liquidate, and
                       that margin is forfeited INTO the pool that pays us
net drain            ≈ x · OI(side) − min(x · OI(opp), R(opp))
```

Requiring `net drain ≤ availableCover` and multiplying by `M`:

```
OI(side) ≤ M · availableCover + min(OI(opp), M · R(opp))
```

The old rule is that with the second term set to zero. `R` is `min(costBasis, positionValue)` — deliberately the *same* reserved quantity `availableCover` deducts, not raw cost basis, which is what makes the terms telescope to at most `M × opposing pool`. (Raw cb has no such bound: on a wedged book `Σ cb` exceeds the pool, which is failure #1.) A final `min` enforces that ceiling directly for books whose cover has already gone negative.

BTC under the new rule: limit 735,477 → 1,070,921, long headroom 1,129 → ~336,572. The `min` is what stops a thin-margin book granting unbounded capacity — 929k of short notional on 34k of reserved margin credits 335k, not 929k.

Strictly a loosening. With no opposing positions it's identical to today, so **no market gets tighter.**

## Explicitly not in this PR

**Reserving at full cost basis.** That's the fix that stops principal being spent against an opposing side's unrealized loss *in the first place*, rather than letting the pot honour the resulting claim from its own surplus. It's the honest fix and it's what makes "markets without growing subsidy" reachable — but it materially lowers profit capacity on every live market, so it changes the economics of things people already have open. It deserves its own PR and its own argument. Documented in the README section so the decision is on the record rather than forgotten.

Also not here: funding is levied on margin while the imbalance it corrects is in notional, which under-prices high-leverage crowding by roughly the leverage ratio. Separate issue. (Funding keying and sign are both *correct* — I checked: keyed on OI at `engine.ts:1960`, and BTC's 390k-long-vs-51k-short book was correctly paying a positive rate.)

## Testing

- `common` — 769 pass (36 suites), including 8 new `applyADL` cross-side-transfer cases and 4 new capacity cases.
- `backend/shared` — 29 pass (4 suites). Run explicitly because its ts-jest transpiles imported `common/src` under ES2017 and can fail where `tsc -b` passes.
- `tsc` clean: `backend/api -b`, `backend/scheduler -b`, `web --noEmit`.

Three existing capacity assertions moved deliberately — they encode the old limit — and are updated in place with the reasoning. Two guard tests are worth a look on review: *"is load-bearing: the book is unrepresentable without it"* pins the premise of the whole transfer block, and *"never promises more than the whole opposing pool"* pins the ceiling.

## Deploy

No migration — `solvencyHaltTime`/`solvencyHaltReason` are `contracts.data` jsonb fields, absent on every existing row and read as "not halted".

API and scheduler both carry engine changes, so ship them on the **same SHA**. Order doesn't matter: the capacity change is a pure loosening, and the halt fields are only written by the scheduler and only read by the API.

The OpenRouter market has already self-healed (mark advanced 8/29 23:50Z, pools L=34,470 / S=40,239, long headroom +3,985), so nothing here is racing a live incident.
