### PR TITLE
feat(perps): five new oracle feeds (VoteHub x2, Crypto Fear & Greed, OpenRouter lab share x2)

### DIFF
--- a/backend/api/src/openrouter-lab-classifications.ts
+++ b/backend/api/src/openrouter-lab-classifications.ts
@@ -1,0 +1,168 @@
+import { CHINESE_LAB_LIST_VERSION } from 'common/perps/lab-share'
+import { throwErrorIfNotMod } from 'shared/helpers/auth'
+import {
+  LabClassificationRow,
+  getLabClassificationRows,
+  upsertLabClassification,
+  validateLabClassificationWrite,
+} from 'shared/perps/lab-classifications'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+import { APIError, APIHandler } from './helpers/endpoint'
+
+// Human adjudication for the Chinese-lab OpenRouter index. This is deliberately
+// separate from the weights classifier: the latter decides whether one model's
+// weights are downloadable, while this queue decides where an author is
+// headquartered (or attributes one anonymous model after its reveal).
+
+const evidenceRecords = (
+  evidence: Record<string, unknown>
+): Record<string, unknown>[] => {
+  const history = evidence['history']
+  const historical = !Array.isArray(history)
+    ? []
+    : history
+        .slice()
+        .reverse()
+        .flatMap((entry): Record<string, unknown>[] => {
+          if (!entry || typeof entry !== 'object') return []
+          const nested = (entry as Record<string, unknown>)['evidence']
+          return nested && typeof nested === 'object' && !Array.isArray(nested)
+            ? [nested as Record<string, unknown>]
+            : []
+        })
+  return [evidence, ...historical]
+}
+
+const firstEvidenceString = (
+  row: LabClassificationRow,
+  key: string
+): string | null => {
+  for (const evidence of evidenceRecords(row.evidence)) {
+    const value = evidence[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+const allEvidenceStrings = (
+  row: LabClassificationRow,
+  keys: string[]
+): string[] => {
+  const values = new Set<string>()
+  for (const evidence of evidenceRecords(row.evidence)) {
+    for (const key of keys) {
+      const value = evidence[key]
+      if (typeof value === 'string' && value.trim()) values.add(value.trim())
+      if (Array.isArray(value))
+        for (const entry of value)
+          if (typeof entry === 'string' && entry.trim())
+            values.add(entry.trim())
+    }
+  }
+  return [...values]
+}
+
+const rowContext = (row: LabClassificationRow) => ({
+  exampleModels:
+    row.subject_type === 'model'
+      ? [row.subject_slug]
+      : allEvidenceStrings(row, ['relatedPermaslugs']),
+  exampleNames: allEvidenceStrings(row, ['openRouterName', 'openRouterNames']),
+})
+
+const isEditableRow = (row: LabClassificationRow) => {
+  // Apply the shared scope rules on read as well as write. That hides malformed
+  // legacy rows, seeded subjects, broad `stealth` author rows, and dangerous
+  // exact-model rows under ordinary corporate authors.
+  return validateLabClassificationWrite(row.subject_type, row.subject_slug).ok
+}
+
+const timestamp = (value: string): number => {
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export const getOpenRouterLabClassifications: APIHandler<
+  'get-openrouter-lab-classifications'
+> = async (_, auth) => {
+  throwErrorIfNotMod(auth.uid)
+  const rows = (
+    await getLabClassificationRows(createSupabaseDirectClient())
+  ).filter(isEditableRow)
+
+  return {
+    pending: rows
+      .filter((row) => row.is_chinese === null)
+      .map((row) => ({
+        subjectType: row.subject_type,
+        subjectSlug: row.subject_slug,
+        discoveredVia: firstEvidenceString(row, 'discoveredVia'),
+        ...rowContext(row),
+        firstSeen: timestamp(row.first_seen),
+        firstRankedAt: row.first_ranked_at
+          ? timestamp(row.first_ranked_at)
+          : null,
+      })),
+    decided: rows
+      .filter(
+        (row): row is LabClassificationRow & { is_chinese: boolean } =>
+          row.is_chinese !== null
+      )
+      .map((row) => ({
+        subjectType: row.subject_type,
+        subjectSlug: row.subject_slug,
+        isChinese: row.is_chinese,
+        evidence:
+          firstEvidenceString(row, 'evidence') ??
+          firstEvidenceString(row, 'summary') ??
+          '',
+        sourceUrl: firstEvidenceString(row, 'sourceUrl'),
+        ...rowContext(row),
+        source: row.source,
+        classifiedAt: row.classified_at ? timestamp(row.classified_at) : 0,
+        classifiedBy: row.classified_by,
+      }))
+      .sort((a, b) => b.classifiedAt - a.classifiedAt),
+    seedVersion: CHINESE_LAB_LIST_VERSION,
+  }
+}
+
+export const setOpenRouterLabClassification: APIHandler<
+  'set-openrouter-lab-classification'
+> = async (body, auth) => {
+  throwErrorIfNotMod(auth.uid)
+
+  const validation = validateLabClassificationWrite(
+    body.subjectType,
+    body.subjectSlug
+  )
+  if (!validation.ok)
+    throw new APIError(
+      400,
+      `${validation.reason} (audited seed version ${CHINESE_LAB_LIST_VERSION})`
+    )
+  const subjectSlug = validation.subjectSlug
+
+  await upsertLabClassification(createSupabaseDirectClient(), {
+    subjectType: body.subjectType,
+    subjectSlug,
+    isChinese: body.isChinese,
+    evidence: {
+      evidence: body.evidence.trim(),
+      sourceUrl: body.sourceUrl.trim(),
+    },
+    classifiedBy: auth.uid,
+  })
+
+  log(
+    `mod ${auth.uid} classified OpenRouter ${body.subjectType} ${subjectSlug} ` +
+      `as ${body.isChinese ? 'Chinese' : 'non-Chinese'} (${body.sourceUrl})`
+  )
+  return {
+    success: true as const,
+    subjectType: body.subjectType,
+    subjectSlug,
+    isChinese: body.isChinese,
+  }
+}

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -79,6 +79,10 @@ import {
   getModelClassifications,
   setModelClassification,
 } from './model-classifications'
+import {
+  getOpenRouterLabClassifications,
+  setOpenRouterLabClassification,
+} from './openrouter-lab-classifications'
 import { getOraclePrice, getOraclePriceSeries } from './get-oracle-price'
 import { getKnownOracleFeeds } from './get-known-oracle-feeds'
 import { internalWriteOraclePrice } from './internal-write-oracle-price'
@@ -457,6 +461,8 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'add-perp-subsidy': addPerpSubsidy,
   'get-model-classifications': getModelClassifications,
   'set-model-classification': setModelClassification,
+  'get-openrouter-lab-classifications': getOpenRouterLabClassifications,
+  'set-openrouter-lab-classification': setOpenRouterLabClassification,
   'get-oracle-price': getOraclePrice,
   'get-oracle-price-series': getOraclePriceSeries,
   'get-known-oracle-feeds': getKnownOracleFeeds,

--- a/backend/scheduler/src/jobs/daily-feed-failure.ts
+++ b/backend/scheduler/src/jobs/daily-feed-failure.ts
@@ -19,6 +19,11 @@ import { log } from 'shared/utils'
 //      retry is no longer the fix, every failure is an ERROR and none are
 //      throttled: a feed that has gone stale is the one thing here worth
 //      paging on every time it is observed.
+//   3. A feed that has NEVER published is also an ERROR — a wrong source key
+//      on a freshly deployed feed is a real fault — but throttled to one an
+//      hour: nothing is marking against an ageing price yet, and the hourly
+//      `[oracle-feeds]` staleness probe already covers it, so twelve pages
+//      an hour would only bury the one that says why.
 //
 // State is in-memory, so a scheduler restart re-logs immediately — which is
 // the behaviour you want.
@@ -85,20 +90,21 @@ export const reportDailyFeedFailure = async (
   // once an hour for one outage. Escalate only once the feed itself has gone
   // long enough without a point that the next retry is no longer the fix.
   const ageMs = await getAgeOfLatestPoint(pg, feedId)
-  const stale = ageMs == null || ageMs >= staleErrorMs
+  const neverPublished = ageMs == null
+  const stale = neverPublished || ageMs >= staleErrorMs
   // Throttle, but never throttle away the escalation: a feed that has gone
   // stale is the one thing here worth paging on every time it is observed.
+  // The never-published case is the exception (rule 3 above): it pages, but
+  // once an hour.
   const now = Date.now()
-  if (
-    !stale &&
+  const throttled =
     now - (lastFailureLog[feedId] ?? 0) < DAILY_FEED_FAILURE_LOG_INTERVAL_MS
-  )
-    return
+  if ((!stale || neverPublished) && throttled) return
   lastFailureLog[feedId] = now
   if (stale)
     log.error(
       `${message}; last point ${
-        ageMs == null ? 'never' : `${Math.round(ageMs / HOUR_MS)}h ago`
+        neverPublished ? 'never' : `${Math.round(ageMs / HOUR_MS)}h ago`
       }, feed is going stale`
     )
   else log.warn(`${message}; ${retryHint}`)

--- a/backend/scheduler/src/jobs/daily-feed-failure.ts
+++ b/backend/scheduler/src/jobs/daily-feed-failure.ts
@@ -1,0 +1,105 @@
+import { HOUR_MS } from 'common/util/time'
+
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+
+// Failure reporting shared by the slow-feed publisher jobs (Trump approval,
+// the other VoteHub averages, Fear & Greed). Each of those polls its source
+// every few minutes and publishes on change, so a source outage produces one
+// failed attempt per firing; this module decides which of those attempts is
+// worth a log line and at what severity.
+//
+// Two rules, both keyed per feed:
+//
+//   1. Retryable failures are WARN and throttled to one an hour. At a
+//      5-minute cadence an outage that used to produce one line an hour would
+//      produce 288 a day. The feed's own staleness alerting is the durable
+//      signal; these lines exist to say why, so one an hour is plenty.
+//   2. Once the feed has gone long enough without a point that the next
+//      retry is no longer the fix, every failure is an ERROR and none are
+//      throttled: a feed that has gone stale is the one thing here worth
+//      paging on every time it is observed.
+//
+// State is in-memory, so a scheduler restart re-logs immediately — which is
+// the behaviour you want.
+
+/** Retryable failures are logged at most this often per feed. */
+export const DAILY_FEED_FAILURE_LOG_INTERVAL_MS = HOUR_MS
+
+/**
+ * How long a feed may go without a published point before a failed attempt
+ * is an ERROR rather than a retryable blip.
+ *
+ * Replaces the old "is this the last firing of the day?" test, which only
+ * made sense when the Trump job published once daily. With publication on
+ * change the question that matters is not what time it is, it is how long
+ * the market has been marking against an ageing price. Set below every daily
+ * feed's 26h staleAfterMs so the page arrives before the staleness alert,
+ * not after it.
+ */
+export const DAILY_FEED_STALE_ERROR_MS = 20 * HOUR_MS
+
+const lastFailureLog: Record<string, number> = {}
+
+/** How long since the feed last got a point, or null if it never has. */
+export const getAgeOfLatestPoint = async (
+  pg: SupabaseDirectClient,
+  feedId: string
+): Promise<number | null> => {
+  const row = await pg.oneOrNone<{ ts: string }>(
+    `select ts from oracle_prices where feed_id = $1 order by ts desc limit 1`,
+    [feedId]
+  )
+  if (!row) return null
+  const ts = new Date(row.ts).getTime()
+  return Number.isFinite(ts) ? Date.now() - ts : null
+}
+
+export const reportDailyFeedFailure = async (
+  pg: SupabaseDirectClient,
+  args: {
+    feedId: string
+    /**
+     * Everything before "publish failed" — the bracketed alert prefix, plus
+     * the feed id where one prefix covers several feeds (`[votehub]
+     * vance-favorability`). GCP alert policies match on the prefix.
+     */
+    label: string
+    day: string
+    reason: string
+    staleErrorMs?: number
+    retryHint?: string
+  }
+) => {
+  const {
+    feedId,
+    label,
+    day,
+    reason,
+    staleErrorMs = DAILY_FEED_STALE_ERROR_MS,
+    retryHint = 'retrying in 5 minutes',
+  } = args
+  const message = `${label} publish failed for ${day} — ${reason}`
+  // Feed staleness is alerted on separately by update-perps and
+  // update-oracle-feeds, so a retryable attempt stays at WARN to avoid paging
+  // once an hour for one outage. Escalate only once the feed itself has gone
+  // long enough without a point that the next retry is no longer the fix.
+  const ageMs = await getAgeOfLatestPoint(pg, feedId)
+  const stale = ageMs == null || ageMs >= staleErrorMs
+  // Throttle, but never throttle away the escalation: a feed that has gone
+  // stale is the one thing here worth paging on every time it is observed.
+  const now = Date.now()
+  if (
+    !stale &&
+    now - (lastFailureLog[feedId] ?? 0) < DAILY_FEED_FAILURE_LOG_INTERVAL_MS
+  )
+    return
+  lastFailureLog[feedId] = now
+  if (stale)
+    log.error(
+      `${message}; last point ${
+        ageMs == null ? 'never' : `${Math.round(ageMs / HOUR_MS)}h ago`
+      }, feed is going stale`
+    )
+  else log.warn(`${message}; ${retryHint}`)
+}

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -71,6 +71,7 @@ import { updateClassificationAudit } from './update-classification-audit'
 import { updateModelClassifications } from './update-model-classifications'
 import { updateTrumpApproval } from './update-trump-approval'
 import { updateVoteHubAverages } from './update-votehub-averages'
+import { updateFearGreed } from './update-fear-greed'
 import { resolveSportsMarkets } from './sports-resolve'
 import { createUpcomingSportsMarkets } from './sports-create-markets'
 import { pollSportsLiveScores } from './sports-live'
@@ -89,6 +90,7 @@ const PERP_JOB_NAMES = new Set([
   'update-openrouter-share',
   'update-trump-approval',
   'update-votehub-averages',
+  'update-fear-greed',
 ])
 
 export function getSchedulerJobSet(): SchedulerJobSet {
@@ -418,6 +420,15 @@ export function createJobs(jobSet: SchedulerJobSet) {
       // feeds alert under `[votehub]`.
       '0 2-59/5 * * * *',
       updateVoteHubAverages
+    ),
+    createJob(
+      'update-fear-greed',
+      // Alternative.me's Crypto Fear & Greed index steps once a day around
+      // 00:00 UTC; polling every 5 minutes bounds how long the new daily
+      // value is public before it is the market's mark. Offset from the two
+      // VoteHub jobs so the three slow-feed publishers never fire together.
+      '0 3-59/5 * * * *',
+      updateFearGreed
     ),
     createJob(
       'onboarding-notification',

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -70,6 +70,7 @@ import { updateOpenRouterShare } from './update-openrouter-share'
 import { updateClassificationAudit } from './update-classification-audit'
 import { updateModelClassifications } from './update-model-classifications'
 import { updateTrumpApproval } from './update-trump-approval'
+import { updateVoteHubAverages } from './update-votehub-averages'
 import { resolveSportsMarkets } from './sports-resolve'
 import { createUpcomingSportsMarkets } from './sports-create-markets'
 import { pollSportsLiveScores } from './sports-live'
@@ -87,6 +88,7 @@ const PERP_JOB_NAMES = new Set([
   'update-oracle-feeds',
   'update-openrouter-share',
   'update-trump-approval',
+  'update-votehub-averages',
 ])
 
 export function getSchedulerJobSet(): SchedulerJobSet {
@@ -405,6 +407,17 @@ export function createJobs(jobSet: SchedulerJobSet) {
       // publicly visible while the market still traded on the old mark.
       '0 */5 * * * *',
       updateTrumpApproval
+    ),
+    createJob(
+      'update-votehub-averages',
+      // The other VoteHub averages (2026 generic ballot, Vance favorability).
+      // Same 5-minute cadence and the same max-age=300 reasoning as the Trump
+      // job above, offset by two minutes so the two never hit VoteHub in the
+      // same instant. A separate job because the Trump job's name and
+      // `[trump-approval]` prefix are what the alert policies key on; these
+      // feeds alert under `[votehub]`.
+      '0 2-59/5 * * * *',
+      updateVoteHubAverages
     ),
     createJob(
       'onboarding-notification',

--- a/backend/scheduler/src/jobs/update-fear-greed.ts
+++ b/backend/scheduler/src/jobs/update-fear-greed.ts
@@ -1,0 +1,40 @@
+import { CRYPTO_FEAR_GREED_FEED_ID } from 'shared/oracle'
+import {
+  fearGreedDay,
+  publishFearGreedPoint,
+} from 'shared/perps/publish-fear-greed'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { reportDailyFeedFailure } from './daily-feed-failure'
+
+// Publishes points for the `crypto-fear-greed` feed from Alternative.me.
+//
+// Runs EVERY 5 MINUTES and publishes whenever the value moves, plus a 12h
+// heartbeat — see decideDailyFeedPublish. The index itself steps once a day
+// around 00:00 UTC, so almost every firing is a silent `unchanged`; the
+// cadence exists to bound the window in which the new daily value is public
+// on alternative.me but not yet the market's mark. That window is at most
+// one poll, which is the whole latency exposure of this feed.
+//
+// Failure reporting is the shared throttled-WARN / stale-ERROR rule in
+// daily-feed-failure.ts, under the `[fear-greed]` prefix the GCP alert
+// policy matches on. A thrown fetch/parse error and a returned rejection
+// are reported the same way; neither is logged inside the publisher.
+export const updateFearGreed = async () => {
+  const pg = createSupabaseDirectClient()
+  const today = fearGreedDay()
+  const report = (reason: string) =>
+    reportDailyFeedFailure(pg, {
+      feedId: CRYPTO_FEAR_GREED_FEED_ID,
+      label: '[fear-greed]',
+      day: today,
+      reason,
+    })
+
+  try {
+    const result = await publishFearGreedPoint(pg)
+    if (result.status === 'published' || result.status === 'unchanged') return
+    await report(result.reason)
+  } catch (err) {
+    await report(`${err}`)
+  }
+}

--- a/backend/scheduler/src/jobs/update-model-classifications.ts
+++ b/backend/scheduler/src/jobs/update-model-classifications.ts
@@ -15,6 +15,10 @@ import {
 } from 'shared/perps/model-classifications'
 import { classifyModelWithAgent } from 'shared/perps/classify-model-agent'
 import {
+  recordPendingLabSubjectsFromCatalog,
+  resolveLabClassifications,
+} from 'shared/perps/lab-classifications'
+import {
   fetchOpenRouterCatalog,
   OpenRouterCatalogEntry,
 } from 'shared/openrouter-tokens'
@@ -75,6 +79,25 @@ const updateModelClassificationsInternal = async () => {
   const pg = createSupabaseDirectClient()
 
   const catalog = await fetchOpenRouterCatalog()
+
+  // The same catalog fetch also supplies the Chinese-lab author queue. Do
+  // this before the model classifier's early return: an author such as
+  // nex-agi can be new to the lab index even when all of its models already
+  // have open-weight verdicts. Live rankings provide a second discovery path.
+  try {
+    const labClassifications = await resolveLabClassifications(pg)
+    await recordPendingLabSubjectsFromCatalog(
+      pg,
+      catalog,
+      Date.now(),
+      labClassifications
+    )
+  } catch (err) {
+    // This queue is operationally independent of the open-weight model
+    // classifier. A migration/config bug here must not suppress model work.
+    log.error(`[lab-classifier] catalog discovery failed — ${err}`)
+  }
+
   const adjudicated = await pg.manyOrNone<{ permaslug: string }>(
     `select permaslug from model_classifications where open is not null`
   )

--- a/backend/scheduler/src/jobs/update-openrouter-share.ts
+++ b/backend/scheduler/src/jobs/update-openrouter-share.ts
@@ -1,4 +1,10 @@
 import {
+  CHINESE_LAB_LIST_VERSION,
+  LabShareFeed,
+  computeLabShare,
+  validateLabSharePublication,
+} from 'common/perps/lab-share'
+import {
   computeOpenWeightShare,
   OPEN_WEIGHT_LIST_VERSION,
   OPEN_WEIGHT_WINDOW_DAYS,
@@ -9,13 +15,21 @@ import {
   recordUnclassifiedInRankings,
   resolveModelClassifications,
 } from 'shared/perps/model-classifications'
-import { fetchOpenRouterRankings } from 'shared/openrouter-tokens'
 import {
+  OpenRouterRankings,
+  fetchOpenRouterRankings,
+} from 'shared/openrouter-tokens'
+import {
+  OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+  OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
   insertOraclePrices,
 } from 'shared/oracle'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
-import { createSupabaseDirectClient } from 'shared/supabase/init'
+import {
+  SupabaseDirectClient,
+  createSupabaseDirectClient,
+} from 'shared/supabase/init'
 import { log } from 'shared/utils'
 import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
 
@@ -43,6 +57,16 @@ import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
 // though points are written hourly. The 7-day window dilutes that step ~7x.
 // We do not manufacture intraday movement to paper over this; a synthesised
 // price on a market people trade would be worse than a visible step.
+//
+// THREE INDEXES, ONE FETCH. The same payload also prices the Anthropic-share
+// and Chinese-lab-share feeds (common/perps/lab-share.ts): they use the same
+// window and the same denominator exclusions, so computing them here costs
+// zero additional OpenRouter calls against the 500/day account limit (this
+// job spends 24). Each feed is published INDEPENDENTLY through the same
+// validate → insert → apply sequence, with the previous point read per feed:
+// a refusal or a thrown error on one feed must never withhold the others,
+// and each has its own registry entry, bounds and market. The open-weight
+// path is unchanged; its log lines are kept verbatim.
 export const updateOpenRouterShare = async () => {
   try {
     await updateOpenRouterShareInternal()
@@ -65,7 +89,48 @@ const updateOpenRouterShareInternal = async () => {
     log.error('[openrouter] response has no valid meta.as_of — skipping')
     return
   }
+  const sourceTs = Date.parse(rankings.asOf)
 
+  await guarded('open-weight share', () =>
+    publishOpenWeightShare(pg, rankings, now, sourceTs)
+  )
+  await guarded('anthropic share', () =>
+    publishLabShare(
+      pg,
+      'anthropic',
+      OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+      rankings,
+      now,
+      sourceTs
+    )
+  )
+  await guarded('chinese-lab share', () =>
+    publishLabShare(
+      pg,
+      'chinese-lab',
+      OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
+      rankings,
+      now,
+      sourceTs
+    )
+  )
+}
+
+/** One feed's failure is that feed's ERROR line, not the tick's. */
+const guarded = async (label: string, run: () => Promise<void>) => {
+  try {
+    await run()
+  } catch (err) {
+    log.error(`[openrouter] ${label} failed — ${err}`)
+  }
+}
+
+const publishOpenWeightShare = async (
+  pg: SupabaseDirectClient,
+  rankings: OpenRouterRankings,
+  now: number,
+  sourceTs: number
+) => {
   // Seed list plus any operator/auto overrides that landed since the last
   // deploy, so a classification takes effect on the next tick rather than the
   // next release.
@@ -89,7 +154,7 @@ const updateOpenRouterShareInternal = async () => {
   // has one: an exclusion nobody can see is indistinguishable from full
   // coverage, and if one ever carries real volume that is the signal to
   // resolve it through OpenRouter's `alias_target` rather than keep dropping
-  // it.
+  // it. Logged once here for all three indexes: they share the exclusion.
   if (result.compositeSlugs.length > 0)
     log.warn(
       `[openrouter] excluded ${result.compositeSlugs.length} router/alias slug(s) ` +
@@ -120,18 +185,81 @@ const updateOpenRouterShareInternal = async () => {
       )}pp)`
     )
 
-  const point = {
-    ts: now,
-    price: publication.share,
-    sourceTs: Date.parse(rankings.asOf),
+  await publishOpenRouterPoint(
+    pg,
+    OPENROUTER_OPEN_WEIGHT_FEED_ID,
+    'open-weight share',
+    publication.share,
+    now,
+    sourceTs,
+    `over ${result.dates[0]}..${result.dates[result.dates.length - 1]} ` +
+      `(${result.dates.length}d, as_of ${rankings.asOf}, classification ${OPEN_WEIGHT_LIST_VERSION})`
+  )
+}
+
+const publishLabShare = async (
+  pg: SupabaseDirectClient,
+  feed: LabShareFeed,
+  feedId: string,
+  rankings: OpenRouterRankings,
+  now: number,
+  sourceTs: number
+) => {
+  const label = feed === 'anthropic' ? 'anthropic share' : 'chinese-lab share'
+  const result = computeLabShare(feed, rankings.rows, OPEN_WEIGHT_WINDOW_DAYS)
+
+  const publication = validateLabSharePublication(result)
+  if (!publication.ok) {
+    // For the Chinese-lab feed the reason names the unknown author(s), their
+    // share of tokens, and the two constants one of which needs a line. That
+    // is the whole maintenance path (see lab-share.ts), so it pages.
+    log.error(`[openrouter] ${label} halted — ${publication.reason}`)
+    return
   }
-  const feed = getOracleFeed(OPENROUTER_OPEN_WEIGHT_FEED_ID)
-  // Fetch the previous point so validateOraclePoint can enforce strictly
-  // increasing timestamps against what is already stored.
+  if (publication.unknownAuthors.length > 0)
+    log.warn(
+      `[openrouter] ${label} publishing with unknown author(s) ` +
+        `${publication.unknownAuthors.join(', ')} excluded from both sides (${(
+          publication.unknownShareOfClassified * 100
+        ).toFixed(3)}% of classified tokens); ` +
+        `add to CHINESE_LAB_AUTHORS or KNOWN_NON_CHINESE_AUTHORS`
+    )
+
+  await publishOpenRouterPoint(
+    pg,
+    feedId,
+    label,
+    publication.share,
+    now,
+    sourceTs,
+    `over ${result.dates[0]}..${result.dates[result.dates.length - 1]} ` +
+      `(${result.dates.length}d, as_of ${rankings.asOf}, authors ${CHINESE_LAB_LIST_VERSION}; ` +
+      `other ${result.otherTokens.toExponential(3)} and composite ` +
+      `${result.compositeTokens.toExponential(3)} tokens excluded)`
+  )
+}
+
+/**
+ * The validate → insert → apply sequence, per feed. Fetches the previous
+ * point so validateOraclePoint can enforce strictly increasing timestamps
+ * against what is already stored; `sourceTs` is mandatory for these feeds
+ * (insertOraclePrices refuses a point without it, per OpenRouter's terms).
+ */
+const publishOpenRouterPoint = async (
+  pg: SupabaseDirectClient,
+  feedId: string,
+  label: string,
+  share: number,
+  now: number,
+  sourceTs: number,
+  detail: string
+) => {
+  const point = { ts: now, price: share, sourceTs }
+  const feed = getOracleFeed(feedId)
   const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
     `select ts, price from oracle_prices where feed_id = $1
      order by ts desc limit 1`,
-    [OPENROUTER_OPEN_WEIGHT_FEED_ID]
+    [feedId]
   )
   const rejection = feed
     ? validateOraclePoint(
@@ -141,23 +269,15 @@ const updateOpenRouterShareInternal = async () => {
           : null,
         point
       )
-    : `missing OracleFeedDef for ${OPENROUTER_OPEN_WEIGHT_FEED_ID}`
+    : `missing OracleFeedDef for ${feedId}`
   if (rejection) {
     log.error(
-      `[openrouter] rejected share ${publication.share.toFixed(
-        3
-      )} — ${rejection}`
+      `[openrouter] rejected ${label} ${share.toFixed(3)} — ${rejection}`
     )
     return
   }
 
-  await insertOraclePrices(pg, OPENROUTER_OPEN_WEIGHT_FEED_ID, [point])
-  await applyOraclePointToLivePerps(pg, OPENROUTER_OPEN_WEIGHT_FEED_ID, point)
-  log(
-    `[openrouter] inserted ${publication.share.toFixed(
-      3
-    )}% open-weight share ` +
-      `over ${result.dates[0]}..${result.dates[result.dates.length - 1]} ` +
-      `(${result.dates.length}d, as_of ${rankings.asOf}, classification ${OPEN_WEIGHT_LIST_VERSION})`
-  )
+  await insertOraclePrices(pg, feedId, [point])
+  await applyOraclePointToLivePerps(pg, feedId, point)
+  log(`[openrouter] inserted ${share.toFixed(3)}% ${label} ${detail}`)
 }

--- a/backend/scheduler/src/jobs/update-openrouter-share.ts
+++ b/backend/scheduler/src/jobs/update-openrouter-share.ts
@@ -17,6 +17,10 @@ import {
   resolveModelClassifications,
 } from 'shared/perps/model-classifications'
 import {
+  recordUnclassifiedLabSubjectsInRankings,
+  resolveLabClassifications,
+} from 'shared/perps/lab-classifications'
+import {
   OpenRouterRankings,
   fetchOpenRouterRankings,
 } from 'shared/openrouter-tokens'
@@ -222,24 +226,61 @@ const publishLabShare = async (
   sourceTs: number
 ) => {
   const label = feed === 'anthropic' ? 'anthropic share' : 'chinese-lab share'
-  const result = computeLabShare(feed, rankings.rows, OPEN_WEIGHT_WINDOW_DAYS)
+  // Anthropic is an exact author comparison and needs no classification
+  // state. Chinese-lab placements are the audited seed plus operator rows,
+  // resolved on every tick so a queue decision takes effect without a deploy.
+  const classifications =
+    feed === 'chinese-lab' ? await resolveLabClassifications(pg) : undefined
+  const result = computeLabShare(
+    feed,
+    rankings.rows,
+    OPEN_WEIGHT_WINDOW_DAYS,
+    classifications
+  )
+
+  // Rankings are the authoritative fallback discovery surface: OpenRouter can
+  // rank a model that is absent from /models. Record before validation so the
+  // same tick that warns or halts also creates the operator's remedy.
+  if (
+    feed === 'chinese-lab' &&
+    (result.unknownAuthors.length > 0 || result.unknownModels.length > 0)
+  )
+    await recordUnclassifiedLabSubjectsInRankings(
+      pg,
+      {
+        unknownAuthors: result.unknownAuthors,
+        unknownModels: result.unknownModels,
+      },
+      now
+    )
 
   const publication = validateLabSharePublication(result)
   if (!publication.ok) {
-    // For the Chinese-lab feed the reason names the unknown author(s), their
-    // share of tokens, and the two constants one of which needs a line. That
-    // is the whole maintenance path (see lab-share.ts), so it pages.
+    // For the Chinese-lab feed the reason names every pending author/model
+    // and its aggregate token share. The queue row was written above, so the
+    // error points at work an operator can clear without a deploy.
     log.error(`[openrouter] ${label} halted — ${publication.reason}`)
     return
   }
-  if (publication.unknownAuthors.length > 0)
+  if (
+    publication.unknownAuthors.length > 0 ||
+    publication.unknownModels.length > 0
+  )
     log.warn(
-      `[openrouter] ${label} publishing with unknown author(s) ` +
-        `${publication.unknownAuthors.join(', ')} excluded from both sides (${(
+      `[openrouter] ${label} publishing with pending subject(s) ` +
+        `${[
+          ...publication.unknownAuthors.map((author) => `author:${author}`),
+          ...publication.unknownModels.map((model) => `model:${model}`),
+        ].join(', ')} excluded from both sides (${(
           publication.unknownShareOfClassified * 100
         ).toFixed(3)}% of classified tokens); ` +
-        `add to CHINESE_LAB_AUTHORS or KNOWN_NON_CHINESE_AUTHORS`
+        `review at /admin/model-classifications`
     )
+
+  const classificationDetail =
+    feed === 'anthropic'
+      ? 'exact author anthropic'
+      : `author/model seed ${CHINESE_LAB_LIST_VERSION} + DB overrides`
 
   await publishOpenRouterPoint(
     pg,
@@ -249,7 +290,7 @@ const publishLabShare = async (
     now,
     sourceTs,
     `over ${result.dates[0]}..${result.dates[result.dates.length - 1]} ` +
-      `(${result.dates.length}d, as_of ${rankings.asOf}, authors ${CHINESE_LAB_LIST_VERSION}; ` +
+      `(${result.dates.length}d, as_of ${rankings.asOf}, ${classificationDetail}; ` +
       `other ${result.otherTokens.toExponential(3)} and composite ` +
       `${result.compositeTokens.toExponential(3)} tokens excluded)`
   )

--- a/backend/scheduler/src/jobs/update-openrouter-share.ts
+++ b/backend/scheduler/src/jobs/update-openrouter-share.ts
@@ -9,6 +9,7 @@ import {
   OPEN_WEIGHT_LIST_VERSION,
   OPEN_WEIGHT_WINDOW_DAYS,
   openWeightWindowRange,
+  validateOpenRouterSourceFreshness,
   validateOpenWeightPublication,
 } from 'common/perps/open-weight-models'
 import {
@@ -90,6 +91,19 @@ const updateOpenRouterShareInternal = async () => {
     return
   }
   const sourceTs = Date.parse(rankings.asOf)
+
+  // Points are stamped at Date.now(), so a frozen upstream response would
+  // otherwise be relaid as fresh every hour and never trip the 3h staleness
+  // or 6h trading gates. Checked once, before any of the three feeds: a
+  // stale dataset is stale for all of them, and it pages.
+  const staleness = validateOpenRouterSourceFreshness({
+    rows: rankings.rows,
+    now,
+  })
+  if (staleness) {
+    log.error(`[openrouter] ${staleness} — skipping every feed`)
+    return
+  }
 
   await guarded('open-weight share', () =>
     publishOpenWeightShare(pg, rankings, now, sourceTs)
@@ -242,8 +256,12 @@ const publishLabShare = async (
 /**
  * The validate → insert → apply sequence, per feed. Fetches the previous
  * point so validateOraclePoint can enforce strictly increasing timestamps
- * against what is already stored; `sourceTs` is mandatory for these feeds
- * (insertOraclePrices refuses a point without it, per OpenRouter's terms).
+ * against what is already stored, and so the dataset `as_of` can be held to
+ * never regress: an older dataset re-served after a newer one must not be
+ * published as a fresh observation. Equal is fine — that is the same day's
+ * dataset re-stamped hourly, by design. `sourceTs` is mandatory for these
+ * feeds (insertOraclePrices refuses a point without it, per OpenRouter's
+ * terms).
  */
 const publishOpenRouterPoint = async (
   pg: SupabaseDirectClient,
@@ -256,20 +274,32 @@ const publishOpenRouterPoint = async (
 ) => {
   const point = { ts: now, price: share, sourceTs }
   const feed = getOracleFeed(feedId)
-  const prev = await pg.oneOrNone<{ ts: string; price: number | string }>(
-    `select ts, price from oracle_prices where feed_id = $1
+  const prev = await pg.oneOrNone<{
+    ts: string
+    price: number | string
+    source_ts: string | null
+  }>(
+    `select ts, price, source_ts from oracle_prices where feed_id = $1
      order by ts desc limit 1`,
     [feedId]
   )
-  const rejection = feed
-    ? validateOraclePoint(
+  const prevSourceTs =
+    prev?.source_ts == null ? null : new Date(prev.source_ts).getTime()
+  const rejection = !feed
+    ? `missing OracleFeedDef for ${feedId}`
+    : prevSourceTs != null &&
+      Number.isFinite(prevSourceTs) &&
+      sourceTs < prevSourceTs
+    ? `dataset as_of ${new Date(sourceTs).toISOString()} is older than the ` +
+      `as_of already published (${new Date(prevSourceTs).toISOString()}); ` +
+      `not relaying a regressed dataset`
+    : validateOraclePoint(
         feed,
         prev
           ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
           : null,
         point
       )
-    : `missing OracleFeedDef for ${feedId}`
   if (rejection) {
     log.error(
       `[openrouter] rejected ${label} ${share.toFixed(3)} — ${rejection}`

--- a/backend/scheduler/src/jobs/update-openrouter-share.ts
+++ b/backend/scheduler/src/jobs/update-openrouter-share.ts
@@ -27,6 +27,7 @@ import {
   insertOraclePrices,
 } from 'shared/oracle'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
+import { advisoryLockQuery } from 'shared/perps/queries'
 import {
   SupabaseDirectClient,
   createSupabaseDirectClient,
@@ -64,10 +65,11 @@ import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
 // window and the same denominator exclusions, so computing them here costs
 // zero additional OpenRouter calls against the 500/day account limit (this
 // job spends 24). Each feed is published INDEPENDENTLY through the same
-// validate → insert → apply sequence, with the previous point read per feed:
-// a refusal or a thrown error on one feed must never withhold the others,
-// and each has its own registry entry, bounds and market. The open-weight
-// path is unchanged; its log lines are kept verbatim.
+// lock → reread → validate → insert → apply sequence, with the previous
+// point read per feed under that feed's advisory lock: a refusal or a thrown
+// error on one feed must never withhold the others, and each has its own
+// registry entry, bounds and market. The open-weight computation is
+// unchanged and its log lines are kept verbatim.
 export const updateOpenRouterShare = async () => {
   try {
     await updateOpenRouterShareInternal()
@@ -254,14 +256,28 @@ const publishLabShare = async (
 }
 
 /**
- * The validate → insert → apply sequence, per feed. Fetches the previous
- * point so validateOraclePoint can enforce strictly increasing timestamps
- * against what is already stored, and so the dataset `as_of` can be held to
- * never regress: an older dataset re-served after a newer one must not be
- * published as a fresh observation. Equal is fine — that is the same day's
- * dataset re-stamped hourly, by design. `sourceTs` is mandatory for these
- * feeds (insertOraclePrices refuses a point without it, per OpenRouter's
- * terms).
+ * The lock → reread → validate → insert → apply sequence, per feed — the
+ * same shape as the VoteHub and Fear & Greed publishers.
+ *
+ * The previous point is read and both checks are made INSIDE a transaction
+ * holding the feed's advisory lock, and the insert happens in that same
+ * transaction. Read-check-insert as three unrelated statements let two
+ * publishers (a second scheduler instance mid-deploy, a manual run) both pass
+ * the checks and both write — which for the as_of guard means an older
+ * dataset could become the executable mark after a newer one was already
+ * published. Croner's `protect` only covers one Cron object in one process.
+ *
+ * Two checks under the lock: validateOraclePoint (bounds, positivity, and a
+ * strictly newer `ts` than what is stored), and the dataset `as_of` may never
+ * regress below the one already published — an older dataset re-served after
+ * a newer one must not be published as a fresh observation. Equal is fine;
+ * that is the same day's dataset re-stamped hourly, by design. `sourceTs` is
+ * mandatory for these feeds (insertOraclePrices refuses a point without it,
+ * per OpenRouter's terms).
+ *
+ * The apply runs OUTSIDE the transaction, exactly as the other publishers
+ * and the fast tick do it: runOracleUpdate takes its own per-contract lock,
+ * and nesting it here would hold both across engine work.
  */
 const publishOpenRouterPoint = async (
   pg: SupabaseDirectClient,
@@ -274,40 +290,59 @@ const publishOpenRouterPoint = async (
 ) => {
   const point = { ts: now, price: share, sourceTs }
   const feed = getOracleFeed(feedId)
-  const prev = await pg.oneOrNone<{
-    ts: string
-    price: number | string
-    source_ts: string | null
-  }>(
-    `select ts, price, source_ts from oracle_prices where feed_id = $1
-     order by ts desc limit 1`,
-    [feedId]
-  )
-  const prevSourceTs =
-    prev?.source_ts == null ? null : new Date(prev.source_ts).getTime()
-  const rejection = !feed
-    ? `missing OracleFeedDef for ${feedId}`
-    : prevSourceTs != null &&
-      Number.isFinite(prevSourceTs) &&
-      sourceTs < prevSourceTs
-    ? `dataset as_of ${new Date(sourceTs).toISOString()} is older than the ` +
-      `as_of already published (${new Date(prevSourceTs).toISOString()}); ` +
-      `not relaying a regressed dataset`
-    : validateOraclePoint(
-        feed,
-        prev
-          ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
-          : null,
-        point
-      )
-  if (rejection) {
+  if (!feed) {
     log.error(
-      `[openrouter] rejected ${label} ${share.toFixed(3)} — ${rejection}`
+      `[openrouter] rejected ${label} ${share.toFixed(
+        3
+      )} — missing OracleFeedDef for ${feedId}`
     )
     return
   }
 
-  await insertOraclePrices(pg, feedId, [point])
+  const outcome = await pg.tx(async (tx) => {
+    await tx.one(advisoryLockQuery(`oracle-publish:${feedId}`))
+    const prev = await tx.oneOrNone<{
+      ts: string
+      price: number | string
+      source_ts: string | null
+    }>(
+      `select ts, price, source_ts from oracle_prices where feed_id = $1
+       order by ts desc limit 1`,
+      [feedId]
+    )
+    const prevSourceTs =
+      prev?.source_ts == null ? null : new Date(prev.source_ts).getTime()
+    const rejection =
+      prevSourceTs != null &&
+      Number.isFinite(prevSourceTs) &&
+      sourceTs < prevSourceTs
+        ? `dataset as_of ${new Date(
+            sourceTs
+          ).toISOString()} is older than the ` +
+          `as_of already published (${new Date(
+            prevSourceTs
+          ).toISOString()}); not relaying a regressed dataset`
+        : validateOraclePoint(
+            feed,
+            prev
+              ? { ts: new Date(prev.ts).getTime(), price: Number(prev.price) }
+              : null,
+            point
+          )
+    if (rejection) return { ok: false as const, rejection }
+    await insertOraclePrices(tx, feedId, [point])
+    return { ok: true as const }
+  })
+
+  if (!outcome.ok) {
+    log.error(
+      `[openrouter] rejected ${label} ${share.toFixed(3)} — ${
+        outcome.rejection
+      }`
+    )
+    return
+  }
+
   await applyOraclePointToLivePerps(pg, feedId, point)
   log(`[openrouter] inserted ${share.toFixed(3)}% ${label} ${detail}`)
 }

--- a/backend/scheduler/src/jobs/update-trump-approval.ts
+++ b/backend/scheduler/src/jobs/update-trump-approval.ts
@@ -1,44 +1,26 @@
-import { HOUR_MS } from 'common/util/time'
-
 import { TRUMP_APPROVAL_FEED_ID } from 'shared/oracle'
 import {
   publishTrumpApprovalPoint,
   trumpApprovalDay,
 } from 'shared/perps/publish-trump-approval'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
 import {
-  createSupabaseDirectClient,
-  SupabaseDirectClient,
-} from 'shared/supabase/init'
-import { log } from 'shared/utils'
-
-/**
- * Failures are logged at most this often.
- *
- * At a 5-minute cadence an outage that used to produce one line an hour would
- * produce 288 a day. The feed's own staleness alerting is the durable signal;
- * these lines exist to say why, so one an hour is plenty. In-memory, so a
- * scheduler restart re-logs immediately — which is the behaviour you want.
- */
-const FAILURE_LOG_INTERVAL_MS = HOUR_MS
-let lastFailureLog = 0
+  DAILY_FEED_STALE_ERROR_MS,
+  reportDailyFeedFailure,
+} from './daily-feed-failure'
 
 /**
  * How long the feed may go without a published point before a failed attempt
- * is an ERROR rather than a retryable blip.
- *
- * Replaces the old "is this the last firing of the day?" test, which only
- * made sense when the job published once daily. With hourly publication the
- * question that matters is not what time it is, it is how long the market has
- * been marking against an ageing price. Set below the feed's 26h staleAfterMs
- * so the page arrives before the staleness alert, not after it.
+ * is an ERROR rather than a retryable blip. The rationale and the number are
+ * DAILY_FEED_STALE_ERROR_MS; this name is kept for the feed's own docs.
  */
-export const TRUMP_APPROVAL_STALE_ERROR_MS = 20 * HOUR_MS
+export const TRUMP_APPROVAL_STALE_ERROR_MS = DAILY_FEED_STALE_ERROR_MS
 
 // Publishes points for the `trump-approval-rating` feed from VoteHub's
 // published average.
 //
 // Runs EVERY 5 MINUTES and publishes whenever the source value moves — see
-// decideApprovalPublish. Publishing once a day, as this job did originally,
+// decideDailyFeedPublish. Publishing once a day, as this job did originally,
 // left every intraday move by the source sitting in public view as the exact
 // next morning's mark: the same timing edge the feed was rebuilt to remove,
 // relocated from the averaging window to the publication schedule. Hourly
@@ -55,6 +37,11 @@ export const TRUMP_APPROVAL_STALE_ERROR_MS = 20 * HOUR_MS
 // maxOraclePriceAgeMs, which pauses the engine and with it liquidations and
 // ADL. That retry behaviour is preserved — a failed hour is simply followed
 // by another hour — it is just no longer the only reason to run.
+//
+// The other VoteHub averages (generic ballot, Vance favorability) run in
+// their own job, update-votehub-averages, offset by two minutes from this
+// one. This job keeps its name and its `[trump-approval]` prefix because the
+// GCP alert policies are keyed on both.
 export const updateTrumpApproval = async () => {
   const pg = createSupabaseDirectClient()
   const today = trumpApprovalDay()
@@ -71,40 +58,15 @@ export const updateTrumpApproval = async () => {
   }
 }
 
-/** How long since the feed last got a point, or null if it never has. */
-const getAgeOfLatestPoint = async (
-  pg: SupabaseDirectClient
-): Promise<number | null> => {
-  const row = await pg.oneOrNone<{ ts: string }>(
-    `select ts from oracle_prices where feed_id = $1 order by ts desc limit 1`,
-    [TRUMP_APPROVAL_FEED_ID]
-  )
-  if (!row) return null
-  const ts = new Date(row.ts).getTime()
-  return Number.isFinite(ts) ? Date.now() - ts : null
-}
-
-const reportFailure = async (
-  pg: SupabaseDirectClient,
+const reportFailure = (
+  pg: ReturnType<typeof createSupabaseDirectClient>,
   day: string,
   reason: string
-) => {
-  const message = `[trump-approval] publish failed for ${day} — ${reason}`
-  // Feed staleness is alerted on separately by update-perps and
-  // update-oracle-feeds, so a retryable attempt stays at WARN to avoid paging
-  // once an hour for one outage. Escalate only once the feed itself has gone
-  // long enough without a point that the next retry is no longer the fix.
-  const ageMs = await getAgeOfLatestPoint(pg)
-  const stale = ageMs == null || ageMs >= TRUMP_APPROVAL_STALE_ERROR_MS
-  // Throttle, but never throttle away the escalation: a feed that has gone
-  // stale is the one thing here worth paging on every time it is observed.
-  if (!stale && Date.now() - lastFailureLog < FAILURE_LOG_INTERVAL_MS) return
-  lastFailureLog = Date.now()
-  if (stale)
-    log.error(
-      `${message}; last point ${
-        ageMs == null ? 'never' : `${Math.round(ageMs / HOUR_MS)}h ago`
-      }, feed is going stale`
-    )
-  else log.warn(`${message}; retrying in 5 minutes`)
-}
+) =>
+  reportDailyFeedFailure(pg, {
+    feedId: TRUMP_APPROVAL_FEED_ID,
+    label: '[trump-approval]',
+    day,
+    reason,
+    staleErrorMs: TRUMP_APPROVAL_STALE_ERROR_MS,
+  })

--- a/backend/scheduler/src/jobs/update-votehub-averages.ts
+++ b/backend/scheduler/src/jobs/update-votehub-averages.ts
@@ -1,0 +1,55 @@
+import {
+  publishVoteHubPoint,
+  voteHubDay,
+} from 'shared/perps/publish-votehub-average'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { VOTEHUB_FEED_SPECS, VoteHubFeedSpec } from 'shared/votehub-feeds'
+import { reportDailyFeedFailure } from './daily-feed-failure'
+
+// Publishes points for the VoteHub average feeds OTHER than Trump approval —
+// today the 2026 generic ballot (`votehub-generic-ballot-2026`) and JD Vance
+// favorability (`vance-favorability`), see VOTEHUB_FEED_SPECS.
+//
+// Same cadence and same reasoning as update-trump-approval: every 5 minutes,
+// which is VoteHub's own freshness bound (`Cache-Control: max-age=300` on the
+// averages endpoint), publishing only when the value moves plus a 12h
+// heartbeat. Scheduled two minutes off the Trump job so the two never fire
+// against VoteHub at the same instant.
+//
+// Why a separate job rather than more specs in the Trump loop: the Trump job's
+// name and its `[trump-approval]` log prefix are what the GCP alert policies
+// match on, and both are required to stay byte-for-byte unchanged. These
+// feeds alert under `[votehub]` instead; every WARN/ERROR line below carries
+// the feed id after the prefix so one policy covers all of them.
+//
+// Each spec is published independently: a thrown fetch error or a refused
+// point on one feed reports for that feed and moves on to the next. Failure
+// reporting is the shared throttled-WARN / stale-ERROR rule in
+// daily-feed-failure.ts.
+export const updateVoteHubAverages = async () => {
+  const pg = createSupabaseDirectClient()
+  for (const spec of VOTEHUB_FEED_SPECS) await publishOne(pg, spec)
+}
+
+const publishOne = async (
+  pg: ReturnType<typeof createSupabaseDirectClient>,
+  spec: VoteHubFeedSpec
+) => {
+  const today = voteHubDay(spec)
+  const report = (reason: string) =>
+    reportDailyFeedFailure(pg, {
+      feedId: spec.feedId,
+      label: `${spec.logPrefix} ${spec.feedId}`,
+      day: today,
+      reason,
+    })
+  try {
+    const result = await publishVoteHubPoint(pg, spec)
+    // `unchanged` is the ordinary outcome and is deliberately silent, as in
+    // the Trump job: the sources move about once a day.
+    if (result.status === 'published' || result.status === 'unchanged') return
+    await report(result.reason)
+  } catch (err) {
+    await report(`${err}`)
+  }
+}

--- a/backend/scripts/backfill-fear-greed-oracle.ts
+++ b/backend/scripts/backfill-fear-greed-oracle.ts
@@ -5,6 +5,7 @@ import { fetchFearGreedHistory } from 'shared/fear-greed'
 import { CRYPTO_FEAR_GREED_FEED_ID, insertOraclePrices } from 'shared/oracle'
 import { getOracleFeed } from 'shared/oracle-feeds'
 import { log } from 'shared/utils'
+import { assertBackfillTarget } from './backfill-guard'
 import { runScript } from './run-script'
 
 // Backfill `crypto-fear-greed` from Alternative.me's full history
@@ -27,6 +28,7 @@ if (require.main === module)
   runScript(async ({ pg }) => {
     const feed = getOracleFeed(CRYPTO_FEAR_GREED_FEED_ID)
     if (!feed) throw new Error(`${CRYPTO_FEAR_GREED_FEED_ID} is not registered`)
+    await assertBackfillTarget(pg, CRYPTO_FEAR_GREED_FEED_ID)
 
     const history = await fetchFearGreedHistory()
     log(`fetched ${history.length} readings`)

--- a/backend/scripts/backfill-fear-greed-oracle.ts
+++ b/backend/scripts/backfill-fear-greed-oracle.ts
@@ -1,0 +1,73 @@
+import { fearGreedDayStartUtc } from 'common/perps/fear-greed'
+import { normalizeOraclePointBatch } from 'common/perps/oracle'
+
+import { fetchFearGreedHistory } from 'shared/fear-greed'
+import { CRYPTO_FEAR_GREED_FEED_ID, insertOraclePrices } from 'shared/oracle'
+import { getOracleFeed } from 'shared/oracle-feeds'
+import { log } from 'shared/utils'
+import { runScript } from './run-script'
+
+// Backfill `crypto-fear-greed` from Alternative.me's full history
+// (`/fng/?limit=0`), so the market chart has context on day one.
+//
+// One point per historical UTC day, stamped at that day's 00:00 UTC — the
+// instant the provider publishes it — with the provider's own timestamp as
+// `sourceTs`. Day-boundary stamps never collide with the live job's
+// Date.now() stamps, so the series is continuous across the handoff.
+//
+// ⚠️ NOT for a live feed. Points already published are immutable and may have
+// been consumed by funding and liquidations; this exists for standing up a
+// NEW feed, and `insertOraclePrices` is on-conflict-do-nothing, so existing
+// rows are left alone even if it is run by accident.
+//
+// A reading outside the registry bounds — in practice only a literal 0, which
+// the positivity rule forbids — is skipped and reported rather than clamped;
+// the live feed would have paused on that day too.
+if (require.main === module)
+  runScript(async ({ pg }) => {
+    const feed = getOracleFeed(CRYPTO_FEAR_GREED_FEED_ID)
+    if (!feed) throw new Error(`${CRYPTO_FEAR_GREED_FEED_ID} is not registered`)
+
+    const history = await fetchFearGreedHistory()
+    log(`fetched ${history.length} readings`)
+
+    const skipped: string[] = []
+    const raw = history.flatMap((reading) => {
+      if (reading.value < feed.minPrice || reading.value > feed.maxPrice) {
+        skipped.push(
+          `${new Date(reading.sourceTs).toISOString()} = ${reading.value}`
+        )
+        return []
+      }
+      return [
+        {
+          ts: fearGreedDayStartUtc(reading.sourceTs),
+          price: reading.value,
+          sourceTs: reading.sourceTs,
+        },
+      ]
+    })
+    if (skipped.length > 0)
+      log.warn(
+        `skipping ${skipped.length} reading(s) outside [${feed.minPrice}, ${
+          feed.maxPrice
+        }]: ${skipped.slice(0, 10).join(', ')}`
+      )
+
+    // Two readings in one UTC day would map to one stamp; refuse the batch
+    // rather than let insert order pick the winner.
+    const batch = normalizeOraclePointBatch(raw)
+    if (!batch.ok) throw new Error(`refusing to backfill: ${batch.reason}`)
+    const points = batch.points
+
+    if (points.length > 0) {
+      const first = points[0]
+      const last = points[points.length - 1]
+      const values = points.map((p) => p.price)
+      log(`first: ${new Date(first.ts).toISOString()} = ${first.price}`)
+      log(`last:  ${new Date(last.ts).toISOString()} = ${last.price}`)
+      log(`range: ${Math.min(...values)} .. ${Math.max(...values)}`)
+    }
+    await insertOraclePrices(pg, CRYPTO_FEAR_GREED_FEED_ID, points)
+    log(`backfilled ${points.length} ${CRYPTO_FEAR_GREED_FEED_ID} points`)
+  })

--- a/backend/scripts/backfill-guard.ts
+++ b/backend/scripts/backfill-guard.ts
@@ -1,0 +1,38 @@
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+
+// Shared guard for the oracle backfill scripts. Published history is
+// append-only and a backfill stamps day boundaries, so on a feed that already
+// backs an unresolved market it would add a second point to every day rather
+// than fill a hole — and those markets have already priced funding and
+// liquidations against the history as it stands. Every backfill header says
+// "NOT for a live feed"; this makes the script check rather than trust the
+// operator to have read it. `--force` is the deliberate override for a
+// rerun someone has actually decided on.
+export const assertBackfillTarget = async (
+  pg: SupabaseDirectClient,
+  feedId: string,
+  argv: readonly string[] = process.argv
+) => {
+  const rows = await pg.manyOrNone<{ slug: string }>(
+    `select data->>'slug' as slug from contracts
+     where mechanism = 'perp'
+       and resolution_time is null
+       and data->>'oracleFeedId' = $1`,
+    [feedId]
+  )
+  if (rows.length === 0) return
+  const slugs = rows.map((row) => row.slug).join(', ')
+  if (argv.includes('--force')) {
+    log.warn(
+      `--force: backfilling ${feedId} although it backs live market(s) ${slugs}; ` +
+        `day-boundary points will be appended next to the live job's stamps`
+    )
+    return
+  }
+  throw new Error(
+    `refusing to backfill ${feedId}: it backs live market(s) ${slugs}. ` +
+      `Published history is append-only and those markets have priced against ` +
+      `it; pass --force only for a rerun that has been deliberately decided.`
+  )
+}

--- a/backend/scripts/backfill-openrouter-oracle.ts
+++ b/backend/scripts/backfill-openrouter-oracle.ts
@@ -19,6 +19,7 @@ import {
 } from 'shared/oracle'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
 import { log } from 'shared/utils'
+import { assertBackfillTarget } from './backfill-guard'
 import { runScript } from './run-script'
 
 // Backfill an OpenRouter index feed so the market chart has context on day
@@ -41,8 +42,9 @@ import { runScript } from './run-script'
 // do-nothing, so existing rows are left alone even if it is run by accident —
 // but a run against a feed that already has a live market would still append
 // a day-boundary point next to every live Date.now() point. The DEFAULT
-// target (no --feed) is the open-weight feed, which already has a market:
-// only re-run it deliberately.
+// target (no --feed) is the open-weight feed, which already has a market —
+// so the script REFUSES any feed that backs an unresolved market unless
+// --force is passed (assertBackfillTarget), whatever the default says.
 //
 // Two honest limitations, both of which belong in the market description:
 //  - Historical points are classified with the CURRENT list (models for the
@@ -84,6 +86,7 @@ if (require.main === module)
 
     const feed = getOracleFeed(feedId)
     if (!feed) throw new Error(`${feedId} is not registered`)
+    await assertBackfillTarget(pg, feedId)
 
     const now = Date.now()
     const startDate = utcDateString(now - BACKFILL_DAYS * DAY_MS)

--- a/backend/scripts/backfill-openrouter-oracle.ts
+++ b/backend/scripts/backfill-openrouter-oracle.ts
@@ -1,4 +1,9 @@
 import {
+  LabShareFeed,
+  computeLabShare,
+  validateLabSharePublication,
+} from 'common/perps/lab-share'
+import {
   OPEN_WEIGHT_WINDOW_DAYS,
   computeOpenWeightShare,
   utcDateString,
@@ -7,14 +12,20 @@ import {
 import { DAY_MS } from 'common/util/time'
 import { fetchOpenRouterRankings } from 'shared/openrouter-tokens'
 import {
+  OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+  OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
   insertOraclePrices,
 } from 'shared/oracle'
 import { log } from 'shared/utils'
 import { runScript } from './run-script'
 
-// Backfill the `openrouter-open-weight-share` feed so the market chart has
-// context on day one — the perps chart needs history to render timeframes.
+// Backfill an OpenRouter index feed so the market chart has context on day
+// one — the perps chart needs history to render timeframes.
+//
+//   npx ts-node backfill-openrouter-oracle.ts                       (open-weight, the default)
+//   npx ts-node backfill-openrouter-oracle.ts --feed=openrouter-anthropic-share
+//   npx ts-node backfill-openrouter-oracle.ts --feed=openrouter-chinese-lab-share
 //
 // One point per historical UTC day D, valued at the trailing-7-day share over
 // [D-6, D] — the same window the hourly job computes, so the series is
@@ -23,19 +34,38 @@ import { runScript } from './run-script'
 // stamps never collide with the live job's Date.now() stamps.
 //
 // Two honest limitations, both of which belong in the market description:
-//  - Historical points are classified with the CURRENT list. Reconstructing
+//  - Historical points are classified with the CURRENT list (models for the
+//    open-weight feed, authors for the Chinese-lab feed). Reconstructing
 //    "what we would have thought at the time" is not possible, and the
 //    alternative (retroactive reclassification) rewrites settled history.
-//  - Re-running this after the classification list changes will NOT rewrite
+//  - Re-running this after a classification list changes will NOT rewrite
 //    the stable day-boundary points: published history is append-only. A new
 //    methodology therefore needs a new feed id rather than a live rerun.
 //
 // OpenRouter caps a single request at 366 days, which comfortably covers a
-// year of chart history in one call.
+// year of chart history in one call — ONE call for whichever feed is chosen.
 const BACKFILL_DAYS = 365
+
+const LAB_FEEDS: Record<string, LabShareFeed> = {
+  [OPENROUTER_ANTHROPIC_SHARE_FEED_ID]: 'anthropic',
+  [OPENROUTER_CHINESE_LAB_SHARE_FEED_ID]: 'chinese-lab',
+}
 
 if (require.main === module)
   runScript(async ({ pg }) => {
+    const feedId =
+      process.argv
+        .find((arg) => arg.startsWith('--feed='))
+        ?.slice('--feed='.length) ?? OPENROUTER_OPEN_WEIGHT_FEED_ID
+    const labFeed: LabShareFeed | undefined = LAB_FEEDS[feedId]
+    if (feedId !== OPENROUTER_OPEN_WEIGHT_FEED_ID && !labFeed)
+      throw new Error(
+        `unknown --feed=${feedId}; expected ${[
+          OPENROUTER_OPEN_WEIGHT_FEED_ID,
+          ...Object.keys(LAB_FEEDS),
+        ].join(', ')}`
+      )
+
     const now = Date.now()
     const startDate = utcDateString(now - BACKFILL_DAYS * DAY_MS)
     const endDate = utcDateString(now)
@@ -70,9 +100,8 @@ if (require.main === module)
     for (let i = OPEN_WEIGHT_WINDOW_DAYS - 1; i < dates.length; i++) {
       const window = dates.slice(i - OPEN_WEIGHT_WINDOW_DAYS + 1, i + 1)
       const rows = window.flatMap((d) => byDate[d])
-      const result = computeOpenWeightShare(rows)
-      // Cap 0 = halt on ANY unclassified model, which is what this call meant
-      // before the grace window existed and still has to mean here.
+      // Cap 0 = halt on ANY unclassified model (open-weight) or unknown
+      // author (Chinese-lab), which is what this script has always meant.
       //
       // Grace is a trade the LIVE feed can make: publishing a bounded sub-point
       // error for a few hours beats marking a live market against a stale
@@ -84,12 +113,16 @@ if (require.main === module)
       // written under grace here is a permanently wrong point in published
       // history, computed from a denominator that silently omitted a model.
       //
-      // So this script keeps its original posture: any unclassified model in
-      // any window aborts the whole run with no inserts, and a human extends
-      // the seed list before retrying.
-      const publication = validateOpenWeightPublication(result, {
-        unclassifiedShareCap: 0,
-      })
+      // So this script keeps its original posture: any unclassified model (or
+      // unknown author) in any window aborts the whole run with no inserts,
+      // and a human extends the list before retrying.
+      const publication = labFeed
+        ? validateLabSharePublication(computeLabShare(labFeed, rows), {
+            unknownShareCap: 0,
+          })
+        : validateOpenWeightPublication(computeOpenWeightShare(rows), {
+            unclassifiedShareCap: 0,
+          })
       if (!publication.ok) {
         rejections.push(`${dates[i]}: ${publication.reason}`)
         continue
@@ -103,14 +136,14 @@ if (require.main === module)
 
     if (rejections.length > 0) {
       log.error(
-        `unsafe OpenRouter history — aborting without inserts:\n${rejections
+        `unsafe OpenRouter history for ${feedId} — aborting without inserts:\n${rejections
           .slice(0, 20)
           .join('\n')}`
       )
       return
     }
 
-    log(`computed ${points.length} daily trailing-window points`)
+    log(`computed ${points.length} daily trailing-window points for ${feedId}`)
     if (points.length > 0) {
       const first = points[0]
       const last = points[points.length - 1]
@@ -129,6 +162,6 @@ if (require.main === module)
         ).toFixed(2)}%`
       )
     }
-    await insertOraclePrices(pg, OPENROUTER_OPEN_WEIGHT_FEED_ID, points)
-    log(`backfilled ${points.length} ${OPENROUTER_OPEN_WEIGHT_FEED_ID} points`)
+    await insertOraclePrices(pg, feedId, points)
+    log(`backfilled ${points.length} ${feedId} points`)
   })

--- a/backend/scripts/backfill-openrouter-oracle.ts
+++ b/backend/scripts/backfill-openrouter-oracle.ts
@@ -18,6 +18,11 @@ import {
   insertOraclePrices,
 } from 'shared/oracle'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
+import {
+  recordPendingLabClassifications,
+  resolveLabClassifications,
+} from 'shared/perps/lab-classifications'
+import type { PendingLabClassification } from 'shared/perps/lab-classifications'
 import { log } from 'shared/utils'
 import { assertBackfillTarget } from './backfill-guard'
 import { runScript } from './run-script'
@@ -37,7 +42,7 @@ import { runScript } from './run-script'
 //
 // ⚠️ NOT for a live feed. Points already published are immutable and may have
 // been consumed by funding and liquidations; this writes day-boundary history
-// under the CURRENT classification lists and exists for standing up a NEW
+// under the CURRENT resolved classifications and exists for standing up a NEW
 // feed (today, the two lab-share feeds). `insertOraclePrices` is on-conflict-
 // do-nothing, so existing rows are left alone even if it is run by accident —
 // but a run against a feed that already has a live market would still append
@@ -47,11 +52,11 @@ import { runScript } from './run-script'
 // --force is passed (assertBackfillTarget), whatever the default says.
 //
 // Two honest limitations, both of which belong in the market description:
-//  - Historical points are classified with the CURRENT list (models for the
-//    open-weight feed, authors for the Chinese-lab feed). Reconstructing
-//    "what we would have thought at the time" is not possible, and the
-//    alternative (retroactive reclassification) rewrites settled history.
-//  - Re-running this after a classification list changes will NOT rewrite
+//  - Historical points are classified with the CURRENT snapshot (models for
+//    the open-weight feed, author/model placements for the Chinese-lab feed).
+//    Reconstructing "what we would have thought at the time" is not possible;
+//    retroactive reclassification would rewrite settled history.
+//  - Re-running this after a classification snapshot changes will NOT rewrite
 //    the stable day-boundary points: published history is append-only. A new
 //    methodology therefore needs a new feed id rather than a live rerun.
 //
@@ -88,6 +93,14 @@ if (require.main === module)
     if (!feed) throw new Error(`${feedId} is not registered`)
     await assertBackfillTarget(pg, feedId)
 
+    // Freeze one resolved classification snapshot for the entire run. A
+    // click in the operator queue must unblock the backfill without a deploy,
+    // while every historical window in one run must use the same methodology.
+    const labClassifications =
+      labFeed === 'chinese-lab'
+        ? await resolveLabClassifications(pg)
+        : undefined
+
     const now = Date.now()
     const startDate = utcDateString(now - BACKFILL_DAYS * DAY_MS)
     const endDate = utcDateString(now)
@@ -117,13 +130,14 @@ if (require.main === module)
     const sourceTs = Date.parse(rankings.asOf)
     const points: { ts: number; price: number; sourceTs: number }[] = []
     const rejections: string[] = []
+    const pendingLabSubjects: PendingLabClassification[] = []
     // Start once a full window is available, so no point is computed from a
     // short window (which would read as a spike at the left edge).
     for (let i = OPEN_WEIGHT_WINDOW_DAYS - 1; i < dates.length; i++) {
       const window = dates.slice(i - OPEN_WEIGHT_WINDOW_DAYS + 1, i + 1)
       const rows = window.flatMap((d) => byDate[d])
       // Cap 0 = halt on ANY unclassified model (open-weight) or unknown
-      // author (Chinese-lab), which is what this script has always meant.
+      // author/model (Chinese-lab), which is what this script has always meant.
       //
       // Grace is a trade the LIVE feed can make: publishing a bounded sub-point
       // error for a few hours beats marking a live market against a stale
@@ -135,13 +149,36 @@ if (require.main === module)
       // written under grace here is a permanently wrong point in published
       // history, computed from a denominator that silently omitted a model.
       //
-      // So this script keeps its original posture: any unclassified model (or
-      // unknown author) in any window aborts the whole run with no inserts,
-      // and a human extends the list before retrying.
-      const publication = labFeed
-        ? validateLabSharePublication(computeLabShare(labFeed, rows), {
-            unknownShareCap: 0,
-          })
+      // So this script keeps its original posture: any unclassified model or
+      // unknown lab subject in any window aborts the whole run with no inserts,
+      // and a human clears the database queue before retrying.
+      const labResult = labFeed
+        ? computeLabShare(
+            labFeed,
+            rows,
+            OPEN_WEIGHT_WINDOW_DAYS,
+            labClassifications
+          )
+        : undefined
+      if (labFeed === 'chinese-lab' && labResult) {
+        const firstRankedAt = Date.parse(`${dates[i]}T00:00:00.000Z`)
+        pendingLabSubjects.push(
+          ...labResult.unknownAuthors.map((subjectSlug) => ({
+            subjectType: 'author' as const,
+            subjectSlug,
+            evidence: { discoveredVia: 'backfill' },
+            firstRankedAt,
+          })),
+          ...labResult.unknownModels.map((subjectSlug) => ({
+            subjectType: 'model' as const,
+            subjectSlug,
+            evidence: { discoveredVia: 'backfill' },
+            firstRankedAt,
+          }))
+        )
+      }
+      const publication = labResult
+        ? validateLabSharePublication(labResult, { unknownShareCap: 0 })
         : validateOpenWeightPublication(computeOpenWeightShare(rows), {
             unclassifiedShareCap: 0,
           })
@@ -169,6 +206,18 @@ if (require.main === module)
         continue
       }
       points.push(point)
+    }
+
+    // A delisted historical subject may be absent from today's catalog and
+    // rankings. Populate the same operator queue before reporting the
+    // zero-tolerance rejection, so a failed first run always exposes its own
+    // no-deploy remedy.
+    if (pendingLabSubjects.length > 0) {
+      const changed = await recordPendingLabClassifications(
+        pg,
+        pendingLabSubjects
+      )
+      log(`recorded ${changed} historical lab subject(s) for review`)
     }
 
     if (rejections.length > 0) {

--- a/backend/scripts/backfill-openrouter-oracle.ts
+++ b/backend/scripts/backfill-openrouter-oracle.ts
@@ -33,6 +33,16 @@ import { runScript } from './run-script'
 // (D+1 00:00 UTC), the instant that window became complete; day-boundary
 // stamps never collide with the live job's Date.now() stamps.
 //
+// ⚠️ NOT for a live feed. Points already published are immutable and may have
+// been consumed by funding and liquidations; this writes day-boundary history
+// under the CURRENT classification lists and exists for standing up a NEW
+// feed (today, the two lab-share feeds). `insertOraclePrices` is on-conflict-
+// do-nothing, so existing rows are left alone even if it is run by accident —
+// but a run against a feed that already has a live market would still append
+// a day-boundary point next to every live Date.now() point. The DEFAULT
+// target (no --feed) is the open-weight feed, which already has a market:
+// only re-run it deliberately.
+//
 // Two honest limitations, both of which belong in the market description:
 //  - Historical points are classified with the CURRENT list (models for the
 //    open-weight feed, authors for the Chinese-lab feed). Reconstructing
@@ -57,7 +67,12 @@ if (require.main === module)
       process.argv
         .find((arg) => arg.startsWith('--feed='))
         ?.slice('--feed='.length) ?? OPENROUTER_OPEN_WEIGHT_FEED_ID
-    const labFeed: LabShareFeed | undefined = LAB_FEEDS[feedId]
+    // Own-property lookup: `--feed=constructor` must not resolve to
+    // Object.prototype and write rows under that feed id.
+    const labFeed: LabShareFeed | undefined =
+      Object.prototype.hasOwnProperty.call(LAB_FEEDS, feedId)
+        ? LAB_FEEDS[feedId]
+        : undefined
     if (feedId !== OPENROUTER_OPEN_WEIGHT_FEED_ID && !labFeed)
       throw new Error(
         `unknown --feed=${feedId}; expected ${[

--- a/backend/scripts/backfill-openrouter-oracle.ts
+++ b/backend/scripts/backfill-openrouter-oracle.ts
@@ -17,6 +17,7 @@ import {
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
   insertOraclePrices,
 } from 'shared/oracle'
+import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
 import { log } from 'shared/utils'
 import { runScript } from './run-script'
 
@@ -81,6 +82,9 @@ if (require.main === module)
         ].join(', ')}`
       )
 
+    const feed = getOracleFeed(feedId)
+    if (!feed) throw new Error(`${feedId} is not registered`)
+
     const now = Date.now()
     const startDate = utcDateString(now - BACKFILL_DAYS * DAY_MS)
     const endDate = utcDateString(now)
@@ -142,11 +146,26 @@ if (require.main === module)
         rejections.push(`${dates[i]}: ${publication.reason}`)
         continue
       }
-      points.push({
+      const point = {
         ts: Date.parse(`${dates[i]}T00:00:00.000Z`) + DAY_MS,
         price: publication.share,
         sourceTs,
-      })
+      }
+      // Every historical point is held to the same registry definition the
+      // live job applies (validateOraclePoint: bounds, positivity, strictly
+      // increasing stamps). A share the live feed would refuse must not enter
+      // history just because it is old — and a real value outside the bounds
+      // is exactly the conversation the bounds exist to force.
+      const rejection = validateOraclePoint(
+        feed,
+        points[points.length - 1] ?? null,
+        point
+      )
+      if (rejection) {
+        rejections.push(`${dates[i]}: ${rejection}`)
+        continue
+      }
+      points.push(point)
     }
 
     if (rejections.length > 0) {

--- a/backend/scripts/backfill-votehub-oracle.ts
+++ b/backend/scripts/backfill-votehub-oracle.ts
@@ -8,11 +8,8 @@ import { readPublishedSeries } from 'common/perps/votehub-average'
 
 import { log } from 'shared/utils'
 import { insertOraclePrices } from 'shared/oracle'
-import {
-  ALL_VOTEHUB_FEED_SPECS,
-  fetchVoteHubAverage,
-  getVoteHubFeedSpec,
-} from 'shared/votehub-feeds'
+import { getOracleFeed } from 'shared/oracle-feeds'
+import { VOTEHUB_FEED_SPECS, fetchVoteHubAverage } from 'shared/votehub-feeds'
 import { runScript } from './run-script'
 
 // Backfill a VoteHub average feed from VoteHub's published, time-weighted
@@ -22,8 +19,10 @@ import { runScript } from './run-script'
 //   npx ts-node backfill-votehub-oracle.ts --feed=votehub-generic-ballot-2026
 //   npx ts-node backfill-votehub-oracle.ts --feed=vance-favorability
 //
-// (`--feed=trump-approval-rating` works too and is equivalent to
-// backfill-trump-approval-oracle.ts.)
+// Only the specs in VOTEHUB_FEED_SPECS are accepted. `trump-approval-rating`
+// is deliberately refused: that feed has a live market, and its own
+// (equivalent) script, backfill-trump-approval-oracle.ts, exists for the
+// record.
 //
 // ⚠️ NOT for a live feed. Points already published are immutable and may have
 // been consumed by funding and liquidations; this writes history under
@@ -41,13 +40,15 @@ if (require.main === module)
     const feedId = process.argv
       .find((arg) => arg.startsWith('--feed='))
       ?.slice('--feed='.length)
-    const spec = feedId ? getVoteHubFeedSpec(feedId) : undefined
+    const spec = VOTEHUB_FEED_SPECS.find((s) => s.feedId === feedId)
     if (!spec)
       throw new Error(
-        `pass --feed=<feedId>; known VoteHub feeds: ${ALL_VOTEHUB_FEED_SPECS.map(
+        `pass --feed=<feedId>; backfillable VoteHub feeds: ${VOTEHUB_FEED_SPECS.map(
           (s) => s.feedId
         ).join(', ')}`
       )
+    const feed = getOracleFeed(spec.feedId)
+    if (!feed) throw new Error(`${spec.feedId} is not registered`)
 
     // Stamp each day's point from its own calendar date rather than adding a
     // day to a running instant: dayjs.tz(...).add(1,'day') adds 24 UTC hours,
@@ -57,10 +58,27 @@ if (require.main === module)
     const series = readPublishedSeries(await fetchVoteHubAverage(spec), {
       answerKey: spec.answerKey,
     })
-    const points = series.map((entry) => ({
-      ts: dayjs.tz(entry.day, spec.tz).valueOf(),
-      price: entry.price,
-    }))
+    // The live publisher runs every point through validateOraclePoint; give
+    // history the same registry bounds rather than writing a value the feed
+    // itself would have refused. Skipped, reported, never clamped.
+    const skipped = series.filter(
+      (entry) => entry.price < feed.minPrice || entry.price > feed.maxPrice
+    )
+    if (skipped.length > 0)
+      log.warn(
+        `skipping ${skipped.length} day(s) outside [${feed.minPrice}, ${
+          feed.maxPrice
+        }]: ${skipped
+          .slice(0, 10)
+          .map((entry) => `${entry.day}=${entry.price}`)
+          .join(', ')}`
+      )
+    const points = series
+      .filter((entry) => !skipped.includes(entry))
+      .map((entry) => ({
+        ts: dayjs.tz(entry.day, spec.tz).valueOf(),
+        price: entry.price,
+      }))
     const fromDay = series[0]?.day ?? 'n/a'
     const toDay = series[series.length - 1]?.day ?? 'n/a'
     log(

--- a/backend/scripts/backfill-votehub-oracle.ts
+++ b/backend/scripts/backfill-votehub-oracle.ts
@@ -13,6 +13,7 @@ import { log } from 'shared/utils'
 import { insertOraclePrices } from 'shared/oracle'
 import { getOracleFeed } from 'shared/oracle-feeds'
 import { VOTEHUB_FEED_SPECS, fetchVoteHubAverage } from 'shared/votehub-feeds'
+import { assertBackfillTarget } from './backfill-guard'
 import { runScript } from './run-script'
 
 // Backfill a VoteHub average feed from VoteHub's published, time-weighted
@@ -52,6 +53,7 @@ if (require.main === module)
       )
     const feed = getOracleFeed(spec.feedId)
     if (!feed) throw new Error(`${spec.feedId} is not registered`)
+    await assertBackfillTarget(pg, spec.feedId)
 
     // Stamp each day's point from its own calendar date rather than adding a
     // day to a running instant: dayjs.tz(...).add(1,'day') adds 24 UTC hours,

--- a/backend/scripts/backfill-votehub-oracle.ts
+++ b/backend/scripts/backfill-votehub-oracle.ts
@@ -1,0 +1,87 @@
+import * as dayjs from 'dayjs'
+import * as utc from 'dayjs/plugin/utc'
+import * as timezone from 'dayjs/plugin/timezone'
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+import { readPublishedSeries } from 'common/perps/votehub-average'
+
+import { log } from 'shared/utils'
+import { insertOraclePrices } from 'shared/oracle'
+import {
+  ALL_VOTEHUB_FEED_SPECS,
+  fetchVoteHubAverage,
+  getVoteHubFeedSpec,
+} from 'shared/votehub-feeds'
+import { runScript } from './run-script'
+
+// Backfill a VoteHub average feed from VoteHub's published, time-weighted
+// series — the same series the live job publishes, so a backfill and the
+// live feed can never disagree about what the index means.
+//
+//   npx ts-node backfill-votehub-oracle.ts --feed=votehub-generic-ballot-2026
+//   npx ts-node backfill-votehub-oracle.ts --feed=vance-favorability
+//
+// (`--feed=trump-approval-rating` works too and is equivalent to
+// backfill-trump-approval-oracle.ts.)
+//
+// ⚠️ NOT for a live feed. Points already published are immutable and may have
+// been consumed by funding and liquidations; this writes history under
+// whatever the methodology is TODAY, so running it against a feed with open
+// positions rewrites the basis those positions were priced against. It exists
+// for standing up a NEW feed, and `insertOraclePrices` is on-conflict-do-
+// nothing, so existing rows are left alone even if it is run by accident.
+//
+// Run `list-votehub-averages.ts` first for a feed whose spec is marked as not
+// yet verified against a live response: a wrong average key fails here with
+// an HTTP error, a wrong answer key reads zero usable days, and either is the
+// signal to fix the spec constant rather than the data.
+if (require.main === module)
+  runScript(async ({ pg }) => {
+    const feedId = process.argv
+      .find((arg) => arg.startsWith('--feed='))
+      ?.slice('--feed='.length)
+    const spec = feedId ? getVoteHubFeedSpec(feedId) : undefined
+    if (!spec)
+      throw new Error(
+        `pass --feed=<feedId>; known VoteHub feeds: ${ALL_VOTEHUB_FEED_SPECS.map(
+          (s) => s.feedId
+        ).join(', ')}`
+      )
+
+    // Stamp each day's point from its own calendar date rather than adding a
+    // day to a running instant: dayjs.tz(...).add(1,'day') adds 24 UTC hours,
+    // so a loop started in PST drifts to 1 AM once PDT begins, and every
+    // summer stamp lands an hour off midnight — colliding with the correctly
+    // stamped rows the live job writes.
+    const series = readPublishedSeries(await fetchVoteHubAverage(spec), {
+      answerKey: spec.answerKey,
+    })
+    const points = series.map((entry) => ({
+      ts: dayjs.tz(entry.day, spec.tz).valueOf(),
+      price: entry.price,
+    }))
+    const fromDay = series[0]?.day ?? 'n/a'
+    const toDay = series[series.length - 1]?.day ?? 'n/a'
+    log(
+      `read ${points.length} published \`${spec.answerKey}\` daily averages ` +
+        `for ${spec.averageKey} from ${fromDay} to ${toDay}`
+    )
+    if (points.length === 0)
+      throw new Error(
+        `no usable days under answer key \`${spec.answerKey}\` — check the ` +
+          `spec against list-votehub-averages.ts before retrying`
+      )
+    log(
+      `first point: ${new Date(
+        points[0].ts
+      ).toISOString()} = ${points[0].price.toFixed(2)}`
+    )
+    log(
+      `last point: ${new Date(
+        points[points.length - 1].ts
+      ).toISOString()} = ${points[points.length - 1].price.toFixed(2)}`
+    )
+    await insertOraclePrices(pg, spec.feedId, points)
+    log(`backfilled ${points.length} ${spec.feedId} oracle points`)
+  })

--- a/backend/scripts/backfill-votehub-oracle.ts
+++ b/backend/scripts/backfill-votehub-oracle.ts
@@ -4,7 +4,10 @@ import * as timezone from 'dayjs/plugin/timezone'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-import { readPublishedSeries } from 'common/perps/votehub-average'
+import {
+  readPublishedSeries,
+  voteHubDaySourceTs,
+} from 'common/perps/votehub-average'
 
 import { log } from 'shared/utils'
 import { insertOraclePrices } from 'shared/oracle'
@@ -78,6 +81,9 @@ if (require.main === module)
       .map((entry) => ({
         ts: dayjs.tz(entry.day, spec.tz).valueOf(),
         price: entry.price,
+        // The live publisher records VoteHub's day as source_ts so it can
+        // refuse to roll back to an earlier day; history carries it too.
+        sourceTs: voteHubDaySourceTs(entry.day) ?? undefined,
       }))
     const fromDay = series[0]?.day ?? 'n/a'
     const toDay = series[series.length - 1]?.day ?? 'n/a'

--- a/backend/scripts/list-votehub-averages.ts
+++ b/backend/scripts/list-votehub-averages.ts
@@ -19,8 +19,14 @@ import { runScript } from './run-script'
 // verified against a live response, and fix the constant if it disagrees.
 if (require.main === module)
   runScript(async () => {
-    log('GET /averages:')
-    log(JSON.stringify(await fetchVoteHubAverageList(), null, 2))
+    // Guarded like the per-spec fetches below: a failing list endpoint must
+    // not hide the per-spec diagnostics, which are the part that matters.
+    try {
+      log('GET /averages:')
+      log(JSON.stringify(await fetchVoteHubAverageList(), null, 2))
+    } catch (err) {
+      log.error(`GET /averages failed: ${err}`)
+    }
 
     for (const spec of ALL_VOTEHUB_FEED_SPECS) {
       log(`--- ${spec.feedId} (averageKey=${spec.averageKey})`)

--- a/backend/scripts/list-votehub-averages.ts
+++ b/backend/scripts/list-votehub-averages.ts
@@ -1,0 +1,58 @@
+import { log } from 'shared/utils'
+import {
+  ALL_VOTEHUB_FEED_SPECS,
+  fetchVoteHubAverage,
+  fetchVoteHubAverageList,
+  fetchVoteHubPolls,
+} from 'shared/votehub-feeds'
+import { runScript } from './run-script'
+
+// Discovery helper for the VoteHub feed specs — read-only, writes nothing.
+//
+//   npx ts-node list-votehub-averages.ts
+//
+// Prints VoteHub's `GET /averages` list verbatim, then for every spec in
+// ALL_VOTEHUB_FEED_SPECS: the answer keys of the latest day of its published
+// series (what `answerKey` must match), and the `answers[].choice` strings of
+// the most recent raw poll (what `pollAnswerChoice` must match). Run it
+// before backfilling any spec whose comment says its key and shape were not
+// verified against a live response, and fix the constant if it disagrees.
+if (require.main === module)
+  runScript(async () => {
+    log('GET /averages:')
+    log(JSON.stringify(await fetchVoteHubAverageList(), null, 2))
+
+    for (const spec of ALL_VOTEHUB_FEED_SPECS) {
+      log(`--- ${spec.feedId} (averageKey=${spec.averageKey})`)
+      try {
+        const series = await fetchVoteHubAverage(spec)
+        const days = Object.keys(series ?? {})
+          .filter((k) => /^\d{4}-\d{2}-\d{2}$/.test(k))
+          .sort()
+        const latest = days[days.length - 1]
+        log(
+          `  ${days.length} days, latest ${latest ?? 'n/a'}: ${JSON.stringify(
+            latest ? series[latest] : null
+          )} (spec answerKey=${spec.answerKey})`
+        )
+      } catch (err) {
+        log.error(`  averages fetch failed: ${err}`)
+      }
+      try {
+        const since = new Date(Date.now() - 60 * 86_400_000)
+          .toISOString()
+          .slice(0, 10)
+        const polls = await fetchVoteHubPolls(spec, since)
+        const newest = polls[0]
+        log(
+          `  ${polls.length} polls since ${since}; newest ${
+            newest?.end_date ?? 'n/a'
+          } ${newest?.pollster ?? ''}: choices ${JSON.stringify(
+            newest?.answers?.map((a) => a.choice) ?? []
+          )} (spec pollAnswerChoice=${spec.pollAnswerChoice})`
+        )
+      } catch (err) {
+        log.error(`  polls fetch failed: ${err}`)
+      }
+    }
+  })

--- a/backend/scripts/publish-fear-greed-now.ts
+++ b/backend/scripts/publish-fear-greed-now.ts
@@ -1,0 +1,36 @@
+import {
+  fearGreedDay,
+  publishFearGreedPoint,
+} from 'shared/perps/publish-fear-greed'
+import { log } from 'shared/utils'
+import { runScript } from './run-script'
+
+// Manually publish the current `crypto-fear-greed` reading, for when the
+// scheduled job's retries have all failed and the feed is about to cross the
+// market's maxOraclePriceAgeMs — which pauses the PERP engine, and with it
+// liquidations and ADL.
+//
+//   npx ts-node publish-fear-greed-now.ts [--force]
+//
+// Runs exactly what the scheduled job runs: ONE point stamped at Date.now(),
+// applied to live perps. Without --force it respects the same unchanged gate
+// the job uses; pass --force during an incident to re-stamp the current value
+// regardless. Never backfills: backfill-fear-greed-oracle is for feeds with
+// no live market. Exits nonzero unless a point actually landed.
+if (require.main === module)
+  runScript(async ({ pg }) => {
+    const force = process.argv.includes('--force')
+    const today = fearGreedDay()
+    const result = await publishFearGreedPoint(pg, { force })
+    if (result.status !== 'published')
+      throw new Error(
+        `nothing published for ${today} (${result.status}): ${result.reason}`
+      )
+    log(
+      `published ${result.price}${
+        result.classification ? ` (${result.classification})` : ''
+      } for ${today} at ${new Date(result.ts).toISOString()} (source ${new Date(
+        result.sourceTs
+      ).toISOString()})`
+    )
+  })

--- a/backend/scripts/publish-votehub-now.ts
+++ b/backend/scripts/publish-votehub-now.ts
@@ -1,0 +1,66 @@
+import {
+  publishVoteHubPoint,
+  voteHubDay,
+} from 'shared/perps/publish-votehub-average'
+import { log } from 'shared/utils'
+import { ALL_VOTEHUB_FEED_SPECS, getVoteHubFeedSpec } from 'shared/votehub-feeds'
+import { runScript } from './run-script'
+
+// Manually publish today's point for a VoteHub average feed, for when the
+// scheduled job's retries have all failed (e.g. a multi-hour VoteHub outage)
+// and the feed is about to cross the market's maxOraclePriceAgeMs — which
+// pauses the PERP engine, and with it liquidations and ADL.
+//
+//   npx ts-node publish-votehub-now.ts --feed=vance-favorability [--force]
+//
+// This runs exactly what the scheduled job runs: ONE point stamped at
+// Date.now(), applied to live perps. So any liquidations and ADL the new
+// price implies happen immediately, as they would on a normal publication.
+//
+// Without --force this respects the same gate the scheduled job uses, so it
+// declines when VoteHub's value has not moved and the feed already carries a
+// recent point — there is nothing to publish and saying so is more useful
+// than appending a duplicate. Pass --force during an incident to stamp the
+// current value regardless, which is the whole point of the escape hatch.
+//
+// It does NOT backfill missed days. A value is stamped when it became
+// available to the market and is never backdated into a window where funding
+// and liquidations have already run. backfill-votehub-oracle is for feeds
+// with no live market.
+//
+// Exits nonzero unless a point was actually published — during an incident
+// the one thing an operator must not be told is that the escape hatch worked
+// when nothing landed.
+if (require.main === module)
+  runScript(async ({ pg }) => {
+    const force = process.argv.includes('--force')
+    const feedId = process.argv
+      .find((arg) => arg.startsWith('--feed='))
+      ?.slice('--feed='.length)
+    const spec = feedId ? getVoteHubFeedSpec(feedId) : undefined
+    if (!spec)
+      throw new Error(
+        `pass --feed=<feedId>; known VoteHub feeds: ${ALL_VOTEHUB_FEED_SPECS.map(
+          (s) => s.feedId
+        ).join(', ')}`
+      )
+    const today = voteHubDay(spec)
+
+    const result = await publishVoteHubPoint(pg, spec, { force })
+    if (result.status !== 'published')
+      throw new Error(
+        `nothing published for ${spec.feedId} on ${today} (${result.status}): ${result.reason}`
+      )
+
+    log(
+      `published ${spec.feedId} ${result.price.toFixed(
+        2
+      )} for ${today} at ${new Date(result.ts).toISOString()} (as of ${
+        result.asOfDay
+      }, cross-check ${
+        result.crossCheckGap == null
+          ? 'unavailable'
+          : `gap ${result.crossCheckGap.toFixed(2)}`
+      })`
+    )
+  })

--- a/backend/scripts/publish-votehub-now.ts
+++ b/backend/scripts/publish-votehub-now.ts
@@ -3,7 +3,10 @@ import {
   voteHubDay,
 } from 'shared/perps/publish-votehub-average'
 import { log } from 'shared/utils'
-import { ALL_VOTEHUB_FEED_SPECS, getVoteHubFeedSpec } from 'shared/votehub-feeds'
+import {
+  ALL_VOTEHUB_FEED_SPECS,
+  getVoteHubFeedSpec,
+} from 'shared/votehub-feeds'
 import { runScript } from './run-script'
 
 // Manually publish today's point for a VoteHub average feed, for when the

--- a/backend/shared/src/fear-greed.test.ts
+++ b/backend/shared/src/fear-greed.test.ts
@@ -1,0 +1,62 @@
+import { getOracleAttribution } from 'common/perps/oracle-attribution'
+import { ORACLE_TICK_DECORATIONS } from 'common/perps/oracle-display'
+import { FEAR_GREED_MAX } from 'common/perps/fear-greed'
+
+import { FEAR_GREED_API_URL } from './fear-greed'
+import { CRYPTO_FEAR_GREED_FEED_ID } from './oracle'
+import { getOracleFeed } from './oracle-feeds'
+import {
+  PERP_LAUNCH_MARKETS,
+  PERP_LAUNCH_SCHEDULER_EXPECTATIONS,
+  getPerpLaunchManifestErrors,
+} from './perps/launch-manifest'
+
+// Presence checks for the `crypto-fear-greed` feed: registry, attribution,
+// chart decoration, launch manifest, scheduler expectation. A missing entry
+// is a red build rather than a runtime surprise.
+describe('crypto-fear-greed feed wiring', () => {
+  const id = CRYPTO_FEAR_GREED_FEED_ID
+
+  it('uses the documented API endpoint, not the website', () => {
+    expect(FEAR_GREED_API_URL).toBe('https://api.alternative.me/fng/')
+  })
+
+  it('is registered as a daily feed with positive bounds', () => {
+    const feed = getOracleFeed(id)
+    expect(feed?.cadence).toBe('daily')
+    expect(feed?.marketCreationEnabled).toBe(true)
+    // 1, not 0: a literal 0 print is refused by the positivity rule and the
+    // feed pauses at the stale gate rather than publishing it.
+    expect(feed?.minPrice).toBe(1)
+    expect(feed?.maxPrice).toBe(FEAR_GREED_MAX)
+    expect(feed?.staleAfterMs).toBe(26 * 60 * 60 * 1000)
+    expect(feed?.updatePeriodMs).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('credits Alternative.me with a link and no unverified licence label', () => {
+    const attribution = getOracleAttribution(id)
+    expect(attribution?.source).toBe('Alternative.me Crypto Fear & Greed Index')
+    expect(attribution?.url).toBe(
+      'https://alternative.me/crypto/fear-and-greed-index/'
+    )
+    expect(attribution?.licence).toBeUndefined()
+    expect(attribution?.licenceUrl).toBeUndefined()
+    expect(attribution?.showAsOf).toBeUndefined()
+  })
+
+  it('renders as unitless index points', () => {
+    expect(ORACLE_TICK_DECORATIONS[id]).toEqual({})
+  })
+
+  it('has a launch-manifest entry and a scheduler expectation', () => {
+    const market = PERP_LAUNCH_MARKETS.find((m) => m.feedId === id)
+    expect(market?.question).toBe('Crypto Fear & Greed index (Alternative.me)')
+    expect(market?.oracleBehavior).toBe('scheduled-step')
+    expect(market?.requiresSourceAsOf).toBe(false)
+    expect(market?.requiredTopics.map((t) => t.name)).toEqual(['Crypto'])
+    expect(
+      PERP_LAUNCH_SCHEDULER_EXPECTATIONS.map((e) => e.jobName)
+    ).toContain('update-fear-greed')
+    expect(getPerpLaunchManifestErrors()).toEqual([])
+  })
+})

--- a/backend/shared/src/fear-greed.test.ts
+++ b/backend/shared/src/fear-greed.test.ts
@@ -54,9 +54,9 @@ describe('crypto-fear-greed feed wiring', () => {
     expect(market?.oracleBehavior).toBe('scheduled-step')
     expect(market?.requiresSourceAsOf).toBe(false)
     expect(market?.requiredTopics.map((t) => t.name)).toEqual(['Crypto'])
-    expect(
-      PERP_LAUNCH_SCHEDULER_EXPECTATIONS.map((e) => e.jobName)
-    ).toContain('update-fear-greed')
+    expect(PERP_LAUNCH_SCHEDULER_EXPECTATIONS.map((e) => e.jobName)).toContain(
+      'update-fear-greed'
+    )
     expect(getPerpLaunchManifestErrors()).toEqual([])
   })
 })

--- a/backend/shared/src/fear-greed.ts
+++ b/backend/shared/src/fear-greed.ts
@@ -1,0 +1,62 @@
+import {
+  FearGreedPoint,
+  parseFearGreedPayload,
+} from 'common/perps/fear-greed'
+
+import { log } from './utils'
+
+// Alternative.me Crypto Fear & Greed adapter. Documented API, no scraping:
+//
+//   GET https://api.alternative.me/fng/?limit=1&format=json   latest reading
+//   GET https://api.alternative.me/fng/?limit=0&format=json   full history
+//
+// This module is the ADAPTER only: it fetches and hands the body to the
+// parser in common/perps/fear-greed.ts, which is where the payload shape is
+// documented and where every field is validated. What the index is and how
+// it is published is written up there and in publish-fear-greed.ts.
+
+export const FEAR_GREED_API_URL = 'https://api.alternative.me/fng/'
+const FETCH_TIMEOUT_MS = 30_000
+
+const fetchFearGreed = async (limit: number): Promise<FearGreedPoint[]> => {
+  const url = `${FEAR_GREED_API_URL}?limit=${limit}&format=json`
+  const response = await fetch(url, {
+    headers: {
+      accept: 'application/json',
+      'user-agent': 'Manifold/1.0 (+https://manifold.markets)',
+    },
+    // Without this a slow-trickling response never times out (undici's body
+    // timeout resets per chunk), the job never finishes, and croner's
+    // `protect` then silently skips subsequent firings with only a warning —
+    // below the ERROR severity that alerting pages on.
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  if (!response.ok)
+    throw new Error(
+      `Fear & Greed request failed: ${response.status} ${response.statusText}`
+    )
+  const body = (await response.json()) as unknown
+  const parsed = parseFearGreedPayload(body)
+  if (!parsed.ok) throw new Error(`Fear & Greed payload rejected: ${parsed.reason}`)
+  log(
+    `[fear-greed] fetched ${parsed.points.length} reading(s)` +
+      (parsed.points.length > 0
+        ? `, latest ${parsed.points[parsed.points.length - 1].value} at ${new Date(
+            parsed.points[parsed.points.length - 1].sourceTs
+          ).toISOString()}`
+        : '')
+  )
+  return parsed.points
+}
+
+/** The current reading — the oracle price. */
+export const fetchFearGreedLatest = async (): Promise<FearGreedPoint> => {
+  const points = await fetchFearGreed(1)
+  const latest = points[points.length - 1]
+  if (!latest) throw new Error('Fear & Greed payload carried no reading')
+  return latest
+}
+
+/** Every reading the provider still serves, oldest first. Backfill only. */
+export const fetchFearGreedHistory = (): Promise<FearGreedPoint[]> =>
+  fetchFearGreed(0)

--- a/backend/shared/src/fear-greed.ts
+++ b/backend/shared/src/fear-greed.ts
@@ -1,7 +1,4 @@
-import {
-  FearGreedPoint,
-  parseFearGreedPayload,
-} from 'common/perps/fear-greed'
+import { FearGreedPoint, parseFearGreedPayload } from 'common/perps/fear-greed'
 
 import { log } from './utils'
 
@@ -37,11 +34,14 @@ const fetchFearGreed = async (limit: number): Promise<FearGreedPoint[]> => {
     )
   const body = (await response.json()) as unknown
   const parsed = parseFearGreedPayload(body)
-  if (!parsed.ok) throw new Error(`Fear & Greed payload rejected: ${parsed.reason}`)
+  if (!parsed.ok)
+    throw new Error(`Fear & Greed payload rejected: ${parsed.reason}`)
   log(
     `[fear-greed] fetched ${parsed.points.length} reading(s)` +
       (parsed.points.length > 0
-        ? `, latest ${parsed.points[parsed.points.length - 1].value} at ${new Date(
+        ? `, latest ${
+            parsed.points[parsed.points.length - 1].value
+          } at ${new Date(
             parsed.points[parsed.points.length - 1].sourceTs
           ).toISOString()}`
         : '')

--- a/backend/shared/src/openrouter-feeds.test.ts
+++ b/backend/shared/src/openrouter-feeds.test.ts
@@ -9,6 +9,7 @@ import {
 import { getOracleFeed } from './oracle-feeds'
 import {
   PERP_LAUNCH_MARKETS,
+  PERP_LAUNCH_PENDING_MARKETS,
   getPerpLaunchManifestErrors,
 } from './perps/launch-manifest'
 
@@ -26,7 +27,6 @@ describe('OpenRouter lab-share feed wiring', () => {
     for (const id of ids) {
       const feed = getOracleFeed(id)
       expect([id, feed?.cadence]).toEqual([id, 'daily'])
-      expect([id, feed?.marketCreationEnabled]).toEqual([id, true])
       expect([id, feed?.staleAfterMs]).toEqual([id, openWeight?.staleAfterMs])
       expect([id, feed?.updatePeriodMs]).toEqual([
         id,
@@ -55,7 +55,10 @@ describe('OpenRouter lab-share feed wiring', () => {
 
   it('has launch-manifest entries that require the source as-of', () => {
     for (const id of ids) {
-      const market = PERP_LAUNCH_MARKETS.find((m) => m.feedId === id)
+      const market = [
+        ...PERP_LAUNCH_MARKETS,
+        ...PERP_LAUNCH_PENDING_MARKETS,
+      ].find((m) => m.feedId === id)
       expect([id, market?.requiresSourceAsOf]).toEqual([id, true])
       expect([id, market?.oracleBehavior]).toEqual([id, 'scheduled-step'])
       expect([id, market?.requiredTopics.map((t) => t.name)]).toEqual([
@@ -69,5 +72,32 @@ describe('OpenRouter lab-share feed wiring', () => {
       )?.gameDesign
     ).toContain('THROUGH OpenRouter')
     expect(getPerpLaunchManifestErrors()).toEqual([])
+  })
+
+  it('launches the Anthropic feed and holds the Chinese-lab feed pending', () => {
+    // nex-agi is in neither author list, so the Chinese-lab backfill aborts
+    // and the feed must not be creatable until a human places it. The
+    // manifest check enforces the pairing: pending <=> creation-disabled.
+    expect(
+      getOracleFeed(OPENROUTER_ANTHROPIC_SHARE_FEED_ID)?.marketCreationEnabled
+    ).toBe(true)
+    expect(
+      PERP_LAUNCH_MARKETS.some(
+        (m) => m.feedId === OPENROUTER_ANTHROPIC_SHARE_FEED_ID
+      )
+    ).toBe(true)
+    expect(
+      getOracleFeed(OPENROUTER_CHINESE_LAB_SHARE_FEED_ID)?.marketCreationEnabled
+    ).toBe(false)
+    expect(
+      PERP_LAUNCH_MARKETS.some(
+        (m) => m.feedId === OPENROUTER_CHINESE_LAB_SHARE_FEED_ID
+      )
+    ).toBe(false)
+    const pending = PERP_LAUNCH_PENDING_MARKETS.find(
+      (m) => m.feedId === OPENROUTER_CHINESE_LAB_SHARE_FEED_ID
+    )
+    expect(pending?.pendingReason).toContain('nex-agi')
+    expect(pending?.question).toBe('Chinese-lab share of OpenRouter tokens (%)')
   })
 })

--- a/backend/shared/src/openrouter-feeds.test.ts
+++ b/backend/shared/src/openrouter-feeds.test.ts
@@ -1,0 +1,73 @@
+import { getOracleAttribution } from 'common/perps/oracle-attribution'
+import { ORACLE_TICK_DECORATIONS } from 'common/perps/oracle-display'
+
+import {
+  OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+  OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
+  OPENROUTER_OPEN_WEIGHT_FEED_ID,
+} from './oracle'
+import { getOracleFeed } from './oracle-feeds'
+import {
+  PERP_LAUNCH_MARKETS,
+  getPerpLaunchManifestErrors,
+} from './perps/launch-manifest'
+
+// Presence checks for the two lab-share feeds computed from the OpenRouter
+// payload: registry, attribution (with the as-of requirement the dataset
+// terms impose), chart decoration, launch manifest.
+describe('OpenRouter lab-share feed wiring', () => {
+  const ids = [
+    OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+    OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
+  ]
+  const openWeight = getOracleFeed(OPENROUTER_OPEN_WEIGHT_FEED_ID)
+
+  it('registers both on the open-weight feed cadence', () => {
+    for (const id of ids) {
+      const feed = getOracleFeed(id)
+      expect([id, feed?.cadence]).toEqual([id, 'daily'])
+      expect([id, feed?.marketCreationEnabled]).toEqual([id, true])
+      expect([id, feed?.staleAfterMs]).toEqual([id, openWeight?.staleAfterMs])
+      expect([id, feed?.updatePeriodMs]).toEqual([
+        id,
+        openWeight?.updatePeriodMs,
+      ])
+      expect([id, feed?.minPrice]).toEqual([id, 1])
+    }
+    expect(getOracleFeed(OPENROUTER_ANTHROPIC_SHARE_FEED_ID)?.maxPrice).toBe(90)
+    expect(getOracleFeed(OPENROUTER_CHINESE_LAB_SHARE_FEED_ID)?.maxPrice).toBe(
+      95
+    )
+  })
+
+  it('carries the OpenRouter credit with the as-of stamp on both', () => {
+    const reference = getOracleAttribution(OPENROUTER_OPEN_WEIGHT_FEED_ID)
+    for (const id of ids) {
+      expect([id, getOracleAttribution(id)]).toEqual([id, reference])
+      expect([id, getOracleAttribution(id)?.showAsOf]).toEqual([id, true])
+    }
+  })
+
+  it('renders as a percentage', () => {
+    for (const id of ids)
+      expect([id, ORACLE_TICK_DECORATIONS[id]]).toEqual([id, { suffix: '%' }])
+  })
+
+  it('has launch-manifest entries that require the source as-of', () => {
+    for (const id of ids) {
+      const market = PERP_LAUNCH_MARKETS.find((m) => m.feedId === id)
+      expect([id, market?.requiresSourceAsOf]).toEqual([id, true])
+      expect([id, market?.oracleBehavior]).toEqual([id, 'scheduled-step'])
+      expect([id, market?.requiredTopics.map((t) => t.name)]).toEqual([
+        id,
+        ['AI'],
+      ])
+    }
+    expect(
+      PERP_LAUNCH_MARKETS.find(
+        (m) => m.feedId === OPENROUTER_ANTHROPIC_SHARE_FEED_ID
+      )?.gameDesign
+    ).toContain('THROUGH OpenRouter')
+    expect(getPerpLaunchManifestErrors()).toEqual([])
+  })
+})

--- a/backend/shared/src/openrouter-feeds.test.ts
+++ b/backend/shared/src/openrouter-feeds.test.ts
@@ -74,10 +74,7 @@ describe('OpenRouter lab-share feed wiring', () => {
     expect(getPerpLaunchManifestErrors()).toEqual([])
   })
 
-  it('launches the Anthropic feed and holds the Chinese-lab feed pending', () => {
-    // nex-agi is in neither author list, so the Chinese-lab backfill aborts
-    // and the feed must not be creatable until a human places it. The
-    // manifest check enforces the pairing: pending <=> creation-disabled.
+  it('launches both lab-share feeds after the Chinese seed is complete', () => {
     expect(
       getOracleFeed(OPENROUTER_ANTHROPIC_SHARE_FEED_ID)?.marketCreationEnabled
     ).toBe(true)
@@ -88,16 +85,16 @@ describe('OpenRouter lab-share feed wiring', () => {
     ).toBe(true)
     expect(
       getOracleFeed(OPENROUTER_CHINESE_LAB_SHARE_FEED_ID)?.marketCreationEnabled
-    ).toBe(false)
+    ).toBe(true)
     expect(
       PERP_LAUNCH_MARKETS.some(
         (m) => m.feedId === OPENROUTER_CHINESE_LAB_SHARE_FEED_ID
       )
+    ).toBe(true)
+    expect(
+      PERP_LAUNCH_PENDING_MARKETS.some(
+        (m) => m.feedId === OPENROUTER_CHINESE_LAB_SHARE_FEED_ID
+      )
     ).toBe(false)
-    const pending = PERP_LAUNCH_PENDING_MARKETS.find(
-      (m) => m.feedId === OPENROUTER_CHINESE_LAB_SHARE_FEED_ID
-    )
-    expect(pending?.pendingReason).toContain('nex-agi')
-    expect(pending?.question).toBe('Chinese-lab share of OpenRouter tokens (%)')
   })
 })

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -8,6 +8,8 @@ import {
   CRYPTO_FEAR_GREED_FEED_ID,
   GLDX_USD_FEED_ID,
   NVDAX_USD_FEED_ID,
+  OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+  OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
   QQQX_USD_FEED_ID,
   SPYX_USD_FEED_ID,
@@ -325,6 +327,43 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     // a new VALUE, and we write a point every hour — so a 24h period would
     // free-run to an arbitrary time and let anyone flat at that instant pay
     // nothing.
+    updatePeriodMs: HOUR_MS,
+  },
+  // Two more indexes over the SAME OpenRouter payload, computed by the same
+  // hourly job from the rows it already fetched — no additional API calls
+  // against the 500/day account limit. Same window, same denominator, same
+  // exclusions as the open-weight index (common/perps/lab-share.ts), so the
+  // three are one comparable family, and the same cadence, staleness and
+  // funding reasoning as the entry above. Corruption is caught at the
+  // source by validateLabSharePublication: malformed rows or slugs and an
+  // incomplete window fail both feeds closed, and the Chinese-lab feed also
+  // refuses to publish when authors it cannot place exceed
+  // UNKNOWN_AUTHOR_TOKEN_SHARE_CAP.
+  {
+    id: OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+    description:
+      'Anthropic share of top-50 model tokens on OpenRouter, trailing 7 UTC days (%)',
+    marketCreationEnabled: true,
+    cadence: 'daily',
+    // A single publisher's share of a marketplace: anywhere from a few
+    // percent to a clear majority is a real reading, and the bounds only
+    // reject a 0-1 fraction or a share of the wrong population.
+    minPrice: 1,
+    maxPrice: 90,
+    staleAfterMs: 3 * HOUR_MS,
+    updatePeriodMs: HOUR_MS,
+  },
+  {
+    id: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
+    description:
+      'Chinese-lab share of top-50 model tokens on OpenRouter, trailing 7 UTC days (%)',
+    marketCreationEnabled: true,
+    cadence: 'daily',
+    // A group of publishers can plausibly dominate the marketplace; the
+    // upper bound is set so that even near-total dominance still publishes.
+    minPrice: 1,
+    maxPrice: 95,
+    staleAfterMs: 3 * HOUR_MS,
     updatePeriodMs: HOUR_MS,
   },
 ]

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -357,7 +357,19 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     id: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
     description:
       'Chinese-lab share of top-50 model tokens on OpenRouter, trailing 7 UTC days (%)',
-    marketCreationEnabled: true,
+    // DISABLED FOR CREATION until every author in the ranked window is
+    // placed. `nex-agi` sits in the open-weight seed list (it ranked in the
+    // past year) but in neither CHINESE_LAB_AUTHORS nor
+    // KNOWN_NON_CHINESE_AUTHORS, because its headquarters could not be
+    // established when the lists were written and the rule is to place an
+    // author on evidence, never by default. Until it is placed the backfill
+    // aborts (cap 0) and the live job publishes only while its tokens stay
+    // under the 1% cap — so a market could not be backed by a full year of
+    // history and could inherit a halted oracle. Ingestion and health checks
+    // run regardless. Promotion is one commit: add the author line, flip
+    // this to true, and move the entry from PERP_LAUNCH_PENDING_MARKETS to
+    // PERP_LAUNCH_MARKETS.
+    marketCreationEnabled: false,
     cadence: 'daily',
     // A group of publishers can plausibly dominate the marketplace; the
     // upper bound is set so that even near-total dominance still publishes.

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -357,19 +357,12 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     id: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
     description:
       'Chinese-lab share of top-50 model tokens on OpenRouter, trailing 7 UTC days (%)',
-    // DISABLED FOR CREATION until every author in the ranked window is
-    // placed. `nex-agi` sits in the open-weight seed list (it ranked in the
-    // past year) but in neither CHINESE_LAB_AUTHORS nor
-    // KNOWN_NON_CHINESE_AUTHORS, because its headquarters could not be
-    // established when the lists were written and the rule is to place an
-    // author on evidence, never by default. Until it is placed the backfill
-    // aborts (cap 0) and the live job publishes only while its tokens stay
-    // under the 1% cap — so a market could not be backed by a full year of
-    // history and could inherit a halted oracle. Ingestion and health checks
-    // run regardless. Promotion is one commit: add the author line, flip
-    // this to true, and move the entry from PERP_LAUNCH_PENDING_MARKETS to
-    // PERP_LAUNCH_MARKETS.
-    marketCreationEnabled: false,
+    // New authors are discovered into the operator queue and resolved from
+    // the DB on each hourly tick. The audited seed covers the historical
+    // backfill, including exact-model attribution for the anonymous
+    // stealth/ox-alpha preview; future unknown volume still fails closed at
+    // UNKNOWN_AUTHOR_TOKEN_SHARE_CAP.
+    marketCreationEnabled: true,
     cadence: 'daily',
     // A group of publishers can plausibly dominate the marketplace; the
     // upper bound is set so that even near-total dominance still publishes.

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -10,6 +10,8 @@ import {
   QQQX_USD_FEED_ID,
   SPYX_USD_FEED_ID,
   TRUMP_APPROVAL_FEED_ID,
+  VANCE_FAVORABILITY_FEED_ID,
+  VOTEHUB_GENERIC_BALLOT_2026_FEED_ID,
 } from './oracle'
 import { XSTOCK_SPECS, fetchXStockUsdPrice } from './xstocks-price'
 
@@ -230,6 +232,46 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     // feed (max(1h, updatePeriodMs)). Holding it at a day keeps funding
     // matched to how often the number actually moves rather than to how
     // often we look at it. The live market carries its own frozen 24h value.
+    updatePeriodMs: DAY_MS,
+  },
+  // The other VoteHub averages. Same publisher structure as Trump (polled
+  // every 5 minutes by update-votehub-averages, published on change plus a
+  // 12h heartbeat), same 26h dead-man threshold, same once-a-day
+  // updatePeriodMs so a new market's funding period matches how often the
+  // number actually moves. Bounds are wide on purpose and reject only
+  // unit-confused garbage (a 0-1 fraction, a margin, a percent-of-percent):
+  // corruption is caught at the source by readPublishedAverage, which
+  // rejects a published value outside (0,100) or staler than
+  // maxSourceAgeDays, and by the cross-check canary, which refuses to publish
+  // a value our own poll average disagrees with by more than the spec's
+  // tolerance.
+  {
+    id: VOTEHUB_GENERIC_BALLOT_2026_FEED_ID,
+    description:
+      "Democratic share (%) of VoteHub's published 2026 generic-ballot average",
+    marketCreationEnabled: true,
+    cadence: 'daily',
+    // A major party's generic-ballot share has sat between the high 30s and
+    // the mid 50s for as long as the question has been polled; 20-80 leaves
+    // room for any real result and still catches a margin (D-R, typically
+    // single digits) or a fraction being published in its place.
+    minPrice: 20,
+    maxPrice: 80,
+    staleAfterMs: 26 * HOUR_MS,
+    updatePeriodMs: DAY_MS,
+  },
+  {
+    id: VANCE_FAVORABILITY_FEED_ID,
+    description:
+      "Favorable (%) from VoteHub's published JD Vance favorability average",
+    marketCreationEnabled: true,
+    cadence: 'daily',
+    // Same bounds as Trump approval: favorability of a national politician
+    // ranges more widely than a party's ballot share, and 10-90 still rejects
+    // a net-favorability margin or a 0-1 fraction.
+    minPrice: 10,
+    maxPrice: 90,
+    staleAfterMs: 26 * HOUR_MS,
     updatePeriodMs: DAY_MS,
   },
   {

--- a/backend/shared/src/oracle-feeds.ts
+++ b/backend/shared/src/oracle-feeds.ts
@@ -1,9 +1,11 @@
 import { DAY_MS, HOUR_MS, MINUTE_MS } from 'common/util/time'
 import { validateBasicOraclePoint } from 'common/perps/oracle'
+import { FEAR_GREED_MAX } from 'common/perps/fear-greed'
 
 import { fetchBtcUsdSpot } from './btc-price'
 import {
   BTC_USD_FEED_ID,
+  CRYPTO_FEAR_GREED_FEED_ID,
   GLDX_USD_FEED_ID,
   NVDAX_USD_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
@@ -272,6 +274,32 @@ export const ORACLE_FEEDS: OracleFeedDef[] = [
     minPrice: 10,
     maxPrice: 90,
     staleAfterMs: 26 * HOUR_MS,
+    updatePeriodMs: DAY_MS,
+  },
+  {
+    id: CRYPTO_FEAR_GREED_FEED_ID,
+    description:
+      'Alternative.me Crypto Fear & Greed index (0-100 sentiment points)',
+    marketCreationEnabled: true,
+    // Own job (update-fear-greed, every 5 minutes, publishes on change plus
+    // a 12h heartbeat); the value itself steps once a day around 00:00 UTC.
+    cadence: 'daily',
+    // The index is an integer on [0, 100]. The LOWER bound is 1, not 0, on
+    // purpose: oracle prices must be strictly positive
+    // (validateBasicOraclePoint), so a literal 0 print cannot be published
+    // under any bounds. That is acceptable — the index has never printed 0;
+    // its historical floor is in the single digits — and the failure mode is
+    // the safe one: if it ever does print 0 the publisher rejects the point,
+    // nothing is written, the market pauses at its maxOraclePriceAgeMs stale
+    // gate, and trading resumes on the next non-zero print. Pausing beats
+    // publishing a non-positive price or inventing a floor. Everything else
+    // the parser already enforces (integer, in range, provider error flag,
+    // parseable timestamp) — see common/perps/fear-greed.ts.
+    minPrice: 1,
+    maxPrice: FEAR_GREED_MAX,
+    staleAfterMs: 26 * HOUR_MS,
+    // Steps once a day, so a new market's funding period matches how often
+    // the number moves rather than how often we look at it.
     updatePeriodMs: DAY_MS,
   },
   {

--- a/backend/shared/src/oracle.ts
+++ b/backend/shared/src/oracle.ts
@@ -12,6 +12,10 @@ export const SPYX_USD_FEED_ID = 'spyx-usd'
 export const QQQX_USD_FEED_ID = 'qqqx-usd'
 export const GLDX_USD_FEED_ID = 'gldx-usd'
 export const NVDAX_USD_FEED_ID = 'nvdax-usd'
+// VoteHub published averages beyond Trump approval. Same publisher, same
+// licence, different answer key — see backend/shared/src/votehub-feeds.ts.
+export const VOTEHUB_GENERIC_BALLOT_2026_FEED_ID = 'votehub-generic-ballot-2026'
+export const VANCE_FAVORABILITY_FEED_ID = 'vance-favorability'
 
 // Append oracle price points for a feed. Published history is immutable:
 // duplicate (feed_id, ts) values remain unchanged even if a source later

--- a/backend/shared/src/oracle.ts
+++ b/backend/shared/src/oracle.ts
@@ -8,6 +8,12 @@ export const MANIFOLD_DAU_FEED_ID = 'manifold-dau'
 export const TRUMP_APPROVAL_FEED_ID = 'trump-approval-rating'
 export const BTC_USD_FEED_ID = 'btc-usd'
 export const OPENROUTER_OPEN_WEIGHT_FEED_ID = 'openrouter-open-weight-share'
+// Two more indexes computed from the SAME rankings payload the open-weight
+// job already fetches (no additional OpenRouter calls) — see
+// common/perps/lab-share.ts.
+export const OPENROUTER_ANTHROPIC_SHARE_FEED_ID = 'openrouter-anthropic-share'
+export const OPENROUTER_CHINESE_LAB_SHARE_FEED_ID =
+  'openrouter-chinese-lab-share'
 export const SPYX_USD_FEED_ID = 'spyx-usd'
 export const QQQX_USD_FEED_ID = 'qqqx-usd'
 export const GLDX_USD_FEED_ID = 'gldx-usd'

--- a/backend/shared/src/oracle.ts
+++ b/backend/shared/src/oracle.ts
@@ -16,6 +16,7 @@ export const NVDAX_USD_FEED_ID = 'nvdax-usd'
 // licence, different answer key — see backend/shared/src/votehub-feeds.ts.
 export const VOTEHUB_GENERIC_BALLOT_2026_FEED_ID = 'votehub-generic-ballot-2026'
 export const VANCE_FAVORABILITY_FEED_ID = 'vance-favorability'
+export const CRYPTO_FEAR_GREED_FEED_ID = 'crypto-fear-greed'
 
 // Append oracle price points for a feed. Published history is immutable:
 // duplicate (feed_id, ts) values remain unchanged even if a source later

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -292,7 +292,9 @@ temporal cap cannot self-heal, because the rejected point remains the
 comparison basis. Validation that has to tell "corrupt" apart from "moved
 fast" belongs in the adapter, where the source is visible: cross-exchange
 agreement in `btc-price.ts`, `validateOpenWeightPublication` in
-`open-weight-models.ts`, and the per-poll range check in `trump-approval.ts`.
+`open-weight-models.ts` (and its sibling `validateLabSharePublication` in
+`lab-share.ts`), the published-value cross-check canary in
+`votehub-average.ts`, and the untrusted-payload parser in `fear-greed.ts`.
 
 Feed adapters live next to it:
 
@@ -303,9 +305,28 @@ Feed adapters live next to it:
   pools (Raydium/Orca account state fetched via `solana-rpc.ts`, decoded in
   `common/src/perps/solana-pools.ts`, unit-tested against captured
   accounts). Chain state only — every venue API evaluated came with terms.
-- `trump-approval.ts` — 14-day rolling approval average (VoteHub).
-- `openrouter-tokens.ts` — trailing seven-day open-weight share of classified
-  top-50 OpenRouter model traffic.
+- `votehub-feeds.ts` — VoteHub's published, time-weighted polling averages,
+  parameterised by a `VoteHubFeedSpec` (average key, answer key, canary poll
+  query, log prefix, rules). Three feeds: `trump-approval-rating` (via the
+  thin `trump-approval.ts` wrapper, unchanged in behaviour),
+  `votehub-generic-ballot-2026` (Democratic share of the 2026 generic
+  ballot), and `vance-favorability` (JD Vance's Favorable share). Always a
+  share, never a margin, so the price is strictly positive. The
+  answer-key-parameterised reader and the cross-check canary live in
+  `common/src/perps/votehub-average.ts`; the publish-on-change plus 12h
+  heartbeat rule every slow feed shares is `common/src/perps/daily-feed-publish.ts`.
+- `fear-greed.ts` — Alternative.me's Crypto Fear & Greed index
+  (`crypto-fear-greed`, 0-100 sentiment points, documented `/fng/` API only).
+  The parser in `common/src/perps/fear-greed.ts` treats every field as
+  untrusted; the registry lower bound is 1 so a literal 0 print pauses the
+  feed instead of publishing a non-positive price.
+- `openrouter-tokens.ts` — one hourly fetch of OpenRouter's top-50 daily
+  token totals prices THREE feeds over the same trailing-7-UTC-day window and
+  the same denominator exclusions: `openrouter-open-weight-share`
+  (`common/src/perps/open-weight-models.ts`), and the author-level
+  `openrouter-anthropic-share` and `openrouter-chinese-lab-share`
+  (`common/src/perps/lab-share.ts`, where a new author is a one-line constant
+  and an unplaced author over 1% of tokens halts the Chinese-lab feed).
 
 **Monotone feeds make bad perps:** a monotone non-decreasing index (the Epoch
 Capabilities Index frontier was prototyped and then removed for this reason)
@@ -315,8 +336,12 @@ short thesis. If an ingest-only feed is ever added again, list it in
 enforces that exclusion.
 
 Backfill scripts
-(`backend/scripts/backfill-{btc,xstocks,trump-approval,openrouter}-oracle.ts`)
-seed chart history before market creation.
+(`backend/scripts/backfill-{btc,xstocks,trump-approval,votehub,fear-greed,openrouter}-oracle.ts`;
+`backfill-votehub-oracle` and `backfill-openrouter-oracle` take
+`--feed=<feedId>`) seed chart history before market creation. They are for
+feeds with NO live market: published history is append-only and a backfill
+stamps day boundaries, so on a live feed it would add a second point to every
+day rather than fill a hole.
 
 The executable launch set, conservative initial parameters, feed-specific game
 design notes, and oracle-latency risks live in
@@ -338,14 +363,29 @@ sequence and rollback are in `perps-launch-runbook.md`.
   contract. The once-per-`FUNDING_PERIOD_MS` funding gate lives INSIDE
   `runFunding`, under the advisory lock, so overlapping ticks can't
   double-fund.
-- `update-trump-approval.ts` writes one daily point.
-- `update-openrouter-share.ts` polls hourly. OpenRouter currently returns
-  complete UTC days, so most hourly observations repeat the same underlying
-  value; a fresh timestamp proves job liveness but does not create intraday
-  price discovery.
+- `update-trump-approval.ts` polls VoteHub every 5 minutes and publishes
+  the Trump average on change plus a 12h heartbeat, under `[trump-approval]`.
+- `update-votehub-averages.ts` does the same for the other VoteHub specs
+  (generic ballot, Vance favorability), every 5 minutes offset two minutes
+  from the Trump job, each spec published independently, under `[votehub]`.
+- `update-fear-greed.ts` polls Alternative.me every 5 minutes and publishes
+  on change plus a heartbeat, under `[fear-greed]`. The index itself steps
+  once a day around 00:00 UTC.
+- `update-openrouter-share.ts` polls hourly and publishes the open-weight,
+  Anthropic-share and Chinese-lab-share feeds from ONE fetch, each through
+  its own validate → insert → apply pass so one refusing never withholds the
+  others, under `[openrouter]`. OpenRouter currently returns complete UTC
+  days, so most hourly observations repeat the same underlying value; a fresh
+  timestamp proves job liveness but does not create intraday price discovery.
+
+The slow-feed jobs share `daily-feed-failure.ts`: a failed attempt is a
+throttled WARN until the feed has gone 20h without a point, then every
+failure is an ERROR.
 
 Feed-health alerts are `log.error` lines prefixed `[oracle-feeds]` /
-`[update-perps]` — wire GCP log-based alerting to those.
+`[update-perps]`, and the publisher jobs page under `[trump-approval]`,
+`[votehub]`, `[fear-greed]` and `[openrouter]` — wire GCP log-based alerting
+to all of those.
 
 Trading and closes share `getOracleFreshness` from
 `common/src/perps/oracle.ts`. A stale price, missing timestamp, or invalid

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -325,11 +325,12 @@ Feed adapters live next to it:
   the same denominator exclusions: `openrouter-open-weight-share`
   (`common/src/perps/open-weight-models.ts`), and the author-level
   `openrouter-anthropic-share` and `openrouter-chinese-lab-share`
-  (`common/src/perps/lab-share.ts`, where a new author is a one-line constant
-  and an unplaced author over 1% of tokens halts the Chinese-lab feed). The
-  Chinese-lab feed is registered but **creation-disabled and pending**
-  (`PERP_LAUNCH_PENDING_MARKETS`) until `nex-agi` is placed in an author
-  list; promotion is one commit. One fetch also gates all three: if the
+  (`common/src/perps/lab-share.ts`). The audited author/model constants are a
+  seed; the backend overlays operator classifications from
+  `openrouter_lab_classifications`, discovers new subjects from both the
+  catalog and live rankings, and exposes the pending queue at
+  `/admin/model-classifications`. An unresolved subject over 1% of tokens
+  halts only the Chinese-lab feed. One fetch also gates all three: if the
   newest complete day in the payload is more than
   `OPENROUTER_MAX_SOURCE_LAG_DAYS` behind today, nothing publishes, and a
   point whose dataset `as_of` regresses is refused.

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -355,7 +355,9 @@ Backfill scripts
 `--feed=<feedId>`) seed chart history before market creation. They are for
 feeds with NO live market: published history is append-only and a backfill
 stamps day boundaries, so on a live feed it would add a second point to every
-day rather than fill a hole.
+day rather than fill a hole. The VoteHub, Fear & Greed and OpenRouter scripts
+check this (`backfill-guard.ts`) and refuse a feed that backs an unresolved
+market unless `--force` is passed.
 
 The executable launch set, conservative initial parameters, feed-specific game
 design notes, and oracle-latency risks live in
@@ -386,9 +388,10 @@ sequence and rollback are in `perps-launch-runbook.md`.
   on change plus a heartbeat, under `[fear-greed]`. The index itself steps
   once a day around 00:00 UTC.
 - `update-openrouter-share.ts` polls hourly and publishes the open-weight,
-  Anthropic-share and Chinese-lab-share feeds from ONE fetch, each through
-  its own validate → insert → apply pass so one refusing never withholds the
-  others, under `[openrouter]`. OpenRouter currently returns complete UTC
+  Anthropic-share and Chinese-lab-share feeds from ONE fetch, each under its
+  own per-feed advisory lock (lock → reread → validate → insert, then apply
+  outside the transaction) so one refusing never withholds the others, under
+  `[openrouter]`. OpenRouter currently returns complete UTC
   days, so most hourly observations repeat the same underlying value; a fresh
   timestamp proves job liveness but does not create intraday price discovery.
 

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -326,7 +326,21 @@ Feed adapters live next to it:
   (`common/src/perps/open-weight-models.ts`), and the author-level
   `openrouter-anthropic-share` and `openrouter-chinese-lab-share`
   (`common/src/perps/lab-share.ts`, where a new author is a one-line constant
-  and an unplaced author over 1% of tokens halts the Chinese-lab feed).
+  and an unplaced author over 1% of tokens halts the Chinese-lab feed). The
+  Chinese-lab feed is registered but **creation-disabled and pending**
+  (`PERP_LAUNCH_PENDING_MARKETS`) until `nex-agi` is placed in an author
+  list; promotion is one commit. One fetch also gates all three: if the
+  newest complete day in the payload is more than
+  `OPENROUTER_MAX_SOURCE_LAG_DAYS` behind today, nothing publishes, and a
+  point whose dataset `as_of` regresses is refused.
+
+Every slow-feed publisher carries the provider's own timestamp as
+`source_ts` (the VoteHub day, the Fear & Greed reading time, the OpenRouter
+`as_of`) and refuses, under the advisory lock, to publish a value the
+provider stamped EARLIER than the one already on the feed. That is what
+stops a source that briefly regresses (a day dropping out of VoteHub's
+series, a cached older reading) from rolling the executable mark back;
+same-stamp corrections still go through.
 
 **Monotone feeds make bad perps:** a monotone non-decreasing index (the Epoch
 Capabilities Index frontier was prototyped and then removed for this reason)

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -380,7 +380,8 @@ sequence and rollback are in `perps-launch-runbook.md`.
 
 The slow-feed jobs share `daily-feed-failure.ts`: a failed attempt is a
 throttled WARN until the feed has gone 20h without a point, then every
-failure is an ERROR.
+failure is an ERROR (a feed that has never published is an ERROR too, but
+throttled to one an hour).
 
 Feed-health alerts are `log.error` lines prefixed `[oracle-feeds]` /
 `[update-perps]`, and the publisher jobs page under `[trump-approval]`,

--- a/backend/shared/src/perps/lab-classifications.test.ts
+++ b/backend/shared/src/perps/lab-classifications.test.ts
@@ -1,0 +1,197 @@
+jest.mock('common/perps/open-weight-models', () => {
+  const basePermaslug = (slug: string) => slug.split(':', 1)[0]
+  const routerKeys = ['openrouter/auto', 'openrouter/auto-beta']
+  return {
+    basePermaslug,
+    isValidPermaslug: (slug: string) => /^[^/\s]+\/[^/\s]+$/.test(slug),
+    isCompositeSlug: (slug: string) =>
+      slug.startsWith('~') || routerKeys.includes(basePermaslug(slug)),
+  }
+})
+
+jest.mock('common/perps/lab-share', () => ({
+  DEFAULT_LAB_SHARE_CLASSIFICATIONS: {
+    chinese: {},
+    nonChinese: {},
+    chineseModels: {},
+    nonChineseModels: {},
+  },
+  authorOfPermaslug: (slug: string) => {
+    const base = slug.split(':', 1)[0]
+    return /^[^/\s]+\/[^/\s]+$/.test(base) ? base.split('/', 1)[0] : null
+  },
+}))
+
+import {
+  LabClassificationRow,
+  mergeLabClassificationRows,
+  normalizeLabClassificationSubject,
+  pendingLabSubjectsFromCatalog,
+  validateLabClassificationWrite,
+} from './lab-classifications'
+
+const evidence = (value: string) => ({ evidence: value })
+
+const row = (
+  overrides: Partial<LabClassificationRow> &
+    Pick<LabClassificationRow, 'subject_type' | 'subject_slug' | 'is_chinese'>
+): LabClassificationRow => ({
+  source: 'admin',
+  evidence: evidence('database decision'),
+  first_seen: '2026-09-01T00:00:00.000Z',
+  first_ranked_at: null,
+  classified_at:
+    overrides.is_chinese === null ? null : '2026-09-02T00:00:00.000Z',
+  classified_by: overrides.is_chinese === null ? null : 'operator-id',
+  updated_time: '2026-09-02T00:00:00.000Z',
+  ...overrides,
+})
+
+describe('lab classification resolution', () => {
+  const seed: NonNullable<Parameters<typeof mergeLabClassificationRows>[1]> = {
+    chinese: { 'seed-cn': evidence('seed Chinese author') },
+    nonChinese: { 'seed-us': evidence('seed non-Chinese author') },
+    chineseModels: {
+      'stealth/known': evidence('seed exact Chinese model'),
+    },
+    nonChineseModels: {},
+  }
+
+  test('normalizes model variants and rejects unusable subject keys', () => {
+    expect(normalizeLabClassificationSubject('author', ' nex-agi ')).toBe(
+      'nex-agi'
+    )
+    expect(normalizeLabClassificationSubject('model', 'stealth/new:free')).toBe(
+      'stealth/new'
+    )
+    expect(() => normalizeLabClassificationSubject('author', 'x/y')).toThrow(
+      'malformed OpenRouter author'
+    )
+    expect(() => normalizeLabClassificationSubject('model', 'x/')).toThrow(
+      'malformed OpenRouter model'
+    )
+    expect(() =>
+      normalizeLabClassificationSubject('model', 'openrouter/auto')
+    ).toThrow('composite OpenRouter model')
+  })
+
+  test('keeps seed verdicts and only accepts exact DB rows in model-scoped namespaces', () => {
+    const merged = mergeLabClassificationRows(
+      [
+        row({
+          subject_type: 'author',
+          subject_slug: 'seed-cn',
+          is_chinese: false,
+        }),
+        row({
+          subject_type: 'model',
+          subject_slug: 'stealth/known',
+          is_chinese: false,
+        }),
+        row({
+          subject_type: 'model',
+          subject_slug: 'seed-cn/exception',
+          is_chinese: false,
+        }),
+        row({
+          subject_type: 'model',
+          subject_slug: 'stealth/new',
+          is_chinese: false,
+        }),
+        row({
+          subject_type: 'author',
+          subject_slug: 'new-lab',
+          is_chinese: true,
+        }),
+        row({
+          subject_type: 'author',
+          subject_slug: 'still-pending',
+          is_chinese: null,
+        }),
+      ],
+      seed
+    )
+
+    expect(merged.chinese['seed-cn']).toEqual(evidence('seed Chinese author'))
+    expect(merged.chineseModels['stealth/known']).toEqual(
+      evidence('seed exact Chinese model')
+    )
+    expect(merged.nonChineseModels['seed-cn/exception']).toBeUndefined()
+    expect(merged.nonChineseModels['stealth/new']).toEqual(
+      evidence('database decision')
+    )
+    expect(merged.chinese['new-lab']).toEqual(evidence('database decision'))
+    expect(merged.chinese['still-pending']).toBeUndefined()
+    expect(merged.nonChinese['still-pending']).toBeUndefined()
+  })
+
+  test('write validation prevents broad shared-author and narrow ordinary-author verdicts', () => {
+    expect(
+      validateLabClassificationWrite('model', 'stealth/new', seed)
+    ).toEqual({ ok: true, subjectSlug: 'stealth/new' })
+    expect(validateLabClassificationWrite('author', 'stealth', seed)).toEqual({
+      ok: false,
+      reason:
+        'author stealth is intentionally model-scoped; classify its individual model instead',
+    })
+    expect(
+      validateLabClassificationWrite('model', 'seed-cn/exception', seed)
+    ).toEqual({
+      ok: false,
+      reason:
+        'author seed-cn is author-scoped; an exact-model verdict could override its author classification',
+    })
+  })
+
+  test('merges prototype-named DB authors as own classification keys', () => {
+    const merged = mergeLabClassificationRows(
+      [
+        row({
+          subject_type: 'author',
+          subject_slug: '__proto__',
+          is_chinese: true,
+        }),
+      ],
+      seed
+    )
+
+    expect(
+      Object.prototype.hasOwnProperty.call(merged.chinese, '__proto__')
+    ).toBe(true)
+    expect(merged.chinese['__proto__']).toEqual(evidence('database decision'))
+  })
+
+  test('catalog discovery queues exact models for model-scoped authors', () => {
+    const pending = pendingLabSubjectsFromCatalog(
+      [
+        { permaslug: 'seed-cn/model', name: 'Already covered' },
+        { permaslug: 'stealth/known', name: 'Known reveal' },
+        { permaslug: 'stealth/new:free', name: 'Anonymous preview' },
+        { permaslug: 'new-lab/one', name: 'One' },
+        { permaslug: 'new-lab/two', name: 'Two' },
+        { permaslug: 'malformed', name: 'Bad row' },
+      ],
+      seed
+    )
+
+    expect(pending).toEqual([
+      {
+        subjectType: 'model',
+        subjectSlug: 'stealth/new',
+        evidence: {
+          discoveredVia: 'catalog',
+          openRouterName: 'Anonymous preview',
+        },
+      },
+      {
+        subjectType: 'author',
+        subjectSlug: 'new-lab',
+        evidence: {
+          discoveredVia: 'catalog',
+          relatedPermaslugs: ['new-lab/one', 'new-lab/two'],
+          openRouterNames: ['One', 'Two'],
+        },
+      },
+    ])
+  })
+})

--- a/backend/shared/src/perps/lab-classifications.ts
+++ b/backend/shared/src/perps/lab-classifications.ts
@@ -1,0 +1,573 @@
+import {
+  AuthorEvidence,
+  DEFAULT_LAB_SHARE_CLASSIFICATIONS,
+  LabShareClassifications,
+  authorOfPermaslug,
+} from 'common/perps/lab-share'
+import {
+  basePermaslug,
+  isCompositeSlug,
+  isValidPermaslug,
+} from 'common/perps/open-weight-models'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+// Database-backed maintenance layer for the Chinese-lab OpenRouter index.
+//
+// The constants in common/perps/lab-share remain the audited seed and always
+// win at their own specificity. Database rows add classifications for newly
+// observed authors, plus exact-model exceptions such as an anonymous preview
+// once its publisher is known. Exact-model rules are evaluated before author
+// rules by computeLabShare, so a DB model verdict can intentionally be more
+// specific than a seeded author verdict without silently rewriting the seed.
+
+export const LAB_CLASSIFICATION_SUBJECT_TYPES = ['author', 'model'] as const
+export type LabClassificationSubjectType =
+  (typeof LAB_CLASSIFICATION_SUBJECT_TYPES)[number]
+
+export type LabClassificationSource = 'auto' | 'admin'
+
+export type LabClassificationRow = {
+  subject_type: LabClassificationSubjectType
+  subject_slug: string
+  is_chinese: boolean | null
+  source: LabClassificationSource
+  evidence: Record<string, unknown>
+  first_seen: string
+  first_ranked_at: string | null
+  classified_at: string | null
+  classified_by: string | null
+  updated_time: string
+}
+
+export type LabClassificationSubject = {
+  subjectType: LabClassificationSubjectType
+  subjectSlug: string
+}
+
+export type PendingLabClassification = LabClassificationSubject & {
+  evidence?: Record<string, unknown>
+  /** Set when this subject affects a live ranking or historical backfill. */
+  firstRankedAt?: number | null
+}
+
+type MutableLabShareClassifications = {
+  chinese: Record<string, AuthorEvidence>
+  nonChinese: Record<string, AuthorEvidence>
+  chineseModels: Record<string, AuthorEvidence>
+  nonChineseModels: Record<string, AuthorEvidence>
+}
+
+const own = (record: Readonly<Record<string, unknown>>, key: string) =>
+  Object.prototype.hasOwnProperty.call(record, key)
+
+// Assignment to `record.__proto__` invokes Object.prototype's legacy setter
+// instead of creating an own key. Upstream author/model segments are untrusted,
+// and the common scorer intentionally supports prototype-named authors, so DB
+// overlays must use an explicit own data property too.
+const setOwn = <T>(record: Record<string, T>, key: string, value: T) =>
+  Object.defineProperty(record, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  })
+
+export const isLabClassificationSubjectType = (
+  value: string
+): value is LabClassificationSubjectType =>
+  (LAB_CLASSIFICATION_SUBJECT_TYPES as readonly string[]).includes(value)
+
+/**
+ * Normalize and validate the key stored in the composite primary key.
+ *
+ * Model variants (`:free`, etc.) collapse to their base permaslug because
+ * they are the same model. Composite router/floating aliases are excluded by
+ * the index and therefore cannot carry a useful verdict. Author keys are the
+ * literal first segment emitted by OpenRouter: no slash, colon or whitespace.
+ */
+export const normalizeLabClassificationSubject = (
+  subjectType: LabClassificationSubjectType,
+  subjectSlug: string
+): string => {
+  const trimmed = subjectSlug.trim()
+  if (subjectType === 'author') {
+    if (!/^[^/:\s]+$/.test(trimmed))
+      throw new Error(
+        `refusing malformed OpenRouter author: ${JSON.stringify(subjectSlug)}`
+      )
+    return trimmed
+  }
+
+  const slug = basePermaslug(trimmed)
+  if (!isValidPermaslug(slug))
+    throw new Error(
+      `refusing malformed OpenRouter model: ${JSON.stringify(subjectSlug)}`
+    )
+  if (isCompositeSlug(slug))
+    throw new Error(
+      `refusing composite OpenRouter model classification: ${JSON.stringify(
+        subjectSlug
+      )}`
+    )
+  return slug
+}
+
+/** True only when the audited seed owns this exact subject key. */
+export const isSeededLabClassification = (
+  subjectType: LabClassificationSubjectType,
+  subjectSlug: string,
+  seed: LabShareClassifications = DEFAULT_LAB_SHARE_CLASSIFICATIONS
+): boolean => {
+  const slug = normalizeLabClassificationSubject(subjectType, subjectSlug)
+  const chinese = subjectType === 'author' ? seed.chinese : seed.chineseModels
+  const nonChinese =
+    subjectType === 'author' ? seed.nonChinese : seed.nonChineseModels
+  return own(chinese, slug) || own(nonChinese, slug)
+}
+
+/**
+ * Authors with an exact-model rule are intentionally model-scoped. A broad
+ * author click would defeat the reason the exception exists (notably the
+ * shared `stealth/*` namespace), so discovery queues their individual models.
+ */
+export const isModelScopedLabAuthor = (
+  author: string,
+  classifications: LabShareClassifications = DEFAULT_LAB_SHARE_CLASSIFICATIONS
+): boolean => {
+  const normalized = normalizeLabClassificationSubject('author', author)
+  return [
+    ...Object.keys(classifications.chineseModels),
+    ...Object.keys(classifications.nonChineseModels),
+  ].some((model) => authorOfPermaslug(model) === normalized)
+}
+
+export type LabClassificationWriteValidation =
+  | { ok: true; subjectSlug: string }
+  | { ok: false; reason: string }
+
+/**
+ * Enforce the scope boundary at the shared write layer, not just in the UI.
+ *
+ * A model verdict is more specific than an author verdict. Consequently it is
+ * also more powerful: without this check, a forged/stale request could insert
+ * `deepseek/foo = non-Chinese` and override the audited DeepSeek author seed.
+ * Exact DB rows are therefore allowed only under a namespace the audited seed
+ * has explicitly marked model-scoped. Establishing a new such namespace is a
+ * methodology change and starts with a reviewed exact-model seed entry.
+ */
+export const validateLabClassificationWrite = (
+  subjectType: LabClassificationSubjectType,
+  subjectSlug: string,
+  seed: LabShareClassifications = DEFAULT_LAB_SHARE_CLASSIFICATIONS
+): LabClassificationWriteValidation => {
+  let slug: string
+  try {
+    slug = normalizeLabClassificationSubject(subjectType, subjectSlug)
+  } catch (err) {
+    return { ok: false, reason: `${err}` }
+  }
+  if (isSeededLabClassification(subjectType, slug, seed))
+    return {
+      ok: false,
+      reason: `${subjectType} ${slug} is classified in the audited seed`,
+    }
+
+  const author = subjectType === 'author' ? slug : authorOfPermaslug(slug) ?? ''
+  const modelScoped = isModelScopedLabAuthor(author, seed)
+  if (subjectType === 'author' && modelScoped)
+    return {
+      ok: false,
+      reason:
+        `author ${author} is intentionally model-scoped; classify its ` +
+        `individual model instead`,
+    }
+  if (subjectType === 'model' && !modelScoped)
+    return {
+      ok: false,
+      reason:
+        `author ${author} is author-scoped; an exact-model verdict could ` +
+        `override its author classification`,
+    }
+  return { ok: true, subjectSlug: slug }
+}
+
+const evidenceText = (row: LabClassificationRow): string => {
+  for (const key of ['evidence', 'summary', 'reasoning']) {
+    const value = row.evidence?.[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return `${row.source} classification recorded ${
+    row.classified_at ?? 'without a timestamp'
+  }`
+}
+
+const rowEvidence = (row: LabClassificationRow): AuthorEvidence => ({
+  evidence: evidenceText(row),
+})
+
+/**
+ * Pure seed + DB merge, exported so precedence can be tested without a DB.
+ *
+ * Pending rows are ignored. A seed entry cannot be overridden by a DB row at
+ * the same specificity. Model maps remain separate from author maps, allowing
+ * the common scorer's exact-model-before-author precedence to do the rest.
+ */
+export const mergeLabClassificationRows = (
+  rows: readonly LabClassificationRow[],
+  seed: LabShareClassifications = DEFAULT_LAB_SHARE_CLASSIFICATIONS
+): LabShareClassifications => {
+  const classifications: MutableLabShareClassifications = {
+    chinese: { ...seed.chinese },
+    nonChinese: { ...seed.nonChinese },
+    chineseModels: { ...seed.chineseModels },
+    nonChineseModels: { ...seed.nonChineseModels },
+  }
+
+  for (const row of rows) {
+    if (row.is_chinese === null) continue
+    const validation = validateLabClassificationWrite(
+      row.subject_type,
+      row.subject_slug,
+      seed
+    )
+    // Includes same-specificity seed rows, broad verdicts for a model-scoped
+    // namespace, and exact verdicts under an ordinary author. Ignore on read
+    // too, so a manually inserted/stale row cannot bypass the write invariant.
+    if (!validation.ok) continue
+    const slug = validation.subjectSlug
+
+    const chinese =
+      row.subject_type === 'author'
+        ? classifications.chinese
+        : classifications.chineseModels
+    const nonChinese =
+      row.subject_type === 'author'
+        ? classifications.nonChinese
+        : classifications.nonChineseModels
+    const evidence = rowEvidence(row)
+    if (row.is_chinese) {
+      delete nonChinese[slug]
+      setOwn(chinese, slug, evidence)
+    } else {
+      delete chinese[slug]
+      setOwn(nonChinese, slug, evidence)
+    }
+  }
+  return classifications
+}
+
+/** Resolve the exact classification snapshot one oracle tick should use. */
+export const resolveLabClassifications = async (
+  pg: SupabaseDirectClient
+): Promise<LabShareClassifications> => {
+  const rows = await pg.manyOrNone<LabClassificationRow>(
+    `select subject_type, subject_slug, is_chinese, source, evidence,
+            first_seen, first_ranked_at, classified_at, classified_by,
+            updated_time
+     from openrouter_lab_classifications
+     where is_chinese is not null`
+  )
+  return mergeLabClassificationRows(rows)
+}
+
+const normalizePending = (
+  subjects: readonly PendingLabClassification[]
+): Array<PendingLabClassification & { normalizedSlug: string }> => {
+  const unique = new Map<
+    string,
+    PendingLabClassification & {
+      normalizedSlug: string
+    }
+  >()
+  for (const subject of subjects) {
+    let normalizedSlug: string
+    try {
+      normalizedSlug = normalizeLabClassificationSubject(
+        subject.subjectType,
+        subject.subjectSlug
+      )
+    } catch {
+      // Catalog/rankings payloads are external data. A malformed entry should
+      // fail scoring if ranked, but must not poison the entire discovery batch.
+      continue
+    }
+    if (isSeededLabClassification(subject.subjectType, normalizedSlug)) continue
+    const key = `${subject.subjectType}:${normalizedSlug}`
+    const previous = unique.get(key)
+    if (previous) {
+      const earlierRankedAt = [previous.firstRankedAt, subject.firstRankedAt]
+        .filter((value): value is number => value != null)
+        .reduce<number | null>(
+          (earliest, value) =>
+            earliest == null ? value : Math.min(earliest, value),
+          null
+        )
+      unique.set(key, { ...previous, firstRankedAt: earlierRankedAt })
+      continue
+    }
+    unique.set(key, {
+      ...subject,
+      normalizedSlug,
+    })
+  }
+  return [...unique.values()]
+}
+
+/**
+ * Idempotently create review-queue rows.
+ *
+ * Conflict updates may fill an absent first_ranked_at for an existing pending
+ * row, but never reset first_seen and never touch a decided row. This mirrors
+ * the open-weight classifier's deadline semantics.
+ */
+export const recordPendingLabClassifications = async (
+  pg: SupabaseDirectClient,
+  subjects: readonly PendingLabClassification[],
+  firstSeen = Date.now()
+): Promise<number> => {
+  const pending = normalizePending(subjects)
+  if (pending.length === 0) return 0
+
+  const firstSeenIso = new Date(firstSeen).toISOString()
+  const result = await pg.result(
+    `insert into openrouter_lab_classifications
+       (subject_type, subject_slug, is_chinese, source, evidence,
+        first_seen, first_ranked_at)
+     select subject_type, subject_slug, null::boolean, 'auto', evidence::jsonb,
+            $4::timestamptz, first_ranked_at::timestamptz
+     from unnest($1::text[], $2::text[], $3::text[], $5::text[])
+       as t(subject_type, subject_slug, evidence, first_ranked_at)
+     on conflict (subject_type, subject_slug) do update set
+       first_ranked_at = case
+         when openrouter_lab_classifications.first_ranked_at is null
+           then excluded.first_ranked_at
+         else least(
+           openrouter_lab_classifications.first_ranked_at,
+           excluded.first_ranked_at
+         )
+       end,
+       updated_time = now()
+     where openrouter_lab_classifications.is_chinese is null
+       and excluded.first_ranked_at is not null
+       and (
+         openrouter_lab_classifications.first_ranked_at is null or
+         excluded.first_ranked_at <
+           openrouter_lab_classifications.first_ranked_at
+       )`,
+    [
+      pending.map((row) => row.subjectType),
+      pending.map((row) => row.normalizedSlug),
+      pending.map((row) => JSON.stringify(row.evidence ?? {})),
+      firstSeenIso,
+      pending.map((row) =>
+        row.firstRankedAt == null
+          ? null
+          : new Date(row.firstRankedAt).toISOString()
+      ),
+    ]
+  )
+  // Inserts plus the one legitimate conflict update (filling/advancing the
+  // earliest first-ranked timestamp), not merely the number attempted.
+  return result.rowCount
+}
+
+export type LabCatalogModel = {
+  permaslug: string
+  name?: string | null
+}
+
+/**
+ * Derive catalog queue entries without touching the database.
+ *
+ * Ordinary publishers yield one author row. Publishers already known to need
+ * exact decisions yield model rows instead, so `stealth/new-preview` can never
+ * invite a dangerously broad classification of every future `stealth/*` slug.
+ */
+export const pendingLabSubjectsFromCatalog = (
+  models: readonly LabCatalogModel[],
+  classifications: LabShareClassifications = DEFAULT_LAB_SHARE_CLASSIFICATIONS
+): PendingLabClassification[] => {
+  const authors = new Map<string, { models: string[]; names: string[] }>()
+  for (const model of models) {
+    if (isCompositeSlug(model.permaslug)) continue
+    const permaslug = basePermaslug(model.permaslug)
+    const author = authorOfPermaslug(permaslug)
+    if (!author) continue
+    const current = authors.get(author) ?? { models: [], names: [] }
+    current.models.push(permaslug)
+    if (model.name) current.names.push(model.name)
+    authors.set(author, current)
+  }
+
+  const pending: PendingLabClassification[] = []
+  for (const [author, context] of authors) {
+    if (isModelScopedLabAuthor(author, classifications)) {
+      for (const model of new Set(context.models)) {
+        if (isSeededLabClassification('model', model, classifications)) continue
+        pending.push({
+          subjectType: 'model' as const,
+          subjectSlug: model,
+          evidence: {
+            discoveredVia: 'catalog',
+            openRouterName:
+              models.find((entry) => basePermaslug(entry.permaslug) === model)
+                ?.name ?? null,
+          },
+        })
+      }
+      continue
+    }
+    if (isSeededLabClassification('author', author, classifications)) continue
+    pending.push({
+      subjectType: 'author' as const,
+      subjectSlug: author,
+      evidence: {
+        discoveredVia: 'catalog',
+        relatedPermaslugs: [...new Set(context.models)].sort(),
+        openRouterNames: [...new Set(context.names)].sort(),
+      },
+    })
+  }
+  return pending
+}
+
+export const recordPendingLabSubjectsFromCatalog = async (
+  pg: SupabaseDirectClient,
+  models: readonly LabCatalogModel[],
+  firstSeen = Date.now(),
+  classifications?: LabShareClassifications
+): Promise<number> => {
+  // Resolve when the caller does not already have a snapshot so settled DB
+  // authors/models are filtered before the idempotent insert attempt.
+  const resolved = classifications ?? (await resolveLabClassifications(pg))
+  return recordPendingLabClassifications(
+    pg,
+    pendingLabSubjectsFromCatalog(models, resolved),
+    firstSeen
+  )
+}
+
+/**
+ * Rankings fallback for subjects the catalog sweep did not catch.
+ *
+ * Unknown authors and their exact models are both retained: ordinary labs can
+ * be classified once at author scope, while anonymous/shared author prefixes
+ * can receive a narrow model verdict without misclassifying future releases.
+ */
+export const recordUnclassifiedLabSubjectsInRankings = async (
+  pg: SupabaseDirectClient,
+  params: {
+    unknownAuthors: readonly string[]
+    unknownModels: readonly string[]
+  },
+  rankedAt = Date.now()
+): Promise<number> =>
+  recordPendingLabClassifications(
+    pg,
+    [
+      ...params.unknownAuthors.map((subjectSlug) => ({
+        subjectType: 'author' as const,
+        subjectSlug,
+        evidence: { discoveredVia: 'rankings' },
+        firstRankedAt: rankedAt,
+      })),
+      ...params.unknownModels.map((subjectSlug) => ({
+        subjectType: 'model' as const,
+        subjectSlug,
+        evidence: { discoveredVia: 'rankings' },
+        firstRankedAt: rankedAt,
+      })),
+    ],
+    rankedAt
+  )
+
+/**
+ * Atomically write a human verdict and preserve the previous state in
+ * evidence.history. Seed entries are intentionally immutable through this
+ * path; changing them remains a reviewed methodology edit.
+ */
+export const upsertLabClassification = async (
+  pg: SupabaseDirectClient,
+  params: LabClassificationSubject & {
+    isChinese: boolean
+    evidence: Record<string, unknown>
+    classifiedBy: string
+  }
+): Promise<void> => {
+  const validation = validateLabClassificationWrite(
+    params.subjectType,
+    params.subjectSlug
+  )
+  if (!validation.ok) throw new Error(validation.reason)
+  const subjectSlug = validation.subjectSlug
+  if (!params.classifiedBy.trim())
+    throw new Error('classifiedBy is required for a human lab classification')
+  const evidenceSummary = params.evidence?.['evidence']
+  if (typeof evidenceSummary !== 'string' || !evidenceSummary.trim())
+    throw new Error('evidence is required for a human lab classification')
+
+  const evidence = {
+    ...params.evidence,
+    evidence: evidenceSummary.trim(),
+  }
+
+  await pg.none(
+    `insert into openrouter_lab_classifications
+       (subject_type, subject_slug, is_chinese, source, evidence,
+        classified_at, classified_by, updated_time)
+     values ($1, $2, $3, 'admin', $4::jsonb, now(), $5, now())
+     on conflict (subject_type, subject_slug) do update set
+       is_chinese = excluded.is_chinese,
+       source = excluded.source,
+       evidence = excluded.evidence || jsonb_build_object(
+         'history',
+         coalesce(
+           openrouter_lab_classifications.evidence->'history', '[]'::jsonb
+         ) || jsonb_build_array(jsonb_build_object(
+           'isChinese', openrouter_lab_classifications.is_chinese,
+           'source', openrouter_lab_classifications.source,
+           'classifiedAt', openrouter_lab_classifications.classified_at,
+           'classifiedBy', openrouter_lab_classifications.classified_by,
+           'supersededAt', now(),
+           'evidence', openrouter_lab_classifications.evidence - 'history'
+         ))
+       ),
+       classified_at = excluded.classified_at,
+       classified_by = excluded.classified_by,
+       updated_time = now()`,
+    [
+      params.subjectType,
+      subjectSlug,
+      params.isChinese,
+      JSON.stringify(evidence),
+      params.classifiedBy.trim(),
+    ]
+  )
+}
+
+export const getLabClassificationRows = async (
+  pg: SupabaseDirectClient
+): Promise<LabClassificationRow[]> =>
+  pg.manyOrNone<LabClassificationRow>(
+    `select subject_type, subject_slug, is_chinese, source, evidence,
+            first_seen, first_ranked_at, classified_at, classified_by,
+            updated_time
+     from openrouter_lab_classifications
+     order by first_ranked_at asc nulls last, first_seen asc`
+  )
+
+export const getPendingLabClassifications = async (
+  pg: SupabaseDirectClient
+): Promise<LabClassificationRow[]> => {
+  const rows = await pg.manyOrNone<LabClassificationRow>(
+    `select subject_type, subject_slug, is_chinese, source, evidence,
+            first_seen, first_ranked_at, classified_at, classified_by,
+            updated_time
+     from openrouter_lab_classifications
+     where is_chinese is null
+     order by first_ranked_at asc nulls last, first_seen asc`
+  )
+  return rows.filter((row) => {
+    return validateLabClassificationWrite(row.subject_type, row.subject_slug).ok
+  })
+}

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -258,6 +258,34 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
     },
     minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
   },
+  {
+    feedId: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
+    question: 'Chinese-lab share of OpenRouter tokens (%)',
+    requiredTopics: [
+      {
+        name: 'AI',
+        slugByEnvironment: {
+          DEV: 'ai',
+          PROD: 'ai',
+        },
+      },
+    ],
+    oracleBehavior: 'scheduled-step',
+    requiresSourceAsOf: true,
+    gameDesign:
+      'The share of OpenRouter-routed tokens attributed to labs headquartered in China. Two-sided with coherent theses both ways: open-weight Chinese releases and their price advantage push it up, frontier closed releases and enterprise routing patterns push it down. New authors enter a database-backed review queue; an unresolved author is excluded from both sides and, past 1% of tokens, pauses the feed until an operator classifies it.',
+    latencyArbitrageRisk:
+      'OpenRouter currently exposes complete UTC days, so hourly Manifold points usually repeat one daily value. Re-stamping a flat value does not remove the predictable next-step arbitrage window.',
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 6 * HOUR_MS,
+      subsidyLong: 10_000,
+      subsidyShort: 10_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+  },
   // Tokenized-equity trio (xStocks by Backed). These deliberately track the
   // TOKEN's venue price, not the underlying index: that is what makes the
   // feed free and licence-clean (we composite public crypto-venue quotes,
@@ -407,38 +435,7 @@ export type PerpPendingLaunchMarketDefinition = PerpLaunchMarketDefinition & {
 // manifest check enforces that a pending feed is creation-disabled, so the
 // two lists cannot silently disagree.
 export const PERP_LAUNCH_PENDING_MARKETS: readonly PerpPendingLaunchMarketDefinition[] =
-  [
-    {
-      feedId: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
-      question: 'Chinese-lab share of OpenRouter tokens (%)',
-      requiredTopics: [
-        {
-          name: 'AI',
-          slugByEnvironment: {
-            DEV: 'ai',
-            PROD: 'ai',
-          },
-        },
-      ],
-      pendingReason:
-        'nex-agi (in the open-weight seed list) is placed in neither CHINESE_LAB_AUTHORS nor KNOWN_NON_CHINESE_AUTHORS; the backfill aborts on it and the live feed halts if it exceeds 1% of tokens. Place the author with evidence, bump CHINESE_LAB_LIST_VERSION, enable creation in the registry, and move this entry into PERP_LAUNCH_MARKETS.',
-      oracleBehavior: 'scheduled-step',
-      requiresSourceAsOf: true,
-      gameDesign:
-        'The share of OpenRouter-routed tokens attributed to labs headquartered in China (classified by author slug, list in common/perps/lab-share.ts). Two-sided with coherent theses both ways: open-weight Chinese releases and their price advantage push it up, frontier closed releases and enterprise routing patterns push it down. An author the list cannot place is excluded from both sides and, past 1% of tokens, pauses the feed until a one-line classification is deployed — expect an occasional short pause after a brand-new lab enters the top 50.',
-      latencyArbitrageRisk:
-        'OpenRouter currently exposes complete UTC days, so hourly Manifold points usually repeat one daily value. Re-stamping a flat value does not remove the predictable next-step arbitrage window.',
-      recommended: {
-        maxLeverage: 3,
-        annualMaxFundingRate: 1,
-        fundingSensitivity: 1,
-        maxOraclePriceAgeMs: 6 * HOUR_MS,
-        subsidyLong: 10_000,
-        subsidyShort: 10_000,
-      },
-      minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
-    },
-  ]
+  []
 
 // Residual pool value returns to the market creator at settlement. Restrict
 // the launch set to the environment's official Manifold account so a personal

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -258,34 +258,6 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
     },
     minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
   },
-  {
-    feedId: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
-    question: 'Chinese-lab share of OpenRouter tokens (%)',
-    requiredTopics: [
-      {
-        name: 'AI',
-        slugByEnvironment: {
-          DEV: 'ai',
-          PROD: 'ai',
-        },
-      },
-    ],
-    oracleBehavior: 'scheduled-step',
-    requiresSourceAsOf: true,
-    gameDesign:
-      'The share of OpenRouter-routed tokens attributed to labs headquartered in China (classified by author slug, list in common/perps/lab-share.ts). Two-sided with coherent theses both ways: open-weight Chinese releases and their price advantage push it up, frontier closed releases and enterprise routing patterns push it down. An author the list cannot place is excluded from both sides and, past 1% of tokens, pauses the feed until a one-line classification is deployed — expect an occasional short pause after a brand-new lab enters the top 50.',
-    latencyArbitrageRisk:
-      'OpenRouter currently exposes complete UTC days, so hourly Manifold points usually repeat one daily value. Re-stamping a flat value does not remove the predictable next-step arbitrage window.',
-    recommended: {
-      maxLeverage: 3,
-      annualMaxFundingRate: 1,
-      fundingSensitivity: 1,
-      maxOraclePriceAgeMs: 6 * HOUR_MS,
-      subsidyLong: 10_000,
-      subsidyShort: 10_000,
-    },
-    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
-  },
   // Tokenized-equity trio (xStocks by Backed). These deliberately track the
   // TOKEN's venue price, not the underlying index: that is what makes the
   // feed free and licence-clean (we composite public crypto-venue quotes,
@@ -421,6 +393,53 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
 // and any future ingest-only feed must be listed here explicitly.
 export const PERP_LAUNCH_EXCLUDED_FEED_IDS: readonly string[] = []
 
+export type PerpPendingLaunchMarketDefinition = PerpLaunchMarketDefinition & {
+  /** What blocks the launch, and what promotes the entry. */
+  pendingReason: string
+}
+
+// Reviewed definitions that are NOT yet launchable. The feed stays in the
+// registry with marketCreationEnabled: false — ingestion, backfill scripts and
+// health checks all run, the admin form refuses to create a market, and the
+// preflight fails any market that appears on it. The reviewed settings live
+// here so promotion is a move, not a rewrite: resolve the reason, enable
+// creation in the registry, move the entry into PERP_LAUNCH_MARKETS. The
+// manifest check enforces that a pending feed is creation-disabled, so the
+// two lists cannot silently disagree.
+export const PERP_LAUNCH_PENDING_MARKETS: readonly PerpPendingLaunchMarketDefinition[] =
+  [
+    {
+      feedId: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
+      question: 'Chinese-lab share of OpenRouter tokens (%)',
+      requiredTopics: [
+        {
+          name: 'AI',
+          slugByEnvironment: {
+            DEV: 'ai',
+            PROD: 'ai',
+          },
+        },
+      ],
+      pendingReason:
+        'nex-agi (in the open-weight seed list) is placed in neither CHINESE_LAB_AUTHORS nor KNOWN_NON_CHINESE_AUTHORS; the backfill aborts on it and the live feed halts if it exceeds 1% of tokens. Place the author with evidence, bump CHINESE_LAB_LIST_VERSION, enable creation in the registry, and move this entry into PERP_LAUNCH_MARKETS.',
+      oracleBehavior: 'scheduled-step',
+      requiresSourceAsOf: true,
+      gameDesign:
+        'The share of OpenRouter-routed tokens attributed to labs headquartered in China (classified by author slug, list in common/perps/lab-share.ts). Two-sided with coherent theses both ways: open-weight Chinese releases and their price advantage push it up, frontier closed releases and enterprise routing patterns push it down. An author the list cannot place is excluded from both sides and, past 1% of tokens, pauses the feed until a one-line classification is deployed — expect an occasional short pause after a brand-new lab enters the top 50.',
+      latencyArbitrageRisk:
+        'OpenRouter currently exposes complete UTC days, so hourly Manifold points usually repeat one daily value. Re-stamping a flat value does not remove the predictable next-step arbitrage window.',
+      recommended: {
+        maxLeverage: 3,
+        annualMaxFundingRate: 1,
+        fundingSensitivity: 1,
+        maxOraclePriceAgeMs: 6 * HOUR_MS,
+        subsidyLong: 10_000,
+        subsidyShort: 10_000,
+      },
+      minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+    },
+  ]
+
 // Residual pool value returns to the market creator at settlement. Restrict
 // the launch set to the environment's official Manifold account so a personal
 // admin account cannot accidentally own those economics.
@@ -489,11 +508,91 @@ export const getNominalAnnualFundingRate = (
   return Number.isFinite(annualRate) ? annualRate : Number.NaN
 }
 
+/** Field checks every reviewed definition must pass, launchable or pending. */
+const collectDefinitionErrors = (
+  market: PerpLaunchMarketDefinition,
+  feed: ReturnType<typeof getOracleFeed>,
+  errors: string[]
+) => {
+  if (!market.question.trim())
+    errors.push(`${market.feedId} has no launch question`)
+  if (market.question !== market.question.trim())
+    errors.push(`${market.feedId} launch question has surrounding whitespace`)
+  if (market.question.length > MAX_QUESTION_LENGTH)
+    errors.push(
+      `${market.feedId} launch question exceeds ${MAX_QUESTION_LENGTH} characters`
+    )
+  if (/\bperpetual\b/i.test(market.question))
+    errors.push(
+      `${market.feedId} repeats "perpetual" in its title; the market type is rendered separately`
+    )
+  if (
+    market.requiresSourceAsOf !==
+    (getOracleAttribution(market.feedId)?.showAsOf === true)
+  )
+    errors.push(
+      `${market.feedId} source-as-of requirement disagrees with its attribution metadata`
+    )
+  if (
+    !Number.isFinite(market.recommended.maxLeverage) ||
+    market.recommended.maxLeverage <= 1 ||
+    market.recommended.maxLeverage > 100
+  )
+    errors.push(`${market.feedId} has an invalid recommended leverage`)
+  if (
+    !Number.isFinite(market.recommended.annualMaxFundingRate) ||
+    market.recommended.annualMaxFundingRate <= 0 ||
+    !Number.isFinite(market.recommended.fundingSensitivity) ||
+    market.recommended.fundingSensitivity <= 0
+  )
+    errors.push(`${market.feedId} has an invalid funding recommendation`)
+  if (
+    !Number.isFinite(market.recommended.subsidyLong) ||
+    market.recommended.subsidyLong <= 0 ||
+    !Number.isFinite(market.recommended.subsidyShort) ||
+    market.recommended.subsidyShort <= 0
+  )
+    errors.push(`${market.feedId} has an invalid backing recommendation`)
+  if (market.requiredTopics.length === 0)
+    errors.push(`${market.feedId} has no required discovery topic`)
+  for (const environment of ['DEV', 'PROD'] as const) {
+    const requiredTopicSlugs = market.requiredTopics.map((topic) =>
+      getPerpLaunchTopicSlug(topic, environment)
+    )
+    if (new Set(requiredTopicSlugs).size !== requiredTopicSlugs.length)
+      errors.push(
+        `${market.feedId} has duplicate ${environment} discovery topics`
+      )
+  }
+  for (const topic of market.requiredTopics) {
+    if (
+      !topic.name ||
+      !getPerpLaunchTopicSlug(topic, 'DEV') ||
+      !getPerpLaunchTopicSlug(topic, 'PROD')
+    )
+      errors.push(`${market.feedId} has an invalid required discovery topic`)
+  }
+  if (
+    feed &&
+    (market.recommended.maxOraclePriceAgeMs < feed.staleAfterMs ||
+      !Number.isFinite(market.recommended.maxOraclePriceAgeMs))
+  )
+    errors.push(
+      `${market.feedId} recommended max oracle age is below its health threshold`
+    )
+}
+
 export const getPerpLaunchManifestErrors = () => {
   const errors: string[] = []
   const feedIds = PERP_LAUNCH_MARKETS.map((market) => market.feedId)
+  const pendingIds = PERP_LAUNCH_PENDING_MARKETS.map((market) => market.feedId)
   if (new Set(feedIds).size !== feedIds.length)
     errors.push('launch manifest has duplicate feed ids')
+  if (
+    new Set([...feedIds, ...pendingIds]).size !==
+    feedIds.length + pendingIds.length
+  )
+    errors.push('a feed appears in both the launch and pending manifests')
   for (const environment of ['DEV', 'PROD'] as const) {
     if (!getPerpLaunchCreatorId(environment))
       errors.push(`${environment} has no official launch creator`)
@@ -501,77 +600,32 @@ export const getPerpLaunchManifestErrors = () => {
 
   for (const market of PERP_LAUNCH_MARKETS) {
     const feed = getOracleFeed(market.feedId)
-    if (!market.question.trim())
-      errors.push(`${market.feedId} has no launch question`)
-    if (market.question !== market.question.trim())
-      errors.push(`${market.feedId} launch question has surrounding whitespace`)
-    if (market.question.length > MAX_QUESTION_LENGTH)
-      errors.push(
-        `${market.feedId} launch question exceeds ${MAX_QUESTION_LENGTH} characters`
-      )
-    if (/\bperpetual\b/i.test(market.question))
-      errors.push(
-        `${market.feedId} repeats "perpetual" in its title; the market type is rendered separately`
-      )
+    collectDefinitionErrors(market, feed, errors)
     if (!feed) {
       errors.push(`${market.feedId} is absent from the oracle registry`)
       continue
     }
     if (!feed.marketCreationEnabled)
       errors.push(`${market.feedId} is disabled for market creation`)
-    if (
-      market.requiresSourceAsOf !==
-      (getOracleAttribution(market.feedId)?.showAsOf === true)
-    )
+  }
+
+  for (const market of PERP_LAUNCH_PENDING_MARKETS) {
+    const feed = getOracleFeed(market.feedId)
+    collectDefinitionErrors(market, feed, errors)
+    if (!market.pendingReason.trim())
+      errors.push(`${market.feedId} is pending without a stated reason`)
+    if (!feed) {
       errors.push(
-        `${market.feedId} source-as-of requirement disagrees with its attribution metadata`
+        `${market.feedId} (pending) is absent from the oracle registry`
       )
-    if (
-      !Number.isFinite(market.recommended.maxLeverage) ||
-      market.recommended.maxLeverage <= 1 ||
-      market.recommended.maxLeverage > 100
-    )
-      errors.push(`${market.feedId} has an invalid recommended leverage`)
-    if (
-      !Number.isFinite(market.recommended.annualMaxFundingRate) ||
-      market.recommended.annualMaxFundingRate <= 0 ||
-      !Number.isFinite(market.recommended.fundingSensitivity) ||
-      market.recommended.fundingSensitivity <= 0
-    )
-      errors.push(`${market.feedId} has an invalid funding recommendation`)
-    if (
-      !Number.isFinite(market.recommended.subsidyLong) ||
-      market.recommended.subsidyLong <= 0 ||
-      !Number.isFinite(market.recommended.subsidyShort) ||
-      market.recommended.subsidyShort <= 0
-    )
-      errors.push(`${market.feedId} has an invalid backing recommendation`)
-    if (market.requiredTopics.length === 0)
-      errors.push(`${market.feedId} has no required discovery topic`)
-    for (const environment of ['DEV', 'PROD'] as const) {
-      const requiredTopicSlugs = market.requiredTopics.map((topic) =>
-        getPerpLaunchTopicSlug(topic, environment)
-      )
-      if (new Set(requiredTopicSlugs).size !== requiredTopicSlugs.length)
-        errors.push(
-          `${market.feedId} has duplicate ${environment} discovery topics`
-        )
+      continue
     }
-    for (const topic of market.requiredTopics) {
-      if (
-        !topic.name ||
-        !getPerpLaunchTopicSlug(topic, 'DEV') ||
-        !getPerpLaunchTopicSlug(topic, 'PROD')
-      )
-        errors.push(`${market.feedId} has an invalid required discovery topic`)
-    }
-    if (
-      market.recommended.maxOraclePriceAgeMs < feed.staleAfterMs ||
-      !Number.isFinite(market.recommended.maxOraclePriceAgeMs)
-    )
+    if (feed.marketCreationEnabled)
       errors.push(
-        `${market.feedId} recommended max oracle age is below its health threshold`
+        `${market.feedId} is pending but enabled for creation; promote it into PERP_LAUNCH_MARKETS or disable creation`
       )
+    if (PERP_LAUNCH_EXCLUDED_FEED_IDS.includes(market.feedId))
+      errors.push(`${market.feedId} is both pending and explicitly excluded`)
   }
 
   for (const feedId of PERP_LAUNCH_EXCLUDED_FEED_IDS) {

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -11,6 +11,8 @@ import {
   QQQX_USD_FEED_ID,
   SPYX_USD_FEED_ID,
   TRUMP_APPROVAL_FEED_ID,
+  VANCE_FAVORABILITY_FEED_ID,
+  VOTEHUB_GENERIC_BALLOT_2026_FEED_ID,
 } from '../oracle'
 import { getOracleFeed } from '../oracle-feeds'
 
@@ -96,6 +98,66 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
       "Two-sided political exposure, but VoteHub's time-weighted average is slow and often unchanged between poll releases.",
     latencyArbitrageRisk:
       "The source value is public, so ingestion latency is the whole exposure: the feed is polled every 5 minutes against VoteHub's own max-age=300 cache, which bounds the window in which a move is visible to a trader but not yet to the market. Recommended leverage assumes that bound holds.",
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 30 * HOUR_MS,
+      subsidyLong: 5_000,
+      subsidyShort: 5_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+  },
+  // The other two VoteHub averages: same publisher, same cadence, same
+  // conservative settings as the Trump market. Both are shares, never
+  // margins, so the price is always positive and both directions are
+  // tradeable.
+  {
+    feedId: VOTEHUB_GENERIC_BALLOT_2026_FEED_ID,
+    question: 'Democratic share of 2026 generic ballot (VoteHub avg, %)',
+    requiredTopics: [
+      {
+        name: 'Politics',
+        slugByEnvironment: {
+          DEV: 'politics-default',
+          PROD: 'politics-default',
+        },
+      },
+    ],
+    oracleBehavior: 'scheduled-step',
+    requiresSourceAsOf: false,
+    gameDesign:
+      "Two-sided: the Democratic share of the generic ballot moves with the national environment and has coherent theses on both sides, but VoteHub's time-weighted average is slow and often unchanged between poll releases. The midterm is 2026-11-03; polling of a 2026 generic ballot stops after it and the published average goes quiet, so this market needs a close date or a resolution plan (settle at the last published average) set before then rather than being left to run into a frozen feed.",
+    latencyArbitrageRisk:
+      "The source value is public, so ingestion latency is the whole exposure: the feed is polled every 5 minutes against VoteHub's own max-age=300 cache, which bounds the window in which a move is visible to a trader but not yet to the market. Recommended leverage assumes that bound holds.",
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 30 * HOUR_MS,
+      subsidyLong: 5_000,
+      subsidyShort: 5_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+  },
+  {
+    feedId: VANCE_FAVORABILITY_FEED_ID,
+    question: 'JD Vance favorability (VoteHub avg, %)',
+    requiredTopics: [
+      {
+        name: 'Politics',
+        slugByEnvironment: {
+          DEV: 'politics-default',
+          PROD: 'politics-default',
+        },
+      },
+    ],
+    oracleBehavior: 'scheduled-step',
+    requiresSourceAsOf: false,
+    gameDesign:
+      "Two-sided political exposure on a figure whose standing is contested in both directions, priced as the Favorable share rather than net favorability so the level is always positive. Favorability is polled less often than presidential approval, so expect longer flat stretches between releases than the Trump market shows, and expect the independent cross-check to report 'unchecked' more often.",
+    latencyArbitrageRisk:
+      "Same as the other VoteHub feeds: the value is public and the feed is polled every 5 minutes against VoteHub's max-age=300 cache, so a trader can see a new average at most a few minutes before the market does. Fewer polls means fewer, larger steps, each of them public before the poll reaches the market.",
     recommended: {
       maxLeverage: 3,
       annualMaxFundingRate: 1,
@@ -305,6 +367,12 @@ export const PERP_LAUNCH_SCHEDULER_EXPECTATIONS = [
     jobName: 'update-trump-approval',
     // Polls every 5 minutes, so a 26h last-success age would have described
     // a job that had been dead for over 300 consecutive runs.
+    maxEndAgeMs: 30 * MINUTE_MS,
+    maxRunMs: 2 * MINUTE_MS,
+  },
+  {
+    jobName: 'update-votehub-averages',
+    // The other VoteHub averages, on the Trump job's cadence and bounds.
     maxEndAgeMs: 30 * MINUTE_MS,
     maxRunMs: 2 * MINUTE_MS,
   },

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -5,6 +5,7 @@ import { getOracleAttribution } from 'common/perps/oracle-attribution'
 
 import {
   BTC_USD_FEED_ID,
+  CRYPTO_FEAR_GREED_FEED_ID,
   GLDX_USD_FEED_ID,
   NVDAX_USD_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
@@ -158,6 +159,34 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
       "Two-sided political exposure on a figure whose standing is contested in both directions, priced as the Favorable share rather than net favorability so the level is always positive. Favorability is polled less often than presidential approval, so expect longer flat stretches between releases than the Trump market shows, and expect the independent cross-check to report 'unchecked' more often.",
     latencyArbitrageRisk:
       "Same as the other VoteHub feeds: the value is public and the feed is polled every 5 minutes against VoteHub's max-age=300 cache, so a trader can see a new average at most a few minutes before the market does. Fewer polls means fewer, larger steps, each of them public before the poll reaches the market.",
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 30 * HOUR_MS,
+      subsidyLong: 5_000,
+      subsidyShort: 5_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+  },
+  {
+    feedId: CRYPTO_FEAR_GREED_FEED_ID,
+    question: 'Crypto Fear & Greed index (Alternative.me)',
+    requiredTopics: [
+      {
+        name: 'Crypto',
+        slugByEnvironment: {
+          DEV: 'crypto-default',
+          PROD: 'crypto-speculation',
+        },
+      },
+    ],
+    oracleBehavior: 'scheduled-step',
+    requiresSourceAsOf: false,
+    gameDesign:
+      'A bounded 0-100 sentiment gauge that is mean-reverting by construction and genuinely two-sided: extreme readings in either direction tend to revert, momentum traders and contrarians both have a thesis, and the index is decorrelated enough from BTC spot to be its own market rather than a proxy for the BTC perp. It steps once a day, so expect long flat stretches between moves.',
+    latencyArbitrageRisk:
+      'The new daily value is public on alternative.me at roughly 00:00 UTC and the feed is polled every 5 minutes, so the window in which a trader can see the new print before the market marks it is bounded by that poll. The step is predictable in timing but not in direction or size.',
     recommended: {
       maxLeverage: 3,
       annualMaxFundingRate: 1,
@@ -373,6 +402,12 @@ export const PERP_LAUNCH_SCHEDULER_EXPECTATIONS = [
   {
     jobName: 'update-votehub-averages',
     // The other VoteHub averages, on the Trump job's cadence and bounds.
+    maxEndAgeMs: 30 * MINUTE_MS,
+    maxRunMs: 2 * MINUTE_MS,
+  },
+  {
+    jobName: 'update-fear-greed',
+    // Every 5 minutes, one small fetch.
     maxEndAgeMs: 30 * MINUTE_MS,
     maxRunMs: 2 * MINUTE_MS,
   },

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -8,6 +8,8 @@ import {
   CRYPTO_FEAR_GREED_FEED_ID,
   GLDX_USD_FEED_ID,
   NVDAX_USD_FEED_ID,
+  OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+  OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
   OPENROUTER_OPEN_WEIGHT_FEED_ID,
   QQQX_USD_FEED_ID,
   SPYX_USD_FEED_ID,
@@ -213,6 +215,65 @@ export const PERP_LAUNCH_MARKETS: readonly PerpLaunchMarketDefinition[] = [
     requiresSourceAsOf: true,
     gameDesign:
       'The trailing share can rise or fall and has coherent AI-adoption theses in both directions.',
+    latencyArbitrageRisk:
+      'OpenRouter currently exposes complete UTC days, so hourly Manifold points usually repeat one daily value. Re-stamping a flat value does not remove the predictable next-step arbitrage window.',
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 6 * HOUR_MS,
+      subsidyLong: 10_000,
+      subsidyShort: 10_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+  },
+  // Two more indexes over the same OpenRouter payload (lab-share.ts), with
+  // the open-weight entry's settings: same source, same cadence, same
+  // dataset terms (hence requiresSourceAsOf).
+  {
+    feedId: OPENROUTER_ANTHROPIC_SHARE_FEED_ID,
+    question: 'Anthropic share of OpenRouter tokens (%)',
+    requiredTopics: [
+      {
+        name: 'AI',
+        slugByEnvironment: {
+          DEV: 'ai',
+          PROD: 'ai',
+        },
+      },
+    ],
+    oracleBehavior: 'scheduled-step',
+    requiresSourceAsOf: true,
+    gameDesign:
+      "Measures tokens routed THROUGH OpenRouter to Anthropic models, not Anthropic's total usage: most Anthropic traffic goes direct to Anthropic and the cloud providers and never touches OpenRouter, so this is a proxy for third-party-routed demand, not for Anthropic's market share. Read that way it is genuinely two-sided — a new Claude release, a pricing change, a competitor launch, or a shift in what OpenRouter's own user base builds all move it in either direction — and the trailing 7-day window keeps any single day's step small.",
+    latencyArbitrageRisk:
+      'OpenRouter currently exposes complete UTC days, so hourly Manifold points usually repeat one daily value. Re-stamping a flat value does not remove the predictable next-step arbitrage window.',
+    recommended: {
+      maxLeverage: 3,
+      annualMaxFundingRate: 1,
+      fundingSensitivity: 1,
+      maxOraclePriceAgeMs: 6 * HOUR_MS,
+      subsidyLong: 10_000,
+      subsidyShort: 10_000,
+    },
+    minimumHistory: { spanMs: 30 * DAY_MS, points: 30 },
+  },
+  {
+    feedId: OPENROUTER_CHINESE_LAB_SHARE_FEED_ID,
+    question: 'Chinese-lab share of OpenRouter tokens (%)',
+    requiredTopics: [
+      {
+        name: 'AI',
+        slugByEnvironment: {
+          DEV: 'ai',
+          PROD: 'ai',
+        },
+      },
+    ],
+    oracleBehavior: 'scheduled-step',
+    requiresSourceAsOf: true,
+    gameDesign:
+      'The share of OpenRouter-routed tokens attributed to labs headquartered in China (classified by author slug, list in common/perps/lab-share.ts). Two-sided with coherent theses both ways: open-weight Chinese releases and their price advantage push it up, frontier closed releases and enterprise routing patterns push it down. An author the list cannot place is excluded from both sides and, past 1% of tokens, pauses the feed until a one-line classification is deployed — expect an occasional short pause after a brand-new lab enters the top 50.',
     latencyArbitrageRisk:
       'OpenRouter currently exposes complete UTC days, so hourly Manifold points usually repeat one daily value. Re-stamping a flat value does not remove the predictable next-step arbitrage window.',
     recommended: {

--- a/backend/shared/src/perps/publish-fear-greed.ts
+++ b/backend/shared/src/perps/publish-fear-greed.ts
@@ -1,0 +1,160 @@
+import { decideDailyFeedPublish } from 'common/perps/daily-feed-publish'
+import { FEAR_GREED_MAX_SOURCE_AGE_MS } from 'common/perps/fear-greed'
+import { utcDateString } from 'common/perps/open-weight-models'
+
+import { fetchFearGreedLatest } from 'shared/fear-greed'
+import { CRYPTO_FEAR_GREED_FEED_ID, insertOraclePrices } from 'shared/oracle'
+import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
+import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
+import { advisoryLockQuery } from 'shared/perps/queries'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+
+// Publisher for the `crypto-fear-greed` feed. Structurally the VoteHub
+// publisher (publish-votehub-average.ts) with the canary removed — the
+// provider publishes a single integer, there is no second series to
+// corroborate it against, and the source-staleness check plus the registry
+// bounds are the whole validation. The sequence is the same one every slow
+// feed in this folder follows: fetch → observe → early-out → advisory lock →
+// re-decide → validateOraclePoint → insertOraclePrices →
+// applyOraclePointToLivePerps outside the transaction.
+
+/** Today's UTC calendar day, for log lines and failure reports. */
+export const fearGreedDay = (now: number = Date.now()) => utcDateString(now)
+
+export type FearGreedPublishResult =
+  | {
+      status: 'published'
+      price: number
+      ts: number
+      /** The provider's own timestamp for the reading. */
+      sourceTs: number
+      classification: string | null
+    }
+  | { status: 'unchanged'; price: number; reason: string }
+  | { status: 'rejected'; reason: string }
+
+/**
+ * Publish ONE observation of the current Fear & Greed reading, stamped when
+ * it became available to the market (`Date.now()` at fetch), with the
+ * provider's own timestamp carried as `sourceTs`. Never stamped at the day
+ * boundary: a live job that backdated a reading to 00:00 UTC would be
+ * writing it into a window where funding and liquidations have already run.
+ *
+ * Every unsuccessful outcome is REPORTED, never logged here — only the
+ * caller knows whether another attempt is coming.
+ */
+export const publishFearGreedPoint = async (
+  pg: SupabaseDirectClient,
+  options: { force?: boolean } = {}
+): Promise<FearGreedPublishResult> => {
+  const feedId = CRYPTO_FEAR_GREED_FEED_ID
+  const latest = await fetchFearGreedLatest()
+  // Stamp the observation the moment it arrives: the point is when we saw
+  // the value, and under the lock below validateOraclePoint uses this stamp
+  // to stop a stalled publisher rolling the mark back onto an older reading.
+  const observedAt = Date.now()
+
+  // A source that stops updating must stop the feed, not be relaid every
+  // heartbeat under a fresh timestamp.
+  if (observedAt - latest.sourceTs > FEAR_GREED_MAX_SOURCE_AGE_MS)
+    return {
+      status: 'rejected',
+      reason: `provider reading is stale: stamped ${new Date(
+        latest.sourceTs
+      ).toISOString()}, more than ${
+        FEAR_GREED_MAX_SOURCE_AGE_MS / 3_600_000
+      }h ago`,
+    }
+
+  const readLast = async (
+    db: SupabaseDirectClient
+  ): Promise<{ ts: number; price: number } | null> => {
+    const row = await db.oneOrNone<{ ts: string; price: number | string }>(
+      `select ts, price from oracle_prices where feed_id = $1
+       order by ts desc limit 1`,
+      [feedId]
+    )
+    if (!row) return null
+    return { ts: new Date(row.ts).getTime(), price: Number(row.price) }
+  }
+
+  // `force` is the operator escape hatch, as on the VoteHub feeds: stamp the
+  // current value regardless of the unchanged gate during an incident.
+  const decide = (last: { ts: number; price: number } | null) =>
+    options.force
+      ? ({ publish: true, reason: 'forced' } as const)
+      : decideDailyFeedPublish({ price: latest.value, last, now: observedAt })
+
+  // Cheap early-out OUTSIDE the lock. Unchanged is the overwhelming common
+  // case at a 5-minute cadence against a once-a-day source. The authoritative
+  // re-check happens under the lock; this one is an optimisation and may race.
+  const earlyDecision = decide(await readLast(pg))
+  if (!earlyDecision.publish)
+    return {
+      status: 'unchanged',
+      price: latest.value,
+      reason: earlyDecision.reason,
+    }
+
+  const point = {
+    ts: observedAt,
+    price: latest.value,
+    sourceTs: latest.sourceTs,
+  }
+  const feed = getOracleFeed(feedId)
+  if (!feed)
+    return { status: 'rejected', reason: `missing OracleFeedDef for ${feedId}` }
+
+  // Serialize decide-and-write against every other publisher on this feed
+  // (the manual script, a second scheduler instance mid-deploy). The decision
+  // is re-made INSIDE the lock against a fresh read.
+  const outcome = await pg.tx(async (tx) => {
+    await tx.one(advisoryLockQuery(`oracle-publish:${feedId}`))
+    const last = await readLast(tx)
+
+    const decision = decide(last)
+    if (!decision.publish)
+      return {
+        status: 'unchanged' as const,
+        price: latest.value,
+        reason: decision.reason,
+      }
+
+    // Bounds are [1, 100]: a literal 0 print is refused here (and by
+    // validateBasicOraclePoint's positivity rule) and the feed pauses at the
+    // stale gate rather than publishing a non-positive price. See the
+    // registry entry and common/perps/fear-greed.ts.
+    const rejection = validateOraclePoint(feed, last, point)
+    if (rejection)
+      return {
+        status: 'rejected' as const,
+        reason: `reading ${point.price} but ${rejection}`,
+      }
+
+    log(
+      `[fear-greed] publishing ${point.price}${
+        latest.classification ? ` (${latest.classification})` : ''
+      } (${decision.reason}; source ${new Date(
+        point.sourceTs
+      ).toISOString()}) at ${new Date(point.ts).toISOString()}`
+    )
+    await insertOraclePrices(tx, feedId, [point])
+    return { status: 'published' as const }
+  })
+
+  if (outcome.status !== 'published') return outcome
+
+  // Applied OUTSIDE the publishing transaction, exactly as the fast oracle
+  // path does it: runOracleUpdate takes its own per-contract advisory lock,
+  // and nesting that inside this one would hold both across engine work.
+  await applyOraclePointToLivePerps(pg, feedId, point)
+  log(`inserted 1 ${feedId} oracle point for ${fearGreedDay(observedAt)}`)
+  return {
+    status: 'published',
+    price: point.price,
+    ts: point.ts,
+    sourceTs: point.sourceTs,
+    classification: latest.classification,
+  }
+}

--- a/backend/shared/src/perps/publish-fear-greed.ts
+++ b/backend/shared/src/perps/publish-fear-greed.ts
@@ -69,14 +69,24 @@ export const publishFearGreedPoint = async (
 
   const readLast = async (
     db: SupabaseDirectClient
-  ): Promise<{ ts: number; price: number } | null> => {
-    const row = await db.oneOrNone<{ ts: string; price: number | string }>(
-      `select ts, price from oracle_prices where feed_id = $1
+  ): Promise<{ ts: number; price: number; sourceTs: number | null } | null> => {
+    const row = await db.oneOrNone<{
+      ts: string
+      price: number | string
+      source_ts: string | null
+    }>(
+      `select ts, price, source_ts from oracle_prices where feed_id = $1
        order by ts desc limit 1`,
       [feedId]
     )
     if (!row) return null
-    return { ts: new Date(row.ts).getTime(), price: Number(row.price) }
+    const lastSourceTs =
+      row.source_ts == null ? null : new Date(row.source_ts).getTime()
+    return {
+      ts: new Date(row.ts).getTime(),
+      price: Number(row.price),
+      sourceTs: Number.isFinite(lastSourceTs) ? lastSourceTs : null,
+    }
   }
 
   // `force` is the operator escape hatch, as on the VoteHub feeds: stamp the
@@ -119,6 +129,22 @@ export const publishFearGreedPoint = async (
         status: 'unchanged' as const,
         price: latest.value,
         reason: decision.reason,
+      }
+
+    // Never publish a reading the provider stamped EARLIER than the one
+    // already on the feed. A stale cached response (an older reading, still
+    // inside the 3-day source-age allowance, with a different value) would
+    // otherwise be applied as a fresh move. Equal provider stamps are the
+    // same reading (heartbeats, corrections); older fails closed.
+    if (last?.sourceTs != null && point.sourceTs < last.sourceTs)
+      return {
+        status: 'rejected' as const,
+        reason:
+          `provider reading stamped ${new Date(
+            point.sourceTs
+          ).toISOString()} is older than the one already published ` +
+          `(${new Date(last.sourceTs).toISOString()}); not rolling the mark ` +
+          `back to an earlier reading`,
       }
 
     // Bounds are [1, 100]: a literal 0 print is refused here (and by

--- a/backend/shared/src/perps/publish-trump-approval.ts
+++ b/backend/shared/src/perps/publish-trump-approval.ts
@@ -1,266 +1,30 @@
-import * as dayjs from 'dayjs'
-import * as timezone from 'dayjs/plugin/timezone'
-import * as utc from 'dayjs/plugin/utc'
-dayjs.extend(utc)
-dayjs.extend(timezone)
-
 import {
-  TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP,
-  TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS,
-  TRUMP_APPROVAL_MAX_WINDOW_DAYS,
-  computeApprovalPoint,
-  decideApprovalPublish,
-  getApprovalCrossCheckGap,
-  readPublishedApprovalAverage,
-} from 'common/perps/trump-approval'
-
-import { TRUMP_APPROVAL_FEED_ID, insertOraclePrices } from 'shared/oracle'
-import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
-import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
-import { advisoryLockQuery } from 'shared/perps/queries'
+  VoteHubPublishResult,
+  publishVoteHubPoint,
+  voteHubDay,
+} from 'shared/perps/publish-votehub-average'
 import { SupabaseDirectClient } from 'shared/supabase/init'
-import {
-  fetchTrumpApprovalAverage,
-  fetchTrumpApprovalPolls,
-  toApprovalPolls,
-} from 'shared/trump-approval'
-import { log } from 'shared/utils'
+import { TRUMP_APPROVAL_SPEC, VOTEHUB_TZ } from 'shared/votehub-feeds'
 
-// Fetch enough poll history to cover the WIDEST window the methodology can
-// ask for, not just the nominal 14 days: when polling goes quiet the window
-// extends to satisfy TRUMP_APPROVAL_MIN_POLLS, and a lookback that stopped at
-// the nominal width would starve exactly the case the floor exists to handle.
-// The extra 21 days is buffer for long fielding periods (some polls span 2+
-// weeks, so their end_date can trail their start_date well past the bound).
-// ...and reach back from the OLDEST day we might value, not from today: the
-// published value can be up to TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS behind, and
-// the cross-check is computed for that day. Measuring the lookback from today
-// silently delivered a window three days short of what these comments claim.
-const FETCH_LOOKBACK_DAYS =
-  TRUMP_APPROVAL_MAX_WINDOW_DAYS + TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS + 21
+// The Trump approval publisher: publishVoteHubPoint with TRUMP_APPROVAL_SPEC.
+// The structure (observe → early-out → canary → advisory lock → re-decide →
+// validate → insert → apply) lives in publish-votehub-average.ts and is
+// shared with the other VoteHub feeds; this file keeps the names the
+// scheduler job and the operator scripts have always used.
 
-export const TRUMP_APPROVAL_TZ = 'America/Los_Angeles'
+export const TRUMP_APPROVAL_TZ = VOTEHUB_TZ
 
 export const trumpApprovalDay = (now: number = Date.now()) =>
-  dayjs.tz(dayjs(now), TRUMP_APPROVAL_TZ).format('YYYY-MM-DD')
+  voteHubDay(TRUMP_APPROVAL_SPEC, now)
 
-export type TrumpApprovalPublishResult =
-  | {
-      status: 'published'
-      price: number
-      ts: number
-      /** The day VoteHub stamped the value we published, and how far behind
-       * `today` that is. Surfaced so a published point can be reconciled
-       * against their site without re-deriving it. */
-      asOfDay: string
-      ageDays: number
-      /** Distance from our independent computation, or null when we could not
-       * produce one. Null is "unchecked", never "agrees". */
-      crossCheckGap: number | null
-    }
-  | { status: 'unchanged'; price: number; reason: string }
-  | { status: 'no-polls'; reason: string }
-  | { status: 'rejected'; reason: string }
+export type TrumpApprovalPublishResult = VoteHubPublishResult
 
 /**
- * Publish ONE observation of VoteHub's current approval average, stamped when
- * it becomes available to the market. Corrections append another observation
- * instead of pretending the revised value was tradable from midnight or
- * rewriting a point that liquidations/funding may already have consumed.
- *
- * Every unsuccessful outcome is REPORTED, never logged here: a thrown fetch
- * error and a returned `no-polls` are the same kind of event to a caller
- * that retries, and only the caller knows whether another attempt is coming.
- * Logging failures at this level is what made an hourly retry loop page
- * hourly for a single outage.
+ * Publish ONE observation of VoteHub's current Trump approval average,
+ * stamped when it becomes available to the market. See publishVoteHubPoint.
  */
-export const publishTrumpApprovalPoint = async (
+export const publishTrumpApprovalPoint = (
   pg: SupabaseDirectClient,
   options: { force?: boolean } = {}
-): Promise<TrumpApprovalPublishResult> => {
-  const now = dayjs.tz(dayjs(), TRUMP_APPROVAL_TZ)
-  const today = now.format('YYYY-MM-DD')
-
-  // The price. Fetched first so a failure here costs one request, not two.
-  const averages = await fetchTrumpApprovalAverage()
-  // Stamp the observation the moment it arrives, NOT after the cross-check
-  // below. With the timestamp taken later, a publisher that stalled in the
-  // canary fetch could write its stale reading with a timestamp newer than a
-  // concurrent publisher's fresher one, and the older observation would
-  // become the executable mark. The point is when we saw the value.
-  const observedAt = Date.now()
-  const published = readPublishedApprovalAverage(averages, today)
-  if (!published.ok) return { status: 'no-polls', reason: published.reason }
-
-  const fetchStart = dayjs
-    .utc(published.asOfDay)
-    .subtract(FETCH_LOOKBACK_DAYS, 'day')
-    .format('YYYY-MM-DD')
-
-  const readLast = async (
-    db: SupabaseDirectClient
-  ): Promise<{ ts: number; price: number } | null> => {
-    const row = await db.oneOrNone<{ ts: string; price: number | string }>(
-      `select ts, price from oracle_prices where feed_id = $1
-       order by ts desc limit 1`,
-      [TRUMP_APPROVAL_FEED_ID]
-    )
-    if (!row) return null
-    return { ts: new Date(row.ts).getTime(), price: Number(row.price) }
-  }
-
-  // `force` is the operator escape hatch: during an incident the point of
-  // running this by hand is to put a fresh stamp on the feed before it
-  // crosses maxOraclePriceAgeMs and pauses the engine, which is exactly the
-  // case the unchanged-value gate would otherwise refuse.
-  const decide = (last: { ts: number; price: number } | null) =>
-    options.force
-      ? ({ publish: true, reason: 'forced' } as const)
-      : decideApprovalPublish({ price: published.price, last, now: observedAt })
-
-  // Cheap early-out OUTSIDE the lock. An unchanged reading is the overwhelming
-  // common case at a 5-minute cadence — the value moves about once a day — and
-  // concluding that costs one indexed read rather than a second HTTP request,
-  // a full window computation, and a lock. The authoritative re-check happens
-  // under the lock below; this one is only an optimisation and is allowed to
-  // race.
-  const earlyDecision = decide(await readLast(pg))
-  if (!earlyDecision.publish)
-    return {
-      status: 'unchanged',
-      price: published.price,
-      reason: earlyDecision.reason,
-    }
-
-  // The canary. Computed from the raw polls, never used as the price.
-  //
-  // Its whole contract is that failing to produce it must not withhold a good
-  // published value, so the fetch and the computation are both inside the
-  // try: a timeout or an HTTP error here previously threw straight past the
-  // "unchecked" path and blocked publication, which is the opposite of what
-  // the surrounding comments promised.
-  //
-  // Computed for `published.asOfDay`, NOT for today. The published value can
-  // be a day or two behind, and comparing it against a reference built from
-  // polls it had not seen manufactures a divergence out of nothing but the
-  // date mismatch. Residual: a poll whose end_date precedes asOfDay but which
-  // VoteHub ingested afterwards still lands in our reference and not in
-  // theirs. Filtering on the provider's `created_at` would be a guess at when
-  // they folded it in rather than a fact. The drift it leaves is small — our
-  // own computation moves ~0.17/day on average against a tolerance of 3 —
-  // though that is a mean and not a bound, so an unusually eventful few days
-  // could narrow the margin.
-  let reference: ReturnType<typeof computeApprovalPoint> | null = null
-  try {
-    const polls = await fetchTrumpApprovalPolls(fetchStart)
-    reference = computeApprovalPoint(toApprovalPolls(polls), published.asOfDay)
-  } catch (err) {
-    reference = null
-    log.warn(
-      `[trump-approval] cross-check reference unavailable: ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    )
-  }
-  const referencePrice = reference?.ok === true ? reference.price : null
-  const referenceLabel =
-    referencePrice == null ? '?' : referencePrice.toFixed(2)
-  const crossCheckGap =
-    referencePrice == null
-      ? null
-      : getApprovalCrossCheckGap(published.price, referencePrice)
-
-  if (crossCheckGap == null)
-    log.warn(
-      `[trump-approval] publishing ${published.price.toFixed(2)} unchecked — ` +
-        `no independent reference (${
-          reference == null
-            ? 'fetch failed'
-            : reference.ok
-            ? 'gap not computable'
-            : reference.reason
-        })`
-    )
-  else if (crossCheckGap > TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP)
-    return {
-      status: 'rejected',
-      reason:
-        `published average ${published.price.toFixed(2)} (as of ` +
-        `${published.asOfDay}) is ${crossCheckGap.toFixed(2)} from our own ` +
-        `${referenceLabel}, over the ` +
-        `${TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP} tolerance — not publishing a ` +
-        `value two independent computations disagree about`,
-    }
-
-  const point = { price: published.price, ts: observedAt }
-  const feed = getOracleFeed(TRUMP_APPROVAL_FEED_ID)
-  if (!feed)
-    return {
-      status: 'rejected',
-      reason: `missing OracleFeedDef for ${TRUMP_APPROVAL_FEED_ID}`,
-    }
-
-  // Serialize the decide-and-write against every other publisher on this
-  // feed. Croner's `protect` only covers one Cron object inside one process,
-  // so it does nothing about the standalone publish script, a second
-  // scheduler instance during a rolling deploy, or a manual run. Without this
-  // the read of the previous point and the insert are two unrelated
-  // statements, and two publishers can both decide to write.
-  //
-  // The decision is re-made INSIDE the lock against a fresh read, because the
-  // early-out above ran before the cross-check's HTTP call and its answer may
-  // be seconds stale by now.
-  const outcome = await pg.tx(async (tx) => {
-    await tx.one(advisoryLockQuery(`oracle-publish:${TRUMP_APPROVAL_FEED_ID}`))
-    const last = await readLast(tx)
-
-    const decision = decide(last)
-    if (!decision.publish)
-      return {
-        status: 'unchanged' as const,
-        price: published.price,
-        reason: decision.reason,
-      }
-
-    // validateOraclePoint rejects `point.ts <= prev.ts`, which under the lock
-    // is what stops a stalled publisher from rolling the mark backwards onto
-    // an older observation.
-    const rejection = validateOraclePoint(feed, last, point)
-    if (rejection)
-      return {
-        status: 'rejected' as const,
-        reason: `published average ${point.price.toFixed(2)} but ${rejection}`,
-      }
-
-    log(
-      `VoteHub published Trump approval average: ${point.price.toFixed(2)} ` +
-        `(as of ${published.asOfDay}, ${published.ageDays}d old, ` +
-        `${decision.reason}); ` +
-        `${
-          crossCheckGap == null
-            ? 'cross-check unavailable'
-            : `cross-check gap ${crossCheckGap.toFixed(
-                2
-              )} vs our own ${referenceLabel}`
-        } at ${new Date(point.ts).toISOString()}`
-    )
-    await insertOraclePrices(tx, TRUMP_APPROVAL_FEED_ID, [point])
-    return { status: 'published' as const }
-  })
-
-  if (outcome.status !== 'published') return outcome
-
-  // Applied OUTSIDE the publishing transaction, exactly as the fast oracle
-  // path does it: runOracleUpdate takes its own per-contract advisory lock,
-  // and nesting that inside this one would hold both across engine work.
-  await applyOraclePointToLivePerps(pg, TRUMP_APPROVAL_FEED_ID, point)
-  log(`inserted 1 ${TRUMP_APPROVAL_FEED_ID} oracle point for ${today}`)
-  return {
-    status: 'published',
-    price: point.price,
-    ts: point.ts,
-    asOfDay: published.asOfDay,
-    ageDays: published.ageDays,
-    crossCheckGap,
-  }
-}
+): Promise<TrumpApprovalPublishResult> =>
+  publishVoteHubPoint(pg, TRUMP_APPROVAL_SPEC, options)

--- a/backend/shared/src/perps/publish-votehub-average.ts
+++ b/backend/shared/src/perps/publish-votehub-average.ts
@@ -9,6 +9,7 @@ import {
   computePollAveragePoint,
   getCrossCheckGap,
   readPublishedAverage,
+  voteHubDaySourceTs,
 } from 'common/perps/votehub-average'
 
 import { insertOraclePrices } from 'shared/oracle'
@@ -113,16 +114,34 @@ export const publishVoteHubPoint = async (
     .subtract(voteHubFetchLookbackDays(spec), 'day')
     .format('YYYY-MM-DD')
 
+  // The day VoteHub stamped this value travels with the point as source_ts.
+  const sourceTs = voteHubDaySourceTs(published.asOfDay)
+  if (sourceTs == null)
+    return {
+      status: 'rejected',
+      reason: `published as-of day ${published.asOfDay} is not a valid date`,
+    }
+
   const readLast = async (
     db: SupabaseDirectClient
-  ): Promise<{ ts: number; price: number } | null> => {
-    const row = await db.oneOrNone<{ ts: string; price: number | string }>(
-      `select ts, price from oracle_prices where feed_id = $1
+  ): Promise<{ ts: number; price: number; sourceTs: number | null } | null> => {
+    const row = await db.oneOrNone<{
+      ts: string
+      price: number | string
+      source_ts: string | null
+    }>(
+      `select ts, price, source_ts from oracle_prices where feed_id = $1
        order by ts desc limit 1`,
       [feedId]
     )
     if (!row) return null
-    return { ts: new Date(row.ts).getTime(), price: Number(row.price) }
+    const lastSourceTs =
+      row.source_ts == null ? null : new Date(row.source_ts).getTime()
+    return {
+      ts: new Date(row.ts).getTime(),
+      price: Number(row.price),
+      sourceTs: Number.isFinite(lastSourceTs) ? lastSourceTs : null,
+    }
   }
 
   // `force` is the operator escape hatch: during an incident the point of
@@ -218,7 +237,7 @@ export const publishVoteHubPoint = async (
         `value two independent computations disagree about`,
     }
 
-  const point = { price: published.price, ts: observedAt }
+  const point = { price: published.price, ts: observedAt, sourceTs }
   const feed = getOracleFeed(feedId)
   if (!feed)
     return {
@@ -246,6 +265,23 @@ export const publishVoteHubPoint = async (
         status: 'unchanged' as const,
         price: published.price,
         reason: decision.reason,
+      }
+
+    // Never roll the mark back to an EARLIER source day. If VoteHub's series
+    // temporarily loses day D and the latest usable entry becomes D-1 (still
+    // inside maxSourceAgeDays), that older value would otherwise go out as a
+    // fresh observation and be applied as a move. Same-day corrections
+    // (equal source day, different value) and newer days pass; an older day
+    // fails closed until the series catches up. Rows written before
+    // source_ts was recorded carry null and impose no bound.
+    if (last?.sourceTs != null && point.sourceTs < last.sourceTs)
+      return {
+        status: 'rejected' as const,
+        reason:
+          `VoteHub's latest usable day ${published.asOfDay} is earlier than ` +
+          `the day already published (${new Date(last.sourceTs)
+            .toISOString()
+            .slice(0, 10)}); not rolling the mark back to an older day's value`,
       }
 
     // validateOraclePoint rejects `point.ts <= prev.ts`, which under the lock

--- a/backend/shared/src/perps/publish-votehub-average.ts
+++ b/backend/shared/src/perps/publish-votehub-average.ts
@@ -1,0 +1,292 @@
+import * as dayjs from 'dayjs'
+import * as timezone from 'dayjs/plugin/timezone'
+import * as utc from 'dayjs/plugin/utc'
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+import { decideDailyFeedPublish } from 'common/perps/daily-feed-publish'
+import {
+  computePollAveragePoint,
+  getCrossCheckGap,
+  readPublishedAverage,
+} from 'common/perps/votehub-average'
+
+import { insertOraclePrices } from 'shared/oracle'
+import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
+import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
+import { advisoryLockQuery } from 'shared/perps/queries'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { log } from 'shared/utils'
+import {
+  VoteHubFeedSpec,
+  fetchVoteHubAverage,
+  fetchVoteHubPolls,
+  toVoteHubPolls,
+} from 'shared/votehub-feeds'
+
+// Publisher for every VoteHub published-average feed. `publishTrumpApprovalPoint`
+// is this function with TRUMP_APPROVAL_SPEC; the generic ballot and Vance
+// favorability feeds use it through update-votehub-averages. One structure,
+// three feeds — the sequence below (fetch → observe → early-out → canary →
+// advisory lock → re-decide → validateOraclePoint → insertOraclePrices →
+// applyOraclePointToLivePerps outside the transaction) is the one every
+// slow-feed publisher in this folder follows, and the Fear & Greed publisher
+// copies it rather than inventing another.
+
+/**
+ * How far back to fetch polls for the canary.
+ *
+ * Enough to cover the WIDEST window the methodology can ask for, not just the
+ * nominal window: when polling goes quiet the window extends to satisfy
+ * `minPolls`, and a lookback that stopped at the nominal width would starve
+ * exactly the case the floor exists to handle. The extra 21 days is buffer for
+ * long fielding periods (some polls span 2+ weeks, so their end_date can trail
+ * their start_date well past the bound).
+ *
+ * ...and reach back from the OLDEST day we might value, not from today: the
+ * published value can be up to `maxSourceAgeDays` behind, and the cross-check
+ * is computed for that day. Measuring the lookback from today silently
+ * delivered a window three days short of what these comments claim.
+ */
+export const voteHubFetchLookbackDays = (spec: VoteHubFeedSpec) =>
+  spec.rules.maxWindowDays + spec.rules.maxSourceAgeDays + 21
+
+/** Today's calendar day in the spec's timezone (Pacific). */
+export const voteHubDay = (spec: VoteHubFeedSpec, now: number = Date.now()) =>
+  dayjs.tz(dayjs(now), spec.tz).format('YYYY-MM-DD')
+
+export type VoteHubPublishResult =
+  | {
+      status: 'published'
+      price: number
+      ts: number
+      /** The day VoteHub stamped the value we published, and how far behind
+       * `today` that is. Surfaced so a published point can be reconciled
+       * against their site without re-deriving it. */
+      asOfDay: string
+      ageDays: number
+      /** Distance from our independent computation, or null when we could not
+       * produce one. Null is "unchecked", never "agrees". */
+      crossCheckGap: number | null
+    }
+  | { status: 'unchanged'; price: number; reason: string }
+  | { status: 'no-polls'; reason: string }
+  | { status: 'rejected'; reason: string }
+
+/**
+ * Publish ONE observation of VoteHub's current average for `spec`, stamped
+ * when it becomes available to the market. Corrections append another
+ * observation instead of pretending the revised value was tradable from
+ * midnight or rewriting a point that liquidations/funding may already have
+ * consumed.
+ *
+ * Every unsuccessful outcome is REPORTED, never logged here: a thrown fetch
+ * error and a returned `no-polls` are the same kind of event to a caller
+ * that retries, and only the caller knows whether another attempt is coming.
+ * Logging failures at this level is what made an hourly retry loop page
+ * hourly for a single outage.
+ */
+export const publishVoteHubPoint = async (
+  pg: SupabaseDirectClient,
+  spec: VoteHubFeedSpec,
+  options: { force?: boolean } = {}
+): Promise<VoteHubPublishResult> => {
+  const { feedId, rules } = spec
+  const today = voteHubDay(spec)
+
+  // The price. Fetched first so a failure here costs one request, not two.
+  const averages = await fetchVoteHubAverage(spec)
+  // Stamp the observation the moment it arrives, NOT after the cross-check
+  // below. With the timestamp taken later, a publisher that stalled in the
+  // canary fetch could write its stale reading with a timestamp newer than a
+  // concurrent publisher's fresher one, and the older observation would
+  // become the executable mark. The point is when we saw the value.
+  const observedAt = Date.now()
+  const published = readPublishedAverage(averages, today, {
+    answerKey: spec.answerKey,
+    maxAgeDays: rules.maxSourceAgeDays,
+  })
+  if (!published.ok) return { status: 'no-polls', reason: published.reason }
+
+  const fetchStart = dayjs
+    .utc(published.asOfDay)
+    .subtract(voteHubFetchLookbackDays(spec), 'day')
+    .format('YYYY-MM-DD')
+
+  const readLast = async (
+    db: SupabaseDirectClient
+  ): Promise<{ ts: number; price: number } | null> => {
+    const row = await db.oneOrNone<{ ts: string; price: number | string }>(
+      `select ts, price from oracle_prices where feed_id = $1
+       order by ts desc limit 1`,
+      [feedId]
+    )
+    if (!row) return null
+    return { ts: new Date(row.ts).getTime(), price: Number(row.price) }
+  }
+
+  // `force` is the operator escape hatch: during an incident the point of
+  // running this by hand is to put a fresh stamp on the feed before it
+  // crosses maxOraclePriceAgeMs and pauses the engine, which is exactly the
+  // case the unchanged-value gate would otherwise refuse.
+  const decide = (last: { ts: number; price: number } | null) =>
+    options.force
+      ? ({ publish: true, reason: 'forced' } as const)
+      : decideDailyFeedPublish({
+          price: published.price,
+          last,
+          now: observedAt,
+          heartbeatMs: rules.heartbeatMs,
+        })
+
+  // Cheap early-out OUTSIDE the lock. An unchanged reading is the overwhelming
+  // common case at a 5-minute cadence — the value moves about once a day — and
+  // concluding that costs one indexed read rather than a second HTTP request,
+  // a full window computation, and a lock. The authoritative re-check happens
+  // under the lock below; this one is only an optimisation and is allowed to
+  // race.
+  const earlyDecision = decide(await readLast(pg))
+  if (!earlyDecision.publish)
+    return {
+      status: 'unchanged',
+      price: published.price,
+      reason: earlyDecision.reason,
+    }
+
+  // The canary. Computed from the raw polls, never used as the price.
+  //
+  // Its whole contract is that failing to produce it must not withhold a good
+  // published value, so the fetch and the computation are both inside the
+  // try: a timeout or an HTTP error here previously threw straight past the
+  // "unchecked" path and blocked publication, which is the opposite of what
+  // the surrounding comments promised.
+  //
+  // Computed for `published.asOfDay`, NOT for today. The published value can
+  // be a day or two behind, and comparing it against a reference built from
+  // polls it had not seen manufactures a divergence out of nothing but the
+  // date mismatch. Residual: a poll whose end_date precedes asOfDay but which
+  // VoteHub ingested afterwards still lands in our reference and not in
+  // theirs. Filtering on the provider's `created_at` would be a guess at when
+  // they folded it in rather than a fact. The drift it leaves is small — the
+  // Trump computation moves ~0.17/day on average against a tolerance of 3 —
+  // though that is a mean and not a bound, so an unusually eventful few days
+  // could narrow the margin.
+  let reference: ReturnType<typeof computePollAveragePoint> | null = null
+  try {
+    const polls = await fetchVoteHubPolls(spec, fetchStart)
+    reference = computePollAveragePoint(
+      toVoteHubPolls(spec, polls),
+      published.asOfDay,
+      rules
+    )
+  } catch (err) {
+    reference = null
+    log.warn(
+      `${spec.logPrefix} cross-check reference unavailable for ${feedId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
+  const referencePrice = reference?.ok === true ? reference.price : null
+  const referenceLabel =
+    referencePrice == null ? '?' : referencePrice.toFixed(2)
+  const crossCheckGap =
+    referencePrice == null
+      ? null
+      : getCrossCheckGap(published.price, referencePrice)
+
+  if (crossCheckGap == null)
+    log.warn(
+      `${spec.logPrefix} publishing ${feedId} ${published.price.toFixed(
+        2
+      )} unchecked — no independent reference (${
+        reference == null
+          ? 'fetch failed'
+          : reference.ok
+          ? 'gap not computable'
+          : reference.reason
+      })`
+    )
+  else if (crossCheckGap > rules.maxCrossCheckGap)
+    return {
+      status: 'rejected',
+      reason:
+        `published average ${published.price.toFixed(2)} (as of ` +
+        `${published.asOfDay}) is ${crossCheckGap.toFixed(2)} from our own ` +
+        `${referenceLabel}, over the ` +
+        `${rules.maxCrossCheckGap} tolerance — not publishing a ` +
+        `value two independent computations disagree about`,
+    }
+
+  const point = { price: published.price, ts: observedAt }
+  const feed = getOracleFeed(feedId)
+  if (!feed)
+    return {
+      status: 'rejected',
+      reason: `missing OracleFeedDef for ${feedId}`,
+    }
+
+  // Serialize the decide-and-write against every other publisher on this
+  // feed. Croner's `protect` only covers one Cron object inside one process,
+  // so it does nothing about the standalone publish script, a second
+  // scheduler instance during a rolling deploy, or a manual run. Without this
+  // the read of the previous point and the insert are two unrelated
+  // statements, and two publishers can both decide to write.
+  //
+  // The decision is re-made INSIDE the lock against a fresh read, because the
+  // early-out above ran before the cross-check's HTTP call and its answer may
+  // be seconds stale by now.
+  const outcome = await pg.tx(async (tx) => {
+    await tx.one(advisoryLockQuery(`oracle-publish:${feedId}`))
+    const last = await readLast(tx)
+
+    const decision = decide(last)
+    if (!decision.publish)
+      return {
+        status: 'unchanged' as const,
+        price: published.price,
+        reason: decision.reason,
+      }
+
+    // validateOraclePoint rejects `point.ts <= prev.ts`, which under the lock
+    // is what stops a stalled publisher from rolling the mark backwards onto
+    // an older observation.
+    const rejection = validateOraclePoint(feed, last, point)
+    if (rejection)
+      return {
+        status: 'rejected' as const,
+        reason: `published average ${point.price.toFixed(2)} but ${rejection}`,
+      }
+
+    log(
+      `VoteHub published ${spec.label} average: ${point.price.toFixed(2)} ` +
+        `(as of ${published.asOfDay}, ${published.ageDays}d old, ` +
+        `${decision.reason}); ` +
+        `${
+          crossCheckGap == null
+            ? 'cross-check unavailable'
+            : `cross-check gap ${crossCheckGap.toFixed(
+                2
+              )} vs our own ${referenceLabel}`
+        } at ${new Date(point.ts).toISOString()}`
+    )
+    await insertOraclePrices(tx, feedId, [point])
+    return { status: 'published' as const }
+  })
+
+  if (outcome.status !== 'published') return outcome
+
+  // Applied OUTSIDE the publishing transaction, exactly as the fast oracle
+  // path does it: runOracleUpdate takes its own per-contract advisory lock,
+  // and nesting that inside this one would hold both across engine work.
+  await applyOraclePointToLivePerps(pg, feedId, point)
+  log(`inserted 1 ${feedId} oracle point for ${today}`)
+  return {
+    status: 'published',
+    price: point.price,
+    ts: point.ts,
+    asOfDay: published.asOfDay,
+    ageDays: published.ageDays,
+    crossCheckGap,
+  }
+}

--- a/backend/shared/src/trump-approval.ts
+++ b/backend/shared/src/trump-approval.ts
@@ -1,189 +1,35 @@
+import { ApprovalPoll } from 'common/perps/trump-approval'
+
 import {
-  ApprovalPoll,
-  PublishedAverageSeries,
-  hasApproveAnswer,
-  readApprovePct,
-} from 'common/perps/trump-approval'
+  TRUMP_APPROVAL_SPEC,
+  VoteHubPoll as VoteHubFeedPoll,
+  fetchVoteHubAverage,
+  fetchVoteHubPolls,
+  toVoteHubPolls,
+} from './votehub-feeds'
 
-import { log } from './utils'
+// The Trump approval adapter. Everything here delegates to the parameterised
+// VoteHub adapter in ./votehub-feeds.ts with TRUMP_APPROVAL_SPEC, which
+// reproduces this feed exactly: same endpoints, same query parameters, same
+// `Approve` choice, same `[trump-approval]` log prefix. These names are kept
+// so the backfill script and the publisher read as they always did.
 
-// VoteHub API: https://polling.votehub.com/polls
-// Returns a list of polls for a given subject. We use poll_type=approval,
-// in_averages_only=true (their aggregator already excludes internal/partisan
-// junk here), and filter by start_date. Each item has an `answers` array
-// with { choice, pct }; we want "Approve". The poll's representative date
-// is its `end_date` (last day of fielding) — not `created_at`, which is
-// when the poll was published.
-//
-// This module is the ADAPTER only: it fetches and shapes. How the polls are
-// then windowed and averaged is the published methodology and lives in
-// common/perps/trump-approval.ts, where a UI can read the same rule the
-// oracle prices against.
-
-export type VoteHubPoll = {
-  id: string
-  poll_type: string
-  start_date: string // YYYY-MM-DD
-  end_date: string // YYYY-MM-DD
-  pollster: string
-  subject: string
-  answers: { choice: string; pct: number }[]
-}
+export type VoteHubPoll = VoteHubFeedPoll
 
 export const TRUMP_INAUGURATION_DATE = '2025-01-21'
 
-const getApprovePct = (poll: VoteHubPoll): number | null => {
-  const pct = readApprovePct(poll?.answers)
-  // Distinguish "no Approve answer" (structural, not newsworthy) from a
-  // percentage that cannot be a percentage. The latter is a provider
-  // data-entry error and worth an ERROR: one pct of 460 against ~20 polls
-  // near 45 moves the unweighted mean ~20 points, which lands inside the
-  // feed's [10,90] plausibility bounds and would price live positions.
-  if (pct == null && hasApproveAnswer(poll?.answers))
-    log.error(
-      `[trump-approval] dropping poll ${poll?.id} with unusable approve pct`
-    )
-  return pct
-}
-
-/**
- * Fetch every Trump approval poll from VoteHub since `startDate`.
- *
- * ONE REQUEST, DELIBERATELY. An earlier revision of this function paged by
- * `offset`, on the belief that the endpoint truncated silently — the giveaway
- * being that `items.length` comes back well under the reported `total` (26 of
- * 37 over 28 days, 57 of 69 over 56, 807 of 995 over the full history). That
- * was a misreading, and the paging it motivated made things worse rather than
- * better. What the response body actually does:
- *
- *   - `items` is COMPLETE. Verified across six range sizes from 2 polls to
- *     807: `items.length` always equals the distinct-id count, and the entire
- *     history since inauguration arrives in a single response.
- *   - `total` counts a different and larger population than `items` — it does
- *     not match the item count under any combination of the filters we send,
- *     including with `in_averages_only=false`. It is not a completeness
- *     signal, and any check comparing the two fires on every single request.
- *   - `offset` past the end of `items` does NOT return further rows. It
- *     returns byte-identical copies of rows already delivered, then empties.
- *     The "unstable sort producing duplicates" the paging loop deduplicated
- *     against was an artifact the loop itself created by requesting offsets
- *     that only existed in `total`'s larger population.
- *
- * So there is nothing to page and nothing to reconcile. Do not reintroduce a
- * loop here on the strength of `items.length < total` alone; confirm first
- * that distinct ids are actually missing, which so far they never are.
- *
- * The real backstop against a future truncation lives in the methodology
- * rather than here: selectApprovalWindow refuses to publish unless it finds
- * TRUMP_APPROVAL_MIN_POLLS within TRUMP_APPROVAL_MAX_WINDOW_DAYS. Truncation
- * would drop the OLDEST polls (responses arrive newest-first), which is
- * exactly what a widened window reaches for, so a short read surfaces as a
- * refusal to publish rather than as a quietly wrong average.
- */
-export const fetchTrumpApprovalPolls = async (
-  startDate: string
-): Promise<VoteHubPoll[]> => {
-  const url = new URL('https://polling.votehub.com/polls')
-  url.searchParams.set('poll_type', 'approval')
-  url.searchParams.set('subject', 'Donald Trump')
-  url.searchParams.set('in_averages_only', 'true')
-  url.searchParams.set('start_date', startDate)
-
-  const response = await fetch(url.toString(), {
-    headers: {
-      accept: '*/*',
-      // VoteHub's CORS is locked to the votehub.com origin in browsers, but
-      // server-to-server requests don't need Origin. Setting a user-agent
-      // is polite.
-      'user-agent': 'Manifold/1.0 (+https://manifold.markets)',
-    },
-    // Without this a slow-trickling response never times out (undici's body
-    // timeout resets per chunk), the daily job never finishes, and croner's
-    // `protect` then silently skips subsequent firings with only a warning —
-    // below the ERROR severity that alerting pages on. Every sibling adapter
-    // sets a timeout; this one did not.
-    signal: AbortSignal.timeout(30_000),
-  })
-  if (!response.ok) {
-    throw new Error(
-      `VoteHub request failed: ${response.status} ${response.statusText}`
-    )
-  }
-  const body = (await response.json()) as {
-    items: VoteHubPoll[]
-    total: number
-  }
-  const items = Array.isArray(body.items) ? body.items : []
-  const distinct = new Set(items.map((poll) => poll?.id)).size
-
-  // Log the oldest date reached, not `total`: coverage of the window we are
-  // about to price is the property that matters, and it is the one a future
-  // truncation would visibly break.
-  const oldest = items.reduce<string | null>(
-    (acc, poll) => (acc == null || poll?.end_date < acc ? poll?.end_date : acc),
-    null
-  )
-  log(
-    `fetched ${items.length} Trump approval polls from VoteHub ` +
-      `(start_date=${startDate}, oldest end_date ${oldest ?? 'n/a'})`
-  )
-  // Distinct ids have always equalled the item count. If that ever changes,
-  // the response really is repeating rows and the assumptions above need
-  // revisiting — so say so loudly rather than silently deduplicating.
-  if (distinct !== items.length)
-    log.error(
-      `[trump-approval] VoteHub returned ${items.length} rows but only ${distinct} distinct ids`
-    )
-  return items
-}
-
 /** VoteHub's key for the Trump approval average. */
-export const VOTEHUB_TRUMP_APPROVAL_KEY = 'trump_approval'
+export const VOTEHUB_TRUMP_APPROVAL_KEY = TRUMP_APPROVAL_SPEC.averageKey
 
-/**
- * Fetch VoteHub's published, time-weighted approval average.
- *
- * This is the oracle price. The raw `/polls` feed above is still read, but
- * only to compute the independent cross-check described in
- * common/perps/trump-approval.ts — it no longer sets the price.
- *
- * Returns the whole series (one entry per day back to inauguration, ~50KB).
- * There is no "latest only" parameter, and the full payload is small enough
- * that adding one would be optimising the wrong thing: having the history in
- * hand is what lets readPublishedApprovalAverage tell "posted late today" from
- * "stopped updating three days ago".
- */
-export const fetchTrumpApprovalAverage =
-  async (): Promise<PublishedAverageSeries> => {
-    const url = `https://polling.votehub.com/averages/${VOTEHUB_TRUMP_APPROVAL_KEY}/values`
+/** Fetch every Trump approval poll from VoteHub since `startDate`. */
+export const fetchTrumpApprovalPolls = (
+  startDate: string
+): Promise<VoteHubPoll[]> => fetchVoteHubPolls(TRUMP_APPROVAL_SPEC, startDate)
 
-    const response = await fetch(url, {
-      headers: {
-        accept: '*/*',
-        'user-agent': 'Manifold/1.0 (+https://manifold.markets)',
-      },
-      // Same reasoning as the polls fetch: without an explicit timeout a
-      // slow-trickling body never resolves, the job never finishes, and
-      // croner's `protect` silently skips later firings at WARN severity.
-      signal: AbortSignal.timeout(30_000),
-    })
-    if (!response.ok) {
-      throw new Error(
-        `VoteHub averages request failed: ${response.status} ${response.statusText}`
-      )
-    }
-    const body = (await response.json()) as PublishedAverageSeries
-    log(
-      `fetched VoteHub published approval average ` +
-        `(${Object.keys(body ?? {}).length} daily points)`
-    )
-    return body
-  }
+/** Fetch VoteHub's published, time-weighted Trump approval average. */
+export const fetchTrumpApprovalAverage = () =>
+  fetchVoteHubAverage(TRUMP_APPROVAL_SPEC)
 
 /** Shape VoteHub rows into the methodology's input, dropping unusable ones. */
 export const toApprovalPolls = (polls: VoteHubPoll[]): ApprovalPoll[] =>
-  polls.flatMap((poll) => {
-    const pct = getApprovePct(poll)
-    if (pct == null) return []
-    return [{ endDate: poll.end_date, pct, pollster: poll.pollster }]
-  })
+  toVoteHubPolls(TRUMP_APPROVAL_SPEC, polls)

--- a/backend/shared/src/votehub-feeds.test.ts
+++ b/backend/shared/src/votehub-feeds.test.ts
@@ -1,0 +1,123 @@
+import { getOracleAttribution } from 'common/perps/oracle-attribution'
+import { ORACLE_TICK_DECORATIONS } from 'common/perps/oracle-display'
+import { TRUMP_APPROVAL_RULES } from 'common/perps/trump-approval'
+
+import { TRUMP_APPROVAL_FEED_ID } from './oracle'
+import { getOracleFeed } from './oracle-feeds'
+import {
+  PERP_LAUNCH_MARKETS,
+  PERP_LAUNCH_SCHEDULER_EXPECTATIONS,
+  getPerpLaunchManifestErrors,
+} from './perps/launch-manifest'
+import {
+  ALL_VOTEHUB_FEED_SPECS,
+  GENERIC_BALLOT_2026_SPEC,
+  TRUMP_APPROVAL_SPEC,
+  VANCE_FAVORABILITY_SPEC,
+  VOTEHUB_FEED_SPECS,
+  getVoteHubFeedSpec,
+} from './votehub-feeds'
+
+// The spec table is the one place a VoteHub feed is defined; everything else
+// (registry, attribution, chart decoration, launch manifest) is keyed on the
+// feed id and has to exist for the feed to be usable. These tests make a
+// missing entry a red build rather than a runtime surprise.
+describe('VoteHub feed specs', () => {
+  it('every spec is wired end to end', () => {
+    for (const spec of ALL_VOTEHUB_FEED_SPECS) {
+      const feed = getOracleFeed(spec.feedId)
+      expect([spec.feedId, feed?.cadence]).toEqual([spec.feedId, 'daily'])
+      expect([spec.feedId, feed?.marketCreationEnabled]).toEqual([
+        spec.feedId,
+        true,
+      ])
+      // Same CC BY 4.0 credit as the Trump feed, with the licence link that
+      // CC BY 4.0 s3(a)(1)(C) asks for.
+      const attribution = getOracleAttribution(spec.feedId)
+      expect([spec.feedId, attribution?.source]).toEqual([
+        spec.feedId,
+        'VoteHub',
+      ])
+      expect([spec.feedId, attribution?.licence]).toEqual([
+        spec.feedId,
+        'CC BY 4.0',
+      ])
+      expect([spec.feedId, typeof attribution?.licenceUrl]).toEqual([
+        spec.feedId,
+        'string',
+      ])
+      expect([spec.feedId, attribution?.showAsOf]).toEqual([
+        spec.feedId,
+        undefined,
+      ])
+      // A percentage on the chart axis.
+      expect([spec.feedId, ORACLE_TICK_DECORATIONS[spec.feedId]]).toEqual([
+        spec.feedId,
+        { suffix: '%' },
+      ])
+      const market = PERP_LAUNCH_MARKETS.find((m) => m.feedId === spec.feedId)
+      expect([spec.feedId, market?.oracleBehavior]).toEqual([
+        spec.feedId,
+        'scheduled-step',
+      ])
+      expect([spec.feedId, market?.requiresSourceAsOf]).toEqual([
+        spec.feedId,
+        false,
+      ])
+    }
+  })
+
+  it('has a spec for every feed the job publishes, and no duplicates', () => {
+    const ids = ALL_VOTEHUB_FEED_SPECS.map((spec) => spec.feedId)
+    expect(new Set(ids).size).toBe(ids.length)
+    const keys = ALL_VOTEHUB_FEED_SPECS.map((spec) => spec.averageKey)
+    expect(new Set(keys).size).toBe(keys.length)
+    for (const spec of VOTEHUB_FEED_SPECS)
+      expect(getVoteHubFeedSpec(spec.feedId)).toBe(spec)
+    expect(getVoteHubFeedSpec('nope')).toBeUndefined()
+  })
+
+  it('keeps the Trump feed exactly as it was', () => {
+    // The alert policies key on the feed id and the log prefix; the job name
+    // is pinned in the scheduler expectations below.
+    expect(TRUMP_APPROVAL_SPEC.feedId).toBe(TRUMP_APPROVAL_FEED_ID)
+    expect(TRUMP_APPROVAL_SPEC.feedId).toBe('trump-approval-rating')
+    expect(TRUMP_APPROVAL_SPEC.logPrefix).toBe('[trump-approval]')
+    expect(TRUMP_APPROVAL_SPEC.averageKey).toBe('trump_approval')
+    expect(TRUMP_APPROVAL_SPEC.answerKey).toBe('approve')
+    expect(TRUMP_APPROVAL_SPEC.pollType).toBe('approval')
+    expect(TRUMP_APPROVAL_SPEC.subject).toBe('Donald Trump')
+    expect(TRUMP_APPROVAL_SPEC.pollAnswerChoice).toBe('Approve')
+    expect(TRUMP_APPROVAL_SPEC.rules).toBe(TRUMP_APPROVAL_RULES)
+    // And it is NOT published by the generic job.
+    expect(VOTEHUB_FEED_SPECS).not.toContain(TRUMP_APPROVAL_SPEC)
+  })
+
+  it('the new feeds alert under [votehub] and never publish a margin', () => {
+    for (const spec of VOTEHUB_FEED_SPECS) {
+      expect(spec.logPrefix).toBe('[votehub]')
+      expect(spec.tz).toBe('America/Los_Angeles')
+      // Their rules are copies, not the Trump object, so a per-spec
+      // adjustment cannot leak into the Trump feed.
+      expect(spec.rules).not.toBe(TRUMP_APPROVAL_RULES)
+      expect(spec.rules).toEqual(TRUMP_APPROVAL_RULES)
+    }
+    expect(GENERIC_BALLOT_2026_SPEC.answerKey).toBe('dem')
+    expect(GENERIC_BALLOT_2026_SPEC.pollType).toBe('generic-ballot')
+    expect(GENERIC_BALLOT_2026_SPEC.subject).toBe('2026')
+    expect(VANCE_FAVORABILITY_SPEC.answerKey).toBe('favorable')
+    expect(VANCE_FAVORABILITY_SPEC.pollType).toBe('favorability')
+    expect(VANCE_FAVORABILITY_SPEC.subject).toBe('JD Vance')
+    expect(VANCE_FAVORABILITY_SPEC.pollAnswerChoice).toBe('Favorable')
+  })
+
+  it('both VoteHub jobs are in the launch scheduler expectations', () => {
+    const names = PERP_LAUNCH_SCHEDULER_EXPECTATIONS.map((e) => e.jobName)
+    expect(names).toContain('update-trump-approval')
+    expect(names).toContain('update-votehub-averages')
+  })
+
+  it('the launch manifest still validates with the new feeds', () => {
+    expect(getPerpLaunchManifestErrors()).toEqual([])
+  })
+})

--- a/backend/shared/src/votehub-feeds.test.ts
+++ b/backend/shared/src/votehub-feeds.test.ts
@@ -111,6 +111,45 @@ describe('VoteHub feed specs', () => {
     expect(VANCE_FAVORABILITY_SPEC.pollAnswerChoice).toBe('Favorable')
   })
 
+  it('pins the registry bounds and launch settings per feed', () => {
+    const bounds: Record<string, [number, number]> = {
+      'trump-approval-rating': [10, 90],
+      'votehub-generic-ballot-2026': [20, 80],
+      'vance-favorability': [10, 90],
+    }
+    for (const spec of ALL_VOTEHUB_FEED_SPECS) {
+      const feed = getOracleFeed(spec.feedId)
+      expect([spec.feedId, feed?.minPrice, feed?.maxPrice]).toEqual([
+        spec.feedId,
+        ...bounds[spec.feedId],
+      ])
+      expect([spec.feedId, feed?.staleAfterMs]).toEqual([
+        spec.feedId,
+        26 * 60 * 60 * 1000,
+      ])
+      expect([spec.feedId, feed?.updatePeriodMs]).toEqual([
+        spec.feedId,
+        24 * 60 * 60 * 1000,
+      ])
+      const market = PERP_LAUNCH_MARKETS.find((m) => m.feedId === spec.feedId)
+      expect([spec.feedId, market?.recommended]).toEqual([
+        spec.feedId,
+        {
+          maxLeverage: 3,
+          annualMaxFundingRate: 1,
+          fundingSensitivity: 1,
+          maxOraclePriceAgeMs: 30 * 60 * 60 * 1000,
+          subsidyLong: 5_000,
+          subsidyShort: 5_000,
+        },
+      ])
+      expect([spec.feedId, market?.requiredTopics.map((t) => t.name)]).toEqual([
+        spec.feedId,
+        ['Politics'],
+      ])
+    }
+  })
+
   it('both VoteHub jobs are in the launch scheduler expectations', () => {
     const names = PERP_LAUNCH_SCHEDULER_EXPECTATIONS.map((e) => e.jobName)
     expect(names).toContain('update-trump-approval')

--- a/backend/shared/src/votehub-feeds.ts
+++ b/backend/shared/src/votehub-feeds.ts
@@ -101,11 +101,14 @@ export const TRUMP_APPROVAL_SPEC: VoteHubFeedSpec = {
 /**
  * Democratic share (%) of VoteHub's published 2026 generic-ballot average.
  *
- * ⚠️ KEY AND SHAPE NOT YET VERIFIED AGAINST A LIVE RESPONSE. This spec was
- * written on 2026-09-02 from a build environment whose egress policy blocks
+ * ⚠️ KEY AND SHAPE NOT VERIFIED FROM THIS CODEBASE. This spec was written on
+ * 2026-09-02 from a build environment whose egress policy blocks
  * polling.votehub.com, so the average key (`generic_ballot_2026`), the answer
- * key (`dem`) and the poll choice (`Dem`) are INFERRED from the pattern the
- * verified Trump feed follows (key `trump_approval`, answer key `approve`,
+ * key (`dem`) and the poll choice (`Dem`) were INFERRED from the pattern the
+ * verified Trump feed follows. A reviewer of the introducing PR (#4034,
+ * 2026-09-03) with network access reported that the live series at this key
+ * matched the expected shape; that is second-hand here, so the operator
+ * check below still applies before the first backfill (key `trump_approval`, answer key `approve`,
  * poll choice `Approve` — VoteHub keys the average's answer objects on the
  * lower-cased poll choice) and from the feed-id chosen for this market. Before
  * the backfill is run, confirm all three with
@@ -144,10 +147,11 @@ export const GENERIC_BALLOT_2026_SPEC: VoteHubFeedSpec = {
 /**
  * Favorable (%) from VoteHub's published JD Vance favorability average.
  *
- * ⚠️ KEY AND SHAPE NOT YET VERIFIED AGAINST A LIVE RESPONSE — same caveat and
- * same verification step as GENERIC_BALLOT_2026_SPEC (2026-09-02). Inferred:
- * average key `vance_favorability` (by analogy with `trump_approval`), answer
- * key `favorable`, poll choice `Favorable`.
+ * ⚠️ KEY AND SHAPE NOT VERIFIED FROM THIS CODEBASE — same caveat, same
+ * second-hand confirmation from the PR #4034 review (2026-09-03), and the
+ * same verification step as GENERIC_BALLOT_2026_SPEC. Inferred: average key
+ * `vance_favorability` (by analogy with `trump_approval`), answer key
+ * `favorable`, poll choice `Favorable`.
  *
  * Rules start from the Trump numbers. Favorability polling for a vice
  * president is thinner than presidential approval, so expect the canary to

--- a/backend/shared/src/votehub-feeds.ts
+++ b/backend/shared/src/votehub-feeds.ts
@@ -1,0 +1,339 @@
+import { TRUMP_APPROVAL_RULES } from 'common/perps/trump-approval'
+import {
+  AveragePoll,
+  PublishedAverageSeries,
+  VoteHubAverageRules,
+  hasAnswer,
+  readAnswerPct,
+} from 'common/perps/votehub-average'
+
+import {
+  TRUMP_APPROVAL_FEED_ID,
+  VANCE_FAVORABILITY_FEED_ID,
+  VOTEHUB_GENERIC_BALLOT_2026_FEED_ID,
+} from './oracle'
+import { log } from './utils'
+
+// VoteHub API adapter, parameterised by feed.
+//
+// VoteHub (https://votehub.com/polls/api/) publishes two things we read:
+//
+//   - `GET https://polling.votehub.com/polls` — the raw poll list for a
+//     subject. We pass poll_type, subject, in_averages_only=true (their
+//     aggregator already excludes internal/partisan junk here) and a
+//     start_date. Each item has an `answers` array of { choice, pct }. The
+//     poll's representative date is its `end_date` (last day of fielding),
+//     not `created_at`, which is when the poll was published.
+//   - `GET https://polling.votehub.com/averages/<key>/values` — their
+//     published, time-weighted average, one entry per day keyed YYYY-MM-DD,
+//     each entry an object keyed by answer (`approve`, `dem`, `favorable`...)
+//     carrying `{ average }`. THIS is the oracle price; the raw polls only
+//     feed the canary. `GET /averages` lists every available key.
+//
+// This module is the ADAPTER only: it fetches and shapes. How a series is
+// read and how the canary windows the polls is the published methodology in
+// common/perps/votehub-average.ts, where a UI can read the same rule the
+// oracle prices against. The three feeds are described by a `VoteHubFeedSpec`
+// each; the Trump spec reproduces the pre-generalisation feed exactly (same
+// feed id, key, choice, constants, and `[trump-approval]` log prefix).
+//
+// Every request sets a timeout: without one a slow-trickling response never
+// times out (undici's body timeout resets per chunk), the job never finishes,
+// and croner's `protect` then silently skips subsequent firings with only a
+// warning — below the ERROR severity that alerting pages on.
+
+export const VOTEHUB_POLLING_API = 'https://polling.votehub.com'
+export const VOTEHUB_TZ = 'America/Los_Angeles'
+const USER_AGENT = 'Manifold/1.0 (+https://manifold.markets)'
+const FETCH_TIMEOUT_MS = 30_000
+
+export type VoteHubFeedSpec = {
+  /** Oracle feed id (`oracle_prices.feed_id`). */
+  feedId: string
+  /** Human label for log lines: "Trump approval", "JD Vance favorability". */
+  label: string
+  /** Key under `/averages/<averageKey>/values`. */
+  averageKey: string
+  /** Answer object inside each day's entry whose `average` is the price. */
+  answerKey: string
+  /** `subject` query parameter on `/polls`, for the canary. */
+  subject: string
+  /** `poll_type` query parameter on `/polls`, for the canary. */
+  pollType: string
+  /** `answers[].choice` string the canary averages (matched case-insensitively). */
+  pollAnswerChoice: string
+  /** Bracketed prefix on every WARN/ERROR line; GCP alerting keys on it. */
+  logPrefix: string
+  /** Calendar days are Pacific, like the rest of the scheduler. */
+  tz: typeof VOTEHUB_TZ
+  rules: VoteHubAverageRules
+}
+
+export type VoteHubPoll = {
+  id: string
+  poll_type: string
+  start_date: string // YYYY-MM-DD
+  end_date: string // YYYY-MM-DD
+  pollster: string
+  subject: string
+  answers: { choice: string; pct: number }[]
+}
+
+/**
+ * The original feed, unchanged. Key `trump_approval`, entries shaped
+ * `{ approve: { average }, disapprove: { average } }`, raw polls
+ * `poll_type=approval&subject=Donald Trump` with an `Approve` answer —
+ * all verified in production since 2026-08.
+ */
+export const TRUMP_APPROVAL_SPEC: VoteHubFeedSpec = {
+  feedId: TRUMP_APPROVAL_FEED_ID,
+  label: 'Trump approval',
+  averageKey: 'trump_approval',
+  answerKey: 'approve',
+  subject: 'Donald Trump',
+  pollType: 'approval',
+  pollAnswerChoice: 'Approve',
+  logPrefix: '[trump-approval]',
+  tz: VOTEHUB_TZ,
+  rules: TRUMP_APPROVAL_RULES,
+}
+
+/**
+ * Democratic share (%) of VoteHub's published 2026 generic-ballot average.
+ *
+ * ⚠️ KEY AND SHAPE NOT YET VERIFIED AGAINST A LIVE RESPONSE. This spec was
+ * written on 2026-09-02 from a build environment whose egress policy blocks
+ * polling.votehub.com, so the average key (`generic_ballot_2026`), the answer
+ * key (`dem`) and the poll choice (`Dem`) are INFERRED from the pattern the
+ * verified Trump feed follows (key `trump_approval`, answer key `approve`,
+ * poll choice `Approve` — VoteHub keys the average's answer objects on the
+ * lower-cased poll choice) and from the feed-id chosen for this market. Before
+ * the backfill is run, confirm all three with
+ * `backend/scripts/list-votehub-averages.ts`, which prints `GET /averages`
+ * and the answer keys of each spec's latest entry, and correct this constant
+ * if they differ. Nothing guesses at runtime: a wrong `averageKey` is an HTTP
+ * 404 (fetch throws, job reports failure), a wrong `answerKey` reads as "no
+ * usable published average" (nothing publishes), and a wrong
+ * `pollAnswerChoice` only blinds the canary (publishes unchecked, with a
+ * WARN naming the spec).
+ *
+ * The price is the DEMOCRATIC SHARE, never the D-minus-R margin: a margin
+ * can be zero or negative, and an oracle price must be strictly positive.
+ * If VoteHub only publishes a margin for this average — i.e. the entry has
+ * no per-party answer object — this feed must not be launched; do not
+ * synthesise a share from a margin.
+ *
+ * Rules start from the Trump numbers. Generic-ballot polling runs at a
+ * comparable density to presidential approval in a midterm year, so the same
+ * floor should engage about as rarely; revisit after the first month of
+ * cross-check gaps has been observed.
+ */
+export const GENERIC_BALLOT_2026_SPEC: VoteHubFeedSpec = {
+  feedId: VOTEHUB_GENERIC_BALLOT_2026_FEED_ID,
+  label: '2026 generic ballot (Democratic share)',
+  averageKey: 'generic_ballot_2026',
+  answerKey: 'dem',
+  subject: '2026',
+  pollType: 'generic-ballot',
+  pollAnswerChoice: 'Dem',
+  logPrefix: '[votehub]',
+  tz: VOTEHUB_TZ,
+  rules: { ...TRUMP_APPROVAL_RULES },
+}
+
+/**
+ * Favorable (%) from VoteHub's published JD Vance favorability average.
+ *
+ * ⚠️ KEY AND SHAPE NOT YET VERIFIED AGAINST A LIVE RESPONSE — same caveat and
+ * same verification step as GENERIC_BALLOT_2026_SPEC (2026-09-02). Inferred:
+ * average key `vance_favorability` (by analogy with `trump_approval`), answer
+ * key `favorable`, poll choice `Favorable`.
+ *
+ * Rules start from the Trump numbers. Favorability polling for a vice
+ * president is thinner than presidential approval, so expect the canary to
+ * report "unchecked" more often than Trump's does — that is a WARN per
+ * publication, never a refusal to publish, because a canary that cannot be
+ * computed has no opinion. If the first backfill dry run shows the floor
+ * failing on most days, widen `maxWindowDays` HERE (not in the Trump rules)
+ * and say why in this comment.
+ */
+export const VANCE_FAVORABILITY_SPEC: VoteHubFeedSpec = {
+  feedId: VANCE_FAVORABILITY_FEED_ID,
+  label: 'JD Vance favorability',
+  averageKey: 'vance_favorability',
+  answerKey: 'favorable',
+  subject: 'JD Vance',
+  pollType: 'favorability',
+  pollAnswerChoice: 'Favorable',
+  logPrefix: '[votehub]',
+  tz: VOTEHUB_TZ,
+  rules: { ...TRUMP_APPROVAL_RULES },
+}
+
+/**
+ * The feeds published by the `update-votehub-averages` job. Trump is NOT in
+ * this list: it keeps its own job, name and log prefix, because GCP alert
+ * policies are keyed on `[trump-approval]` and `update-trump-approval`.
+ */
+export const VOTEHUB_FEED_SPECS: readonly VoteHubFeedSpec[] = [
+  GENERIC_BALLOT_2026_SPEC,
+  VANCE_FAVORABILITY_SPEC,
+]
+
+/** Every VoteHub spec, for the scripts and the spec-table test. */
+export const ALL_VOTEHUB_FEED_SPECS: readonly VoteHubFeedSpec[] = [
+  TRUMP_APPROVAL_SPEC,
+  ...VOTEHUB_FEED_SPECS,
+]
+
+export const getVoteHubFeedSpec = (feedId: string) =>
+  ALL_VOTEHUB_FEED_SPECS.find((spec) => spec.feedId === feedId)
+
+const voteHubFetch = async (url: string, what: string) => {
+  const response = await fetch(url, {
+    headers: {
+      accept: '*/*',
+      // VoteHub's CORS is locked to the votehub.com origin in browsers, but
+      // server-to-server requests don't need Origin. Setting a user-agent
+      // is polite.
+      'user-agent': USER_AGENT,
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
+  if (!response.ok)
+    throw new Error(
+      `VoteHub ${what} request failed: ${response.status} ${response.statusText}`
+    )
+  return response.json() as Promise<unknown>
+}
+
+/**
+ * Fetch every poll for the spec's subject since `startDate`.
+ *
+ * ONE REQUEST, DELIBERATELY. An earlier revision of the Trump fetcher paged by
+ * `offset`, on the belief that the endpoint truncated silently — the giveaway
+ * being that `items.length` comes back well under the reported `total` (26 of
+ * 37 over 28 days, 57 of 69 over 56, 807 of 995 over the full history). That
+ * was a misreading, and the paging it motivated made things worse rather than
+ * better. What the response body actually does:
+ *
+ *   - `items` is COMPLETE. Verified across six range sizes from 2 polls to
+ *     807: `items.length` always equals the distinct-id count, and the entire
+ *     history since inauguration arrives in a single response.
+ *   - `total` counts a different and larger population than `items` — it does
+ *     not match the item count under any combination of the filters we send,
+ *     including with `in_averages_only=false`. It is not a completeness
+ *     signal, and any check comparing the two fires on every single request.
+ *   - `offset` past the end of `items` does NOT return further rows. It
+ *     returns byte-identical copies of rows already delivered, then empties.
+ *
+ * So there is nothing to page and nothing to reconcile. Do not reintroduce a
+ * loop here on the strength of `items.length < total` alone; confirm first
+ * that distinct ids are actually missing, which so far they never are.
+ *
+ * The real backstop against a future truncation lives in the methodology
+ * rather than here: selectPollWindow refuses to produce a canary unless it
+ * finds `minPolls` within `maxWindowDays`. Truncation would drop the OLDEST
+ * polls (responses arrive newest-first), which is exactly what a widened
+ * window reaches for, so a short read surfaces as an unchecked publication
+ * rather than as a quietly wrong canary.
+ */
+export const fetchVoteHubPolls = async (
+  spec: VoteHubFeedSpec,
+  startDate: string
+): Promise<VoteHubPoll[]> => {
+  const url = new URL(`${VOTEHUB_POLLING_API}/polls`)
+  url.searchParams.set('poll_type', spec.pollType)
+  url.searchParams.set('subject', spec.subject)
+  url.searchParams.set('in_averages_only', 'true')
+  url.searchParams.set('start_date', startDate)
+
+  const body = (await voteHubFetch(url.toString(), 'polls')) as {
+    items?: VoteHubPoll[]
+    total?: number
+  }
+  const items = Array.isArray(body?.items) ? body.items : []
+  const distinct = new Set(items.map((poll) => poll?.id)).size
+
+  // Log the oldest date reached, not `total`: coverage of the window we are
+  // about to price is the property that matters, and it is the one a future
+  // truncation would visibly break.
+  const oldest = items.reduce<string | null>(
+    (acc, poll) => (acc == null || poll?.end_date < acc ? poll?.end_date : acc),
+    null
+  )
+  log(
+    `fetched ${items.length} ${spec.label} polls from VoteHub ` +
+      `(start_date=${startDate}, oldest end_date ${oldest ?? 'n/a'})`
+  )
+  // Distinct ids have always equalled the item count. If that ever changes,
+  // the response really is repeating rows and the assumptions above need
+  // revisiting — so say so loudly rather than silently deduplicating.
+  if (distinct !== items.length)
+    log.error(
+      `${spec.logPrefix} VoteHub returned ${items.length} rows but only ${distinct} distinct ids for ${spec.feedId}`
+    )
+  return items
+}
+
+/**
+ * Fetch VoteHub's published, time-weighted average for the spec.
+ *
+ * This is the oracle price. The raw `/polls` feed above is still read, but
+ * only to compute the independent cross-check described in
+ * common/perps/votehub-average.ts — it never sets the price.
+ *
+ * Returns the whole series (one entry per day, ~50KB for Trump). There is no
+ * "latest only" parameter, and the full payload is small enough that adding
+ * one would be optimising the wrong thing: having the history in hand is what
+ * lets readPublishedAverage tell "posted late today" from "stopped updating
+ * three days ago".
+ */
+export const fetchVoteHubAverage = async (
+  spec: VoteHubFeedSpec
+): Promise<PublishedAverageSeries> => {
+  const url = `${VOTEHUB_POLLING_API}/averages/${encodeURIComponent(
+    spec.averageKey
+  )}/values`
+  const body = (await voteHubFetch(url, 'averages')) as PublishedAverageSeries
+  log(
+    `fetched VoteHub published ${spec.label} average ` +
+      `(${Object.keys(body ?? {}).length} daily points)`
+  )
+  return body
+}
+
+/**
+ * `GET /averages` — VoteHub's list of every published average. Discovery only
+ * (see backend/scripts/list-votehub-averages.ts); nothing on the price path
+ * calls this, so its shape is left untyped.
+ */
+export const fetchVoteHubAverageList = async (): Promise<unknown> =>
+  voteHubFetch(`${VOTEHUB_POLLING_API}/averages`, 'averages list')
+
+const getTrackedPct = (spec: VoteHubFeedSpec, poll: VoteHubPoll) => {
+  const pct = readAnswerPct(poll?.answers, spec.pollAnswerChoice)
+  // Distinguish "no such answer" (structural, not newsworthy) from a
+  // percentage that cannot be a percentage. The latter is a provider
+  // data-entry error and worth an ERROR: one pct of 460 against ~20 polls
+  // near 45 moves the unweighted mean ~20 points, which lands inside the
+  // feed's plausibility bounds and would blind the canary.
+  if (pct == null && hasAnswer(poll?.answers, spec.pollAnswerChoice))
+    log.error(
+      `${spec.logPrefix} dropping poll ${
+        poll?.id
+      } with unusable ${spec.pollAnswerChoice.toLowerCase()} pct`
+    )
+  return pct
+}
+
+/** Shape VoteHub rows into the methodology's input, dropping unusable ones. */
+export const toVoteHubPolls = (
+  spec: VoteHubFeedSpec,
+  polls: VoteHubPoll[]
+): AveragePoll[] =>
+  polls.flatMap((poll) => {
+    const pct = getTrackedPct(spec, poll)
+    if (pct == null) return []
+    return [{ endDate: poll.end_date, pct, pollster: poll.pollster }]
+  })

--- a/backend/supabase/migrations/2026090401_openrouter_lab_classifications.sql
+++ b/backend/supabase/migrations/2026090401_openrouter_lab_classifications.sql
@@ -1,0 +1,66 @@
+begin;
+
+-- Runtime classifications for the OpenRouter Chinese-lab token-share index.
+--
+-- The audited constants in common/src/perps/lab-share.ts remain the published
+-- seed and always win. This table is the no-deploy maintenance layer for new
+-- OpenRouter authors and for the occasional model-specific exception (for
+-- example, an anonymous preview model that is attributed after its reveal).
+--
+-- `is_chinese is null` means PENDING. Pending subjects remain unknown to the
+-- index; the row merely makes them visible to the operator queue and records
+-- when they first appeared.
+create table if not exists
+  openrouter_lab_classifications (
+    subject_type text not null check (subject_type in ('author', 'model')),
+    subject_slug text not null,
+    -- null = pending. Never guess a side for an executable index.
+    is_chinese boolean,
+    -- 'auto' is discovery/research; 'admin' is a human verdict.
+    source text not null check (source in ('auto', 'admin')),
+    -- Discovery context, citations/research, and append-only verdict history.
+    evidence jsonb not null default '{}'::jsonb,
+    first_seen timestamptz not null default now(),
+    first_ranked_at timestamptz,
+    classified_at timestamptz,
+    classified_by text,
+    updated_time timestamptz not null default now(),
+    primary key (subject_type, subject_slug),
+    constraint openrouter_lab_classifications_nonempty_slug check (
+      length(subject_slug) > 0
+      and subject_slug = btrim(subject_slug)
+    ),
+    -- A verdict always records when it was reached; pending never does.
+    constraint openrouter_lab_classifications_verdict_timestamped check ((is_chinese is null) = (classified_at is null)),
+    -- Human decisions are attributable; pending rows have no classifier.
+    -- A future automatic verdict may use source='auto' without pretending a
+    -- person made it, but discovery alone never fills is_chinese.
+    constraint openrouter_lab_classifications_verdict_attributed check (
+      (
+        is_chinese is null
+        and classified_by is null
+      )
+      or (
+        is_chinese is not null
+        and (
+          source = 'auto'
+          or classified_by is not null
+        )
+      )
+    )
+  );
+
+comment on table openrouter_lab_classifications is 'Seed-external author/model classifications for the OpenRouter Chinese-lab index; is_chinese null means pending review';
+
+-- Ranked work is urgent, then catalog-only backlog. The primary key already
+-- serves point lookups; this partial index serves the review queue.
+create index if not exists openrouter_lab_classifications_pending_idx on openrouter_lab_classifications (first_ranked_at asc nulls last, first_seen asc)
+where
+  is_chinese is null;
+
+-- No browser client needs direct access. API and scheduler paths use the
+-- direct server connection, so deny anon/authenticated access by enabling RLS
+-- without adding a policy. A classification is a lever on a money market.
+alter table openrouter_lab_classifications enable row level security;
+
+commit;

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1161,6 +1161,66 @@ export const API = (_apiTypeCheck = {
         message: 'An open classification must cite a public weights repo',
       }),
   },
+  // Runtime maintenance for the Chinese-lab OpenRouter index. Ordinary
+  // publishers are classified once at author scope; anonymous/shared
+  // namespaces can instead receive an exact-model verdict.
+  'get-openrouter-lab-classifications': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    returns: {} as {
+      pending: {
+        subjectType: 'author' | 'model'
+        subjectSlug: string
+        discoveredVia: string | null
+        exampleModels: string[]
+        exampleNames: string[]
+        firstSeen: number
+        firstRankedAt: number | null
+      }[]
+      decided: {
+        subjectType: 'author' | 'model'
+        subjectSlug: string
+        isChinese: boolean
+        evidence: string
+        sourceUrl: string | null
+        exampleModels: string[]
+        exampleNames: string[]
+        source: 'auto' | 'admin'
+        classifiedAt: number
+        classifiedBy: string | null
+      }[]
+      seedVersion: string
+    },
+    props: z.object({}).strict(),
+  },
+  'set-openrouter-lab-classification': {
+    method: 'POST',
+    visibility: 'undocumented',
+    authed: true,
+    returns: {} as {
+      success: true
+      subjectType: 'author' | 'model'
+      subjectSlug: string
+      isChinese: boolean
+    },
+    props: z
+      .object({
+        subjectType: z.enum(['author', 'model']),
+        subjectSlug: z.string().trim().min(1).max(300),
+        isChinese: z.boolean(),
+        evidence: z.string().trim().min(1).max(2_000),
+        sourceUrl: z
+          .string()
+          .trim()
+          .url()
+          .max(2_000)
+          .refine((url) => /^https?:\/\//i.test(url), {
+            message: 'Evidence URL must use http or https',
+          }),
+      })
+      .strict(),
+  },
   // Admin-only live risk tuning; undocumented deliberately — internal
   // operator tooling, not part of the public perp API surface.
   'update-perp-config': {

--- a/common/src/perps/daily-feed-publish.test.ts
+++ b/common/src/perps/daily-feed-publish.test.ts
@@ -1,0 +1,84 @@
+import {
+  DAILY_FEED_HEARTBEAT_MS,
+  decideDailyFeedPublish,
+} from './daily-feed-publish'
+import {
+  TRUMP_APPROVAL_HEARTBEAT_MS,
+  decideApprovalPublish,
+} from './trump-approval'
+
+// The publish-on-change rule shared by every slow feed. The Trump test file
+// exercises it through decideApprovalPublish; these pin that the generic
+// rule is that same function and that an integer-valued source (Fear &
+// Greed) and a one-decimal source (VoteHub) both trip on their own smallest
+// move.
+describe('decideDailyFeedPublish', () => {
+  const now = Date.parse('2026-09-02T12:00:00Z')
+
+  it('is the rule the Trump feed has always used', () => {
+    expect(TRUMP_APPROVAL_HEARTBEAT_MS).toBe(DAILY_FEED_HEARTBEAT_MS)
+    const last = { price: 38.4, ts: now - 60_000 }
+    for (const price of [38.4, 38.5])
+      expect(decideApprovalPublish({ price, last, now })).toEqual(
+        decideDailyFeedPublish({ price, last, now })
+      )
+  })
+
+  it('publishes first, on change, and on heartbeat — and otherwise not', () => {
+    expect(decideDailyFeedPublish({ price: 52, last: null, now })).toEqual({
+      publish: true,
+      reason: 'first',
+    })
+    expect(
+      decideDailyFeedPublish({
+        price: 53,
+        last: { price: 52, ts: now - 1000 },
+        now,
+      })
+    ).toEqual({ publish: true, reason: 'changed' })
+    expect(
+      decideDailyFeedPublish({
+        price: 52,
+        last: { price: 52, ts: now - DAILY_FEED_HEARTBEAT_MS },
+        now,
+      })
+    ).toEqual({ publish: true, reason: 'heartbeat' })
+    const held = decideDailyFeedPublish({
+      price: 52,
+      last: { price: 52, ts: now - DAILY_FEED_HEARTBEAT_MS + 1 },
+      now,
+    })
+    expect(held.publish).toBe(false)
+    expect(held.reason).toContain('unchanged')
+  })
+
+  it('keeps the heartbeat inside every daily feed staleness bound', () => {
+    // 26h staleAfterMs on the daily feeds, 30h maxOraclePriceAgeMs on their
+    // markets; two heartbeats a day leaves real margin under both.
+    expect(DAILY_FEED_HEARTBEAT_MS).toBeLessThan(26 * 60 * 60 * 1000)
+  })
+
+  it('honours a per-feed heartbeat override', () => {
+    const last = { price: 52, ts: now - 2 * 60 * 60 * 1000 }
+    expect(
+      decideDailyFeedPublish({ price: 52, last, now, heartbeatMs: 60 * 60 * 1000 })
+        .publish
+    ).toBe(true)
+    expect(
+      decideDailyFeedPublish({ price: 52, last, now, heartbeatMs: 0 }).publish
+    ).toBe(false)
+  })
+
+  it('refuses garbage rather than publishing it', () => {
+    expect(decideDailyFeedPublish({ price: NaN, last: null, now }).publish).toBe(
+      false
+    )
+    expect(
+      decideDailyFeedPublish({ price: 52, last: null, now: NaN }).publish
+    ).toBe(false)
+    // A corrupt prior point is no prior point.
+    expect(
+      decideDailyFeedPublish({ price: 52, last: { price: NaN, ts: now }, now })
+    ).toEqual({ publish: true, reason: 'first' })
+  })
+})

--- a/common/src/perps/daily-feed-publish.test.ts
+++ b/common/src/perps/daily-feed-publish.test.ts
@@ -61,8 +61,12 @@ describe('decideDailyFeedPublish', () => {
   it('honours a per-feed heartbeat override', () => {
     const last = { price: 52, ts: now - 2 * 60 * 60 * 1000 }
     expect(
-      decideDailyFeedPublish({ price: 52, last, now, heartbeatMs: 60 * 60 * 1000 })
-        .publish
+      decideDailyFeedPublish({
+        price: 52,
+        last,
+        now,
+        heartbeatMs: 60 * 60 * 1000,
+      }).publish
     ).toBe(true)
     expect(
       decideDailyFeedPublish({ price: 52, last, now, heartbeatMs: 0 }).publish
@@ -70,9 +74,9 @@ describe('decideDailyFeedPublish', () => {
   })
 
   it('refuses garbage rather than publishing it', () => {
-    expect(decideDailyFeedPublish({ price: NaN, last: null, now }).publish).toBe(
-      false
-    )
+    expect(
+      decideDailyFeedPublish({ price: NaN, last: null, now }).publish
+    ).toBe(false)
     expect(
       decideDailyFeedPublish({ price: 52, last: null, now: NaN }).publish
     ).toBe(false)

--- a/common/src/perps/daily-feed-publish.ts
+++ b/common/src/perps/daily-feed-publish.ts
@@ -1,0 +1,76 @@
+// The publish-on-change rule shared by every slow ("daily"-cadence) oracle
+// feed that is polled far more often than its source actually moves: the
+// VoteHub averages (Trump approval, the 2026 generic ballot, Vance
+// favorability) and the Alternative.me Crypto Fear & Greed index.
+//
+// It lives in `common` for the same reason the rest of the methodology does:
+// it decides WHEN a new oracle point exists, which is part of what a market is
+// priced against, and it should be one auditable rule rather than a copy per
+// feed that drifts.
+//
+// The rule: publish the first reading, publish whenever the value moves, and
+// otherwise re-stamp the unchanged value once a heartbeat has elapsed so a
+// genuinely flat stretch cannot be mistaken for a dead feed. Every point is
+// stamped at the instant the value was OBSERVED (Date.now() in the
+// publisher), never at a day boundary — a live job that stamped at midnight
+// would be backdating a reading into a window where funding and liquidations
+// have already run.
+
+/**
+ * How long a published point may stand before we re-publish an unchanged
+ * value purely to prove the feed is alive.
+ *
+ * Publishing only on change is what closes the intraday arbitrage window, but
+ * on its own it would starve the feed during a flat stretch — VoteHub's
+ * Trump average genuinely held 38.4 for three straight days in August 2026 —
+ * and staleness alerting keys on ROW age. So a value that has not moved is
+ * re-stamped twice a day, comfortably inside every daily feed's 26h
+ * staleAfterMs and the markets' 30h maxOraclePriceAgeMs.
+ */
+export const DAILY_FEED_HEARTBEAT_MS = 12 * 60 * 60 * 1000
+
+export type DailyFeedPublishDecision =
+  | { publish: true; reason: 'first' | 'changed' | 'heartbeat' }
+  | { publish: false; reason: string }
+
+/**
+ * Should this reading be written as a new oracle point?
+ *
+ * The original Trump rule published the first usable value of each Pacific
+ * day and then stopped, which left every later move by the source sitting in
+ * public view as the exact next day's mark — the same shape of timing edge
+ * the feed was changed to remove, just relocated from the window to the
+ * schedule. So the jobs run every few minutes and publish whenever the value
+ * actually moves.
+ *
+ * Prices are compared exactly rather than within an epsilon: the sources
+ * publish to one decimal (VoteHub) or to an integer (Fear & Greed), so any
+ * real move is at least the source's own resolution, and rounding slack here
+ * would silently swallow the smallest genuine moves.
+ */
+export const decideDailyFeedPublish = (args: {
+  price: number
+  last: { price: number; ts: number } | null
+  now: number
+  heartbeatMs?: number
+}): DailyFeedPublishDecision => {
+  const { price, last, now, heartbeatMs = DAILY_FEED_HEARTBEAT_MS } = args
+
+  if (!Number.isFinite(price))
+    return { publish: false, reason: `invalid price ${price}` }
+  if (!Number.isFinite(now))
+    return { publish: false, reason: `invalid now ${now}` }
+  if (!Number.isFinite(heartbeatMs) || heartbeatMs <= 0)
+    return { publish: false, reason: `invalid heartbeatMs ${heartbeatMs}` }
+  if (!last) return { publish: true, reason: 'first' }
+  if (!Number.isFinite(last.price) || !Number.isFinite(last.ts))
+    return { publish: true, reason: 'first' }
+
+  if (price !== last.price) return { publish: true, reason: 'changed' }
+  if (now - last.ts >= heartbeatMs)
+    return { publish: true, reason: 'heartbeat' }
+  return {
+    publish: false,
+    reason: `unchanged at ${price} since ${new Date(last.ts).toISOString()}`,
+  }
+}

--- a/common/src/perps/fear-greed.test.ts
+++ b/common/src/perps/fear-greed.test.ts
@@ -1,0 +1,170 @@
+import { DAY_MS } from '../util/time'
+import {
+  FEAR_GREED_EPOCH_MS,
+  FEAR_GREED_MAX_SOURCE_AGE_MS,
+  fearGreedDayStartUtc,
+  parseFearGreedPayload,
+} from './fear-greed'
+
+// The provider payload, as documented: newest first, integers as strings,
+// unix seconds as strings, and a metadata.error slot.
+const payload = (
+  rows: { value: unknown; timestamp: unknown; value_classification?: unknown }[],
+  metadata: unknown = { error: null }
+) => ({
+  name: 'Fear and Greed Index',
+  data: rows,
+  metadata,
+})
+
+const T0 = Date.UTC(2026, 8, 2) / 1000 // 2026-09-02T00:00:00Z, seconds
+
+describe('parseFearGreedPayload', () => {
+  it('parses a good payload and returns it oldest first', () => {
+    const result = parseFearGreedPayload(
+      payload([
+        {
+          value: '52',
+          value_classification: 'Neutral',
+          timestamp: String(T0),
+          time_until_update: '43210',
+        } as never,
+        { value: '47', value_classification: 'Fear', timestamp: String(T0 - 86400) },
+      ])
+    )
+    expect(result).toEqual({
+      ok: true,
+      points: [
+        {
+          value: 47,
+          sourceTs: (T0 - 86400) * 1000,
+          classification: 'Fear',
+        },
+        { value: 52, sourceTs: T0 * 1000, classification: 'Neutral' },
+      ],
+    })
+  })
+
+  it('accepts a bare number for value and timestamp too', () => {
+    const result = parseFearGreedPayload(
+      payload([{ value: 12, timestamp: T0 }])
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok)
+      expect(result.points[0]).toEqual({
+        value: 12,
+        sourceTs: T0 * 1000,
+        classification: null,
+      })
+  })
+
+  it('accepts the range endpoints 0 and 100 — the parser is faithful to the source', () => {
+    // Positivity is enforced at publication (registry bounds [1,100]), not
+    // by pretending the index cannot print 0.
+    for (const value of ['0', '100'])
+      expect(
+        parseFearGreedPayload(payload([{ value, timestamp: String(T0) }])).ok
+      ).toBe(true)
+  })
+
+  it('rejects the payload when the provider reports an error', () => {
+    const result = parseFearGreedPayload(
+      payload([{ value: '52', timestamp: String(T0) }], {
+        error: 'rate limit exceeded',
+      })
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('rate limit exceeded')
+    // ...but an empty-string error, like null, is "no error".
+    expect(
+      parseFearGreedPayload(
+        payload([{ value: '52', timestamp: String(T0) }], { error: '' })
+      ).ok
+    ).toBe(true)
+  })
+
+  it('rejects an out-of-range or non-integer value', () => {
+    for (const value of ['101', '-1', '52.5', '5e1', 'fifty', '', null, 101, 52.5, NaN])
+      expect([
+        value,
+        parseFearGreedPayload(payload([{ value, timestamp: String(T0) }])).ok,
+      ]).toEqual([value, false])
+  })
+
+  it('rejects a timestamp that does not parse as unix seconds', () => {
+    for (const timestamp of [
+      'yesterday',
+      '2026-09-02',
+      '',
+      '0',
+      '-5',
+      '1.5',
+      null,
+      // Milliseconds are not seconds; 2026 in ms parses to the year 56,000.
+      // Guard the other direction too: a small integer is 1970, before the
+      // index existed.
+      '86400',
+    ])
+      expect([
+        timestamp,
+        parseFearGreedPayload(payload([{ value: '52', timestamp }])).ok,
+      ]).toEqual([timestamp, false])
+    expect(FEAR_GREED_EPOCH_MS).toBe(Date.UTC(2018, 0, 1))
+  })
+
+  it('rejects the whole payload on one bad row rather than dropping it', () => {
+    const result = parseFearGreedPayload(
+      payload([
+        { value: '52', timestamp: String(T0) },
+        { value: 'bad', timestamp: String(T0 - 86400) },
+        { value: '50', timestamp: String(T0 - 2 * 86400) },
+      ])
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('row 1')
+  })
+
+  it('rejects duplicate timestamps', () => {
+    const result = parseFearGreedPayload(
+      payload([
+        { value: '52', timestamp: String(T0) },
+        { value: '51', timestamp: String(T0) },
+      ])
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('duplicate')
+  })
+
+  it('rejects a payload that is not the documented shape', () => {
+    expect(parseFearGreedPayload(null).ok).toBe(false)
+    expect(parseFearGreedPayload('x').ok).toBe(false)
+    expect(parseFearGreedPayload([]).ok).toBe(false)
+    expect(parseFearGreedPayload({}).ok).toBe(false)
+    expect(parseFearGreedPayload({ data: 'x' }).ok).toBe(false)
+    expect(parseFearGreedPayload({ data: [] }).ok).toBe(false)
+    expect(parseFearGreedPayload({ data: [null] }).ok).toBe(false)
+    expect(parseFearGreedPayload({ data: [{ value: '52' }] }).ok).toBe(false)
+  })
+
+  it('does not require metadata to be present', () => {
+    expect(
+      parseFearGreedPayload({ data: [{ value: '52', timestamp: String(T0) }] })
+        .ok
+    ).toBe(true)
+  })
+})
+
+describe('fearGreedDayStartUtc', () => {
+  it('floors a reading to 00:00 UTC of its day', () => {
+    const noon = Date.UTC(2026, 8, 2, 12, 30)
+    expect(fearGreedDayStartUtc(noon)).toBe(Date.UTC(2026, 8, 2))
+    expect(fearGreedDayStartUtc(Date.UTC(2026, 8, 2))).toBe(Date.UTC(2026, 8, 2))
+    expect(fearGreedDayStartUtc(Date.UTC(2026, 8, 2, 23, 59, 59))).toBe(
+      Date.UTC(2026, 8, 2)
+    )
+  })
+
+  it('keeps the source-staleness bound inside a few daily updates', () => {
+    expect(FEAR_GREED_MAX_SOURCE_AGE_MS).toBe(3 * DAY_MS)
+  })
+})

--- a/common/src/perps/fear-greed.test.ts
+++ b/common/src/perps/fear-greed.test.ts
@@ -9,7 +9,11 @@ import {
 // The provider payload, as documented: newest first, integers as strings,
 // unix seconds as strings, and a metadata.error slot.
 const payload = (
-  rows: { value: unknown; timestamp: unknown; value_classification?: unknown }[],
+  rows: {
+    value: unknown
+    timestamp: unknown
+    value_classification?: unknown
+  }[],
   metadata: unknown = { error: null }
 ) => ({
   name: 'Fear and Greed Index',
@@ -29,7 +33,11 @@ describe('parseFearGreedPayload', () => {
           timestamp: String(T0),
           time_until_update: '43210',
         } as never,
-        { value: '47', value_classification: 'Fear', timestamp: String(T0 - 86400) },
+        {
+          value: '47',
+          value_classification: 'Fear',
+          timestamp: String(T0 - 86400),
+        },
       ])
     )
     expect(result).toEqual({
@@ -84,7 +92,18 @@ describe('parseFearGreedPayload', () => {
   })
 
   it('rejects an out-of-range or non-integer value', () => {
-    for (const value of ['101', '-1', '52.5', '5e1', 'fifty', '', null, 101, 52.5, NaN])
+    for (const value of [
+      '101',
+      '-1',
+      '52.5',
+      '5e1',
+      'fifty',
+      '',
+      null,
+      101,
+      52.5,
+      NaN,
+    ])
       expect([
         value,
         parseFearGreedPayload(payload([{ value, timestamp: String(T0) }])).ok,
@@ -158,7 +177,9 @@ describe('fearGreedDayStartUtc', () => {
   it('floors a reading to 00:00 UTC of its day', () => {
     const noon = Date.UTC(2026, 8, 2, 12, 30)
     expect(fearGreedDayStartUtc(noon)).toBe(Date.UTC(2026, 8, 2))
-    expect(fearGreedDayStartUtc(Date.UTC(2026, 8, 2))).toBe(Date.UTC(2026, 8, 2))
+    expect(fearGreedDayStartUtc(Date.UTC(2026, 8, 2))).toBe(
+      Date.UTC(2026, 8, 2)
+    )
     expect(fearGreedDayStartUtc(Date.UTC(2026, 8, 2, 23, 59, 59))).toBe(
       Date.UTC(2026, 8, 2)
     )

--- a/common/src/perps/fear-greed.test.ts
+++ b/common/src/perps/fear-greed.test.ts
@@ -123,6 +123,8 @@ describe('parseFearGreedPayload', () => {
       // Guard the other direction too: a small integer is 1970, before the
       // index existed.
       '86400',
+      // Past the largest Date; toISOString() would throw a RangeError.
+      '99999999999999999',
     ])
       expect([
         timestamp,

--- a/common/src/perps/fear-greed.ts
+++ b/common/src/perps/fear-greed.ts
@@ -109,11 +109,19 @@ const parseTimestamp = (raw: unknown): number | null => {
   if (!Number.isInteger(seconds) || seconds <= 0) return null
   const ms = seconds * 1000
   if (!Number.isFinite(ms) || ms < FEAR_GREED_EPOCH_MS) return null
+  // Beyond the largest instant a Date can hold, toISOString() throws; that
+  // would surface as an opaque RangeError from a log line instead of a
+  // rejection that names the field. (A merely future timestamp is left to
+  // validateBasicOraclePoint, which refuses a sourceTs ahead of now.)
+  if (ms > MAX_DATE_MS) return null
   return ms
 }
 
 /** 2018-01-01T00:00:00Z — the index did not exist before 2018. */
 export const FEAR_GREED_EPOCH_MS = Date.UTC(2018, 0, 1)
+
+/** ECMAScript's maximum Date value, ±8.64e15 ms from the epoch. */
+const MAX_DATE_MS = 8.64e15
 
 /**
  * Parse the `/fng/` payload, treating every field as untrusted.

--- a/common/src/perps/fear-greed.ts
+++ b/common/src/perps/fear-greed.ts
@@ -1,0 +1,194 @@
+import { DAY_MS } from '../util/time'
+
+// The Crypto Fear & Greed index, as published by Alternative.me, mirrored as
+// an oracle price.
+//
+// This file is the published methodology for the feed and the parser for the
+// provider payload. It lives in `common` (a leaf package) so the rule the
+// oracle is scored against is one auditable artifact a UI can render, and so
+// the parser is unit-tested where the repo has a test runner.
+//
+// WHAT THE PRICE IS
+//
+// Alternative.me computes a daily sentiment score for the crypto market on a
+// 0-100 scale — 0 "Extreme Fear", 100 "Extreme Greed" — from volatility,
+// market momentum/volume, social media, surveys, Bitcoin dominance and search
+// trends, weighted by their published scheme. We mirror the integer they
+// publish; we do not compute, smooth, or rescale it. The number on the market
+// is the number on https://alternative.me/crypto/fear-and-greed-index/.
+//
+// The index updates ONCE A DAY, around 00:00 UTC, and the API serves the
+// current value with a `time_until_update` countdown. It is mean-reverting by
+// construction (a bounded sentiment gauge) and genuinely two-sided: neither
+// direction is structurally favoured, which is what makes it a usable perp.
+//
+// POSITIVITY
+//
+// Oracle prices must be strictly positive (validateBasicOraclePoint), and the
+// index's range includes 0. The parser below ACCEPTS a 0 print — it is a
+// valid reading of the index and the parser's job is fidelity to the source —
+// but the feed's registry bounds are [1, 100] and a 0 is refused at
+// publication. That is acceptable because the index has never printed 0
+// (its historical floor is in the single digits), and if it ever did the
+// feed would simply pause: no point published, the market's freshness gate
+// trips after maxOraclePriceAgeMs, and trading resumes on the next non-zero
+// print. Pausing at the stale gate is strictly better than publishing a
+// non-positive price or inventing a floor.
+//
+// TERMS
+//
+// The credit line is in oracle-attribution.ts. See the note there: the
+// provider's terms page could not be read from the environment this feed was
+// written in, so the entry carries a credit and a link and no licence label,
+// and confirming those terms is an operator gate before a market is created.
+
+/** The index is an integer on this closed range. */
+export const FEAR_GREED_MIN = 0
+export const FEAR_GREED_MAX = 100
+
+/**
+ * How stale the provider's own latest datapoint may be before we stop
+ * publishing.
+ *
+ * Same reasoning as the VoteHub feeds' maxSourceAgeDays: a source that stops
+ * updating must stop the feed, not be relaid every heartbeat under a fresh
+ * timestamp. The index posts daily, so three days is slack for a missed
+ * update or a short outage without tolerating a genuinely dead source.
+ */
+export const FEAR_GREED_MAX_SOURCE_AGE_MS = 3 * DAY_MS
+
+export type FearGreedPoint = {
+  /** The published integer, FEAR_GREED_MIN..FEAR_GREED_MAX inclusive. */
+  value: number
+  /** Provider timestamp for the reading, epoch MILLISECONDS. */
+  sourceTs: number
+  /** `value_classification` verbatim ("Extreme Fear" ... "Extreme Greed"), display only. */
+  classification: string | null
+}
+
+export type FearGreedParseResult =
+  | { ok: true; points: FearGreedPoint[] }
+  | { ok: false; reason: string }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value != null && typeof value === 'object' && !Array.isArray(value)
+
+/**
+ * Parse one `data[]` row's `value` — a decimal-integer string in the payload
+ * (an actual number is also accepted, in case the provider ever stops
+ * stringifying). Anything non-integer or outside the index range is a
+ * rejection, never a clamp or a round.
+ */
+const parseValue = (raw: unknown): number | null => {
+  let value: number
+  if (typeof raw === 'string') {
+    if (!/^\s*\d+\s*$/.test(raw)) return null
+    value = Number(raw.trim())
+  } else if (typeof raw === 'number') {
+    value = raw
+  } else return null
+  if (!Number.isInteger(value)) return null
+  if (value < FEAR_GREED_MIN || value > FEAR_GREED_MAX) return null
+  return value
+}
+
+/**
+ * Parse `timestamp` — unix SECONDS as a decimal string (or number). Returns
+ * epoch milliseconds. Rejects anything that is not a positive integer number
+ * of seconds, and anything before the index existed (it launched in 2018; a
+ * value that parses to the 1970s is a units mistake, not a reading).
+ */
+const parseTimestamp = (raw: unknown): number | null => {
+  let seconds: number
+  if (typeof raw === 'string') {
+    if (!/^\s*\d+\s*$/.test(raw)) return null
+    seconds = Number(raw.trim())
+  } else if (typeof raw === 'number') {
+    seconds = raw
+  } else return null
+  if (!Number.isInteger(seconds) || seconds <= 0) return null
+  const ms = seconds * 1000
+  if (!Number.isFinite(ms) || ms < FEAR_GREED_EPOCH_MS) return null
+  return ms
+}
+
+/** 2018-01-01T00:00:00Z — the index did not exist before 2018. */
+export const FEAR_GREED_EPOCH_MS = Date.UTC(2018, 0, 1)
+
+/**
+ * Parse the `/fng/` payload, treating every field as untrusted.
+ *
+ * Shape (verified against the provider's documentation; a live response
+ * could not be fetched from the environment this was written in):
+ *
+ *   { name: "Fear and Greed Index",
+ *     data: [ { value: "<int>", value_classification: "<label>",
+ *               timestamp: "<unix seconds>", time_until_update?: "<s>" }, ... ],
+ *     metadata: { error: null | "<message>" } }
+ *
+ * `data` is newest first; the result is OLDEST first. The whole payload is
+ * rejected on any malformed row rather than the row dropped: for a
+ * single-value fetch the two are the same thing, and for a history fetch a
+ * silently dropped day is a hole in published history nobody would notice.
+ */
+export const parseFearGreedPayload = (body: unknown): FearGreedParseResult => {
+  if (!isRecord(body)) return { ok: false, reason: 'payload is not an object' }
+
+  const metadata = body.metadata
+  if (isRecord(metadata)) {
+    const error = metadata.error
+    if (error != null && !(typeof error === 'string' && error.trim() === ''))
+      return { ok: false, reason: `provider reported error: ${String(error)}` }
+  }
+
+  const data = body.data
+  if (!Array.isArray(data))
+    return { ok: false, reason: 'payload `data` is not an array' }
+  if (data.length === 0) return { ok: false, reason: 'payload `data` is empty' }
+
+  const points: FearGreedPoint[] = []
+  const seenTs: Record<number, true> = {}
+  for (let index = 0; index < data.length; index++) {
+    const row: unknown = data[index]
+    if (!isRecord(row))
+      return { ok: false, reason: `row ${index} is not an object` }
+    const value = parseValue(row.value)
+    if (value == null)
+      return {
+        ok: false,
+        reason: `row ${index} has an unusable value ${JSON.stringify(
+          row.value
+        )} (need an integer in [${FEAR_GREED_MIN}, ${FEAR_GREED_MAX}])`,
+      }
+    const sourceTs = parseTimestamp(row.timestamp)
+    if (sourceTs == null)
+      return {
+        ok: false,
+        reason: `row ${index} has an unusable timestamp ${JSON.stringify(
+          row.timestamp
+        )}`,
+      }
+    // Two readings at one instant cannot both be right, and an
+    // on-conflict-do-nothing insert would make the published value depend on
+    // array order — the same reason normalizeOraclePointBatch rejects it.
+    if (seenTs[sourceTs])
+      return {
+        ok: false,
+        reason: `duplicate timestamp ${new Date(sourceTs).toISOString()}`,
+      }
+    seenTs[sourceTs] = true
+    const classification =
+      typeof row.value_classification === 'string' &&
+      row.value_classification.trim().length > 0
+        ? row.value_classification.trim()
+        : null
+    points.push({ value, sourceTs, classification })
+  }
+
+  points.sort((a, b) => a.sourceTs - b.sourceTs)
+  return { ok: true, points }
+}
+
+/** 00:00 UTC of the day a reading belongs to — the backfill's stamp. */
+export const fearGreedDayStartUtc = (sourceTs: number): number =>
+  Math.floor(sourceTs / DAY_MS) * DAY_MS

--- a/common/src/perps/lab-share.test.ts
+++ b/common/src/perps/lab-share.test.ts
@@ -188,6 +188,44 @@ describe('Chinese-lab share', () => {
     expect(res.unknownAuthors).toEqual([])
     expect(res.share).toBeCloseTo(30)
   })
+
+  it('treats Object.prototype-named authors as unknown, not as listed', () => {
+    // The author segment is untrusted. A truthy plain-object lookup would
+    // have put `constructor/x` into the NUMERATOR silently, and an
+    // `__proto__` object key would have vanished from the reported list.
+    for (const author of [
+      'constructor',
+      '__proto__',
+      'toString',
+      'hasOwnProperty',
+    ]) {
+      const rows = [
+        row(D, 'deepseek/deepseek-v4-pro-20260423', 500),
+        row(D, 'openai/gpt-5.5-20260423', 500),
+        row(D, `${author}/mystery-model`, 100),
+      ]
+      const res = computeChineseLabShare(rows)
+      expect([author, res.unknownAuthors]).toEqual([author, [author]])
+      expect([author, res.unknownTokens]).toEqual([author, 100])
+      expect([author, res.numeratorTokens]).toEqual([author, 500])
+      expect([author, res.share]).toEqual([author, 50])
+      // ...and over the cap it halts like any other unknown.
+      const validation = validateLabSharePublication({
+        ...res,
+        dates: [
+          '2026-08-20',
+          '2026-08-21',
+          '2026-08-22',
+          '2026-08-23',
+          '2026-08-24',
+          '2026-08-25',
+          '2026-08-26',
+        ],
+        hasExcludedPayload: true,
+      })
+      expect([author, validation.ok]).toEqual([author, false])
+    }
+  })
 })
 
 describe('publication validation', () => {
@@ -246,6 +284,18 @@ describe('publication validation', () => {
     expect(validation.share).toBeCloseTo(40)
     expect(validation.unknownAuthors).toEqual(['mystery-lab'])
     expect(validation.unknownShareOfClassified).toBeCloseTo(0.005)
+  })
+
+  it('publishes exactly at the cap and halts just above it', () => {
+    // 70 unknown against 7000 classified is exactly 1%; 71 is over.
+    const at = computeChineseLabShare(
+      completeWindow([row(D, 'mystery-lab/model-x', 70)])
+    )
+    expect(validateLabSharePublication(at).ok).toBe(true)
+    const over = computeChineseLabShare(
+      completeWindow([row(D, 'mystery-lab/model-x', 71)])
+    )
+    expect(validateLabSharePublication(over).ok).toBe(false)
   })
 
   it('halts on any unknown when the cap is zero (backfill posture)', () => {
@@ -328,8 +378,9 @@ describe('publication validation', () => {
 })
 
 describe('the author lists', () => {
-  it('reuse the open-weight cap number', () => {
+  it('reuse the open-weight cap number — 1% of classified tokens', () => {
     expect(UNKNOWN_AUTHOR_TOKEN_SHARE_CAP).toBe(UNCLASSIFIED_TOKEN_SHARE_CAP)
+    expect(UNKNOWN_AUTHOR_TOKEN_SHARE_CAP).toBe(0.01)
   })
 
   it('never place an author on both sides', () => {

--- a/common/src/perps/lab-share.test.ts
+++ b/common/src/perps/lab-share.test.ts
@@ -1,0 +1,388 @@
+import {
+  CHINESE_LAB_AUTHORS,
+  KNOWN_NON_CHINESE_AUTHORS,
+  UNKNOWN_AUTHOR_TOKEN_SHARE_CAP,
+  authorOfPermaslug,
+  computeAnthropicShare,
+  computeChineseLabShare,
+  computeLabShare,
+  validateLabSharePublication,
+} from './lab-share'
+import {
+  OPEN_WEIGHT_MODELS,
+  OPEN_WEIGHT_WINDOW_DAYS,
+  RankingRow,
+  UNCLASSIFIED_TOKEN_SHARE_CAP,
+} from './open-weight-models'
+
+const row = (
+  date: string,
+  model_permaslug: string,
+  total_tokens: string | number
+): RankingRow => ({
+  date,
+  model_permaslug,
+  total_tokens: String(total_tokens),
+})
+
+const D = '2026-08-26'
+
+describe('authorOfPermaslug', () => {
+  it('is the segment before the first slash of the base slug', () => {
+    expect(authorOfPermaslug('anthropic/claude-opus-5-20260723')).toBe(
+      'anthropic'
+    )
+    expect(authorOfPermaslug('z-ai/glm-5.2-20260616')).toBe('z-ai')
+    expect(authorOfPermaslug('meta-llama/llama-3.3-70b-instruct')).toBe(
+      'meta-llama'
+    )
+  })
+
+  it('collapses :free and other variants to the base author', () => {
+    expect(authorOfPermaslug('deepseek/deepseek-r1:free')).toBe('deepseek')
+    expect(authorOfPermaslug('qwen/qwen3-max:nitro')).toBe('qwen')
+  })
+
+  it('rejects malformed keys via isValidPermaslug', () => {
+    for (const bad of ['other', '/x', 'x/', 'a/b/c', 'openai /gpt-4', ''])
+      expect([bad, authorOfPermaslug(bad)]).toEqual([bad, null])
+  })
+})
+
+describe('Anthropic share', () => {
+  it('is Anthropic tokens over every classified token', () => {
+    const rows = [
+      row(D, 'anthropic/claude-opus-5-20260723', 300),
+      row(D, 'openai/gpt-5.5-20260423', 500),
+      row(D, 'deepseek/deepseek-v4-pro-20260423', 200),
+    ]
+    expect(computeAnthropicShare(rows).share).toBeCloseTo(30)
+  })
+
+  it('excludes `other` and composite slugs from the denominator', () => {
+    const base = [
+      row(D, 'anthropic/claude-opus-5-20260723', 300),
+      row(D, 'openai/gpt-5.5-20260423', 700),
+    ]
+    const withExcluded = [
+      ...base,
+      row(D, 'other', 5000),
+      row(D, 'openrouter/fusion', 400),
+      row(D, '~z-ai/glm-latest', 100),
+    ]
+    const res = computeAnthropicShare(withExcluded)
+    expect(res.share).toBe(computeAnthropicShare(base).share)
+    expect(res.share).toBeCloseTo(30)
+    expect(res.otherTokens).toBe(5000)
+    expect(res.compositeTokens).toBe(500)
+    expect(res.compositeSlugs).toEqual([
+      'openrouter/fusion',
+      '~z-ai/glm-latest',
+    ])
+    expect(res.hasExcludedPayload).toBe(true)
+  })
+
+  it('keeps cloaked openrouter/* slugs in the denominator, never the numerator', () => {
+    const rows = [
+      row(D, 'anthropic/claude-opus-5-20260723', 300),
+      row(D, 'openrouter/horizon-beta', 700),
+    ]
+    const res = computeAnthropicShare(rows)
+    expect(res.share).toBeCloseTo(30)
+    expect(res.classifiedTokens).toBe(1000)
+    expect(res.numeratorTokens).toBe(300)
+  })
+
+  it('has no unknown-author concept: every valid author is classified', () => {
+    const rows = [
+      row(D, 'anthropic/claude-opus-5-20260723', 300),
+      row(D, 'brand-new-lab/model-1', 700),
+    ]
+    const res = computeAnthropicShare(rows)
+    expect(res.unknownAuthors).toEqual([])
+    expect(res.unknownTokens).toBe(0)
+    expect(res.share).toBeCloseTo(30)
+  })
+
+  it('collapses :free variants into the same author', () => {
+    const rows = [
+      row(D, 'anthropic/claude-4.5-haiku-20251001', 100),
+      row(D, 'anthropic/claude-4.5-haiku-20251001:free', 100),
+      row(D, 'openai/gpt-oss-120b:free', 200),
+    ]
+    expect(computeAnthropicShare(rows).share).toBeCloseTo(50)
+  })
+
+  it('counts the author exactly, not by substring', () => {
+    const rows = [
+      row(D, 'anthropic/claude-opus-5-20260723', 100),
+      row(D, 'not-anthropic/claude-clone', 100),
+      row(D, 'anthropic-ai/other-thing', 100),
+    ]
+    expect(computeAnthropicShare(rows).share).toBeCloseTo(100 / 3)
+  })
+})
+
+describe('Chinese-lab share', () => {
+  it('is Chinese-lab tokens over every classified token', () => {
+    const rows = [
+      row(D, 'deepseek/deepseek-v4-pro-20260423', 250),
+      row(D, 'qwen/qwen3.7-flash-20260727', 250),
+      row(D, 'anthropic/claude-opus-5-20260723', 300),
+      row(D, 'openai/gpt-5.5-20260423', 200),
+    ]
+    const res = computeChineseLabShare(rows)
+    expect(res.share).toBeCloseTo(50)
+    expect(res.unknownAuthors).toEqual([])
+  })
+
+  it('excludes an unknown author from both sides and reports it', () => {
+    const rows = [
+      row(D, 'deepseek/deepseek-v4-pro-20260423', 500),
+      row(D, 'openai/gpt-5.5-20260423', 500),
+      row(D, 'mystery-lab/model-x', 100_000),
+    ]
+    const res = computeChineseLabShare(rows)
+    // A huge unknown must not drag the index toward either side.
+    expect(res.share).toBeCloseTo(50)
+    expect(res.unknownAuthors).toEqual(['mystery-lab'])
+    expect(res.unknownTokens).toBe(100_000)
+    expect(res.classifiedTokens).toBe(1000)
+    expect(res.unknownShareOfClassified).toBeCloseTo(100)
+  })
+
+  it('reports one unknown author across its :free variant and several models', () => {
+    const rows = [
+      row(D, 'deepseek/deepseek-v4-pro-20260423', 500),
+      row(D, 'openai/gpt-5.5-20260423', 500),
+      row(D, 'mystery-lab/model-x', 3),
+      row(D, 'mystery-lab/model-x:free', 2),
+      row(D, 'mystery-lab/model-y', 1),
+    ]
+    const res = computeChineseLabShare(rows)
+    expect(res.unknownAuthors).toEqual(['mystery-lab'])
+    expect(res.unknownTokens).toBe(6)
+    expect(res.unknownShareOfClassified).toBeCloseTo(0.006)
+  })
+
+  it('honours caller-supplied author lists', () => {
+    const rows = [
+      row(D, 'mystery-lab/model-x', 500),
+      row(D, 'openai/gpt-5.5-20260423', 500),
+    ]
+    expect(computeChineseLabShare(rows).unknownAuthors).toEqual(['mystery-lab'])
+    const placed = computeChineseLabShare(rows, OPEN_WEIGHT_WINDOW_DAYS, {
+      chinese: { ...CHINESE_LAB_AUTHORS, 'mystery-lab': { evidence: 'test' } },
+      nonChinese: KNOWN_NON_CHINESE_AUTHORS,
+    })
+    expect(placed.unknownAuthors).toEqual([])
+    expect(placed.share).toBeCloseTo(50)
+  })
+
+  it('keeps cloaked openrouter/* slugs in the denominator, never the numerator', () => {
+    const rows = [
+      row(D, 'deepseek/deepseek-v4-pro-20260423', 300),
+      row(D, 'openrouter/horizon-beta', 700),
+    ]
+    const res = computeChineseLabShare(rows)
+    expect(res.unknownAuthors).toEqual([])
+    expect(res.share).toBeCloseTo(30)
+  })
+})
+
+describe('publication validation', () => {
+  const completeWindow = (extra: RankingRow[] = []) => {
+    const rows: RankingRow[] = []
+    for (let day = 20; day <= 26; day++) {
+      const date = `2026-08-${day}`
+      rows.push(row(date, 'anthropic/claude-opus-5-20260723', 300))
+      rows.push(row(date, 'deepseek/deepseek-v4-pro-20260423', 400))
+      rows.push(row(date, 'openai/gpt-5.5-20260423', 300))
+      rows.push(row(date, 'other', 1000))
+    }
+    return [...rows, ...extra]
+  }
+
+  it('accepts a complete, classified payload for both feeds', () => {
+    expect(
+      validateLabSharePublication(computeAnthropicShare(completeWindow()))
+    ).toEqual({
+      ok: true,
+      share: 30,
+      unknownAuthors: [],
+      unknownShareOfClassified: 0,
+    })
+    expect(
+      validateLabSharePublication(computeChineseLabShare(completeWindow()))
+    ).toEqual({
+      ok: true,
+      share: 40,
+      unknownAuthors: [],
+      unknownShareOfClassified: 0,
+    })
+  })
+
+  it('refuses the Chinese-lab feed when unknown authors exceed the cap', () => {
+    // 1000 unknown against 7000 classified — 14%, far over the 1% cap.
+    const res = computeChineseLabShare(
+      completeWindow([row(D, 'mystery-lab/model-x', 1000)])
+    )
+    const validation = validateLabSharePublication(res)
+    expect(validation.ok).toBe(false)
+    if (validation.ok) return
+    expect(validation.reason).toContain('mystery-lab')
+    expect(validation.reason).toContain('CHINESE_LAB_AUTHORS')
+    expect(validation.reason).toContain('KNOWN_NON_CHINESE_AUTHORS')
+  })
+
+  it('publishes the Chinese-lab feed under the cap and names the unknown', () => {
+    // 35 unknown against 7000 classified = 0.5%, inside the 1% cap.
+    const res = computeChineseLabShare(
+      completeWindow([row(D, 'mystery-lab/model-x', 35)])
+    )
+    const validation = validateLabSharePublication(res)
+    expect(validation.ok).toBe(true)
+    if (!validation.ok) return
+    expect(validation.share).toBeCloseTo(40)
+    expect(validation.unknownAuthors).toEqual(['mystery-lab'])
+    expect(validation.unknownShareOfClassified).toBeCloseTo(0.005)
+  })
+
+  it('halts on any unknown when the cap is zero (backfill posture)', () => {
+    const res = computeChineseLabShare(
+      completeWindow([row(D, 'mystery-lab/model-x', 1)])
+    )
+    expect(validateLabSharePublication(res, { unknownShareCap: 0 }).ok).toBe(
+      false
+    )
+  })
+
+  it('an unknown author never affects the Anthropic feed', () => {
+    const res = computeAnthropicShare(
+      completeWindow([row(D, 'mystery-lab/model-x', 1_000_000)])
+    )
+    const validation = validateLabSharePublication(res)
+    expect(validation.ok).toBe(true)
+    if (validation.ok) expect(validation.unknownAuthors).toEqual([])
+  })
+
+  it('fails closed on an incomplete or gapped window for both feeds', () => {
+    const short = completeWindow().filter((r) => r.date !== '2026-08-20')
+    for (const feed of ['anthropic', 'chinese-lab'] as const) {
+      const validation = validateLabSharePublication(
+        computeLabShare(feed, short)
+      )
+      expect(validation.ok).toBe(false)
+      if (!validation.ok) expect(validation.reason).toContain('incomplete')
+    }
+    const gapped = completeWindow().filter((r) => r.date !== '2026-08-23')
+    gapped.push(row('2026-08-27', 'anthropic/claude-opus-5-20260723', 1))
+    gapped.push(row('2026-08-27', 'other', 1))
+    const gapValidation = validateLabSharePublication(
+      computeAnthropicShare(gapped)
+    )
+    expect(gapValidation.ok).toBe(false)
+    if (!gapValidation.ok)
+      expect(gapValidation.reason).toContain('non-consecutive')
+  })
+
+  it('fails closed on malformed rows for both feeds', () => {
+    const badTokens = completeWindow([
+      row(D, 'openai/gpt-5.5-20260423', 'not-a-number'),
+    ])
+    const badSlug = completeWindow([row(D, 'a/b/c', 10)])
+    for (const feed of ['anthropic', 'chinese-lab'] as const) {
+      const tokens = validateLabSharePublication(
+        computeLabShare(feed, badTokens)
+      )
+      expect(tokens.ok).toBe(false)
+      if (!tokens.ok) expect(tokens.reason).toContain('malformed token')
+      const slug = validateLabSharePublication(computeLabShare(feed, badSlug))
+      expect(slug.ok).toBe(false)
+      if (!slug.ok) expect(slug.reason).toContain('malformed model slugs')
+    }
+  })
+
+  it('rejects a window with no `other` row', () => {
+    const noOther = completeWindow().filter(
+      (r) => r.model_permaslug !== 'other'
+    )
+    expect(validateLabSharePublication(computeAnthropicShare(noOther)).ok).toBe(
+      false
+    )
+  })
+
+  it('returns null rather than 0 when nothing is classified', () => {
+    expect(computeAnthropicShare([row(D, 'other', 100)]).share).toBeNull()
+    expect(computeChineseLabShare([]).share).toBeNull()
+  })
+
+  it('sums past Number.MAX_SAFE_INTEGER without losing units', () => {
+    const big = '9007199254740993'
+    const rows = [
+      row(D, 'anthropic/claude-opus-5-20260723', big),
+      row(D, 'openai/gpt-5.5-20260423', big),
+    ]
+    expect(computeAnthropicShare(rows).share).toBeCloseTo(50)
+  })
+})
+
+describe('the author lists', () => {
+  it('reuse the open-weight cap number', () => {
+    expect(UNKNOWN_AUTHOR_TOKEN_SHARE_CAP).toBe(UNCLASSIFIED_TOKEN_SHARE_CAP)
+  })
+
+  it('never place an author on both sides', () => {
+    for (const author of Object.keys(CHINESE_LAB_AUTHORS))
+      expect([author, KNOWN_NON_CHINESE_AUTHORS[author]]).toEqual([
+        author,
+        undefined,
+      ])
+  })
+
+  it('carry evidence for every entry', () => {
+    for (const [author, entry] of [
+      ...Object.entries(CHINESE_LAB_AUTHORS),
+      ...Object.entries(KNOWN_NON_CHINESE_AUTHORS),
+    ]) {
+      expect([author, entry.evidence.trim().length > 0]).toEqual([author, true])
+      // Keyed on a bare author segment, never a slug.
+      expect([author, author.includes('/')]).toEqual([author, false])
+    }
+  })
+
+  it('cover every author in the open-weight seed list except the ones the header names', () => {
+    // "unknown" must mean genuinely new. The single deliberate omission is
+    // nex-agi, whose headquarters is left for a human to place.
+    const seedAuthors = new Set(
+      Object.keys(OPEN_WEIGHT_MODELS).map((slug) =>
+        slug.slice(0, slug.indexOf('/'))
+      )
+    )
+    const unplaced = [...seedAuthors].filter(
+      (author) =>
+        !CHINESE_LAB_AUTHORS[author] && !KNOWN_NON_CHINESE_AUTHORS[author]
+    )
+    expect(unplaced).toEqual(['nex-agi'])
+  })
+
+  it('classify Anthropic as non-Chinese and the seed Chinese labs as Chinese', () => {
+    expect(KNOWN_NON_CHINESE_AUTHORS.anthropic).toBeDefined()
+    for (const author of [
+      'qwen',
+      'deepseek',
+      'z-ai',
+      'moonshotai',
+      'xiaomi',
+      'minimax',
+      'inclusionai',
+      'tencent',
+      'stepfun',
+      'bytedance-seed',
+      'baai',
+      'alibaba',
+      'kwaipilot',
+    ])
+      expect([author, CHINESE_LAB_AUTHORS[author]]).toBeDefined()
+  })
+})

--- a/common/src/perps/lab-share.test.ts
+++ b/common/src/perps/lab-share.test.ts
@@ -212,6 +212,7 @@ describe('Chinese-lab share', () => {
       // ...and over the cap it halts like any other unknown.
       const validation = validateLabSharePublication({
         ...res,
+        datesMissingOther: [],
         dates: [
           '2026-08-20',
           '2026-08-21',
@@ -351,6 +352,32 @@ describe('publication validation', () => {
       expect(slug.ok).toBe(false)
       if (!slug.ok) expect(slug.reason).toContain('malformed model slugs')
     }
+  })
+
+  it('requires the `other` row on EVERY window day, not just one', () => {
+    // Six truncated days plus one complete day used to pass on a single
+    // boolean; completeness is per date.
+    const truncated = completeWindow().filter(
+      (r) => !(r.model_permaslug === 'other' && r.date !== '2026-08-26')
+    )
+    for (const feed of ['anthropic', 'chinese-lab'] as const) {
+      const result = computeLabShare(feed, truncated)
+      expect(result.hasExcludedPayload).toBe(true)
+      expect(result.datesMissingOther).toEqual([
+        '2026-08-20',
+        '2026-08-21',
+        '2026-08-22',
+        '2026-08-23',
+        '2026-08-24',
+        '2026-08-25',
+      ])
+      const validation = validateLabSharePublication(result)
+      expect(validation.ok).toBe(false)
+      if (!validation.ok) expect(validation.reason).toContain('truncated')
+    }
+    expect(computeAnthropicShare(completeWindow()).datesMissingOther).toEqual(
+      []
+    )
   })
 
   it('rejects a window with no `other` row', () => {

--- a/common/src/perps/lab-share.test.ts
+++ b/common/src/perps/lab-share.test.ts
@@ -1,5 +1,8 @@
 import {
+  CHINESE_LAB_LIST_VERSION,
+  CHINESE_LAB_MODELS,
   CHINESE_LAB_AUTHORS,
+  KNOWN_NON_CHINESE_MODELS,
   KNOWN_NON_CHINESE_AUTHORS,
   UNKNOWN_AUTHOR_TOKEN_SHARE_CAP,
   authorOfPermaslug,
@@ -13,6 +16,8 @@ import {
   OPEN_WEIGHT_WINDOW_DAYS,
   RankingRow,
   UNCLASSIFIED_TOKEN_SHARE_CAP,
+  basePermaslug,
+  isValidPermaslug,
 } from './open-weight-models'
 
 const row = (
@@ -100,6 +105,7 @@ describe('Anthropic share', () => {
     ]
     const res = computeAnthropicShare(rows)
     expect(res.unknownAuthors).toEqual([])
+    expect(res.unknownModels).toEqual([])
     expect(res.unknownTokens).toBe(0)
     expect(res.share).toBeCloseTo(30)
   })
@@ -120,6 +126,16 @@ describe('Anthropic share', () => {
       row(D, 'anthropic-ai/other-thing', 100),
     ]
     expect(computeAnthropicShare(rows).share).toBeCloseTo(100 / 3)
+  })
+
+  it('does not apply Chinese exact-model placements to the Anthropic feed', () => {
+    const res = computeAnthropicShare([
+      row(D, 'anthropic/claude-opus-5-20260723', 300),
+      row(D, 'stealth/ox-alpha', 700),
+    ])
+    expect(res.share).toBeCloseTo(30)
+    expect(res.unknownAuthors).toEqual([])
+    expect(res.unknownModels).toEqual([])
   })
 })
 
@@ -146,6 +162,7 @@ describe('Chinese-lab share', () => {
     // A huge unknown must not drag the index toward either side.
     expect(res.share).toBeCloseTo(50)
     expect(res.unknownAuthors).toEqual(['mystery-lab'])
+    expect(res.unknownModels).toEqual([])
     expect(res.unknownTokens).toBe(100_000)
     expect(res.classifiedTokens).toBe(1000)
     expect(res.unknownShareOfClassified).toBeCloseTo(100)
@@ -177,6 +194,68 @@ describe('Chinese-lab share', () => {
     })
     expect(placed.unknownAuthors).toEqual([])
     expect(placed.share).toBeCloseTo(50)
+  })
+
+  it('applies exact-model placements before author placements', () => {
+    const classifications = {
+      chinese: { chinese: { evidence: 'test' } },
+      nonChinese: { western: { evidence: 'test' } },
+      chineseModels: {
+        'western/chinese-exception': { evidence: 'test' },
+      },
+      nonChineseModels: {
+        'chinese/non-chinese-exception': { evidence: 'test' },
+      },
+    }
+    const res = computeChineseLabShare(
+      [
+        row(D, 'western/chinese-exception', 300),
+        row(D, 'western/ordinary', 200),
+        row(D, 'chinese/non-chinese-exception', 100),
+        row(D, 'chinese/ordinary', 400),
+      ],
+      OPEN_WEIGHT_WINDOW_DAYS,
+      classifications
+    )
+    expect(res.share).toBeCloseTo(70)
+    expect(res.unknownAuthors).toEqual([])
+    expect(res.unknownModels).toEqual([])
+  })
+
+  it('classifies the revealed stealth model without classifying its author', () => {
+    const revealed = computeChineseLabShare([
+      row(D, 'stealth/ox-alpha', 300),
+      row(D, 'openai/gpt-5.5-20260423', 700),
+    ])
+    expect(revealed.share).toBeCloseTo(30)
+    expect(revealed.unknownAuthors).toEqual([])
+    expect(revealed.unknownModels).toEqual([])
+
+    const future = computeChineseLabShare([
+      row(D, 'stealth/future-anonymous-preview', 10),
+      row(D, 'openai/gpt-5.5-20260423', 1000),
+    ])
+    expect(future.share).toBe(0)
+    expect(future.unknownAuthors).toEqual([])
+    expect(future.unknownModels).toEqual(['stealth/future-anonymous-preview'])
+    expect(future.unknownTokens).toBe(10)
+  })
+
+  it('normalises variants for exact placements and pending model reports', () => {
+    const placed = computeChineseLabShare([
+      row(D, 'stealth/ox-alpha', 100),
+      row(D, 'stealth/ox-alpha:free', 200),
+      row(D, 'openai/gpt-5.5-20260423', 700),
+    ])
+    expect(placed.share).toBeCloseTo(30)
+
+    const pending = computeChineseLabShare([
+      row(D, 'stealth/next:free', 2),
+      row(D, 'stealth/next:nitro', 3),
+      row(D, 'openai/gpt-5.5-20260423', 1000),
+    ])
+    expect(pending.unknownModels).toEqual(['stealth/next'])
+    expect(pending.unknownTokens).toBe(5)
   })
 
   it('keeps cloaked openrouter/* slugs in the denominator, never the numerator', () => {
@@ -249,6 +328,7 @@ describe('publication validation', () => {
       ok: true,
       share: 30,
       unknownAuthors: [],
+      unknownModels: [],
       unknownShareOfClassified: 0,
     })
     expect(
@@ -257,6 +337,7 @@ describe('publication validation', () => {
       ok: true,
       share: 40,
       unknownAuthors: [],
+      unknownModels: [],
       unknownShareOfClassified: 0,
     })
   })
@@ -270,8 +351,7 @@ describe('publication validation', () => {
     expect(validation.ok).toBe(false)
     if (validation.ok) return
     expect(validation.reason).toContain('mystery-lab')
-    expect(validation.reason).toContain('CHINESE_LAB_AUTHORS')
-    expect(validation.reason).toContain('KNOWN_NON_CHINESE_AUTHORS')
+    expect(validation.reason).toContain('classify the pending subject')
   })
 
   it('publishes the Chinese-lab feed under the cap and names the unknown', () => {
@@ -284,6 +364,19 @@ describe('publication validation', () => {
     if (!validation.ok) return
     expect(validation.share).toBeCloseTo(40)
     expect(validation.unknownAuthors).toEqual(['mystery-lab'])
+    expect(validation.unknownModels).toEqual([])
+    expect(validation.unknownShareOfClassified).toBeCloseTo(0.005)
+  })
+
+  it('publishes under the cap and names a pending model-scoped subject', () => {
+    const res = computeChineseLabShare(
+      completeWindow([row(D, 'stealth/future-preview:free', 35)])
+    )
+    const validation = validateLabSharePublication(res)
+    expect(validation.ok).toBe(true)
+    if (!validation.ok) return
+    expect(validation.unknownAuthors).toEqual([])
+    expect(validation.unknownModels).toEqual(['stealth/future-preview'])
     expect(validation.unknownShareOfClassified).toBeCloseTo(0.005)
   })
 
@@ -404,7 +497,7 @@ describe('publication validation', () => {
   })
 })
 
-describe('the author lists', () => {
+describe('the classification seed', () => {
   it('reuse the open-weight cap number — 1% of classified tokens', () => {
     expect(UNKNOWN_AUTHOR_TOKEN_SHARE_CAP).toBe(UNCLASSIFIED_TOKEN_SHARE_CAP)
     expect(UNKNOWN_AUTHOR_TOKEN_SHARE_CAP).toBe(0.01)
@@ -418,6 +511,14 @@ describe('the author lists', () => {
       ])
   })
 
+  it('never places an exact model on both sides', () => {
+    for (const model of Object.keys(CHINESE_LAB_MODELS))
+      expect([model, KNOWN_NON_CHINESE_MODELS[model]]).toEqual([
+        model,
+        undefined,
+      ])
+  })
+
   it('carry evidence for every entry', () => {
     for (const [author, entry] of [
       ...Object.entries(CHINESE_LAB_AUTHORS),
@@ -427,11 +528,19 @@ describe('the author lists', () => {
       // Keyed on a bare author segment, never a slug.
       expect([author, author.includes('/')]).toEqual([author, false])
     }
+    for (const [model, entry] of [
+      ...Object.entries(CHINESE_LAB_MODELS),
+      ...Object.entries(KNOWN_NON_CHINESE_MODELS),
+    ]) {
+      expect([model, entry.evidence.trim().length > 0]).toEqual([model, true])
+      expect([model, isValidPermaslug(model)]).toEqual([model, true])
+      expect([model, basePermaslug(model)]).toEqual([model, model])
+    }
   })
 
-  it('cover every author in the open-weight seed list except the ones the header names', () => {
-    // "unknown" must mean genuinely new. The single deliberate omission is
-    // nex-agi, whose headquarters is left for a human to place.
+  it('covers every author in the open-weight seed list', () => {
+    // "unknown" must mean genuinely new, not an omission from the audited
+    // open-weight seed that ships beside this one.
     const seedAuthors = new Set(
       Object.keys(OPEN_WEIGHT_MODELS).map((slug) =>
         slug.slice(0, slug.indexOf('/'))
@@ -441,11 +550,16 @@ describe('the author lists', () => {
       (author) =>
         !CHINESE_LAB_AUTHORS[author] && !KNOWN_NON_CHINESE_AUTHORS[author]
     )
-    expect(unplaced).toEqual(['nex-agi'])
+    expect(unplaced).toEqual([])
   })
 
-  it('classify Anthropic as non-Chinese and the seed Chinese labs as Chinese', () => {
+  it('contains the current known placements', () => {
+    expect(CHINESE_LAB_LIST_VERSION).toBe('2026-09-04')
     expect(KNOWN_NON_CHINESE_AUTHORS.anthropic).toBeDefined()
+    expect(KNOWN_NON_CHINESE_AUTHORS.thinkingmachines).toBeDefined()
+    expect(CHINESE_LAB_MODELS['stealth/ox-alpha']).toBeDefined()
+    expect(CHINESE_LAB_AUTHORS.stealth).toBeUndefined()
+    expect(KNOWN_NON_CHINESE_AUTHORS.stealth).toBeUndefined()
     for (const author of [
       'qwen',
       'deepseek',
@@ -460,6 +574,8 @@ describe('the author lists', () => {
       'baai',
       'alibaba',
       'kwaipilot',
+      'nex-agi',
+      'dots-studio',
     ])
       expect([author, CHINESE_LAB_AUTHORS[author] != null]).toEqual([
         author,

--- a/common/src/perps/lab-share.test.ts
+++ b/common/src/perps/lab-share.test.ts
@@ -383,6 +383,9 @@ describe('the author lists', () => {
       'alibaba',
       'kwaipilot',
     ])
-      expect([author, CHINESE_LAB_AUTHORS[author]]).toBeDefined()
+      expect([author, CHINESE_LAB_AUTHORS[author] != null]).toEqual([
+        author,
+        true,
+      ])
   })
 })

--- a/common/src/perps/lab-share.ts
+++ b/common/src/perps/lab-share.ts
@@ -262,14 +262,26 @@ export type LabShareResult = {
 
 type AuthorVerdict = 'in' | 'out' | 'unknown'
 
+/**
+ * Own-property membership. The author segment is untrusted input, and a
+ * plain `lists.chinese[author]` would be truthy for `constructor`,
+ * `__proto__`, `toString` and every other Object.prototype member — which
+ * would put a slug like `constructor/x` straight into the Chinese-lab
+ * NUMERATOR with no warning, bypassing the whole unknown-author rule.
+ */
+const listed = (
+  list: Readonly<Record<string, AuthorEvidence>>,
+  author: string
+): boolean => Object.prototype.hasOwnProperty.call(list, author)
+
 const classifyAuthor = (
   feed: LabShareFeed,
   author: string,
   lists: LabShareAuthorLists
 ): AuthorVerdict => {
   if (feed === 'anthropic') return author === ANTHROPIC_AUTHOR ? 'in' : 'out'
-  if (lists.chinese[author]) return 'in'
-  if (lists.nonChinese[author]) return 'out'
+  if (listed(lists.chinese, author)) return 'in'
+  if (listed(lists.nonChinese, author)) return 'out'
   return 'unknown'
 }
 
@@ -297,15 +309,17 @@ export const computeLabShare = (
   let otherTokens = 0n
   let compositeTokens = 0n
   let payloadTokens = 0n
-  const unknownSet: Record<string, true> = {}
-  const compositeSet: Record<string, true> = {}
-  const invalidTokenRowSet: Record<string, true> = {}
-  const malformedSlugSet: Record<string, true> = {}
+  // Sets, not plain objects: an author of `__proto__` written as an object
+  // key would silently vanish from Object.keys and never be reported.
+  const unknownSet = new Set<string>()
+  const compositeSet = new Set<string>()
+  const invalidTokenRowSet = new Set<string>()
+  const malformedSlugSet = new Set<string>()
 
   for (const row of rows) {
     const tokens = parseTokens(row.total_tokens)
     if (tokens == null) {
-      invalidTokenRowSet[`${row.date}:${row.model_permaslug}`] = true
+      invalidTokenRowSet.add(`${row.date}:${row.model_permaslug}`)
       continue
     }
     payloadTokens += tokens
@@ -319,20 +333,20 @@ export const computeLabShare = (
     // Routers and floating aliases are not one publisher's model. Out of both
     // sides, and recorded so the caller can log the volume.
     if (isCompositeSlug(row.model_permaslug)) {
-      compositeSet[basePermaslug(row.model_permaslug)] = true
+      compositeSet.add(basePermaslug(row.model_permaslug))
       compositeTokens += tokens
       continue
     }
 
     const author = authorOfPermaslug(row.model_permaslug)
     if (author == null) {
-      malformedSlugSet[row.model_permaslug] = true
+      malformedSlugSet.add(row.model_permaslug)
       continue
     }
 
     const verdict = classifyAuthor(feed, author, lists)
     if (verdict === 'unknown') {
-      unknownSet[author] = true
+      unknownSet.add(author)
       unknownTokens += tokens
       continue
     }
@@ -340,8 +354,8 @@ export const computeLabShare = (
     if (verdict === 'in') numeratorTokens += tokens
   }
 
-  const invalidTokenRows = Object.keys(invalidTokenRowSet).sort()
-  const malformedSlugs = Object.keys(malformedSlugSet).sort()
+  const invalidTokenRows = [...invalidTokenRowSet].sort()
+  const malformedSlugs = [...malformedSlugSet].sort()
   const share =
     classifiedTokens > 0n &&
     invalidTokenRows.length === 0 &&
@@ -357,13 +371,13 @@ export const computeLabShare = (
     invalidTokenRows,
     malformedSlugs,
     hasExcludedPayload: otherTokens > 0n,
-    unknownAuthors: Object.keys(unknownSet).sort(),
+    unknownAuthors: [...unknownSet].sort(),
     unknownTokens: finiteBigIntTelemetry(unknownTokens),
     unknownShareOfClassified: ratioOfBigInts(unknownTokens, classifiedTokens),
     numeratorTokens: finiteBigIntTelemetry(numeratorTokens),
     classifiedTokens: finiteBigIntTelemetry(classifiedTokens),
     otherTokens: finiteBigIntTelemetry(otherTokens),
-    compositeSlugs: Object.keys(compositeSet).sort(),
+    compositeSlugs: [...compositeSet].sort(),
     compositeTokens: finiteBigIntTelemetry(compositeTokens),
     payloadTokens: finiteBigIntTelemetry(payloadTokens),
   }

--- a/common/src/perps/lab-share.ts
+++ b/common/src/perps/lab-share.ts
@@ -21,16 +21,18 @@ import {
 // `common` (a leaf package) so the rule the oracle is scored against is one
 // auditable artifact.
 //
-// THE UNIT OF CLASSIFICATION IS THE AUTHOR, NOT THE MODEL.
+// THE DEFAULT UNIT OF CLASSIFICATION IS THE AUTHOR. Exact model overrides are
+// available where an author slug is not a stable company identity (notably
+// anonymous previews such as `stealth/ox-alpha`).
 //
 // OpenRouter keys every ranked row on a permaslug `author/model[:variant]`.
 // The author segment is the publisher's OpenRouter organisation — `anthropic`,
 // `deepseek`, `qwen` — and it is stable across that publisher's releases. So
 // where the open-weight index has to adjudicate every new MODEL (weights are
 // released per model), these indexes only ever have to place a new AUTHOR,
-// which happens a few times a year rather than a few times a week. That is
-// the whole design goal: a classification burden of zero for Anthropic and a
-// one-line constant for Chinese labs.
+// which happens a few times a year rather than a few times a week. The audited
+// constants below are a seed: the backend overlays database classifications
+// and supplies the resolved maps, so routine placements do not need a PR.
 //
 //   share = 100 * (numerator tokens) / (denominator tokens)
 //
@@ -55,23 +57,25 @@ import {
 // author concept here: every valid row is either Anthropic or not, so the
 // feed publishes whenever the payload validates.
 //
-// CHINESE LABS: numerator = rows whose author is in CHINESE_LAB_AUTHORS; the
+// CHINESE LABS: an exact base-model classification is consulted first. If
+// there is none, numerator = rows whose author is in CHINESE_LAB_AUTHORS; the
 // rest of the denominator is rows whose author is in KNOWN_NON_CHINESE_AUTHORS.
 // An author in NEITHER list is UNKNOWN: its tokens are excluded from both
 // sides (never defaulted — a mis-defaulted lab would move the index on a
-// guess) and returned in `unknownAuthors`. The publication rule:
+// guess) and returned in `unknownAuthors`. If an author has exact-model
+// placements, its unmatched models are instead returned in `unknownModels`,
+// because that author must not be classified wholesale. The publication rule:
 //
-//   - unknown-author tokens over UNKNOWN_AUTHOR_TOKEN_SHARE_CAP of classified
+//   - unknown tokens over UNKNOWN_AUTHOR_TOKEN_SHARE_CAP of classified
 //     tokens -> the feed REFUSES to publish and the job logs an ERROR naming
-//     the authors and telling the reader which constant to extend;
+//     the pending authors/models;
 //   - at or below the cap -> the feed publishes and the job logs a WARN
-//     naming the same authors.
+//     naming the same pending subjects.
 //
-// That is the entire maintenance path, on purpose. No database rows, no
-// grace window, no admin tool, no auto-classifier: a new author is a one-line
-// addition to one of the two constants below (with its evidence) and a
-// deploy. Authors appear rarely enough that this is the right budget, and a
-// mechanism heavier than a constant would be more code than the feed itself.
+// The backend discovers new subjects and stores reviewed placements in the
+// database. Those rows overlay this audited seed and are passed through
+// `LabShareClassifications`, parallel to the open-weight resolver. There is no
+// grace clock: pending volume is bounded by the cap however it was discovered.
 // KNOWN_NON_CHINESE_AUTHORS exists so that "unknown" means genuinely new, not
 // "we never wrote it down": every author seen in the open-weight seed list on
 // the version date is in exactly one of the two lists, except where the
@@ -90,26 +94,28 @@ import {
 //     OpenRouter to authors headquartered in China", not "models with
 //     Chinese ancestry" — the former is checkable in seconds, the latter is
 //     not.
-//   - `openrouter/*` stealth slugs are KNOWN_NON_CHINESE for denominator
-//     purposes (they are in the denominator, not the numerator) and never
-//     unknown: an unknown that can never be resolved would halt the feed
-//     forever. If one is unmasked as a Chinese lab's model, forward-only.
+//   - `openrouter/*` router-owned cloaked slugs are KNOWN_NON_CHINESE for
+//     denominator purposes and never unknown. If OpenRouter later emits the
+//     revealed lab's own author slug, those later rows classify normally; a
+//     retained cloaked slug is not rewritten retroactively. Separately
+//     published anonymous authors such as `stealth/*` are classified per exact
+//     model after reveal; one reveal never classifies all future previews.
 
-/** Bump when either author list changes. */
-export const CHINESE_LAB_LIST_VERSION = '2026-09-02'
+/** Bump when any audited author/model seed changes. */
+export const CHINESE_LAB_LIST_VERSION = '2026-09-04'
 
 /** The one author the Anthropic index counts. */
 export const ANTHROPIC_AUTHOR = 'anthropic'
 
 /**
- * How much of the classified token pool may sit in unknown authors before
+ * How much of the classified token pool may sit in unknown subjects before
  * the Chinese-lab index refuses to publish, as U/C (unknown tokens over
  * classified tokens). The same number as the open-weight index's unclassified
  * cap and for the same reason: the bound it buys on the published share is
  * strictly under the cap (see UNCLASSIFIED_TOKEN_SHARE_CAP for the algebra),
- * so a sub-cap unknown costs at most a fraction of a point until someone adds
- * one line. Its own constant so the two can be tuned apart if they ever need
- * to be.
+ * so a sub-cap unknown costs at most a fraction of a point until an operator
+ * records a verdict. Its own constant so the two can be tuned apart if they
+ * ever need to be.
  */
 export const UNKNOWN_AUTHOR_TOKEN_SHARE_CAP = UNCLASSIFIED_TOKEN_SHARE_CAP
 
@@ -141,6 +147,8 @@ export const CHINESE_LAB_AUTHORS: Readonly<Record<string, AuthorEvidence>> = {
   baai: { evidence: 'Beijing Academy of Artificial Intelligence, Beijing' },
   alibaba: { evidence: 'Alibaba (Tongyi), Hangzhou' },
   kwaipilot: { evidence: "Kuaishou's KwaiPilot team, Beijing" },
+  'nex-agi': { evidence: 'Nex AGI, Shanghai' },
+  'dots-studio': { evidence: 'Xiaohongshu (dots.studio), Shanghai' },
   // Pre-seeded: not in the ranked window on the version date.
   baidu: { evidence: 'Baidu (ERNIE), Beijing' },
   '01-ai': { evidence: '01.AI, Beijing' },
@@ -156,15 +164,6 @@ export const CHINESE_LAB_AUTHORS: Readonly<Record<string, AuthorEvidence>> = {
  * Every other author seen in the open-weight seed list on the version date,
  * so an author absent from BOTH lists is genuinely new rather than merely
  * unrecorded. Plus a pre-seeded set of well-known non-Chinese labs.
- *
- * NOT LISTED, DELIBERATELY: `nex-agi` (Nex-N2-Pro, DeepSeek-V3.1-Nex-N1),
- * which IS in the open-weight seed list. The company's headquarters could
- * not be established with confidence when this list was written (2026-09-02,
- * without network access), and the rule is to list an author in the PR for a
- * human to place rather than default it either way. Until it is placed, its
- * tokens are unknown to the Chinese-lab index: excluded from both sides,
- * named in every WARN, and a halt if they exceed the cap. Placing it is one
- * line in whichever list is right.
  */
 export const KNOWN_NON_CHINESE_AUTHORS: Readonly<
   Record<string, AuthorEvidence>
@@ -193,6 +192,9 @@ export const KNOWN_NON_CHINESE_AUTHORS: Readonly<
   'sentence-transformers': {
     evidence: 'UKP Lab, TU Darmstadt / Hugging Face community, Germany',
   },
+  thinkingmachines: {
+    evidence: 'Thinking Machines Lab, San Francisco, US',
+  },
   openrouter: {
     evidence:
       'OpenRouter cloaked pre-release slugs: publisher unknown by design; denominator only, never numerator, forward-only if unmasked',
@@ -207,6 +209,22 @@ export const KNOWN_NON_CHINESE_AUTHORS: Readonly<
   inception: { evidence: 'Inception Labs, Palo Alto, US' },
   eleutherai: { evidence: 'EleutherAI, US non-profit' },
 }
+
+/**
+ * Exact base-model overrides for authors that cannot safely be classified as
+ * a company. They take precedence over author placement. Keys never include
+ * OpenRouter variants; rows are normalised with `basePermaslug` before lookup.
+ */
+export const CHINESE_LAB_MODELS: Readonly<Record<string, AuthorEvidence>> = {
+  'stealth/ox-alpha': {
+    evidence:
+      'Z.ai GLM-5.3-Flash, Beijing; revealed after its anonymous preview',
+  },
+}
+
+export const KNOWN_NON_CHINESE_MODELS: Readonly<
+  Record<string, AuthorEvidence>
+> = {}
 
 /**
  * The author segment of a permaslug, or null when the slug is not a valid
@@ -225,10 +243,27 @@ export type LabShareAuthorLists = {
   nonChinese: Readonly<Record<string, AuthorEvidence>>
 }
 
-export const DEFAULT_LAB_SHARE_AUTHOR_LISTS: LabShareAuthorLists = {
+export type LabShareClassifications = LabShareAuthorLists & {
+  /** Exact base-model placements, consulted before author placement. */
+  chineseModels: Readonly<Record<string, AuthorEvidence>>
+  nonChineseModels: Readonly<Record<string, AuthorEvidence>>
+}
+
+/** Existing author-only callers remain valid and simply have no overrides. */
+export type LabShareClassificationInput =
+  | LabShareAuthorLists
+  | LabShareClassifications
+
+export const DEFAULT_LAB_SHARE_CLASSIFICATIONS: LabShareClassifications = {
   chinese: CHINESE_LAB_AUTHORS,
   nonChinese: KNOWN_NON_CHINESE_AUTHORS,
+  chineseModels: CHINESE_LAB_MODELS,
+  nonChineseModels: KNOWN_NON_CHINESE_MODELS,
 }
+
+/** @deprecated Prefer DEFAULT_LAB_SHARE_CLASSIFICATIONS. */
+export const DEFAULT_LAB_SHARE_AUTHOR_LISTS: LabShareAuthorLists =
+  DEFAULT_LAB_SHARE_CLASSIFICATIONS
 
 /** Parallel to OpenWeightShareResult. */
 export type LabShareResult = {
@@ -255,6 +290,8 @@ export type LabShareResult = {
    * UNKNOWN_AUTHOR_TOKEN_SHARE_CAP bounds.
    */
   unknownAuthors: string[]
+  /** Unplaced base models under intentionally model-scoped authors. */
+  unknownModels: string[]
   unknownTokens: number
   unknownShareOfClassified: number
   /** Token counts, as doubles — display/telemetry only, never the divisor. */
@@ -266,7 +303,9 @@ export type LabShareResult = {
   payloadTokens: number
 }
 
-type AuthorVerdict = 'in' | 'out' | 'unknown'
+type LabVerdict =
+  | { placement: 'in' | 'out' }
+  | { placement: 'unknown'; scope: 'author' | 'model' }
 
 /**
  * Own-property membership. The author segment is untrusted input, and a
@@ -277,18 +316,56 @@ type AuthorVerdict = 'in' | 'out' | 'unknown'
  */
 const listed = (
   list: Readonly<Record<string, AuthorEvidence>>,
-  author: string
-): boolean => Object.prototype.hasOwnProperty.call(list, author)
+  key: string
+): boolean => Object.prototype.hasOwnProperty.call(list, key)
 
-const classifyAuthor = (
+const EMPTY_EXACT_MODEL_LISTS: Pick<
+  LabShareClassifications,
+  'chineseModels' | 'nonChineseModels'
+> = { chineseModels: {}, nonChineseModels: {} }
+
+const exactModelLists = (
+  classifications: LabShareClassificationInput
+): Pick<LabShareClassifications, 'chineseModels' | 'nonChineseModels'> =>
+  Object.prototype.hasOwnProperty.call(classifications, 'chineseModels') &&
+  Object.prototype.hasOwnProperty.call(classifications, 'nonChineseModels')
+    ? (classifications as LabShareClassifications)
+    : EMPTY_EXACT_MODEL_LISTS
+
+const modelScopedAuthors = (
+  classifications: LabShareClassificationInput
+): ReadonlySet<string> => {
+  const models = exactModelLists(classifications)
+  const authors = new Set<string>()
+  for (const model of [
+    ...Object.keys(models.chineseModels),
+    ...Object.keys(models.nonChineseModels),
+  ]) {
+    const author = authorOfPermaslug(model)
+    if (author != null) authors.add(author)
+  }
+  return authors
+}
+
+const classifyLabSubject = (
   feed: LabShareFeed,
+  model: string,
   author: string,
-  lists: LabShareAuthorLists
-): AuthorVerdict => {
-  if (feed === 'anthropic') return author === ANTHROPIC_AUTHOR ? 'in' : 'out'
-  if (listed(lists.chinese, author)) return 'in'
-  if (listed(lists.nonChinese, author)) return 'out'
-  return 'unknown'
+  classifications: LabShareClassificationInput,
+  exactAuthors: ReadonlySet<string>
+): LabVerdict => {
+  if (feed === 'anthropic')
+    return { placement: author === ANTHROPIC_AUTHOR ? 'in' : 'out' }
+
+  const models = exactModelLists(classifications)
+  if (listed(models.chineseModels, model)) return { placement: 'in' }
+  if (listed(models.nonChineseModels, model)) return { placement: 'out' }
+  if (listed(classifications.chinese, author)) return { placement: 'in' }
+  if (listed(classifications.nonChinese, author)) return { placement: 'out' }
+  return {
+    placement: 'unknown',
+    scope: exactAuthors.has(author) ? 'model' : 'author',
+  }
 }
 
 /**
@@ -302,7 +379,7 @@ export const computeLabShare = (
   feed: LabShareFeed,
   allRows: RankingRow[],
   days = OPEN_WEIGHT_WINDOW_DAYS,
-  lists: LabShareAuthorLists = DEFAULT_LAB_SHARE_AUTHOR_LISTS
+  classifications: LabShareClassificationInput = DEFAULT_LAB_SHARE_CLASSIFICATIONS
 ): LabShareResult => {
   const dates = newestWindowDates(allRows, days)
   const inWindow: Record<string, true> = {}
@@ -317,11 +394,13 @@ export const computeLabShare = (
   let payloadTokens = 0n
   // Sets, not plain objects: an author of `__proto__` written as an object
   // key would silently vanish from Object.keys and never be reported.
-  const unknownSet = new Set<string>()
+  const unknownAuthorSet = new Set<string>()
+  const unknownModelSet = new Set<string>()
   const compositeSet = new Set<string>()
   const invalidTokenRowSet = new Set<string>()
   const malformedSlugSet = new Set<string>()
   const datesWithOther = new Set<string>()
+  const exactAuthors = modelScopedAuthors(classifications)
 
   for (const row of rows) {
     const tokens = parseTokens(row.total_tokens)
@@ -346,20 +425,28 @@ export const computeLabShare = (
       continue
     }
 
-    const author = authorOfPermaslug(row.model_permaslug)
+    const model = basePermaslug(row.model_permaslug)
+    const author = authorOfPermaslug(model)
     if (author == null) {
       malformedSlugSet.add(row.model_permaslug)
       continue
     }
 
-    const verdict = classifyAuthor(feed, author, lists)
-    if (verdict === 'unknown') {
-      unknownSet.add(author)
+    const verdict = classifyLabSubject(
+      feed,
+      model,
+      author,
+      classifications,
+      exactAuthors
+    )
+    if (verdict.placement === 'unknown') {
+      if (verdict.scope === 'model') unknownModelSet.add(model)
+      else unknownAuthorSet.add(author)
       unknownTokens += tokens
       continue
     }
     classifiedTokens += tokens
-    if (verdict === 'in') numeratorTokens += tokens
+    if (verdict.placement === 'in') numeratorTokens += tokens
   }
 
   const invalidTokenRows = [...invalidTokenRowSet].sort()
@@ -380,7 +467,8 @@ export const computeLabShare = (
     malformedSlugs,
     hasExcludedPayload: otherTokens > 0n,
     datesMissingOther: dates.filter((d) => !datesWithOther.has(d)),
-    unknownAuthors: [...unknownSet].sort(),
+    unknownAuthors: [...unknownAuthorSet].sort(),
+    unknownModels: [...unknownModelSet].sort(),
     unknownTokens: finiteBigIntTelemetry(unknownTokens),
     unknownShareOfClassified: ratioOfBigInts(unknownTokens, classifiedTokens),
     numeratorTokens: finiteBigIntTelemetry(numeratorTokens),
@@ -400,8 +488,8 @@ export const computeAnthropicShare = (
 export const computeChineseLabShare = (
   rows: RankingRow[],
   days = OPEN_WEIGHT_WINDOW_DAYS,
-  lists: LabShareAuthorLists = DEFAULT_LAB_SHARE_AUTHOR_LISTS
-): LabShareResult => computeLabShare('chinese-lab', rows, days, lists)
+  classifications: LabShareClassificationInput = DEFAULT_LAB_SHARE_CLASSIFICATIONS
+): LabShareResult => computeLabShare('chinese-lab', rows, days, classifications)
 
 const LAB_SHARE_SCALE = 1_000_000_000n
 
@@ -427,15 +515,16 @@ export type LabSharePublicationValidation =
   | {
       ok: true
       share: number
-      /** Unknown authors published under the cap — never silent. */
+      /** Pending subjects published under the cap — never silent. */
       unknownAuthors: string[]
+      unknownModels: string[]
       unknownShareOfClassified: number
     }
   | { ok: false; reason: string }
 
 export type LabSharePublicationOptions = {
   expectedDays?: number
-  /** Override the cap; 0 halts on ANY unknown author. */
+  /** Override the cap; 0 halts on ANY unknown author/model. */
   unknownShareCap?: number
   /** Bound on router/alias tokens; defaults to COMPOSITE_TOKEN_SHARE_CAP. */
   compositeShareCap?: number
@@ -445,7 +534,7 @@ export type LabSharePublicationOptions = {
  * Fail-closed publication gate shared by the live writer and the backfill,
  * parallel to validateOpenWeightPublication. Structural checks (malformed
  * rows, malformed slugs, incomplete or gapped window, missing `other`,
- * composite volume) run first for BOTH feeds; the unknown-author decision
+ * composite volume) run first for BOTH feeds; the unknown-subject decision
  * applies only to the Chinese-lab feed, whose result is the only one that can
  * carry unknowns.
  */
@@ -521,30 +610,40 @@ export const validateLabSharePublication = (
       ).toFixed(2)}% cap: ${result.compositeSlugs.join(', ')}`,
     }
 
-  if (result.unknownAuthors.length === 0)
+  if (result.unknownAuthors.length === 0 && result.unknownModels.length === 0)
     return {
       ok: true,
       share: result.share,
       unknownAuthors: [],
+      unknownModels: [],
       unknownShareOfClassified: 0,
     }
 
   const w = result.unknownShareOfClassified
+  const pending = [
+    result.unknownAuthors.length > 0
+      ? `unknown author(s) ${result.unknownAuthors.join(', ')}`
+      : null,
+    result.unknownModels.length > 0
+      ? `unknown model(s) ${result.unknownModels.join(', ')}`
+      : null,
+  ]
+    .filter((part): part is string => part != null)
+    .join('; ')
   if (!Number.isFinite(w) || w > unknownShareCap)
     return {
       ok: false,
-      reason:
-        `unknown author(s) ${result.unknownAuthors.join(', ')} hold ${(
-          w * 100
-        ).toFixed(3)}% of classified tokens, over the ${(
-          unknownShareCap * 100
-        ).toFixed(3)}% cap; add to CHINESE_LAB_AUTHORS or ` +
-        `KNOWN_NON_CHINESE_AUTHORS`,
+      reason: `${pending} hold ${(w * 100).toFixed(
+        3
+      )}% of classified tokens, over the ${(unknownShareCap * 100).toFixed(
+        3
+      )}% cap; classify the pending subject(s)`,
     }
   return {
     ok: true,
     share: result.share,
     unknownAuthors: result.unknownAuthors,
+    unknownModels: result.unknownModels,
     unknownShareOfClassified: w,
   }
 }

--- a/common/src/perps/lab-share.ts
+++ b/common/src/perps/lab-share.ts
@@ -244,6 +244,12 @@ export type LabShareResult = {
   /** True when the aggregated `other` row is present in the payload. */
   hasExcludedPayload: boolean
   /**
+   * Window dates with NO `other` row. OpenRouter emits one aggregate row per
+   * day, so a day without it is a truncated day, and one complete day must
+   * not vouch for six truncated ones — completeness is per date.
+   */
+  datesMissingOther: string[]
+  /**
    * Authors in neither list (Chinese-lab feed only; always empty for the
    * Anthropic feed), and their volume as U/C — the quantity
    * UNKNOWN_AUTHOR_TOKEN_SHARE_CAP bounds.
@@ -315,6 +321,7 @@ export const computeLabShare = (
   const compositeSet = new Set<string>()
   const invalidTokenRowSet = new Set<string>()
   const malformedSlugSet = new Set<string>()
+  const datesWithOther = new Set<string>()
 
   for (const row of rows) {
     const tokens = parseTokens(row.total_tokens)
@@ -327,6 +334,7 @@ export const computeLabShare = (
     // `other` is unclassifiable by construction — never in the denominator.
     if (basePermaslug(row.model_permaslug) === OTHER_MODEL_KEY) {
       otherTokens += tokens
+      datesWithOther.add(row.date)
       continue
     }
 
@@ -371,6 +379,7 @@ export const computeLabShare = (
     invalidTokenRows,
     malformedSlugs,
     hasExcludedPayload: otherTokens > 0n,
+    datesMissingOther: dates.filter((d) => !datesWithOther.has(d)),
     unknownAuthors: [...unknownSet].sort(),
     unknownTokens: finiteBigIntTelemetry(unknownTokens),
     unknownShareOfClassified: ratioOfBigInts(unknownTokens, classifiedTokens),
@@ -484,6 +493,13 @@ export const validateLabSharePublication = (
   }
   if (!result.hasExcludedPayload)
     return { ok: false, reason: 'payload has no excluded `other` tokens' }
+  if (result.datesMissingOther.length > 0)
+    return {
+      ok: false,
+      reason: `truncated day(s) with no \`other\` row: ${result.datesMissingOther.join(
+        ', '
+      )}`,
+    }
   if (
     result.share == null ||
     !Number.isFinite(result.share) ||

--- a/common/src/perps/lab-share.ts
+++ b/common/src/perps/lab-share.ts
@@ -1,0 +1,520 @@
+import { DAY_MS } from '../util/time'
+import {
+  COMPOSITE_TOKEN_SHARE_CAP,
+  OPEN_WEIGHT_WINDOW_DAYS,
+  OTHER_MODEL_KEY,
+  RankingRow,
+  UNCLASSIFIED_TOKEN_SHARE_CAP,
+  basePermaslug,
+  isCompositeSlug,
+  isValidPermaslug,
+  newestWindowDates,
+} from './open-weight-models'
+
+// Lab-share indexes on OpenRouter: what fraction of the tokens routed through
+// OpenRouter's top-50 models went to (a) Anthropic, and (b) Chinese labs.
+//
+// This file is the published methodology, not an implementation detail — the
+// same reasoning as open-weight-models.ts, and deliberately the same window,
+// the same denominator, and the same exclusions, so the three OpenRouter
+// indexes are one family that a reader can compare directly. It lives in
+// `common` (a leaf package) so the rule the oracle is scored against is one
+// auditable artifact.
+//
+// THE UNIT OF CLASSIFICATION IS THE AUTHOR, NOT THE MODEL.
+//
+// OpenRouter keys every ranked row on a permaslug `author/model[:variant]`.
+// The author segment is the publisher's OpenRouter organisation — `anthropic`,
+// `deepseek`, `qwen` — and it is stable across that publisher's releases. So
+// where the open-weight index has to adjudicate every new MODEL (weights are
+// released per model), these indexes only ever have to place a new AUTHOR,
+// which happens a few times a year rather than a few times a week. That is
+// the whole design goal: a classification burden of zero for Anthropic and a
+// one-line constant for Chinese labs.
+//
+//   share = 100 * (numerator tokens) / (denominator tokens)
+//
+//   window        the newest OPEN_WEIGHT_WINDOW_DAYS complete UTC days present
+//                 in the payload (newestWindowDates), trailing seven days
+//   author(row)   the segment of basePermaslug(model_permaslug) before the
+//                 first `/`; a slug that is not `owner/model` (isValidPermaslug)
+//                 is MALFORMED and fails the whole publication closed, exactly
+//                 as an unparseable token count does
+//   denominator   every row in the window except OTHER_MODEL_KEY and composite
+//                 slugs (routers and `~` floating aliases, isCompositeSlug) —
+//                 the same exclusions the open-weight index makes, for the same
+//                 reasons written up there; both volumes are reported so the
+//                 job can log the exclusion like it does today
+//
+// ANTHROPIC: numerator = rows whose author is exactly `anthropic`. Nothing
+// else: no name matching, no "Claude" heuristics. Cloaked `openrouter/*`
+// slugs stay in the denominator and never in the numerator, whoever is behind
+// them; if one is later unmasked as an Anthropic model, that reclassifies
+// FORWARD from the unmasking, never retroactively — the same rule the
+// open-weight index applies to unmasked stealth models. There is no unknown-
+// author concept here: every valid row is either Anthropic or not, so the
+// feed publishes whenever the payload validates.
+//
+// CHINESE LABS: numerator = rows whose author is in CHINESE_LAB_AUTHORS; the
+// rest of the denominator is rows whose author is in KNOWN_NON_CHINESE_AUTHORS.
+// An author in NEITHER list is UNKNOWN: its tokens are excluded from both
+// sides (never defaulted — a mis-defaulted lab would move the index on a
+// guess) and returned in `unknownAuthors`. The publication rule:
+//
+//   - unknown-author tokens over UNKNOWN_AUTHOR_TOKEN_SHARE_CAP of classified
+//     tokens -> the feed REFUSES to publish and the job logs an ERROR naming
+//     the authors and telling the reader which constant to extend;
+//   - at or below the cap -> the feed publishes and the job logs a WARN
+//     naming the same authors.
+//
+// That is the entire maintenance path, on purpose. No database rows, no
+// grace window, no admin tool, no auto-classifier: a new author is a one-line
+// addition to one of the two constants below (with its evidence) and a
+// deploy. Authors appear rarely enough that this is the right budget, and a
+// mechanism heavier than a constant would be more code than the feed itself.
+// KNOWN_NON_CHINESE_AUTHORS exists so that "unknown" means genuinely new, not
+// "we never wrote it down": every author seen in the open-weight seed list on
+// the version date is in exactly one of the two lists, except where the
+// header of that constant says otherwise.
+//
+// The test for "Chinese lab" is the company's headquarters (its principal
+// place of business), recorded as the evidence string. Where a publisher's
+// weights are served under a different organisation's slug, the SLUG's author
+// decides, because that is what OpenRouter attributes the tokens to.
+//
+// Pre-committed edge cases, so they are never adjudicated mid-market:
+//   - A lab relocating or being acquired reclassifies FORWARD from the
+//     announcement, with the list version bumped; history is never rewritten.
+//   - A Chinese lab's model served under a non-Chinese author slug (or vice
+//     versa) counts by SLUG. The methodology is "tokens attributed by
+//     OpenRouter to authors headquartered in China", not "models with
+//     Chinese ancestry" — the former is checkable in seconds, the latter is
+//     not.
+//   - `openrouter/*` stealth slugs are KNOWN_NON_CHINESE for denominator
+//     purposes (they are in the denominator, not the numerator) and never
+//     unknown: an unknown that can never be resolved would halt the feed
+//     forever. If one is unmasked as a Chinese lab's model, forward-only.
+
+/** Bump when either author list changes. */
+export const CHINESE_LAB_LIST_VERSION = '2026-09-02'
+
+/** The one author the Anthropic index counts. */
+export const ANTHROPIC_AUTHOR = 'anthropic'
+
+/**
+ * How much of the classified token pool may sit in unknown authors before
+ * the Chinese-lab index refuses to publish, as U/C (unknown tokens over
+ * classified tokens). The same number as the open-weight index's unclassified
+ * cap and for the same reason: the bound it buys on the published share is
+ * strictly under the cap (see UNCLASSIFIED_TOKEN_SHARE_CAP for the algebra),
+ * so a sub-cap unknown costs at most a fraction of a point until someone adds
+ * one line. Its own constant so the two can be tuned apart if they ever need
+ * to be.
+ */
+export const UNKNOWN_AUTHOR_TOKEN_SHARE_CAP = UNCLASSIFIED_TOKEN_SHARE_CAP
+
+export type AuthorEvidence = {
+  /** One line: the company and where it is headquartered. */
+  evidence: string
+}
+
+/**
+ * Authors headquartered in China. Keyed on the OpenRouter author segment.
+ *
+ * Seeded from every author present in OPEN_WEIGHT_MODELS at
+ * OPEN_WEIGHT_LIST_VERSION 2026-08-24, plus a pre-seeded set of well-known
+ * labs that have not (yet) entered the ranked window, so that their first
+ * appearance is a numerator move rather than a halt.
+ */
+export const CHINESE_LAB_AUTHORS: Readonly<Record<string, AuthorEvidence>> = {
+  // Seen in the open-weight seed list.
+  qwen: { evidence: "Alibaba Cloud's Qwen team, Hangzhou" },
+  deepseek: { evidence: 'DeepSeek, Hangzhou' },
+  'z-ai': { evidence: 'Zhipu AI (Z.ai), Beijing' },
+  moonshotai: { evidence: 'Moonshot AI, Beijing' },
+  xiaomi: { evidence: 'Xiaomi (MiMo), Beijing' },
+  minimax: { evidence: 'MiniMax, Shanghai' },
+  inclusionai: { evidence: "inclusionAI, Ant Group's model lab, Hangzhou" },
+  tencent: { evidence: 'Tencent (Hunyuan), Shenzhen' },
+  stepfun: { evidence: 'StepFun, Shanghai' },
+  'bytedance-seed': { evidence: 'ByteDance Seed, Beijing' },
+  baai: { evidence: 'Beijing Academy of Artificial Intelligence, Beijing' },
+  alibaba: { evidence: 'Alibaba (Tongyi), Hangzhou' },
+  kwaipilot: { evidence: "Kuaishou's KwaiPilot team, Beijing" },
+  // Pre-seeded: not in the ranked window on the version date.
+  baidu: { evidence: 'Baidu (ERNIE), Beijing' },
+  '01-ai': { evidence: '01.AI, Beijing' },
+  thudm: { evidence: 'Tsinghua KEG / Zhipu (GLM), Beijing' },
+  internlm: { evidence: 'Shanghai AI Laboratory (InternLM), Shanghai' },
+  opengvlab: { evidence: 'Shanghai AI Laboratory (InternVL), Shanghai' },
+  bytedance: { evidence: 'ByteDance, Beijing' },
+  meituan: { evidence: 'Meituan (LongCat), Beijing' },
+  openbmb: { evidence: 'OpenBMB, Tsinghua NLP / ModelBest, Beijing' },
+}
+
+/**
+ * Every other author seen in the open-weight seed list on the version date,
+ * so an author absent from BOTH lists is genuinely new rather than merely
+ * unrecorded. Plus a pre-seeded set of well-known non-Chinese labs.
+ *
+ * NOT LISTED, DELIBERATELY: `nex-agi` (Nex-N2-Pro, DeepSeek-V3.1-Nex-N1),
+ * which IS in the open-weight seed list. The company's headquarters could
+ * not be established with confidence when this list was written (2026-09-02,
+ * without network access), and the rule is to list an author in the PR for a
+ * human to place rather than default it either way. Until it is placed, its
+ * tokens are unknown to the Chinese-lab index: excluded from both sides,
+ * named in every WARN, and a halt if they exceed the cap. Placing it is one
+ * line in whichever list is right.
+ */
+export const KNOWN_NON_CHINESE_AUTHORS: Readonly<
+  Record<string, AuthorEvidence>
+> = {
+  // Seen in the open-weight seed list.
+  anthropic: { evidence: 'Anthropic, San Francisco, US' },
+  openai: { evidence: 'OpenAI, San Francisco, US' },
+  google: { evidence: 'Google (Gemini, Gemma), Mountain View, US' },
+  'x-ai': { evidence: 'xAI (listed by OpenRouter as SpaceXAI), US' },
+  meta: { evidence: 'Meta, Menlo Park, US' },
+  'meta-llama': { evidence: 'Meta (Llama), Menlo Park, US' },
+  nvidia: { evidence: 'NVIDIA, Santa Clara, US' },
+  mistralai: { evidence: 'Mistral AI, Paris, France' },
+  microsoft: { evidence: 'Microsoft, Redmond, US' },
+  cohere: { evidence: 'Cohere, Toronto, Canada' },
+  amazon: { evidence: 'Amazon (Nova), Seattle, US' },
+  perplexity: { evidence: 'Perplexity, San Francisco, US' },
+  poolside: { evidence: 'Poolside AI, Paris / US' },
+  'arcee-ai': { evidence: 'Arcee AI, San Francisco, US' },
+  tngtech: { evidence: 'TNG Technology Consulting, Munich, Germany' },
+  upstage: { evidence: 'Upstage, Seoul, South Korea' },
+  intfloat: {
+    evidence:
+      "Microsoft's E5 embedding family, published under a researcher account; Microsoft, US",
+  },
+  'sentence-transformers': {
+    evidence: 'UKP Lab, TU Darmstadt / Hugging Face community, Germany',
+  },
+  openrouter: {
+    evidence:
+      'OpenRouter cloaked pre-release slugs: publisher unknown by design; denominator only, never numerator, forward-only if unmasked',
+  },
+  // Pre-seeded: not in the ranked window on the version date.
+  ai21: { evidence: 'AI21 Labs, Tel Aviv, Israel' },
+  liquid: { evidence: 'Liquid AI, Boston, US' },
+  nousresearch: { evidence: 'Nous Research, US' },
+  allenai: { evidence: 'Allen Institute for AI, Seattle, US' },
+  'ibm-granite': { evidence: 'IBM, Armonk, US' },
+  writer: { evidence: 'Writer, San Francisco, US' },
+  inception: { evidence: 'Inception Labs, Palo Alto, US' },
+  eleutherai: { evidence: 'EleutherAI, US non-profit' },
+}
+
+/**
+ * The author segment of a permaslug, or null when the slug is not a valid
+ * `owner/model` key after stripping the variant suffix.
+ */
+export const authorOfPermaslug = (permaslug: string): string | null => {
+  const base = basePermaslug(permaslug)
+  if (!isValidPermaslug(base)) return null
+  return base.slice(0, base.indexOf('/'))
+}
+
+export type LabShareFeed = 'anthropic' | 'chinese-lab'
+
+export type LabShareAuthorLists = {
+  chinese: Readonly<Record<string, AuthorEvidence>>
+  nonChinese: Readonly<Record<string, AuthorEvidence>>
+}
+
+export const DEFAULT_LAB_SHARE_AUTHOR_LISTS: LabShareAuthorLists = {
+  chinese: CHINESE_LAB_AUTHORS,
+  nonChinese: KNOWN_NON_CHINESE_AUTHORS,
+}
+
+/** Parallel to OpenWeightShareResult. */
+export type LabShareResult = {
+  feed: LabShareFeed
+  /** 0-100, or null when nothing classified or any row is malformed. */
+  share: number | null
+  /** UTC dates actually included, oldest first. */
+  dates: string[]
+  /** Rows in the window whose token count could not be parsed. */
+  invalidTokenRows: string[]
+  /** Rows in the window whose permaslug is not `owner/model`. */
+  malformedSlugs: string[]
+  /** True when the aggregated `other` row is present in the payload. */
+  hasExcludedPayload: boolean
+  /**
+   * Authors in neither list (Chinese-lab feed only; always empty for the
+   * Anthropic feed), and their volume as U/C — the quantity
+   * UNKNOWN_AUTHOR_TOKEN_SHARE_CAP bounds.
+   */
+  unknownAuthors: string[]
+  unknownTokens: number
+  unknownShareOfClassified: number
+  /** Token counts, as doubles — display/telemetry only, never the divisor. */
+  numeratorTokens: number
+  classifiedTokens: number
+  otherTokens: number
+  compositeSlugs: string[]
+  compositeTokens: number
+  payloadTokens: number
+}
+
+type AuthorVerdict = 'in' | 'out' | 'unknown'
+
+const classifyAuthor = (
+  feed: LabShareFeed,
+  author: string,
+  lists: LabShareAuthorLists
+): AuthorVerdict => {
+  if (feed === 'anthropic') return author === ANTHROPIC_AUTHOR ? 'in' : 'out'
+  if (lists.chinese[author]) return 'in'
+  if (lists.nonChinese[author]) return 'out'
+  return 'unknown'
+}
+
+/**
+ * The index. Percentage of tokens, among the top-50 models over the trailing
+ * window, attributed to the feed's authors.
+ *
+ * Summed as BigInt for the same reason the open-weight index is: the 7-day
+ * aggregate runs past Number.MAX_SAFE_INTEGER.
+ */
+export const computeLabShare = (
+  feed: LabShareFeed,
+  allRows: RankingRow[],
+  days = OPEN_WEIGHT_WINDOW_DAYS,
+  lists: LabShareAuthorLists = DEFAULT_LAB_SHARE_AUTHOR_LISTS
+): LabShareResult => {
+  const dates = newestWindowDates(allRows, days)
+  const inWindow: Record<string, true> = {}
+  for (const d of dates) inWindow[d] = true
+  const rows = allRows.filter((r) => inWindow[r.date])
+
+  let numeratorTokens = 0n
+  let classifiedTokens = 0n
+  let unknownTokens = 0n
+  let otherTokens = 0n
+  let compositeTokens = 0n
+  let payloadTokens = 0n
+  const unknownSet: Record<string, true> = {}
+  const compositeSet: Record<string, true> = {}
+  const invalidTokenRowSet: Record<string, true> = {}
+  const malformedSlugSet: Record<string, true> = {}
+
+  for (const row of rows) {
+    const tokens = parseTokens(row.total_tokens)
+    if (tokens == null) {
+      invalidTokenRowSet[`${row.date}:${row.model_permaslug}`] = true
+      continue
+    }
+    payloadTokens += tokens
+
+    // `other` is unclassifiable by construction — never in the denominator.
+    if (basePermaslug(row.model_permaslug) === OTHER_MODEL_KEY) {
+      otherTokens += tokens
+      continue
+    }
+
+    // Routers and floating aliases are not one publisher's model. Out of both
+    // sides, and recorded so the caller can log the volume.
+    if (isCompositeSlug(row.model_permaslug)) {
+      compositeSet[basePermaslug(row.model_permaslug)] = true
+      compositeTokens += tokens
+      continue
+    }
+
+    const author = authorOfPermaslug(row.model_permaslug)
+    if (author == null) {
+      malformedSlugSet[row.model_permaslug] = true
+      continue
+    }
+
+    const verdict = classifyAuthor(feed, author, lists)
+    if (verdict === 'unknown') {
+      unknownSet[author] = true
+      unknownTokens += tokens
+      continue
+    }
+    classifiedTokens += tokens
+    if (verdict === 'in') numeratorTokens += tokens
+  }
+
+  const invalidTokenRows = Object.keys(invalidTokenRowSet).sort()
+  const malformedSlugs = Object.keys(malformedSlugSet).sort()
+  const share =
+    classifiedTokens > 0n &&
+    invalidTokenRows.length === 0 &&
+    malformedSlugs.length === 0
+      ? Number((numeratorTokens * 100n * LAB_SHARE_SCALE) / classifiedTokens) /
+        Number(LAB_SHARE_SCALE)
+      : null
+
+  return {
+    feed,
+    share,
+    dates,
+    invalidTokenRows,
+    malformedSlugs,
+    hasExcludedPayload: otherTokens > 0n,
+    unknownAuthors: Object.keys(unknownSet).sort(),
+    unknownTokens: finiteBigIntTelemetry(unknownTokens),
+    unknownShareOfClassified: ratioOfBigInts(unknownTokens, classifiedTokens),
+    numeratorTokens: finiteBigIntTelemetry(numeratorTokens),
+    classifiedTokens: finiteBigIntTelemetry(classifiedTokens),
+    otherTokens: finiteBigIntTelemetry(otherTokens),
+    compositeSlugs: Object.keys(compositeSet).sort(),
+    compositeTokens: finiteBigIntTelemetry(compositeTokens),
+    payloadTokens: finiteBigIntTelemetry(payloadTokens),
+  }
+}
+
+export const computeAnthropicShare = (
+  rows: RankingRow[],
+  days = OPEN_WEIGHT_WINDOW_DAYS
+): LabShareResult => computeLabShare('anthropic', rows, days)
+
+export const computeChineseLabShare = (
+  rows: RankingRow[],
+  days = OPEN_WEIGHT_WINDOW_DAYS,
+  lists: LabShareAuthorLists = DEFAULT_LAB_SHARE_AUTHOR_LISTS
+): LabShareResult => computeLabShare('chinese-lab', rows, days, lists)
+
+const LAB_SHARE_SCALE = 1_000_000_000n
+
+const ratioOfBigInts = (numerator: bigint, denominator: bigint): number =>
+  denominator > 0n
+    ? Number((numerator * LAB_SHARE_SCALE) / denominator) /
+      Number(LAB_SHARE_SCALE)
+    : 0
+
+const finiteBigIntTelemetry = (value: bigint) => {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : Number.MAX_VALUE
+}
+
+/** Same rule as the open-weight index: truncate a fractional count, reject anything else. */
+const parseTokens = (raw: string): bigint | null => {
+  if (typeof raw !== 'string') return null
+  const m = /^(\d+)(?:\.\d+)?$/.exec(raw.trim())
+  return m ? BigInt(m[1]) : null
+}
+
+export type LabSharePublicationValidation =
+  | {
+      ok: true
+      share: number
+      /** Unknown authors published under the cap — never silent. */
+      unknownAuthors: string[]
+      unknownShareOfClassified: number
+    }
+  | { ok: false; reason: string }
+
+export type LabSharePublicationOptions = {
+  expectedDays?: number
+  /** Override the cap; 0 halts on ANY unknown author. */
+  unknownShareCap?: number
+  /** Bound on router/alias tokens; defaults to COMPOSITE_TOKEN_SHARE_CAP. */
+  compositeShareCap?: number
+}
+
+/**
+ * Fail-closed publication gate shared by the live writer and the backfill,
+ * parallel to validateOpenWeightPublication. Structural checks (malformed
+ * rows, malformed slugs, incomplete or gapped window, missing `other`,
+ * composite volume) run first for BOTH feeds; the unknown-author decision
+ * applies only to the Chinese-lab feed, whose result is the only one that can
+ * carry unknowns.
+ */
+export const validateLabSharePublication = (
+  result: LabShareResult,
+  options: LabSharePublicationOptions = {}
+): LabSharePublicationValidation => {
+  const {
+    expectedDays = OPEN_WEIGHT_WINDOW_DAYS,
+    unknownShareCap = UNKNOWN_AUTHOR_TOKEN_SHARE_CAP,
+    compositeShareCap = COMPOSITE_TOKEN_SHARE_CAP,
+  } = options
+
+  if (result.invalidTokenRows.length > 0)
+    return {
+      ok: false,
+      reason: `malformed token count rows: ${result.invalidTokenRows.join(
+        ', '
+      )}`,
+    }
+  if (result.malformedSlugs.length > 0)
+    return {
+      ok: false,
+      reason: `malformed model slugs: ${result.malformedSlugs.join(', ')}`,
+    }
+  if (result.dates.length !== expectedDays)
+    return {
+      ok: false,
+      reason: `incomplete window: expected ${expectedDays} days, got ${result.dates.length}`,
+    }
+  for (let i = 1; i < result.dates.length; i++) {
+    const previous = Date.parse(result.dates[i - 1])
+    const current = Date.parse(result.dates[i])
+    if (!Number.isFinite(previous) || !Number.isFinite(current)) {
+      const invalidDate = !Number.isFinite(previous)
+        ? result.dates[i - 1]
+        : result.dates[i]
+      return { ok: false, reason: `invalid window date: ${invalidDate}` }
+    }
+    if (current - previous !== DAY_MS)
+      return {
+        ok: false,
+        reason: `non-consecutive window dates: ${result.dates.join(', ')}`,
+      }
+  }
+  if (!result.hasExcludedPayload)
+    return { ok: false, reason: 'payload has no excluded `other` tokens' }
+  if (
+    result.share == null ||
+    !Number.isFinite(result.share) ||
+    result.share < 0 ||
+    result.share > 100
+  )
+    return { ok: false, reason: `invalid share ${result.share}` }
+  if (
+    result.classifiedTokens > 0 &&
+    result.compositeTokens / result.classifiedTokens > compositeShareCap
+  )
+    return {
+      ok: false,
+      reason: `composite (router/alias) slugs are ${(
+        (result.compositeTokens / result.classifiedTokens) *
+        100
+      ).toFixed(2)}% of classified tokens, over the ${(
+        compositeShareCap * 100
+      ).toFixed(2)}% cap: ${result.compositeSlugs.join(', ')}`,
+    }
+
+  if (result.unknownAuthors.length === 0)
+    return {
+      ok: true,
+      share: result.share,
+      unknownAuthors: [],
+      unknownShareOfClassified: 0,
+    }
+
+  const w = result.unknownShareOfClassified
+  if (!Number.isFinite(w) || w > unknownShareCap)
+    return {
+      ok: false,
+      reason:
+        `unknown author(s) ${result.unknownAuthors.join(', ')} hold ${(
+          w * 100
+        ).toFixed(3)}% of classified tokens, over the ${(
+          unknownShareCap * 100
+        ).toFixed(3)}% cap; add to CHINESE_LAB_AUTHORS or ` +
+        `KNOWN_NON_CHINESE_AUTHORS`,
+    }
+  return {
+    ok: true,
+    share: result.share,
+    unknownAuthors: result.unknownAuthors,
+    unknownShareOfClassified: w,
+  }
+}

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -1,5 +1,6 @@
 import { DAY_MS } from '../util/time'
 import {
+  OPENROUTER_MAX_SOURCE_LAG_DAYS,
   OPEN_WEIGHT_MODELS,
   OPEN_WEIGHT_WINDOW_DAYS,
   RankingRow,
@@ -9,8 +10,10 @@ import {
   isCompositeSlug,
   isValidPermaslug,
   newestWindowDates,
+  openRouterSourceLagDays,
   openWeightWindowRange,
   utcDateString,
+  validateOpenRouterSourceFreshness,
   validateOpenWeightPublication,
 } from './open-weight-models'
 
@@ -540,5 +543,65 @@ describe('isValidPermaslug', () => {
     // the read path generates.
     for (const raw of ['qwen/qwen3-max:free', 'z-ai/glm-5.3-20260816:nitro'])
       expect([raw, isValidPermaslug(basePermaslug(raw))]).toEqual([raw, true])
+  })
+})
+
+describe('source freshness', () => {
+  // 2026-09-02T10:00:00Z. Yesterday is the newest COMPLETE day upstream.
+  const now = Date.UTC(2026, 8, 2, 10)
+  const window = (newest: string) => {
+    const rows: RankingRow[] = []
+    const newestMs = Date.parse(`${newest}T00:00:00Z`)
+    for (let i = 6; i >= 0; i--)
+      rows.push(row(utcDateString(newestMs - i * DAY_MS), OPEN, 1))
+    return rows
+  }
+
+  it('measures whole UTC days behind today', () => {
+    expect(openRouterSourceLagDays('2026-09-01', now)).toBe(1)
+    expect(openRouterSourceLagDays('2026-08-30', now)).toBe(3)
+    expect(openRouterSourceLagDays('2026-09-02', now)).toBe(0)
+    expect(openRouterSourceLagDays('2026-09-03', now)).toBe(-1)
+    expect(openRouterSourceLagDays('nope', now)).toBeNull()
+  })
+
+  it('accepts yesterday, a late publish, and the documented maximum', () => {
+    expect(OPENROUTER_MAX_SOURCE_LAG_DAYS).toBe(3)
+    for (const newest of ['2026-09-01', '2026-08-31', '2026-08-30'])
+      expect([
+        newest,
+        validateOpenRouterSourceFreshness({ rows: window(newest), now }),
+      ]).toEqual([newest, null])
+  })
+
+  it('refuses a frozen dataset instead of re-stamping it as fresh', () => {
+    // The failure this exists for: the same seven old days served forever
+    // would otherwise be published hourly with a fresh ts and never trip the
+    // staleness or trading gates.
+    const reason = validateOpenRouterSourceFreshness({
+      rows: window('2026-08-29'),
+      now,
+    })
+    expect(reason).toContain('2026-08-29')
+    expect(reason).toContain('stale')
+  })
+
+  it('refuses an empty or future-dated payload', () => {
+    expect(validateOpenRouterSourceFreshness({ rows: [], now })).toContain(
+      'no dated rows'
+    )
+    expect(
+      validateOpenRouterSourceFreshness({ rows: window('2026-09-03'), now })
+    ).toContain('after today')
+  })
+
+  it('honours a caller-supplied bound', () => {
+    expect(
+      validateOpenRouterSourceFreshness({
+        rows: window('2026-08-31'),
+        now,
+        maxLagDays: 1,
+      })
+    ).not.toBeNull()
   })
 })

--- a/common/src/perps/open-weight-models.test.ts
+++ b/common/src/perps/open-weight-models.test.ts
@@ -563,6 +563,9 @@ describe('source freshness', () => {
     expect(openRouterSourceLagDays('2026-09-02', now)).toBe(0)
     expect(openRouterSourceLagDays('2026-09-03', now)).toBe(-1)
     expect(openRouterSourceLagDays('nope', now)).toBeNull()
+    // Impossible calendar dates are invalid, not rolled forward.
+    expect(openRouterSourceLagDays('2026-02-31', now)).toBeNull()
+    expect(openRouterSourceLagDays('2026-13-01', now)).toBeNull()
   })
 
   it('accepts yesterday, a late publish, and the documented maximum', () => {
@@ -586,10 +589,18 @@ describe('source freshness', () => {
     expect(reason).toContain('stale')
   })
 
-  it('refuses an empty or future-dated payload', () => {
+  it('refuses an empty, impossible-dated, or future-dated payload', () => {
     expect(validateOpenRouterSourceFreshness({ rows: [], now })).toContain(
       'no dated rows'
     )
+    // '2026-09-31' sorts newest and does not exist; it must not be read as
+    // October 1st.
+    expect(
+      validateOpenRouterSourceFreshness({
+        rows: [...window('2026-09-01'), row('2026-09-31', OPEN, 1)],
+        now,
+      })
+    ).toContain('not a valid date')
     expect(
       validateOpenRouterSourceFreshness({ rows: window('2026-09-03'), now })
     ).toContain('after today')

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -928,6 +928,10 @@ export const openRouterSourceLagDays = (
   const newestMs = Date.parse(`${newestDate}T00:00:00Z`)
   const todayMs = Date.parse(`${utcDateString(nowMs)}T00:00:00Z`)
   if (!Number.isFinite(newestMs) || !Number.isFinite(todayMs)) return null
+  // Date.parse is lenient about impossible calendar dates: '2026-02-31'
+  // rolls forward to March 3 instead of failing. Round-trip so a provider
+  // typo is reported as invalid rather than measured against a different day.
+  if (utcDateString(newestMs) !== newestDate) return null
   return Math.round((todayMs - newestMs) / DAY_MS)
 }
 

--- a/common/src/perps/open-weight-models.ts
+++ b/common/src/perps/open-weight-models.ts
@@ -902,6 +902,60 @@ export const openWeightWindowRange = (
 export const utcDateString = (ms: number): string =>
   new Date(ms).toISOString().slice(0, 10)
 
+/**
+ * How far behind today's UTC date the newest complete day in an OpenRouter
+ * payload may be before every index computed from it refuses to publish.
+ *
+ * The hourly job stamps each point at Date.now(), which is what keeps the
+ * 3h feed-staleness and 6h trading gates honest — but only if the payload
+ * underneath is actually moving. A frozen response (the same seven old days
+ * served forever) would otherwise be re-stamped as fresh every hour and
+ * never trip either gate. Normally the newest complete day is yesterday
+ * (lag 1); a late upstream publish makes it 2. Three tolerates that without
+ * relaying a dead dataset for a week.
+ */
+export const OPENROUTER_MAX_SOURCE_LAG_DAYS = 3
+
+/**
+ * Whole UTC days between the newest date in the payload and today's UTC
+ * date, or null when the date does not parse.
+ */
+export const openRouterSourceLagDays = (
+  newestDate: string,
+  nowMs: number
+): number | null => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(newestDate)) return null
+  const newestMs = Date.parse(`${newestDate}T00:00:00Z`)
+  const todayMs = Date.parse(`${utcDateString(nowMs)}T00:00:00Z`)
+  if (!Number.isFinite(newestMs) || !Number.isFinite(todayMs)) return null
+  return Math.round((todayMs - newestMs) / DAY_MS)
+}
+
+/**
+ * Reject a payload whose newest complete day is too far behind today. Shared
+ * by every OpenRouter index, checked once per fetch before any of them
+ * publishes. Returns the reason, or null when the source is fresh enough.
+ */
+export const validateOpenRouterSourceFreshness = (args: {
+  rows: RankingRow[]
+  now: number
+  maxLagDays?: number
+}): string | null => {
+  const { rows, now, maxLagDays = OPENROUTER_MAX_SOURCE_LAG_DAYS } = args
+  const newest = newestWindowDates(rows, 1)[0]
+  if (!newest) return 'payload has no dated rows'
+  const lag = openRouterSourceLagDays(newest, now)
+  if (lag == null) return `newest day ${newest} is not a valid date`
+  if (lag < 0)
+    return `newest day ${newest} is after today (${utcDateString(now)})`
+  if (lag > maxLagDays)
+    return (
+      `newest complete day ${newest} is ${lag} days behind ` +
+      `${utcDateString(now)} (max ${maxLagDays}); the source is stale`
+    )
+  return null
+}
+
 /** The newest `days` distinct dates present in `rows`, oldest first. */
 export const newestWindowDates = (
   rows: RankingRow[],

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -14,7 +14,10 @@
 // Verification status of each claim below, because asserting a licence we
 // haven't read is its own problem:
 //   - OpenRouter — their dataset terms specify the exact credit line,
-//     including the data's as-of time. Hence `showAsOf`.
+//     including the data's as-of time. Hence `showAsOf`. The Anthropic-share
+//     and Chinese-lab-share feeds are computed from the same dataset payload
+//     and carry the identical credit; `showAsOf` on them is what makes
+//     insertOraclePrices refuse a point without the dataset's `as_of`.
 //   - VoteHub — their API documentation states "This API is licensed under
 //     Creative Commons Attribution 4.0 International". Read directly, so it
 //     carries a licence label and a link to the licence deed. The same
@@ -63,6 +66,17 @@ export type OracleAttribution = {
 
 export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
   'openrouter-open-weight-share': {
+    source: 'OpenRouter (openrouter.ai/rankings)',
+    url: 'https://openrouter.ai/rankings',
+    showAsOf: true,
+  },
+  // Same dataset, same terms, same credit line with the as-of stamp.
+  'openrouter-anthropic-share': {
+    source: 'OpenRouter (openrouter.ai/rankings)',
+    url: 'https://openrouter.ai/rankings',
+    showAsOf: true,
+  },
+  'openrouter-chinese-lab-share': {
     source: 'OpenRouter (openrouter.ai/rankings)',
     url: 'https://openrouter.ai/rankings',
     showAsOf: true,

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -133,7 +133,10 @@ export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
   // `licence` / `licenceUrl`. If the page turns out NOT to permit commercial
   // reuse with attribution, do not create the market; the registry entry is
   // harmless without one. Until then: a credit and a link, no licence label
-  // we cannot back up (the NESO stance above).
+  // we cannot back up (the NESO stance above). A reviewer of the introducing
+  // PR (#4034, 2026-09-03) with network access reported that the page's API
+  // documentation and terms permit attributed commercial use — encouraging,
+  // but second-hand: the gate stands until the text is pasted here.
   'crypto-fear-greed': {
     source: 'Alternative.me Crypto Fear & Greed Index',
     url: 'https://alternative.me/crypto/fear-and-greed-index/',

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -23,6 +23,11 @@
 //   - NESO — publishes under an open licence requiring attribution, but the
 //     exact current licence text was NOT read directly. So it gets a credit
 //     and a link, and no licence label we can't back up.
+//   - Alternative.me (Crypto Fear & Greed) — same status as NESO, see the
+//     entry: the terms section of their index page could not be fetched
+//     from the environment the feed was written in, so it carries a credit
+//     and a link and no licence label, and reading that page is an operator
+//     gate before a market is created on the feed.
 //   - BTC — we compute the median ourselves from three public tickers, so
 //     nothing is being republished. Credited for transparency, not obligation.
 //   - xStocks (SPYx/QQQx/GLDx/NVDAx) — stronger than BTC's stance: the
@@ -99,6 +104,25 @@ export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
     url: 'https://votehub.com',
     licence: 'CC BY 4.0',
     licenceUrl: 'https://creativecommons.org/licenses/by/4.0/',
+  },
+  // ⚠️ TERMS NOT YET READ DIRECTLY (2026-09-02). The feed was written in a
+  // build environment whose egress policy blocks alternative.me, so the
+  // section of https://alternative.me/crypto/fear-and-greed-index/ that
+  // states the terms for using the data could not be fetched and is NOT
+  // quoted here. Prior research expects it to permit use, including
+  // commercial use, provided the index is credited with a link next to the
+  // displayed data — which is exactly what this entry renders under the
+  // chart on the market page and on the /perps hub. But an expectation is
+  // not a licence: before an admin creates a market on `crypto-fear-greed`,
+  // someone must read that page, paste the relevant sentence(s) verbatim
+  // into this comment with the date, and — only if the page names one — set
+  // `licence` / `licenceUrl`. If the page turns out NOT to permit commercial
+  // reuse with attribution, do not create the market; the registry entry is
+  // harmless without one. Until then: a credit and a link, no licence label
+  // we cannot back up (the NESO stance above).
+  'crypto-fear-greed': {
+    source: 'Alternative.me Crypto Fear & Greed Index',
+    url: 'https://alternative.me/crypto/fear-and-greed-index/',
   },
   'btc-usd': {
     source: 'Coinbase, Kraken, Bitstamp & Gemini',

--- a/common/src/perps/oracle-attribution.ts
+++ b/common/src/perps/oracle-attribution.ts
@@ -17,7 +17,9 @@
 //     including the data's as-of time. Hence `showAsOf`.
 //   - VoteHub — their API documentation states "This API is licensed under
 //     Creative Commons Attribution 4.0 International". Read directly, so it
-//     carries a licence label and a link to the licence deed.
+//     carries a licence label and a link to the licence deed. The same
+//     documentation page covers every `/averages/<key>/values` endpoint, so
+//     the generic-ballot and Vance favorability feeds carry the same credit.
 //   - NESO — publishes under an open licence requiring attribution, but the
 //     exact current licence text was NOT read directly. So it gets a credit
 //     and a link, and no licence label we can't back up.
@@ -78,6 +80,23 @@ export const ORACLE_ATTRIBUTION: Record<string, OracleAttribution> = {
     // condition that the source is credited. The oracle mirrors their
     // published average, so this credit IS the compliance, not decoration —
     // which is why the licence link is required rather than ornamental.
+    licence: 'CC BY 4.0',
+    licenceUrl: 'https://creativecommons.org/licenses/by/4.0/',
+  },
+  // Two more VoteHub published averages, read from the same
+  // polling.votehub.com API under the same documentation and therefore the
+  // same CC BY 4.0 statement quoted above (verified for the Trump feed; the
+  // statement covers the API as a whole, not one endpoint). Identical credit,
+  // identical obligation: the credit IS the compliance.
+  'votehub-generic-ballot-2026': {
+    source: 'VoteHub',
+    url: 'https://votehub.com',
+    licence: 'CC BY 4.0',
+    licenceUrl: 'https://creativecommons.org/licenses/by/4.0/',
+  },
+  'vance-favorability': {
+    source: 'VoteHub',
+    url: 'https://votehub.com',
     licence: 'CC BY 4.0',
     licenceUrl: 'https://creativecommons.org/licenses/by/4.0/',
   },

--- a/common/src/perps/oracle-display.ts
+++ b/common/src/perps/oracle-display.ts
@@ -23,6 +23,8 @@ export const ORACLE_TICK_DECORATIONS: Readonly<
   // Index points on a 0-100 sentiment scale: a level, not a percentage.
   'crypto-fear-greed': {},
   'openrouter-open-weight-share': { suffix: '%' },
+  'openrouter-anthropic-share': { suffix: '%' },
+  'openrouter-chinese-lab-share': { suffix: '%' },
 }
 
 // Decimals needed to distinguish axis ticks `step` apart: 0 for steps >= 1,

--- a/common/src/perps/oracle-display.ts
+++ b/common/src/perps/oracle-display.ts
@@ -8,9 +8,18 @@ type OracleTickDecoration = {
 // Oracle prices are plain numbers in storage. Keep their presentation metadata
 // explicit and keyed by the stable feed id: inferring a unit from a market
 // question would silently mislabel renamed or user-created markets.
-const ORACLE_TICK_DECORATIONS: Record<string, OracleTickDecoration> = {
+//
+// Exported (read-only) so the feed-table tests in backend/shared can assert
+// that every feed in a spec table has an entry here; an index-point feed with
+// no unit still gets an explicit empty entry so "missing" and "unitless" are
+// different states.
+export const ORACLE_TICK_DECORATIONS: Readonly<
+  Record<string, OracleTickDecoration>
+> = {
   'btc-usd': { prefix: '$' },
   'trump-approval-rating': { suffix: '%' },
+  'votehub-generic-ballot-2026': { suffix: '%' },
+  'vance-favorability': { suffix: '%' },
   'openrouter-open-weight-share': { suffix: '%' },
 }
 

--- a/common/src/perps/oracle-display.ts
+++ b/common/src/perps/oracle-display.ts
@@ -20,6 +20,8 @@ export const ORACLE_TICK_DECORATIONS: Readonly<
   'trump-approval-rating': { suffix: '%' },
   'votehub-generic-ballot-2026': { suffix: '%' },
   'vance-favorability': { suffix: '%' },
+  // Index points on a 0-100 sentiment scale: a level, not a percentage.
+  'crypto-fear-greed': {},
   'openrouter-open-weight-share': { suffix: '%' },
 }
 

--- a/common/src/perps/trump-approval.ts
+++ b/common/src/perps/trump-approval.ts
@@ -1,4 +1,27 @@
-import { DAY_MS } from '../util/time'
+import {
+  DAILY_FEED_HEARTBEAT_MS,
+  DailyFeedPublishDecision,
+  decideDailyFeedPublish,
+} from './daily-feed-publish'
+import {
+  AveragePoll,
+  PollAnswer,
+  PollAveragePointResult,
+  PollWindow,
+  PollWindowResult,
+  PublishedAverageResult as VoteHubPublishedAverageResult,
+  PublishedAverageSeries as VoteHubPublishedAverageSeries,
+  VoteHubAverageRules,
+  averagePollPct,
+  computePollAveragePoint,
+  getCrossCheckGap,
+  hasAnswer,
+  isUsablePoll,
+  readAnswerPct,
+  readPublishedAverage,
+  readPublishedSeries,
+  selectPollWindow,
+} from './votehub-average'
 
 // The Trump approval index: VoteHub's published, time-weighted polling
 // average, mirrored as the oracle price.
@@ -8,6 +31,15 @@ import { DAY_MS } from '../util/time'
 // package) so the rule the oracle is scored against is one auditable artifact
 // that a UI can render directly, rather than a description in a market blurb
 // that drifts from the code that actually prices the market.
+//
+// The mechanics — reading the published series, the poll-window canary, the
+// cross-check gap, the publish-on-change rule — are shared with the other
+// VoteHub feeds (2026 generic ballot, Vance favorability) and live in
+// `votehub-average.ts` and `daily-feed-publish.ts`, parameterised by the
+// answer key. Everything exported from here is the Trump-specific
+// instantiation: the constants below, whose values were set from this feed's
+// observed history, and thin wrappers that behave exactly as this module did
+// before the generalisation (its test file is unchanged and still passes).
 //
 // WHY WE MIRROR RATHER THAN COMPUTE
 //
@@ -55,8 +87,8 @@ import { DAY_MS } from '../util/time'
 // WE STILL COMPUTE OUR OWN AVERAGE — AS A CANARY, NOT AS THE PRICE
 //
 // Mirroring a third party means a silent change on their side would reprice a
-// live market with nobody noticing. So the window code below still runs, on
-// the same raw polls, and its result is compared against theirs. It never sets
+// live market with nobody noticing. So the window code still runs, on the
+// same raw polls, and its result is compared against theirs. It never sets
 // the price; it exists to answer "does their number still look like a Trump
 // approval average?" Over 554 days the two differ by a median of 0.435 and
 // never by more than 1.70, so a large divergence means something broke — a
@@ -77,7 +109,13 @@ import { DAY_MS } from '../util/time'
 // PT waited until 04:00 the next day for the first new point, making that
 // interval 26 hours.
 
-/** Trailing window, in whole days, that the index averages over. */
+/** The answer object inside each day of VoteHub's `trump_approval` series. */
+export const TRUMP_APPROVAL_ANSWER_KEY = 'approve'
+
+/** The `answers[].choice` string on a raw approval poll. */
+export const TRUMP_APPROVAL_POLL_CHOICE = 'Approve'
+
+/** Trailing window, in whole days, that the canary averages over. */
 export const TRUMP_APPROVAL_WINDOW_DAYS = 14
 
 /**
@@ -100,9 +138,8 @@ export const TRUMP_APPROVAL_MIN_POLLS = 12
  * Reaching further does not make the number better — past some age the polls
  * are describing a different month. The observed worst case needed 22 days,
  * so 35 leaves real headroom while still failing closed on a source outage.
- * Hitting this cap means the feed publishes nothing and goes stale, which
- * pauses the engine: a visible, safe stop, and strictly better than pricing a
- * leveraged market off four polls from five weeks ago.
+ * Hitting this cap means the canary publishes nothing: the published value
+ * then goes out unchecked, with a WARN saying so.
  */
 export const TRUMP_APPROVAL_MAX_WINDOW_DAYS = 35
 
@@ -139,260 +176,66 @@ export const TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS = 3
  */
 export const TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP = 3
 
-export type ApprovalPoll = {
-  /**
-   * Last day of fielding (YYYY-MM-DD) — the poll's representative date. Not
-   * the publication date: when a poll becomes visible says something about
-   * the pollster's release schedule, not about when opinion was measured.
-   */
-  endDate: string
-  /** Approve percentage, on a 0-100 scale. */
-  pct: number
-  /** Attribution and display only. Never affects selection or weighting. */
-  pollster?: string
-}
-
-export type ApprovalWindow = {
-  /** The selected polls, newest end_date first. */
-  polls: ApprovalPoll[]
-  /** Inclusive earliest end_date admitted (YYYY-MM-DD). */
-  startDate: string
-  /** Inclusive latest end_date admitted — the valuation day (YYYY-MM-DD). */
-  endDate: string
-  /** Whole days spanned, inclusive of both ends. */
-  spanDays: number
-  /** Whether the count floor widened the window past the base window. */
-  extended: boolean
-}
-
-export type ApprovalWindowResult =
-  | { ok: true; window: ApprovalWindow }
-  | { ok: false; reason: string }
-
-export type ApprovalPointResult =
-  | { ok: true; price: number; window: ApprovalWindow }
-  | { ok: false; reason: string }
-
-const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
-
 /**
- * Calendar dates are compared and shifted as UTC midnights, never as local
- * instants. Both operations then have no DST to be wrong about, and because
- * every date is zero-padded ISO, string ordering is already chronological
- * ordering — so membership tests need no parsing at all.
+ * How long a published point may stand before we re-publish an unchanged
+ * value purely to prove the feed is alive. See DAILY_FEED_HEARTBEAT_MS; this
+ * name is kept because the feed's alerting docs and tests refer to it.
  */
-const parseDay = (date: string): number | null => {
-  if (typeof date !== 'string' || !DATE_PATTERN.test(date)) return null
-  const ms = Date.parse(`${date}T00:00:00Z`)
-  if (!Number.isFinite(ms)) return null
-  // Date.parse is lenient about impossible calendar dates: '2026-02-31'
-  // silently rolls forward to March 3 rather than returning NaN. Round-trip
-  // the result so a provider typo is rejected instead of being quietly
-  // reinterpreted as a different day at the window boundary.
-  return new Date(ms).toISOString().slice(0, 10) === date ? ms : null
+export const TRUMP_APPROVAL_HEARTBEAT_MS = DAILY_FEED_HEARTBEAT_MS
+
+/** The full rule set, in the shape the backend's VoteHub feed spec carries. */
+export const TRUMP_APPROVAL_RULES: VoteHubAverageRules = {
+  windowDays: TRUMP_APPROVAL_WINDOW_DAYS,
+  minPolls: TRUMP_APPROVAL_MIN_POLLS,
+  maxWindowDays: TRUMP_APPROVAL_MAX_WINDOW_DAYS,
+  maxSourceAgeDays: TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS,
+  maxCrossCheckGap: TRUMP_APPROVAL_MAX_CROSS_CHECK_GAP,
+  heartbeatMs: TRUMP_APPROVAL_HEARTBEAT_MS,
 }
 
-const shiftDay = (date: string, days: number): string | null => {
-  const ms = parseDay(date)
-  if (ms == null) return null
-  const shifted = ms + days * DAY_MS
-  if (!Number.isFinite(shifted)) return null
-  return new Date(shifted).toISOString().slice(0, 10)
-}
+export type ApprovalPoll = AveragePoll
+export type ApprovalWindow = PollWindow
+export type ApprovalWindowResult = PollWindowResult
+export type ApprovalPointResult = PollAveragePointResult
+export type PublishedAverageSeries = VoteHubPublishedAverageSeries
+export type PublishedAverageResult = VoteHubPublishedAverageResult
+/** One row of a provider's answer array, before any validation. */
+export type ApprovalAnswer = PollAnswer
+export type ApprovalPublishDecision = DailyFeedPublishDecision
 
-const daysBetween = (from: string, to: string): number | null => {
-  const a = parseDay(from)
-  const b = parseDay(to)
-  if (a == null || b == null) return null
-  return Math.round((b - a) / DAY_MS)
-}
-
-/**
- * A poll is usable if it reports a percentage that could be a percentage.
- *
- * The provider response is cast rather than schema-validated, so a data-entry
- * error arrives as an ordinary number. One pct of 460 against ~20 polls near
- * 40 moves the mean by ~20 points, which lands inside the feed's [10,90]
- * plausibility bounds and would price live positions.
- */
 export const isUsableApprovalPoll = (poll: ApprovalPoll): boolean =>
-  poll != null &&
-  parseDay(poll.endDate) != null &&
-  typeof poll.pct === 'number' &&
-  Number.isFinite(poll.pct) &&
-  poll.pct >= 0 &&
-  poll.pct <= 100
+  isUsablePoll(poll)
 
-/**
- * VoteHub's published average series, keyed by ISO day.
- *
- * Typed loosely on purpose: this is an external payload, so every field is
- * treated as absent-or-wrong until checked rather than trusted through a cast.
- */
-export type PublishedAverageSeries = Record<
-  string,
-  { approve?: { average?: number } | null } | null | undefined
->
-
-export type PublishedAverageResult =
-  | { ok: true; price: number; asOfDay: string; ageDays: number }
-  | { ok: false; reason: string }
-
-/**
- * Read the most recent published average at or before `day`.
- *
- * Takes the latest available entry rather than requiring one stamped `day`,
- * because the provider posts a same-day value at an hour we do not control and
- * a missing entry at 5:30am Pacific is routine, not a fault. Age is then
- * checked explicitly — see TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS — so "slightly
- * behind" and "stopped updating" get different answers.
- */
+/** Read the most recent published Approve average at or before `day`. */
 export const readPublishedApprovalAverage = (
   series: PublishedAverageSeries | null | undefined,
   day: string,
   options: { maxAgeDays?: number } = {}
-): PublishedAverageResult => {
-  const { maxAgeDays = TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS } = options
+): PublishedAverageResult =>
+  readPublishedAverage(series, day, {
+    answerKey: TRUMP_APPROVAL_ANSWER_KEY,
+    maxAgeDays: options.maxAgeDays ?? TRUMP_APPROVAL_MAX_SOURCE_AGE_DAYS,
+  })
 
-  if (parseDay(day) == null)
-    return { ok: false, reason: `invalid valuation day ${day}` }
-  if (!Number.isFinite(maxAgeDays) || maxAgeDays < 0)
-    return { ok: false, reason: `invalid maxAgeDays ${maxAgeDays}` }
-  if (series == null || typeof series !== 'object')
-    return { ok: false, reason: 'published average series is missing' }
-
-  let best: { asOfDay: string; price: number } | null = null
-  for (const [key, entry] of Object.entries(series)) {
-    if (parseDay(key) == null || key > day) continue
-    const average = entry?.approve?.average
-    // A percentage of exactly 0 or 100 is not a real approval reading; it is
-    // the shape a cleared or defaulted field takes.
-    if (
-      typeof average !== 'number' ||
-      !Number.isFinite(average) ||
-      average <= 0 ||
-      average >= 100
-    )
-      continue
-    if (!best || key > best.asOfDay) best = { asOfDay: key, price: average }
-  }
-
-  if (!best)
-    return {
-      ok: false,
-      reason: `no usable published average on or before ${day}`,
-    }
-
-  const ageDays = daysBetween(best.asOfDay, day)
-  if (ageDays == null)
-    return { ok: false, reason: `could not measure age of ${best.asOfDay}` }
-  if (ageDays > maxAgeDays)
-    return {
-      ok: false,
-      reason: `published average is ${ageDays} days stale (as of ${best.asOfDay}, max ${maxAgeDays})`,
-    }
-
-  return { ok: true, price: best.price, asOfDay: best.asOfDay, ageDays }
-}
-
-/**
- * Every usable day of the published series, oldest first.
- *
- * Shares its validity rules with readPublishedApprovalAverage so a backfill
- * and the daily job cannot disagree about which entries are real.
- */
+/** Every usable day of the published Approve series, oldest first. */
 export const readPublishedApprovalSeries = (
   series: PublishedAverageSeries | null | undefined
-): { day: string; price: number }[] => {
-  if (series == null || typeof series !== 'object') return []
-  return Object.entries(series)
-    .flatMap(([key, entry]) => {
-      if (parseDay(key) == null) return []
-      const average = entry?.approve?.average
-      if (
-        typeof average !== 'number' ||
-        !Number.isFinite(average) ||
-        average <= 0 ||
-        average >= 100
-      )
-        return []
-      return [{ day: key, price: average }]
-    })
-    .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0))
-}
+): { day: string; price: number }[] =>
+  readPublishedSeries(series, { answerKey: TRUMP_APPROVAL_ANSWER_KEY })
 
-/**
- * Absolute distance between the published average and our own computation,
- * or null when either side is unusable — which is "no opinion", not "agrees".
- */
 export const getApprovalCrossCheckGap = (
   published: number,
   reference: number
-): number | null => {
-  if (!Number.isFinite(published) || !Number.isFinite(reference)) return null
-  const gap = Math.abs(published - reference)
-  return Number.isFinite(gap) ? gap : null
-}
+): number | null => getCrossCheckGap(published, reference)
 
-/** One row of a provider's answer array, before any validation. */
-export type ApprovalAnswer = { choice: string; pct: number }
-
-const findApprove = (answers: readonly ApprovalAnswer[] | undefined) =>
-  Array.isArray(answers)
-    ? answers.find(
-        (answer) =>
-          typeof answer?.choice === 'string' &&
-          answer.choice.toLowerCase() === 'approve'
-      )
-    : undefined
-
-/**
- * Whether the provider offered an Approve row at all.
- *
- * Separate from reading it, so a caller can tell "this poll asks a different
- * question" (ordinary, silent) from "this poll answers our question with a
- * number that cannot be a percentage" (a data error worth alerting on).
- */
 export const hasApproveAnswer = (
   answers: readonly ApprovalAnswer[] | undefined
-): boolean => findApprove(answers) != null
+): boolean => hasAnswer(answers, TRUMP_APPROVAL_POLL_CHOICE)
 
-/**
- * Read the Approve percentage, or null when it is absent or unusable.
- *
- * Lives here rather than in the backend adapter because it is the point where
- * provider data becomes oracle input, and the repo has no test runner under
- * backend/shared to pin that behaviour.
- */
 export const readApprovePct = (
   answers: readonly ApprovalAnswer[] | undefined
-): number | null => {
-  const approve = findApprove(answers)
-  if (!approve || typeof approve.pct !== 'number') return null
-  if (!Number.isFinite(approve.pct) || approve.pct < 0 || approve.pct > 100)
-    return null
-  return approve.pct
-}
+): number | null => readAnswerPct(answers, TRUMP_APPROVAL_POLL_CHOICE)
 
-/**
- * Choose the polls that price `day`.
- *
- * The base window is the TRUMP_APPROVAL_WINDOW_DAYS days ending on `day`. If
- * that holds at least TRUMP_APPROVAL_MIN_POLLS polls it is used unchanged.
- * Otherwise the window widens to the end_date of the Nth most recent poll.
- *
- * That cut is taken by DATE and is tie-inclusive: every poll sharing the
- * cut-off end_date is admitted, so the result never depends on the input
- * order. Picking "the first N after sorting" would let two polls that ended
- * the same day be separated by nothing but array position — the same
- * order-dependence normalizeOraclePointBatch refuses to tolerate when
- * publishing points, and it matters more here because a tie at the boundary
- * is the common case (five polls ended 2026-07-27).
- *
- * Because the widened cut is defined by rank rather than by age, it does not
- * move as `day` advances. A drought therefore reselects exactly the same
- * polls tomorrow, and the price does not move until a poll actually arrives.
- */
 export const selectApprovalWindow = (
   polls: readonly ApprovalPoll[],
   day: string,
@@ -401,172 +244,31 @@ export const selectApprovalWindow = (
     minPolls?: number
     maxWindowDays?: number
   } = {}
-): ApprovalWindowResult => {
-  const {
-    windowDays = TRUMP_APPROVAL_WINDOW_DAYS,
-    minPolls = TRUMP_APPROVAL_MIN_POLLS,
-    maxWindowDays = TRUMP_APPROVAL_MAX_WINDOW_DAYS,
-  } = options
+): ApprovalWindowResult =>
+  selectPollWindow(polls, day, {
+    windowDays: options.windowDays ?? TRUMP_APPROVAL_WINDOW_DAYS,
+    minPolls: options.minPolls ?? TRUMP_APPROVAL_MIN_POLLS,
+    maxWindowDays: options.maxWindowDays ?? TRUMP_APPROVAL_MAX_WINDOW_DAYS,
+  })
 
-  if (parseDay(day) == null)
-    return { ok: false, reason: `invalid valuation day ${day}` }
-  if (!Number.isFinite(windowDays) || windowDays < 1)
-    return { ok: false, reason: `invalid windowDays ${windowDays}` }
-  if (!Number.isFinite(minPolls) || minPolls < 1)
-    return { ok: false, reason: `invalid minPolls ${minPolls}` }
-  if (!Number.isFinite(maxWindowDays) || maxWindowDays < windowDays)
-    return { ok: false, reason: `invalid maxWindowDays ${maxWindowDays}` }
-
-  // A poll that ends after the valuation day cannot inform it. This also
-  // keeps a provider's future-dated row out of a backfilled day.
-  const eligible = polls
-    .filter((poll) => isUsableApprovalPoll(poll) && poll.endDate <= day)
-    .sort((a, b) =>
-      a.endDate < b.endDate ? 1 : a.endDate > b.endDate ? -1 : 0
-    )
-
-  if (eligible.length === 0)
-    return { ok: false, reason: `no usable polls on or before ${day}` }
-
-  const baseStart = shiftDay(day, -(windowDays - 1))
-  const floorStart = shiftDay(day, -(maxWindowDays - 1))
-  if (baseStart == null || floorStart == null)
-    return { ok: false, reason: `could not derive window bounds for ${day}` }
-
-  const inBase = eligible.filter((poll) => poll.endDate >= baseStart)
-
-  let startDate = baseStart
-  let extended = false
-  if (inBase.length < minPolls) {
-    // eligible is sorted newest-first, so index minPolls-1 is the Nth most
-    // recent poll. With fewer than N polls in total, reach as far as the data
-    // goes and let the count check below decide whether that is publishable.
-    const cut =
-      eligible.length >= minPolls
-        ? eligible[minPolls - 1].endDate
-        : eligible[eligible.length - 1].endDate
-    // Never narrower than the base window: the floor may only widen.
-    if (cut < baseStart) {
-      startDate = cut
-      extended = true
-    }
-  }
-
-  if (startDate < floorStart)
-    return {
-      ok: false,
-      reason:
-        `only ${
-          eligible.filter((p) => p.endDate >= floorStart).length
-        } polls ` + `within ${maxWindowDays} days of ${day}, need ${minPolls}`,
-    }
-
-  const selected = eligible.filter((poll) => poll.endDate >= startDate)
-  // Unconditional, NOT gated on `extended`. When the base window already
-  // covers every poll we hold, no widening happens and `extended` stays
-  // false — so gating here would wave a three-poll average straight through
-  // the floor that is the entire point of this function.
-  if (selected.length < minPolls)
-    return {
-      ok: false,
-      reason: `only ${selected.length} polls available on or before ${day}, need ${minPolls}`,
-    }
-
-  const spanDays = daysBetween(startDate, day)
-  if (spanDays == null)
-    return { ok: false, reason: `could not measure window span for ${day}` }
-
-  return {
-    ok: true,
-    window: {
-      polls: selected,
-      startDate,
-      endDate: day,
-      spanDays: spanDays + 1,
-      extended,
-    },
-  }
-}
-
-/** Unweighted mean of Approve pct. Null rather than NaN on an empty set. */
 export const averageApprovalPct = (
   polls: readonly ApprovalPoll[]
-): number | null => {
-  const usable = polls.filter(isUsableApprovalPoll)
-  if (usable.length === 0) return null
-  const mean = usable.reduce((sum, poll) => sum + poll.pct, 0) / usable.length
-  return Number.isFinite(mean) ? mean : null
-}
+): number | null => averagePollPct(polls)
 
-/** Select the window for `day` and average it. */
 export const computeApprovalPoint = (
   polls: readonly ApprovalPoll[],
   day: string,
   options?: Parameters<typeof selectApprovalWindow>[2]
-): ApprovalPointResult => {
-  const selection = selectApprovalWindow(polls, day, options)
-  if (!selection.ok) return selection
+): ApprovalPointResult =>
+  computePollAveragePoint(polls, day, {
+    windowDays: options?.windowDays ?? TRUMP_APPROVAL_WINDOW_DAYS,
+    minPolls: options?.minPolls ?? TRUMP_APPROVAL_MIN_POLLS,
+    maxWindowDays: options?.maxWindowDays ?? TRUMP_APPROVAL_MAX_WINDOW_DAYS,
+  })
 
-  const price = averageApprovalPct(selection.window.polls)
-  if (price == null)
-    return { ok: false, reason: `could not average the window for ${day}` }
-
-  return { ok: true, price, window: selection.window }
-}
-
-/**
- * How long a published point may stand before we re-publish an unchanged
- * value purely to prove the feed is alive.
- *
- * Publishing only on change is what closes the intraday arbitrage window, but
- * on its own it would starve the feed during a flat stretch — VoteHub's
- * average genuinely held 38.4 for three straight days in August 2026 — and
- * staleness alerting keys on ROW age. So a value that has not moved is
- * re-stamped twice a day, comfortably inside the feed's 26h staleAfterMs and
- * the market's 30h maxOraclePriceAgeMs.
- */
-export const TRUMP_APPROVAL_HEARTBEAT_MS = 12 * 60 * 60 * 1000
-
-export type ApprovalPublishDecision =
-  | { publish: true; reason: 'first' | 'changed' | 'heartbeat' }
-  | { publish: false; reason: string }
-
-/**
- * Should this reading be written as a new oracle point?
- *
- * The old rule published the first usable value of each Pacific day and then
- * stopped, which left every later move by the source sitting in public view
- * as the exact next day's mark — the same shape of timing edge this feed was
- * changed to remove, just relocated from the window to the schedule. So the
- * job now runs hourly and publishes whenever the value actually moves.
- *
- * Prices are compared exactly rather than within an epsilon: the source
- * publishes to one decimal, so any real move is at least 0.1, and rounding
- * slack here would silently swallow the smallest genuine moves.
- */
 export const decideApprovalPublish = (args: {
   price: number
   last: { price: number; ts: number } | null
   now: number
   heartbeatMs?: number
-}): ApprovalPublishDecision => {
-  const { price, last, now, heartbeatMs = TRUMP_APPROVAL_HEARTBEAT_MS } = args
-
-  if (!Number.isFinite(price))
-    return { publish: false, reason: `invalid price ${price}` }
-  if (!Number.isFinite(now))
-    return { publish: false, reason: `invalid now ${now}` }
-  if (!Number.isFinite(heartbeatMs) || heartbeatMs <= 0)
-    return { publish: false, reason: `invalid heartbeatMs ${heartbeatMs}` }
-  if (!last) return { publish: true, reason: 'first' }
-  if (!Number.isFinite(last.price) || !Number.isFinite(last.ts))
-    return { publish: true, reason: 'first' }
-
-  if (price !== last.price) return { publish: true, reason: 'changed' }
-  if (now - last.ts >= heartbeatMs)
-    return { publish: true, reason: 'heartbeat' }
-  return {
-    publish: false,
-    reason: `unchanged at ${price} since ${new Date(last.ts).toISOString()}`,
-  }
-}
+}): ApprovalPublishDecision => decideDailyFeedPublish(args)

--- a/common/src/perps/votehub-average.test.ts
+++ b/common/src/perps/votehub-average.test.ts
@@ -13,6 +13,7 @@ import {
   readPublishedSeries,
   selectPollWindow,
   shiftDay,
+  voteHubDaySourceTs,
 } from './votehub-average'
 import {
   TRUMP_APPROVAL_RULES,
@@ -346,6 +347,20 @@ describe('selectPollWindow / computePollAveragePoint with explicit rules', () =>
     const result = selectPollWindow(polls, '2026-09-01', TRUMP_APPROVAL_RULES)
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.window.spanDays).toBe(14)
+  })
+})
+
+describe('voteHubDaySourceTs', () => {
+  it('is the UTC midnight of the day VoteHub stamped, so days order as numbers', () => {
+    expect(voteHubDaySourceTs('2026-09-01')).toBe(Date.UTC(2026, 8, 1))
+    const earlier = voteHubDaySourceTs('2026-08-31') as number
+    const later = voteHubDaySourceTs('2026-09-01') as number
+    // The publisher's guard: an as-of day EARLIER than the one already on
+    // the feed is refused; equal (a same-day correction) is not.
+    expect(earlier < later).toBe(true)
+    expect(voteHubDaySourceTs('2026-09-01')).toBe(later)
+    expect(voteHubDaySourceTs('2026-02-31')).toBeNull()
+    expect(voteHubDaySourceTs('nope')).toBeNull()
   })
 })
 

--- a/common/src/perps/votehub-average.test.ts
+++ b/common/src/perps/votehub-average.test.ts
@@ -259,7 +259,12 @@ describe('readAnswerPct / hasAnswer — arbitrary choices', () => {
     expect(readAnswerPct(ballotPoll, 'Dem')).toBe(47)
     expect(readAnswerPct(ballotPoll, 'dem')).toBe(47)
     expect(readAnswerPct(ballotPoll, 'Rep')).toBe(44)
-    expect(readAnswerPct(answers(['Unfavorable', 52], ['Favorable', 41]), 'Favorable')).toBe(41)
+    expect(
+      readAnswerPct(
+        answers(['Unfavorable', 52], ['Favorable', 41]),
+        'Favorable'
+      )
+    ).toBe(41)
   })
 
   it('returns null when the choice is absent, and says so via hasAnswer', () => {

--- a/common/src/perps/votehub-average.test.ts
+++ b/common/src/perps/votehub-average.test.ts
@@ -1,0 +1,372 @@
+import {
+  AveragePoll,
+  PublishedAverageSeries,
+  averagePollPct,
+  computePollAveragePoint,
+  getCrossCheckGap,
+  hasAnswer,
+  isUsablePoll,
+  parseDay,
+  readAnswerPct,
+  readPublishedAverage,
+  readPublishedAverageValue,
+  readPublishedSeries,
+  selectPollWindow,
+  shiftDay,
+} from './votehub-average'
+import {
+  TRUMP_APPROVAL_RULES,
+  readPublishedApprovalAverage,
+  readPublishedApprovalSeries,
+} from './trump-approval'
+
+// The parameterised reader behind every VoteHub feed. The Trump test file
+// pins the Trump wrappers; this one pins what the generalisation added —
+// answer-key selection — and that the shared validity rules hold for every
+// key, not just `approve`.
+
+const poll = (endDate: string, pct: number, pollster = 'P'): AveragePoll => ({
+  endDate,
+  pct,
+  pollster,
+})
+
+/** One poll per day for `count` days, ending on `endDate`. */
+const daily = (endDate: string, count: number, pct: number) =>
+  Array.from({ length: count }, (_, i) =>
+    poll(shiftDay(endDate, -i) as string, pct)
+  )
+
+// A generic-ballot day carries both parties; a favorability day both
+// verdicts. The reader must pick the requested one and only that one.
+const ballot = (dem: number, rep: number) => ({
+  dem: { average: dem },
+  rep: { average: rep },
+})
+const favorability = (favorable: number, unfavorable: number) => ({
+  favorable: { average: favorable },
+  unfavorable: { average: unfavorable },
+})
+
+describe('readPublishedAverage — answer key selection', () => {
+  const series: PublishedAverageSeries = {
+    '2026-09-01': ballot(46.2, 43.9),
+    '2026-08-31': ballot(46.0, 44.1),
+  }
+
+  it('reads the requested answer and ignores its siblings', () => {
+    const dem = readPublishedAverage(series, '2026-09-01', {
+      answerKey: 'dem',
+      maxAgeDays: 3,
+    })
+    const rep = readPublishedAverage(series, '2026-09-01', {
+      answerKey: 'rep',
+      maxAgeDays: 3,
+    })
+    expect(dem.ok && rep.ok).toBe(true)
+    if (!dem.ok || !rep.ok) return
+    expect(dem.price).toBeCloseTo(46.2, 10)
+    expect(rep.price).toBeCloseTo(43.9, 10)
+    expect(dem.asOfDay).toBe('2026-09-01')
+  })
+
+  it('finds nothing under an answer key the series does not carry', () => {
+    // The failure mode a mis-specified feed must have: no price, not a
+    // sibling's price and not a default.
+    const result = readPublishedAverage(series, '2026-09-01', {
+      answerKey: 'approve',
+      maxAgeDays: 3,
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toContain('approve')
+  })
+
+  it('reads favorability the same way', () => {
+    const result = readPublishedAverage(
+      { '2026-09-01': favorability(41.5, 49.0) },
+      '2026-09-01',
+      { answerKey: 'favorable', maxAgeDays: 3 }
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.price).toBeCloseTo(41.5, 10)
+  })
+
+  it('refuses an empty or non-string answer key', () => {
+    expect(
+      readPublishedAverage(series, '2026-09-01', {
+        answerKey: '',
+        maxAgeDays: 3,
+      }).ok
+    ).toBe(false)
+    expect(
+      readPublishedAverage(series, '2026-09-01', {
+        answerKey: undefined as never,
+        maxAgeDays: 3,
+      }).ok
+    ).toBe(false)
+  })
+})
+
+describe('readPublishedAverage — validity rules apply per key', () => {
+  it('rejects 0 and 100 under any key, and skips to the next usable day', () => {
+    // A cleared field on the tracked answer must not be read as a price even
+    // when its sibling is perfectly healthy.
+    const series: PublishedAverageSeries = {
+      '2026-09-01': ballot(0, 54),
+      '2026-08-31': ballot(100, 0),
+      '2026-08-30': ballot(46.5, 43.5),
+    }
+    const dem = readPublishedAverage(series, '2026-09-01', {
+      answerKey: 'dem',
+      maxAgeDays: 3,
+    })
+    expect(dem.ok).toBe(true)
+    if (!dem.ok) return
+    expect(dem.asOfDay).toBe('2026-08-30')
+    expect(dem.ageDays).toBe(2)
+  })
+
+  it('rejects a non-finite, missing, or null answer object', () => {
+    const series: PublishedAverageSeries = {
+      '2026-09-01': { dem: { average: NaN } },
+      '2026-08-31': { dem: null },
+      '2026-08-30': { dem: {} },
+      '2026-08-29': null,
+      '2026-08-28': { rep: { average: 44 } },
+    }
+    expect(
+      readPublishedAverage(series, '2026-09-01', {
+        answerKey: 'dem',
+        maxAgeDays: 30,
+      }).ok
+    ).toBe(false)
+  })
+
+  it('refuses once the source itself has stopped updating', () => {
+    const result = readPublishedAverage(
+      { '2026-08-20': ballot(46, 44) },
+      '2026-09-01',
+      { answerKey: 'dem', maxAgeDays: 3 }
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('stale')
+  })
+
+  it('accepts a value a day or two behind', () => {
+    const result = readPublishedAverage(
+      { '2026-08-30': ballot(46, 44) },
+      '2026-09-01',
+      { answerKey: 'dem', maxAgeDays: 3 }
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.ageDays).toBe(2)
+  })
+
+  it('never reads a margin as a share', () => {
+    // If a provider only published D-R, the entry would carry no per-party
+    // object; the feed must refuse rather than synthesise a share.
+    const series: PublishedAverageSeries = {
+      '2026-09-01': { margin: { average: 2.3 } },
+    }
+    expect(
+      readPublishedAverage(series, '2026-09-01', {
+        answerKey: 'dem',
+        maxAgeDays: 3,
+      }).ok
+    ).toBe(false)
+  })
+})
+
+describe('readPublishedAverageValue', () => {
+  it('reads a usable average and nothing else', () => {
+    expect(readPublishedAverageValue(ballot(46.2, 43.9), 'dem')).toBe(46.2)
+    expect(readPublishedAverageValue(ballot(46.2, 43.9), 'rep')).toBe(43.9)
+    expect(readPublishedAverageValue(ballot(46.2, 43.9), 'ind')).toBeNull()
+    expect(readPublishedAverageValue(null, 'dem')).toBeNull()
+    expect(readPublishedAverageValue('x' as never, 'dem')).toBeNull()
+    expect(readPublishedAverageValue({ dem: { average: 0 } }, 'dem')).toBeNull()
+    expect(
+      readPublishedAverageValue({ dem: { average: 100 } }, 'dem')
+    ).toBeNull()
+    expect(
+      readPublishedAverageValue({ dem: { average: '46' as never } }, 'dem')
+    ).toBeNull()
+  })
+})
+
+describe('readPublishedSeries', () => {
+  it('returns the requested answer, usable days only, oldest first', () => {
+    const out = readPublishedSeries(
+      {
+        '2026-09-01': ballot(46.2, 43.9),
+        '2026-08-30': ballot(46.0, 44.1),
+        '2026-08-31': ballot(46.1, 0),
+        bogus: ballot(46, 44),
+      },
+      { answerKey: 'rep' }
+    )
+    expect(out).toEqual([
+      { day: '2026-08-30', price: 44.1 },
+      { day: '2026-09-01', price: 43.9 },
+    ])
+  })
+
+  it('returns empty rather than throwing on junk or a bad key', () => {
+    expect(readPublishedSeries(null, { answerKey: 'dem' })).toEqual([])
+    expect(readPublishedSeries('x' as never, { answerKey: 'dem' })).toEqual([])
+    expect(
+      readPublishedSeries({ '2026-09-01': ballot(46, 44) }, { answerKey: '' })
+    ).toEqual([])
+  })
+})
+
+describe('the Trump wrappers are the generic reader with answerKey approve', () => {
+  const series: PublishedAverageSeries = {
+    '2026-08-17': { approve: { average: 38.8 }, disapprove: { average: 57 } },
+    '2026-08-15': { approve: { average: 38.6 }, disapprove: { average: 57 } },
+  }
+
+  it('reads the same value through either path', () => {
+    const generic = readPublishedAverage(series, '2026-08-17', {
+      answerKey: 'approve',
+      maxAgeDays: TRUMP_APPROVAL_RULES.maxSourceAgeDays,
+    })
+    expect(readPublishedApprovalAverage(series, '2026-08-17')).toEqual(generic)
+    expect(readPublishedApprovalSeries(series)).toEqual(
+      readPublishedSeries(series, { answerKey: 'approve' })
+    )
+  })
+
+  it('carries the documented Trump constants', () => {
+    expect(TRUMP_APPROVAL_RULES).toEqual({
+      windowDays: 14,
+      minPolls: 12,
+      maxWindowDays: 35,
+      maxSourceAgeDays: 3,
+      maxCrossCheckGap: 3,
+      heartbeatMs: 12 * 60 * 60 * 1000,
+    })
+  })
+})
+
+describe('readAnswerPct / hasAnswer — arbitrary choices', () => {
+  const answers = (...rows: [string, number][]) =>
+    rows.map(([choice, pct]) => ({ choice, pct }))
+
+  it('reads the requested choice regardless of case or position', () => {
+    const ballotPoll = answers(['Rep', 44], ['Dem', 47], ['Other', 3])
+    expect(readAnswerPct(ballotPoll, 'Dem')).toBe(47)
+    expect(readAnswerPct(ballotPoll, 'dem')).toBe(47)
+    expect(readAnswerPct(ballotPoll, 'Rep')).toBe(44)
+    expect(readAnswerPct(answers(['Unfavorable', 52], ['Favorable', 41]), 'Favorable')).toBe(41)
+  })
+
+  it('returns null when the choice is absent, and says so via hasAnswer', () => {
+    expect(readAnswerPct(answers(['Approve', 39]), 'Dem')).toBeNull()
+    expect(hasAnswer(answers(['Approve', 39]), 'Dem')).toBe(false)
+    expect(hasAnswer(answers(['Approve', 39]), 'approve')).toBe(true)
+  })
+
+  it('returns null for a value that cannot be a percentage but reports the row', () => {
+    for (const bad of [460, -1, NaN, Infinity]) {
+      expect(readAnswerPct(answers(['Dem', bad]), 'Dem')).toBeNull()
+      expect(hasAnswer(answers(['Dem', bad]), 'Dem')).toBe(true)
+    }
+  })
+
+  it('survives malformed input', () => {
+    expect(readAnswerPct(undefined, 'Dem')).toBeNull()
+    expect(readAnswerPct([{ pct: 39 }] as never, 'Dem')).toBeNull()
+    expect(readAnswerPct(answers(['Dem', 47]), undefined as never)).toBeNull()
+    expect(hasAnswer(answers(['Dem', 47]), undefined as never)).toBe(false)
+  })
+})
+
+describe('selectPollWindow / computePollAveragePoint with explicit rules', () => {
+  const rules = { windowDays: 14, minPolls: 3, maxWindowDays: 35 }
+
+  it('averages the base window when the floor is met', () => {
+    const point = computePollAveragePoint(
+      daily('2026-09-01', 5, 46),
+      '2026-09-01',
+      rules
+    )
+    expect(point.ok).toBe(true)
+    if (!point.ok) return
+    expect(point.price).toBeCloseTo(46, 10)
+    expect(point.window.extended).toBe(false)
+    expect(point.window.spanDays).toBe(14)
+  })
+
+  it('widens to the Nth most recent poll when polling is thin', () => {
+    // Favorability-shaped input: sparse polls, so the floor engages.
+    const polls = [
+      poll('2026-08-30', 40),
+      poll('2026-08-10', 42),
+      poll('2026-08-05', 44),
+    ]
+    const result = selectPollWindow(polls, '2026-09-01', rules)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.window.extended).toBe(true)
+    expect(result.window.startDate).toBe('2026-08-05')
+    expect(result.window.polls).toHaveLength(3)
+  })
+
+  it('fails closed past maxWindowDays instead of averaging stale polls', () => {
+    const polls = [poll('2026-08-30', 40), poll('2026-07-01', 42)]
+    const result = selectPollWindow(polls, '2026-09-01', rules)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toContain('need 3')
+  })
+
+  it('rejects invalid rules rather than defaulting them', () => {
+    expect(
+      selectPollWindow(daily('2026-09-01', 5, 46), '2026-09-01', {
+        ...rules,
+        minPolls: 0,
+      }).ok
+    ).toBe(false)
+    expect(
+      selectPollWindow(daily('2026-09-01', 5, 46), '2026-09-01', {
+        ...rules,
+        maxWindowDays: 7,
+      }).ok
+    ).toBe(false)
+  })
+
+  it('is the Trump selection when given the Trump rules', () => {
+    const polls = daily('2026-09-01', TRUMP_APPROVAL_RULES.minPolls + 1, 40)
+    const result = selectPollWindow(polls, '2026-09-01', TRUMP_APPROVAL_RULES)
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.window.spanDays).toBe(14)
+  })
+})
+
+describe('helpers', () => {
+  it('isUsablePoll mirrors the validity rules', () => {
+    expect(isUsablePoll(poll('2026-09-01', 46))).toBe(true)
+    expect(isUsablePoll(poll('2026-09-01', 460))).toBe(false)
+    expect(isUsablePoll(poll('2026-13-01', 46))).toBe(false)
+  })
+
+  it('averagePollPct ignores corrupt polls and returns null on none', () => {
+    expect(averagePollPct([poll('a', 460), poll('2026-09-01', 46)])).toBe(46)
+    expect(averagePollPct([])).toBeNull()
+  })
+
+  it('getCrossCheckGap is symmetric and null on junk', () => {
+    expect(getCrossCheckGap(46.2, 45.1)).toBeCloseTo(1.1, 10)
+    expect(getCrossCheckGap(45.1, 46.2)).toBeCloseTo(1.1, 10)
+    expect(getCrossCheckGap(NaN, 45.1)).toBeNull()
+  })
+
+  it('parseDay rejects impossible calendar dates', () => {
+    expect(parseDay('2026-09-01')).toBe(Date.UTC(2026, 8, 1))
+    expect(parseDay('2026-02-31')).toBeNull()
+    expect(parseDay('2026-9-1')).toBeNull()
+    expect(shiftDay('2026-09-01', -1)).toBe('2026-08-31')
+    expect(shiftDay('nope', -1)).toBeNull()
+  })
+})

--- a/common/src/perps/votehub-average.ts
+++ b/common/src/perps/votehub-average.ts
@@ -447,7 +447,9 @@ export const selectPollWindow = (
 }
 
 /** Unweighted mean of the tracked pct. Null rather than NaN on an empty set. */
-export const averagePollPct = (polls: readonly AveragePoll[]): number | null => {
+export const averagePollPct = (
+  polls: readonly AveragePoll[]
+): number | null => {
   const usable = polls.filter(isUsablePoll)
   if (usable.length === 0) return null
   const mean = usable.reduce((sum, poll) => sum + poll.pct, 0) / usable.length

--- a/common/src/perps/votehub-average.ts
+++ b/common/src/perps/votehub-average.ts
@@ -77,6 +77,15 @@ export const shiftDay = (date: string, days: number): string | null => {
   return new Date(shifted).toISOString().slice(0, 10)
 }
 
+/**
+ * The provider timestamp an oracle point carries for a VoteHub value: the UTC
+ * midnight of the day VoteHub stamped it. Stored as `source_ts` so the
+ * publisher can refuse to roll the mark back to an earlier day's value when
+ * the series temporarily regresses (a day dropping out of the response and
+ * reappearing later) while still allowing same-day corrections.
+ */
+export const voteHubDaySourceTs = (day: string): number | null => parseDay(day)
+
 export const daysBetween = (from: string, to: string): number | null => {
   const a = parseDay(from)
   const b = parseDay(to)

--- a/common/src/perps/votehub-average.ts
+++ b/common/src/perps/votehub-average.ts
@@ -1,0 +1,471 @@
+import { DAY_MS } from '../util/time'
+
+// VoteHub published-average feeds: the methodology shared by every oracle
+// that mirrors one of VoteHub's time-weighted polling averages as its price.
+//
+// Three feeds price off this module today — the Trump approval index
+// (`trump-approval.ts`, which is where the reasoning for mirroring rather
+// than computing is written up), the Democratic share of the 2026 generic
+// ballot, and JD Vance's favorability. They differ only in WHICH published
+// average they read and WHICH answer inside it is the price, so everything
+// below takes the answer key as a parameter rather than hard-coding
+// `approve`. The Trump-named exports are thin wrappers over these functions
+// and behave exactly as they did before this generalisation.
+//
+// This file is the published methodology, not an implementation detail. It
+// lives in `common` (a leaf package) so the rule the oracle is scored against
+// is one auditable artifact that a UI can render directly, rather than a
+// description in a market blurb that drifts from the code that actually
+// prices the market.
+//
+// WHAT THE PRICE IS
+//
+// The oracle price is the `average` of ONE answer object in VoteHub's
+// `/averages/<key>/values` series — the Approve share for approval, the
+// Democratic share for the generic ballot, the Favorable share for
+// favorability — read for the most recent day at or before the valuation day
+// and rejected if that day is too far behind (`maxSourceAgeDays`). It is
+// always a SHARE on a 0-100 scale, never a margin: a margin (D minus R,
+// favorable minus unfavorable) can be zero or negative, and an oracle price
+// must be strictly positive (validateBasicOraclePoint). A share also has no
+// sign to get wrong.
+//
+// THE CANARY
+//
+// Mirroring a third party means a silent change on their side would reprice
+// a live market with nobody noticing. So the poll-window code below still
+// runs on the same raw polls and its unweighted mean is compared against the
+// published value. It never sets the price; it exists to answer "does their
+// number still look like a <subject> average?" A large divergence means
+// something broke — a units change, an answer swap, a methodology rewrite —
+// and the feed stops rather than publishing a number we cannot corroborate.
+// A canary that cannot be computed at all (thin polling, a failed fetch) does
+// NOT block publication; the publisher logs that the value went out
+// unchecked, which is the honest reading of "no opinion".
+//
+// The window / floor / max-window rules (`PollWindowRules`) exist to stop the
+// canary going haywire during a polling drought and raising a false alarm
+// against a perfectly good published value. Their numbers are per feed: the
+// Trump values were set from 560 days of observed poll density and are
+// documented on `trump-approval.ts`; the newer feeds start from the same
+// numbers and are adjusted per spec in `backend/shared/src/votehub-feeds.ts`.
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Calendar dates are compared and shifted as UTC midnights, never as local
+ * instants. Both operations then have no DST to be wrong about, and because
+ * every date is zero-padded ISO, string ordering is already chronological
+ * ordering — so membership tests need no parsing at all.
+ */
+export const parseDay = (date: string): number | null => {
+  if (typeof date !== 'string' || !DATE_PATTERN.test(date)) return null
+  const ms = Date.parse(`${date}T00:00:00Z`)
+  if (!Number.isFinite(ms)) return null
+  // Date.parse is lenient about impossible calendar dates: '2026-02-31'
+  // silently rolls forward to March 3 rather than returning NaN. Round-trip
+  // the result so a provider typo is rejected instead of being quietly
+  // reinterpreted as a different day at the window boundary.
+  return new Date(ms).toISOString().slice(0, 10) === date ? ms : null
+}
+
+export const shiftDay = (date: string, days: number): string | null => {
+  const ms = parseDay(date)
+  if (ms == null) return null
+  const shifted = ms + days * DAY_MS
+  if (!Number.isFinite(shifted)) return null
+  return new Date(shifted).toISOString().slice(0, 10)
+}
+
+export const daysBetween = (from: string, to: string): number | null => {
+  const a = parseDay(from)
+  const b = parseDay(to)
+  if (a == null || b == null) return null
+  return Math.round((b - a) / DAY_MS)
+}
+
+export type AveragePoll = {
+  /**
+   * Last day of fielding (YYYY-MM-DD) — the poll's representative date. Not
+   * the publication date: when a poll becomes visible says something about
+   * the pollster's release schedule, not about when opinion was measured.
+   */
+  endDate: string
+  /** The tracked answer's percentage, on a 0-100 scale. */
+  pct: number
+  /** Attribution and display only. Never affects selection or weighting. */
+  pollster?: string
+}
+
+export type PollWindow = {
+  /** The selected polls, newest end_date first. */
+  polls: AveragePoll[]
+  /** Inclusive earliest end_date admitted (YYYY-MM-DD). */
+  startDate: string
+  /** Inclusive latest end_date admitted — the valuation day (YYYY-MM-DD). */
+  endDate: string
+  /** Whole days spanned, inclusive of both ends. */
+  spanDays: number
+  /** Whether the count floor widened the window past the base window. */
+  extended: boolean
+}
+
+export type PollWindowResult =
+  | { ok: true; window: PollWindow }
+  | { ok: false; reason: string }
+
+export type PollAveragePointResult =
+  | { ok: true; price: number; window: PollWindow }
+  | { ok: false; reason: string }
+
+/**
+ * A poll is usable if it reports a percentage that could be a percentage.
+ *
+ * The provider response is cast rather than schema-validated, so a data-entry
+ * error arrives as an ordinary number. One pct of 460 against ~20 polls near
+ * 40 moves the mean by ~20 points, which lands inside a feed's plausibility
+ * bounds and would price live positions.
+ */
+export const isUsablePoll = (poll: AveragePoll): boolean =>
+  poll != null &&
+  parseDay(poll.endDate) != null &&
+  typeof poll.pct === 'number' &&
+  Number.isFinite(poll.pct) &&
+  poll.pct >= 0 &&
+  poll.pct <= 100
+
+/**
+ * One day of a VoteHub published-average series: an object keyed by answer
+ * (`approve`, `disapprove`, `dem`, `rep`, `favorable`, `unfavorable`, ...),
+ * each carrying that answer's time-weighted `average`.
+ *
+ * Typed loosely on purpose: this is an external payload, so every field is
+ * treated as absent-or-wrong until checked rather than trusted through a
+ * cast.
+ */
+export type PublishedAverageEntry = Record<
+  string,
+  { average?: number } | null | undefined
+>
+
+/** VoteHub's published average series, keyed by ISO day. */
+export type PublishedAverageSeries = Record<
+  string,
+  PublishedAverageEntry | null | undefined
+>
+
+export type PublishedAverageResult =
+  | { ok: true; price: number; asOfDay: string; ageDays: number }
+  | { ok: false; reason: string }
+
+/**
+ * The usable average under `answerKey` for one day, or null.
+ *
+ * A percentage of exactly 0 or 100 is not a real polling average; it is the
+ * shape a cleared or defaulted field takes. Rejecting it here also keeps a
+ * literal 0 — which validateBasicOraclePoint would refuse anyway — from ever
+ * reaching the price path.
+ */
+export const readPublishedAverageValue = (
+  entry: PublishedAverageEntry | null | undefined,
+  answerKey: string
+): number | null => {
+  if (entry == null || typeof entry !== 'object') return null
+  const average = entry[answerKey]?.average
+  if (
+    typeof average !== 'number' ||
+    !Number.isFinite(average) ||
+    average <= 0 ||
+    average >= 100
+  )
+    return null
+  return average
+}
+
+/**
+ * Read the most recent published average at or before `day`.
+ *
+ * Takes the latest available entry rather than requiring one stamped `day`,
+ * because the provider posts a same-day value at an hour we do not control and
+ * a missing entry early in the morning is routine, not a fault. Age is then
+ * checked explicitly — see `maxSourceAgeDays` — so "slightly behind" and
+ * "stopped updating" get different answers.
+ */
+export const readPublishedAverage = (
+  series: PublishedAverageSeries | null | undefined,
+  day: string,
+  options: { answerKey: string; maxAgeDays: number }
+): PublishedAverageResult => {
+  const { answerKey, maxAgeDays } = options
+
+  if (parseDay(day) == null)
+    return { ok: false, reason: `invalid valuation day ${day}` }
+  if (typeof answerKey !== 'string' || answerKey.length === 0)
+    return { ok: false, reason: `invalid answer key ${answerKey}` }
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays < 0)
+    return { ok: false, reason: `invalid maxAgeDays ${maxAgeDays}` }
+  if (series == null || typeof series !== 'object')
+    return { ok: false, reason: 'published average series is missing' }
+
+  let best: { asOfDay: string; price: number } | null = null
+  for (const [key, entry] of Object.entries(series)) {
+    if (parseDay(key) == null || key > day) continue
+    const average = readPublishedAverageValue(entry, answerKey)
+    if (average == null) continue
+    if (!best || key > best.asOfDay) best = { asOfDay: key, price: average }
+  }
+
+  if (!best)
+    return {
+      ok: false,
+      reason: `no usable published \`${answerKey}\` average on or before ${day}`,
+    }
+
+  const ageDays = daysBetween(best.asOfDay, day)
+  if (ageDays == null)
+    return { ok: false, reason: `could not measure age of ${best.asOfDay}` }
+  if (ageDays > maxAgeDays)
+    return {
+      ok: false,
+      reason: `published average is ${ageDays} days stale (as of ${best.asOfDay}, max ${maxAgeDays})`,
+    }
+
+  return { ok: true, price: best.price, asOfDay: best.asOfDay, ageDays }
+}
+
+/**
+ * Every usable day of the published series, oldest first.
+ *
+ * Shares its validity rules with readPublishedAverage so a backfill and the
+ * live job cannot disagree about which entries are real.
+ */
+export const readPublishedSeries = (
+  series: PublishedAverageSeries | null | undefined,
+  options: { answerKey: string }
+): { day: string; price: number }[] => {
+  const { answerKey } = options
+  if (series == null || typeof series !== 'object') return []
+  if (typeof answerKey !== 'string' || answerKey.length === 0) return []
+  return Object.entries(series)
+    .flatMap(([key, entry]) => {
+      if (parseDay(key) == null) return []
+      const average = readPublishedAverageValue(entry, answerKey)
+      if (average == null) return []
+      return [{ day: key, price: average }]
+    })
+    .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0))
+}
+
+/**
+ * Absolute distance between the published average and our own computation,
+ * or null when either side is unusable — which is "no opinion", not "agrees".
+ */
+export const getCrossCheckGap = (
+  published: number,
+  reference: number
+): number | null => {
+  if (!Number.isFinite(published) || !Number.isFinite(reference)) return null
+  const gap = Math.abs(published - reference)
+  return Number.isFinite(gap) ? gap : null
+}
+
+/** One row of a provider's answer array, before any validation. */
+export type PollAnswer = { choice: string; pct: number }
+
+/**
+ * Find the answer row for `choice`. Case-insensitive, as the original Trump
+ * reader was for "Approve": VoteHub's casing is stable in practice but it is
+ * not a contract, and the alternative — a silent empty canary — is worse
+ * than admitting `APPROVE`.
+ */
+const findAnswer = (
+  answers: readonly PollAnswer[] | undefined,
+  choice: string
+) =>
+  Array.isArray(answers) && typeof choice === 'string'
+    ? answers.find(
+        (answer) =>
+          typeof answer?.choice === 'string' &&
+          answer.choice.toLowerCase() === choice.toLowerCase()
+      )
+    : undefined
+
+/**
+ * Whether the provider offered a row for `choice` at all.
+ *
+ * Separate from reading it, so a caller can tell "this poll asks a different
+ * question" (ordinary, silent) from "this poll answers our question with a
+ * number that cannot be a percentage" (a data error worth alerting on).
+ */
+export const hasAnswer = (
+  answers: readonly PollAnswer[] | undefined,
+  choice: string
+): boolean => findAnswer(answers, choice) != null
+
+/**
+ * Read the percentage for `choice`, or null when it is absent or unusable.
+ *
+ * Lives here rather than in the backend adapter because it is the point where
+ * provider data becomes oracle input, and the repo has no test runner under
+ * backend/shared to pin that behaviour.
+ */
+export const readAnswerPct = (
+  answers: readonly PollAnswer[] | undefined,
+  choice: string
+): number | null => {
+  const answer = findAnswer(answers, choice)
+  if (!answer || typeof answer.pct !== 'number') return null
+  if (!Number.isFinite(answer.pct) || answer.pct < 0 || answer.pct > 100)
+    return null
+  return answer.pct
+}
+
+/** How the canary chooses the polls that price a day. */
+export type PollWindowRules = {
+  /** Trailing window, in whole days, that the canary averages over. */
+  windowDays: number
+  /** Minimum polls the window must contain before it may be only windowDays wide. */
+  minPolls: number
+  /** Hard cap on how far the window may reach back to satisfy the floor. */
+  maxWindowDays: number
+}
+
+/** Everything a VoteHub feed needs beyond its identity. */
+export type VoteHubAverageRules = PollWindowRules & {
+  /** How stale VoteHub's own latest datapoint may be before we stop publishing. */
+  maxSourceAgeDays: number
+  /** How far the canary may sit from the published value before we refuse. */
+  maxCrossCheckGap: number
+  /** Re-stamp an unchanged value after this long (see daily-feed-publish). */
+  heartbeatMs: number
+}
+
+/**
+ * Choose the polls that price `day`.
+ *
+ * The base window is the `windowDays` days ending on `day`. If that holds at
+ * least `minPolls` polls it is used unchanged. Otherwise the window widens to
+ * the end_date of the Nth most recent poll.
+ *
+ * That cut is taken by DATE and is tie-inclusive: every poll sharing the
+ * cut-off end_date is admitted, so the result never depends on the input
+ * order. Picking "the first N after sorting" would let two polls that ended
+ * the same day be separated by nothing but array position — the same
+ * order-dependence normalizeOraclePointBatch refuses to tolerate when
+ * publishing points, and it matters more here because a tie at the boundary
+ * is the common case (five Trump polls ended 2026-07-27).
+ *
+ * Because the widened cut is defined by rank rather than by age, it does not
+ * move as `day` advances. A drought therefore reselects exactly the same
+ * polls tomorrow, and the canary does not move until a poll actually arrives.
+ */
+export const selectPollWindow = (
+  polls: readonly AveragePoll[],
+  day: string,
+  rules: PollWindowRules
+): PollWindowResult => {
+  const { windowDays, minPolls, maxWindowDays } = rules
+
+  if (parseDay(day) == null)
+    return { ok: false, reason: `invalid valuation day ${day}` }
+  if (!Number.isFinite(windowDays) || windowDays < 1)
+    return { ok: false, reason: `invalid windowDays ${windowDays}` }
+  if (!Number.isFinite(minPolls) || minPolls < 1)
+    return { ok: false, reason: `invalid minPolls ${minPolls}` }
+  if (!Number.isFinite(maxWindowDays) || maxWindowDays < windowDays)
+    return { ok: false, reason: `invalid maxWindowDays ${maxWindowDays}` }
+
+  // A poll that ends after the valuation day cannot inform it. This also
+  // keeps a provider's future-dated row out of a backfilled day.
+  const eligible = polls
+    .filter((poll) => isUsablePoll(poll) && poll.endDate <= day)
+    .sort((a, b) =>
+      a.endDate < b.endDate ? 1 : a.endDate > b.endDate ? -1 : 0
+    )
+
+  if (eligible.length === 0)
+    return { ok: false, reason: `no usable polls on or before ${day}` }
+
+  const baseStart = shiftDay(day, -(windowDays - 1))
+  const floorStart = shiftDay(day, -(maxWindowDays - 1))
+  if (baseStart == null || floorStart == null)
+    return { ok: false, reason: `could not derive window bounds for ${day}` }
+
+  const inBase = eligible.filter((poll) => poll.endDate >= baseStart)
+
+  let startDate = baseStart
+  let extended = false
+  if (inBase.length < minPolls) {
+    // eligible is sorted newest-first, so index minPolls-1 is the Nth most
+    // recent poll. With fewer than N polls in total, reach as far as the data
+    // goes and let the count check below decide whether that is publishable.
+    const cut =
+      eligible.length >= minPolls
+        ? eligible[minPolls - 1].endDate
+        : eligible[eligible.length - 1].endDate
+    // Never narrower than the base window: the floor may only widen.
+    if (cut < baseStart) {
+      startDate = cut
+      extended = true
+    }
+  }
+
+  if (startDate < floorStart)
+    return {
+      ok: false,
+      reason:
+        `only ${
+          eligible.filter((p) => p.endDate >= floorStart).length
+        } polls ` + `within ${maxWindowDays} days of ${day}, need ${minPolls}`,
+    }
+
+  const selected = eligible.filter((poll) => poll.endDate >= startDate)
+  // Unconditional, NOT gated on `extended`. When the base window already
+  // covers every poll we hold, no widening happens and `extended` stays
+  // false — so gating here would wave a three-poll average straight through
+  // the floor that is the entire point of this function.
+  if (selected.length < minPolls)
+    return {
+      ok: false,
+      reason: `only ${selected.length} polls available on or before ${day}, need ${minPolls}`,
+    }
+
+  const spanDays = daysBetween(startDate, day)
+  if (spanDays == null)
+    return { ok: false, reason: `could not measure window span for ${day}` }
+
+  return {
+    ok: true,
+    window: {
+      polls: selected,
+      startDate,
+      endDate: day,
+      spanDays: spanDays + 1,
+      extended,
+    },
+  }
+}
+
+/** Unweighted mean of the tracked pct. Null rather than NaN on an empty set. */
+export const averagePollPct = (polls: readonly AveragePoll[]): number | null => {
+  const usable = polls.filter(isUsablePoll)
+  if (usable.length === 0) return null
+  const mean = usable.reduce((sum, poll) => sum + poll.pct, 0) / usable.length
+  return Number.isFinite(mean) ? mean : null
+}
+
+/** Select the window for `day` and average it — the canary value. */
+export const computePollAveragePoint = (
+  polls: readonly AveragePoll[],
+  day: string,
+  rules: PollWindowRules
+): PollAveragePointResult => {
+  const selection = selectPollWindow(polls, day, rules)
+  if (!selection.ok) return selection
+
+  const price = averagePollPct(selection.window.polls)
+  if (price == null)
+    return { ok: false, reason: `could not average the window for ${day}` }
+
+  return { ok: true, price, window: selection.window }
+}

--- a/perps-launch-runbook.md
+++ b/perps-launch-runbook.md
@@ -165,11 +165,12 @@ Keep that redesign separate from the capped day-one launch.
    Before creating a market on `crypto-fear-greed`, read the terms section of
    https://alternative.me/crypto/fear-and-greed-index/ and record it in
    `common/src/perps/oracle-attribution.ts`; the entry says why.
-   `openrouter-chinese-lab-share` is registered but creation-disabled and
-   listed in `PERP_LAUNCH_PENDING_MARKETS` until `nex-agi` is placed in
-   `CHINESE_LAB_AUTHORS` or `KNOWN_NON_CHINESE_AUTHORS`; its backfill aborts
-   until then. Promote it in one commit (author line, registry flag, manifest
-   move) and rerun `getPerpLaunchManifestErrors()`.
+   Before the Chinese-lab backfill, open `/admin/model-classifications` and
+   clear every ranked lab-classification row. The audited seed covers the
+   launch history; future authors/models are discovered into this DB-backed
+   queue. If the zero-tolerance backfill finds a delisted historical subject,
+   it aborts without inserts, adds that subject to the same queue, and succeeds
+   after the verdict is recorded and the script is rerun.
 5. Review and settle/retire out-of-manifest or legacy prototypes. This changes
    balances; record the intended final oracle point and affected positions
    before executing it.

--- a/perps-launch-runbook.md
+++ b/perps-launch-runbook.md
@@ -275,7 +275,11 @@ For an incident:
 
 2. Unlist affected markets.
 3. If the oracle is merely stale, restore it and let users close. Do not publish
-   an invented point to make the warning disappear.
+   an invented point to make the warning disappear. The slow feeds have manual
+   escape hatches that publish the source's CURRENT value stamped now
+   (`publish-trump-approval-now`, `publish-votehub-now --feed=<feedId>`,
+   `publish-fear-greed-now`, each with `--force` to bypass the unchanged gate);
+   they never backdate.
 4. If a still-fresh cached point is known corrupt, use `halted` before
    investigating; unlisting alone does not block a direct API close. Preserve
    immutable history and resolve only against a validated published point.

--- a/perps-launch-runbook.md
+++ b/perps-launch-runbook.md
@@ -165,6 +165,11 @@ Keep that redesign separate from the capped day-one launch.
    Before creating a market on `crypto-fear-greed`, read the terms section of
    https://alternative.me/crypto/fear-and-greed-index/ and record it in
    `common/src/perps/oracle-attribution.ts`; the entry says why.
+   `openrouter-chinese-lab-share` is registered but creation-disabled and
+   listed in `PERP_LAUNCH_PENDING_MARKETS` until `nex-agi` is placed in
+   `CHINESE_LAB_AUTHORS` or `KNOWN_NON_CHINESE_AUTHORS`; its backfill aborts
+   until then. Promote it in one commit (author line, registry flag, manifest
+   move) and rerun `getPerpLaunchManifestErrors()`.
 5. Review and settle/retire out-of-manifest or legacy prototypes. This changes
    balances; record the intended final oracle point and affected positions
    before executing it.

--- a/perps-launch-runbook.md
+++ b/perps-launch-runbook.md
@@ -2,10 +2,13 @@
 
 This is the operational source of truth for the first public PERP rollout.
 `backend/shared/src/perps/launch-manifest.ts` is the executable source of truth
-for the seven intended feeds and their conservative day-one settings (BTC, the
-four xStocks tokenized equities, Trump approval, and OpenRouter open-weight
-share). It is executable on purpose: run `getPerpLaunchManifestErrors()` rather
-than trusting this count, which has drifted before.
+for the intended feeds and their conservative day-one settings: BTC, the four
+xStocks tokenized equities, the three VoteHub averages (Trump approval, the
+Democratic share of the 2026 generic ballot, JD Vance favorability), the
+Alternative.me Crypto Fear & Greed index, and the three OpenRouter token-share
+indexes (open-weight, Anthropic, Chinese labs). It is executable on purpose:
+run `getPerpLaunchManifestErrors()` rather than trusting a count here, which
+has drifted before.
 
 Current DEV state (2026-07-28): all six July PERP follow-up migrations are
 installed and their schema/immutability checks pass; do not rerun them. Exactly
@@ -70,12 +73,15 @@ fee. A trader can observe a public source before Manifold ingests it, trade
 against the old cached value, and exit after the update. Funding does not
 protect the pools when the trader is flat at the funding timestamp.
 
-| Feed                           | Day-one game design                           | Execution risk                                                                               |
-| ------------------------------ | --------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| BTC/USD                        | Best fit: continuous and genuinely two-sided  | Exchange prices can lead the 5-second poll                                                   |
-| xStocks (SPYx/QQQx/GLDx/NVDAx) | Equity/commodity exposure, two-sided          | Pools can lead the 2-second poll; liquidity far thinner than BTC                             |
-| Trump approval                 | Coherent politics theses, but slow            | Public daily step plus known scheduler timing                                                |
-| OpenRouter open-weight share   | Two-sided index with coherent adoption theses | Upstream exposes complete UTC days, so hourly writes usually repeat a predictable daily step |
+| Feed                           | Day-one game design                             | Execution risk                                                                               |
+| ------------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| BTC/USD                        | Best fit: continuous and genuinely two-sided    | Exchange prices can lead the 5-second poll                                                   |
+| xStocks (SPYx/QQQx/GLDx/NVDAx) | Equity/commodity exposure, two-sided            | Pools can lead the 2-second poll; liquidity far thinner than BTC                             |
+| Trump approval                 | Coherent politics theses, but slow              | Public daily step plus known scheduler timing                                                |
+| VoteHub generic ballot / Vance | Same shape as Trump approval; Vance is thinner  | Same 5-minute poll against VoteHub's max-age=300 cache; fewer, larger steps for Vance        |
+| Crypto Fear & Greed            | Mean-reverting sentiment gauge, two-sided       | New daily value is public at ~00:00 UTC; exposure bounded by the 5-minute poll               |
+| OpenRouter open-weight share   | Two-sided index with coherent adoption theses   | Upstream exposes complete UTC days, so hourly writes usually repeat a predictable daily step |
+| OpenRouter Anthropic / CN labs | Two-sided proxies for third-party-routed demand | Same payload and same daily step as the open-weight share                                    |
 
 ### xStocks on-chain sources (ongoing, post-launch)
 
@@ -148,9 +154,17 @@ Keep that redesign separate from the capped day-one launch.
    scheduler. Configure the API runtime with `PERP_TRADING_MODE=enabled` and
    verify OpenRouter writes a point with provider `source_ts`.
 3. Provision `OPENROUTER_API_KEY` in the target environment.
-4. Run the BTC, xStocks, Trump, and OpenRouter oracle backfills if history is
-   absent. (The UK carbon feed and its backfill script were removed when that
-   market was sunset on 2026-08-10.)
+4. Run the oracle backfills for any launch feed whose history is absent: BTC,
+   xStocks, Trump (`backfill-trump-approval-oracle`), the other VoteHub feeds
+   (`backfill-votehub-oracle --feed=<feedId>`, after confirming the spec's
+   average and answer keys with `list-votehub-averages`), Fear & Greed
+   (`backfill-fear-greed-oracle`), and each OpenRouter index
+   (`backfill-openrouter-oracle [--feed=<feedId>]`). Backfills are for feeds
+   with no live market only. (The UK carbon feed and its backfill script were
+   removed when that market was sunset on 2026-08-10.)
+   Before creating a market on `crypto-fear-greed`, read the terms section of
+   https://alternative.me/crypto/fear-and-greed-index/ and record it in
+   `common/src/perps/oracle-attribution.ts`; the entry says why.
 5. Review and settle/retire out-of-manifest or legacy prototypes. This changes
    balances; record the intended final oracle point and affected positions
    before executing it.
@@ -158,7 +172,8 @@ Keep that redesign separate from the capped day-one launch.
    warning must be understood.
 7. Verify GCP alert policies and deliver a test incident:
    - ERROR presence for `[oracle-feeds]`, `[update-perps]`, `[openrouter]`,
-     `[trump-approval]`, and scheduler `Error during job execution`.
+     `[trump-approval]`, `[votehub]`, `[fear-greed]`, and scheduler
+     `Error during job execution`.
    - Absence/dead-man alerts for `update-oracle-feeds` within two minutes and
      `update-perps` within two hours.
    - Route both policies to a channel with a real on-call owner.

--- a/web/components/nav/sidebar.tsx
+++ b/web/components/nav/sidebar.tsx
@@ -383,6 +383,11 @@ const getDesktopNav = (
         name: 'Reports',
         href: '/reports',
         icon: ReportsIcon,
+      },
+      options.isAdminOrMod && {
+        name: 'AI classifications',
+        href: '/admin/model-classifications',
+        icon: SparklesIcon,
       }
     )
 
@@ -451,6 +456,11 @@ const getMobileNav = (
       name: 'Reports',
       href: '/reports',
       icon: ReportsIcon,
+    },
+    isAdminOrMod && {
+      name: 'AI classifications',
+      href: '/admin/model-classifications',
+      icon: SparklesIcon,
     },
     // Show shop when enabled OR for admins (testing). On mobile we omit the
     // "$10k prize" pill because the Prize Drawing tab above already advertises

--- a/web/pages/admin/index.tsx
+++ b/web/pages/admin/index.tsx
@@ -92,6 +92,10 @@ export default function AdminPage() {
         />
         <LabCard title="⚽ sports markets" href="/admin/sports" />
         <LabCard title="📈 create perp market" href="/admin/create-perp" />
+        <LabCard
+          title="🧭 OpenRouter classifications"
+          href="/admin/model-classifications"
+        />
         <LabCard title="🤬 reports" href="/admin/reports" />
         <LabCard title="👕 merch management" href="/admin/merch" />
         <LabCard title="🎨 design system" href="/styles" />
@@ -133,13 +137,5 @@ export default function AdminPage() {
         </Row>
       </div>
     </Page>
-  )
-}
-
-const Badge = (props: { src: string; href: string }) => {
-  return (
-    <a href={props.href}>
-      <img src={props.src} alt="" />
-    </a>
   )
 }

--- a/web/pages/admin/model-classifications.tsx
+++ b/web/pages/admin/model-classifications.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { toast } from 'react-hot-toast'
 import clsx from 'clsx'
+import type { APIResponse } from 'common/api/schema'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
 import { Page } from 'web/components/layout/page'
@@ -8,7 +9,7 @@ import { Row } from 'web/components/layout/row'
 import { NoSEO } from 'web/components/NoSEO'
 import { Input } from 'web/components/widgets/input'
 import { Title } from 'web/components/widgets/title'
-import { useAdmin } from 'web/hooks/use-admin'
+import { useAdmin, useAdminOrMod } from 'web/hooks/use-admin'
 import { useAPIGetter } from 'web/hooks/use-api-getter'
 import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
 import { api } from 'web/lib/api/api'
@@ -23,13 +24,27 @@ import { api } from 'web/lib/api/api'
 export default function AdminModelClassificationsPage() {
   useRedirectIfSignedOut()
   const isAdmin = useAdmin()
-  const { data, refresh } = useAPIGetter('get-model-classifications', {})
+  const isAdminOrMod = useAdminOrMod()
+  const { data, refresh } = useAPIGetter(
+    'get-model-classifications',
+    {},
+    undefined,
+    undefined,
+    isAdmin
+  )
+  const { data: labData, refresh: refreshLabData } = useAPIGetter(
+    'get-openrouter-lab-classifications',
+    {},
+    undefined,
+    undefined,
+    isAdminOrMod
+  )
 
-  if (!isAdmin)
+  if (!isAdminOrMod)
     return (
       <Page trackPageView={false}>
         <NoSEO />
-        <Title>Admin only</Title>
+        <Title>Mods and admins only</Title>
       </Page>
     )
 
@@ -44,80 +59,417 @@ export default function AdminModelClassificationsPage() {
     <Page trackPageView={false}>
       <NoSEO />
       <Col className="mx-auto w-full max-w-4xl gap-4 p-4">
-        <Title>Model classifications</Title>
+        <Title>OpenRouter classifications</Title>
 
-        <Col className="bg-canvas-50 gap-1 rounded p-3 text-sm">
-          <div className="text-ink-700">
-            The open-weight index scores OpenRouter's top 50 on one test:{' '}
-            <b>are the weights publicly downloadable?</b> Downloadable is open;
-            API-only is closed. Unknown models are excluded from both sides of
-            the index, so a wrong call here moves a market people trade.
-          </div>
-          <div className="text-ink-500">
-            Seed list version {data?.seedVersion ?? '—'} · grace window{' '}
-            {data ? Math.round(data.graceWindowMs / 3_600_000) : '—'}h
-          </div>
-        </Col>
+        <LabClassificationSection data={labData} onDone={refreshLabData} />
 
-        {expired.length > 0 && (
-          <div className="bg-scarlet-100 text-scarlet-700 rounded p-3 text-sm">
-            <b>{expired.length} past the grace window.</b> The index is halting
-            on these right now — the feed is not publishing until they are
-            classified.
-          </div>
-        )}
-
-        <Col className="gap-2">
-          <div className="text-ink-700 font-semibold">
-            In the index right now ({ranked.length})
-          </div>
-          {ranked.length === 0 && (
-            <div className="text-ink-500 text-sm">
-              Nothing unclassified is currently ranked — the index is scoring a
-              complete denominator.
+        {isAdmin && (
+          <Col className="gap-4 border-t pt-6">
+            <div className="text-ink-800 text-lg font-semibold">
+              Open-weight models
             </div>
-          )}
-          {ranked.map((model) => (
-            <PendingRow key={model.permaslug} model={model} onDone={refresh} />
-          ))}
-        </Col>
 
-        {backlog.length > 0 && (
-          <Col className="gap-2 pt-2">
-            <div className="text-ink-700 font-semibold">
-              Not yet ranked ({backlog.length})
-            </div>
-            <div className="text-ink-500 text-sm">
-              In OpenRouter's catalog but outside the top 50, so they are not
-              affecting the index. Classifying them ahead of time is what stops
-              the next one becoming an outage.
-            </div>
-            {backlog.map((model) => (
-              <PendingRow
-                key={model.permaslug}
-                model={model}
-                onDone={refresh}
-              />
-            ))}
-          </Col>
-        )}
+            <Col className="bg-canvas-50 gap-1 rounded p-3 text-sm">
+              <div className="text-ink-700">
+                The open-weight index scores OpenRouter's top 50 on one test:{' '}
+                <b>are the weights publicly downloadable?</b> Downloadable is
+                open; API-only is closed. Unknown models are excluded from both
+                sides of the index, so a wrong call here moves a market people
+                trade.
+              </div>
+              <div className="text-ink-500">
+                Seed list version {data?.seedVersion ?? '—'} · grace window{' '}
+                {data ? Math.round(data.graceWindowMs / 3_600_000) : '—'}h
+              </div>
+            </Col>
 
-        {!!data?.recent.length && (
-          <Col className="gap-1 pt-4">
-            <div className="text-ink-700 font-semibold">Recently decided</div>
-            <div className="text-ink-500 text-xs">
-              A verdict can go stale without anything here changing: a publisher
-              may ship weights after launch, which the methodology treats as a
-              reclassification from the release date forward. The nightly audit
-              flags those, so these stay editable.
-            </div>
-            {data.recent.map((r) => (
-              <DecidedRow key={r.permaslug} model={r} onDone={refresh} />
-            ))}
+            {expired.length > 0 && (
+              <div className="bg-scarlet-100 text-scarlet-700 rounded p-3 text-sm">
+                <b>{expired.length} past the grace window.</b> The index is
+                halting on these right now — the feed is not publishing until
+                they are classified.
+              </div>
+            )}
+
+            <Col className="gap-2">
+              <div className="text-ink-700 font-semibold">
+                In the index right now ({ranked.length})
+              </div>
+              {ranked.length === 0 && (
+                <div className="text-ink-500 text-sm">
+                  Nothing unclassified is currently ranked — the index is
+                  scoring a complete denominator.
+                </div>
+              )}
+              {ranked.map((model) => (
+                <PendingRow
+                  key={model.permaslug}
+                  model={model}
+                  onDone={refresh}
+                />
+              ))}
+            </Col>
+
+            {backlog.length > 0 && (
+              <Col className="gap-2 pt-2">
+                <div className="text-ink-700 font-semibold">
+                  Not yet ranked ({backlog.length})
+                </div>
+                <div className="text-ink-500 text-sm">
+                  In OpenRouter's catalog but outside the top 50, so they are
+                  not affecting the index. Classifying them ahead of time is
+                  what stops the next one becoming an outage.
+                </div>
+                {backlog.map((model) => (
+                  <PendingRow
+                    key={model.permaslug}
+                    model={model}
+                    onDone={refresh}
+                  />
+                ))}
+              </Col>
+            )}
+
+            {!!data?.recent.length && (
+              <Col className="gap-1 pt-4">
+                <div className="text-ink-700 font-semibold">
+                  Recently decided
+                </div>
+                <div className="text-ink-500 text-xs">
+                  A verdict can go stale without anything here changing: a
+                  publisher may ship weights after launch, which the methodology
+                  treats as a reclassification from the release date forward.
+                  The nightly audit flags those, so these stay editable.
+                </div>
+                {data.recent.map((r) => (
+                  <DecidedRow key={r.permaslug} model={r} onDone={refresh} />
+                ))}
+              </Col>
+            )}
           </Col>
         )}
       </Col>
     </Page>
+  )
+}
+
+type LabClassificationData = APIResponse<'get-openrouter-lab-classifications'>
+type PendingLabClassification = LabClassificationData['pending'][number]
+type DecidedLabClassification = LabClassificationData['decided'][number]
+type LabClassificationDisplay = PendingLabClassification &
+  Partial<
+    Pick<
+      DecidedLabClassification,
+      | 'isChinese'
+      | 'evidence'
+      | 'sourceUrl'
+      | 'source'
+      | 'classifiedAt'
+      | 'classifiedBy'
+    >
+  >
+
+function LabClassificationSection(props: {
+  data: LabClassificationData | undefined
+  onDone: () => void
+}) {
+  const { data, onDone } = props
+  const pending = data?.pending ?? []
+  const ranked = pending.filter((row) => row.firstRankedAt !== null)
+  const backlog = pending.filter((row) => row.firstRankedAt === null)
+
+  return (
+    <Col className="gap-4">
+      <div>
+        <div className="text-ink-800 text-lg font-semibold">
+          Chinese-lab publishers
+        </div>
+        <div className="text-ink-600 text-sm">
+          Classify where an OpenRouter publisher is headquartered. Normal labs
+          are decided once by author; anonymous or shared namespaces use an
+          exact-model decision. Every verdict needs a short evidence summary and
+          a public source.
+        </div>
+        <div className="text-ink-400 mt-1 text-xs">
+          Audited seed version {data?.seedVersion ?? '—'} · database decisions
+          take effect on the next hourly feed run without a deploy.
+        </div>
+      </div>
+
+      {!data ? (
+        <div className="text-ink-500 text-sm">
+          Loading classification queue…
+        </div>
+      ) : (
+        <>
+          <Col className="gap-2">
+            <div className="text-ink-700 font-semibold">
+              Ranked or backfill-blocking ({ranked.length})
+            </div>
+            {ranked.length === 0 && (
+              <div className="text-ink-500 text-sm">
+                No ranked or historical publisher is waiting for a decision.
+              </div>
+            )}
+            {ranked.map((row) => (
+              <LabClassificationRow
+                key={`${row.subjectType}:${row.subjectSlug}`}
+                row={row}
+                ranked
+                onDone={onDone}
+              />
+            ))}
+          </Col>
+
+          {backlog.length > 0 && (
+            <Col className="gap-2">
+              <div className="text-ink-700 font-semibold">
+                Catalog backlog ({backlog.length})
+              </div>
+              <div className="text-ink-500 text-sm">
+                These are not in the ranked window yet. Deciding them now
+                prevents a future launch from becoming an alert or feed pause.
+              </div>
+              {backlog.map((row) => (
+                <LabClassificationRow
+                  key={`${row.subjectType}:${row.subjectSlug}`}
+                  row={row}
+                  onDone={onDone}
+                />
+              ))}
+            </Col>
+          )}
+
+          {data.decided.length > 0 && (
+            <Col className="gap-2 pt-2">
+              <div className="text-ink-700 font-semibold">
+                Database decisions ({data.decided.length})
+              </div>
+              <div className="text-ink-500 text-xs">
+                Seed entries remain code-reviewed. These newer decisions can be
+                corrected here, with the prior verdict retained in database
+                history.
+              </div>
+              {data.decided.map((row) => (
+                <LabClassificationRow
+                  key={`${row.subjectType}:${row.subjectSlug}`}
+                  row={{
+                    ...row,
+                    discoveredVia: null,
+                    firstSeen: row.classifiedAt,
+                    firstRankedAt: null,
+                  }}
+                  onDone={onDone}
+                />
+              ))}
+            </Col>
+          )}
+        </>
+      )}
+    </Col>
+  )
+}
+
+function LabClassificationRow(props: {
+  row: LabClassificationDisplay
+  ranked?: boolean
+  onDone: () => void
+}) {
+  const { row, ranked = false, onDone } = props
+  const decided = row.isChinese !== undefined
+  const [editing, setEditing] = useState(!decided)
+  const [evidence, setEvidence] = useState(row.evidence ?? '')
+  const [sourceUrl, setSourceUrl] = useState(row.sourceUrl ?? '')
+  const [saving, setSaving] = useState(false)
+
+  const classify = async (isChinese: boolean) => {
+    if (!evidence.trim()) {
+      toast.error('Add a short headquarters evidence summary')
+      return
+    }
+    let url: URL
+    try {
+      url = new URL(sourceUrl.trim())
+    } catch {
+      toast.error('Add a valid public evidence URL')
+      return
+    }
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+      toast.error('Evidence URL must use http or https')
+      return
+    }
+
+    setSaving(true)
+    try {
+      await api('set-openrouter-lab-classification', {
+        subjectType: row.subjectType,
+        subjectSlug: row.subjectSlug,
+        isChinese,
+        evidence: evidence.trim(),
+        sourceUrl: url.toString(),
+      })
+      toast.success(
+        `${row.subjectSlug} → ${isChinese ? 'Chinese' : 'non-Chinese'}`
+      )
+      setEditing(false)
+      onDone()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const ageHours = Math.max(
+    0,
+    Math.floor((Date.now() - row.firstSeen) / 3_600_000)
+  )
+  const rankedAgeHours =
+    row.firstRankedAt === null
+      ? null
+      : Math.max(0, Math.floor((Date.now() - row.firstRankedAt) / 3_600_000))
+  const decisionChanged =
+    evidence.trim() !== (row.evidence ?? '') ||
+    sourceUrl.trim() !== (row.sourceUrl ?? '')
+
+  return (
+    <Col
+      className={clsx(
+        'gap-2 rounded border p-3',
+        ranked ? 'border-amber-400' : 'border-ink-200'
+      )}
+    >
+      <Row className="flex-wrap items-baseline gap-2">
+        {decided && (
+          <span
+            className={row.isChinese ? 'text-scarlet-600' : 'text-teal-600'}
+          >
+            {row.isChinese ? 'Chinese' : 'non-Chinese'}
+          </span>
+        )}
+        <span className="bg-canvas-100 text-ink-500 rounded px-1.5 py-0.5 text-xs">
+          {row.subjectType}
+        </span>
+        <span className="font-mono text-sm font-semibold">
+          {row.subjectSlug}
+        </span>
+        {!decided && (
+          <span className="text-ink-400 text-xs">
+            seen {ageHours}h ago
+            {rankedAgeHours === null
+              ? ''
+              : ` · ranked ${rankedAgeHours}h ago`}{' '}
+            · via {row.discoveredVia ?? 'unknown'}
+          </span>
+        )}
+        {decided && (
+          <button
+            className="text-primary-600 text-xs hover:underline"
+            onClick={() => setEditing((value) => !value)}
+          >
+            {editing ? 'cancel' : 'change'}
+          </button>
+        )}
+      </Row>
+
+      {(row.exampleModels.length > 0 || row.exampleNames.length > 0) && (
+        <div className="text-ink-500 text-xs">
+          {row.exampleModels.length > 0 && (
+            <>
+              Models:{' '}
+              <span className="font-mono">
+                {row.exampleModels.slice(0, 5).join(', ')}
+              </span>
+              {row.exampleModels.length > 5 &&
+                ` +${row.exampleModels.length - 5} more`}
+            </>
+          )}
+          {row.exampleNames.length > 0 && (
+            <div>
+              OpenRouter names: {row.exampleNames.slice(0, 5).join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+
+      {decided && !editing && (
+        <Col className="gap-0.5 text-xs">
+          <div className="text-ink-600">{row.evidence}</div>
+          {row.sourceUrl && (
+            <a
+              className="text-primary-600 w-fit hover:underline"
+              href={row.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Evidence source ↗
+            </a>
+          )}
+          <div className="text-ink-400">
+            via {row.source ?? 'unknown'}
+            {row.classifiedBy ? ` · by ${row.classifiedBy}` : ''}
+          </div>
+        </Col>
+      )}
+
+      {editing && (
+        <Col className="gap-2">
+          <Input
+            className="h-10 text-sm"
+            placeholder="Evidence summary, e.g. Company’s principal office is Shanghai"
+            value={evidence}
+            maxLength={2_000}
+            onChange={(event) => setEvidence(event.target.value)}
+          />
+          <Input
+            className="h-10 font-mono text-xs"
+            placeholder="https://public-source.example/company/about"
+            type="url"
+            value={sourceUrl}
+            maxLength={2_000}
+            onChange={(event) => setSourceUrl(event.target.value)}
+          />
+          {!!sourceUrl.trim() && (
+            <a
+              className="text-primary-600 w-fit text-xs hover:underline"
+              href={sourceUrl.trim()}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Check source ↗
+            </a>
+          )}
+          <Row className="flex-wrap gap-2">
+            <Button
+              size="xs"
+              color="red"
+              disabled={
+                saving ||
+                (row.isChinese === true && !decisionChanged) ||
+                !evidence.trim() ||
+                !sourceUrl.trim()
+              }
+              onClick={() => classify(true)}
+            >
+              Chinese-headquartered
+            </Button>
+            <Button
+              size="xs"
+              color="green"
+              disabled={
+                saving ||
+                (row.isChinese === false && !decisionChanged) ||
+                !evidence.trim() ||
+                !sourceUrl.trim()
+              }
+              onClick={() => classify(false)}
+            >
+              Non-Chinese
+            </Button>
+          </Row>
+        </Col>
+      )}
+    </Col>
   )
 }
 

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -128,6 +128,7 @@ const FEED_TICKERS: Record<string, string> = {
   'trump-approval-rating': 'TRUMP',
   'votehub-generic-ballot-2026': 'BALLOT',
   'vance-favorability': 'VANCE',
+  'crypto-fear-greed': 'FEAR',
   'openrouter-open-weight-share': 'OPENW',
   'spyx-usd': 'SPYx',
   'qqqx-usd': 'QQQx',

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -126,6 +126,8 @@ export async function getStaticProps() {
 const FEED_TICKERS: Record<string, string> = {
   'btc-usd': 'BTC',
   'trump-approval-rating': 'TRUMP',
+  'votehub-generic-ballot-2026': 'BALLOT',
+  'vance-favorability': 'VANCE',
   'openrouter-open-weight-share': 'OPENW',
   'spyx-usd': 'SPYx',
   'qqqx-usd': 'QQQx',
@@ -140,6 +142,8 @@ const tickerOf = (c: PerpContract) =>
 
 const PERCENT_FEEDS = new Set([
   'trump-approval-rating',
+  'votehub-generic-ballot-2026',
+  'vance-favorability',
   'openrouter-open-weight-share',
 ])
 

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -130,6 +130,8 @@ const FEED_TICKERS: Record<string, string> = {
   'vance-favorability': 'VANCE',
   'crypto-fear-greed': 'FEAR',
   'openrouter-open-weight-share': 'OPENW',
+  'openrouter-anthropic-share': 'ANTH',
+  'openrouter-chinese-lab-share': 'CNLAB',
   'spyx-usd': 'SPYx',
   'qqqx-usd': 'QQQx',
   'nvdax-usd': 'NVDAx',
@@ -146,6 +148,8 @@ const PERCENT_FEEDS = new Set([
   'votehub-generic-ballot-2026',
   'vance-favorability',
   'openrouter-open-weight-share',
+  'openrouter-anthropic-share',
+  'openrouter-chinese-lab-share',
 ])
 
 const displayPrice = (c: PerpContract) => {


### PR DESCRIPTION
Adds five oracle feeds for the PERP market type, end to end (adapter, registry, scheduler job, attribution, display metadata, launch manifest, backfill script, tests, docs). No markets are created; an admin does that through `/admin/create-perp`.

| Feed id | Value | Source | Job | Prefix |
| --- | --- | --- | --- | --- |
| `votehub-generic-ballot-2026` | Democratic share (%) of VoteHub's 2026 generic-ballot average | VoteHub `/averages/<key>/values` | `update-votehub-averages` (every 5 min, `:02/:07/…`) | `[votehub]` |
| `vance-favorability` | Favorable (%) from VoteHub's JD Vance favorability average | VoteHub | `update-votehub-averages` | `[votehub]` |
| `crypto-fear-greed` | Alternative.me Crypto Fear & Greed index (0–100 points) | `https://api.alternative.me/fng/` | `update-fear-greed` (every 5 min, `:03/:08/…`) | `[fear-greed]` |
| `openrouter-anthropic-share` | Anthropic share (%) of OpenRouter top-50 tokens, trailing 7 UTC days | same payload as open-weight | `update-openrouter-share` (unchanged hourly cron) | `[openrouter]` |
| `openrouter-chinese-lab-share` | Chinese labs' share (%) of the same tokens | same payload as open-weight | `update-openrouter-share` | `[openrouter]` |

## What changed

**Package A — VoteHub (commit `feat(perps): VoteHub generic-ballot and Vance favorability oracle feeds`).** The Trump pipeline is generalized underneath, not around: `common/src/perps/votehub-average.ts` carries the answer-key-parameterized series reader, the cross-check canary window, and the gap; `common/src/perps/daily-feed-publish.ts` carries the publish-on-change + 12h heartbeat rule; `common/src/perps/trump-approval.ts` keeps every export as a thin wrapper and **`trump-approval.test.ts` is byte-identical and passes**. The backend has a `VoteHubFeedSpec` table (`backend/shared/src/votehub-feeds.ts`), `publishVoteHubPoint` with the Trump publisher's exact observe → early-out → canary → advisory lock → re-decide → `validateOraclePoint` → `insertOraclePrices` → `applyOraclePointToLivePerps`-outside-the-transaction structure, a new `update-votehub-averages` job offset two minutes from the Trump job, and a shared throttled-WARN / stale-ERROR failure reporter (`daily-feed-failure.ts`) that the Trump job now also uses. The Trump feed keeps its id, job name, `[trump-approval]` prefix, cadence, constants and escalation threshold.

**Package B — Fear & Greed (commit `feat(perps): Crypto Fear & Greed oracle feed`).** Parser in `common/src/perps/fear-greed.ts` treats every field as untrusted (rejects `metadata.error`, non-integer or out-of-range `value`, unparseable `timestamp`, duplicates, shape drift; the whole payload, never a row). Adapter on the documented `/fng/` endpoint only. Publisher mirrors the VoteHub one (no canary; 3-day source-staleness gate). Registry bounds `[1, 100]`: a literal `0` print is refused by the positivity rule and the feed pauses at the stale gate instead of publishing a non-positive price (the index has never printed 0).

**Package C — OpenRouter lab shares (commit `feat(perps): OpenRouter Anthropic-share and Chinese-lab-share oracle feeds`, restructured by commit `Add database-backed OpenRouter lab classifier`).** `common/src/perps/lab-share.ts` reuses the open-weight window, denominator and `other`/composite exclusions; the unit of classification is the author segment of the permaslug, with exact-model overrides for namespaces that are not a company identity (anonymous `stealth/*` previews). Anthropic numerator is `author === 'anthropic'` and nothing else; cloaked `openrouter/*` slugs stay in the denominator. Chinese-lab classification is an audited seed (`CHINESE_LAB_AUTHORS`, `KNOWN_NON_CHINESE_AUTHORS`, `CHINESE_LAB_MODELS`) overlaid with operator verdicts from a new `openrouter_lab_classifications` table (migration `2026090401`), resolved on every hourly tick so a decision takes effect without a deploy. Seed entries always win at their own specificity; DB model rows are only accepted under seed-declared model-scoped namespaces (write- and read-validated). New authors and models are discovered into a review queue from both the nightly catalog sweep and live rankings, and adjudicated (mods and admins) at `/admin/model-classifications` with an evidence summary and a public source URL; prior verdicts are kept in the row's history. Unknown subjects are excluded from both sides, refuse publication with `log.error` above 1% of classified tokens, and publish with `log.warn` below it. `update-openrouter-share` publishes three feeds from ONE fetch, each independently; the open-weight computation and cron are unchanged; no new OpenRouter calls. `backfill-openrouter-oracle.ts --feed=<feedId>` defaults to the open-weight feed and queues any historical unknown subject before aborting.

**Docs:** README adapter/scheduler lists and alert prefixes; runbook feed list, latency table, backfill step, and step-7 prefixes.

**Review pass 1 (commit `fix(perps): harden the new feeds after adversarial review`).** A five-lens adversarial review confirmed five findings, all fixed: own-property author classification in `lab-share.ts`, own-property `--feed` lookup and the no-live-feed header in the OpenRouter backfill, a guarded list fetch in the discovery script, plus hardening from refuted-but-useful notes (hourly throttle for a never-published feed's ERROR, registry bounds and a Trump guard in the VoteHub backfill, a max-Date bound in the Fear & Greed parser, pinned bounds/settings in the spec-table test). The Trump refactor was confirmed behaviour-preserving function by function; the test file is byte-identical.

**Review pass 2 — Codex review, six findings (commit `fix(perps): source-freshness and source-regression guards; hold Chinese-lab feed pending`).** OpenRouter payloads whose newest complete day is more than `OPENROUTER_MAX_SOURCE_LAG_DAYS` (3) behind today are refused for all three indexes, and a regressed dataset `as_of` is refused; VoteHub points carry the VoteHub day as `source_ts` and the publisher refuses an earlier day's value under the advisory lock (Trump included; pre-existing null rows impose no bound); Fear & Greed has the same guard on the provider reading time; the OpenRouter backfill validates every historical point against its feed definition; the `other` row is required on every window date. The Chinese-lab feed was held pending at that point; the classifier restructure below supersedes that.

**Review pass 3 — Codex follow-up (commit `fix(perps): publish OpenRouter points under the feed's advisory lock; backfill guards`).** `publishOpenRouterPoint` reads, checks and inserts inside one transaction holding `advisoryLockQuery('oracle-publish:<feedId>')`; `openRouterSourceLagDays` round-trips dates; `backfill-guard.ts` makes the VoteHub, Fear & Greed and OpenRouter backfills refuse a feed that backs an unresolved market unless `--force` is passed.

**Classifier restructure (commit `Add database-backed OpenRouter lab classifier`, by the reviewer).** Replaces the constants-only maintenance path for the Chinese-lab feed with the seed-plus-database design described under Package C, places `nex-agi` (Shanghai), `dots-studio` (Xiaohongshu, Shanghai) and `thinkingmachines` (US) in the seed, attributes the revealed `stealth/ox-alpha` preview to Z.ai as an exact-model seed entry, re-enables market creation for the Chinese-lab feed and returns it to `PERP_LAUNCH_MARKETS` (the pending list is now empty; the mechanism stays).

## Verification (at the current head)

- `yarn typecheck` (web, api, scheduler), `yarn lint` (common, api, shared): green.
- `yarn --cwd=common test`: 40 suites / 846 tests; `yarn --cwd=backend/shared test`: 8 suites / 51 tests.
- `getPerpLaunchManifestErrors()` via a one-off ts-node call from `backend/scripts`: `[]` (12 launch feeds, 0 pending, 6 scheduler expectations).
- The backend scripts project typechecks for every new/changed script.

## ⚠️ Read before deploying or backfilling

- **Migration first.** `backend/supabase/migrations/2026090401_openrouter_lab_classifications.sql` must be applied before the scheduler and API carrying this branch are deployed. Without the table, every hourly tick logs `[openrouter] chinese-lab share failed` (the other two OpenRouter feeds and the catalog sweep are unaffected, each is guarded), and the Chinese-lab backfill throws.
- **No live checks were run from this branch's build environment** (its egress policy blocks `polling.votehub.com`, `votehub.com`, `api.alternative.me`, `alternative.me` and `openrouter.ai`). The Codex review reported live checks confirming the VoteHub shapes at `generic_ballot_2026` and `vance_favorability`, and that Alternative.me's API documentation and terms permit attributed commercial use; those are recorded in the code comments as second-hand, and the operator gates below stand until someone verifies from their own session.
  1. **VoteHub keys.** `GENERIC_BALLOT_2026_SPEC` assumes average key `generic_ballot_2026`, answer key `dem`, canary poll `poll_type=generic-ballot&subject=2026` with choice `Dem`; `VANCE_FAVORABILITY_SPEC` assumes `vance_favorability` / `favorable` / `poll_type=favorability&subject=JD Vance` / `Favorable`. Nothing guesses at runtime (a wrong average key is an HTTP 404 and nothing publishes; a wrong answer key reads "no usable published average" and nothing publishes; a wrong poll choice only blinds the canary). **Run `npx ts-node list-votehub-averages.ts` first.** If VoteHub publishes only a D−R margin for the generic ballot, do not launch that feed.
  2. **Alternative.me terms.** The attribution entry carries a credit and a link and no licence label. Before creating a market on `crypto-fear-greed`, read the terms section of https://alternative.me/crypto/fear-and-greed-index/, paste it verbatim into the comment in `common/src/perps/oracle-attribution.ts`, and set `licence`/`licenceUrl` only if the page names one.
  3. **Seed placements added by the restructure** (`nex-agi`, `dots-studio`, `thinkingmachines`, `stealth/ox-alpha`) carry a one-line evidence string but no source URL in code; they were researched by the reviewer with network access. Worth a second pair of eyes before the Chinese-lab backfill, since the seed is immutable through the admin queue.
- The Vance canary rules start from the Trump numbers; if the first backfill dry run shows the floor failing most days, widen `maxWindowDays` on that spec only.

## Operator checklist

**Backfills** (from `backend/scripts`; feeds with no live market only — history is append-only, and the scripts refuse a feed that backs an unresolved market unless `--force` is passed):

```
npx ts-node list-votehub-averages.ts                                   # confirm keys first
npx ts-node backfill-votehub-oracle.ts --feed=votehub-generic-ballot-2026
npx ts-node backfill-votehub-oracle.ts --feed=vance-favorability
npx ts-node backfill-fear-greed-oracle.ts
npx ts-node backfill-openrouter-oracle.ts --feed=openrouter-anthropic-share
npx ts-node backfill-openrouter-oracle.ts --feed=openrouter-chinese-lab-share   # after the migration; clear any queued row at /admin/model-classifications and rerun if it aborts
```

Manual publish during an incident: `publish-votehub-now.ts --feed=<feedId> [--force]`, `publish-fear-greed-now.ts [--force]`.

**Creating each market** (`/admin/create-perp`): sign in as the environment's official Manifold account (PROD: the house liquidity provider; DEV: the launch creator id in the manifest), pick the feed from the picker, click **Apply launch recommendation** (leverage 3; max oracle age 30h for the VoteHub and Fear & Greed feeds, 6h for the OpenRouter feeds; backing 5k/5k and 10k/10k respectively; required topic attached automatically), leave **unlisted**. Then `perp-launch-preflight.ts --phase=unlisted`.

**Chinese-lab classification queue** (`/admin/model-classifications`, mods and admins): ranked or backfill-blocking subjects first, catalog backlog second; every verdict needs an evidence summary and a public URL; seed entries are changed only in code.

**GCP alert policies** — add ERROR-presence conditions for the new prefixes: `[votehub]`, `[fear-greed]` (the lab-share feeds page under the existing `[openrouter]` policy; the catalog discovery logs under `[lab-classifier]`). Every ERROR line from the slow-feed jobs is prefixed and names the feed id.

**Scheduler job sets** (`SCHEDULER_JOBS`): `update-votehub-averages` and `update-fear-greed` are in `PERP_JOB_NAMES`, so they run on the **`perps`** instance (with `update-trump-approval`, `update-openrouter-share`, `update-perps`, `update-oracle-feeds`), or on `all` in single-instance mode. The lab-classification catalog discovery rides the existing `update-model-classifications` job on `main`. The `perps` set count check in `index.ts` is updated to 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRWKmikMaCwXKByhGu83di