### PR TITLE
fix(jobs): tidy up the job board's visual hierarchy

### DIFF
--- a/web/components/jobs/job-interest-card.tsx
+++ b/web/components/jobs/job-interest-card.tsx
@@ -122,7 +122,7 @@ export function JobInterestCard() {
   // Registered and not editing → a collapsible summary panel.
   if (registered && !open) {
     return (
-      <div className="border-primary-200 bg-primary-50/50 dark:border-primary-800 dark:bg-primary-950/20 rounded-xl border p-4 sm:p-5">
+      <div className="border-primary-200 bg-canvas-0 dark:border-primary-800 rounded-xl border p-4 sm:p-5">
         <Col className="gap-3">
           <button
             type="button"
@@ -180,7 +180,7 @@ export function JobInterestCard() {
   }
 
   return (
-    <div className="border-primary-200 bg-primary-50/50 dark:border-primary-800 dark:bg-primary-950/20 rounded-xl border p-4 sm:p-5">
+    <div className="border-primary-200 bg-canvas-0 dark:border-primary-800 rounded-xl border p-4 sm:p-5">
       <Col className="gap-2">
         {open ? (
           <h3 className="text-ink-1000 text-lg font-semibold">

--- a/web/components/jobs/job-interest-card.tsx
+++ b/web/components/jobs/job-interest-card.tsx
@@ -41,6 +41,9 @@ export function JobInterestCard() {
 
   const [open, setOpen] = useState(false)
   const [collapsed, setCollapsed] = useState(true)
+  // Separate from `collapsed`, which belongs to the registered-state panel.
+  // Starts expanded: an unregistered visitor hasn't seen the pitch yet.
+  const [pitchCollapsed, setPitchCollapsed] = useState(false)
   const [skills, setSkills] = useState<JobSkill[]>([])
   const [interests, setInterests] = useState<JobInterest[]>([])
   const [region, setRegion] = useState<JobRegion | null>(null)
@@ -169,18 +172,35 @@ export function JobInterestCard() {
 
   return (
     <div className="border-primary-200 bg-canvas-0 rounded-lg border p-5">
+      {/* Collapsible like the registered state, so someone who isn't job
+          hunting can fold this away and get to the listings. The toggle is
+          suppressed while the form is open — collapsing a half-filled form
+          would throw away their selections with no warning. */}
       <Col className="gap-1">
-        <h3 className="text-ink-1000 text-lg font-semibold">
-          Looking for a role? Let employers reach you
-        </h3>
-        <p className="text-ink-600 max-w-xl text-sm leading-relaxed">
-          Tag your strengths and what you're after. We'll aim to connect you
-          with employers hiring from the community, and may notify you of
-          relevant postings.
-        </p>
+        <button
+          onClick={() => open || setPitchCollapsed((c) => !c)}
+          className="flex items-start justify-between gap-3 text-left"
+          aria-expanded={!pitchCollapsed}
+        >
+          <h3 className="text-ink-1000 text-lg font-semibold">
+            Looking for a role? Let employers reach you
+          </h3>
+          {!open && (
+            <span className="text-primary-600 shrink-0 pt-1 font-mono text-sm font-medium">
+              {pitchCollapsed ? 'Show ↓' : 'Hide ↑'}
+            </span>
+          )}
+        </button>
+        {!pitchCollapsed && (
+          <p className="text-ink-600 max-w-xl text-sm leading-relaxed">
+            Tag your strengths and what you're after. We'll aim to connect you
+            with employers hiring from the community, and may notify you of
+            relevant postings.
+          </p>
+        )}
       </Col>
 
-      {!user ? (
+      {pitchCollapsed ? null : !user ? (
         <Button className="mt-4" color="indigo" onClick={() => firebaseLogin()}>
           Sign in to register interest
         </Button>

--- a/web/components/jobs/job-interest-card.tsx
+++ b/web/components/jobs/job-interest-card.tsx
@@ -1,3 +1,4 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/solid'
 import { useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 
@@ -121,18 +122,24 @@ export function JobInterestCard() {
   // Registered and not editing → a collapsible summary panel.
   if (registered && !open) {
     return (
-      <div className="border-primary-200 bg-canvas-0 rounded-lg border p-5">
+      <div className="border-primary-200 bg-primary-50/50 dark:border-primary-800 dark:bg-primary-950/20 rounded-xl border p-4 sm:p-5">
         <Col className="gap-3">
           <button
+            type="button"
             onClick={() => setCollapsed((c) => !c)}
-            className="flex items-center justify-between gap-3 text-left"
+            className="focus-visible:ring-primary-500 flex w-full cursor-pointer items-center justify-between gap-3 rounded text-left focus:outline-none focus-visible:ring-2"
             aria-expanded={!collapsed}
           >
-            <h3 className="text-ink-1000 text-lg font-semibold">
+            <h3 className="text-ink-1000 text-base font-semibold sm:text-lg">
               You're on the list for new roles
             </h3>
-            <span className="text-primary-600 shrink-0 font-mono text-sm font-medium">
-              {collapsed ? 'Show ↓' : 'Hide ↑'}
+            <span className="text-primary-600 flex shrink-0 items-center gap-1 text-sm font-semibold">
+              {collapsed ? 'Show' : 'Hide'}
+              {collapsed ? (
+                <ChevronDownIcon className="h-4 w-4" aria-hidden />
+              ) : (
+                <ChevronUpIcon className="h-4 w-4" aria-hidden />
+              )}
             </span>
           </button>
 
@@ -150,15 +157,17 @@ export function JobInterestCard() {
               </Row>
               <Row className="items-center gap-4">
                 <button
+                  type="button"
                   onClick={() => setOpen(true)}
-                  className="text-primary-600 hover:text-primary-700 text-sm font-medium"
+                  className="text-primary-600 hover:text-primary-700 focus-visible:ring-primary-500 rounded text-sm font-medium focus:outline-none focus-visible:ring-2"
                 >
                   Update preferences
                 </button>
                 <button
+                  type="button"
                   onClick={remove}
                   disabled={saving}
-                  className="text-ink-500 hover:text-ink-700 text-sm disabled:opacity-50"
+                  className="text-ink-500 hover:text-ink-700 focus-visible:ring-primary-500 rounded text-sm focus:outline-none focus-visible:ring-2 disabled:opacity-50"
                 >
                   Remove me
                 </button>
@@ -171,28 +180,34 @@ export function JobInterestCard() {
   }
 
   return (
-    <div className="border-primary-200 bg-canvas-0 rounded-lg border p-5">
-      {/* Collapsible like the registered state, so someone who isn't job
-          hunting can fold this away and get to the listings. The toggle is
-          suppressed while the form is open — collapsing a half-filled form
-          would throw away their selections with no warning. */}
-      <Col className="gap-1">
-        <button
-          onClick={() => open || setPitchCollapsed((c) => !c)}
-          className="flex items-start justify-between gap-3 text-left"
-          aria-expanded={!pitchCollapsed}
-        >
+    <div className="border-primary-200 bg-primary-50/50 dark:border-primary-800 dark:bg-primary-950/20 rounded-xl border p-4 sm:p-5">
+      <Col className="gap-2">
+        {open ? (
           <h3 className="text-ink-1000 text-lg font-semibold">
             Looking for a role? Let employers reach you
           </h3>
-          {!open && (
-            <span className="text-primary-600 shrink-0 pt-1 font-mono text-sm font-medium">
-              {pitchCollapsed ? 'Show ↓' : 'Hide ↑'}
+        ) : (
+          <button
+            type="button"
+            onClick={() => setPitchCollapsed((c) => !c)}
+            className="focus-visible:ring-primary-500 flex w-full cursor-pointer items-center justify-between gap-3 rounded text-left focus:outline-none focus-visible:ring-2"
+            aria-expanded={!pitchCollapsed}
+          >
+            <h3 className="text-ink-1000 text-base font-semibold sm:text-lg">
+              Looking for a role? Let employers reach you
+            </h3>
+            <span className="text-primary-600 flex shrink-0 items-center gap-1 text-sm font-semibold">
+              {pitchCollapsed ? 'Show' : 'Hide'}
+              {pitchCollapsed ? (
+                <ChevronDownIcon className="h-4 w-4" aria-hidden />
+              ) : (
+                <ChevronUpIcon className="h-4 w-4" aria-hidden />
+              )}
             </span>
-          )}
-        </button>
+          </button>
+        )}
         {!pitchCollapsed && (
-          <p className="text-ink-600 max-w-xl text-sm leading-relaxed">
+          <p className="text-ink-600 max-w-2xl text-base leading-relaxed">
             Tag your strengths and what you're after. We'll aim to connect you
             with employers hiring from the community, and may notify you of
             relevant postings.
@@ -206,13 +221,14 @@ export function JobInterestCard() {
         </Button>
       ) : !open ? (
         <button
+          type="button"
           onClick={() => setOpen(true)}
-          className="text-primary-600 hover:text-primary-700 mt-3 self-start text-sm font-medium"
+          className="text-primary-600 hover:text-primary-700 focus-visible:ring-primary-500 mt-3 self-start rounded text-sm font-semibold focus:outline-none focus-visible:ring-2"
         >
           Register interest →
         </button>
       ) : (
-        <Col className="mt-4 gap-4">
+        <Col className="border-primary-100 mt-4 gap-5 border-t pt-4">
           <Col className="gap-2">
             <span className="text-ink-500 font-mono text-xs uppercase tracking-widest">
               Your strengths
@@ -223,6 +239,7 @@ export function JobInterestCard() {
                   key={s}
                   selected={skills.includes(s)}
                   onSelect={() => setSkills((a) => toggle(a, s))}
+                  className="h-8 px-3"
                 >
                   {JOB_SKILL_LABELS[s]}
                 </PillButton>
@@ -240,6 +257,7 @@ export function JobInterestCard() {
                   key={i}
                   selected={interests.includes(i)}
                   onSelect={() => setInterests((a) => toggle(a, i))}
+                  className="h-8 px-3"
                 >
                   {JOB_INTEREST_LABELS[i]}
                 </PillButton>
@@ -257,6 +275,7 @@ export function JobInterestCard() {
                   key={r}
                   selected={region === r}
                   onSelect={() => setRegion((cur) => (cur === r ? null : r))}
+                  className="h-8 px-3"
                 >
                   {JOB_REGION_LABELS[r]}
                 </PillButton>
@@ -264,7 +283,7 @@ export function JobInterestCard() {
             </Row>
           </Col>
 
-          <Row className="items-center gap-4">
+          <Row className="flex-wrap items-center gap-4">
             <Button
               color="indigo"
               loading={saving}
@@ -274,8 +293,9 @@ export function JobInterestCard() {
               {registered ? 'Save changes' : "I'm interested"}
             </Button>
             <button
+              type="button"
               onClick={cancel}
-              className="text-ink-500 hover:text-ink-700 text-sm"
+              className="text-ink-500 hover:text-ink-700 focus-visible:ring-primary-500 rounded text-sm focus:outline-none focus-visible:ring-2"
             >
               Cancel
             </button>

--- a/web/pages/jobs/index.tsx
+++ b/web/pages/jobs/index.tsx
@@ -1,4 +1,7 @@
-import { useState } from 'react'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/solid'
+import { ExternalLinkIcon } from '@heroicons/react/outline'
+import clsx from 'clsx'
+import { useId, useState } from 'react'
 import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Page } from 'web/components/layout/page'
@@ -82,116 +85,118 @@ const JOBS: Job[] = [
 
 function MetaField({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex flex-row items-baseline gap-3 sm:flex-col sm:items-start sm:gap-0">
-      <span className="text-ink-400 w-20 shrink-0 font-mono text-[10px] uppercase tracking-widest sm:w-auto">
+    <div className="flex items-baseline gap-2">
+      <dt className="text-ink-400 shrink-0 font-mono text-xs uppercase tracking-wide">
         {label}
-      </span>
-      <span className="text-ink-700 text-sm font-medium">{value}</span>
+      </dt>
+      <dd className="text-ink-700 text-sm font-medium">{value}</dd>
     </div>
   )
 }
 
 function JobCard({ job }: { job: Job }) {
   const [open, setOpen] = useState(false)
+  const detailsId = useId()
 
   return (
-    <div className="border-ink-200 bg-canvas-0 overflow-hidden rounded-lg border transition-shadow hover:shadow-sm">
-      {/* Card header — always visible */}
-      {/* The whole header is the toggle, so it needs to look pressable:
-          pointer cursor + a faint hover wash, otherwise the only affordance is
-          the "Show role" text in the corner. */}
+    <article
+      className={clsx(
+        'bg-canvas-0 overflow-hidden rounded-xl border transition-all',
+        open
+          ? 'border-primary-300 shadow-sm'
+          : 'border-ink-200 hover:border-ink-300 hover:shadow-sm'
+      )}
+    >
       <button
+        type="button"
         onClick={() => setOpen((v) => !v)}
-        className="hover:bg-canvas-50 w-full cursor-pointer px-6 py-5 text-left transition-colors"
+        className="hover:bg-canvas-50 focus-visible:ring-primary-500 group w-full cursor-pointer px-5 py-5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset sm:px-6"
         aria-expanded={open}
+        aria-controls={detailsId}
       >
-        <Col className="gap-2">
+        <Col className="gap-3">
           <Row className="items-start justify-between gap-3">
-            {/* h3, under the company's h2 — and capped at text-xl so a role
-                never outsizes the company heading above it. */}
             <h3 className="text-ink-1000 text-lg font-bold sm:text-xl">
               {job.title}
             </h3>
-            <span className="text-ink-400 shrink-0 pt-1 font-mono text-[10px] uppercase tracking-widest">
+            <span className="bg-canvas-100 text-ink-600 shrink-0 rounded-full px-2.5 py-1 text-xs font-medium">
               Full time
             </span>
           </Row>
-          <p className="text-ink-600 text-sm leading-relaxed">{job.blurb}</p>
+          <p className="text-ink-600 text-base leading-relaxed">{job.blurb}</p>
 
-          {/* Compact vertical stack on mobile; horizontal spread on desktop.
-              Toggle drops below on mobile, inline bottom-right on sm+. */}
-          <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
-            <div className="flex flex-col gap-1 sm:flex-row sm:flex-wrap sm:gap-8">
+          <div className="border-ink-100 flex flex-col gap-3 border-t pt-3 sm:flex-row sm:items-center sm:justify-between">
+            <dl className="flex flex-wrap gap-x-6 gap-y-2">
               <MetaField label="Location" value={job.location} />
               <MetaField label="Comp" value={job.comp} />
               <MetaField label="Stage" value={job.stage} />
-            </div>
+            </dl>
 
-            <span className="text-primary-600 shrink-0 self-end font-mono text-sm font-medium">
-              {open ? 'Hide ↑' : 'Show role ↓'}
+            <span className="text-primary-600 group-hover:text-primary-700 flex shrink-0 items-center gap-1 self-end text-sm font-semibold sm:self-auto">
+              {open ? 'Hide details' : 'View details'}
+              {open ? (
+                <ChevronUpIcon className="h-4 w-4" aria-hidden />
+              ) : (
+                <ChevronDownIcon className="h-4 w-4" aria-hidden />
+              )}
             </span>
           </div>
         </Col>
       </button>
 
-      {/* Expandable body */}
-      {open && (
-        <div className="border-ink-100 border-t px-6 pb-6 pt-5">
-          <p className="text-ink-700 mb-6 text-sm leading-relaxed">
-            {job.intro}
-          </p>
+      <div
+        id={detailsId}
+        hidden={!open}
+        className="border-ink-100 bg-canvas-50/50 border-t px-5 pb-6 pt-5 sm:px-6"
+      >
+        <p className="text-ink-700 mb-6 text-base leading-relaxed">
+          {job.intro}
+        </p>
 
-          <div className="mb-5">
-            <span className="text-ink-400 mb-3 block font-mono text-xs uppercase tracking-widest">
-              What you'll do
-            </span>
-            <ul className="flex flex-col gap-2">
-              {job.whatYoullDo.map((item, i) => (
-                <li
-                  key={i}
-                  className="text-ink-700 flex gap-2.5 text-sm leading-relaxed"
-                >
-                  <span className="text-ink-300 mt-0.5 shrink-0">·</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+        <section className="mb-6">
+          <h4 className="text-ink-900 mb-3 text-sm font-semibold">
+            What you'll do
+          </h4>
+          <ul className="marker:text-primary-400 flex list-disc flex-col gap-2 pl-5">
+            {job.whatYoullDo.map((item, i) => (
+              <li key={i} className="text-ink-700 text-base leading-relaxed">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
 
-          <div className="mb-6">
-            <span className="text-ink-400 mb-3 block font-mono text-xs uppercase tracking-widest">
-              What we're looking for
-            </span>
-            <ul className="flex flex-col gap-2">
-              {job.whatWereLookingFor.map((item, i) => (
-                <li
-                  key={i}
-                  className="text-ink-700 flex gap-2.5 text-sm leading-relaxed"
-                >
-                  <span className="text-ink-300 mt-0.5 shrink-0">·</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
+        <section className="mb-6">
+          <h4 className="text-ink-900 mb-3 text-sm font-semibold">
+            What we're looking for
+          </h4>
+          <ul className="marker:text-primary-400 flex list-disc flex-col gap-2 pl-5">
+            {job.whatWereLookingFor.map((item, i) => (
+              <li key={i} className="text-ink-700 text-base leading-relaxed">
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
 
-          <Row className="items-center justify-between">
-            <button
-              onClick={() => setOpen(false)}
-              className="text-primary-600 hover:text-primary-700 font-mono text-sm font-medium transition-colors"
-            >
-              Hide ↑
-            </button>
-            <a
-              href={`mailto:${job.contactEmail}`}
-              className="bg-primary-600 hover:bg-primary-700 rounded-md px-5 py-2 font-mono text-sm text-white transition-colors"
-            >
-              Apply →
-            </a>
-          </Row>
-        </div>
-      )}
-    </div>
+        <Row className="flex-wrap items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="text-primary-600 hover:text-primary-700 focus-visible:ring-primary-500 flex items-center gap-1 rounded text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2"
+          >
+            Hide details
+            <ChevronUpIcon className="h-4 w-4" aria-hidden />
+          </button>
+          <a
+            href={`mailto:${job.contactEmail}`}
+            className="bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 rounded-md px-5 py-2 text-sm font-semibold text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          >
+            Apply by email →
+          </a>
+        </Row>
+      </div>
+    </article>
   )
 }
 
@@ -203,11 +208,8 @@ export default function JobsPage() {
         description="Curated jobs by employers who value forecasting."
         url="/jobs"
       />
-      <Col className="mx-auto w-full max-w-3xl gap-8 p-4 py-8">
-        {/* Back arrow sits inline with the heading only — the subtitle drops
-            below the whole row, so the arrow doesn't float against the centre
-            of a two-line block. */}
-        <Col className="gap-2">
+      <Col className="mx-auto w-full max-w-4xl gap-7 px-4 py-8 sm:px-6 sm:py-10">
+        <header className="flex flex-col gap-2">
           <Row className="items-center gap-2">
             <BackButton />
             <h1 className="text-ink-1000 text-3xl font-semibold sm:text-4xl">
@@ -217,57 +219,60 @@ export default function JobsPage() {
           <p className="text-ink-500 max-w-xl text-base leading-relaxed">
             Curated jobs by employers who value forecasting
           </p>
-        </Col>
+        </header>
 
         <JobInterestCard />
 
-        {/* gap-4 inside the company block vs the page's gap-8 between
-            sections, so the listings read as belonging to the company header
-            rather than floating equidistant from everything. */}
-        <Col className="gap-4">
-          <Col className="gap-1">
-            {/* Role count sits beside the company name rather than orphaned
-                under the description, where it read as a third stray line. */}
-            <Row className="items-baseline justify-between gap-3">
-              <Row className="items-baseline gap-2">
-                <h2 className="text-ink-1000 text-xl font-semibold">
+        <section aria-labelledby="mnx-heading" className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <h2
+                  id="mnx-heading"
+                  className="text-ink-1000 text-xl font-semibold"
+                >
                   MNX — The AI Exchange
                 </h2>
                 <a
                   href="https://mnx.fi"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-primary-600 hover:text-primary-700 shrink-0 text-xs"
+                  aria-label="Visit the MNX website"
+                  className="text-primary-600 hover:text-primary-700 focus-visible:ring-primary-500 flex shrink-0 items-center gap-1 rounded text-sm font-medium focus:outline-none focus-visible:ring-2"
                 >
-                  mnx.fi ↗
+                  mnx.fi
+                  <ExternalLinkIcon className="h-3.5 w-3.5" aria-hidden />
                 </a>
-              </Row>
-              <span className="text-ink-400 shrink-0 font-mono text-xs uppercase tracking-wider">
-                {JOBS.length} open role{JOBS.length !== 1 ? 's' : ''}
-              </span>
-            </Row>
-            <p className="text-ink-500 max-w-xl text-sm leading-relaxed">
-              MNX is building the financial architecture for the AI era. We are
-              a small, highly talented, and maximally AI-pilled team based in
-              San Francisco.
-            </p>
-          </Col>
-          {JOBS.map((job) => (
-            <JobCard key={job.title} job={job} />
-          ))}
-        </Col>
+              </div>
+              <p className="text-ink-500 max-w-2xl text-base leading-relaxed">
+                MNX is building the financial architecture for the AI era. We
+                are a small, highly talented, and maximally AI-pilled team based
+                in San Francisco.
+              </p>
+            </div>
+            <span className="bg-canvas-100 text-ink-600 shrink-0 self-start rounded-full px-3 py-1 text-sm font-medium">
+              {JOBS.length} open role{JOBS.length !== 1 ? 's' : ''}
+            </span>
+          </div>
 
-        <div className="border-ink-100 border-t pt-6">
-          <p className="text-ink-400 text-sm">
+          <div className="flex flex-col gap-3">
+            {JOBS.map((job) => (
+              <JobCard key={job.title} job={job} />
+            ))}
+          </div>
+        </section>
+
+        <aside className="border-ink-200 bg-canvas-50 rounded-lg border px-5 py-4">
+          <p className="text-ink-600 text-sm">
             Hiring in trading, AI, or fintech?{' '}
             <a
               href="mailto:info@manifold.markets"
-              className="text-primary-600 hover:text-primary-700"
+              className="text-primary-600 hover:text-primary-700 focus-visible:ring-primary-500 rounded font-medium focus:outline-none focus-visible:ring-2"
             >
               Get in touch to list a role.
             </a>
           </p>
-        </div>
+        </aside>
       </Col>
     </Page>
   )

--- a/web/pages/jobs/index.tsx
+++ b/web/pages/jobs/index.tsx
@@ -199,17 +199,20 @@ export default function JobsPage() {
         url="/jobs"
       />
       <Col className="mx-auto w-full max-w-3xl gap-8 p-4 py-8">
-        <Row className="items-center gap-2">
-          <BackButton />
-          <Col className="gap-2">
+        {/* Back arrow sits inline with the heading only — the subtitle drops
+            below the whole row, so the arrow doesn't float against the centre
+            of a two-line block. */}
+        <Col className="gap-2">
+          <Row className="items-center gap-2">
+            <BackButton />
             <h1 className="text-ink-1000 text-3xl font-semibold sm:text-4xl">
               Job Board
             </h1>
-            <p className="text-ink-500 max-w-xl text-base leading-relaxed">
-              Curated jobs by employers who value forecasting
-            </p>
-          </Col>
-        </Row>
+          </Row>
+          <p className="text-ink-500 max-w-xl text-base leading-relaxed">
+            Curated jobs by employers who value forecasting
+          </p>
+        </Col>
 
         <JobInterestCard />
 

--- a/web/pages/jobs/index.tsx
+++ b/web/pages/jobs/index.tsx
@@ -97,16 +97,21 @@ function JobCard({ job }: { job: Job }) {
   return (
     <div className="border-ink-200 bg-canvas-0 overflow-hidden rounded-lg border transition-shadow hover:shadow-sm">
       {/* Card header — always visible */}
+      {/* The whole header is the toggle, so it needs to look pressable:
+          pointer cursor + a faint hover wash, otherwise the only affordance is
+          the "Show role" text in the corner. */}
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full px-6 py-5 text-left"
+        className="hover:bg-canvas-50 w-full cursor-pointer px-6 py-5 text-left transition-colors"
         aria-expanded={open}
       >
         <Col className="gap-2">
           <Row className="items-start justify-between gap-3">
-            <h2 className="text-ink-1000 text-lg font-bold sm:text-xl md:text-2xl">
+            {/* h3, under the company's h2 — and capped at text-xl so a role
+                never outsizes the company heading above it. */}
+            <h3 className="text-ink-1000 text-lg font-bold sm:text-xl">
               {job.title}
-            </h2>
+            </h3>
             <span className="text-ink-400 shrink-0 pt-1 font-mono text-[10px] uppercase tracking-widest">
               Full time
             </span>
@@ -173,7 +178,7 @@ function JobCard({ job }: { job: Job }) {
           <Row className="items-center justify-between">
             <button
               onClick={() => setOpen(false)}
-              className="text-primary-600 font-mono text-sm font-medium"
+              className="text-primary-600 hover:text-primary-700 font-mono text-sm font-medium transition-colors"
             >
               Hide ↑
             </button>
@@ -216,19 +221,36 @@ export default function JobsPage() {
 
         <JobInterestCard />
 
-        <Col className="gap-3">
+        {/* gap-4 inside the company block vs the page's gap-8 between
+            sections, so the listings read as belonging to the company header
+            rather than floating equidistant from everything. */}
+        <Col className="gap-4">
           <Col className="gap-1">
-            <h2 className="text-ink-1000 text-xl font-semibold">
-              MNX - The AI Exchange
-            </h2>
-            <p className="text-ink-500 text-sm leading-relaxed">
+            {/* Role count sits beside the company name rather than orphaned
+                under the description, where it read as a third stray line. */}
+            <Row className="items-baseline justify-between gap-3">
+              <Row className="items-baseline gap-2">
+                <h2 className="text-ink-1000 text-xl font-semibold">
+                  MNX — The AI Exchange
+                </h2>
+                <a
+                  href="https://mnx.fi"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-600 hover:text-primary-700 shrink-0 text-xs"
+                >
+                  mnx.fi ↗
+                </a>
+              </Row>
+              <span className="text-ink-400 shrink-0 font-mono text-xs uppercase tracking-wider">
+                {JOBS.length} open role{JOBS.length !== 1 ? 's' : ''}
+              </span>
+            </Row>
+            <p className="text-ink-500 max-w-xl text-sm leading-relaxed">
               MNX is building the financial architecture for the AI era. We are
               a small, highly talented, and maximally AI-pilled team based in
               San Francisco.
             </p>
-            <span className="text-ink-400 mt-1 font-mono text-xs uppercase tracking-wider">
-              {JOBS.length} open role{JOBS.length !== 1 ? 's' : ''}
-            </span>
           </Col>
           {JOBS.map((job) => (
             <JobCard key={job.title} job={job} />

--- a/web/pages/jobs/index.tsx
+++ b/web/pages/jobs/index.tsx
@@ -119,7 +119,7 @@ function JobCard({ job }: { job: Job }) {
             <h3 className="text-ink-1000 text-lg font-bold sm:text-xl">
               {job.title}
             </h3>
-            <span className="bg-canvas-100 text-ink-600 shrink-0 rounded-full px-2.5 py-1 text-xs font-medium">
+            <span className="text-ink-400 shrink-0 pt-1 font-mono text-xs uppercase tracking-wider">
               Full time
             </span>
           </Row>
@@ -250,7 +250,7 @@ export default function JobsPage() {
                 in San Francisco.
               </p>
             </div>
-            <span className="bg-canvas-100 text-ink-600 shrink-0 self-start rounded-full px-3 py-1 text-sm font-medium">
+            <span className="text-ink-400 shrink-0 self-start font-mono text-xs uppercase tracking-wider sm:pt-1">
               {JOBS.length} open role{JOBS.length !== 1 ? 's' : ''}
             </span>
           </div>


### PR DESCRIPTION
Small visual cleanups to `/jobs`. No changes to any role copy — titles, comp, blurbs and bullets are the employers own wording and are untouched.

### Layout / hierarchy
- Back arrow now sits inline with the `Job Board` heading only. It previously shared a `Row` with a `Col` holding both the title and subtitle, so it centred against the whole two-line block and floated between the lines.
- Job titles were `md:text-2xl`, making them **larger than the company heading above them** and nearly the size of the page `h1`. Capped at `sm:text-xl`.
- Job titles were `h2`, the same level as the company name, so roles read as siblings of the company rather than nested under it. Now `h3`.
- `N open roles` moved up beside the company name; it was orphaned as a third stray line under the description.
- Tightened the company block gap so its listings read as belonging to that company.

### Affordances
- The whole card header is a `button`, but had no cursor change or hover feedback — the only affordance was the small `Show role` text in the corner. Added a pointer cursor and a faint hover wash.
- `Hide` gained the hover state its neighbouring `Apply` button already had.

### Content
- Linked the company name out to mnx.fi (verified against the site, which matches the listings).
- En dash in `MNX - The AI Exchange`.

### Register-interest card
Now collapses from the top right, matching the panel already-registered users see. The toggle is deliberately suppressed while the form is open, so a half-filled form cant be folded away and its selections lost.

### Follow-up polish
- Made the company heading and role count wrap cleanly on narrow screens.
- Reworked role cards into semantic, keyboard-visible disclosure panels with clearer open/closed states.
- Raised body and metadata type sizes, replaced text arrows with icons, and strengthened the expanded role hierarchy.
- Clarified the email application CTA and improved the employer-listing callout.
- Restyled the job-interest panel as a compact secondary callout, with larger selection targets and a non-interactive heading while its form is open.

### Verification
- Web TypeScript check passes.
- Focused ESLint and Prettier checks pass.
- The Next.js production bundle compiles successfully; local static generation later stops on the existing `/welcomeoffer` page because production Google credentials are not present.