### PR TITLE
fix(elections): drop the duplicate "who's running" card where the party panel names candidates

### DIFF
--- a/web/components/usa-map/homepage-map.tsx
+++ b/web/components/usa-map/homepage-map.tsx
@@ -22,10 +22,25 @@ import { GovernorState } from './governor-state'
 import { HouseMapSection } from './house-map'
 import { FeedContractCard } from '../contract/feed-contract-card'
 import { MapContractsDictionary } from 'web/public/data/elections-data'
+import { isCandidateLabelledAnswer } from './state-election-map'
 
 // 2026 midterms: no presidential race. The Senate/Governor races map onto
 // states; the House is decided by district, so it's a table rather than a map.
 type MapMode = 'senate' | 'house' | 'governor'
+
+/**
+ * Whether the state's party market already names the candidates — e.g. its
+ * answers read "Josh Turek (D)" rather than "Democratic party".
+ *
+ * When it does, the separate "who's running" card is pure duplication: the
+ * same two names a few pixels apart, and at slightly different prices, since
+ * they are two independent markets. Show it only where the party panel still
+ * says nothing about who is on the ballot.
+ */
+const partyMarketNamesCandidates = (contract: Contract | null | undefined) =>
+  !!contract &&
+  contract.mechanism === 'cpmm-multi-1' &&
+  contract.answers.some((a) => isCandidateLabelledAnswer(a.text))
 
 export function HomepageMap(props: {
   rawSenateStateContracts: MapContractsDictionary
@@ -131,13 +146,17 @@ export function HomepageMap(props: {
           ) : (
             <EmptyStateContract />
           )}
-          {selectedState && rawGovernorCandidateContracts[selectedState] && (
-            <CandidateRaceCard
-              contract={
-                rawGovernorCandidateContracts[selectedState] as Contract
-              }
-            />
-          )}
+          {selectedState &&
+            rawGovernorCandidateContracts[selectedState] &&
+            !partyMarketNamesCandidates(
+              governorContractsDictionary[selectedState]
+            ) && (
+              <CandidateRaceCard
+                contract={
+                  rawGovernorCandidateContracts[selectedState] as Contract
+                }
+              />
+            )}
         </>
       ) : mode === 'house' ? (
         <>
@@ -199,11 +218,17 @@ export function HomepageMap(props: {
           ) : (
             <EmptyStateContract />
           )}
-          {selectedState && rawSenateCandidateContracts[selectedState] && (
-            <CandidateRaceCard
-              contract={rawSenateCandidateContracts[selectedState] as Contract}
-            />
-          )}
+          {selectedState &&
+            rawSenateCandidateContracts[selectedState] &&
+            !partyMarketNamesCandidates(
+              senateContractsDictionary[selectedState]
+            ) && (
+              <CandidateRaceCard
+                contract={
+                  rawSenateCandidateContracts[selectedState] as Contract
+                }
+              />
+            )}
         </>
       )}
     </Col>


### PR DESCRIPTION
Follow-up to #4042, once the renamed answers were live.

Renaming the party answers finished the job the separate candidate card existed to do — but the card was still rendering underneath it. Iowa currently shows, on prod:

| | |
|---|---|
| **Party panel** | `Ashley Hinson (R) 59%` · `Josh Turek (D) 41%` |
| **"Who's running" card, just below** | `Ashley Hinson (Republican) 61%` · `Josh Turek (Democrat) 39%` |

The same two names twice, a few pixels apart, at *different* prices — they're two independent markets. That reads as a contradiction rather than as extra information, and it's the duplication this whole change set out to remove.

The card now renders only where the state's party market doesn't already name the candidates, keyed on the same `isCandidateLabelledAnswer` that drives the map colouring and the resolves-by-party note.

**TX, OH, IA and ME** lose the redundant card. **MN and MT** keep theirs, since their party answers are still bare — and they'll drop out on their own if those ever get renamed, with no second deploy. Same rule applies to the governor map (CA, NY).

`tsc` and `eslint` clean.

---

*This PR originally also carried a House district row-layout tweak. Dropped — the merged `parseDistrict` split from #4042 already renders the matchup above the bar at full column width, and the proposed tweak would have given the names **less** room by putting a fixed-width bar beside them.*