### PR TITLE
feat(reports): sort and include/exclude filter pills

### DIFF
--- a/backend/api/src/get-mod-reports.ts
+++ b/backend/api/src/get-mod-reports.ts
@@ -4,7 +4,11 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 
 export const getModReports: APIHandler<'get-mod-reports'> = async (props) => {
   const pg = createSupabaseDirectClient()
-  const { statuses, limit, offset, count } = props
+  const { statuses, limit, offset, count, order } = props
+
+  if (statuses.length === 0) {
+    return { status: 'success', count: 0, reports: [] }
+  }
 
   if (count) {
     const total = await pg.one<{ count: number }>(
@@ -34,7 +38,7 @@ export const getModReports: APIHandler<'get-mod-reports'> = async (props) => {
     join users creator on creator.id = c.creator_id
     join users owner on owner.id = mr.user_id
     where mr.status in ($1:list)
-    order by mr.created_time desc
+    order by mr.created_time ${order === 'asc' ? 'asc' : 'desc'}
     limit $2
     offset $3
   `,

--- a/backend/api/src/get-mod-reports.ts
+++ b/backend/api/src/get-mod-reports.ts
@@ -4,7 +4,8 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 
 export const getModReports: APIHandler<'get-mod-reports'> = async (props) => {
   const pg = createSupabaseDirectClient()
-  const { statuses, limit, offset, count, order } = props
+  const { statuses, limit, offset, count, order, cursorTime, cursorId } = props
+  const direction = order === 'asc' ? 'asc' : 'desc'
 
   if (statuses.length === 0) {
     return { status: 'success', count: 0, reports: [] }
@@ -24,6 +25,7 @@ export const getModReports: APIHandler<'get-mod-reports'> = async (props) => {
     `
     select
       mr.*,
+      to_char(mr.created_time at time zone 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') as created_time,
       cc.data->'content' as comment_content,
       c.question as contract_question,
       c.slug as contract_slug,
@@ -38,11 +40,14 @@ export const getModReports: APIHandler<'get-mod-reports'> = async (props) => {
     join users creator on creator.id = c.creator_id
     join users owner on owner.id = mr.user_id
     where mr.status in ($1:list)
-    order by mr.created_time ${order === 'asc' ? 'asc' : 'desc'}
+      and ($4::timestamptz is null or
+        (mr.created_time, mr.report_id) ${order === 'asc' ? '>' : '<'}
+        ($4::timestamptz, $5::int))
+    order by mr.created_time ${direction}, mr.report_id ${direction}
     limit $2
     offset $3
   `,
-    [statuses, limit, offset]
+    [statuses, limit, offset, cursorTime ?? null, cursorId ?? null]
   )
 
   return { status: 'success', reports }

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -2675,6 +2675,7 @@ export const API = (_apiTypeCheck = {
         limit: z.coerce.number().gte(0).lte(100).default(25),
         offset: z.coerce.number().gte(0).default(0),
         count: coerceBoolean.optional(),
+        order: z.enum(['asc', 'desc']).default('desc'),
       })
       .strict(),
     returns: {} as {

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -2676,6 +2676,8 @@ export const API = (_apiTypeCheck = {
         offset: z.coerce.number().gte(0).default(0),
         count: coerceBoolean.optional(),
         order: z.enum(['asc', 'desc']).default('desc'),
+        cursorTime: z.string().datetime({ offset: true }).optional(),
+        cursorId: z.coerce.number().int().optional(),
       })
       .strict(),
     returns: {} as {

--- a/web/components/widgets/filter-pill.tsx
+++ b/web/components/widgets/filter-pill.tsx
@@ -1,0 +1,56 @@
+import { CheckIcon, XIcon } from '@heroicons/react/solid'
+import clsx from 'clsx'
+import { ReactNode } from 'react'
+
+/** Off = don't filter on this at all, include = only these, exclude = never these. */
+export type FilterState = 'off' | 'include' | 'exclude'
+
+const NEXT_STATE: Record<FilterState, FilterState> = {
+  off: 'include',
+  include: 'exclude',
+  exclude: 'off',
+}
+
+export const cycleFilterState = (state: FilterState) => NEXT_STATE[state]
+
+/** Whether an item with the given attribute passes the filter. */
+export const passesFilter = (state: FilterState, hasAttribute: boolean) =>
+  state === 'off' || (state === 'include' ? hasAttribute : !hasAttribute)
+
+/** A pill you click to cycle between not filtering, including, and excluding. */
+export function FilterPill(props: {
+  state: FilterState
+  onChange: (state: FilterState) => void
+  className?: string
+  children: ReactNode
+}) {
+  const { state, onChange, className, children } = props
+
+  return (
+    <button
+      type="button"
+      aria-pressed={state !== 'off'}
+      title={
+        state === 'include'
+          ? 'Only showing these — click to exclude them'
+          : state === 'exclude'
+          ? 'Hiding these — click to clear'
+          : 'Click to only show these'
+      }
+      className={clsx(
+        'flex h-6 cursor-pointer select-none flex-row items-center gap-1 whitespace-nowrap rounded-full px-2 text-sm outline-none transition-colors',
+        state === 'include'
+          ? 'bg-primary-500 hover:bg-primary-600 focus-visible:bg-primary-600 text-white'
+          : state === 'exclude'
+          ? 'bg-scarlet-500 hover:bg-scarlet-600 focus-visible:bg-scarlet-600 text-white'
+          : 'bg-ink-200 hover:bg-ink-300 focus-visible:bg-ink-300 text-ink-600 dark:bg-ink-300 dark:hover:bg-ink-400',
+        className
+      )}
+      onClick={() => onChange(NEXT_STATE[state])}
+    >
+      {state === 'include' && <CheckIcon className="h-3 w-3" />}
+      {state === 'exclude' && <XIcon className="h-3 w-3" />}
+      {children}
+    </button>
+  )
+}

--- a/web/hooks/use-mod-reports.ts
+++ b/web/hooks/use-mod-reports.ts
@@ -3,7 +3,10 @@ import { api } from 'web/lib/api/api'
 import { ModReport, ReportStatus } from 'common/src/mod-report'
 import { keyBy, mapValues } from 'lodash'
 
-export const useModReports = (statuses: ReportStatus[]) => {
+export const useModReports = (
+  statuses: ReportStatus[],
+  order: 'asc' | 'desc' = 'desc'
+) => {
   const [reports, setReports] = useState<ModReport[] | undefined>(undefined)
   const [reportStatuses, setReportStatuses] = useState<{
     [key: number]: ReportStatus
@@ -13,20 +16,26 @@ export const useModReports = (statuses: ReportStatus[]) => {
   }>({})
 
   const getModReports = async () => {
+    if (statuses.length === 0) {
+      setReports([])
+      return
+    }
     try {
       const response = await api('get-mod-reports', {
         statuses,
         limit: 50,
         offset: 0,
+        order,
       })
       if (response && response.status === 'success') {
         const newReports = response.reports
 
-        const sortedReports = newReports.sort(
-          (a: ModReport, b: ModReport) =>
-            new Date(b.created_time).getTime() -
-            new Date(a.created_time).getTime()
-        )
+        const sortedReports = newReports.sort((a: ModReport, b: ModReport) => {
+          const diff =
+            new Date(a.created_time).getTime() -
+            new Date(b.created_time).getTime()
+          return order === 'asc' ? diff : -diff
+        })
 
         setReports(sortedReports)
 
@@ -46,7 +55,7 @@ export const useModReports = (statuses: ReportStatus[]) => {
 
   useEffect(() => {
     getModReports()
-  }, [JSON.stringify(statuses)])
+  }, [JSON.stringify(statuses), order])
 
   return {
     reports,

--- a/web/hooks/use-mod-reports.ts
+++ b/web/hooks/use-mod-reports.ts
@@ -1,65 +1,136 @@
 import { useEffect, useState } from 'react'
 import { api } from 'web/lib/api/api'
-import { ModReport, ReportStatus } from 'common/src/mod-report'
+import { ModReport, ReportStatus } from 'common/mod-report'
 import { keyBy, mapValues } from 'lodash'
+
+const REPORTS_BATCH_SIZE = 50
+
+/** The key must include every input that changes which reports are fetched. */
+export function useReportPages<T, Cursor>(
+  key: string,
+  fetchPage: (cursor?: Cursor) => Promise<{
+    reports: T[]
+    nextCursor?: Cursor
+  }>,
+  enabled = true
+) {
+  const [request, setRequest] = useState<{ key: string; cursor?: Cursor }>({
+    key,
+  })
+  const [state, setState] = useState<{
+    key: string
+    reports?: T[]
+    nextCursor?: Cursor
+    isLoading: boolean
+    error: boolean
+  }>({ key, isLoading: enabled, error: false })
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    const cursor =
+      request.key === key && state.key === key ? request.cursor : undefined
+    setState((prev) => ({
+      key,
+      reports:
+        cursor !== undefined && prev.key === key ? prev.reports : undefined,
+      nextCursor: cursor,
+      isLoading: true,
+      error: false,
+    }))
+    fetchPage(cursor)
+      .then((page) => {
+        if (cancelled) return
+        setState((prev) => ({
+          key,
+          reports:
+            cursor === undefined
+              ? page.reports
+              : [...(prev.reports ?? []), ...page.reports],
+          nextCursor: page.nextCursor,
+          isLoading: false,
+          error: false,
+        }))
+      })
+      .catch((error) => {
+        if (cancelled) return
+        console.error('Error fetching reports:', error)
+        setState((prev) => ({ ...prev, isLoading: false, error: true }))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [key, enabled, request])
+
+  const current = state.key === key ? state : undefined
+  return {
+    reports: current?.reports,
+    isLoading: enabled && (current?.isLoading ?? true),
+    error: current?.error ?? false,
+    hasMore: current?.nextCursor !== undefined,
+    // Also retries the initial request when its cursor is undefined.
+    loadMore: () => {
+      if (!enabled || current?.isLoading) return
+      setRequest({ key, cursor: current?.nextCursor })
+    },
+  }
+}
 
 export const useModReports = (
   statuses: ReportStatus[],
-  order: 'asc' | 'desc' = 'desc'
+  order: 'asc' | 'desc' = 'desc',
+  enabled = true
 ) => {
-  const [reports, setReports] = useState<ModReport[] | undefined>(undefined)
-  const [reportStatuses, setReportStatuses] = useState<{
-    [key: number]: ReportStatus
-  }>({})
-  const [modNotes, setModNotes] = useState<{
-    [key: number]: string | undefined
-  }>({})
-
-  const getModReports = async () => {
-    if (statuses.length === 0) {
-      setReports([])
-      return
-    }
-    try {
+  const key = JSON.stringify([statuses, order])
+  const pages = useReportPages<
+    ModReport,
+    { cursorTime: string; cursorId: number }
+  >(
+    key,
+    async (cursor) => {
+      if (statuses.length === 0) return { reports: [] }
       const response = await api('get-mod-reports', {
         statuses,
-        limit: 50,
-        offset: 0,
+        limit: REPORTS_BATCH_SIZE,
         order,
+        ...cursor,
       })
-      if (response && response.status === 'success') {
-        const newReports = response.reports
-
-        const sortedReports = newReports.sort((a: ModReport, b: ModReport) => {
-          const diff =
-            new Date(a.created_time).getTime() -
-            new Date(b.created_time).getTime()
-          return order === 'asc' ? diff : -diff
-        })
-
-        setReports(sortedReports)
-
-        const reportsById = keyBy(sortedReports, 'report_id')
-        const initialStatuses = mapValues(reportsById, (r) => r.status)
-        const initialNotes = mapValues(reportsById, (r) => r.mod_note)
-
-        setReportStatuses(initialStatuses)
-        setModNotes(initialNotes)
-      } else {
-        console.error('Failed to fetch reports:', response)
+      if (response.status !== 'success')
+        throw new Error('Failed to fetch reports')
+      const last = response.reports.at(-1)
+      return {
+        reports: response.reports,
+        nextCursor:
+          response.reports.length === REPORTS_BATCH_SIZE && last
+            ? { cursorTime: last.created_time, cursorId: last.report_id }
+            : undefined,
       }
-    } catch (error) {
-      console.error('Error fetching reports:', error)
-    }
-  }
-
+    },
+    enabled
+  )
+  const [statusChanges, setReportStatuses] = useState<
+    Record<number, ReportStatus>
+  >({})
+  const [noteChanges, setModNotes] = useState<
+    Record<number, string | undefined>
+  >({})
   useEffect(() => {
-    getModReports()
-  }, [JSON.stringify(statuses), order])
+    setReportStatuses({})
+    setModNotes({})
+  }, [key])
 
+  const reportsById = keyBy(pages.reports, 'report_id')
+  const reportStatuses: Record<number, ReportStatus> = {
+    ...mapValues(reportsById, (r) => r.status),
+    ...statusChanges,
+  }
+  const modNotes: Record<number, string | undefined> = {
+    ...mapValues(reportsById, (r) => r.mod_note),
+    ...noteChanges,
+  }
   return {
-    reports,
-    initialLoading: reports === undefined,
+    ...pages,
+    initialLoading: pages.isLoading && pages.reports === undefined,
     reportStatuses,
     modNotes,
     setReportStatuses,

--- a/web/pages/admin/reports.tsx
+++ b/web/pages/admin/reports.tsx
@@ -141,12 +141,15 @@ export const getReports = async (p: {
   limit: number
   offset?: number
   after?: { createdTime?: number | undefined }
+  /** Oldest first, instead of the default newest first. */
+  ascending?: boolean
 }) => {
+  const ascending = p.ascending ?? false
   const q = db
     .from('reports')
     .select()
     .is('dismissed_by_user_id', null)
-    .order('created_time', { ascending: false })
+    .order('created_time', { ascending })
 
   if (p.offset) {
     q.range(p.offset, p.limit + p.offset)
@@ -155,7 +158,9 @@ export const getReports = async (p: {
   }
 
   if (p.after?.createdTime) {
-    q.lt('created_time', millisToTs(p.after.createdTime))
+    const cursor = millisToTs(p.after.createdTime)
+    if (ascending) q.gt('created_time', cursor)
+    else q.lt('created_time', cursor)
   }
 
   const { data } = await run(q)

--- a/web/pages/admin/reports.tsx
+++ b/web/pages/admin/reports.tsx
@@ -16,10 +16,10 @@ import { Tooltip } from 'web/components/widgets/tooltip'
 import { BannedBadge, UserLink } from 'web/components/widgets/user-link'
 import { useAdmin } from 'web/hooks/use-admin'
 import { usePagination } from 'web/hooks/use-pagination'
-import { api } from 'web/lib/api/api'
-import { getComment } from 'web/lib/supabase/comments'
+import { APIError, api } from 'web/lib/api/api'
+import { convertContractComment } from 'common/supabase/comments'
 import { db } from 'web/lib/supabase/db'
-import { DisplayUser, getUserById } from 'web/lib/supabase/users'
+import { DisplayUser, getDisplayUsers } from 'web/lib/supabase/users'
 import { convertPost } from 'common/top-level-post'
 
 const PAGE_SIZE = 20
@@ -137,11 +137,16 @@ export default function Reports(props: { reports: LiteReport[] }) {
   )
 }
 
-export const getReports = async (p: {
+export type ReportCursor = {
+  createdTime?: number
+  createdTimeIso?: string
+  id?: string
+}
+
+export const getReportBatch = async (p: {
   limit: number
   offset?: number
-  after?: { createdTime?: number | undefined }
-  /** Oldest first, instead of the default newest first. */
+  after?: ReportCursor
   ascending?: boolean
 }) => {
   const ascending = p.ascending ?? false
@@ -150,24 +155,42 @@ export const getReports = async (p: {
     .select()
     .is('dismissed_by_user_id', null)
     .order('created_time', { ascending })
+    .order('id', { ascending })
 
-  if (p.offset) {
-    q.range(p.offset, p.limit + p.offset)
-  } else {
+  const cursorTime =
+    p.after?.createdTimeIso ??
+    (p.after?.createdTime != null ? millisToTs(p.after.createdTime) : undefined)
+  if (cursorTime) {
+    const op = ascending ? 'gt' : 'lt'
+    if (p.after?.id) {
+      q.or(
+        `created_time.${op}.${cursorTime},and(created_time.eq.${cursorTime},id.${op}.${JSON.stringify(
+          p.after.id
+        )})`
+      )
+    } else if (ascending) q.gt('created_time', cursorTime)
+    else q.lt('created_time', cursorTime)
     q.limit(p.limit)
-  }
-
-  if (p.after?.createdTime) {
-    const cursor = millisToTs(p.after.createdTime)
-    if (ascending) q.gt('created_time', cursor)
-    else q.lt('created_time', cursor)
+  } else {
+    const offset = p.offset ?? 0
+    q.range(offset, offset + p.limit - 1)
   }
 
   const { data } = await run(q)
-  return await convertReports(data)
+  const last = data.at(-1)
+  return {
+    reports: await convertReports(data),
+    // Advance using raw rows, including reports whose content has been deleted.
+    // Preserve timestamp precision and use the ID to break timestamp ties.
+    nextCursor:
+      data.length === p.limit && last?.created_time
+        ? { createdTimeIso: last.created_time, id: last.id }
+        : undefined,
+  }
 }
 
-// adapted from api/v0/reports
+export const getReports = async (p: Parameters<typeof getReportBatch>[0]) =>
+  (await getReportBatch(p)).reports
 
 export type LiteReport = {
   slug: string
@@ -179,98 +202,124 @@ export type LiteReport = {
   contentId: string
   contentType: string
   createdTime?: number
+  createdTimeIso?: string
 }
 
 const convertReports = async (
   rows: Row<'reports'>[]
 ): Promise<LiteReport[]> => {
-  return filterDefined(
-    await Promise.all(
-      rows.map(async (report) => {
-        const {
-          content_id: contentId,
-          content_type: contentType,
-          content_owner_id: contentOwnerId,
-          parent_type: parentType,
-          parent_id: parentId,
-          user_id: userId,
-          created_time: createdTime,
-          id,
-          description,
-        } = report
-
-        let partialReport: { slug: string; text: JSONContent | string } | null =
-          null
-        // Reported contract
-        if (contentType === 'contract') {
-          const contract = await api('market/:id', {
-            id: contentId,
-            lite: true,
-          })
-          partialReport = contract
-            ? {
-                slug: contractPath(contract),
-                text: contract.question,
-              }
+  if (rows.length === 0) return []
+  const userIds = [
+    ...new Set(
+      rows.flatMap((r) => [
+        r.content_owner_id,
+        r.user_id,
+        ...(r.content_type === 'user' ? [r.content_id] : []),
+      ])
+    ),
+  ]
+  const marketIds = [
+    ...new Set(
+      filterDefined(
+        rows.map((r) =>
+          r.content_type === 'contract'
+            ? r.content_id
+            : r.content_type === 'comment' && r.parent_type === 'contract'
+            ? r.parent_id
             : null
-          // Reported comment on a contract
-        } else if (
-          contentType === 'comment' &&
-          parentType === 'contract' &&
-          parentId
-        ) {
-          const contract = await api('market/:id', { id: parentId, lite: true })
-          if (contract) {
-            const comment = await getComment(contentId)
-            partialReport = comment && {
-              slug: contractPath(contract) + '#' + comment.id,
-              text: comment.content,
-            }
-          }
-        } else if (contentType === 'user') {
-          const reportedUser = await getUserById(contentId)
-          partialReport = {
-            slug: `/${reportedUser?.username}`,
-            text: reportedUser?.name ?? '',
-          }
-        } else if (contentType === 'post') {
-          const { data: postRow, error: postError } = await db
-            .from('old_posts')
-            .select('*')
-            .eq('id', contentId)
-            .single()
+        )
+      )
+    ),
+  ]
+  const commentIds = rows
+    .filter((r) => r.content_type === 'comment' && r.parent_type === 'contract')
+    .map((r) => r.content_id)
+  const postIds = rows
+    .filter((r) => r.content_type === 'post')
+    .map((r) => r.content_id)
 
-          if (postError || !postRow) {
-            console.error(
-              `Error fetching post ${contentId} for report:`,
-              postError
-            )
-            partialReport = null
-          } else {
-            const post = convertPost(postRow)
-            partialReport = {
-              slug: `/post/${post.slug}`,
-              text: post.content,
-            }
-          }
+  // Fetch each entity once per batch, with independent lookups in parallel.
+  const [users, marketEntries, comments, posts] = await Promise.all([
+    getDisplayUsers(userIds),
+    Promise.all(
+      marketIds.map(async (id) => {
+        try {
+          return [id, await api('market/:id', { id, lite: true })] as const
+        } catch (error) {
+          if (error instanceof APIError && error.code === 404)
+            return [id, null] as const
+          throw error
         }
-
-        const owner = await getUserById(contentOwnerId)
-        const reporter = await getUserById(userId)
-
-        return partialReport && owner
-          ? {
-              ...partialReport,
-              reasonsDescription: description,
-              owner,
-              reporter,
-              contentType,
-              contentId,
-              id,
-              createdTime: tsToMillis(createdTime as any),
-            }
-          : null
       })
-    )
+    ),
+    commentIds.length
+      ? run(db.from('contract_comments').select().in('comment_id', commentIds))
+      : Promise.resolve({ data: [] }),
+    postIds.length
+      ? run(db.from('old_posts').select().in('id', postIds))
+      : Promise.resolve({ data: [] }),
+  ])
+  const usersById = new Map(users.map((user) => [user.id, user]))
+  const marketsById = new Map(marketEntries)
+  const commentsById = new Map(
+    comments.data.map((r) => [r.comment_id, convertContractComment(r)])
+  )
+  const postsById = new Map(posts.data.map((r) => [r.id, convertPost(r)]))
+
+  return filterDefined(
+    rows.map((report) => {
+      const {
+        content_id: contentId,
+        content_type: contentType,
+        content_owner_id: contentOwnerId,
+        parent_type: parentType,
+        parent_id: parentId,
+        user_id: userId,
+        created_time: createdTime,
+        id,
+        description,
+      } = report
+      const owner = usersById.get(contentOwnerId)
+      const reporter = usersById.get(userId)
+      if (!owner || !reporter) return null
+
+      let content: { slug: string; text: JSONContent | string } | undefined
+      if (contentType === 'contract') {
+        const contract = marketsById.get(contentId)
+        if (contract)
+          content = { slug: contractPath(contract), text: contract.question }
+      } else if (
+        contentType === 'comment' &&
+        parentType === 'contract' &&
+        parentId
+      ) {
+        const contract = marketsById.get(parentId)
+        const comment = commentsById.get(contentId)
+        if (contract && comment)
+          content = {
+            slug: contractPath(contract) + '#' + comment.id,
+            text: comment.content,
+          }
+      } else if (contentType === 'user') {
+        const user = usersById.get(contentId)
+        if (user) content = { slug: `/${user.username}`, text: user.name }
+      } else if (contentType === 'post') {
+        const post = postsById.get(contentId)
+        if (post) content = { slug: `/post/${post.slug}`, text: post.content }
+      }
+      return content
+        ? {
+            ...content,
+            reasonsDescription: description,
+            owner,
+            reporter,
+            contentType,
+            contentId,
+            id,
+            createdTime: tsToMillis(createdTime),
+            createdTimeIso: createdTime ?? undefined,
+          }
+        : null
+    })
   )
 }

--- a/web/pages/reports.tsx
+++ b/web/pages/reports.tsx
@@ -10,13 +10,78 @@ import ModReportItem from 'web/components/mod-report-item'
 import UserReportItem from 'web/components/user-report-item'
 import { Title } from 'web/components/widgets/title'
 import { api } from 'web/lib/api/api'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { PaginationNextPrev } from 'web/components/widgets/pagination'
 import { getReports, LiteReport } from 'web/pages/admin/reports'
-import { Select } from 'web/components/widgets/select'
 import { Row } from 'web/components/layout/row'
+import { Button } from 'web/components/buttons/button'
+import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
+import {
+  FilterPill,
+  FilterState,
+  passesFilter,
+} from 'web/components/widgets/filter-pill'
 
 const USER_REPORTS_PAGE_SIZE = 10
+
+type SortOrder = 'desc' | 'asc'
+
+const SORT_CHOICES: { [label: string]: SortOrder } = {
+  Newest: 'desc',
+  Oldest: 'asc',
+}
+
+const MOD_REPORT_STATUSES: ReportStatus[] = [
+  'new',
+  'under review',
+  'needs admin',
+  'resolved',
+]
+
+const STATUS_LABELS: { [status in ReportStatus]: string } = {
+  new: 'New',
+  'under review': 'Under review',
+  'needs admin': 'Needs admin',
+  resolved: 'Resolved',
+}
+
+const USER_REPORT_TYPES = ['contract', 'comment', 'user', 'post']
+
+type Filters<T extends string> = { [key in T]: FilterState }
+
+function makeFilters<T extends string>(
+  keys: readonly T[],
+  overrides: Partial<Filters<T>> = {}
+) {
+  const filters = Object.fromEntries(
+    keys.map((key) => [key, 'off'])
+  ) as Filters<T>
+  return { ...filters, ...overrides }
+}
+
+/** The keys left visible by a set of include/exclude pills: the explicitly
+ * included ones, or everything that wasn't explicitly excluded. */
+function includedKeys<T extends string>(
+  keys: readonly T[],
+  filters: Filters<T>
+) {
+  const included = keys.filter((key) => filters[key] === 'include')
+  return included.length
+    ? included
+    : keys.filter((key) => filters[key] !== 'exclude')
+}
+
+const isDefault = <T extends string>(
+  filters: Filters<T>,
+  defaults: Filters<T>
+) =>
+  Object.keys(defaults).every((key) => filters[key as T] === defaults[key as T])
+
+const DEFAULT_MOD_STATUS_FILTERS = makeFilters(MOD_REPORT_STATUSES, {
+  resolved: 'exclude',
+})
+
+const DEFAULT_USER_TYPE_FILTERS = makeFilters(USER_REPORT_TYPES)
 
 const updateModReport = async (
   reportId: number,
@@ -34,11 +99,18 @@ const updateModReport = async (
 export default function ReportsPage() {
   const isAdminOrMod = useAdminOrMod()
   const [activeTab, setActiveTab] = useState('mod-reports')
-  const [selectedStatuses, setSelectedStatuses] = useState<ReportStatus[]>([
-    'new',
-    'under review',
-    'needs admin',
-  ])
+
+  // Mod report sorting & filtering.
+  const [modSort, setModSort] = useState<SortOrder>('desc')
+  const [statusFilters, setStatusFilters] = useState(DEFAULT_MOD_STATUS_FILTERS)
+  const [modNoteFilter, setModNoteFilter] = useState<FilterState>('off')
+  const [modBannedFilter, setModBannedFilter] = useState<FilterState>('off')
+
+  const selectedStatuses = useMemo(
+    () => includedKeys(MOD_REPORT_STATUSES, statusFilters),
+    [statusFilters]
+  )
+
   const {
     reports: modReports,
     initialLoading,
@@ -46,24 +118,94 @@ export default function ReportsPage() {
     modNotes,
     setReportStatuses,
     setModNotes,
-  } = useModReports(selectedStatuses)
-  const [showBannedUsers, setShowBannedUsers] = useState(false)
+  } = useModReports(selectedStatuses, modSort)
+
+  const visibleModReports = useMemo(
+    () =>
+      (modReports ?? []).filter((report) => {
+        const note = (
+          modNotes[report.report_id] ??
+          report.mod_note ??
+          ''
+        ).trim()
+        return (
+          passesFilter(modNoteFilter, !!note) &&
+          passesFilter(modBannedFilter, !!report.owner_is_banned_from_posting)
+        )
+      }),
+    [modReports, modNotes, modNoteFilter, modBannedFilter]
+  )
+
+  const modFiltersAreDefault =
+    isDefault(statusFilters, DEFAULT_MOD_STATUS_FILTERS) &&
+    modNoteFilter === 'off' &&
+    modBannedFilter === 'off'
+
+  const resetModFilters = () => {
+    setStatusFilters(DEFAULT_MOD_STATUS_FILTERS)
+    setModNoteFilter('off')
+    setModBannedFilter('off')
+  }
+
+  // User report sorting & filtering.
+  const [userSort, setUserSort] = useState<SortOrder>('desc')
+  const [typeFilters, setTypeFilters] = useState(DEFAULT_USER_TYPE_FILTERS)
+  const [userBannedFilter, setUserBannedFilter] =
+    useState<FilterState>('exclude')
+  const [userReasonFilter, setUserReasonFilter] = useState<FilterState>('off')
   const [allUserReports, setAllUserReports] = useState<LiteReport[]>()
   const [userReportsError, setUserReportsError] = useState(false)
   const [bannedIds, setBannedIds] = useState<string[]>([])
 
   useEffect(() => {
-    getReports({ limit: 50 })
+    setAllUserReports(undefined)
+    setUserReportsError(false)
+    getReports({ limit: 50, ascending: userSort === 'asc' })
       .then(setAllUserReports)
       .catch((e) => {
         console.error('Error fetching user reports:', e)
         setUserReportsError(true)
       })
-  }, [])
+  }, [userSort])
 
-  const filteredUserReports = allUserReports?.filter(
-    (r) => !r.owner.isBannedFromPosting && !bannedIds.includes(r.owner.id)
+  const isBanned = (report: LiteReport) =>
+    !!report.owner.isBannedFromPosting || bannedIds.includes(report.owner.id)
+
+  const unbannedUserReports = allUserReports?.filter((r) => !isBanned(r))
+
+  const visibleTypes = useMemo(
+    () => includedKeys(USER_REPORT_TYPES, typeFilters),
+    [typeFilters]
   )
+
+  const visibleUserReports = useMemo(
+    () =>
+      allUserReports?.filter(
+        (report) =>
+          (!USER_REPORT_TYPES.includes(report.contentType) ||
+            visibleTypes.includes(report.contentType)) &&
+          passesFilter(userBannedFilter, isBanned(report)) &&
+          passesFilter(userReasonFilter, !!report.reasonsDescription)
+      ),
+    [
+      allUserReports,
+      visibleTypes,
+      userBannedFilter,
+      userReasonFilter,
+      bannedIds,
+    ]
+  )
+
+  const userFiltersAreDefault =
+    isDefault(typeFilters, DEFAULT_USER_TYPE_FILTERS) &&
+    userBannedFilter === 'exclude' &&
+    userReasonFilter === 'off'
+
+  const resetUserFilters = () => {
+    setTypeFilters(DEFAULT_USER_TYPE_FILTERS)
+    setUserBannedFilter('exclude')
+    setUserReasonFilter('off')
+  }
 
   const handleStatusChange = async (
     reportId: number,
@@ -86,33 +228,12 @@ export default function ReportsPage() {
     await updateModReport(reportId, { mod_note: newNote })
   }
 
-  const handleStatusFilterChange = (
-    e: React.ChangeEvent<HTMLSelectElement>
-  ) => {
-    const value = e.target.value
-
-    if (value === 'all') {
-      setSelectedStatuses(['new', 'under review', 'needs admin', 'resolved'])
-    } else if (value === 'unresolved') {
-      setSelectedStatuses(['new', 'under review', 'needs admin'])
-    } else {
-      setSelectedStatuses([value as ReportStatus])
-    }
-  }
-
   if (!isAdminOrMod)
     return (
       <Page trackPageView={'mod reports'}>
         <div className="mt-24 self-center">
           You must be a Mod or Admin to view this page.
         </div>
-      </Page>
-    )
-
-  if (initialLoading)
-    return (
-      <Page trackPageView={'mod reports'}>
-        <div className="mt-24 self-center">Loading reports...</div>
       </Page>
     )
 
@@ -131,62 +252,49 @@ export default function ReportsPage() {
         ))
       ) : (
         <div className="mt-8 text-center">
-          No reports found with the selected filter.
+          No reports found with the selected filters.
         </div>
       )}
     </Col>
   )
 
-  const renderUserReportsList = () => (
-    <Col className="w-full">
-      <Row className="mb-4 mt-2 justify-end">
-        <Select
-          className="max-w-xs"
-          onChange={(e) => setShowBannedUsers(e.target.value === 'all')}
-          value={showBannedUsers ? 'all' : 'hide-banned'}
-        >
-          <option value="all">Show All Users</option>
-          <option value="hide-banned">Hide Banned Users</option>
-        </Select>
-      </Row>
-      <UserReportsListInner
-        allReports={allUserReports}
-        allReportsError={userReportsError}
-        hideBanned={!showBannedUsers}
-        bannedIds={bannedIds}
-        onBan={(userId) => setBannedIds((ids) => [...ids, userId])}
-      />
-    </Col>
-  )
-
   const renderModReportsContent = () => (
     <Col className="w-full">
-      <Row className="mb-4 mt-2 justify-end">
-        <Select
-          className="max-w-xs"
-          onChange={handleStatusFilterChange}
-          value={
-            selectedStatuses.length === 4
-              ? 'all'
-              : selectedStatuses.length === 3 &&
-                selectedStatuses.includes('new') &&
-                selectedStatuses.includes('under review') &&
-                selectedStatuses.includes('needs admin')
-              ? 'unresolved'
-              : selectedStatuses.length === 1
-              ? selectedStatuses[0]
-              : 'custom'
-          }
-        >
-          <option value="all">All Statuses</option>
-          <option value="unresolved">Unresolved</option>
-          <option value="new">New</option>
-          <option value="under review">Under Review</option>
-          <option value="needs admin">Needs Admin</option>
-          <option value="resolved">Resolved</option>
-        </Select>
-      </Row>
-      {renderReportList(modReports ?? [])}
+      <FilterRow
+        sort={modSort}
+        setSort={setModSort}
+        onReset={modFiltersAreDefault ? undefined : resetModFilters}
+      >
+        {MOD_REPORT_STATUSES.map((status) => (
+          <FilterPill
+            key={status}
+            state={statusFilters[status]}
+            onChange={(state) =>
+              setStatusFilters((prev) => ({ ...prev, [status]: state }))
+            }
+          >
+            {STATUS_LABELS[status]}
+          </FilterPill>
+        ))}
+        <FilterPill state={modNoteFilter} onChange={setModNoteFilter}>
+          Has mod note
+        </FilterPill>
+        <FilterPill state={modBannedFilter} onChange={setModBannedFilter}>
+          Banned author
+        </FilterPill>
+      </FilterRow>
+
+      {initialLoading ? (
+        <div className="mt-8 text-center">Loading reports...</div>
+      ) : (
+        <>
+          <div className="text-ink-500 mb-2 text-sm">
+            Showing {visibleModReports.length} of {modReports?.length ?? 0}{' '}
+            loaded reports
+          </div>
+          {renderReportList(visibleModReports)}
+        </>
+      )}
 
       <div className="mt-4 text-center">
         <Link
@@ -196,6 +304,46 @@ export default function ReportsPage() {
           View additional reports...
         </Link>
       </div>
+    </Col>
+  )
+
+  const renderUserReportsList = () => (
+    <Col className="w-full">
+      <FilterRow
+        sort={userSort}
+        setSort={setUserSort}
+        onReset={userFiltersAreDefault ? undefined : resetUserFilters}
+      >
+        {USER_REPORT_TYPES.map((type) => (
+          <FilterPill
+            key={type}
+            state={typeFilters[type]}
+            onChange={(state) =>
+              setTypeFilters((prev) => ({ ...prev, [type]: state }))
+            }
+          >
+            {type[0].toUpperCase() + type.slice(1)}
+          </FilterPill>
+        ))}
+        <FilterPill state={userBannedFilter} onChange={setUserBannedFilter}>
+          Banned user
+        </FilterPill>
+        <FilterPill state={userReasonFilter} onChange={setUserReasonFilter}>
+          Has reason
+        </FilterPill>
+      </FilterRow>
+      <UserReportsListInner
+        reports={visibleUserReports}
+        allReportsError={userReportsError}
+        bannedIds={bannedIds}
+        onBan={(userId) => setBannedIds((ids) => [...ids, userId])}
+        filterKey={JSON.stringify([
+          userSort,
+          typeFilters,
+          userBannedFilter,
+          userReasonFilter,
+        ])}
+      />
     </Col>
   )
 
@@ -210,9 +358,9 @@ export default function ReportsPage() {
       content: renderUserReportsList(),
       queryString: 'user-reports',
       inlineTabIcon:
-        filteredUserReports && filteredUserReports.length > 0 ? (
+        unbannedUserReports && unbannedUserReports.length > 0 ? (
           <div className="text-ink-0 bg-primary-500 min-w-[15px] rounded-full p-[2px] text-center text-[10px] leading-3">
-            {filteredUserReports.length}
+            {unbannedUserReports.length}
           </div>
         ) : null,
     },
@@ -241,29 +389,59 @@ export default function ReportsPage() {
   )
 }
 
+/** Sort toggle plus a wrapping row of include/exclude filter pills. */
+function FilterRow(props: {
+  sort: SortOrder
+  setSort: (sort: SortOrder) => void
+  onReset?: () => void
+  children: React.ReactNode
+}) {
+  const { sort, setSort, onReset, children } = props
+
+  return (
+    <Col className="mb-4 mt-2 gap-2">
+      <Row className="items-center gap-2">
+        <span className="text-ink-500 text-sm">Sort</span>
+        <ChoicesToggleGroup
+          currentChoice={sort}
+          choicesMap={SORT_CHOICES}
+          setChoice={(choice) => setSort(choice as SortOrder)}
+          toggleClassName="!py-1"
+        />
+      </Row>
+      <Row className="flex-wrap items-center gap-2">
+        <span className="text-ink-500 text-sm">Filter</span>
+        {children}
+        {onReset && (
+          <Button size="2xs" color="gray-white" onClick={onReset}>
+            Reset
+          </Button>
+        )}
+      </Row>
+    </Col>
+  )
+}
+
 function UserReportsListInner(props: {
-  allReports: LiteReport[] | undefined
+  reports: LiteReport[] | undefined
   allReportsError: boolean
-  hideBanned: boolean
   bannedIds: string[]
   onBan: (userId: string) => void
+  filterKey: string
 }) {
-  const { allReports, allReportsError, hideBanned, bannedIds, onBan } = props
+  const { reports, allReportsError, bannedIds, onBan, filterKey } = props
   const [page, setPage] = useState(0)
 
-  const filtered = allReports?.filter((r) => {
-    if (!hideBanned) return true
-    return !r.owner.isBannedFromPosting && !bannedIds.includes(r.owner.id)
-  })
+  useEffect(() => setPage(0), [filterKey])
 
   const pageStart = page * USER_REPORTS_PAGE_SIZE
-  const pageItems = filtered?.slice(
+  const pageItems = reports?.slice(
     pageStart,
     pageStart + USER_REPORTS_PAGE_SIZE
   )
   const isStart = page === 0
-  const isEnd = filtered
-    ? pageStart + USER_REPORTS_PAGE_SIZE >= filtered.length
+  const isEnd = reports
+    ? pageStart + USER_REPORTS_PAGE_SIZE >= reports.length
     : true
 
   if (allReportsError) {
@@ -276,13 +454,13 @@ function UserReportsListInner(props: {
         className="mb-4"
         isStart={isStart}
         isEnd={isEnd}
-        isLoading={!allReports}
-        isComplete={!!allReports}
+        isLoading={!reports}
+        isComplete={!!reports}
         getPrev={() => setPage((p) => Math.max(0, p - 1))}
         getNext={() => setPage((p) => p + 1)}
       />
 
-      {!allReports ? (
+      {!reports ? (
         <div className="my-8 text-center">Loading user reports...</div>
       ) : pageItems && pageItems.length > 0 ? (
         pageItems.map((report) => (
@@ -301,8 +479,8 @@ function UserReportsListInner(props: {
         className="mt-4"
         isStart={isStart}
         isEnd={isEnd}
-        isLoading={!allReports}
-        isComplete={!!allReports}
+        isLoading={!reports}
+        isComplete={!!reports}
         getPrev={() => setPage((p) => Math.max(0, p - 1))}
         getNext={() => setPage((p) => p + 1)}
       />

--- a/web/pages/reports.tsx
+++ b/web/pages/reports.tsx
@@ -3,16 +3,19 @@ import { Page } from 'web/components/layout/page'
 import { ControlledTabs } from 'web/components/layout/tabs'
 import { SEO } from 'web/components/SEO'
 import { useAdminOrMod } from 'web/hooks/use-admin'
-import { ModReport, ReportStatus } from 'common/src/mod-report'
-import Link from 'next/link'
-import { useModReports } from 'web/hooks/use-mod-reports'
+import { ModReport, ReportStatus } from 'common/mod-report'
+import { useModReports, useReportPages } from 'web/hooks/use-mod-reports'
 import ModReportItem from 'web/components/mod-report-item'
 import UserReportItem from 'web/components/user-report-item'
 import { Title } from 'web/components/widgets/title'
 import { api } from 'web/lib/api/api'
 import { useEffect, useMemo, useState } from 'react'
 import { PaginationNextPrev } from 'web/components/widgets/pagination'
-import { getReports, LiteReport } from 'web/pages/admin/reports'
+import {
+  getReportBatch,
+  LiteReport,
+  ReportCursor,
+} from 'web/pages/admin/reports'
 import { Row } from 'web/components/layout/row'
 import { Button } from 'web/components/buttons/button'
 import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
@@ -99,6 +102,7 @@ const updateModReport = async (
 export default function ReportsPage() {
   const isAdminOrMod = useAdminOrMod()
   const [activeTab, setActiveTab] = useState('mod-reports')
+  const [userTabOpened, setUserTabOpened] = useState(false)
 
   // Mod report sorting & filtering.
   const [modSort, setModSort] = useState<SortOrder>('desc')
@@ -114,11 +118,15 @@ export default function ReportsPage() {
   const {
     reports: modReports,
     initialLoading,
+    isLoading: modReportsLoading,
+    error: modReportsError,
+    hasMore: hasMoreModReports,
+    loadMore: loadMoreModReports,
     reportStatuses,
     modNotes,
     setReportStatuses,
     setModNotes,
-  } = useModReports(selectedStatuses, modSort)
+  } = useModReports(selectedStatuses, modSort, !!isAdminOrMod)
 
   const visibleModReports = useMemo(
     () =>
@@ -153,20 +161,19 @@ export default function ReportsPage() {
   const [userBannedFilter, setUserBannedFilter] =
     useState<FilterState>('exclude')
   const [userReasonFilter, setUserReasonFilter] = useState<FilterState>('off')
-  const [allUserReports, setAllUserReports] = useState<LiteReport[]>()
-  const [userReportsError, setUserReportsError] = useState(false)
   const [bannedIds, setBannedIds] = useState<string[]>([])
-
-  useEffect(() => {
-    setAllUserReports(undefined)
-    setUserReportsError(false)
-    getReports({ limit: 50, ascending: userSort === 'asc' })
-      .then(setAllUserReports)
-      .catch((e) => {
-        console.error('Error fetching user reports:', e)
-        setUserReportsError(true)
-      })
-  }, [userSort])
+  const {
+    reports: allUserReports,
+    error: userReportsError,
+    isLoading: userReportsLoading,
+    hasMore: hasMoreUserReports,
+    loadMore: loadMoreUserReports,
+  } = useReportPages<LiteReport, ReportCursor>(
+    userSort,
+    (after) =>
+      getReportBatch({ limit: 50, ascending: userSort === 'asc', after }),
+    !!isAdminOrMod && userTabOpened
+  )
 
   const isBanned = (report: LiteReport) =>
     !!report.owner.isBannedFromPosting || bannedIds.includes(report.owner.id)
@@ -185,7 +192,7 @@ export default function ReportsPage() {
           (!USER_REPORT_TYPES.includes(report.contentType) ||
             visibleTypes.includes(report.contentType)) &&
           passesFilter(userBannedFilter, isBanned(report)) &&
-          passesFilter(userReasonFilter, !!report.reasonsDescription)
+          passesFilter(userReasonFilter, !!report.reasonsDescription?.trim())
       ),
     [
       allUserReports,
@@ -252,7 +259,7 @@ export default function ReportsPage() {
         ))
       ) : (
         <div className="mt-8 text-center">
-          No reports found with the selected filters.
+          No matching reports among the reports loaded so far.
         </div>
       )}
     </Col>
@@ -286,7 +293,7 @@ export default function ReportsPage() {
 
       {initialLoading ? (
         <div className="mt-8 text-center">Loading reports...</div>
-      ) : (
+      ) : modReports ? (
         <>
           <div className="text-ink-500 mb-2 text-sm">
             Showing {visibleModReports.length} of {modReports?.length ?? 0}{' '}
@@ -294,16 +301,13 @@ export default function ReportsPage() {
           </div>
           {renderReportList(visibleModReports)}
         </>
-      )}
-
-      <div className="mt-4 text-center">
-        <Link
-          href="/admin/reports"
-          className="text-primary-700 hover:text-primary-500 hover:underline"
-        >
-          View additional reports...
-        </Link>
-      </div>
+      ) : null}
+      <ReportLoadMore
+        hasMore={hasMoreModReports}
+        isLoading={modReportsLoading && !initialLoading}
+        error={modReportsError}
+        onLoadMore={loadMoreModReports}
+      />
     </Col>
   )
 
@@ -332,6 +336,12 @@ export default function ReportsPage() {
           Has reason
         </FilterPill>
       </FilterRow>
+      {allUserReports && (
+        <div className="text-ink-500 mb-2 text-sm">
+          Showing {visibleUserReports?.length ?? 0} of {allUserReports.length}{' '}
+          loaded reports
+        </div>
+      )}
       <UserReportsListInner
         reports={visibleUserReports}
         allReportsError={userReportsError}
@@ -343,6 +353,12 @@ export default function ReportsPage() {
           userBannedFilter,
           userReasonFilter,
         ])}
+      />
+      <ReportLoadMore
+        hasMore={hasMoreUserReports}
+        isLoading={userReportsLoading && !!allUserReports}
+        error={userReportsError}
+        onLoadMore={loadMoreUserReports}
       />
     </Col>
   )
@@ -381,11 +397,44 @@ export default function ReportsPage() {
           trackingName="mod-reports-tabs"
           onClick={(title, index) => {
             if (index === 0) setActiveTab('mod-reports')
-            else setActiveTab('user-reports')
+            else {
+              setActiveTab('user-reports')
+              setUserTabOpened(true)
+            }
           }}
         />
       </Col>
     </Page>
+  )
+}
+
+function ReportLoadMore(props: {
+  hasMore: boolean
+  isLoading: boolean
+  error: boolean
+  onLoadMore: () => void
+}) {
+  const { hasMore, isLoading, error, onLoadMore } = props
+  return (
+    <Col className="mt-4 items-center gap-2">
+      {error && (
+        <div role="alert">Failed to load reports. Please try again.</div>
+      )}
+      {hasMore && (
+        <div className="text-ink-500 text-center text-sm">
+          Filters apply to loaded reports. More reports are available.
+        </div>
+      )}
+      {(hasMore || error || isLoading) && (
+        <Button color="gray-outline" disabled={isLoading} onClick={onLoadMore}>
+          {isLoading
+            ? 'Loading reports...'
+            : error
+            ? 'Retry'
+            : 'Load 50 more reports'}
+        </Button>
+      )}
+    </Col>
   )
 }
 
@@ -434,19 +483,21 @@ function UserReportsListInner(props: {
 
   useEffect(() => setPage(0), [filterKey])
 
-  const pageStart = page * USER_REPORTS_PAGE_SIZE
+  const currentPage = Math.min(
+    page,
+    Math.max(0, Math.ceil((reports?.length ?? 0) / USER_REPORTS_PAGE_SIZE) - 1)
+  )
+  const pageStart = currentPage * USER_REPORTS_PAGE_SIZE
   const pageItems = reports?.slice(
     pageStart,
     pageStart + USER_REPORTS_PAGE_SIZE
   )
-  const isStart = page === 0
+  const isStart = currentPage === 0
   const isEnd = reports
     ? pageStart + USER_REPORTS_PAGE_SIZE >= reports.length
     : true
 
-  if (allReportsError) {
-    return <div className="my-8 text-center">Failed to load user reports.</div>
-  }
+  if (allReportsError && !reports) return null
 
   return (
     <>
@@ -456,8 +507,8 @@ function UserReportsListInner(props: {
         isEnd={isEnd}
         isLoading={!reports}
         isComplete={!!reports}
-        getPrev={() => setPage((p) => Math.max(0, p - 1))}
-        getNext={() => setPage((p) => p + 1)}
+        getPrev={() => setPage(Math.max(0, currentPage - 1))}
+        getNext={() => setPage(currentPage + 1)}
       />
 
       {!reports ? (
@@ -472,7 +523,9 @@ function UserReportsListInner(props: {
           />
         ))
       ) : (
-        <div className="my-8 text-center">No user reports found.</div>
+        <div className="my-8 text-center">
+          No matching reports among the reports loaded so far.
+        </div>
       )}
 
       <PaginationNextPrev
@@ -481,8 +534,8 @@ function UserReportsListInner(props: {
         isEnd={isEnd}
         isLoading={!reports}
         isComplete={!!reports}
-        getPrev={() => setPage((p) => Math.max(0, p - 1))}
-        getNext={() => setPage((p) => p + 1)}
+        getPrev={() => setPage(Math.max(0, currentPage - 1))}
+        getNext={() => setPage(currentPage + 1)}
       />
     </>
   )


### PR DESCRIPTION
The /reports page could only sort newest-first and pick a single status
from a dropdown. Mods working a backlog want the oldest reports first,
and want to slice the list by more than one attribute at a time.

- Sort toggle (Newest/Oldest) on both tabs. Ordering happens server side
  so "oldest" shows the actual oldest reports, not a reversed page:
  get-mod-reports takes an `order` param, and the user-report query
  takes `ascending` (flipping its keyset cursor along with it).
- Tri-state filter pills replace the status dropdown: click once to only
  show that kind, again to hide it, again to clear. Explicit includes
  win; otherwise everything not excluded is shown. Mod reports filter on
  status, mod note and banned author; user reports on content type,
  banned user and whether a reason was given.
- Mod reports load inside the tab now, so the pills stay usable while a
  new status selection is fetching.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HLm2jbJ2VArmi2VGb74QSF