### PR TITLE
feat(perps): partial closes, with the UI to use them

### DIFF
--- a/backend/api/src/close-perp-position.ts
+++ b/backend/api/src/close-perp-position.ts
@@ -1,10 +1,12 @@
+import { HOUR_MS } from 'common/util/time'
 import { closePosition } from 'shared/perps/engine'
 import { log } from 'shared/utils'
 import { APIHandler } from './helpers/endpoint'
 import { advancePerpBettingStreak } from './helpers/perp-streak'
 import { assertPerpCloseEnabled } from './helpers/perp-trading-mode'
+import { rateLimitByUser } from './helpers/rate-limit'
 
-export const closePerpPosition: APIHandler<'close-perp-position'> = async (
+const closePerpPositionInner: APIHandler<'close-perp-position'> = async (
   body,
   auth
 ) => {
@@ -15,6 +17,7 @@ export const closePerpPosition: APIHandler<'close-perp-position'> = async (
     idempotencyKey,
     expectedOpenedTime,
     fraction,
+    expectedSize,
   } = body
   const isApi = auth.creds.kind === 'key'
   const {
@@ -30,7 +33,8 @@ export const closePerpPosition: APIHandler<'close-perp-position'> = async (
     idempotencyKey,
     expectedOpenedTime,
     isApi,
-    fraction ?? 1
+    fraction ?? 1,
+    expectedSize
   )
 
   return {
@@ -48,3 +52,38 @@ export const closePerpPosition: APIHandler<'close-perp-position'> = async (
     },
   }
 }
+
+/**
+ * Partial closes only.
+ *
+ * The 1% minimum is a fraction of the CURRENT remainder, so repeated 1% closes
+ * decay geometrically rather than terminating in 100 calls: from an M$100 cost
+ * basis it takes ~917 to reach the dust floor that promotes the close to a
+ * full one, and more on a larger position. Each of those is a serializable
+ * transaction under the contract's advisory lock plus an event, a txn, a
+ * metrics rebuild and streak processing — the lock the 2s oracle tick also
+ * wants.
+ *
+ * 60/hour is far above any plausible human scaling-out and still caps the
+ * sustained rate at one per minute. In-memory per instance, like every other
+ * user of this helper.
+ */
+const rateLimitedPartialClose = rateLimitByUser(closePerpPositionInner, {
+  maxCalls: 60,
+  windowMs: HOUR_MS,
+})
+
+/**
+ * A FULL close is never rate-limited. Refusing someone the ability to exit a
+ * leveraged position — possibly while it is running toward liquidation — is a
+ * far worse failure than tolerating close spam, so the limiter above is
+ * reachable only when the caller asked for a fraction of one.
+ */
+export const closePerpPosition: APIHandler<'close-perp-position'> = async (
+  body,
+  auth,
+  req
+) =>
+  body.fraction !== undefined && body.fraction < 1
+    ? rateLimitedPartialClose(body, auth, req)
+    : closePerpPositionInner(body, auth, req)

--- a/backend/api/src/close-perp-position.ts
+++ b/backend/api/src/close-perp-position.ts
@@ -9,19 +9,32 @@ export const closePerpPosition: APIHandler<'close-perp-position'> = async (
   auth
 ) => {
   assertPerpCloseEnabled()
-  const { contractId, direction, idempotencyKey, expectedOpenedTime } = body
+  const {
+    contractId,
+    direction,
+    idempotencyKey,
+    expectedOpenedTime,
+    fraction,
+  } = body
   const isApi = auth.creds.kind === 'key'
-  const { payout, pnl, replayed } = await closePosition(
+  const {
+    payout,
+    pnl,
+    replayed,
+    fraction: closedFraction,
+    remainingSize,
+  } = await closePosition(
     contractId,
     auth.uid,
     direction,
     idempotencyKey,
     expectedOpenedTime,
-    isApi
+    isApi,
+    fraction ?? 1
   )
 
   return {
-    result: { payout, pnl },
+    result: { payout, pnl, fraction: closedFraction, remainingSize },
     continue: async () => {
       // Closes count toward the prediction streak, mirroring sells on normal
       // markets (sell-shares routes through onCreateBets). An idempotent

--- a/backend/api/src/get-balance-changes.ts
+++ b/backend/api/src/get-balance-changes.ts
@@ -90,6 +90,8 @@ const perpTxnDescription = (txn: Txn): string | undefined => {
         ? 'Flipped out of'
         : d.reason === 'resolve'
         ? 'Settled'
+        : d.reason === 'partial-close'
+        ? 'Partly closed'
         : 'Closed'
     return `${verb} ${d.direction} at ${px(d.closePrice)} — profit ${pnlText}`
   }

--- a/backend/api/src/get-perp-events.ts
+++ b/backend/api/src/get-perp-events.ts
@@ -56,9 +56,11 @@ export const getPerpEvents: APIHandler<'get-perp-events'> = async (body) => {
     const payoutRaw = data.payout
     const pnlRaw = data.pnl
     const adlFactorRaw = data.adlFactor
+    const fractionRaw = data.fraction
     const payout = payoutRaw == null ? null : Number(payoutRaw)
     const pnl = pnlRaw == null ? null : Number(pnlRaw)
     const adlFactor = adlFactorRaw == null ? null : Number(adlFactorRaw)
+    const fraction = fractionRaw == null ? null : Number(fractionRaw)
     return {
       id: Number(r.id),
       contractId: r.contract_id,
@@ -85,6 +87,13 @@ export const getPerpEvents: APIHandler<'get-perp-events'> = async (body) => {
         adlFactor >= 0 &&
         adlFactor <= 1
           ? adlFactor
+          : null,
+      fraction:
+        fraction != null &&
+        Number.isFinite(fraction) &&
+        fraction > 0 &&
+        fraction <= 1
+          ? fraction
           : null,
       isApi: data.isApi === true,
       userName: r.user_name,

--- a/backend/api/src/get-unified-feed.ts
+++ b/backend/api/src/get-unified-feed.ts
@@ -417,7 +417,8 @@ async function fetchSiteActivity(
       pe.applied_ts,
       pe.original_cost_basis_delta,
       pe.direction,
-      pe.leverage
+      pe.leverage,
+      pe.data->>'fraction' as fraction
     from contract_perp_events pe
     join contracts c on c.id = pe.contract_id
     where pe.user_id is not null
@@ -560,6 +561,7 @@ type PerpActivityRow = {
   original_cost_basis_delta: number | string
   direction: string | null
   leverage: number | string | null
+  fraction: number | string | null
 }
 
 const convertPerpActivityRow = (
@@ -597,6 +599,18 @@ const convertPerpActivityRow = (
   const leverage =
     parsedLeverage !== null && parsedLeverage >= 0 ? parsedLeverage : null
 
+  // Only a close carries one, and only a value strictly inside (0, 1) says
+  // anything the wording does not already: 1 is a whole close, and a close
+  // written before partial closes existed has none.
+  const parsedFraction = toFiniteNumber(row.fraction)
+  const fraction =
+    row.event_type === 'close' &&
+    parsedFraction !== null &&
+    parsedFraction > 0 &&
+    parsedFraction < 1
+      ? parsedFraction
+      : null
+
   return {
     id: String(row.id),
     contractId: row.contract_id,
@@ -606,6 +620,7 @@ const convertPerpActivityRow = (
     direction: row.direction,
     margin: Math.abs(originalMargin),
     leverage,
+    fraction,
   }
 }
 

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -70,7 +70,8 @@ Endpoints are registered in `backend/api/src/routes.ts` and schemas live in
   New markets preserve their per-side initial backing for later preflight
   auditing.
 - `POST /place-perp-trade` — opens or adds to a position.
-- `POST /close-perp-position` — closes a position.
+- `POST /close-perp-position` — closes all of a position, or the
+  `fraction` of it given (see Partial closes).
 - `GET /get-perp-positions` — reads open positions for a contract (optionally
   filtered by `userId`).
 - `GET /get-oracle-price`, `/get-oracle-price-series` — read oracle data.
@@ -96,6 +97,48 @@ Only sub-millimana floating-point dust is tolerated. Creation, open/flip,
 close, factor-zero ADL, funding, and resolution fail atomically if the ledger
 and pools diverge. This is required because the generic transaction primitive
 does not maintain a balance column for `CONTRACT` senders.
+
+## Partial closes
+
+`close-perp-position` takes an optional `fraction` in `(0, 1]`; omitting it
+closes the whole position. The exit math is **linear in the position**: π is
+linear in `q`, and both the payout and the two pool debits are linear in π and
+`c`, so closing `z` of a row pays exactly `z` times what the full close would
+have paid, debits exactly `z` of each pool delta, and leaves the book in
+precisely the state it would have been in had the trader opened `1 − z` of that
+position and closed a separate `z` one.
+
+That is why the survivor keeps its **entry price**, its **leverage**
+(`ℓ = q/c` is invariant under the split) and therefore its **liquidation
+price**. Reducing exposure never moves the price at which what is left gets
+liquidated. `openedTime` is preserved too, so `expectedOpenedTime` still
+matches on the next close.
+
+Three rules keep the split honest:
+
+- The two halves are produced by **subtraction**, not by scaling both with `z`
+  and `1 − z`: they must add back up to the original exactly, because
+  `metric-periods.ts` reconstructs the pre-close row by adding the event's
+  deltas onto the survivor, and a split that does not conserve leaves that
+  replay drifting on every partial close.
+- `PERP_MIN_CLOSE_FRACTION` (1%) is the smallest close worth its own event —
+  below it the trade mints an event and a streak for a change the trader
+  cannot see.
+- `PERP_MIN_REMAINDER_COST_BASIS` promotes a close whose **remainder** would be
+  dust into a full close, so `fraction = 0.9999` cannot strand a row of a few
+  thousandths of a mana that still accrues funding every period. The bound is
+  on the remaining cost basis rather than on `1 − fraction`, because that is
+  the quantity that has to stay meaningful. The response's `fraction` is what
+  actually happened, which can exceed what was asked for; the stored
+  idempotency `request` holds the **requested** value and the `response` the
+  **actual** one.
+
+There is still no fee on a close — the taker fee is charged in full at open —
+so a partial close realizes its own `z` share of the fees the position already
+paid, and the remainder carries the rest. Solvency, the escrow check and the
+open-interest capacity rule all run unchanged: a partial close only ever
+reduces open interest, and its state is asserted with the same
+`assertPerpStateSolvent` the full close uses.
 
 ## Taker fee
 

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -133,6 +133,23 @@ Three rules keep the split honest:
   idempotency `request` holds the **requested** value and the `response` the
   **actual** one.
 
+A partial close also has to be bound to the row it was **sized against**.
+`expectedOpenedTime` cannot do it: the survivor keeps its `openedTime`, so a
+request sized against the pre-close row passes that check and then applies its
+fraction to the smaller survivor, closing far less than was previewed and
+saying nothing. Callers therefore send `expectedSize`, which is compared to the
+locked row within `PERP_EXPECTED_SIZE_TOLERANCE` — representation dust only, so
+funding scaling the row, an ADL haircut, or another partial close landing first
+all correctly produce a 409. Full closes skip the check: "close everything" is
+unambiguous at any size, and a spurious 409 on the one operation a trader may
+urgently need is a worse failure than any it would prevent.
+
+Partial closes are rate-limited per user (60/hour); full closes are **never**
+rate-limited, for the same reason. The limit exists because the 1% minimum is a
+fraction of the current *remainder*, so repeated 1% closes decay geometrically
+rather than terminating: from an M$100 cost basis it takes ~917 of them to
+reach the dust floor, and more on a larger position.
+
 There is still no fee on a close — the taker fee is charged in full at open —
 so a partial close realizes its own `z` share of the fees the position already
 paid, and the remainder carries the rest. Solvency, the escrow check and the

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -32,6 +32,7 @@ import {
   openPosition as openPositionMath,
   PERP_MIN_CLOSE_FRACTION,
   PERP_OPEN_INTEREST_COVER_MULTIPLE,
+  perpSizeMatchesExpectation,
   PERP_SOLVENCY_FACTOR_TOLERANCE,
   PerpState,
   processLiquidations,
@@ -1145,7 +1146,10 @@ export const closePosition = async (
   /** Fraction of the position to close; 1 (the default) closes all of it.
    * The engine may still close the whole position when the remainder would
    * be dust — the returned `fraction` is what actually happened. */
-  requestedFraction = 1
+  requestedFraction = 1,
+  /** Optimistic-concurrency token for a PARTIAL close: the notional the
+   * caller believed it was taking a fraction OF. See the check below. */
+  expectedSize?: number
 ) => {
   assertIdempotencyKey(idempotencyKey)
   if (
@@ -1169,6 +1173,19 @@ export const closePosition = async (
     throw new APIError(
       400,
       `Close fraction must be at least ${PERP_MIN_CLOSE_FRACTION} (or exactly 1 to close the whole position)`
+    )
+  if (
+    expectedSize !== undefined &&
+    (!Number.isFinite(expectedSize) || expectedSize <= 0)
+  )
+    throw new APIError(400, 'Expected position size must be a positive number')
+  const fractionRequestsPartialClose = requestedFraction < 1
+  // The schema already requires it; this is the same rule stated where the
+  // trade is actually executed, so a non-HTTP caller cannot skip the guard.
+  if (fractionRequestsPartialClose && expectedSize === undefined)
+    throw new APIError(
+      400,
+      'Closing part of a position requires the expected position size'
     )
 
   return runPerpTransaction(async (pgTrans) => {
@@ -1197,10 +1214,15 @@ export const closePosition = async (
           request?.fraction === undefined
             ? 1
             : finiteNumber(request.fraction, 'close fraction')
+        const storedExpectedSize =
+          request?.expectedSize === undefined
+            ? undefined
+            : finiteNumber(request.expectedSize, 'expected position size')
         if (
           request?.direction !== direction ||
           storedExpectedOpenedTime !== expectedOpenedTime ||
-          storedRequestedFraction !== requestedFraction
+          storedRequestedFraction !== requestedFraction ||
+          storedExpectedSize !== expectedSize
         ) {
           throw new APIError(
             409,
@@ -1322,6 +1344,28 @@ export const closePosition = async (
         'This position changed after the page loaded. Refresh before closing it.'
       )
     }
+    // A partial close is a fraction OF something, and `expectedOpenedTime`
+    // cannot police what that something was: the survivor of a partial close
+    // keeps its openedTime, so a second request sized against the pre-close
+    // row passes that check and then applies its fraction to the smaller row —
+    // closing far less than was previewed, silently. (Two tabs both showing
+    // 400 and both sending 75%: the first leaves 100, the second takes 75 of
+    // that instead of the 300 it displayed.) Funding and ADL move `size` the
+    // same way, and invalidate the preview for the same reason.
+    //
+    // Full closes deliberately skip this. "Close everything" is unambiguous at
+    // any size, and a spurious 409 on the one operation a trader may urgently
+    // need is a worse failure than any it would prevent.
+    if (
+      fractionRequestsPartialClose &&
+      expectedSize !== undefined &&
+      !perpSizeMatchesExpectation(position.size, expectedSize)
+    ) {
+      throw new APIError(
+        409,
+        'This position changed after the page loaded. Refresh before closing part of it.'
+      )
+    }
 
     // A stale feed would let a user cherry-pick a favorable cached price after
     // watching the real market move. Opens and closes share one predicate.
@@ -1389,6 +1433,7 @@ export const closePosition = async (
                 direction,
                 expectedOpenedTime,
                 fraction: requestedFraction,
+                ...(expectedSize === undefined ? {} : { expectedSize }),
               },
               response: {
                 payout,

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -30,10 +30,12 @@ import {
   liquidationPrice as computeLiquidationPrice,
   MIN_PERP_LEVERAGE,
   openPosition as openPositionMath,
+  PERP_MIN_CLOSE_FRACTION,
   PERP_OPEN_INTEREST_COVER_MULTIPLE,
   PERP_SOLVENCY_FACTOR_TOLERANCE,
   PerpState,
   processLiquidations,
+  resolvePerpCloseFraction,
   solvencyFactor,
 } from 'common/perps/amm'
 import {
@@ -1139,7 +1141,11 @@ export const closePosition = async (
   idempotencyKey?: string,
   expectedOpenedTime?: number,
   /** See `openOrAddPosition`. */
-  isApi = false
+  isApi = false,
+  /** Fraction of the position to close; 1 (the default) closes all of it.
+   * The engine may still close the whole position when the remainder would
+   * be dust — the returned `fraction` is what actually happened. */
+  requestedFraction = 1
 ) => {
   assertIdempotencyKey(idempotencyKey)
   if (
@@ -1150,6 +1156,20 @@ export const closePosition = async (
   ) {
     throw new APIError(400, 'Invalid expected PERP position opening time')
   }
+  // Mirrors resolvePerpCloseFraction's own bounds, but as a 400 and before
+  // any I/O: the pure helper throws plain Errors because it is also reached
+  // from paths where a bad fraction is an invariant violation, not a request.
+  if (
+    !Number.isFinite(requestedFraction) ||
+    requestedFraction <= 0 ||
+    requestedFraction > 1
+  )
+    throw new APIError(400, 'Close fraction must be a number in (0, 1]')
+  if (requestedFraction < 1 && requestedFraction < PERP_MIN_CLOSE_FRACTION)
+    throw new APIError(
+      400,
+      `Close fraction must be at least ${PERP_MIN_CLOSE_FRACTION} (or exactly 1 to close the whole position)`
+    )
 
   return runPerpTransaction(async (pgTrans) => {
     if (idempotencyKey) {
@@ -1171,9 +1191,16 @@ export const closePosition = async (
                 request.expectedOpenedTime,
                 'expected position opening time'
               )
+        // Closes stored before partial closes existed carry no fraction and
+        // were necessarily whole-position ones.
+        const storedRequestedFraction =
+          request?.fraction === undefined
+            ? 1
+            : finiteNumber(request.fraction, 'close fraction')
         if (
           request?.direction !== direction ||
-          storedExpectedOpenedTime !== expectedOpenedTime
+          storedExpectedOpenedTime !== expectedOpenedTime ||
+          storedRequestedFraction !== requestedFraction
         ) {
           throw new APIError(
             409,
@@ -1181,6 +1208,16 @@ export const closePosition = async (
           )
         }
         const payout = finiteNumber(response?.payout, 'close payout')
+        // The fraction actually closed, which the dust-promotion rule can
+        // lift above the requested one.
+        const closedFraction =
+          response?.fraction === undefined
+            ? 1
+            : finiteNumber(response.fraction, 'closed fraction')
+        const remainingSize =
+          response?.remainingSize === undefined
+            ? 0
+            : finiteNumber(response.remainingSize, 'remaining position size')
         const originalCostBasis =
           typeof data?.originalCostBasis === 'number' &&
           Number.isFinite(data.originalCostBasis) &&
@@ -1206,6 +1243,8 @@ export const closePosition = async (
                   originalCostBasis,
                   takerFeeCostBasis
                 ),
+          fraction: closedFraction,
+          remainingSize,
           // Callers must not re-run trade side effects (streaks) for a
           // replay — no trade happened on this request.
           replayed: true,
@@ -1292,41 +1331,71 @@ export const closePosition = async (
     await assertPerpEscrowBalance(pgTrans, contractId, state.pool)
 
     const price = contract.oraclePrice
+    // The requested fraction is resolved against the row the transaction
+    // actually loaded, so a close sized off a stale page still promotes to a
+    // full one rather than stranding dust.
+    const fraction = resolvePerpCloseFraction(position, requestedFraction)
     // No fee on close: the taker fee is charged in full at open (see
     // openOrAddPosition), so exits pay out untouched. The opening fees the
     // position accumulated still land in this close's user-facing pnl via
-    // takerFeeCostBasis.
-    const result = closePositionMath(state, position, price)
+    // takerFeeCostBasis — a partial close realizes its own share of them.
+    const result = closePositionMath(state, position, price, fraction, now)
     const payout = result.payout
+    // Defence in depth: PERP_MIN_CLOSE_FRACTION and the row soundness check
+    // above already make this unreachable. A close that moves nothing must
+    // not write an event or earn a streak.
+    if (!(result.closedSize > 0) || !(result.closedCostBasis > 0))
+      throw new APIError(
+        400,
+        'That fraction is too small to change this position'
+      )
     assertPerpStateSolvent(result.state, price)
     const userPnl = getUserFacingPnlFromPayout(
       payout,
-      position.originalCostBasis,
-      position.takerFeeCostBasis
+      result.closedOriginalCostBasis,
+      result.closedTakerFeeCostBasis
     )
+    const remainingSize = result.remainingPosition?.size ?? 0
 
     const event: PerpEvent = asEvent(contract, {
       userId,
       eventType: 'close',
       direction,
-      leverage: 0,
-      sizeDelta: -position.size,
-      costBasisDelta: -position.costBasis,
-      originalCostBasisDelta: -position.originalCostBasis,
+      // The survivor's leverage, which the split leaves unchanged; 0 when the
+      // whole position went.
+      leverage: result.remainingPosition?.leverage ?? 0,
+      sizeDelta: -result.closedSize,
+      costBasisDelta: -result.closedCostBasis,
+      originalCostBasisDelta: -result.closedOriginalCostBasis,
       data: {
         payout,
         pnl: userPnl,
         pricePnl: result.pnl,
         entryPrice: position.entryPrice,
         closePrice: price,
-        originalCostBasis: position.originalCostBasis,
-        takerFeeCostBasis: position.takerFeeCostBasis ?? 0,
+        originalCostBasis: result.closedOriginalCostBasis,
+        takerFeeCostBasis: result.closedTakerFeeCostBasis,
+        // Stamped on every close, so a reader never has to infer "whole
+        // position" from the absence of a field.
+        fraction: result.fraction,
+        remainingSize,
         ...(isApi ? { isApi: true } : {}),
         ...(idempotencyKey
           ? {
               idempotencyKey,
-              request: { direction, expectedOpenedTime },
-              response: { payout, pnl: userPnl },
+              // The REQUESTED fraction: it is what a replay is compared
+              // against, and it can differ from the one actually closed.
+              request: {
+                direction,
+                expectedOpenedTime,
+                fraction: requestedFraction,
+              },
+              response: {
+                payout,
+                pnl: userPnl,
+                fraction: result.fraction,
+                remainingSize,
+              },
             }
           : {}),
       },
@@ -1341,8 +1410,10 @@ export const closePosition = async (
       ...openInterestPatch(result.state.positions),
       lastBetTime: now,
       lastUpdatedTime: now,
-      volume: (contract.volume ?? 0) + position.originalCostBasis,
-      volume24Hours: (contract.volume24Hours ?? 0) + position.originalCostBasis,
+      // Only the margin this close actually realized counts as volume.
+      volume: (contract.volume ?? 0) + result.closedOriginalCostBasis,
+      volume24Hours:
+        (contract.volume24Hours ?? 0) + result.closedOriginalCostBasis,
     })
 
     // Credit user balance.
@@ -1363,7 +1434,7 @@ export const closePosition = async (
             pricePnl: result.pnl,
             entryPrice: position.entryPrice,
             closePrice: price,
-            reason: 'close',
+            reason: result.remainingPosition ? 'partial-close' : 'close',
           },
         },
         true
@@ -1381,14 +1452,25 @@ export const closePosition = async (
 
     await pgTrans.multi(
       [
-        deletePositionsQuery(contractId, [{ userId, direction }]),
+        // A partial close leaves the row open — same entry price, same
+        // leverage, same liquidation price, smaller — so it is an upsert, not
+        // a delete.
+        result.remainingPosition
+          ? upsertPositionsQuery([result.remainingPosition])
+          : deletePositionsQuery(contractId, [{ userId, direction }]),
         insertPerpEventsQuery([event]),
         mergeContractDataQuery(contractId, contractPatch),
         metricsQuery,
       ].join(';\n')
     )
 
-    return { payout, pnl: userPnl, replayed: false }
+    return {
+      payout,
+      pnl: userPnl,
+      fraction: result.fraction,
+      remainingSize,
+      replayed: false,
+    }
   })
 }
 

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -697,21 +697,44 @@ export const placePerpTradeSchema = z.object({
   maxFee: z.number().min(0).optional(),
 })
 
-export const closePerpPositionSchema = z.object({
-  contractId: z.string().min(1),
-  direction: z.enum(['long', 'short']),
-  idempotencyKey: z.string().regex(randomStringRegex).length(10),
-  expectedOpenedTime: z.number().int().nonnegative(),
-  // Fraction of the position to close; omitted = the whole position. Either
-  // exactly 1 or at least PERP_MIN_CLOSE_FRACTION — a smaller close cannot
-  // change the position and would only mint an event and streak credit. A
-  // fraction whose remainder would be dust closes the whole position instead;
-  // the response's `fraction` says what actually happened.
-  fraction: z
-    .number()
-    .lte(1)
-    .refine((f) => f === 1 || f >= PERP_MIN_CLOSE_FRACTION, {
-      message: `fraction must be 1 or at least ${PERP_MIN_CLOSE_FRACTION}`,
-    })
-    .optional(),
-})
+export const closePerpPositionSchema = z
+  .object({
+    contractId: z.string().min(1),
+    direction: z.enum(['long', 'short']),
+    idempotencyKey: z.string().regex(randomStringRegex).length(10),
+    expectedOpenedTime: z.number().int().nonnegative(),
+    // Fraction of the position to close; omitted = the whole position. Either
+    // exactly 1 or at least PERP_MIN_CLOSE_FRACTION — a smaller close cannot
+    // change the position and would only mint an event and streak credit. A
+    // fraction whose remainder would be dust closes the whole position instead;
+    // the response's `fraction` says what actually happened.
+    fraction: z
+      .number()
+      .lte(1)
+      .refine((f) => f === 1 || f >= PERP_MIN_CLOSE_FRACTION, {
+        message: `fraction must be 1 or at least ${PERP_MIN_CLOSE_FRACTION}`,
+      })
+      .optional(),
+    // The notional the caller sized `fraction` against. Checked against the
+    // locked row on a partial close and rejected with a 409 if it has moved,
+    // because `expectedOpenedTime` cannot see an intervening partial close: the
+    // survivor keeps its openedTime. Ignored on a full close, which is
+    // unambiguous at any size.
+    expectedSize: z.number().positive().finite().optional(),
+  })
+  // Required, not optional, for a partial close: without it the race is
+  // simply unguarded, and "close half of whatever happens to be there" is
+  // never what a caller means when they previewed a number. A caller has to
+  // read the position to know it exists, so it always has a size to send; if
+  // it raced, the 409 tells it to re-read rather than executing a trade it
+  // did not preview.
+  .refine(
+    (p) =>
+      p.fraction === undefined ||
+      p.fraction >= 1 ||
+      p.expectedSize !== undefined,
+    {
+      message: 'expectedSize is required when closing part of a position',
+      path: ['expectedSize'],
+    }
+  )

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -12,7 +12,7 @@ import { MINIMUM_BOUNTY } from 'common/economy'
 import { DOMAIN } from 'common/envs/constants'
 import { MAX_ID_LENGTH } from 'common/group'
 import { MAX_MULTI_NUMERIC_ANSWERS } from 'common/multi-numeric'
-import { MIN_PERP_LEVERAGE } from 'common/perps/amm'
+import { MIN_PERP_LEVERAGE, PERP_MIN_CLOSE_FRACTION } from 'common/perps/amm'
 import {
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeBps,
@@ -702,4 +702,16 @@ export const closePerpPositionSchema = z.object({
   direction: z.enum(['long', 'short']),
   idempotencyKey: z.string().regex(randomStringRegex).length(10),
   expectedOpenedTime: z.number().int().nonnegative(),
+  // Fraction of the position to close; omitted = the whole position. Either
+  // exactly 1 or at least PERP_MIN_CLOSE_FRACTION — a smaller close cannot
+  // change the position and would only mint an event and streak credit. A
+  // fraction whose remainder would be dust closes the whole position instead;
+  // the response's `fraction` says what actually happened.
+  fraction: z
+    .number()
+    .lte(1)
+    .refine((f) => f === 1 || f >= PERP_MIN_CLOSE_FRACTION, {
+      message: `fraction must be 1 or at least ${PERP_MIN_CLOSE_FRACTION}`,
+    })
+    .optional(),
 })

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1081,7 +1081,15 @@ export const API = (_apiTypeCheck = {
     method: 'POST',
     visibility: 'public',
     authed: true,
-    returns: {} as { payout: number; pnl: number },
+    returns: {} as {
+      payout: number
+      pnl: number
+      /** Fraction actually closed, which can exceed the requested one when
+       * the remainder would have been dust. */
+      fraction: number
+      /** Notional left open; 0 when the whole position was closed. */
+      remainingSize: number
+    },
     props: closePerpPositionSchema,
   },
   // The open-weight index halts on models it cannot classify. These two
@@ -1495,6 +1503,9 @@ export const API = (_apiTypeCheck = {
       payout: number | null
       pnl: number | null
       adlFactor: number | null
+      /** Closes only: the fraction of the position this event took. Null on
+       * closes written before partial closes existed, which were whole. */
+      fraction: number | null
       isApi: boolean
       userName: string | null
       username: string | null

--- a/common/src/perps/activity.ts
+++ b/common/src/perps/activity.ts
@@ -22,4 +22,8 @@ export type PerpTradeActivity = {
   margin: number
   /** Position leverage after an open/add. Close events normally report zero. */
   leverage: number | null
+  /** Closes only: the fraction of the position this event took, when it was a
+   * partial one. Null on a full close and on closes written before partial
+   * closes existed, which were all whole. */
+  fraction: number | null
 }

--- a/common/src/perps/amm.test.ts
+++ b/common/src/perps/amm.test.ts
@@ -1502,6 +1502,7 @@ describe('partial close', () => {
 
     it('passes a valid partial through and reads 1 as a full close', () => {
       expect(resolvePerpCloseFraction(row, 0.25)).toBe(0.25)
+      expect(resolvePerpCloseFraction(row, 0.333)).toBe(0.333)
       expect(resolvePerpCloseFraction(row, PERP_MIN_CLOSE_FRACTION)).toBe(
         PERP_MIN_CLOSE_FRACTION
       )

--- a/common/src/perps/amm.test.ts
+++ b/common/src/perps/amm.test.ts
@@ -19,10 +19,12 @@ import {
   mergedEntryPrice,
   MIN_PERP_LEVERAGE,
   openPosition,
+  PERP_EXPECTED_SIZE_TOLERANCE,
   PERP_MIN_CLOSE_FRACTION,
   PERP_MIN_REMAINDER_COST_BASIS,
   PERP_OPEN_INTEREST_COVER_MULTIPLE,
   PerpState,
+  perpSizeMatchesExpectation,
   processLiquidations,
   resolvePerpCloseFraction,
   solvencyFactor,
@@ -1270,6 +1272,38 @@ describe('partial close', () => {
     }
     return { position, state }
   }
+
+  describe('perpSizeMatchesExpectation', () => {
+    it('forgives representation dust at any scale', () => {
+      expect(perpSizeMatchesExpectation(400, 400)).toBe(true)
+      expect(
+        perpSizeMatchesExpectation(
+          400,
+          400 * (1 + PERP_EXPECTED_SIZE_TOLERANCE / 2)
+        )
+      ).toBe(true)
+      expect(
+        perpSizeMatchesExpectation(
+          12_345_678,
+          12_345_678 * (1 + PERP_EXPECTED_SIZE_TOLERANCE / 2)
+        )
+      ).toBe(true)
+    })
+
+    it('refuses a row that actually moved', () => {
+      // The smallest close that can change a row is 1%, so anything an
+      // intervening close could have done is far outside the tolerance.
+      expect(perpSizeMatchesExpectation(400 * 0.99, 400)).toBe(false)
+      expect(perpSizeMatchesExpectation(100, 400)).toBe(false)
+      // Funding and ADL scale size too, and invalidate the preview the same way.
+      expect(perpSizeMatchesExpectation(400 * 0.999, 400)).toBe(false)
+    })
+
+    it('refuses values it cannot compare', () => {
+      expect(perpSizeMatchesExpectation(NaN, 400)).toBe(false)
+      expect(perpSizeMatchesExpectation(400, Infinity)).toBe(false)
+    })
+  })
 
   describe('resolvePerpCloseFraction', () => {
     const row = { size: 400, costBasis: 100 }

--- a/common/src/perps/amm.test.ts
+++ b/common/src/perps/amm.test.ts
@@ -19,9 +19,12 @@ import {
   mergedEntryPrice,
   MIN_PERP_LEVERAGE,
   openPosition,
+  PERP_MIN_CLOSE_FRACTION,
+  PERP_MIN_REMAINDER_COST_BASIS,
   PERP_OPEN_INTEREST_COVER_MULTIPLE,
   PerpState,
   processLiquidations,
+  resolvePerpCloseFraction,
   solvencyFactor,
   unmergeEntryPrice,
 } from './amm'
@@ -1248,5 +1251,290 @@ describe('assertPerpStateNumbers ordering vs the risk transitions', () => {
     expect(() => assertPerpStateSolvent(insolvent, 150)).toThrow()
     const repaired = applyADL(insolvent, 150)
     expect(() => assertPerpStateSolvent(repaired.state, 150)).not.toThrow()
+  })
+})
+
+describe('partial close', () => {
+  // A long in profit, funded by a short pool with room to pay it.
+  const profitableLong = () => {
+    const position = makePosition({
+      direction: 'long',
+      size: 400,
+      costBasis: 100,
+      entryPrice: 100,
+      takerFeeCostBasis: 4,
+    })
+    const state: PerpState = {
+      pool: { L: 100, S: 500 },
+      positions: [position],
+    }
+    return { position, state }
+  }
+
+  describe('resolvePerpCloseFraction', () => {
+    const row = { size: 400, costBasis: 100 }
+
+    it('refuses a fraction outside (0, 1]', () => {
+      expect(() => resolvePerpCloseFraction(row, 0)).toThrow(/in \(0, 1\]/)
+      expect(() => resolvePerpCloseFraction(row, -0.5)).toThrow(/in \(0, 1\]/)
+      expect(() => resolvePerpCloseFraction(row, 1.5)).toThrow(/in \(0, 1\]/)
+      expect(() => resolvePerpCloseFraction(row, NaN)).toThrow(/in \(0, 1\]/)
+    })
+
+    it('refuses a close too small to be worth its own event', () => {
+      expect(() =>
+        resolvePerpCloseFraction(row, PERP_MIN_CLOSE_FRACTION / 2)
+      ).toThrow(/at least/)
+    })
+
+    it('passes a valid partial through and reads 1 as a full close', () => {
+      expect(resolvePerpCloseFraction(row, 0.25)).toBe(0.25)
+      expect(resolvePerpCloseFraction(row, PERP_MIN_CLOSE_FRACTION)).toBe(
+        PERP_MIN_CLOSE_FRACTION
+      )
+      expect(resolvePerpCloseFraction(row, 1)).toBe(1)
+    })
+
+    it('promotes a close whose remainder would be dust', () => {
+      // Half a mana-cent of margin left open — a row that would still accrue
+      // funding every period and still need closing by hand.
+      expect(resolvePerpCloseFraction(row, 0.99995)).toBe(1)
+      // The bound is on the REMAINING margin, not on 1 - fraction, so the
+      // same fraction survives on a position large enough for the remainder
+      // to be real money.
+      expect(
+        resolvePerpCloseFraction({ size: 40_000, costBasis: 10_000 }, 0.99995)
+      ).toBe(0.99995)
+      // At the bound the remainder is kept: PERP_MIN_REMAINDER_COST_BASIS is
+      // the smallest margin still worth a row.
+      expect(
+        resolvePerpCloseFraction(
+          { size: 4, costBasis: 1 },
+          1 - PERP_MIN_REMAINDER_COST_BASIS
+        )
+      ).toBe(1 - PERP_MIN_REMAINDER_COST_BASIS)
+    })
+  })
+
+  it('leaves the full close bit-for-bit what it was', () => {
+    const { position, state } = profitableLong()
+    const full = closePosition(state, position, 150)
+
+    // π = (150-100)/100 · 400 = 200, paid out of the short pool; the M$100
+    // margin comes back out of the long pool.
+    expect(full.payout).toBe(300)
+    expect(full.pnl).toBe(200)
+    expect(full.state.pool).toEqual({ L: 0, S: 300 })
+    expect(full.state.positions).toEqual([])
+    expect(full.fraction).toBe(1)
+    expect(full.remainingPosition).toBeNull()
+    expect(full.closedSize).toBe(position.size)
+    expect(full.closedCostBasis).toBe(position.costBasis)
+    expect(full.closedOriginalCostBasis).toBe(position.originalCostBasis)
+    expect(full.closedTakerFeeCostBasis).toBe(4)
+  })
+
+  it('pays exactly its fraction of the full close, out of the same pools', () => {
+    const { position, state } = profitableLong()
+    const full = closePosition(state, position, 150)
+    const quarter = closePosition(state, position, 150, 0.25)
+
+    expect(quarter.payout).toBeCloseTo(0.25 * full.payout, 9)
+    expect(quarter.pnl).toBeCloseTo(0.25 * full.pnl, 9)
+    expect(quarter.poolLongDelta).toBeCloseTo(0.25 * full.poolLongDelta, 9)
+    expect(quarter.poolShortDelta).toBeCloseTo(0.25 * full.poolShortDelta, 9)
+    expect(quarter.fraction).toBe(0.25)
+  })
+
+  it('leaves a survivor at the same entry, leverage and liquidation price', () => {
+    const { position, state } = profitableLong()
+    const { remainingPosition } = closePosition(state, position, 150, 0.25)
+    if (!remainingPosition) throw new Error('expected a surviving position')
+
+    // The whole point: reducing exposure must not move the price at which
+    // what is left gets liquidated.
+    expect(remainingPosition.entryPrice).toBe(position.entryPrice)
+    expect(remainingPosition.leverage).toBeCloseTo(position.leverage, 12)
+    expect(remainingPosition.liquidationPrice).toBeCloseTo(
+      position.liquidationPrice,
+      12
+    )
+    expect(remainingPosition.size).toBeCloseTo(300, 9)
+    expect(remainingPosition.costBasis).toBeCloseTo(75, 9)
+    expect(remainingPosition.originalCostBasis).toBeCloseTo(75, 9)
+    expect(remainingPosition.takerFeeCostBasis).toBeCloseTo(3, 9)
+    // openedTime is what `expectedOpenedTime` matches on, so a partial close
+    // must not look like a new position to the next one.
+    expect(remainingPosition.openedTime).toBe(position.openedTime)
+  })
+
+  it('splits the row without losing or minting any of it', () => {
+    const { position, state } = profitableLong()
+    // Exact, not close-to: metric-periods rebuilds the pre-close row by
+    // adding this event's deltas back onto the survivor, and any drift here
+    // is drift in every historical P&L that replays through it.
+    for (const fraction of [0.01, 0.25, 1 / 3, 0.5, 0.9]) {
+      const res = closePosition(state, position, 150, fraction)
+      const survivor = res.remainingPosition
+      if (!survivor) throw new Error('expected a surviving position')
+      expect(res.closedSize + survivor.size).toBe(position.size)
+      expect(res.closedCostBasis + survivor.costBasis).toBe(position.costBasis)
+      expect(res.closedOriginalCostBasis + survivor.originalCostBasis).toBe(
+        position.originalCostBasis
+      )
+      expect(
+        res.closedTakerFeeCostBasis + (survivor.takerFeeCostBasis ?? 0)
+      ).toBe(position.takerFeeCostBasis)
+    }
+  })
+
+  it('pays the same in two steps as in one', () => {
+    const { position, state } = profitableLong()
+    const full = closePosition(state, position, 150)
+
+    const first = closePosition(state, position, 150, 0.4)
+    const survivor = first.remainingPosition
+    if (!survivor) throw new Error('expected a surviving position')
+    const second = closePosition(first.state, survivor, 150)
+
+    expect(first.payout + second.payout).toBeCloseTo(full.payout, 9)
+    expect(second.state.pool.L).toBeCloseTo(full.state.pool.L, 9)
+    expect(second.state.pool.S).toBeCloseTo(full.state.pool.S, 9)
+    expect(second.state.positions).toEqual([])
+  })
+
+  it('is the state a smaller position would have been in all along', () => {
+    const { position, state } = profitableLong()
+    const partial = closePosition(state, position, 150, 0.25)
+
+    // Same book, but the trader only ever opened 75% of the position.
+    const smaller = makePosition({
+      direction: 'long',
+      size: 300,
+      costBasis: 75,
+      entryPrice: 100,
+      originalCostBasis: 75,
+      takerFeeCostBasis: 3,
+    })
+    const reference = closePosition(
+      { pool: { L: 100, S: 500 }, positions: [smaller] },
+      smaller,
+      150
+    )
+    // Closing the survivor next must land exactly where closing the
+    // never-larger position would.
+    const survivor = partial.remainingPosition
+    if (!survivor) throw new Error('expected a surviving position')
+    const closeOut = closePosition(partial.state, survivor, 150)
+    expect(closeOut.payout).toBeCloseTo(reference.payout, 9)
+  })
+
+  it('draws a losing close from the closer own pool only', () => {
+    const position = makePosition({
+      direction: 'long',
+      size: 400,
+      costBasis: 100,
+      entryPrice: 100,
+    })
+    const state: PerpState = { pool: { L: 100, S: 500 }, positions: [position] }
+    // π = (90-100)/100 · 100 = -10 on a quarter of the notional.
+    const res = closePosition(state, position, 90, 0.25)
+    expect(res.pnl).toBeCloseTo(-10, 9)
+    expect(res.payout).toBeCloseTo(15, 9)
+    expect(res.poolLongDelta).toBeCloseTo(-15, 9)
+    expect(res.poolShortDelta).toBe(0)
+    expect(res.state.pool.S).toBe(500)
+  })
+
+  it('pays nothing when the closed leg is past its own margin', () => {
+    const position = makePosition({
+      direction: 'long',
+      size: 400,
+      costBasis: 100,
+      entryPrice: 100,
+    })
+    const state: PerpState = { pool: { L: 100, S: 500 }, positions: [position] }
+    // A 50% move against a 4x long wipes the margin out entirely.
+    const res = closePosition(state, position, 50, 0.5)
+    expect(res.payout).toBe(0)
+    // toBeCloseTo, not toBe: a zero payout debits the pool by -0, exactly as
+    // a full close of the same position always has. Both read as no debit.
+    expect(res.poolLongDelta).toBeCloseTo(0, 12)
+    expect(res.remainingPosition?.costBasis).toBeCloseTo(50, 9)
+  })
+
+  it('leaves a survivor the state validators accept, and a solvent book', () => {
+    const { position, state } = profitableLong()
+    const res = closePosition(state, position, 150, 0.25)
+    expect(() =>
+      assertPerpPositionNumbers(res.remainingPosition as PerpPosition)
+    ).not.toThrow()
+    expect(() => assertPerpStateSolvent(res.state, 150)).not.toThrow()
+  })
+
+  it('replaces the row in place rather than reordering the book', () => {
+    const other = makePosition({
+      userId: 'u2',
+      direction: 'short',
+      size: 100,
+      costBasis: 50,
+      entryPrice: 100,
+    })
+    const { position } = profitableLong()
+    const state: PerpState = {
+      pool: { L: 100, S: 500 },
+      positions: [position, other],
+    }
+    const res = closePosition(state, position, 150, 0.5)
+    expect(res.state.positions).toHaveLength(2)
+    expect(res.state.positions[0].userId).toBe('u1')
+    expect(res.state.positions[1]).toBe(other)
+  })
+
+  it('closes the whole position when the remainder would be dust', () => {
+    const position = makePosition({
+      direction: 'long',
+      size: 400,
+      costBasis: 100,
+      entryPrice: 100,
+    })
+    const state: PerpState = { pool: { L: 100, S: 500 }, positions: [position] }
+    const res = closePosition(state, position, 150, 1 - 1e-5)
+    expect(res.fraction).toBe(1)
+    expect(res.remainingPosition).toBeNull()
+    expect(res.payout).toBe(300)
+    expect(res.state.positions).toEqual([])
+  })
+
+  it('keeps a remainder that is still real money', () => {
+    const position = makePosition({
+      direction: 'long',
+      size: 400,
+      costBasis: 100,
+      entryPrice: 100,
+    })
+    const state: PerpState = { pool: { L: 100, S: 500 }, positions: [position] }
+    // 1% of M$100 is M$1 left open — well above the dust bound.
+    const res = closePosition(state, position, 150, 0.99)
+    expect(res.fraction).toBe(0.99)
+    expect(res.remainingPosition?.costBasis).toBeGreaterThan(
+      PERP_MIN_REMAINDER_COST_BASIS
+    )
+  })
+
+  it('prices a short partial close off the long pool', () => {
+    const position = makePosition({
+      direction: 'short',
+      size: 200,
+      costBasis: 100,
+      entryPrice: 100,
+    })
+    const state: PerpState = { pool: { L: 500, S: 100 }, positions: [position] }
+    // π = (100-80)/100 · 200 = 40 in profit; half of that is 20.
+    const res = closePosition(state, position, 80, 0.5)
+    expect(res.pnl).toBeCloseTo(20, 9)
+    expect(res.payout).toBeCloseTo(70, 9)
+    expect(res.poolShortDelta).toBeCloseTo(-50, 9)
+    expect(res.poolLongDelta).toBeCloseTo(-20, 9)
   })
 })

--- a/common/src/perps/amm.ts
+++ b/common/src/perps/amm.ts
@@ -553,43 +553,178 @@ export const openPosition = (
 export type CloseResult = {
   state: PerpState
   payout: number // mana paid to user
-  pnl: number // π at close
+  pnl: number // π realized on the closed leg
   poolLongDelta: number
   poolShortDelta: number
+  /** Fraction actually closed — 1 for a full close, including a partial one
+   * promoted to a full close because its remainder would have been dust. */
+  fraction: number
+  /** The closed leg's share of the row. Equals the row's own values on a
+   * full close, so callers can stamp events from these unconditionally. */
+  closedSize: number
+  closedCostBasis: number
+  closedOriginalCostBasis: number
+  closedTakerFeeCostBasis: number
+  /** The surviving row, or null when the whole position was closed. */
+  remainingPosition: PerpPosition | null
 }
 
 /**
- * Close a long or short position at the oracle price (paper §2.5, eq. 13–15).
- * Solvency invariant guarantees the opposing pool can cover π > 0.
+ * Smallest fraction of a position a partial close may take.
+ *
+ * Below this the close is not worth the row it writes: it mints an event (and
+ * its streak credit) for a change the trader cannot see, and on a small
+ * position the payout rounds to nothing. A caller wanting less should not
+ * close at all.
+ */
+export const PERP_MIN_CLOSE_FRACTION = 0.01
+
+/**
+ * Margin below which a partial close's REMAINDER is not worth keeping open,
+ * so the close is promoted to a full one.
+ *
+ * Without this, `fraction = 0.9999` leaves a row of a few thousandths of a
+ * mana that still accrues funding every period, still shows on the market
+ * page, and still has to be closed by hand. The bound is on the remaining
+ * COST BASIS rather than on `1 - fraction` because that is the quantity that
+ * has to stay meaningful: a fractional rule would strand dust on a large
+ * position and delete real margin on a small one.
+ */
+export const PERP_MIN_REMAINDER_COST_BASIS = 0.01
+
+/**
+ * The fraction a close will ACTUALLY take, given what the caller asked for.
+ *
+ * Separate from `closePosition` so a caller can price and describe the close
+ * ("this closes your whole position") before committing to it, and so the
+ * promotion rule has exactly one definition.
+ */
+export const resolvePerpCloseFraction = (
+  position: Pick<PerpPosition, 'size' | 'costBasis'>,
+  requested: number
+) => {
+  if (!Number.isFinite(requested) || requested <= 0 || requested > 1)
+    throw new Error('close fraction must be a finite number in (0, 1]')
+  if (requested >= 1) return 1
+  if (requested < PERP_MIN_CLOSE_FRACTION)
+    throw new Error(
+      `close fraction must be at least ${PERP_MIN_CLOSE_FRACTION} or exactly 1`
+    )
+  const remainingSize = position.size - requested * position.size
+  const remainingCostBasis = position.costBasis - requested * position.costBasis
+  if (remainingSize <= 0 || remainingCostBasis < PERP_MIN_REMAINDER_COST_BASIS)
+    return 1
+  return requested
+}
+
+/**
+ * Close all or part of a long or short position at the oracle price (paper
+ * §2.5, eq. 13–15). Solvency invariant guarantees the opposing pool can
+ * cover π > 0.
+ *
+ * A partial close is exactly `fraction` of the full one. π is linear in `q`,
+ * and the payout and both pool debits are linear in π and `c`, so closing
+ * `z` of a row leaves the book in precisely the state it would have been in
+ * had the trader opened `1 - z` of that position and closed a separate `z`
+ * one — which is why the survivor keeps its entry price, its leverage
+ * (ℓ = q/c is invariant under the split) and therefore its liquidation price.
+ * Nothing about the risk of the remaining exposure changes.
  */
 export const closePosition = (
   state: PerpState,
   position: PerpPosition,
-  price: number
+  price: number,
+  /** Fraction of the position to close; 1 (the default) closes all of it.
+   * A fraction whose remainder would be dust is promoted to a full close, so
+   * read `fraction` off the result for what actually happened. */
+  requestedFraction = 1,
+  now = Date.now()
 ): CloseResult => {
-  const π = getUnrealizedEquity(position, price)
+  const fraction = resolvePerpCloseFraction(position, requestedFraction)
+  const isFull = fraction === 1
+
+  const positionFeeBasis = position.takerFeeCostBasis ?? 0
+  const closedSize = isFull ? position.size : fraction * position.size
+  const closedCostBasis = isFull
+    ? position.costBasis
+    : fraction * position.costBasis
+  const closedOriginalCostBasis = isFull
+    ? position.originalCostBasis
+    : fraction * position.originalCostBasis
+  const closedTakerFeeCostBasis = isFull
+    ? positionFeeBasis
+    : fraction * positionFeeBasis
+
+  // Priced on the CLOSED leg. On a full close this is the row itself, so the
+  // arithmetic below is bit-for-bit what it was before partial closes existed.
+  const closedLeg: PerpPosition = isFull
+    ? position
+    : { ...position, size: closedSize, costBasis: closedCostBasis }
+
+  const π = getUnrealizedEquity(closedLeg, price)
   let poolLongDelta = 0
   let poolShortDelta = 0
   let payout = 0
 
   if (π <= 0) {
-    payout = Math.max(position.costBasis + π, 0)
+    payout = Math.max(closedCostBasis + π, 0)
     if (position.direction === 'long') poolLongDelta = -payout
     else poolShortDelta = -payout
   } else {
-    payout = position.costBasis + π
+    payout = closedCostBasis + π
     if (position.direction === 'long') {
-      poolLongDelta = -position.costBasis
+      poolLongDelta = -closedCostBasis
       poolShortDelta = -π
     } else {
-      poolShortDelta = -position.costBasis
+      poolShortDelta = -closedCostBasis
       poolLongDelta = -π
     }
   }
 
-  const positions = state.positions.filter(
-    (p) => !(p.userId === position.userId && p.direction === position.direction)
-  )
+  // The survivor is the row MINUS the closed leg, by subtraction rather than
+  // by scaling with (1 - fraction): the two halves must add back up to the
+  // original exactly, because metric-periods reconstructs the pre-close row
+  // by adding this event's deltas onto the surviving one, and a split that
+  // does not conserve leaves that replay drifting on every partial close.
+  const remainingPosition: PerpPosition | null = isFull
+    ? null
+    : (() => {
+        const size = position.size - closedSize
+        const costBasis = position.costBasis - closedCostBasis
+        // Recomputed rather than carried over: ℓ = q/c is invariant under the
+        // split in exact arithmetic but can move an ulp in float, and the row
+        // has to stay self-consistent for the liquidation scan and for
+        // assertPerpPositionNumbers.
+        const leverage = getLeverage(size, costBasis)
+        return {
+          ...position,
+          size,
+          costBasis,
+          originalCostBasis:
+            position.originalCostBasis - closedOriginalCostBasis,
+          takerFeeCostBasis: positionFeeBasis - closedTakerFeeCostBasis,
+          leverage,
+          liquidationPrice: liquidationPrice(
+            position.direction,
+            position.entryPrice,
+            leverage
+          ),
+          updatedTime: now,
+        }
+      })()
+
+  // Replaced in place rather than filtered and re-appended, so a partial
+  // close does not reorder the book.
+  const positions = remainingPosition
+    ? state.positions.map((p) =>
+        p.userId === position.userId && p.direction === position.direction
+          ? remainingPosition
+          : p
+      )
+    : state.positions.filter(
+        (p) =>
+          !(p.userId === position.userId && p.direction === position.direction)
+      )
 
   return {
     state: {
@@ -609,6 +744,12 @@ export const closePosition = (
     pnl: π,
     poolLongDelta,
     poolShortDelta,
+    fraction,
+    closedSize,
+    closedCostBasis,
+    closedOriginalCostBasis,
+    closedTakerFeeCostBasis,
+    remainingPosition,
   }
 }
 

--- a/common/src/perps/amm.ts
+++ b/common/src/perps/amm.ts
@@ -593,6 +593,37 @@ export const PERP_MIN_CLOSE_FRACTION = 0.01
 export const PERP_MIN_REMAINDER_COST_BASIS = 0.01
 
 /**
+ * Relative slack between the notional a partial close was sized against and
+ * the row the transaction actually locked.
+ *
+ * Representation dust only — NOT semantic drift. `size` round-trips through a
+ * postgres `numeric` and back, and that is the only difference this is here to
+ * forgive. Anything that genuinely moved the row (funding scaling it, an ADL
+ * haircut, another partial close landing first) must fail the check, because
+ * in every one of those cases the fraction the caller chose was chosen against
+ * a position that no longer exists, and applying it to the survivor silently
+ * executes a different trade than the one they consented to.
+ */
+export const PERP_EXPECTED_SIZE_TOLERANCE = 1e-9
+
+/**
+ * Whether a partial close's `expectedSize` still describes the locked row.
+ *
+ * Relative, so it means the same thing on an M$10 position and an M$10m one.
+ */
+export const perpSizeMatchesExpectation = (
+  actualSize: number,
+  expectedSize: number
+) => {
+  if (!Number.isFinite(actualSize) || !Number.isFinite(expectedSize))
+    return false
+  const scale = Math.max(Math.abs(actualSize), Math.abs(expectedSize), 1)
+  return (
+    Math.abs(actualSize - expectedSize) <= PERP_EXPECTED_SIZE_TOLERANCE * scale
+  )
+}
+
+/**
  * The fraction a close will ACTUALLY take, given what the caller asked for.
  *
  * Separate from `closePosition` so a caller can price and describe the close

--- a/common/src/perps/close-amount.test.ts
+++ b/common/src/perps/close-amount.test.ts
@@ -1,0 +1,201 @@
+import {
+  canEnterPerpCloseMana,
+  getPerpCloseAmountError,
+  perpCloseAmountFromFraction,
+  perpCloseAmountFromInput,
+} from './close-amount'
+import { PERP_MIN_CLOSE_FRACTION, resolvePerpCloseFraction } from './amm'
+
+describe('perp close amount selection', () => {
+  it('defaults to a full close in percent mode', () => {
+    expect(perpCloseAmountFromFraction(1, 'percent', 1234.567)).toEqual({
+      unit: 'percent',
+      input: '100',
+      fraction: 1,
+    })
+  })
+
+  it('sizes mana against payout, not margin or leveraged notional', () => {
+    expect(perpCloseAmountFromInput('500', 'mana', 2000).fraction).toBe(0.25)
+    expect(
+      perpCloseAmountFromInput('33.3', 'percent', 2000).fraction
+    ).toBeCloseTo(0.333, 15)
+  })
+
+  it('preserves typed decimal text', () => {
+    expect(perpCloseAmountFromInput('500.00', 'mana', 2000).input).toBe(
+      '500.00'
+    )
+  })
+
+  it('preserves the exact portion through repeated rounded mode switches', () => {
+    let selection = perpCloseAmountFromInput('500', 'mana', 1234.56789)
+    const fraction = selection.fraction
+    for (let i = 0; i < 100; i++) {
+      selection = perpCloseAmountFromFraction(
+        selection.fraction,
+        'percent',
+        1234.56789
+      )
+      expect(selection.fraction).toBe(fraction)
+      selection = perpCloseAmountFromFraction(
+        selection.fraction,
+        'mana',
+        1234.56789
+      )
+      expect(selection.fraction).toBe(fraction)
+      expect(selection.input).toBe('500')
+    }
+  })
+
+  it('does not resize a selection when the payout quote changes', () => {
+    const selection = perpCloseAmountFromInput('500', 'mana', 2000)
+    const switched = perpCloseAmountFromFraction(
+      selection.fraction,
+      'percent',
+      1600
+    )
+    expect(switched.fraction).toBe(0.25)
+    expect(switched.input).toBe('25')
+    expect(
+      perpCloseAmountFromFraction(switched.fraction, 'mana', 1600).input
+    ).toBe('400')
+    // Editing the mana field again sizes the new request at the new quote.
+    expect(perpCloseAmountFromInput('500', 'mana', 1600).fraction).toBe(0.3125)
+  })
+
+  it('keeps Max exactly full even when its displayed payout is rounded', () => {
+    const selection = perpCloseAmountFromFraction(1, 'mana', 1234.56789)
+    expect(selection.input).toBe('1234.57')
+    expect(selection.fraction).toBe(1)
+    expect(getPerpCloseAmountError(selection, 1200)).toBeNull()
+    expect(
+      perpCloseAmountFromFraction(selection.fraction, 'percent', 1200).input
+    ).toBe('100')
+  })
+
+  it('does not round a genuine partial selection to 100%', () => {
+    const selection = perpCloseAmountFromFraction(0.9999999, 'percent', 1000)
+    expect(selection.input).toBe('99.99')
+    expect(selection.fraction).toBe(0.9999999)
+  })
+
+  it('keeps the minimum valid without rounding the selected portion', () => {
+    for (const payout of [0.00001, 0.017, 1.13, 27.13, 1234.56789, 1e10]) {
+      const selection = perpCloseAmountFromInput(
+        String(payout * PERP_MIN_CLOSE_FRACTION),
+        'mana',
+        payout
+      )
+      expect(selection.fraction).toBe(PERP_MIN_CLOSE_FRACTION)
+      expect(getPerpCloseAmountError(selection, payout)).toBeNull()
+      const converted = perpCloseAmountFromFraction(
+        selection.fraction,
+        'mana',
+        payout
+      )
+      expect(Number(converted.input)).toBeGreaterThan(0)
+      expect(getPerpCloseAmountError(converted, payout)).toBeNull()
+    }
+  })
+
+  it.each(['', ' ', 'NaN', 'Infinity', '1e999'])(
+    'rejects non-finite or missing input %p',
+    (input) => {
+      for (const unit of ['percent', 'mana'] as const)
+        expect(
+          getPerpCloseAmountError(
+            perpCloseAmountFromInput(input, unit, 1000),
+            1000
+          )
+        ).toBe('missing')
+    }
+  )
+
+  it.each(['0', '-1', '0.999'])(
+    'does not silently clamp too-small percentages %p',
+    (input) => {
+      expect(
+        getPerpCloseAmountError(
+          perpCloseAmountFromInput(input, 'percent', 1000),
+          1000
+        )
+      ).toBe('below-minimum')
+    }
+  )
+
+  it('rejects mana below the 1% floor and above the available payout', () => {
+    expect(
+      getPerpCloseAmountError(
+        perpCloseAmountFromInput('9.99', 'mana', 1000),
+        1000
+      )
+    ).toBe('below-minimum')
+    expect(
+      getPerpCloseAmountError(
+        perpCloseAmountFromInput('1000.01', 'mana', 1000),
+        1000
+      )
+    ).toBe('above-maximum')
+    expect(
+      getPerpCloseAmountError(
+        perpCloseAmountFromInput('100.01', 'percent', 1000),
+        1000
+      )
+    ).toBe('above-maximum')
+  })
+
+  it.each([0, -1, NaN, Infinity])(
+    'keeps percent closes available when mana cannot be sized (%p)',
+    (payout) => {
+      expect(canEnterPerpCloseMana(payout)).toBe(false)
+      expect(
+        getPerpCloseAmountError(
+          perpCloseAmountFromInput('1', 'mana', payout),
+          payout
+        )
+      ).toBe('unavailable')
+      expect(
+        getPerpCloseAmountError(
+          perpCloseAmountFromInput('100', 'percent', payout),
+          payout
+        )
+      ).toBeNull()
+    }
+  )
+
+  it('keeps empty selections empty when switching modes', () => {
+    const selection = perpCloseAmountFromInput('', 'mana', 1000)
+    expect(
+      perpCloseAmountFromFraction(selection.fraction, 'percent', 1000)
+    ).toEqual({
+      unit: 'percent',
+      input: '',
+      fraction: null,
+    })
+  })
+
+  it('does not disguise invalid input as a valid boundary on a unit switch', () => {
+    for (const amount of ['9.99', '1000.001']) {
+      const selection = perpCloseAmountFromInput(amount, 'mana', 1000)
+      const converted = perpCloseAmountFromFraction(
+        selection.fraction,
+        'percent',
+        1000
+      )
+      expect(Number(converted.input)).not.toBe(1)
+      expect(Number(converted.input)).not.toBe(100)
+      expect(getPerpCloseAmountError(converted, 1000)).toBe(
+        getPerpCloseAmountError(selection, 1000)
+      )
+    }
+  })
+
+  it('leaves remainder-dust promotion to the same engine preview', () => {
+    const selection = perpCloseAmountFromInput('0.999', 'mana', 1)
+    expect(selection.fraction).toBe(0.999)
+    expect(
+      resolvePerpCloseFraction({ size: 3, costBasis: 1 }, selection.fraction!)
+    ).toBe(1)
+  })
+})

--- a/common/src/perps/close-amount.ts
+++ b/common/src/perps/close-amount.ts
@@ -1,0 +1,75 @@
+import { PERP_MIN_CLOSE_FRACTION } from './amm'
+import { formatPerpClosePercent } from './format'
+
+export type PerpCloseAmountUnit = 'percent' | 'mana'
+
+export type PerpCloseAmount = {
+  unit: PerpCloseAmountUnit
+  input: string
+  // Keep the unrounded selection separately from its editable display. Unit
+  // switches and later oracle ticks must not silently resize a chosen close.
+  fraction: number | null
+}
+
+export const canEnterPerpCloseMana = (fullPayout: number) =>
+  Number.isFinite(fullPayout) && fullPayout > 0
+
+export const perpCloseAmountFromInput = (
+  input: string,
+  unit: PerpCloseAmountUnit,
+  fullPayout: number
+): PerpCloseAmount => {
+  const amount = input.trim() === '' ? NaN : Number(input)
+  const max = unit === 'percent' ? 100 : fullPayout
+  const fraction =
+    !Number.isFinite(amount) || !canEnterPerpCloseMana(max)
+      ? null
+      : // Multiplying then dividing the minimum can land one ULP below it.
+      // Recognize the exact endpoint without forgiving genuinely smaller input.
+      amount === max * PERP_MIN_CLOSE_FRACTION
+      ? PERP_MIN_CLOSE_FRACTION
+      : amount / max
+  return { unit, input, fraction }
+}
+
+export const perpCloseAmountFromFraction = (
+  fraction: number | null,
+  unit: PerpCloseAmountUnit,
+  fullPayout: number
+): PerpCloseAmount => {
+  const amount =
+    fraction == null ? NaN : fraction * (unit === 'percent' ? 100 : fullPayout)
+  const input = !Number.isFinite(amount)
+    ? ''
+    : fraction != null && (fraction < PERP_MIN_CLOSE_FRACTION || fraction > 1)
+    ? // Don't display an invalid selection as a valid boundary (e.g. 0.999%
+      // as 1%) while still disabling the confirmation for the original value.
+      String(amount)
+    : unit === 'percent' &&
+      fraction != null &&
+      fraction >= PERP_MIN_CLOSE_FRACTION &&
+      fraction <= 1
+    ? formatPerpClosePercent(fraction).slice(0, -1)
+    : // Show cents normally, but don't turn a positive sub-cent payout into 0.
+      String(
+        Number(
+          Math.abs(amount) > 0 && Math.abs(amount) < 0.01
+            ? amount.toPrecision(2)
+            : amount.toFixed(2)
+        )
+      )
+  return { unit, input, fraction }
+}
+
+export const getPerpCloseAmountError = (
+  selection: PerpCloseAmount,
+  fullPayout: number
+) => {
+  if (selection.unit === 'mana' && !canEnterPerpCloseMana(fullPayout))
+    return 'unavailable'
+  const { fraction } = selection
+  if (fraction == null || !Number.isFinite(fraction)) return 'missing'
+  if (fraction < PERP_MIN_CLOSE_FRACTION) return 'below-minimum'
+  if (fraction > 1) return 'above-maximum'
+  return null
+}

--- a/common/src/perps/format.test.ts
+++ b/common/src/perps/format.test.ts
@@ -1,6 +1,7 @@
 import {
   formatFeePct,
   formatFeePctApprox,
+  formatPerpClosePercent,
   perpFeeScheduleSummary,
   PERP_FEE_EXAMPLE_POOL_SHARES,
 } from './format'
@@ -64,6 +65,21 @@ describe('formatFeePctApprox', () => {
     expect(formatFeePctApprox(1 / 3)).toBe('<0.01%')
     expect(formatFeePctApprox(0.4)).toBe('<0.01%')
     expect(formatFeePctApprox(1 / 3)).not.toContain('~')
+  })
+})
+
+describe('formatPerpClosePercent', () => {
+  it('keeps the ordinary close choices at whole-percent precision', () => {
+    expect(formatPerpClosePercent(0.25)).toBe('25%')
+    expect(formatPerpClosePercent(0.5)).toBe('50%')
+    expect(formatPerpClosePercent(0.75)).toBe('75%')
+  })
+
+  it('never renders a surviving position as fully closed', () => {
+    expect(formatPerpClosePercent(0.995)).toBe('99.5%')
+    expect(formatPerpClosePercent(0.999)).toBe('99.9%')
+    expect(formatPerpClosePercent(0.99999)).toBe('99.99%')
+    expect(formatPerpClosePercent(1)).toBe('100%')
   })
 })
 

--- a/common/src/perps/format.test.ts
+++ b/common/src/perps/format.test.ts
@@ -75,6 +75,12 @@ describe('formatPerpClosePercent', () => {
     expect(formatPerpClosePercent(0.75)).toBe('75%')
   })
 
+  it('keeps the precision of arbitrary close amounts', () => {
+    expect(formatPerpClosePercent(0.333)).toBe('33.3%')
+    expect(formatPerpClosePercent(1 / 3)).toBe('33.33%')
+    expect(formatPerpClosePercent(0.2501)).toBe('25.01%')
+  })
+
   it('never renders a surviving position as fully closed', () => {
     expect(formatPerpClosePercent(0.995)).toBe('99.5%')
     expect(formatPerpClosePercent(0.999)).toBe('99.9%')

--- a/common/src/perps/format.ts
+++ b/common/src/perps/format.ts
@@ -36,6 +36,24 @@ export const formatPrice = (value: number, decimals: number) => {
 }
 
 /**
+ * Render the fraction taken by a close without ever rounding a real partial
+ * close up to 100%. Most values stay at the existing whole-percent precision;
+ * values close enough to 1 to round to 100 keep up to two truncated decimals
+ * instead, so the label cannot claim the survivor is gone.
+ */
+export const formatPerpClosePercent = (fraction: number) => {
+  if (!Number.isFinite(fraction) || fraction <= 0) return '0%'
+  if (fraction >= 1) return '100%'
+
+  const percent = fraction * 100
+  const roundedWhole = Math.round(percent)
+  if (roundedWhole < 100) return `${roundedWhole}%`
+
+  const truncatedHundredths = Math.floor(percent * 100) / 100
+  return `${truncatedHundredths.toFixed(2).replace(/\.?0+$/, '')}%`
+}
+
+/**
  * Short countdown for "next funding in …": minutes under two hours (ceil,
  * floored at 1m so it never shows "0m" while still pending), whole hours
  * beyond. Daily-period contracts count down from 24h — "23h", not "1380m".

--- a/common/src/perps/format.ts
+++ b/common/src/perps/format.ts
@@ -37,20 +37,22 @@ export const formatPrice = (value: number, decimals: number) => {
 
 /**
  * Render the fraction taken by a close without ever rounding a real partial
- * close up to 100%. Most values stay at the existing whole-percent precision;
- * values close enough to 1 to round to 100 keep up to two truncated decimals
- * instead, so the label cannot claim the survivor is gone.
+ * close up to 100%. Values keep up to two decimal places so arbitrary close
+ * amounts are represented faithfully. If normal rounding would carry a real
+ * partial close to 100, truncate instead so the label cannot claim the
+ * survivor is gone.
  */
 export const formatPerpClosePercent = (fraction: number) => {
   if (!Number.isFinite(fraction) || fraction <= 0) return '0%'
   if (fraction >= 1) return '100%'
 
   const percent = fraction * 100
-  const roundedWhole = Math.round(percent)
-  if (roundedWhole < 100) return `${roundedWhole}%`
-
-  const truncatedHundredths = Math.floor(percent * 100) / 100
-  return `${truncatedHundredths.toFixed(2).replace(/\.?0+$/, '')}%`
+  const roundedHundredths = Math.round(percent * 100) / 100
+  const displayPercent =
+    roundedHundredths < 100
+      ? roundedHundredths
+      : Math.floor(percent * 100) / 100
+  return `${displayPercent.toFixed(2).replace(/\.?0+$/, '')}%`
 }
 
 /**

--- a/common/src/perps/metric-periods.test.ts
+++ b/common/src/perps/metric-periods.test.ts
@@ -270,6 +270,70 @@ describe('calculatePerpMetricPeriods', () => {
     expect(result?.from.day.profitPercent).toBeCloseTo(100)
   })
 
+  it('replays a partial close against the row it left open', () => {
+    // Held 1000 notional on M$100 of margin at Pe = 100. Half a day in,
+    // closed 40% at 110 for a payout of 0.4 x (100 + 100) = M$80, leaving
+    // 600 notional on M$60 at the SAME entry price.
+    const result = calculatePerpMetricPeriods({
+      currentPositions: [
+        position({ size: 600, costBasis: 60, originalCostBasis: 60 }),
+      ],
+      events: [
+        event({
+          id: 2,
+          eventType: 'close',
+          appliedTime: NOW - DAY_MS / 2,
+          oraclePrice: 110,
+          sizeDelta: -400,
+          costBasisDelta: -40,
+          originalCostBasisDelta: -40,
+          // The survivor's leverage, not 0 — a partial close does not flatten.
+          leverage: 10,
+          data: {
+            payout: 80,
+            entryPrice: 100,
+            fraction: 0.4,
+            remainingSize: 600,
+          },
+        }),
+      ],
+      currentPrice: 110,
+      periods: periods(100),
+    })
+
+    // Boundary: the WHOLE position at the cutoff price, worth its margin.
+    // End: M$80 realized plus 600 notional now worth M$120.
+    expect(result?.from.day.invested).toBeCloseTo(100)
+    expect(result?.from.day.profit).toBeCloseTo(100)
+    expect(result?.from.day.profitPercent).toBeCloseTo(100)
+  })
+
+  it('refuses a liquidation that left the position open', () => {
+    // Partial closes relaxed the full-exit rule for closes only: liquidation
+    // forfeits the whole position, so a row surviving one is malformed.
+    expect(
+      calculatePerpMetricPeriods({
+        currentPositions: [
+          position({ size: 600, costBasis: 60, originalCostBasis: 60 }),
+        ],
+        events: [
+          event({
+            id: 2,
+            eventType: 'liquidation',
+            appliedTime: NOW - DAY_MS / 2,
+            oraclePrice: 90,
+            sizeDelta: -400,
+            costBasisDelta: -40,
+            originalCostBasisDelta: -40,
+            data: { payout: 0, entryPrice: 100 },
+          }),
+        ],
+        currentPrice: 90,
+        periods: periods(95),
+      })
+    ).toBeUndefined()
+  })
+
   it('captures liquidation loss relative to boundary equity', () => {
     const result = calculatePerpMetricPeriods({
       currentPositions: [],

--- a/common/src/perps/metric-periods.ts
+++ b/common/src/perps/metric-periods.ts
@@ -176,7 +176,21 @@ const reverseEvent = (
       }
       break
     case 'close':
+      if (
+        sizeDelta >= 0 ||
+        costBasisDelta >= 0 ||
+        originalCostBasisDelta >= 0
+      ) {
+        return undefined
+      }
+      // A full close removes the row; a partial one leaves it open with the
+      // same entry price and leverage, smaller — so the surviving row is what
+      // this event's deltas get added back onto. Rejecting anything else
+      // still catches a close replayed against no exposure at all.
+      if (!isFullExit && afterSize <= 0) return undefined
+      break
     case 'liquidation':
+      // Never partial: liquidation forfeits the whole position's margin.
       if (
         sizeDelta >= 0 ||
         costBasisDelta >= 0 ||

--- a/common/src/txn.ts
+++ b/common/src/txn.ts
@@ -628,7 +628,7 @@ type PerpClosePayout = {
     pnl: number
     entryPrice: number
     closePrice: number
-    reason: 'close' | 'flip' | 'resolve' | 'adl'
+    reason: 'close' | 'partial-close' | 'flip' | 'resolve' | 'adl'
   }
 }
 

--- a/web/components/feed/activity-card.tsx
+++ b/web/components/feed/activity-card.tsx
@@ -18,6 +18,7 @@ import {
 } from 'common/contract'
 import { ENV_CONFIG } from 'common/envs/constants'
 import type { PerpTradeActivity } from 'common/perps/activity'
+import { formatPerpClosePercent } from 'common/perps/format'
 import { PrivateUser, User } from 'common/user'
 import { shortFormatNumber } from 'common/util/format'
 import { removeEmojis } from 'common/util/string'
@@ -492,7 +493,7 @@ const PerpTradeLog = memo(function PerpTradeLog(props: {
     Number.isFinite(trade.fraction) &&
     trade.fraction > 0 &&
     trade.fraction < 1
-      ? Math.round(trade.fraction * 100)
+      ? formatPerpClosePercent(trade.fraction)
       : null
 
   return (
@@ -534,7 +535,7 @@ const PerpTradeLog = memo(function PerpTradeLog(props: {
           )}
           {partialPercent !== null && (
             <span className="text-ink-600">
-              {partialPercent}% of the position — the rest stays open
+              {partialPercent} of the position — the rest stays open
             </span>
           )}
           <RelativeTimestamp

--- a/web/components/feed/activity-card.tsx
+++ b/web/components/feed/activity-card.tsx
@@ -482,6 +482,18 @@ const PerpTradeLog = memo(function PerpTradeLog(props: {
     trade.leverage > 0
       ? trade.leverage
       : null
+  // A partial close leaves the position open. `margin` is already the amount
+  // this close actually took, so the sentence above stays true — what it
+  // cannot say is that the rest is still running, which goes in the detail
+  // row alongside where leverage sits for opens.
+  const partialPercent =
+    trade.eventType === 'close' &&
+    trade.fraction !== null &&
+    Number.isFinite(trade.fraction) &&
+    trade.fraction > 0 &&
+    trade.fraction < 1
+      ? Math.round(trade.fraction * 100)
+      : null
 
   return (
     <Row className="items-start gap-2 py-1">
@@ -518,6 +530,11 @@ const PerpTradeLog = memo(function PerpTradeLog(props: {
           {leverage !== null && (
             <span className="text-ink-600">
               {shortFormatNumber(leverage)}× leverage
+            </span>
+          )}
+          {partialPercent !== null && (
+            <span className="text-ink-600">
+              {partialPercent}% of the position — the rest stays open
             </span>
           )}
           <RelativeTimestamp

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -14,7 +14,10 @@ import {
   getUserFacingPnl,
   getUserFacingPnlPercent,
 } from 'common/perps/pnl'
-import { resolvePerpCloseFraction } from 'common/perps/amm'
+import {
+  PERP_MIN_CLOSE_FRACTION,
+  resolvePerpCloseFraction,
+} from 'common/perps/amm'
 import { PerpPosition } from 'common/perps/position'
 import { DAY_MS } from 'common/util/time'
 import {
@@ -32,7 +35,8 @@ import { randomString } from 'common/util/random'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
-import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
+import { Input } from 'web/components/widgets/input'
+import { Slider } from 'web/components/widgets/slider'
 import { api } from 'web/lib/api/api'
 import { useUser } from 'web/hooks/use-user'
 import { track } from 'web/lib/service/analytics'
@@ -462,15 +466,38 @@ const PositionCard = (props: {
   // pool debits all scale with q and c — so the preview below is exact, not
   // an estimate, and the survivor's entry price, leverage and liquidation
   // price are untouched by construction.
-  const [closeFraction, setCloseFraction] = useState(1)
+  const [closePercent, setClosePercent] = useState<number | undefined>(100)
+  const closePercentError =
+    closePercent == null || !Number.isFinite(closePercent)
+      ? 'Enter a percentage to close.'
+      : closePercent < MIN_CLOSE_PERCENT
+      ? `Minimum close is ${MIN_CLOSE_PERCENT}%.`
+      : closePercent > 100
+      ? 'Maximum close is 100%.'
+      : null
+  const closeFraction =
+    closePercent != null &&
+    Number.isFinite(closePercent) &&
+    closePercent >= MIN_CLOSE_PERCENT &&
+    closePercent <= 100
+      ? closePercent / 100
+      : null
   // What the engine will actually take: a remainder that would be dust is
   // closed too, so the button must not promise a position that will not exist.
-  const effectiveFraction = resolvePerpCloseFraction(p, closeFraction)
-  const isPartial = effectiveFraction < 1
+  const effectiveFraction =
+    closeFraction == null ? null : resolvePerpCloseFraction(p, closeFraction)
+  const isPartial = effectiveFraction != null && effectiveFraction < 1
+  const isDustPromoted =
+    closeFraction != null && closeFraction < 1 && effectiveFraction === 1
   const fullPayout = getPositionValue(position, markPrice)
-  const closePayout = effectiveFraction * fullPayout
-  const closePnl = effectiveFraction * pnl
-  const remainingMargin = (1 - effectiveFraction) * p.originalCostBasis
+  const closePayout = (effectiveFraction ?? 0) * fullPayout
+  const closePnl = (effectiveFraction ?? 0) * pnl
+  const remainingMargin = (1 - (effectiveFraction ?? 1)) * p.originalCostBasis
+  const sliderClosePercent =
+    closePercent != null && Number.isFinite(closePercent)
+      ? Math.min(100, Math.max(MIN_CLOSE_PERCENT, closePercent))
+      : 100
+  const closePercentErrorId = `close-percent-error-${direction}`
 
   // Distance to liquidation as a percentage of mark — useful risk signal.
   const distToLiq = isLong
@@ -607,16 +634,58 @@ const PositionCard = (props: {
             <span className={clsx('text-ink-500', CARD_LABEL)}>
               Close how much
             </span>
-            <ChoicesToggleGroup
-              currentChoice={closeFraction}
-              color="gray"
-              disabled={anyClosing || oracleTradingPaused}
-              choicesMap={{ '25%': 0.25, '50%': 0.5, '75%': 0.75, All: 1 }}
-              setChoice={(choice) => setCloseFraction(choice as number)}
-              toggleClassName="!px-2.5 !py-1"
-              className="!text-xs"
-            />
+            <div className="relative w-28">
+              <Input
+                aria-label="Percentage of position to close"
+                type="number"
+                inputMode="decimal"
+                min={MIN_CLOSE_PERCENT}
+                max={100}
+                step="any"
+                value={closePercent ?? ''}
+                error={closePercentError != null}
+                aria-invalid={closePercentError != null}
+                aria-describedby={
+                  closePercentError != null ? closePercentErrorId : undefined
+                }
+                disabled={anyClosing || oracleTradingPaused}
+                onFocus={(e) => e.target.select()}
+                onChange={(e) => {
+                  const value = e.target.value
+                  setClosePercent(value === '' ? undefined : Number(value))
+                }}
+                className="!h-9 !pr-8 text-right font-semibold tabular-nums"
+              />
+              <span className="text-ink-500 pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm">
+                %
+              </span>
+            </div>
           </Row>
+
+          <Slider
+            min={MIN_CLOSE_PERCENT}
+            max={100}
+            step={0.1}
+            amount={sliderClosePercent}
+            onChange={setClosePercent}
+            disabled={anyClosing || oracleTradingPaused}
+            color="gray"
+            ariaLabel="Close percentage slider"
+            ariaValueText={`${sliderClosePercent}% of position`}
+          />
+
+          {closePercentError != null && (
+            <div id={closePercentErrorId} className="text-error text-xs">
+              {closePercentError}
+            </div>
+          )}
+
+          {isDustPromoted && (
+            <div className="text-ink-500 text-xs">
+              That would leave less than the minimum margin, so the full
+              position will close.
+            </div>
+          )}
 
           {isPartial && (
             <div className={clsx('text-ink-500', CARD_LABEL)}>
@@ -641,14 +710,18 @@ const PositionCard = (props: {
 
           <Button
             color="gray-outline"
-            onClick={() => onClose(closeFraction)}
+            onClick={() => closeFraction != null && onClose(closeFraction)}
             loading={closing}
-            disabled={anyClosing || oracleTradingPaused}
+            disabled={
+              anyClosing || oracleTradingPaused || closeFraction == null
+            }
             size="md"
             className="w-full"
           >
             {oracleTradingPaused
               ? 'Close paused — waiting for oracle'
+              : closeFraction == null || effectiveFraction == null
+              ? 'Enter a valid close percentage'
               : `Close ${
                   isPartial
                     ? `${formatPerpClosePercent(effectiveFraction)} of `
@@ -667,6 +740,7 @@ const PositionCard = (props: {
 // Card widths of ~336px and up get exactly text-xs / text-sm.
 const CARD_LABEL = 'text-[clamp(10px,3.6cqw,0.75rem)]'
 const CARD_VALUE = 'text-[clamp(11px,4.2cqw,0.875rem)]'
+const MIN_CLOSE_PERCENT = PERP_MIN_CLOSE_FRACTION * 100
 
 // Drop trailing zeros so whole leverages render as "100×" not "100.00×",
 // but fractional ones keep one decimal of precision (e.g. "1.5×").

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -10,9 +10,11 @@ import {
 } from 'common/perps/funding'
 import {
   fundingPerPeriod,
+  getPositionValue,
   getUserFacingPnl,
   getUserFacingPnlPercent,
 } from 'common/perps/pnl'
+import { resolvePerpCloseFraction } from 'common/perps/amm'
 import { PerpPosition } from 'common/perps/position'
 import { DAY_MS } from 'common/util/time'
 import {
@@ -29,6 +31,7 @@ import { randomString } from 'common/util/random'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
+import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
 import { api } from 'web/lib/api/api'
 import { useUser } from 'web/hooks/use-user'
 import { track } from 'web/lib/service/analytics'
@@ -129,7 +132,7 @@ export const PerpPositionPanel = (props: {
   if (!user) return null
   if (!positions.length && !pastEvents.length) return null
 
-  const close = async (direction: 'long' | 'short') => {
+  const close = async (direction: 'long' | 'short', fraction = 1) => {
     if (oracleTradingPaused) {
       toast.error('Closing is paused until the oracle publishes a fresh price')
       return
@@ -138,9 +141,18 @@ export const PerpPositionPanel = (props: {
     try {
       const position = positions.find((p) => p.direction === direction)
       if (!position) throw new Error('Position is no longer open')
-      const fingerprint = [contract.id, direction, position.openedTime].join(
-        ':'
-      )
+      // A partial close leaves openedTime alone, so the fingerprint has to
+      // carry what the close itself is: two 25% closes in a row are separate
+      // trades, and sharing an idempotency key would silently replay the
+      // first instead of running the second. `size` moves after every close,
+      // so a retry of the SAME click still dedupes.
+      const fingerprint = [
+        contract.id,
+        direction,
+        position.openedTime,
+        position.size,
+        fraction,
+      ].join(':')
       const request =
         pendingCloses.current[direction]?.fingerprint === fingerprint
           ? pendingCloses.current[direction]
@@ -151,9 +163,17 @@ export const PerpPositionPanel = (props: {
         direction,
         idempotencyKey: request.idempotencyKey,
         expectedOpenedTime: position.openedTime,
+        ...(fraction < 1 ? { fraction } : {}),
       })
+      // The engine promotes a close whose remainder would be dust, so what
+      // came back — not what was asked for — decides the wording.
+      const closedAll = res.remainingSize <= 0
       toast.success(
-        `Closed ${direction} — payout ${formatMoneyPrecise(
+        `${
+          closedAll
+            ? `Closed ${direction}`
+            : `Closed ${Math.round(res.fraction * 100)}% of ${direction}`
+        } — payout ${formatMoneyPrecise(
           res.payout
         )} (profit ${formatMoneyPrecise(res.pnl)})`
       )
@@ -161,14 +181,19 @@ export const PerpPositionPanel = (props: {
         outcomeType: contract.outcomeType,
         slug: contract.slug,
         contractId: contract.id,
-        shares: position?.size,
+        shares: position.size * res.fraction,
         outcome: direction,
         token: contract.token,
-        perpAction: 'close',
+        perpAction: closedAll ? 'close' : 'partial-close',
+        fraction: res.fraction,
         payout: res.payout,
         pnl: res.pnl,
       })
-      setClosedAt((prev) => ({ ...prev, [direction]: Date.now() }))
+      // Only a full close may hide the row optimistically. A partial one
+      // keeps the same openedTime, so marking it closed here would hide the
+      // position that is still open — permanently.
+      if (closedAll)
+        setClosedAt((prev) => ({ ...prev, [direction]: Date.now() }))
       setRefresh((r) => r + 1)
       delete pendingCloses.current[direction]
       // Pools changed; let the page re-poll the contract immediately.
@@ -187,7 +212,7 @@ export const PerpPositionPanel = (props: {
           key={p.direction}
           position={p}
           contract={contract}
-          onClose={() => close(p.direction)}
+          onClose={(fraction) => close(p.direction, fraction)}
           closing={closing === p.direction}
           anyClosing={closing !== null}
           oracleTradingPaused={oracleTradingPaused}
@@ -208,6 +233,7 @@ type PerpHistoryEvent = {
   oraclePrice: number
   payout: number | null
   pnl: number | null
+  fraction: number | null
 }
 
 // Tombstones for closed/liquidated positions, so the outcome of a position
@@ -299,15 +325,20 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
           )
         }
 
-        // close
+        // close, whole or partial
         const pnl = e.pnl ?? 0
+        // Closes written before partial closes existed carry no fraction and
+        // were whole ones.
+        const partial = e.fraction != null && e.fraction < 1 ? e.fraction : null
         return (
           <Row
             key={e.id}
             className="flex-wrap items-baseline gap-x-3 gap-y-0.5 text-sm"
           >
             <span className="text-ink-700 font-medium">
-              Closed {e.direction}
+              {partial != null
+                ? `Closed ${Math.round(partial * 100)}% of ${e.direction}`
+                : `Closed ${e.direction}`}
             </span>
             <span className="text-ink-700 tabular-nums">
               payout {formatMoneyPrecise(e.payout ?? 0)}
@@ -349,7 +380,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
 const PositionCard = (props: {
   position: Position
   contract: PerpContract
-  onClose: () => void
+  onClose: (fraction: number) => void
   closing: boolean
   anyClosing: boolean
   oracleTradingPaused: boolean
@@ -416,6 +447,21 @@ const PositionCard = (props: {
           p.originalCostBasis) *
         100
       : 0
+
+  // How much of the position this close takes. Everything a partial close
+  // pays and leaves behind is LINEAR in the fraction — π, the payout and both
+  // pool debits all scale with q and c — so the preview below is exact, not
+  // an estimate, and the survivor's entry price, leverage and liquidation
+  // price are untouched by construction.
+  const [closeFraction, setCloseFraction] = useState(1)
+  // What the engine will actually take: a remainder that would be dust is
+  // closed too, so the button must not promise a position that will not exist.
+  const effectiveFraction = resolvePerpCloseFraction(p, closeFraction)
+  const isPartial = effectiveFraction < 1
+  const fullPayout = getPositionValue(position, markPrice)
+  const closePayout = effectiveFraction * fullPayout
+  const closePnl = effectiveFraction * pnl
+  const remainingMargin = (1 - effectiveFraction) * p.originalCostBasis
 
   // Distance to liquidation as a percentage of mark — useful risk signal.
   const distToLiq = isLong
@@ -547,18 +593,58 @@ const PositionCard = (props: {
           </div>
         )}
 
-        <Button
-          color="gray-outline"
-          onClick={onClose}
-          loading={closing}
-          disabled={anyClosing || oracleTradingPaused}
-          size="md"
-          className="w-full"
-        >
-          {oracleTradingPaused
-            ? 'Close paused — waiting for oracle'
-            : `Close position @ ${formatPrice(markPrice, priceDecimals)}`}
-        </Button>
+        <Col className="gap-2">
+          <Row className="items-center justify-between gap-2">
+            <span className={clsx('text-ink-500', CARD_LABEL)}>
+              Close how much
+            </span>
+            <ChoicesToggleGroup
+              currentChoice={closeFraction}
+              color="gray"
+              disabled={anyClosing || oracleTradingPaused}
+              choicesMap={{ '25%': 0.25, '50%': 0.5, '75%': 0.75, All: 1 }}
+              setChoice={(choice) => setCloseFraction(choice as number)}
+              toggleClassName="!px-2.5 !py-1"
+              className="!text-xs"
+            />
+          </Row>
+
+          {isPartial && (
+            <div className={clsx('text-ink-500', CARD_LABEL)}>
+              Pays out{' '}
+              <span className="text-ink-700 font-semibold tabular-nums">
+                {formatMoneyPrecise(closePayout)}
+              </span>{' '}
+              and realizes{' '}
+              <span
+                className={clsx(
+                  'font-semibold tabular-nums',
+                  closePnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'
+                )}
+              >
+                {closePnl >= 0 ? '+' : ''}
+                {formatMoneyPrecise(closePnl)}
+              </span>
+              . {formatMoneyPrecise(remainingMargin)} of margin stays open at
+              the same entry price, leverage and liquidation price.
+            </div>
+          )}
+
+          <Button
+            color="gray-outline"
+            onClick={() => onClose(closeFraction)}
+            loading={closing}
+            disabled={anyClosing || oracleTradingPaused}
+            size="md"
+            className="w-full"
+          >
+            {oracleTradingPaused
+              ? 'Close paused — waiting for oracle'
+              : `Close ${
+                  isPartial ? `${Math.round(effectiveFraction * 100)}% of ` : ''
+                }position @ ${formatPrice(markPrice, priceDecimals)}`}
+          </Button>
+        </Col>
       </Col>
     </Col>
   )

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -650,7 +650,9 @@ const PositionCard = (props: {
             {oracleTradingPaused
               ? 'Close paused — waiting for oracle'
               : `Close ${
-                  isPartial ? `${Math.round(effectiveFraction * 100)}% of ` : ''
+                  isPartial
+                    ? `${formatPerpClosePercent(effectiveFraction)} of `
+                    : ''
                 }position @ ${formatPrice(markPrice, priceDecimals)}`}
           </Button>
         </Col>

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -19,6 +19,7 @@ import { PerpPosition } from 'common/perps/position'
 import { DAY_MS } from 'common/util/time'
 import {
   formatCountdown,
+  formatPerpClosePercent,
   formatPrice,
   inferPriceDecimals,
 } from 'common/perps/format'
@@ -175,7 +176,7 @@ export const PerpPositionPanel = (props: {
         `${
           closedAll
             ? `Closed ${direction}`
-            : `Closed ${Math.round(res.fraction * 100)}% of ${direction}`
+            : `Closed ${formatPerpClosePercent(res.fraction)} of ${direction}`
         } — payout ${formatMoneyPrecise(
           res.payout
         )} (profit ${formatMoneyPrecise(res.pnl)})`
@@ -345,7 +346,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
           >
             <span className="text-ink-700 font-medium">
               {partial != null
-                ? `Closed ${Math.round(partial * 100)}% of ${e.direction}`
+                ? `Closed ${formatPerpClosePercent(partial)} of ${e.direction}`
                 : `Closed ${e.direction}`}
             </span>
             <span className="text-ink-700 tabular-nums">

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -497,7 +497,7 @@ const PositionCard = (props: {
     closePercent != null && Number.isFinite(closePercent)
       ? Math.min(100, Math.max(MIN_CLOSE_PERCENT, closePercent))
       : 100
-  const closePercentErrorId = `close-percent-error-${direction}`
+  const closePercentErrorId = `close-percent-error-${p.direction}`
 
   // Distance to liquidation as a percentage of mark — useful risk signal.
   const distToLiq = isLong

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -34,6 +34,7 @@ import {
 import { randomString } from 'common/util/random'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
+import { Modal } from 'web/components/layout/modal'
 import { Row } from 'web/components/layout/row'
 import { Input } from 'web/components/widgets/input'
 import { Slider } from 'web/components/widgets/slider'
@@ -140,7 +141,7 @@ export const PerpPositionPanel = (props: {
   const close = async (direction: 'long' | 'short', fraction = 1) => {
     if (oracleTradingPaused) {
       toast.error('Closing is paused until the oracle publishes a fresh price')
-      return
+      return false
     }
     setClosing(direction)
     try {
@@ -206,6 +207,7 @@ export const PerpPositionPanel = (props: {
       delete pendingCloses.current[direction]
       // Pools changed; let the page re-poll the contract immediately.
       onAction?.()
+      return true
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Close failed')
       // A 409 here means the row moved under the request and tells the user
@@ -213,6 +215,7 @@ export const PerpPositionPanel = (props: {
       // against the same stale numbers that just failed.
       setRefresh((r) => r + 1)
       onAction?.()
+      return false
     } finally {
       setClosing(null)
     }
@@ -393,7 +396,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
 const PositionCard = (props: {
   position: Position
   contract: PerpContract
-  onClose: (fraction: number) => void
+  onClose: (fraction: number) => Promise<boolean>
   closing: boolean
   anyClosing: boolean
   oracleTradingPaused: boolean
@@ -466,6 +469,7 @@ const PositionCard = (props: {
   // pool debits all scale with q and c — so the preview below is exact, not
   // an estimate, and the survivor's entry price, leverage and liquidation
   // price are untouched by construction.
+  const [closeModalOpen, setCloseModalOpen] = useState(false)
   const [closePercent, setClosePercent] = useState<number | undefined>(100)
   const closePercentError =
     closePercent == null || !Number.isFinite(closePercent)
@@ -629,106 +633,191 @@ const PositionCard = (props: {
           </div>
         )}
 
-        <Col className="gap-2">
-          <Row className="items-center justify-between gap-2">
-            <span className={clsx('text-ink-500', CARD_LABEL)}>
-              Close how much
-            </span>
-            <div className="relative w-28">
-              <Input
-                aria-label="Percentage of position to close"
-                type="number"
-                inputMode="decimal"
-                min={MIN_CLOSE_PERCENT}
-                max={100}
-                step="any"
-                value={closePercent ?? ''}
-                error={closePercentError != null}
-                aria-invalid={closePercentError != null}
-                aria-describedby={
-                  closePercentError != null ? closePercentErrorId : undefined
-                }
-                disabled={anyClosing || oracleTradingPaused}
-                onFocus={(e) => e.target.select()}
-                onChange={(e) => {
-                  const value = e.target.value
-                  setClosePercent(value === '' ? undefined : Number(value))
-                }}
-                className="!h-9 !pr-8 text-right font-semibold tabular-nums"
-              />
-              <span className="text-ink-500 pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm">
-                %
-              </span>
-            </div>
-          </Row>
+        <Button
+          color="gray-outline"
+          onClick={() => {
+            setClosePercent(100)
+            setCloseModalOpen(true)
+          }}
+          loading={closing}
+          disabled={anyClosing || oracleTradingPaused}
+          size="md"
+          className="w-full"
+        >
+          {oracleTradingPaused
+            ? 'Close paused — waiting for oracle'
+            : 'Close position'}
+        </Button>
 
-          <Slider
-            min={MIN_CLOSE_PERCENT}
-            max={100}
-            step={0.1}
-            amount={sliderClosePercent}
-            onChange={setClosePercent}
-            disabled={anyClosing || oracleTradingPaused}
-            color="gray"
-            ariaLabel="Close percentage slider"
-            ariaValueText={`${sliderClosePercent}% of position`}
-          />
-
-          {closePercentError != null && (
-            <div id={closePercentErrorId} className="text-error text-xs">
-              {closePercentError}
-            </div>
-          )}
-
-          {isDustPromoted && (
-            <div className="text-ink-500 text-xs">
-              That would leave less than the minimum margin, so the full
-              position will close.
-            </div>
-          )}
-
-          {isPartial && (
-            <div className={clsx('text-ink-500', CARD_LABEL)}>
-              Pays out{' '}
-              <span className="text-ink-700 font-semibold tabular-nums">
-                {formatMoneyPrecise(closePayout)}
-              </span>{' '}
-              and realizes{' '}
-              <span
-                className={clsx(
-                  'font-semibold tabular-nums',
-                  closePnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'
-                )}
-              >
-                {closePnl >= 0 ? '+' : ''}
-                {formatMoneyPrecise(closePnl)}
-              </span>
-              . {formatMoneyPrecise(remainingMargin)} of margin stays open at
-              the same entry price, leverage and liquidation price.
-            </div>
-          )}
-
-          <Button
-            color="gray-outline"
-            onClick={() => closeFraction != null && onClose(closeFraction)}
-            loading={closing}
-            disabled={
-              anyClosing || oracleTradingPaused || closeFraction == null
-            }
-            size="md"
-            className="w-full"
+        {closeModalOpen && (
+          <Modal
+            open={closeModalOpen}
+            setOpen={setCloseModalOpen}
+            size="sm"
+            ariaLabel={`Close ${p.direction} position`}
           >
-            {oracleTradingPaused
-              ? 'Close paused — waiting for oracle'
-              : closeFraction == null || effectiveFraction == null
-              ? 'Enter a valid close percentage'
-              : `Close ${
-                  isPartial
-                    ? `${formatPerpClosePercent(effectiveFraction)} of `
-                    : ''
-                }position @ ${formatPrice(markPrice, priceDecimals)}`}
-          </Button>
-        </Col>
+            <Col className="bg-canvas-0 gap-5 rounded-t-xl px-5 py-6 sm:rounded-xl sm:px-8">
+              <div>
+                <h2 className="text-ink-900 text-xl font-semibold">
+                  Close {p.direction} position
+                </h2>
+                <p className="text-ink-500 mt-1 text-sm">
+                  {formatMoney(p.size)} notional at the latest oracle price of{' '}
+                  {formatPrice(markPrice, priceDecimals)}. Closing is free.
+                </p>
+              </div>
+
+              <Col className="gap-2">
+                <Col className="gap-1">
+                  <span className="text-ink-600 text-sm">Close amount (%)</span>
+                  <div className="relative w-full">
+                    <Input
+                      aria-label="Percentage of position to close"
+                      type="number"
+                      inputMode="decimal"
+                      min={MIN_CLOSE_PERCENT}
+                      max={100}
+                      step="any"
+                      value={closePercent ?? ''}
+                      error={closePercentError != null}
+                      aria-invalid={closePercentError != null}
+                      aria-describedby={
+                        closePercentError != null
+                          ? closePercentErrorId
+                          : undefined
+                      }
+                      disabled={anyClosing || oracleTradingPaused}
+                      onFocus={(e) => e.target.select()}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        setClosePercent(
+                          value === '' ? undefined : Number(value)
+                        )
+                      }}
+                      className="h-[60px] w-full min-w-0 !pr-40 !text-xl tabular-nums"
+                    />
+                    <Row className="absolute right-2 top-3.5 gap-1.5">
+                      {[-5, -1, 1, 5].map((increment) => (
+                        <button
+                          key={increment}
+                          type="button"
+                          aria-label={`${
+                            increment < 0 ? 'Decrease' : 'Increase'
+                          } close percentage by ${Math.abs(increment)}`}
+                          className="bg-canvas-100 hover:bg-ink-200 rounded-md px-2 py-1.5 text-sm"
+                          disabled={anyClosing || oracleTradingPaused}
+                          onClick={() =>
+                            setClosePercent((percent) =>
+                              Math.min(
+                                100,
+                                Math.max(
+                                  MIN_CLOSE_PERCENT,
+                                  (percent ?? MIN_CLOSE_PERCENT) + increment
+                                )
+                              )
+                            )
+                          }
+                        >
+                          {increment > 0 ? `+${increment}` : increment}
+                        </button>
+                      ))}
+                    </Row>
+                  </div>
+                </Col>
+
+                <Slider
+                  min={MIN_CLOSE_PERCENT}
+                  max={100}
+                  step={0.1}
+                  amount={sliderClosePercent}
+                  onChange={setClosePercent}
+                  disabled={anyClosing || oracleTradingPaused}
+                  color="gray"
+                  ariaLabel="Close percentage slider"
+                  ariaValueText={`${sliderClosePercent}% of position`}
+                />
+
+                {closePercentError != null && (
+                  <div id={closePercentErrorId} className="text-error text-xs">
+                    {closePercentError}
+                  </div>
+                )}
+
+                {isDustPromoted && (
+                  <div className="text-ink-500 text-xs">
+                    That would leave less than the minimum margin, so the full
+                    position will close.
+                  </div>
+                )}
+              </Col>
+
+              {closeFraction != null && (
+                <Col className="gap-2.5 text-sm">
+                  <Row className="items-center justify-between gap-3">
+                    <span className="text-ink-500">Realized P&amp;L</span>
+                    <span
+                      className={clsx(
+                        'font-medium tabular-nums',
+                        closePnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'
+                      )}
+                    >
+                      {closePnl >= 0 ? '+' : ''}
+                      {formatMoneyPrecise(closePnl)}
+                    </span>
+                  </Row>
+
+                  {isPartial && (
+                    <>
+                      <Row className="items-center justify-between gap-3">
+                        <span className="text-ink-500">Margin remaining</span>
+                        <span className="text-ink-900 tabular-nums">
+                          {formatMoneyPrecise(remainingMargin)}
+                        </span>
+                      </Row>
+                      <p className="text-ink-400 text-xs">
+                        The remainder keeps its entry price, leverage and
+                        liquidation price.
+                      </p>
+                    </>
+                  )}
+
+                  <div className="border-ink-200 my-1 border-t" />
+
+                  <Row className="items-center justify-between gap-3">
+                    <span className="text-ink-900 font-medium">Payout</span>
+                    <span className="text-ink-900 text-lg font-semibold tabular-nums">
+                      {formatMoneyPrecise(closePayout)}
+                    </span>
+                  </Row>
+                </Col>
+              )}
+
+              <Button
+                color="indigo"
+                onClick={async () => {
+                  if (closeFraction != null && (await onClose(closeFraction)))
+                    setCloseModalOpen(false)
+                }}
+                loading={closing}
+                disabled={
+                  anyClosing || oracleTradingPaused || closeFraction == null
+                }
+                size="xl"
+                className="w-full"
+              >
+                {oracleTradingPaused
+                  ? 'Close paused — waiting for oracle'
+                  : closeFraction == null || effectiveFraction == null
+                  ? 'Enter a valid close percentage'
+                  : isPartial
+                  ? `Close ${formatPerpClosePercent(
+                      effectiveFraction
+                    )} of position`
+                  : 'Close entire position'}
+              </Button>
+            </Col>
+          </Modal>
+        )}
       </Col>
     </Col>
   )

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -37,6 +37,7 @@ import { Col } from 'web/components/layout/col'
 import { Modal } from 'web/components/layout/modal'
 import { Row } from 'web/components/layout/row'
 import { Input } from 'web/components/widgets/input'
+import { InfoTooltip } from 'web/components/widgets/info-tooltip'
 import { Slider } from 'web/components/widgets/slider'
 import { api } from 'web/lib/api/api'
 import { useUser } from 'web/hooks/use-user'
@@ -224,7 +225,7 @@ export const PerpPositionPanel = (props: {
   return (
     <Col className="gap-3">
       {positions.map((p) => (
-        <PositionCard
+        <PositionSummary
           key={p.direction}
           position={p}
           contract={contract}
@@ -393,7 +394,7 @@ const PositionHistory = (props: { events: PerpHistoryEvent[] }) => {
   )
 }
 
-const PositionCard = (props: {
+const PositionSummary = (props: {
   position: Position
   contract: PerpContract
   onClose: (fraction: number) => Promise<boolean>
@@ -426,7 +427,6 @@ const PositionCard = (props: {
   const pnlPct = getUserFacingPnlPercent(position, markPrice) * 100
 
   const isLong = p.direction === 'long'
-  const accentBar = isLong ? 'bg-teal-500' : 'bg-scarlet-500'
   const accentText = isLong ? 'text-teal-600' : 'text-scarlet-600'
   const pnlColor = pnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'
 
@@ -515,316 +515,310 @@ const PositionCard = (props: {
       : 'text-ink-900'
 
   return (
-    // Match the compact holdings summaries elsewhere on the site. The
-    // three-column stats scale with the card so they also fit the hub on phones.
-    <Col
-      className={clsx(
-        'border-ink-200 bg-canvas-0 @container relative overflow-hidden rounded-lg border'
-      )}
-    >
-      <div className={clsx('absolute inset-y-0 left-0 w-1', accentBar)} />
-      <Col className="gap-2 p-3 pl-4">
-        <Row className="items-center justify-between gap-3">
-          <span
-            className={clsx('text-sm font-semibold capitalize', accentText)}
-          >
-            {p.direction} {formatLeverage(p.leverage)}×
+    // Use the same unboxed, wrapping holdings row as UserBetSummary. Keep
+    // perp-specific labels: notional exposure is not a binary market's payout.
+    <Col className="gap-2 py-1">
+      <Row className="flex-wrap items-center gap-4">
+        <Col>
+          <div className="text-ink-500 whitespace-nowrap text-sm">
+            Position{' '}
+            <InfoTooltip text="Notional exposure of your remaining open position, including leverage. This is not the amount returned when you close." />
+          </div>
+          <div className="whitespace-nowrap tabular-nums">
+            {formatMoney(p.size)}{' '}
+            <span className={clsx('capitalize', accentText)}>
+              {p.direction} {formatLeverage(p.leverage)}×
+            </span>
+          </div>
+        </Col>
+        <Col>
+          <div className="text-ink-500 whitespace-nowrap text-sm">
+            Margin{' '}
+            <InfoTooltip text="Original margin allocated to the portion of your position still open, excluding opening fees. Closing part of a position reduces this proportionally." />
+          </div>
+          <div className="whitespace-nowrap tabular-nums">
+            {formatMoney(p.originalCostBasis)}
+          </div>
+        </Col>
+        <Col>
+          <div className="text-ink-500 whitespace-nowrap text-sm">
+            Unrealized P&amp;L{' '}
+            <InfoTooltip text="Profit or loss on your remaining open position, including funding and opening fees. Does not include portions you have already closed." />
+          </div>
+          <div className={clsx('whitespace-nowrap tabular-nums', pnlColor)}>
+            {pnl >= 0 ? '+' : ''}
+            {formatMoneyPrecise(pnl)}{' '}
+            <span className="text-xs">
+              ({pnl >= 0 ? '+' : ''}
+              {pnlPct.toFixed(2)}%)
+            </span>
+          </div>
+        </Col>
+        <Col>
+          <div className="text-ink-500 whitespace-nowrap text-sm">
+            Value{' '}
+            <InfoTooltip text="Amount returned if you close the entire remaining position at the current oracle price. Closing is free; the price can change before execution." />
+          </div>
+          <div className="whitespace-nowrap tabular-nums">
+            {formatMoneyPrecise(fullPayout)}
+          </div>
+        </Col>
+        <Button
+          color="gray-outline"
+          onClick={() => {
+            setClosePercent(100)
+            setCloseModalOpen(true)
+          }}
+          loading={closing}
+          disabled={anyClosing || oracleTradingPaused}
+          size="xs"
+          className="shrink-0 !py-1"
+        >
+          Close
+        </Button>
+      </Row>
+
+      <Row className="text-ink-500 flex-wrap gap-x-4 gap-y-1 text-xs tabular-nums">
+        <span>
+          Entry{' '}
+          <span className="text-ink-700">
+            {formatPrice(p.entryPrice, priceDecimals)}
           </span>
-          <Button
-            color="gray-outline"
-            onClick={() => {
-              setClosePercent(100)
-              setCloseModalOpen(true)
-            }}
-            loading={closing}
-            disabled={anyClosing || oracleTradingPaused}
-            size="xs"
-            className="shrink-0 !py-1"
-          >
-            Close
-          </Button>
-        </Row>
-
-        <div className="grid grid-cols-3 gap-2">
-          {[
-            { label: 'Notional', value: formatMoney(p.size) },
-            { label: 'Margin', value: formatMoney(p.originalCostBasis) },
-          ].map(({ label, value }) => (
-            <Col key={label} className="min-w-0 gap-0.5">
-              <div className={clsx('text-ink-500', CARD_LABEL)}>{label}</div>
-              <div
-                className={clsx(
-                  'text-ink-900 font-medium tabular-nums',
-                  CARD_VALUE
-                )}
-              >
-                {value}
-              </div>
-            </Col>
-          ))}
-          <Col className="min-w-0 gap-0.5">
-            <div className={clsx('text-ink-500', CARD_LABEL)}>
-              Unrealized P&amp;L
-            </div>
-            <div
-              className={clsx('font-medium tabular-nums', CARD_VALUE, pnlColor)}
-            >
-              {pnl >= 0 ? '+' : ''}
-              {formatMoneyPrecise(pnl)}
-            </div>
-            <div className={clsx('tabular-nums', CARD_LABEL, pnlColor)}>
-              {pnl >= 0 ? '+' : ''}
-              {pnlPct.toFixed(2)}%
-            </div>
-          </Col>
-        </div>
-
-        {/* Price stats grid */}
-        <div className="border-ink-200 grid grid-cols-3 gap-2 border-t pt-2">
-          <PriceStat
-            label="Entry"
-            value={formatPrice(p.entryPrice, priceDecimals)}
-          />
-          <PriceStat
-            label="Mark"
-            value={formatPrice(markPrice, priceDecimals)}
-          />
-          <PriceStat
-            label="Liquidation"
-            value={formatPrice(p.liquidationPrice, priceDecimals)}
-            valueClass={liqDangerClass}
-            sublabel={
-              distToLiq > 0
-                ? `${(distToLiq * 100).toFixed(1)}% away`
-                : 'at risk'
-            }
-          />
-        </div>
-
-        {/* One left-aligned sentence — a lone "Funding" label with a
-            paragraph-length value right-aligned across the card read as two
-            disconnected columns. */}
-        {Math.abs(fundingMana) >= MONEY_PRECISE_DUST && (
-          <div className="text-xs">
-            <span
-              className={clsx(
-                'tabular-nums',
-                fundingMana > 0 ? 'text-teal-600' : 'text-scarlet-600'
-              )}
-            >
-              {fundingMana > 0 ? 'Earning ' : 'Paying '}
-              {formatMoneyPrecise(Math.abs(fundingMana))}/
-              {fundingPeriodUnit(fundingPeriodMs)}{' '}
-              {fundingMana > 0 ? 'from funding' : 'in funding'}
-            </span>
-            <span className="text-ink-400">
-              {fundingDailyPct >= 0.05 &&
-                ` (${
-                  fundingDailyPct >= 10
-                    ? fundingDailyPct.toFixed(0)
-                    : fundingDailyPct.toFixed(1)
-                }%/day of margin)`}
-              {fundingCountdown != null && ` · next in ${fundingCountdown}`}
-            </span>
-          </div>
-        )}
-
-        {distToLiq < 0.05 && (
-          <div className="bg-scarlet-50 text-scarlet-600 rounded-md px-2.5 py-1.5 text-xs font-medium">
+        </span>
+        <span>
+          Mark{' '}
+          <span className="text-ink-700">
+            {formatPrice(markPrice, priceDecimals)}
+          </span>
+        </span>
+        <span>
+          Liquidation{' '}
+          <span className={liqDangerClass}>
+            {formatPrice(p.liquidationPrice, priceDecimals)}
+            {' ('}
             {distToLiq > 0
-              ? `A ${(distToLiq * 100).toFixed(
-                  1
-                )}% move against you liquidates this position — the remaining margin is forfeited to the pool.`
-              : 'This position is at its liquidation price — the next adverse tick liquidates it and forfeits the remaining margin.'}
-          </div>
-        )}
+              ? `${(distToLiq * 100).toFixed(1)}% away`
+              : 'at risk'}
+            {')'}
+          </span>
+        </span>
+      </Row>
 
-        {oracleTradingPaused && (
-          <div className="text-ink-500 text-xs">
-            Closing is paused until the oracle updates.
-          </div>
-        )}
-
-        {closeModalOpen && (
-          <Modal
-            open={closeModalOpen}
-            setOpen={setCloseModalOpen}
-            size="sm"
-            ariaLabel={`Close ${p.direction} position`}
+      {/* One left-aligned sentence — a lone "Funding" label with a
+            paragraph-length value right-aligned across the summary read as two
+            disconnected columns. */}
+      {Math.abs(fundingMana) >= MONEY_PRECISE_DUST && (
+        <div className="text-xs">
+          <span
+            className={clsx(
+              'tabular-nums',
+              fundingMana > 0 ? 'text-teal-600' : 'text-scarlet-600'
+            )}
           >
-            <Col className="bg-canvas-0 gap-5 rounded-t-xl px-5 py-6 sm:rounded-xl sm:px-8">
-              <div>
-                <h2 className="text-ink-900 text-xl font-semibold">
-                  Close {p.direction} position
-                </h2>
-                <p className="text-ink-500 mt-1 text-sm">
-                  {formatMoney(p.size)} notional at the latest oracle price of{' '}
-                  {formatPrice(markPrice, priceDecimals)}. Closing is free.
-                </p>
-              </div>
+            {fundingMana > 0 ? 'Earning ' : 'Paying '}
+            {formatMoneyPrecise(Math.abs(fundingMana))}/
+            {fundingPeriodUnit(fundingPeriodMs)}{' '}
+            {fundingMana > 0 ? 'from funding' : 'in funding'}
+          </span>
+          <span className="text-ink-400">
+            {fundingDailyPct >= 0.05 &&
+              ` (${
+                fundingDailyPct >= 10
+                  ? fundingDailyPct.toFixed(0)
+                  : fundingDailyPct.toFixed(1)
+              }%/day of margin)`}
+            {fundingCountdown != null && ` · next in ${fundingCountdown}`}
+          </span>
+        </div>
+      )}
 
-              <Col className="gap-2">
-                <Col className="gap-1">
-                  <span className="text-ink-600 text-sm">Close amount (%)</span>
-                  <div className="relative w-full">
-                    <Input
-                      aria-label="Percentage of position to close"
-                      type="number"
-                      inputMode="decimal"
-                      min={MIN_CLOSE_PERCENT}
-                      max={100}
-                      step="any"
-                      value={closePercent ?? ''}
-                      error={closePercentError != null}
-                      aria-invalid={closePercentError != null}
-                      aria-describedby={
-                        closePercentError != null
-                          ? closePercentErrorId
-                          : undefined
-                      }
-                      disabled={anyClosing || oracleTradingPaused}
-                      onFocus={(e) => e.target.select()}
-                      onChange={(e) => {
-                        const value = e.target.value
-                        setClosePercent(
-                          value === '' ? undefined : Number(value)
-                        )
-                      }}
-                      className="h-[60px] w-full min-w-0 !pr-40 !text-xl tabular-nums"
-                    />
-                    <Row className="absolute right-2 top-3.5 gap-1.5">
-                      {[-5, -1, 1, 5].map((increment) => (
-                        <button
-                          key={increment}
-                          type="button"
-                          aria-label={`${
-                            increment < 0 ? 'Decrease' : 'Increase'
-                          } close percentage by ${Math.abs(increment)}`}
-                          className="bg-canvas-100 hover:bg-ink-200 rounded-md px-2 py-1.5 text-sm"
-                          disabled={anyClosing || oracleTradingPaused}
-                          onClick={() =>
-                            setClosePercent((percent) =>
-                              Math.min(
-                                100,
-                                Math.max(
-                                  MIN_CLOSE_PERCENT,
-                                  (percent ?? MIN_CLOSE_PERCENT) + increment
-                                )
+      {distToLiq < 0.05 && (
+        <div className="bg-scarlet-50 text-scarlet-600 rounded-md px-2.5 py-1.5 text-xs font-medium">
+          {distToLiq > 0
+            ? `A ${(distToLiq * 100).toFixed(
+                1
+              )}% move against you liquidates this position — the remaining margin is forfeited to the pool.`
+            : 'This position is at its liquidation price — the next adverse tick liquidates it and forfeits the remaining margin.'}
+        </div>
+      )}
+
+      {oracleTradingPaused && (
+        <div className="text-ink-500 text-xs">
+          Closing is paused until the oracle updates.
+        </div>
+      )}
+
+      {closeModalOpen && (
+        <Modal
+          open={closeModalOpen}
+          setOpen={setCloseModalOpen}
+          size="sm"
+          ariaLabel={`Close ${p.direction} position`}
+        >
+          <Col className="bg-canvas-0 gap-5 rounded-t-xl px-5 py-6 sm:rounded-xl sm:px-8">
+            <div>
+              <h2 className="text-ink-900 text-xl font-semibold">
+                Close {p.direction} position
+              </h2>
+              <p className="text-ink-500 mt-1 text-sm">
+                {formatMoney(p.size)} notional at the latest oracle price of{' '}
+                {formatPrice(markPrice, priceDecimals)}. Closing is free.
+              </p>
+            </div>
+
+            <Col className="gap-2">
+              <Col className="gap-1">
+                <span className="text-ink-600 text-sm">Close amount (%)</span>
+                <div className="relative w-full">
+                  <Input
+                    aria-label="Percentage of position to close"
+                    type="number"
+                    inputMode="decimal"
+                    min={MIN_CLOSE_PERCENT}
+                    max={100}
+                    step="any"
+                    value={closePercent ?? ''}
+                    error={closePercentError != null}
+                    aria-invalid={closePercentError != null}
+                    aria-describedby={
+                      closePercentError != null
+                        ? closePercentErrorId
+                        : undefined
+                    }
+                    disabled={anyClosing || oracleTradingPaused}
+                    onFocus={(e) => e.target.select()}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      setClosePercent(value === '' ? undefined : Number(value))
+                    }}
+                    className="h-[60px] w-full min-w-0 !pr-40 !text-xl tabular-nums"
+                  />
+                  <Row className="absolute right-2 top-3.5 gap-1.5">
+                    {[-5, -1, 1, 5].map((increment) => (
+                      <button
+                        key={increment}
+                        type="button"
+                        aria-label={`${
+                          increment < 0 ? 'Decrease' : 'Increase'
+                        } close percentage by ${Math.abs(increment)}`}
+                        className="bg-canvas-100 hover:bg-ink-200 rounded-md px-2 py-1.5 text-sm"
+                        disabled={anyClosing || oracleTradingPaused}
+                        onClick={() =>
+                          setClosePercent((percent) =>
+                            Math.min(
+                              100,
+                              Math.max(
+                                MIN_CLOSE_PERCENT,
+                                (percent ?? MIN_CLOSE_PERCENT) + increment
                               )
                             )
-                          }
-                        >
-                          {increment > 0 ? `+${increment}` : increment}
-                        </button>
-                      ))}
-                    </Row>
-                  </div>
-                </Col>
-
-                <Slider
-                  min={MIN_CLOSE_PERCENT}
-                  max={100}
-                  step={0.1}
-                  amount={sliderClosePercent}
-                  onChange={setClosePercent}
-                  disabled={anyClosing || oracleTradingPaused}
-                  color="gray"
-                  ariaLabel="Close percentage slider"
-                  ariaValueText={`${sliderClosePercent}% of position`}
-                />
-
-                {closePercentError != null && (
-                  <div id={closePercentErrorId} className="text-error text-xs">
-                    {closePercentError}
-                  </div>
-                )}
-
-                {isDustPromoted && (
-                  <div className="text-ink-500 text-xs">
-                    That would leave less than the minimum margin, so the full
-                    position will close.
-                  </div>
-                )}
+                          )
+                        }
+                      >
+                        {increment > 0 ? `+${increment}` : increment}
+                      </button>
+                    ))}
+                  </Row>
+                </div>
               </Col>
 
-              {closeFraction != null && (
-                <Col className="gap-2.5 text-sm">
-                  <Row className="items-center justify-between gap-3">
-                    <span className="text-ink-500">Realized P&amp;L</span>
-                    <span
-                      className={clsx(
-                        'font-medium tabular-nums',
-                        closePnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'
-                      )}
-                    >
-                      {closePnl >= 0 ? '+' : ''}
-                      {formatMoneyPrecise(closePnl)}
-                    </span>
-                  </Row>
+              <Slider
+                min={MIN_CLOSE_PERCENT}
+                max={100}
+                step={0.1}
+                amount={sliderClosePercent}
+                onChange={setClosePercent}
+                disabled={anyClosing || oracleTradingPaused}
+                color="gray"
+                ariaLabel="Close percentage slider"
+                ariaValueText={`${sliderClosePercent}% of position`}
+              />
 
-                  {isPartial && (
-                    <>
-                      <Row className="items-center justify-between gap-3">
-                        <span className="text-ink-500">Margin remaining</span>
-                        <span className="text-ink-900 tabular-nums">
-                          {formatMoneyPrecise(remainingMargin)}
-                        </span>
-                      </Row>
-                      <p className="text-ink-400 text-xs">
-                        The remainder keeps its entry price, leverage and
-                        liquidation price.
-                      </p>
-                    </>
-                  )}
-
-                  <div className="border-ink-200 my-1 border-t" />
-
-                  <Row className="items-center justify-between gap-3">
-                    <span className="text-ink-900 font-medium">Payout</span>
-                    <span className="text-ink-900 text-lg font-semibold tabular-nums">
-                      {formatMoneyPrecise(closePayout)}
-                    </span>
-                  </Row>
-                </Col>
+              {closePercentError != null && (
+                <div id={closePercentErrorId} className="text-error text-xs">
+                  {closePercentError}
+                </div>
               )}
 
-              <Button
-                color="indigo"
-                onClick={async () => {
-                  if (closeFraction != null && (await onClose(closeFraction)))
-                    setCloseModalOpen(false)
-                }}
-                loading={closing}
-                disabled={
-                  anyClosing || oracleTradingPaused || closeFraction == null
-                }
-                size="xl"
-                className="w-full"
-              >
-                {oracleTradingPaused
-                  ? 'Close paused — waiting for oracle'
-                  : closeFraction == null || effectiveFraction == null
-                  ? 'Enter a valid close percentage'
-                  : isPartial
-                  ? `Close ${formatPerpClosePercent(
-                      effectiveFraction
-                    )} of position`
-                  : 'Close entire position'}
-              </Button>
+              {isDustPromoted && (
+                <div className="text-ink-500 text-xs">
+                  That would leave less than the minimum margin, so the full
+                  position will close.
+                </div>
+              )}
             </Col>
-          </Modal>
-        )}
-      </Col>
+
+            {closeFraction != null && (
+              <Col className="gap-2.5 text-sm">
+                <Row className="items-center justify-between gap-3">
+                  <span className="text-ink-500">Realized P&amp;L</span>
+                  <span
+                    className={clsx(
+                      'font-medium tabular-nums',
+                      closePnl >= 0 ? 'text-teal-600' : 'text-scarlet-600'
+                    )}
+                  >
+                    {closePnl >= 0 ? '+' : ''}
+                    {formatMoneyPrecise(closePnl)}
+                  </span>
+                </Row>
+
+                {isPartial && (
+                  <>
+                    <Row className="items-center justify-between gap-3">
+                      <span className="text-ink-500">Margin remaining</span>
+                      <span className="text-ink-900 tabular-nums">
+                        {formatMoneyPrecise(remainingMargin)}
+                      </span>
+                    </Row>
+                    <p className="text-ink-400 text-xs">
+                      The remainder keeps its entry price, leverage and
+                      liquidation price.
+                    </p>
+                  </>
+                )}
+
+                <div className="border-ink-200 my-1 border-t" />
+
+                <Row className="items-center justify-between gap-3">
+                  <span className="text-ink-900 font-medium">Payout</span>
+                  <span className="text-ink-900 text-lg font-semibold tabular-nums">
+                    {formatMoneyPrecise(closePayout)}
+                  </span>
+                </Row>
+              </Col>
+            )}
+
+            <Button
+              color="indigo"
+              onClick={async () => {
+                if (closeFraction != null && (await onClose(closeFraction)))
+                  setCloseModalOpen(false)
+              }}
+              loading={closing}
+              disabled={
+                anyClosing || oracleTradingPaused || closeFraction == null
+              }
+              size="xl"
+              className="w-full"
+            >
+              {oracleTradingPaused
+                ? 'Close paused — waiting for oracle'
+                : closeFraction == null || effectiveFraction == null
+                ? 'Enter a valid close percentage'
+                : isPartial
+                ? `Close ${formatPerpClosePercent(
+                    effectiveFraction
+                  )} of position`
+                : 'Close entire position'}
+            </Button>
+          </Col>
+        </Modal>
+      )}
     </Col>
   )
 }
 
-// Small type inside the card follows the card's width (cqw) between a px
-// floor and the usual text-xs / text-sm, so three mono prices and the
-// labels above them keep fitting when a phone runs a large text setting.
-// Card widths of ~336px and up get exactly text-xs / text-sm.
-const CARD_LABEL = 'text-[clamp(10px,3.6cqw,0.75rem)] leading-4'
-const CARD_VALUE = 'text-[clamp(11px,4.2cqw,0.875rem)] leading-5'
 const MIN_CLOSE_PERCENT = PERP_MIN_CLOSE_FRACTION * 100
 
 // Drop trailing zeros so whole leverages render as "100×" not "100.00×",
@@ -833,26 +827,3 @@ const formatLeverage = (leverage: number) => {
   const rounded = Math.round(leverage * 10) / 10
   return Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)
 }
-
-const PriceStat = (props: {
-  label: string
-  value: string
-  valueClass?: string
-  sublabel?: string
-}) => (
-  <Col className="min-w-0 gap-0.5">
-    <div className={clsx('text-ink-500', CARD_LABEL)}>{props.label}</div>
-    <div
-      className={clsx(
-        'text-ink-900 whitespace-nowrap font-mono font-semibold tabular-nums',
-        CARD_VALUE,
-        props.valueClass
-      )}
-    >
-      {props.value}
-    </div>
-    {props.sublabel && (
-      <div className={clsx('text-ink-400', CARD_LABEL)}>{props.sublabel}</div>
-    )}
-  </Col>
-)

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -163,7 +163,10 @@ export const PerpPositionPanel = (props: {
         direction,
         idempotencyKey: request.idempotencyKey,
         expectedOpenedTime: position.openedTime,
-        ...(fraction < 1 ? { fraction } : {}),
+        // Bind a partial close to the row it was sized against. openedTime
+        // survives a partial close, so it alone cannot tell the engine that
+        // this 75% was 75% OF 400 rather than of whatever is there now.
+        ...(fraction < 1 ? { fraction, expectedSize: position.size } : {}),
       })
       // The engine promotes a close whose remainder would be dust, so what
       // came back — not what was asked for — decides the wording.
@@ -200,6 +203,11 @@ export const PerpPositionPanel = (props: {
       onAction?.()
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Close failed')
+      // A 409 here means the row moved under the request and tells the user
+      // to refresh — so refresh, rather than leaving them to do it by hand
+      // against the same stale numbers that just failed.
+      setRefresh((r) => r + 1)
+      onAction?.()
     } finally {
       setClosing(null)
     }

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -515,53 +515,59 @@ const PositionCard = (props: {
       : 'text-ink-900'
 
   return (
-    // The card renders at very different widths — full column on the
-    // market page, a phone with large text, the hub's terminal — so its type
-    // steps on the card's own width (@container), in rem so a user's larger
-    // text setting counts as less room. Below that, the header wraps and the
-    // number column can shrink: a flex item's default min-width is its
-    // content, so two wide numbers used to push the P&L block clean out of
-    // the card (overflow-hidden then clipped it).
+    // Match the compact holdings summaries elsewhere on the site. The
+    // three-column stats scale with the card so they also fit the hub on phones.
     <Col
       className={clsx(
         'border-ink-200 bg-canvas-0 @container relative overflow-hidden rounded-lg border'
       )}
     >
       <div className={clsx('absolute inset-y-0 left-0 w-1', accentBar)} />
-      <Col className="gap-3 p-4 pl-5">
-        {/* Header: side + leverage badge, then PnL */}
-        <Row className="items-start justify-between gap-3">
-          <Col className="min-w-0 gap-0.5">
-            <Row className="items-center gap-2">
-              <span
+      <Col className="gap-2 p-3 pl-4">
+        <Row className="items-center justify-between gap-3">
+          <span
+            className={clsx('text-sm font-semibold capitalize', accentText)}
+          >
+            {p.direction} {formatLeverage(p.leverage)}×
+          </span>
+          <Button
+            color="gray-outline"
+            onClick={() => {
+              setClosePercent(100)
+              setCloseModalOpen(true)
+            }}
+            loading={closing}
+            disabled={anyClosing || oracleTradingPaused}
+            size="xs"
+            className="shrink-0 !py-1"
+          >
+            Close
+          </Button>
+        </Row>
+
+        <div className="grid grid-cols-3 gap-2">
+          {[
+            { label: 'Notional', value: formatMoney(p.size) },
+            { label: 'Margin', value: formatMoney(p.originalCostBasis) },
+          ].map(({ label, value }) => (
+            <Col key={label} className="min-w-0 gap-0.5">
+              <div className={clsx('text-ink-500', CARD_LABEL)}>{label}</div>
+              <div
                 className={clsx(
-                  'whitespace-nowrap text-[clamp(13px,4.8cqw,1rem)] font-semibold capitalize',
-                  accentText
+                  'text-ink-900 font-medium tabular-nums',
+                  CARD_VALUE
                 )}
               >
-                {p.direction} {formatLeverage(p.leverage)}×
-              </span>
-            </Row>
-            {/* The two headline numbers must share one line at any card
-                width, so their size follows the card (cqw) between fixed
-                px floors and the desktop sizes. Floors are px, not rem, so
-                a large OS text setting can't re-widen them past the card. */}
-            <div className="text-ink-900 whitespace-nowrap text-[clamp(15px,6.5cqw,1.5rem)] font-bold tabular-nums leading-tight">
-              {formatMoney(p.size)}
-            </div>
+                {value}
+              </div>
+            </Col>
+          ))}
+          <Col className="min-w-0 gap-0.5">
             <div className={clsx('text-ink-500', CARD_LABEL)}>
-              notional · {formatMoney(p.originalCostBasis)} margin
-            </div>
-          </Col>
-          <Col className="shrink-0 items-end">
-            <div className={clsx('text-ink-400 whitespace-nowrap', CARD_LABEL)}>
-              Unrealized profit
+              Unrealized P&amp;L
             </div>
             <div
-              className={clsx(
-                'whitespace-nowrap text-[clamp(13px,5.5cqw,1.25rem)] font-bold tabular-nums leading-tight',
-                pnlColor
-              )}
+              className={clsx('font-medium tabular-nums', CARD_VALUE, pnlColor)}
             >
               {pnl >= 0 ? '+' : ''}
               {formatMoneyPrecise(pnl)}
@@ -571,10 +577,10 @@ const PositionCard = (props: {
               {pnlPct.toFixed(2)}%
             </div>
           </Col>
-        </Row>
+        </div>
 
         {/* Price stats grid */}
-        <div className="border-ink-200 grid grid-cols-3 gap-2 border-t pt-3">
+        <div className="border-ink-200 grid grid-cols-3 gap-2 border-t pt-2">
           <PriceStat
             label="Entry"
             value={formatPrice(p.entryPrice, priceDecimals)}
@@ -599,7 +605,7 @@ const PositionCard = (props: {
             paragraph-length value right-aligned across the card read as two
             disconnected columns. */}
         {Math.abs(fundingMana) >= MONEY_PRECISE_DUST && (
-          <div className="-mt-1 text-sm">
+          <div className="text-xs">
             <span
               className={clsx(
                 'tabular-nums',
@@ -633,21 +639,11 @@ const PositionCard = (props: {
           </div>
         )}
 
-        <Button
-          color="gray-outline"
-          onClick={() => {
-            setClosePercent(100)
-            setCloseModalOpen(true)
-          }}
-          loading={closing}
-          disabled={anyClosing || oracleTradingPaused}
-          size="md"
-          className="w-full"
-        >
-          {oracleTradingPaused
-            ? 'Close paused — waiting for oracle'
-            : 'Close position'}
-        </Button>
+        {oracleTradingPaused && (
+          <div className="text-ink-500 text-xs">
+            Closing is paused until the oracle updates.
+          </div>
+        )}
 
         {closeModalOpen && (
           <Modal
@@ -827,8 +823,8 @@ const PositionCard = (props: {
 // floor and the usual text-xs / text-sm, so three mono prices and the
 // labels above them keep fitting when a phone runs a large text setting.
 // Card widths of ~336px and up get exactly text-xs / text-sm.
-const CARD_LABEL = 'text-[clamp(10px,3.6cqw,0.75rem)]'
-const CARD_VALUE = 'text-[clamp(11px,4.2cqw,0.875rem)]'
+const CARD_LABEL = 'text-[clamp(10px,3.6cqw,0.75rem)] leading-4'
+const CARD_VALUE = 'text-[clamp(11px,4.2cqw,0.875rem)] leading-5'
 const MIN_CLOSE_PERCENT = PERP_MIN_CLOSE_FRACTION * 100
 
 // Drop trailing zeros so whole leverages render as "100×" not "100.00×",

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -2,6 +2,13 @@ import clsx from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { PerpContract } from 'common/contract'
+import {
+  canEnterPerpCloseMana,
+  getPerpCloseAmountError,
+  perpCloseAmountFromFraction,
+  perpCloseAmountFromInput,
+  PerpCloseAmount,
+} from 'common/perps/close-amount'
 import { nextFundingTimes } from 'common/perps/chart-projections'
 import {
   fundingPeriodUnit,
@@ -38,6 +45,7 @@ import { Modal } from 'web/components/layout/modal'
 import { Row } from 'web/components/layout/row'
 import { Input } from 'web/components/widgets/input'
 import { InfoTooltip } from 'web/components/widgets/info-tooltip'
+import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
 import { Slider } from 'web/components/widgets/slider'
 import { api } from 'web/lib/api/api'
 import { useUser } from 'web/hooks/use-user'
@@ -464,28 +472,39 @@ const PositionSummary = (props: {
         100
       : 0
 
-  // How much of the position this close takes. Everything a partial close
-  // pays and leaves behind is LINEAR in the fraction — π, the payout and both
-  // pool debits all scale with q and c — so the preview below is exact, not
-  // an estimate, and the survivor's entry price, leverage and liquidation
-  // price are untouched by construction.
+  // Payout is linear in the selected fraction at a given price. Keep that
+  // fraction stable when switching units or receiving a new oracle quote;
+  // typing a new mana amount sizes it against the latest payout instead.
+  // The final payout can differ if the price moves before execution.
+  const fullPayout = getPositionValue(position, markPrice)
   const [closeModalOpen, setCloseModalOpen] = useState(false)
-  const [closePercent, setClosePercent] = useState<number | undefined>(100)
-  const closePercentError =
-    closePercent == null || !Number.isFinite(closePercent)
-      ? 'Enter a percentage to close.'
-      : closePercent < MIN_CLOSE_PERCENT
-      ? `Minimum close is ${MIN_CLOSE_PERCENT}%.`
-      : closePercent > 100
-      ? 'Maximum close is 100%.'
+  const [closeAmount, setCloseAmount] = useState<PerpCloseAmount>(() =>
+    perpCloseAmountFromFraction(1, 'percent', fullPayout)
+  )
+  const isMana = closeAmount.unit === 'mana'
+  const manaAvailable = canEnterPerpCloseMana(fullPayout)
+  const amountUnavailable = isMana && !manaAvailable
+  const amountDisabled = anyClosing || oracleTradingPaused || amountUnavailable
+  const amountError = getPerpCloseAmountError(closeAmount, fullPayout)
+  const closeAmountError =
+    amountError === 'unavailable'
+      ? 'No positive payout is available. Switch to % to close this position.'
+      : amountError === 'missing'
+      ? `Enter ${isMana ? 'a mana amount' : 'a percentage'} to close.`
+      : amountError === 'below-minimum'
+      ? `Minimum close is ${MIN_CLOSE_PERCENT}%${
+          isMana
+            ? ` (about ${formatMoneyPrecise(
+                fullPayout * PERP_MIN_CLOSE_FRACTION
+              )} returned)`
+            : ''
+        }.`
+      : amountError === 'above-maximum'
+      ? isMana
+        ? `Amount exceeds the available payout. Use Max to close everything.`
+        : 'Maximum close is 100%.'
       : null
-  const closeFraction =
-    closePercent != null &&
-    Number.isFinite(closePercent) &&
-    closePercent >= MIN_CLOSE_PERCENT &&
-    closePercent <= 100
-      ? closePercent / 100
-      : null
+  const closeFraction = amountError == null ? closeAmount.fraction : null
   // What the engine will actually take: a remainder that would be dust is
   // closed too, so the button must not promise a position that will not exist.
   const effectiveFraction =
@@ -493,15 +512,40 @@ const PositionSummary = (props: {
   const isPartial = effectiveFraction != null && effectiveFraction < 1
   const isDustPromoted =
     closeFraction != null && closeFraction < 1 && effectiveFraction === 1
-  const fullPayout = getPositionValue(position, markPrice)
   const closePayout = (effectiveFraction ?? 0) * fullPayout
   const closePnl = (effectiveFraction ?? 0) * pnl
   const remainingMargin = (1 - (effectiveFraction ?? 1)) * p.originalCostBasis
   const sliderClosePercent =
-    closePercent != null && Number.isFinite(closePercent)
-      ? Math.min(100, Math.max(MIN_CLOSE_PERCENT, closePercent))
+    closeAmount.fraction != null && Number.isFinite(closeAmount.fraction)
+      ? Math.min(100, Math.max(MIN_CLOSE_PERCENT, closeAmount.fraction * 100))
       : 100
-  const closePercentErrorId = `close-percent-error-${p.direction}`
+  const closeAmountErrorId = `close-amount-error-${p.direction}`
+  const closeAmountHintId = `close-amount-hint-${p.direction}`
+  const setCloseFraction = (fraction: number) =>
+    setCloseAmount(
+      perpCloseAmountFromFraction(fraction, closeAmount.unit, fullPayout)
+    )
+  const adjustCloseAmount = (increment: number) => {
+    const max = isMana ? fullPayout : 100
+    const min = max * PERP_MIN_CLOSE_FRACTION
+    const current = Number(closeAmount.input)
+    const amount = Math.min(
+      max,
+      Math.max(min, (Number.isFinite(current) ? current : min) + increment)
+    )
+    const selection = perpCloseAmountFromInput(
+      String(amount),
+      closeAmount.unit,
+      fullPayout
+    )
+    setCloseAmount(
+      perpCloseAmountFromFraction(
+        selection.fraction,
+        closeAmount.unit,
+        fullPayout
+      )
+    )
+  }
 
   // Distance to liquidation as a percentage of mark — useful risk signal.
   const distToLiq = isLong
@@ -566,7 +610,9 @@ const PositionSummary = (props: {
         <Button
           color="gray-outline"
           onClick={() => {
-            setClosePercent(100)
+            setCloseAmount(
+              perpCloseAmountFromFraction(1, 'percent', fullPayout)
+            )
             setCloseModalOpen(true)
           }}
           loading={closing}
@@ -668,75 +714,130 @@ const PositionSummary = (props: {
 
             <Col className="gap-2">
               <Col className="gap-1">
-                <span className="text-ink-600 text-sm">Close amount (%)</span>
+                <Row className="flex-wrap items-center justify-between gap-x-3 gap-y-1">
+                  <span className="text-ink-600 text-sm">Close amount</span>
+                  <ChoicesToggleGroup
+                    choicesMap={{ '%': 'percent', Mana: 'mana' }}
+                    currentChoice={closeAmount.unit}
+                    setChoice={(unit) => {
+                      if (unit === 'percent' || unit === 'mana')
+                        setCloseAmount(
+                          perpCloseAmountFromFraction(
+                            closeAmount.fraction,
+                            unit,
+                            fullPayout
+                          )
+                        )
+                    }}
+                    disabled={anyClosing || oracleTradingPaused}
+                    disabledOptions={manaAvailable ? [] : ['mana']}
+                    color="gray"
+                    className="!p-0.5"
+                    toggleClassName="!my-0 !px-3 !py-1 text-xs"
+                  />
+                </Row>
                 <div className="relative w-full">
+                  {isMana && (
+                    <span
+                      aria-hidden
+                      className="text-ink-500 pointer-events-none absolute left-4 top-1/2 z-10 -translate-y-1/2 text-xl"
+                    >
+                      Ṁ
+                    </span>
+                  )}
                   <Input
-                    aria-label="Percentage of position to close"
+                    aria-label={
+                      isMana
+                        ? 'Estimated mana to receive'
+                        : 'Percentage of position to close'
+                    }
                     type="number"
                     inputMode="decimal"
-                    min={MIN_CLOSE_PERCENT}
-                    max={100}
                     step="any"
-                    value={closePercent ?? ''}
-                    error={closePercentError != null}
-                    aria-invalid={closePercentError != null}
-                    aria-describedby={
-                      closePercentError != null
-                        ? closePercentErrorId
-                        : undefined
-                    }
-                    disabled={anyClosing || oracleTradingPaused}
+                    value={closeAmount.input}
+                    error={closeAmountError != null}
+                    aria-invalid={closeAmountError != null}
+                    aria-describedby={`${closeAmountHintId}${
+                      closeAmountError != null ? ` ${closeAmountErrorId}` : ''
+                    }`}
+                    disabled={amountDisabled}
                     onFocus={(e) => e.target.select()}
-                    onChange={(e) => {
-                      const value = e.target.value
-                      setClosePercent(value === '' ? undefined : Number(value))
-                    }}
-                    className="h-[60px] w-full min-w-0 !pr-40 !text-xl tabular-nums"
+                    onChange={(e) =>
+                      setCloseAmount(
+                        perpCloseAmountFromInput(
+                          e.target.value,
+                          closeAmount.unit,
+                          fullPayout
+                        )
+                      )
+                    }
+                    className={clsx(
+                      'h-[60px] w-full min-w-0 !pr-16 !text-xl tabular-nums',
+                      isMana && '!pl-10'
+                    )}
                   />
-                  <Row className="absolute right-2 top-3.5 gap-1.5">
-                    {[-5, -1, 1, 5].map((increment) => (
-                      <button
-                        key={increment}
-                        type="button"
-                        aria-label={`${
-                          increment < 0 ? 'Decrease' : 'Increase'
-                        } close percentage by ${Math.abs(increment)}`}
-                        className="bg-canvas-100 hover:bg-ink-200 rounded-md px-2 py-1.5 text-sm"
-                        disabled={anyClosing || oracleTradingPaused}
-                        onClick={() =>
-                          setClosePercent((percent) =>
-                            Math.min(
-                              100,
-                              Math.max(
-                                MIN_CLOSE_PERCENT,
-                                (percent ?? MIN_CLOSE_PERCENT) + increment
-                              )
-                            )
-                          )
-                        }
-                      >
-                        {increment > 0 ? `+${increment}` : increment}
-                      </button>
-                    ))}
-                  </Row>
+                  <button
+                    type="button"
+                    className="text-primary-600 hover:text-primary-700 absolute right-4 top-1/2 -translate-y-1/2 text-sm font-medium disabled:opacity-50"
+                    disabled={amountDisabled}
+                    onClick={() => setCloseFraction(1)}
+                  >
+                    Max
+                  </button>
                 </div>
               </Col>
 
-              <Slider
-                min={MIN_CLOSE_PERCENT}
-                max={100}
-                step={0.1}
-                amount={sliderClosePercent}
-                onChange={setClosePercent}
-                disabled={anyClosing || oracleTradingPaused}
-                color="gray"
-                ariaLabel="Close percentage slider"
-                ariaValueText={`${sliderClosePercent}% of position`}
-              />
+              <Row className="items-center gap-4">
+                <Slider
+                  min={MIN_CLOSE_PERCENT}
+                  max={100}
+                  step={0.1}
+                  amount={sliderClosePercent}
+                  onChange={(percent) => setCloseFraction(percent / 100)}
+                  disabled={amountDisabled}
+                  color="gray"
+                  className="min-w-0 flex-1"
+                  ariaLabel="Close amount slider"
+                  ariaValueText={
+                    isMana
+                      ? `About ${formatMoneyPrecise(
+                          (sliderClosePercent / 100) * fullPayout
+                        )} returned (${formatPerpClosePercent(
+                          sliderClosePercent / 100
+                        )} of position)`
+                      : `${sliderClosePercent}% of position`
+                  }
+                />
+                <Row className="shrink-0 gap-1.5">
+                  {[-5, -1, 1, 5].map((increment) => (
+                    <button
+                      key={increment}
+                      type="button"
+                      aria-label={`${
+                        increment < 0 ? 'Decrease' : 'Increase'
+                      } close ${isMana ? 'mana' : 'percentage'} by ${Math.abs(
+                        increment
+                      )}`}
+                      className="bg-canvas-100 hover:bg-ink-200 rounded-md px-2 py-1.5 text-sm disabled:opacity-50"
+                      disabled={amountDisabled}
+                      onClick={() => adjustCloseAmount(increment)}
+                    >
+                      {increment > 0 ? `+${increment}` : increment}
+                    </button>
+                  ))}
+                </Row>
+              </Row>
 
-              {closePercentError != null && (
-                <div id={closePercentErrorId} className="text-error text-xs">
-                  {closePercentError}
+              <p id={closeAmountHintId} className="text-ink-500 text-xs">
+                {isMana
+                  ? 'Mana is the estimated amount returned, not position size. '
+                  : ''}
+                Final payout can change with the price.
+              </p>
+
+              {closeAmountError != null && (
+                <div id={closeAmountErrorId} className="text-error text-xs">
+                  {closeAmountError}
                 </div>
               )}
 
@@ -781,7 +882,9 @@ const PositionSummary = (props: {
                 <div className="border-ink-200 my-1 border-t" />
 
                 <Row className="items-center justify-between gap-3">
-                  <span className="text-ink-900 font-medium">Payout</span>
+                  <span className="text-ink-900 font-medium">
+                    Estimated payout
+                  </span>
                   <span className="text-ink-900 text-lg font-semibold tabular-nums">
                     {formatMoneyPrecise(closePayout)}
                   </span>
@@ -805,7 +908,7 @@ const PositionSummary = (props: {
               {oracleTradingPaused
                 ? 'Close paused — waiting for oracle'
                 : closeFraction == null || effectiveFraction == null
-                ? 'Enter a valid close percentage'
+                ? 'Enter a valid close amount'
                 : isPartial
                 ? `Close ${formatPerpClosePercent(
                     effectiveFraction

--- a/web/components/perps/perp-trades-tab.tsx
+++ b/web/components/perps/perp-trades-tab.tsx
@@ -31,6 +31,7 @@ type Event = {
   payout: number | null
   pnl: number | null
   adlFactor: number | null
+  fraction: number | null
   isApi: boolean
   userName: string | null
   username: string | null
@@ -220,6 +221,13 @@ const EventRow = (props: {
     isLiquidation && Number.isFinite(event.originalCostBasisDelta)
       ? Math.abs(event.originalCostBasisDelta)
       : null
+  // A partial close keeps the row open, so the tape must not read as an exit.
+  // Its `leverage` is the SURVIVOR's — unchanged by the split — which is the
+  // right number to show beside "partly closed".
+  const partialClose =
+    event.eventType === 'close' && event.fraction != null && event.fraction < 1
+      ? event.fraction
+      : null
   const partialAdlReduction =
     event.eventType === 'adl' &&
     event.payout == null &&
@@ -246,7 +254,9 @@ const EventRow = (props: {
           {/* Aggregate rows (per-tick ADL) carry no direction; drop the
               trailing "on" so the label doesn't dangle before the price. */}
           <span className="text-ink-600">
-            {event.direction
+            {partialClose != null
+              ? `closed ${Math.round(partialClose * 100)}% of`
+              : event.direction
               ? EVENT_LABELS[event.eventType]
               : EVENT_LABELS[event.eventType].replace(/ on$/, '')}
           </span>

--- a/web/components/perps/perp-trades-tab.tsx
+++ b/web/components/perps/perp-trades-tab.tsx
@@ -2,7 +2,11 @@ import clsx from 'clsx'
 import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
 import { useEffect, useRef, useState } from 'react'
 import { PerpContract } from 'common/contract'
-import { formatPrice, inferPriceDecimals } from 'common/perps/format'
+import {
+  formatPerpClosePercent,
+  formatPrice,
+  inferPriceDecimals,
+} from 'common/perps/format'
 import { formatMoney, formatMoneyPrecise } from 'common/util/format'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
@@ -255,7 +259,7 @@ const EventRow = (props: {
               trailing "on" so the label doesn't dangle before the price. */}
           <span className="text-ink-600">
             {partialClose != null
-              ? `closed ${Math.round(partialClose * 100)}% of`
+              ? `closed ${formatPerpClosePercent(partialClose)} of`
               : event.direction
               ? EVENT_LABELS[event.eventType]
               : EVENT_LABELS[event.eventType].replace(/ on$/, '')}

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -1559,7 +1559,6 @@ const Terminal = (props: {
     contract.id,
     refreshKey
   )
-  const [tradeOpen, setTradeOpen] = useState(false)
   const oracleTradingPaused = useOracleTradingPaused(contract)
 
   const price = Number(contract.oraclePrice)
@@ -1759,41 +1758,13 @@ const Terminal = (props: {
         asOfTime={contract.oracleSourceTime}
       />
 
-      {tradeOpen ? (
-        <Col className="gap-3">
-          <Row className="items-center justify-between">
-            <SectionHeader title={`Trade ${tickerOf(contract)}`} />
-            <button
-              className="text-ink-500 hover:text-ink-700 text-xs"
-              onClick={() => setTradeOpen(false)}
-            >
-              Hide
-            </button>
-          </Row>
-          <PerpBetPanel
-            contract={contract}
-            onTrade={refresh}
-            positions={positions}
-            unsoundPositions={unsoundPositions}
-            oracleTradingPaused={oracleTradingPaused}
-          />
-        </Col>
-      ) : (
-        <Row className="gap-2">
-          <button
-            onClick={() => setTradeOpen(true)}
-            className="flex-1 rounded-md bg-teal-600 py-2 font-semibold text-white hover:bg-teal-500"
-          >
-            Long ↑
-          </button>
-          <button
-            onClick={() => setTradeOpen(true)}
-            className="bg-scarlet-600 hover:bg-scarlet-500 flex-1 rounded-md py-2 font-semibold text-white"
-          >
-            Short ↓
-          </button>
-        </Row>
-      )}
+      <PerpBetPanel
+        contract={contract}
+        onTrade={refresh}
+        positions={positions}
+        unsoundPositions={unsoundPositions}
+        oracleTradingPaused={oracleTradingPaused}
+      />
       <PerpPositionPanel
         contract={contract}
         onAction={refresh}

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -992,6 +992,13 @@ const RecentActivity = (props: {
             const liquidated = e.eventType === 'liquidation'
             const closing =
               e.eventType === 'close' || liquidated || e.eventType === 'adl'
+            // A partial close leaves the position open, so the tape must not
+            // report it as an exit. Closes written before partial closes
+            // existed carry no fraction and were whole ones.
+            const partialClose =
+              e.eventType === 'close' && e.fraction != null && e.fraction < 1
+                ? e.fraction
+                : null
             return (
               <button
                 key={e.id}
@@ -1015,7 +1022,9 @@ const RecentActivity = (props: {
                         : undefined
                     }
                   >
-                    {ACTIVITY_VERB[e.eventType]}
+                    {partialClose != null
+                      ? `closed ${Math.round(partialClose * 100)}% of`
+                      : ACTIVITY_VERB[e.eventType]}
                   </span>{' '}
                   {e.leverage != null && !closing && (
                     <span className="font-mono">

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -19,6 +19,7 @@ import { fromNow } from 'client-common/lib/time'
 import { nextFundingTimes } from 'common/perps/chart-projections'
 import {
   formatCountdown,
+  formatPerpClosePercent,
   formatPrice,
   inferPriceDecimals,
 } from 'common/perps/format'
@@ -1023,7 +1024,7 @@ const RecentActivity = (props: {
                     }
                   >
                     {partialClose != null
-                      ? `closed ${Math.round(partialClose * 100)}% of`
+                      ? `closed ${formatPerpClosePercent(partialClose)} of`
                       : ACTIVITY_VERB[e.eventType]}
                   </span>{' '}
                   {e.leverage != null && !closing && (


### PR DESCRIPTION
Closing a perp is all-or-nothing today, so a trader who wants *less* exposure has to close the whole position and re-enter.

The exit itself is already free — the taker fee is charged in full at open (`engine.ts`, "No fee on close") — so the cost isn't the exit. It's the **re-entry**: a fresh fee on the *whole* new notional including the cubic size-impact term `(impact/3)·P·(s₁³ − s₀³)`, plus a reset entry price, a moved liquidation price, and a reset `openedTime`. Partial closes remove that round trip.

`close-perp-position` now takes an optional `fraction` in `(0, 1]`. Omitting it closes the whole position exactly as before.

## Why this is a small change

**The exit math is linear in the position.** π is linear in `q`, and both the payout and the two pool debits are linear in π and `c`. So closing `z` of a row pays exactly `z` times what the full close would have paid, debits exactly `z` of each pool delta, and leaves the book in precisely the state it would have been in had the trader opened `1 − z` of that position and closed a separate `z` one.

That is why the survivor keeps its **entry price**, its **leverage** (`ℓ = q/c` is invariant under the split) and therefore its **liquidation price**. Reducing exposure never moves the price at which what is left gets liquidated. `openedTime` is preserved too, so `expectedOpenedTime` still matches on the next close.

Everything else runs unchanged. Solvency is asserted with the same `assertPerpStateSolvent`; the escrow check brackets the payout as before; and a partial close only ever *reduces* open interest, so the capacity rule cannot reject one. The flip and resolution call sites pass no fraction and are byte-identical.

## Rules that keep the split honest

- **The halves come from subtraction, not from scaling with `z` and `1 − z`.** They must add back up to the original *exactly*, because `metric-periods.ts` rebuilds the pre-close row by adding the event's deltas onto the survivor — a split that doesn't conserve leaves that replay drifting on every partial close. Pinned with `toBe`, not `toBeCloseTo`.
- **`PERP_MIN_CLOSE_FRACTION` (1%)** — the smallest close worth its own event. Below it the trade mints an event and a streak for a change the trader cannot see.
- **`PERP_MIN_REMAINDER_COST_BASIS`** promotes a close whose *remainder* would be dust into a full close, so `fraction = 0.9999` cannot strand a row of a few thousandths of a mana that still accrues funding every period. The bound is on the remaining cost basis rather than on `1 − fraction`, because that's the quantity that has to stay meaningful: a fractional rule would strand dust on a large position and delete real margin on a small one. The response's `fraction` is what *actually* happened and can exceed what was asked for.
- **`expectedSize` is required for a partial close**, and checked against the locked row inside the transaction. `expectedOpenedTime` cannot police this: the survivor of a partial close keeps its `openedTime`, so a request sized against the pre-close row passes that check and then applies its fraction to the smaller survivor. Two tabs both showing 400 and both sending 75% — the first leaves 100, the second takes 75 of *that* rather than the 300 it displayed, silently. Funding scaling the row and an ADL haircut invalidate the preview identically, so the tolerance (`PERP_EXPECTED_SIZE_TOLERANCE`) is representation dust only and all three cases 409. **Full closes skip the check** — "close everything" is unambiguous at any size, and a spurious 409 on the one operation a trader may urgently need is a worse failure than any it would prevent.

## Two client bugs, both only reachable because a partial close preserves `openedTime`

Both would have failed silently:

1. **The idempotency fingerprint** was `[contractId, direction, openedTime]`. Two 25% closes in a row are separate trades but produced the same fingerprint, so the second would have replayed the first and quietly closed nothing. It now carries the position's `size` and the fraction — `size` moves after every close, so a retry of the *same* click still dedupes. (This protects one client; `expectedSize` above is what protects against two.)
2. **The optimistic hide.** The panel marks a direction closed and filters rows with `openedTime < closedAt`. On a partial close that hides a position that is still open — and since `openedTime` never changes again, hides it *permanently*. Only a full close sets it now.

## Rate limiting

Partial closes are limited to 60/hour per user. **Full closes are never limited** — refusing someone the ability to exit a leveraged position is far worse than tolerating close spam — so the limiter is reachable only when the caller asked for a fraction.

The limit exists because the 1% minimum is a fraction of the *current remainder*, so repeated 1% closes decay geometrically rather than terminating: `0.99^100` still leaves 36.6% open, and reaching the dust floor takes ~917 calls from an M$100 cost basis and ~1375 from M$10,000. (An earlier revision of this description claimed ~100; that was wrong.) Each call is a serializable transaction under the contract's advisory lock plus an event, a txn, a metrics rebuild and streak processing — the same lock the 2s oracle tick wants.

## UI

An unboxed holdings summary mirrors ordinary market pages: Position, Margin, Unrealized P&L and Value use the site's label/value typography and info tooltips, with entry, mark and liquidation details in a quieter row underneath. Its compact outlined **Close** action opens the same responsive modal / mobile bottom-sheet flow used by ordinary sells elsewhere on the site. The sheet defaults to **%**, with a small **% / Mana** toggle beside Close amount, a full-width field, the site's familiar ±5 / ±1 adjustments, one slider and **Max** in both modes. Mana means **estimated amount returned**, not leveraged notional or margin. Entering an amount sizes a fraction at the current quote; switching modes preserves that unrounded fraction, and later oracle updates change the payout preview rather than silently resizing the close. The 1% minimum and remainder-dust rule still apply. Mana entry is unavailable for non-positive/non-finite payouts, while percentage closes remain available. An out-of-range or empty value disables the confirmation and says why; a value whose remainder would be dust says so before submission rather than surprising the user with a full close afterwards.

The sheet previews payout, realized P&L and remaining margin at the displayed oracle price. The split is linear at a fixed price, but **the final payout can change with the price before execution**, so the UI labels it Estimated payout.

Partial closes are labelled as such in the position history, the market's Trades tab, the `/perps` hub tape, the unified discovery feed and the balance-change feed. Every percentage goes through one shared `formatPerpClosePercent`, which keeps two decimals and **truncates rather than rounds** near 1, so a surviving position can never be labelled a 100% close.

## Verification

The full common/shared suites and all three typechecks were re-run locally after the percent/Mana toggle; changed files pass lint and formatting. CI was green on `4755f84`, and the new push triggers fresh checks:

| Check | Result |
| --- | --- |
| `yarn test:common` | 41 suites, 908 tests pass |
| `yarn test:shared` | 8 suites, 51 tests pass |
| `yarn typecheck:web` / `:api` / `:scheduler` | clean |
| `yarn lint`, `yarn format:check` | clean |

New tests cover the conservation property, two-step-equals-one-step payout, the state-a-smaller-position-would-have-been-in equivalence, the dust promotion at and either side of its bound, the expected-size tolerance at both edges, the close-percent formatter at ordinary, arbitrary and near-total fractions, short and underwater legs, and a guard that a *liquidation* leaving a row open is still rejected by the metric replay.

**UI verification:** 24 new amount-selection tests cover mana conversion, exact fraction preservation across repeated mode switches and quote changes, Max, the 1% boundary, invalid values, zero payout, near-total formatting and dust promotion. Manual localhost checks at 320px and 1280px cover both modes, a 500-mana preview, validation, the slider, adjustment buttons and Max; reopening defaults to percent. No trades were submitted during these UI checks.

**What is not covered:** the database-backed close transaction is not exercised by an integration harness. A dev end-to-end check should still verify a partial close's payout, surviving position and history, a subsequent full close, and stale-position rejection.

`yarn install` 403s on the `@flat/in-app-purchase` GitHub tarball from this environment (same blocker #4033 hit). I installed with that one dependency temporarily removed to get jest, then restored `backend/api/package.json` and `yarn.lock` byte-for-byte — both are untouched in this diff.

## Rollout

Deploy the partial-close API from this PR and wait for the rollout to complete **before exposing the new frontend**. The pre-PR API only supports full closes and its object schema discards the new fields, so a partial-close request sent to an old instance can close the entire position. Existing full-close clients remain compatible with the new API. If merging auto-publishes the frontend, coordinate or hold that publication until the API is ready.

## Other notes

- **`common/src/txn.ts`** gains `'partial-close'` on the `PERP_CLOSE_PAYOUT` reason union.
- **No migration.** `fraction` and `remainingSize` live in the event's `data` jsonb; closes written before this read as whole ones everywhere.

## Merged with main

`main` picked up **#4030** (jam-proof oracle tick, OI netting), **#4034** (five new oracle feeds) and **#4036** (job board) while this was open. Both perps PRs touch `common/src/perps/amm.ts`, and #4030 touches `backend/shared/src/perps/engine.ts` — the two files this branch changes most — so the merge was validated rather than trusted:

- One real conflict, in `amm.test.ts`: both sides appended a new top-level `describe` at the same point. Resolved by keeping both suites (`partial close` and `applyADL cross-side deficit transfer`); no test was dropped or altered.
- **#4030's `assertPerpNotSolvencyHalted` now gates partial closes**, as predicted — it sits in `closePosition` before `resolvePerpCloseFraction`, so a halted book refuses a partial close on the same path it refuses a full one.
- #4030's change near `closePosition` in `amm.ts` is the `PerpOpenInterestCapacity` type that follows it, not the close body, so the two edits are independent. Its new capacity-preview caller passes three arguments and so closes the opposite leg in full, which is the right semantics for a flip.

## Relationship to #4033

This should *shrink* **#4033**. That PR already carries a partial close, but protected-mode only (legacy hits an explicit `throw`) and API-only, with no UI. The schema here is its `closePerpPositionSchema` plus `expectedSize` and minus the protected-only restriction, so `market-types.ts`, `schema.ts`, `close-perp-position.ts` and `metric-periods.ts` largely resolve to "keep main's", and its `engine.ts` `else` branch gets a working legacy path instead of a `throw` — which it needs anyway, since a partial close is genuinely non-linear under protected-basis accounting (`z·R` from own pool, `z·E` from opposing, loss-first settlement) and the two paths have to branch on mode regardless. One import to reconcile: `PERP_MIN_CLOSE_FRACTION` lives in `common/perps/amm` here rather than in #4033's new `protected-basis.ts`.

Two things worth adopting there: the remainder-dust rule (#4033 guards that the closed side is material but not that the remainder is), and the `expectedSize` concurrency guard, which its partial close needs for the same reason this one does.

First of a planned series — trigger orders and stop-losses follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtD6jBeqNY5RLwwqMgXeEC