### PR TITLE
Add "Mid %" answer sort for multi-choice markets

### DIFF
--- a/common/src/answer.test.ts
+++ b/common/src/answer.test.ts
@@ -1,0 +1,57 @@
+import { MultiContract, SORTS } from './contract'
+import { Answer, getSortedAnswers, sortAnswers } from './answer'
+
+const makeAnswer = (id: string, prob: number, index: number): Answer => ({
+  id,
+  index,
+  contractId: 'c1',
+  userId: 'u1',
+  text: `Answer ${id}`,
+  createdTime: 0,
+  poolYes: 100,
+  poolNo: 100,
+  prob,
+  totalLiquidity: 100,
+  subsidyPool: 0,
+  volume: 0,
+  probChanges: { day: 0, week: 0, month: 0 },
+})
+
+const answers = [
+  makeAnswer('a', 0.004, 0),
+  makeAnswer('b', 0.5, 1),
+  makeAnswer('c', 0.995, 2),
+  makeAnswer('d', 0.4, 3),
+  makeAnswer('e', 0.8, 4),
+]
+
+const contract = {
+  mechanism: 'cpmm-multi-1',
+  outcomeType: 'MULTIPLE_CHOICE',
+  shouldAnswersSumToOne: false,
+  answers,
+} as unknown as MultiContract
+
+describe('prob-mid answer sort', () => {
+  it('is listed between High % and Low %', () => {
+    const values = SORTS.map((s) => s.value)
+    expect(values.indexOf('prob-mid')).toBe(values.indexOf('prob-desc') + 1)
+    expect(values.indexOf('prob-asc')).toBe(values.indexOf('prob-mid') + 1)
+    expect(SORTS.find((s) => s.value === 'prob-mid')?.label).toBe('Mid %')
+  })
+
+  it('sorts answers by distance from 50%', () => {
+    const sorted = sortAnswers(contract, answers, 'prob-mid')
+    expect(sorted.map((a) => a.id)).toEqual(['b', 'd', 'e', 'c', 'a'])
+  })
+
+  it('hides answers at the extremes by default, unless selected', () => {
+    const sorted = sortAnswers(contract, answers, 'prob-mid')
+    expect(
+      getSortedAnswers(contract, sorted, 'prob-mid').map((a) => a.id)
+    ).toEqual(['b', 'd', 'e'])
+    expect(
+      getSortedAnswers(contract, sorted, 'prob-mid', ['a']).map((a) => a.id)
+    ).toEqual(['b', 'd', 'e', 'a'])
+  })
+})

--- a/common/src/answer.ts
+++ b/common/src/answer.ts
@@ -51,6 +51,7 @@ export const OTHER_TOOLTIP_TEXT =
 
 export type MultiSort =
   | 'prob-desc'
+  | 'prob-mid'
   | 'prob-asc'
   | 'old'
   | 'new'
@@ -93,6 +94,9 @@ export const sortAnswers = <T extends Answer>(
         return answer.prob
       } else if (sort === 'prob-desc') {
         return -1 * answer.prob
+      } else if (sort === 'prob-mid') {
+        // Closest to 50% first
+        return Math.abs(answer.prob - 0.5)
       } else if (sort === 'liquidity') {
         return -1 * answer.volume
       } else if (sort === 'alphabetical') {
@@ -123,6 +127,8 @@ export function getSortedAnswers(
         return answer.prob < 0.99
       } else if (sort === 'prob-desc') {
         return answer.prob > 0.01
+      } else if (sort === 'prob-mid') {
+        return answer.prob > 0.01 && answer.prob < 0.99
       } else if (sort === 'liquidity' || sort === 'new' || sort === 'old') {
         return !answer.resolution
       }

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -517,6 +517,7 @@ export const VISIBILITIES = ['public', 'unlisted'] as const
 
 export const SORTS = [
   { label: 'High %', value: 'prob-desc' },
+  { label: 'Mid %', value: 'prob-mid' },
   { label: 'Low %', value: 'prob-asc' },
   { label: 'Oldest', value: 'old' },
   { label: 'Newest', value: 'new' },


### PR DESCRIPTION
Adds a new answer sort option, "Mid %" (value prob-mid), listed between "High %" and "Low %". It orders answers by their distance from 50%, so the most uncertain answers come first.

Like the other probability sorts, the default (non-expanded) answer list hides answers at the extremes (<= 1% or >= 99%) unless they are selected.


Claude-Session: https://claude.ai/code/session_01CYn6k1JUGeaW4WdHTFfGLY