### PR TITLE
fix(admin): restore the user journeys page

### DIFF
--- a/web/pages/admin/journeys.tsx
+++ b/web/pages/admin/journeys.tsx
@@ -8,6 +8,7 @@ import { Col } from 'web/components/layout/col'
 import { Row } from 'web/components/layout/row'
 import { Button } from 'web/components/buttons/button'
 import { isUserLikelySpammer, User } from 'common/user'
+import { convertUser } from 'common/supabase/users'
 import { UserAvatarAndBadge } from 'web/components/widgets/user-link'
 import { usePersistentQueryState } from 'web/hooks/use-persistent-query-state'
 import clsx from 'clsx'
@@ -44,14 +45,15 @@ export default function Journeys() {
   const [bannedUsers, setBannedUsers] = useState<User[]>([])
   const [referrer, setReferrer] = useState<string>()
   const isAuthed = useIsAuthorized()
-  const usersThatBet = unBannedUsers.filter(
-    (u) => eventsByUser[u.id]?.filter((e) => e.name === 'bet').length > 0
-  )
-  const userIdsThatBet = unBannedUsers
-    .filter(
-      (u) => eventsByUser[u.id]?.filter((e) => e.name === 'bet').length > 0
+  // The plain 'bet' event now only fires for limit orders (limit-order-panel);
+  // every ordinary trade emits 'bet intent'. Keying activation on 'bet' alone
+  // scored virtually every real user as un-activated.
+  const hasBet = (u: User) =>
+    (eventsByUser[u.id] ?? []).some(
+      (e) => e.name === 'bet intent' || e.name === 'bet'
     )
-    .map((u) => u.id)
+  const usersThatBet = unBannedUsers.filter(hasBet)
+  const userIdsThatBet = usersThatBet.map((u) => u.id)
   const likelySpammers = unBannedUsers.filter((u) =>
     isUserLikelySpammer(u, userIdsThatBet.includes(u.id), false)
   )
@@ -62,10 +64,13 @@ export default function Journeys() {
 
   const getEvents = async () => {
     const start = Date.now() - hoursFromNow * HOUR_MS
+    const startIso = new Date(start).toISOString()
+    // Signup time lives in the `created_time` column; it is no longer mirrored
+    // into `data`, so filtering on `data->createdTime` matched zero users.
     let usersQ = db
       .from('users')
       .select('id')
-      .gt('data->createdTime', start)
+      .gt('created_time', startIso)
       .is('data->fromLove', null)
     if (referrer) {
       usersQ = usersQ
@@ -73,14 +78,23 @@ export default function Journeys() {
         .eq('data->>referredByUserId', referrer)
     }
     const users = await run(usersQ)
+    const userIds = users.data.map((u) => u.id)
+    if (!userIds.length) {
+      setMarkets([])
+      setMarketVisitsByUser({})
+      setEventsByUser({})
+      return
+    }
+    // user_events is ~330M rows / 95GB with no index on user_id, so a bare
+    // `.in('user_id', ...)` seq-scans the whole table and blows the 8s
+    // statement timeout. Bounding ts lets it use user_events_ts instead —
+    // and these users didn't exist before `start` anyway.
     const events = await run(
       db
         .from('user_events')
         .select('*')
-        .in(
-          'user_id',
-          users.data.map((u) => u.id)
-        )
+        .gte('ts', startIso)
+        .in('user_id', userIds)
     )
     const contractViews = await run(
       db
@@ -117,10 +131,17 @@ export default function Journeys() {
   }
 
   const getUsers = async () => {
-    const userData = await run(
-      db.from('users').select('data').in('id', Object.keys(eventsByUser))
-    )
-    const users = userData.data.map((d) => d.data as User)
+    const userIds = Object.keys(eventsByUser)
+    if (!userIds.length) {
+      setBannedUsers([])
+      setUnBannedUsers([])
+      return
+    }
+    // `data` alone no longer carries id/name/username/createdTime — select the
+    // whole row and let convertUser stitch the columns back in, or every
+    // journey renders with a blank avatar and name.
+    const userData = await run(db.from('users').select('*').in('id', userIds))
+    const users = userData.data.map(convertUser)
     setBannedUsers(users.filter((u) => u.isBannedFromPosting))
     setUnBannedUsers(users.filter((u) => !u.isBannedFromPosting))
   }
@@ -158,9 +179,11 @@ export default function Journeys() {
         </Row>
         <Row>
           Fraction of (likely real) users that {TRADED_TERM}:{' '}
-          {(userIdsThatBet.length / unlikelySpammers.length).toPrecision(2)}. If
-          a user is highlighted in yellow, they're likely a spammer. If they're
-          highlighted in green, they've {TRADED_TERM}.
+          {unlikelySpammers.length
+            ? (userIdsThatBet.length / unlikelySpammers.length).toPrecision(2)
+            : '—'}
+          . If a user is highlighted in yellow, they're likely a spammer. If
+          they're highlighted in green, they've {TRADED_TERM}.
         </Row>
         <table>
           <thead>
@@ -279,7 +302,6 @@ export default function Journeys() {
                     (group) => group[0].ts,
                     'asc'
                   ).map((group, index) => {
-                    console.log(group)
                     const name = group[0].name
                     const times = group.length
                     const timePeriod =


### PR DESCRIPTION
`/admin/journeys` has been rendering nothing. The event pipeline is fine — prod writes ~140k events/day, 30–45% of them carrying a `user_id` (the rest are logged-out visitors). The page itself was broken, in three independent ways, any one of which empties it on its own.

### 1. The user query matched zero rows

It selected new signups with `.gt('data->createdTime', start)`, but signup time is no longer mirrored into `users.data` — it lives in the `created_time` timestamptz column.

```
select count(*) as total, count(data->'createdTime') as in_data from users;
--  total  | in_data
-- 201853  |       0
```

### 2. `user_events` seq-scanned past the statement timeout

The events query filtered by `user_id` with no time bound. That table is **334M rows / 95 GB** and has only two indexes — `user_events_pkey (id)` and `user_events_ts (ts DESC)`. There is **no index on `user_id`**, so the planner chose a sequential scan, well past the `authenticated` role's 8s `statement_timeout`:

```
Seq Scan on user_events  (cost=0.00..14810413.68 rows=72177 width=263)
  Filter: (user_id = ANY (...))
```

Bounding `ts` to the same window the users were selected from fixes it without a migration:

```
Index Scan using user_events_ts on user_events  (cost=0.58..704.36 rows=1 width=263)
  Index Cond: (ts >= (now() - '05:00:00'::interval))
  Filter: (user_id = ANY (...))
```

~21,000× cheaper. This drops no rows: these users are created after `start`, so they cannot have earlier events.

Indexing `user_id` on a 95GB table would be the alternative — it did not seem worth it for one admin page, but say the word if you'd rather have the index.

### 3. Activation was always zero

The page counted events named `bet`. That event now fires **only** from the limit-order panel (`web/components/bet/limit-order-panel.tsx`); every ordinary trade emits `bet intent`. Over a two-day sample: **9,444 `bet intent`, 0 `bet`**. So the "fraction of users that traded" line read 0 and nobody was highlighted green. Now accepts either.

### Also

- `getUsers` cast the raw `data` column straight to `User`, but `data` no longer carries `id`/`name`/`username`/`createdTime` — every journey rendered with a blank avatar and name. It now selects the row and runs it through `convertUser`.
- Guarded the activation ratio against `NaN` when no users are in range (it rendered a literal "NaN").
- Removed a stray `console.log` in the render loop.

### Verification

- The fixed queries return **16 users / 234 events** in the page's default 5h window, where the previous ones returned 0.
- `tsc --noEmit` and `eslint` both clean.
- Not rendered in a browser — the queries were verified directly against prod and the page logic is otherwise unchanged.

### Follow-up, not in this PR

Journeys only ever covered users who signed up in the last N hours. About 60% of events have no `user_id` but do carry `data->>'deviceId'`, so logged-out journeys are reconstructable if that's wanted later.
