### PR TITLE
Add For You tab and default eligible users to personalized Browse

### DIFF
--- a/backend/api/src/get-browse-personalization.ts
+++ b/backend/api/src/get-browse-personalization.ts
@@ -1,0 +1,12 @@
+import { APIHandler } from './helpers/endpoint'
+import { getBrowsePersonalizationEligibility } from 'shared/browse-personalization'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+
+export const getBrowsePersonalization: APIHandler<
+  'get-browse-personalization'
+> = async (_, auth) => ({
+  eligible: await getBrowsePersonalizationEligibility(
+    createSupabaseDirectClient(),
+    auth.uid
+  ),
+})

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -5,6 +5,7 @@ import { getBalanceChanges } from 'api/get-balance-changes'
 import { getBestComments } from 'api/get-best-comments'
 import { getBoostAnalytics } from 'api/get-boost-analytics'
 import { getBoostHistory } from 'api/get-boost-history'
+import { getBrowsePersonalization } from 'api/get-browse-personalization'
 import { getFeed } from 'api/get-feed'
 import { getInterestingGroupsFromViews } from 'api/get-interesting-groups-from-views'
 import { getManaSummaryStats } from 'api/get-mana-summary-stats'
@@ -487,6 +488,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'request-otp': requestOTP,
   'multi-sell': multiSell,
   'get-feed': getFeed,
+  'get-browse-personalization': getBrowsePersonalization,
   'get-unified-feed': getUnifiedFeed,
   'get-mana-supply': getManaSupply,
   'update-mod-report': updateModReport,

--- a/backend/scripts/tests/browse-personalization.test.cjs
+++ b/backend/scripts/tests/browse-personalization.test.cjs
@@ -1,0 +1,214 @@
+// Actual readiness SQL against disposable PostgreSQL. Requires a locally
+// cached postgres:15-alpine image; no network, credentials, or mounted data.
+// Run after building common: node --test backend/scripts/tests/browse-personalization.test.cjs
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const { randomUUID } = require('node:crypto')
+const fs = require('node:fs')
+const path = require('node:path')
+const { after, before, test } = require('node:test')
+const vm = require('node:vm')
+const ts = require('typescript')
+const pgp = require('pg-promise')()
+
+const root = path.resolve(__dirname, '../../..')
+const rules = require(path.join(root, 'common/lib/browse-personalization'))
+const captured = {}
+vm.runInNewContext(
+  ts.transpileModule(
+    fs.readFileSync(
+      path.join(root, 'backend/shared/src/browse-personalization.ts'),
+      'utf8'
+    ),
+    { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+  ).outputText,
+  {
+    exports: captured,
+    require: (id) => {
+      if (id === 'common/browse-personalization') return rules
+      throw new Error(`Unexpected readiness dependency: ${id}`)
+    },
+  }
+)
+
+const container = `browse-readiness-test-${randomUUID()}`
+let started = false
+const docker = (args, input) =>
+  execFileSync('docker', args, {
+    input,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+const query = (sql) =>
+  docker(
+    [
+      'exec',
+      '-i',
+      container,
+      'psql',
+      '-U',
+      'postgres',
+      '-X',
+      '-qAt',
+      '-v',
+      'ON_ERROR_STOP=1',
+    ],
+    sql
+  )
+
+before(async () => {
+  docker([
+    'run',
+    '--detach',
+    '--rm',
+    '--pull=never',
+    '--name',
+    container,
+    '--network',
+    'none',
+    '--env',
+    'POSTGRES_HOST_AUTH_METHOD=trust',
+    'postgres:15-alpine',
+  ])
+  started = true
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      query('select 1')
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+  }
+  throw new Error('Synthetic PostgreSQL did not become ready')
+})
+after(() => {
+  if (started) docker(['stop', container])
+})
+
+const schema = `
+  drop table if exists user_contract_views, contracts, user_topic_interests;
+  create table contracts (id text primary key, visibility text, deleted boolean default false);
+  create table user_contract_views (
+    user_id text, contract_id text, page_views bigint default 0, card_views bigint default 0,
+    unique(user_id, contract_id)
+  );
+  create table user_topic_interests (user_id text, created_time timestamptz, group_ids_to_activity jsonb);
+  insert into contracts (id, visibility)
+    select 'market-' || n, 'public' from generate_series(1, 30) n;
+`
+const profile = (
+  user = 'alice',
+  value = '{"topic-a":{"conversionScore":0.4}}',
+  date = '2026-09-06'
+) =>
+  pgp.as.format(
+    'insert into user_topic_interests values ($1, $2, $3::jsonb);',
+    [user, date, value]
+  )
+const views = (count, user = 'alice') =>
+  pgp.as.format(
+    `
+  insert into user_contract_views (user_id, contract_id, page_views)
+    select $1, 'market-' || n, 1 from generate_series(1, $2) n;
+`,
+    [user, count]
+  )
+const result = (setup, user = 'alice') => {
+  const sql = pgp.as.format(captured.BROWSE_PERSONALIZATION_SQL, [
+    user,
+    rules.FOR_YOU_MIN_MARKET_VIEWS,
+  ])
+  const [count, learned] = query(schema + setup + sql)
+    .trim()
+    .split('|')
+  return {
+    count: Number(count),
+    eligible: rules.hasEnoughBrowseHistory(Number(count), learned === 't'),
+  }
+}
+
+test('20 different public markets plus a learned profile qualifies; 19 does not', () => {
+  assert.equal(result(views(19) + profile()).eligible, false)
+  assert.deepEqual(result(views(20) + profile()), { count: 20, eligible: true })
+})
+
+test('repeat page views and passive card impressions cannot inflate the threshold', () => {
+  assert.equal(
+    result(
+      profile() +
+        `
+    insert into user_contract_views values ('alice', 'market-1', 10000, 0);
+    insert into user_contract_views select 'alice', 'market-' || n, 0, 10000
+      from generate_series(2, 30) n;
+  `
+    ).eligible,
+    false
+  )
+})
+
+test('private, unlisted, and deleted markets do not qualify', () => {
+  assert.equal(
+    result(
+      views(22) +
+        profile() +
+        `
+    update contracts set visibility = 'private' where id = 'market-20';
+    update contracts set visibility = 'unlisted' where id = 'market-21';
+    update contracts set deleted = true where id = 'market-22';
+  `
+    ).eligible,
+    false
+  )
+})
+
+test('visits alone do not qualify before learned data has been calculated', () => {
+  assert.equal(result(views(30)).eligible, false)
+})
+
+test('another account cannot provide the visits or learned profile', () => {
+  assert.equal(result(views(30, 'bob') + profile('bob')).eligible, false)
+  assert.equal(result(views(30) + profile('bob')).eligible, false)
+})
+
+test('uses the latest learned profile and requires a valid positive score', () => {
+  assert.equal(
+    result(views(20) + profile() + profile('alice', '{}', '2026-09-07'))
+      .eligible,
+    false
+  )
+  assert.equal(
+    result(
+      views(20) +
+        profile(
+          'alice',
+          '{"a":{"conversionScore":"NaN"},"b":{"conversionScore":0},"c":{"conversionScore":2}}'
+        )
+    ).eligible,
+    false
+  )
+})
+
+test('stops counting at the threshold for established users', () => {
+  assert.deepEqual(result(views(30) + profile()), { count: 20, eligible: true })
+})
+
+test('database work receives a transaction-local server timeout and only the authenticated ID', async () => {
+  const calls = []
+  const pg = {
+    tx: async (fn) =>
+      fn({
+        none: async (sql) => calls.push(sql),
+        one: async (sql, args) => {
+          calls.push({ sql, args })
+          return { distinct_market_views: 20, has_learned_interests: true }
+        },
+      }),
+  }
+  assert.equal(
+    await captured.getBrowsePersonalizationEligibility(pg, 'alice'),
+    true
+  )
+  assert.equal(calls[0], 'set local statement_timeout = 1000')
+  assert.equal(calls[1].sql, captured.BROWSE_PERSONALIZATION_SQL)
+  assert.deepEqual(Array.from(calls[1].args), ['alice', 20])
+})

--- a/backend/shared/src/browse-personalization.ts
+++ b/backend/shared/src/browse-personalization.ts
@@ -1,0 +1,53 @@
+import {
+  FOR_YOU_MIN_MARKET_VIEWS,
+  hasEnoughBrowseHistory,
+} from 'common/browse-personalization'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+export const BROWSE_PERSONALIZATION_SQL = `
+  with latest_profile as (
+    select group_ids_to_activity
+    from user_topic_interests
+    where user_id = $1
+    order by created_time desc
+    limit 1
+  ), opened_markets as (
+    select 1
+    from user_contract_views v
+    join contracts c on c.id = v.contract_id
+    where v.user_id = $1
+      and v.page_views > 0
+      and c.visibility = 'public'
+      and c.deleted = false
+    limit $2
+  )
+  select
+    (select count(*)::int from opened_markets) as distinct_market_views,
+    exists (
+      select 1
+      from latest_profile,
+        jsonb_each(group_ids_to_activity) as topic
+      where case when jsonb_typeof(topic.value -> 'conversionScore') = 'number'
+        then (topic.value ->> 'conversionScore')::numeric > 0
+          and (topic.value ->> 'conversionScore')::numeric <= 1
+        else false end
+    ) as has_learned_interests
+`
+
+export const getBrowsePersonalizationEligibility = (
+  pg: SupabaseDirectClient,
+  userId: string
+) =>
+  pg.tx(async (tx) => {
+    // This optional default must not leave work running on the database after
+    // the browser has fallen back to All.
+    await tx.none('set local statement_timeout = 1000')
+    const row = await tx.one<{
+      distinct_market_views: number
+      has_learned_interests: boolean
+    }>(BROWSE_PERSONALIZATION_SQL, [userId, FOR_YOU_MIN_MARKET_VIEWS])
+    return hasEnoughBrowseHistory(
+      row.distinct_market_views,
+      row.has_learned_interests
+    )
+  })

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1,4 +1,5 @@
 import { PerpSuggestion } from '../perps/suggestion'
+import type { BrowsePersonalization } from 'common/browse-personalization'
 import { MAX_ANSWER_LENGTH, type Answer } from 'common/answer'
 import { coerceBoolean, contentSchema } from 'common/api/zod-types'
 import { AnyBalanceChangeType } from 'common/balance-change'
@@ -3251,6 +3252,14 @@ export const API = (_apiTypeCheck = {
         userId: z.string().optional(),
       })
       .strict(),
+  },
+  'get-browse-personalization': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    cache: 'private, no-store',
+    props: z.object({}).strict(),
+    returns: {} as BrowsePersonalization,
   },
   'get-unified-feed': {
     method: 'GET',

--- a/common/src/browse-personalization.test.ts
+++ b/common/src/browse-personalization.test.ts
@@ -1,0 +1,138 @@
+import { API } from './api/schema'
+import {
+  canDefaultToForYou,
+  getInitialBrowseForYou,
+  hasEnoughBrowseHistory,
+  normalizeBrowseChange,
+  readBrowseMode,
+  readBrowseParameters,
+} from './browse-personalization'
+
+describe('Browse personalization readiness', () => {
+  it.each([0, 1, 19, NaN, Infinity, -Infinity])(
+    'does not auto-select with insufficient/invalid history: %s',
+    (views) => expect(hasEnoughBrowseHistory(views, true)).toBe(false)
+  )
+
+  it('requires both 20 distinct opened markets and learned interests', () => {
+    expect(hasEnoughBrowseHistory(20, true)).toBe(true)
+    expect(hasEnoughBrowseHistory(100, true)).toBe(true)
+    expect(hasEnoughBrowseHistory(100, false)).toBe(false)
+  })
+
+  it('keeps the readiness endpoint private and scoped to the caller', () => {
+    const endpoint = API['get-browse-personalization']
+    expect(endpoint.authed).toBe(true)
+    expect(endpoint.cache).toBe('private, no-store')
+    expect(endpoint.props.safeParse({}).success).toBe(true)
+    expect(endpoint.props.safeParse({ userId: 'another-user' }).success).toBe(
+      false
+    )
+  })
+})
+
+describe('initial Browse destination', () => {
+  const initial = (
+    overrides: Partial<Parameters<typeof getInitialBrowseForYou>[0]>
+  ) =>
+    getInitialBrowseForYou({
+      params: { fy: '0', s: 'score', sw: '0' },
+      urlParams: {},
+      eligible: true,
+      ...overrides,
+    })
+
+  it('promotes automatic All on a later visit once enough history exists', () => {
+    expect(initial({ eligible: false })).toBe('0')
+    expect(initial({ eligible: true })).toBe('1')
+  })
+
+  it('keeps explicit All and lets cold-start users manually select For You', () => {
+    expect(initial({ preference: 'all' })).toBe('0')
+    expect(initial({ preference: 'for-you', eligible: false })).toBe('1')
+  })
+
+  it('gives explicit URLs priority over the remembered mode', () => {
+    expect(initial({ urlParams: { fy: '0' }, preference: 'for-you' })).toBe('0')
+    expect(
+      initial({ urlParams: { fy: '1' }, preference: 'all', eligible: false })
+    ).toBe('1')
+  })
+
+  it.each([
+    { tf: 'followed' },
+    { tf: 'science' },
+    { gids: 'topic-a,topic-b' },
+    { q: 'fusion' },
+    { s: 'newest' },
+    { s: '24-hour-vol' },
+    { f: 'news' },
+    { sw: '1' },
+  ])('preserves an explicit destination/filter %j', (params) => {
+    expect(initial({ params })).toBe('0')
+  })
+
+  it.each(['score', 'freshness-score'])(
+    'supports personalization with %s',
+    (s) => {
+      expect(canDefaultToForYou({ s, sw: '0' })).toBe(true)
+      expect(initial({ params: { s } })).toBe('1')
+    }
+  )
+
+  it('ignores malformed local preferences and query arrays', () => {
+    expect(readBrowseMode('treatment')).toBeUndefined()
+    expect(readBrowseMode({ mode: 'all' })).toBeUndefined()
+    expect(readBrowseParameters(['fy', '1'])).toEqual({})
+    expect(readBrowseParameters({ fy: ['1'], tf: 'followed', n: 1 })).toEqual({
+      tf: 'followed',
+    })
+  })
+})
+
+describe('Browse navigation', () => {
+  const current = { fy: '1', tf: '', gids: '', s: 'score', f: 'all', sw: '0' }
+
+  it('exits personalization when selecting All or Followed', () => {
+    expect(
+      normalizeBrowseChange(current, { fy: '0', tf: '', gids: '' }).fy
+    ).toBe('0')
+    expect(
+      normalizeBrowseChange(current, { tf: 'followed', gids: '' }).fy
+    ).toBe('0')
+  })
+
+  it('exits personalization for specific topics, New, news, or cash', () => {
+    for (const changes of [
+      { tf: 'science' },
+      { gids: 'topic-a' },
+      { s: 'newest' },
+      { f: 'news' },
+      { sw: '1' },
+    ]) {
+      expect(normalizeBrowseChange(current, changes).fy).toBe('0')
+    }
+  })
+
+  it('preserves For You when switching between Best and Hot', () => {
+    expect(normalizeBrowseChange(current, { s: 'freshness-score' })).toEqual({
+      s: 'freshness-score',
+    })
+  })
+
+  it('clears Followed and restores a supported sort when selecting For You', () => {
+    expect(
+      normalizeBrowseChange(
+        {
+          ...current,
+          fy: '0',
+          tf: 'followed',
+          s: 'newest',
+          f: 'news',
+          sw: '1',
+        },
+        { fy: '1' }
+      )
+    ).toEqual({ fy: '1', tf: '', gids: '', s: 'score', f: 'open', sw: '0' })
+  })
+})

--- a/common/src/browse-personalization.ts
+++ b/common/src/browse-personalization.ts
@@ -1,0 +1,83 @@
+// A starting heuristic for choosing a default, not a claim of measured lift.
+// Count distinct, deliberately opened public markets, not card impressions,
+// repeat views, account age, or money spent. The ranker also needs learned data.
+export const FOR_YOU_MIN_MARKET_VIEWS = 20
+
+export type BrowseMode = 'all' | 'for-you'
+export type BrowsePersonalization = { eligible: boolean }
+export type BrowseParameters = Record<string, string | undefined>
+
+export const hasEnoughBrowseHistory = (
+  distinctMarketViews: number,
+  hasLearnedInterests: boolean
+) =>
+  Number.isFinite(distinctMarketViews) &&
+  distinctMarketViews >= FOR_YOU_MIN_MARKET_VIEWS &&
+  hasLearnedInterests
+
+export const readBrowseMode = (value: unknown): BrowseMode | undefined =>
+  value === 'all' || value === 'for-you' ? value : undefined
+
+export const readBrowseParameters = (value: unknown): BrowseParameters => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string'
+    )
+  )
+}
+
+export const canDefaultToForYou = (params: BrowseParameters) =>
+  !params.q?.trim() &&
+  !params.tf &&
+  !params.gids &&
+  (!params.s || params.s === 'score' || params.s === 'freshness-score') &&
+  params.f !== 'news' &&
+  params.sw !== '1'
+
+// Explicit URLs win. Otherwise preserve a saved navigation/filter choice and
+// apply the user's All/For You preference before the automatic history rule.
+// A persisted fy=0 alone is not an opt-out: it may be yesterday's cold start.
+export const getInitialBrowseForYou = (args: {
+  params: BrowseParameters
+  urlParams: BrowseParameters
+  preference?: BrowseMode
+  eligible: boolean
+}): '0' | '1' => {
+  const { params, urlParams, preference, eligible } = args
+  if (urlParams.fy === '0' || urlParams.fy === '1') return urlParams.fy
+  if (!canDefaultToForYou(params)) return '0'
+  if (preference) return preference === 'for-you' ? '1' : '0'
+  return eligible ? '1' : '0'
+}
+
+// A topic scope and personalized ranking are separate destinations. Keep the
+// highlighted tab consistent with the API route, including explicit sorts.
+export const normalizeBrowseChange = <T extends BrowseParameters>(
+  current: T,
+  changes: Partial<T>
+): Partial<T> => {
+  if (changes.fy === '1') {
+    const next = { ...current, ...changes }
+    return {
+      ...changes,
+      tf: '',
+      gids: '',
+      s: next.s === 'score' || next.s === 'freshness-score' ? next.s : 'score',
+      f: next.f === 'news' ? 'open' : next.f,
+      sw: next.sw === '1' ? '0' : next.sw,
+    }
+  }
+  if (
+    changes.tf !== undefined ||
+    changes.gids !== undefined ||
+    (changes.s !== undefined &&
+      changes.s !== 'score' &&
+      changes.s !== 'freshness-score') ||
+    changes.f === 'news' ||
+    changes.sw === '1'
+  ) {
+    return { ...changes, fy: '0' }
+  }
+  return changes
+}

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -9,6 +9,10 @@ import { APIError } from 'common/api/utils'
 import { getForcedABTestVariant } from 'common/ab-test'
 import { Contract } from 'common/contract'
 import {
+  BrowseMode,
+  normalizeBrowseChange,
+} from 'common/browse-personalization'
+import {
   DISCOVERY_EXPERIMENT_NAME,
   DISCOVERY_EXPERIMENT_VARIANTS,
   DISCOVERY_EXPOSURE_EVENT,
@@ -250,6 +254,7 @@ type SearchProps = {
   defaultContractType?: ContractTypeType
   defaultSearchType?: SearchType
   defaultForYou?: '1' | '0'
+  onBrowseModeChange?: (mode: BrowseMode) => void
   additionalFilter?: SupabaseAdditionalFilter
   highlightContractIds?: string[]
   onContractClick?: (contract: Contract) => void
@@ -312,6 +317,7 @@ export function Search(props: SearchProps) {
     defaultContractType,
     defaultSearchType,
     defaultForYou,
+    onBrowseModeChange,
     additionalFilter,
     onContractClick,
     hideActions,
@@ -454,7 +460,16 @@ export function Search(props: SearchProps) {
       : `${totalResults} results for ${query}`
 
   const onChange = (changes: Partial<SearchParams>) => {
-    const updatedParams = { ...changes }
+    const updatedParams = showTopicsFilterPills
+      ? normalizeBrowseChange(searchParams, changes)
+      : { ...changes }
+
+    if (changes.fy === '0' || changes.fy === '1') {
+      onBrowseModeChange?.(changes.fy === '1' ? 'for-you' : 'all')
+    }
+    if (updatedParams.sw === '0' && sweepiesState === '1') {
+      setPrefersPlay(true)
+    }
 
     setSearchParams(updatedParams)
     if (isWholePage) window.scrollTo(0, 0)
@@ -544,8 +559,16 @@ export function Search(props: SearchProps) {
         (subtopic) => groupIds === subtopic.groupIds.join(',')
       )
     : undefined
+  const selectedForYou =
+    !!user &&
+    searchParams[FOR_YOU_KEY] === '1' &&
+    !groupIds &&
+    !searchParams[TOPIC_FILTER_KEY]
   const selectedAll =
-    !selectedTopic && !selectedFollowed && !searchParams[TOPIC_FILTER_KEY]
+    !selectedForYou &&
+    !selectedTopic &&
+    !selectedFollowed &&
+    !searchParams[TOPIC_FILTER_KEY]
   const {
     data: followedGroupsData,
     loading: isLoadingFollowedGroups,
@@ -612,14 +635,18 @@ export function Search(props: SearchProps) {
           {showTopicsFilterPills && (
             <Row className="border-ink-100 dark:border-ink-200 items-baseline gap-4 border-b pb-2">
               <button
+                type="button"
+                aria-pressed={selectedAll}
                 className={clsx(
                   'shrink-0 font-medium',
                   selectedAll ? 'text-primary-600' : 'text-ink-500'
                 )}
                 onClick={() => {
+                  if (selectedAll) onBrowseModeChange?.('all')
                   if (!selectedAll) {
                     track('select search topic', { topic: 'all' })
                     const changes: Partial<SearchParams> = {
+                      [FOR_YOU_KEY]: '0',
                       [GROUP_IDS_KEY]: '',
                       [TOPIC_FILTER_KEY]: '',
                     }
@@ -629,6 +656,22 @@ export function Search(props: SearchProps) {
               >
                 All
               </button>
+              {!!user?.id && (
+                <button
+                  type="button"
+                  aria-pressed={selectedForYou}
+                  className={clsx(
+                    'shrink-0 whitespace-nowrap font-medium',
+                    selectedForYou ? 'text-primary-600' : 'text-ink-500'
+                  )}
+                  onClick={() => {
+                    track('select search topic', { topic: 'for-you' })
+                    onChange({ [FOR_YOU_KEY]: '1', [QUERY_KEY]: '' })
+                  }}
+                >
+                  For You
+                </button>
+              )}
               <Carousel
                 fadeEdges
                 showArrowsOnHover

--- a/web/hooks/use-browse-default.ts
+++ b/web/hooks/use-browse-default.ts
@@ -1,0 +1,105 @@
+import {
+  BrowseMode,
+  canDefaultToForYou,
+  getInitialBrowseForYou,
+  readBrowseMode,
+  readBrowseParameters,
+} from 'common/browse-personalization'
+import { User } from 'common/user'
+import { useRouter } from 'next/router'
+import { useEffect, useRef, useState } from 'react'
+import { api } from 'web/lib/api/api'
+import {
+  getPersistentLocalState,
+  setPersistentLocalState,
+} from './use-persistent-local-state'
+
+const READINESS_TIMEOUT_MS = 1500
+
+export const useBrowseDefault = (user: User | null | undefined) => {
+  const router = useRouter()
+  const navigation = useRef(router)
+  navigation.current = router
+  const account = user === undefined ? undefined : user?.id ?? 'anonymous'
+  const persistPrefix = `browse-v1-${account}`
+  const preferenceKey = `${persistPrefix}-mode`
+  const paramsKey = `${persistPrefix}-local-state`
+  const [initial, setInitial] = useState<{
+    account: string
+    forYou: '0' | '1'
+  }>()
+
+  useEffect(() => {
+    if (account === undefined || !router.isReady) return
+    let cancelled = false
+    const controller = new AbortController()
+    const stored = readBrowseParameters(getPersistentLocalState(paramsKey))
+    const urlParams = readBrowseParameters(navigation.current.query)
+    const params = { ...stored, ...urlParams }
+    const preference = readBrowseMode(getPersistentLocalState(preferenceKey))
+    const finish = (eligible: boolean) => {
+      if (cancelled) return
+      const forYou = getInitialBrowseForYou({
+        params,
+        urlParams,
+        preference,
+        eligible,
+      })
+      // Seed the account-scoped search state before mounting Search. In
+      // particular, yesterday's automatic All is not a permanent opt-out.
+      setPersistentLocalState(paramsKey, { ...stored, fy: forYou })
+      // Keep this history entry's choice stable on Back/refresh, even if the
+      // user crosses the threshold after opening a market. A new /browse
+      // navigation without fy can reconsider the automatic default.
+      if (urlParams.fy !== '0' && urlParams.fy !== '1') {
+        const { pathname, query, replace } = navigation.current
+        void replace({ pathname, query: { ...query, fy: forYou } }, undefined, {
+          shallow: true,
+        })
+      }
+      setInitial({ account, forYou })
+    }
+    const needsReadiness =
+      account !== 'anonymous' &&
+      !preference &&
+      urlParams.fy !== '0' &&
+      urlParams.fy !== '1' &&
+      canDefaultToForYou(params)
+
+    if (!needsReadiness) {
+      finish(false)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    // Do not send a preliminary All request and then switch the user mid-page.
+    // The old API, a network error, or a timeout simply starts this visit on All.
+    const timeout = setTimeout(() => {
+      controller.abort()
+      finish(false)
+      cancelled = true
+    }, READINESS_TIMEOUT_MS)
+    void api('get-browse-personalization', {}, { signal: controller.signal })
+      .then(({ eligible }) => finish(eligible === true))
+      .catch(() => finish(false))
+      .finally(() => clearTimeout(timeout))
+
+    return () => {
+      cancelled = true
+      clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [account, paramsKey, preferenceKey, router.isReady])
+
+  const rememberMode = (mode: BrowseMode) => {
+    if (account !== undefined) setPersistentLocalState(preferenceKey, mode)
+  }
+
+  return {
+    ready: account !== undefined && initial?.account === account,
+    defaultForYou: initial?.account === account ? initial?.forYou : '0',
+    persistPrefix,
+    rememberMode,
+  }
+}

--- a/web/pages/browse/index.tsx
+++ b/web/pages/browse/index.tsx
@@ -10,11 +10,12 @@ import {
   useTrendingTopics,
   useUserTrendingTopics,
 } from 'web/components/search/query-topics'
-import { Search } from 'web/components/search'
+import { LoadingContractResults, Search } from 'web/components/search'
+import { useBrowseDefault } from 'web/hooks/use-browse-default'
 import { useIsMobile } from 'web/hooks/use-is-mobile'
 import { usePrivateUser, useUser } from 'web/hooks/use-user'
 import { ManifoldLogo } from 'web/components/nav/manifold-logo'
-import { DEFAULT_FOR_YOU, Welcome } from 'web/components/onboarding/welcome'
+import { Welcome } from 'web/components/onboarding/welcome'
 import { VerificationResultModal } from 'web/components/onboarding/verification-result-modal'
 import { useSaveReferral } from 'web/hooks/use-save-referral'
 export default function BrowsePage() {
@@ -35,6 +36,7 @@ export default function BrowsePage() {
 
 export function BrowsePageContent() {
   const user = useUser()
+  const browseDefault = useBrowseDefault(user)
   const isMobile = useIsMobile()
   const router = useRouter()
   const { q } = router.query
@@ -57,12 +59,16 @@ export function BrowsePageContent() {
 
   const initialTopics = topicsByImportance
 
+  if (!browseDefault.ready) return <LoadingContractResults />
+
   return (
     <Col className={clsx('relative col-span-8 mx-auto w-full')}>
       <Search
+        key={browseDefault.persistPrefix}
         showTopicsFilterPills
         showHotTopics
-        persistPrefix="search"
+        persistPrefix={browseDefault.persistPrefix}
+        onBrowseModeChange={browseDefault.rememberMode}
         autoFocus={autoFocus}
         additionalFilter={{
           excludeContractIds: privateUser?.blockedContractIds,
@@ -79,7 +85,7 @@ export function BrowsePageContent() {
         headerClassName={'pt-0 px-2'}
         defaultFilter="all"
         defaultSort="score"
-        defaultForYou={DEFAULT_FOR_YOU ? '1' : '0'}
+        defaultForYou={browseDefault.defaultForYou}
         initialTopics={initialTopics}
       />
     </Col>


### PR DESCRIPTION
Browse currently hides personalized discovery inside the filter dialog. This adds **For You** beside **All**, keeps **Followed** as its own topic filter, and chooses For You on a fresh visit once a signed-in user has enough browsing history. It applies to both `/browse` and the shared Browse content on `/home`.

The starting threshold is **20 distinct public, non-deleted market pages opened, plus a stored learned topic profile with a valid positive score**. Repeated refreshes and passive card impressions do not count. This is a conservative heuristic to evaluate, not evidence that the twentieth visit guarantees better recommendations. New users and anonymous visitors start on All; any signed-in user can still select For You manually. Readiness can lag the daily topic-profile calculation.

## Behavior

- For You clears a specific-topic/Followed scope and supports both Best and Hot. Selecting All, Followed, a specific topic, New, or another incompatible sort exits personalized ranking. Choosing For You from an incompatible sort restores Best.
- Explicit `fy` URLs take precedence. All/For You choices are remembered in this browser per account; saved scopes and filters in the new account-scoped state remain selected. The old shared `search-local-state` cache is not migrated between accounts.
- The chosen mode is recorded in the current URL so Back/refresh does not change the list when a user crosses the readiness threshold. A fresh Browse navigation without an explicit mode can adopt the newly eligible default.
- A new authenticated, `private, no-store` endpoint returns only eligibility for the authenticated caller. The query uses the existing user/view and latest-profile indexes, stops counting at 20, and has a one-second transaction-local statement timeout. The browser falls back to All after a failure or 1.5 seconds; it resolves the default before mounting Search and cancels stale account requests.

## Rollout and experiment

The same tab and readiness rule apply to both discovery arms; eligibility does not depend on the arm. This PR leaves assignment, treatment ranking, and semantic fallback unchanged. Control still uses the old personalized ranking when For You is selected; treatment uses the new ranking/suppression.

Deploy the API and let Vercel perform its normal web deployment. The manual tab works with the existing discovery API; automatic selection needs the new readiness endpoint, and safely stays on All against old workers. No migration, backfill, or new scheduler job is required.

This broadens entry into the For You surface. Apply the [launch protocol](https://app.notion.com/p/3d354492ea7a818b832ccfa8472b716b?pvs=204) to the final API/web rollout before the analysis window; reset the window if this ships after measurement begins. The existing surface scorecard does not establish the overall benefit of making For You the default versus All.

Readiness can add up to 1.5 seconds before the first search starts. The existing search-request latency metric excludes that wait, so it is not a complete measure of initial Browse loading time.

## Validation

- Common/shared builds; API and scheduler typechecks; web typecheck with worktree-local paths: passed.
- All 1,004 common and 84 shared tests passed, including readiness boundaries, authenticated schema, saved choices, explicit URLs, and routing transitions.
- `node --test backend/scripts/tests/browse-personalization.test.cjs`: 8 passed against disposable PostgreSQL with no network, mounted data, or production credentials. Covers repeat views, public visibility, deleted markets, missing/latest profiles, account isolation, capped counts, and timeout setup.
- 20 local browser checks passed using synthetic users/API responses and the actual default hook, search-state hook, navigation handlers/buttons, and carousel. Includes cold/eligible defaults, manual opt-out, threshold crossing, Back, Best/Hot/New, errors/timeouts, and late responses after account switches. The navigation was inspected at desktop and 390px mobile widths.
- Changed-file formatting and lint passed with Windows line-ending normalization and the existing Browse `autoFocus` lint exception. `git diff --check` passed. No production data or live-account QA was accessed.
