### PR TITLE
Add stored ticker field to perp markets for search and display

### DIFF
--- a/backend/api/src/create-perp.ts
+++ b/backend/api/src/create-perp.ts
@@ -13,6 +13,7 @@ import {
 } from 'common/perps/fees'
 import { validateBasicOraclePoint } from 'common/perps/oracle'
 import { getOracleAttribution } from 'common/perps/oracle-attribution'
+import { derivePerpTicker, getPerpFeedTicker } from 'common/perps/ticker'
 import { removeUndefinedProps } from 'common/util/object'
 import { randomString } from 'common/util/random'
 import { HOUR_MS } from 'common/util/time'
@@ -72,6 +73,7 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
     visibility = 'unlisted',
     groupIds,
     oracleFeedId,
+    ticker: requestedTicker,
     maxLeverage,
     maxFundingRate,
     fundingSensitivity,
@@ -101,8 +103,25 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
   if (launchDefinition && question !== launchDefinition.question)
     throw new APIError(
       400,
-      `The launch title for ${oracleFeedId} must be "${launchDefinition.question}". The Perpetual type label is shown separately.`
+      `The launch title for ${oracleFeedId} must be "${launchDefinition.question}". The ticker and market type are shown separately.`
     )
+  // The ticker is a property of the feed, not of one market on it: two
+  // markets on btc-usd are both "BTC", so a feed named in PERP_FEED_TICKERS
+  // accepts only that name. An unnamed feed takes the caller's choice, or a
+  // label derived from its id — every perp is stored with a ticker, because
+  // search matches the stored value and nothing else.
+  const canonicalTicker = getPerpFeedTicker(oracleFeedId)
+  if (
+    canonicalTicker &&
+    requestedTicker !== undefined &&
+    requestedTicker !== canonicalTicker
+  )
+    throw new APIError(
+      400,
+      `The ticker for ${oracleFeedId} must be "${canonicalTicker}" (PERP_FEED_TICKERS in common/perps/ticker.ts). Change it there if the feed should be renamed.`
+    )
+  const ticker =
+    canonicalTicker ?? requestedTicker ?? derivePerpTicker(oracleFeedId)
 
   const user = await getUser(auth.uid)
   if (!user) throw new APIError(404, 'User not found')
@@ -243,6 +262,7 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
       initialPoolLong: subsidyLong,
       initialPoolShort: subsidyShort,
       oracleFeedId,
+      ticker,
       oraclePrice: oraclePoint.price,
       oraclePriceTime: oraclePoint.ts,
       oracleSourceTime: oracleSourceTime ?? null,

--- a/backend/api/src/get-known-oracle-feeds.ts
+++ b/backend/api/src/get-known-oracle-feeds.ts
@@ -1,6 +1,7 @@
 import { sortBy, uniq } from 'lodash'
 
 import { ENV } from 'common/envs/constants'
+import { getPerpFeedTicker } from 'common/perps/ticker'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { getOracleFeed, ORACLE_FEEDS } from 'shared/oracle-feeds'
 import {
@@ -37,6 +38,7 @@ export const getKnownOracleFeeds: APIHandler<'get-known-oracle-feeds'> = async (
       updatePeriodMs: feed?.updatePeriodMs ?? null,
       marketCreationEnabled: feed?.marketCreationEnabled ?? false,
       description: feed?.description ?? null,
+      ticker: getPerpFeedTicker(id) ?? null,
       launchLatencyRisk: launch?.latencyArbitrageRisk ?? null,
       launchRecommendation: launch
         ? {

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -12,7 +12,11 @@ import {
 import { SEARCH_ANCHOR_CLOCK_SKEW_ERROR } from 'common/search-request-coordination'
 import { isPerpTickerSearchTerm } from 'common/perps/ticker'
 import { convertContract } from 'common/supabase/contracts'
-import { orderBy, uniqBy } from 'lodash'
+import { orderBy } from 'lodash'
+import {
+  getSearchQueryPagination,
+  getSearchResultPage,
+} from 'shared/helpers/search-pagination'
 import { getGroupIdFromSlug } from 'shared/supabase/groups'
 import {
   createSupabaseDirectClient,
@@ -264,6 +268,7 @@ const search = async (
       .map((searchType) =>
         getSearchContractSQL({
           ...props,
+          ...getSearchQueryPagination(props),
           term: cleanTerm,
           uid: userId,
           searchType,
@@ -287,7 +292,10 @@ const search = async (
       searchTypes.map((searchType, i) => [
         searchType,
         results[i].map(
-          (r: any): Match => ({ data: convertContract(r), searchType })
+          (r: Parameters<typeof convertContract>[0]): Match => ({
+            data: convertContract(r),
+            searchType,
+          })
         ),
       ])
     ) as Partial<Record<SearchTypes, Match[]>>
@@ -310,18 +318,18 @@ const search = async (
       sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
     )
 
-    const lexicalResults = orderBy(
-      uniqBy(
-        [
-          ...tickerMatches, // the market's own handle
-          ...contractsWithStopwords, // most obviously relevant
-          ...contractsOfSimilarRelevance, // next most relevant
-          ...contractDescriptionMatches, // least obviously relevant
-        ].map((c) => c.data),
-        'id'
-      ).slice(0, limit),
-      (c) => sortFields[sort].sortCallback(c),
-      sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
+    const lexicalResults = getSearchResultPage(
+      [
+        ...tickerMatches, // the market's own handle
+        ...contractsWithStopwords, // most obviously relevant
+        ...contractsOfSimilarRelevance, // next most relevant
+        ...contractDescriptionMatches, // least obviously relevant
+      ].map((c) => c.data),
+      {
+        ...props,
+        sortCallback: sortFields[sort].sortCallback,
+        order: sortFields[sort].order.includes('DESC') ? 'desc' : 'asc',
+      }
     )
     if (!options.markSearchMatches) return lexicalResults
 

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -10,6 +10,7 @@ import {
   getEffectiveDiscoveryExperimentVariant,
 } from 'common/discovery-experiment'
 import { SEARCH_ANCHOR_CLOCK_SKEW_ERROR } from 'common/search-request-coordination'
+import { isPerpTickerSearchTerm } from 'common/perps/ticker'
 import { convertContract } from 'common/supabase/contracts'
 import { orderBy, uniqBy } from 'lodash'
 import { getGroupIdFromSlug } from 'shared/supabase/groups'
@@ -248,7 +249,10 @@ const search = async (
     )
   } else {
     const cleanTerm = term.replace(/[''"]/g, '')
+    // A single token might be a perp ticker ("BTC"), which no tsvector
+    // covers; a multi-word query never is, so that lookup is skipped.
     const searchTypes: SearchTypes[] = [
+      ...(isPerpTickerSearchTerm(cleanTerm) ? (['ticker'] as const) : []),
       'prefix',
       'without-stopwords',
       'answer',
@@ -276,19 +280,23 @@ const search = async (
       return Array(searchTypes.length).fill([])
     })
 
-    const [
-      contractPrefixMatches,
-      contractsWithoutStopwords,
-      contractsWithMatchingAnswers,
-      contractsWithStopwords,
-      contractDescriptionMatches,
-    ] = results.map(
-      (result, i) =>
-        result.map((r: any) => ({
-          data: convertContract(r),
-          searchType: searchTypes[i],
-        })) as { data: Contract; searchType: SearchTypes }[]
-    )
+    type Match = { data: Contract; searchType: SearchTypes }
+    // Keyed by type rather than destructured by position: the ticker query
+    // is only sometimes in the list.
+    const matchesByType = Object.fromEntries(
+      searchTypes.map((searchType, i) => [
+        searchType,
+        results[i].map(
+          (r: any): Match => ({ data: convertContract(r), searchType })
+        ),
+      ])
+    ) as Partial<Record<SearchTypes, Match[]>>
+    const tickerMatches = matchesByType.ticker ?? []
+    const contractPrefixMatches = matchesByType.prefix ?? []
+    const contractsWithoutStopwords = matchesByType['without-stopwords'] ?? []
+    const contractsWithMatchingAnswers = matchesByType.answer ?? []
+    const contractsWithStopwords = matchesByType['with-stopwords'] ?? []
+    const contractDescriptionMatches = matchesByType.description ?? []
 
     const contractsOfSimilarRelevance = orderBy(
       [
@@ -305,6 +313,7 @@ const search = async (
     const lexicalResults = orderBy(
       uniqBy(
         [
+          ...tickerMatches, // the market's own handle
           ...contractsWithStopwords, // most obviously relevant
           ...contractsOfSimilarRelevance, // next most relevant
           ...contractDescriptionMatches, // least obviously relevant

--- a/backend/api/src/search-contracts.ts
+++ b/backend/api/src/search-contracts.ts
@@ -12,10 +12,10 @@ import {
 import { SEARCH_ANCHOR_CLOCK_SKEW_ERROR } from 'common/search-request-coordination'
 import { isPerpTickerSearchTerm } from 'common/perps/ticker'
 import { convertContract } from 'common/supabase/contracts'
-import { orderBy } from 'lodash'
 import {
   getSearchQueryPagination,
   getSearchResultPage,
+  sortLikeSql,
 } from 'shared/helpers/search-pagination'
 import { getGroupIdFromSlug } from 'shared/supabase/groups'
 import {
@@ -26,10 +26,10 @@ import {
   basicSearchSQL,
   getForYouSQL,
   getSearchContractSQL,
+  getSearchSort,
   getSemanticSearchContractSQL,
   SearchTypes,
   shouldSuppressStaleSeenMarkets,
-  sortFields,
 } from 'shared/supabase/search-contracts'
 import {
   EMBEDDING_MODEL,
@@ -306,16 +306,18 @@ const search = async (
     const contractsWithStopwords = matchesByType['with-stopwords'] ?? []
     const contractDescriptionMatches = matchesByType.description ?? []
 
-    const contractsOfSimilarRelevance = orderBy(
+    // The tiers of similar relevance, merged in the database's own order so
+    // the page cut below is the page it fetched; answer matches count half.
+    const ordering = getSearchSort(sort)
+    const contractsOfSimilarRelevance = sortLikeSql(
       [
         ...contractsWithoutStopwords,
         ...contractsWithMatchingAnswers,
         ...contractPrefixMatches,
       ],
-      (c) =>
-        sortFields[sort].sortCallback(c.data) *
-        (c.searchType === 'answer' ? 0.5 : 1),
-      sortFields[sort].order.includes('DESC') ? 'desc' : 'asc'
+      ordering,
+      (match) => match.data,
+      (match) => (match.searchType === 'answer' ? 0.5 : 1)
     )
 
     const lexicalResults = getSearchResultPage(
@@ -325,11 +327,7 @@ const search = async (
         ...contractsOfSimilarRelevance, // next most relevant
         ...contractDescriptionMatches, // least obviously relevant
       ].map((c) => c.data),
-      {
-        ...props,
-        sortCallback: sortFields[sort].sortCallback,
-        order: sortFields[sort].order.includes('DESC') ? 'desc' : 'asc',
-      }
+      { ...props, sort, ordering }
     )
     if (!options.markSearchMatches) return lexicalResults
 

--- a/backend/api/src/update-market.ts
+++ b/backend/api/src/update-market.ts
@@ -2,6 +2,7 @@ import { JSONContent } from '@tiptap/core'
 import { APIError, APIHandler } from 'api/helpers/endpoint'
 import { Contract } from 'common/contract'
 import { isAdminId, isModId } from 'common/envs/constants'
+import { getPerpFeedTicker } from 'common/perps/ticker'
 import { DAY_MS } from 'common/util/time'
 import { buildArray } from 'common/util/array'
 import { removeUndefinedProps } from 'common/util/object'
@@ -38,6 +39,7 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
       homePageScoreAdjustment,
       homePageScoreAdjustmentDays,
       creatorBannedFromBetting,
+      ticker,
 
       description: raw,
       descriptionHtml: html,
@@ -64,8 +66,25 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
     )
       throw new APIError(
         400,
-        `The launch title for ${launchDefinition.feedId} must be "${launchDefinition.question}". The Perpetual type label is shown separately.`
+        `The launch title for ${launchDefinition.feedId} must be "${launchDefinition.question}". The ticker and market type are shown separately.`
       )
+
+    if (ticker !== undefined) {
+      if (contract.outcomeType !== 'PERP')
+        throw new APIError(400, 'Only perpetual markets have a ticker')
+      // Perps are admin-created, and the ticker is how search and the /perps
+      // hub identify the market — not a creator-editable title.
+      if (!isAdminId(auth.uid))
+        throw new APIError(403, 'Only admins can change a perp market ticker')
+      // Same rule as create-perp: a feed named in PERP_FEED_TICKERS has one
+      // ticker for every market on it.
+      const canonicalTicker = getPerpFeedTicker(contract.oracleFeedId)
+      if (canonicalTicker && ticker !== canonicalTicker)
+        throw new APIError(
+          400,
+          `The ticker for ${contract.oracleFeedId} must be "${canonicalTicker}" (PERP_FEED_TICKERS in common/perps/ticker.ts). Change it there if the feed should be renamed.`
+        )
+    }
 
     const isUpdatingHomePageScoreAdjustment =
       homePageScoreAdjustment !== undefined ||
@@ -157,6 +176,7 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
       description,
       display,
       creatorBannedFromBetting,
+      ticker,
       lastUpdatedTime: Date.now(),
     })
     await updateContract(pg, contractId, {

--- a/backend/scripts/backfill-perp-tickers.ts
+++ b/backend/scripts/backfill-perp-tickers.ts
@@ -1,0 +1,120 @@
+// Stamp the canonical ticker (PERP_FEED_TICKERS in common/perps/ticker.ts) on
+// every perp market whose stored ticker is missing or different. The badge
+// and the /perps hub already show the mapped label for such rows, but search
+// matches only the STORED value, so until this runs those markets cannot be
+// found by ticker — and the launch preflight fails their ticker check.
+// Settled markets are included: their pages still render the badge, and they
+// should still be findable.
+//
+// Dry-run (default):
+//   yarn ts-node backfill-perp-tickers.ts
+//
+// Apply:
+//   yarn ts-node backfill-perp-tickers.ts --apply
+//
+// A market on a feed nobody has named is reported and left alone: add the
+// feed to PERP_FEED_TICKERS rather than letting a script invent a label.
+
+import { getPerpFeedTicker } from 'common/perps/ticker'
+import { updateContract } from 'shared/supabase/contracts'
+import { runScript } from './run-script'
+
+type PerpRow = {
+  id: string
+  slug: string
+  feed_id: string | null
+  ticker: string | null
+  resolved: boolean
+}
+
+const usage = 'Usage: yarn ts-node backfill-perp-tickers.ts [--apply]'
+
+const run = async (apply: boolean) => {
+  await runScript(async ({ pg }) => {
+    console.log(apply ? 'Mode: APPLY' : 'Mode: DRY RUN (no writes)')
+
+    const rows = await pg.manyOrNone<PerpRow>(
+      `select id,
+              slug,
+              data->>'oracleFeedId' as feed_id,
+              data->>'ticker' as ticker,
+              resolution_time is not null as resolved
+       from contracts
+       where outcome_type = 'PERP'
+       order by created_time`
+    )
+
+    const plans: { row: PerpRow; ticker: string }[] = []
+    let ready = 0
+    let unnamed = 0
+    for (const row of rows) {
+      const expected = getPerpFeedTicker(row.feed_id ?? undefined)
+      const stored = row.ticker ? `"${row.ticker}"` : 'none'
+      const status = row.resolved ? 'settled' : 'live'
+      if (!expected) {
+        unnamed++
+        console.log(
+          `[UNNAMED] ${row.slug} (${status}): feed ${
+            row.feed_id ?? 'none'
+          } is not in PERP_FEED_TICKERS; stored ${stored}, left alone`
+        )
+      } else if (row.ticker === expected) {
+        ready++
+        console.log(`[OK] ${row.slug} (${status}): ${expected}`)
+      } else {
+        plans.push({ row, ticker: expected })
+        console.log(`[SET] ${row.slug} (${status}): ${stored} -> "${expected}"`)
+      }
+    }
+    console.log(
+      `Summary: ${rows.length} perp market(s), ${ready} already stamped, ` +
+        `${plans.length} to update, ${unnamed} on unnamed feeds.`
+    )
+
+    if (plans.length === 0) return
+    if (!apply) {
+      console.log(
+        'Dry run complete. Re-run with --apply to write the tickers listed above.'
+      )
+      return
+    }
+
+    for (const { row, ticker } of plans) {
+      // Only the ticker. No lastUpdatedTime bump: a metadata stamp must not
+      // read as market activity anywhere that sorts on it.
+      await updateContract(pg, row.id, { ticker })
+      console.log(`Updated ${row.slug}: ticker = "${ticker}"`)
+    }
+
+    // Verify by re-reading rather than trusting the loop.
+    const stored = await pg.manyOrNone<{ id: string; ticker: string | null }>(
+      `select id, data->>'ticker' as ticker
+       from contracts
+       where id = any($1::text[])`,
+      [plans.map((plan) => plan.row.id)]
+    )
+    const unverified = plans.filter(
+      ({ row, ticker }) =>
+        stored.find((r) => r.id === row.id)?.ticker !== ticker
+    )
+    if (unverified.length > 0)
+      throw new Error(
+        `Backfill verification failed for: ${unverified
+          .map(({ row }) => row.slug)
+          .join(', ')}`
+      )
+    console.log(`Applied and verified ${plans.length} update(s).`)
+  })
+}
+
+const args = process.argv.slice(2)
+const unknown = args.filter((arg) => arg !== '--apply')
+if (unknown.length > 0) {
+  console.error(`Unknown argument(s): ${unknown.join(' ')}\n${usage}`)
+  process.exit(1)
+}
+
+run(args.includes('--apply')).catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/backend/scripts/perp-launch-preflight.ts
+++ b/backend/scripts/perp-launch-preflight.ts
@@ -8,6 +8,7 @@ import { isPerpEscrowBalanced } from 'common/perps/escrow'
 import { shouldApplyFunding } from 'common/perps/funding'
 import { getOracleFreshness } from 'common/perps/oracle'
 import { PerpPosition } from 'common/perps/position'
+import { getPerpFeedTicker } from 'common/perps/ticker'
 import { HOUR_MS, MINUTE_MS } from 'common/util/time'
 
 import {
@@ -588,7 +589,25 @@ if (require.main === module)
             `market ${contract.slug} launch title`,
             contract.question === definition.question
               ? definition.question
-              : `stored="${contract.question}", expected="${definition.question}"; the Perpetual type is rendered separately`
+              : `stored="${contract.question}", expected="${definition.question}"; the ticker and market type are rendered separately`
+          )
+          // The ticker is what the badge shows in place of "Perpetual" and
+          // what search matches, so it must be STORED, not merely mapped: a
+          // launch market without it renders fine and is findable by title
+          // only.
+          const expectedTicker = getPerpFeedTicker(contract.oracleFeedId)
+          report(
+            expectedTicker && contract.ticker === expectedTicker
+              ? 'PASS'
+              : 'FAIL',
+            `market ${contract.slug} launch ticker`,
+            !expectedTicker
+              ? `${contract.oracleFeedId} has no canonical ticker in PERP_FEED_TICKERS (common/perps/ticker.ts)`
+              : contract.ticker === expectedTicker
+              ? expectedTicker
+              : `stored=${
+                  contract.ticker ? `"${contract.ticker}"` : 'none'
+                }, expected="${expectedTicker}"; run backfill-perp-tickers.ts --apply`
           )
           report(
             contract.creatorId === expectedCreatorId ? 'PASS' : 'FAIL',

--- a/backend/shared/src/helpers/search-pagination.test.ts
+++ b/backend/shared/src/helpers/search-pagination.test.ts
@@ -1,0 +1,114 @@
+import { Contract } from 'common/contract'
+import {
+  getSearchQueryPagination,
+  getSearchResultPage,
+} from './search-pagination'
+
+const market = (id: string, createdTime: number) =>
+  ({ id, createdTime } as Contract)
+
+const ticker = market('ticker-only', 1)
+const titles = Array.from({ length: 5 }, (_, i) =>
+  market(`title-${i + 1}`, 10 - i)
+)
+
+const defaults = {
+  limit: 2,
+  offset: 0,
+  sort: 'newest',
+  sortCallback: (contract: Contract) => contract.createdTime,
+  order: 'desc' as const,
+}
+
+// Simulate the existing per-type SQL lookups: each filters by the cursor and
+// applies its own limit/offset before the API merges the returned matches.
+const search = (pagination: typeof defaults & { beforeTime?: number }) => {
+  const query = getSearchQueryPagination(pagination)
+  const candidates = [[ticker], titles, titles].flatMap((matches) =>
+    matches
+      .filter(
+        (contract) =>
+          pagination.beforeTime === undefined ||
+          contract.createdTime < pagination.beforeTime
+      )
+      .slice(query.offset, query.offset + query.limit)
+  )
+  return getSearchResultPage(candidates, pagination)
+}
+
+describe('search pagination across ticker and title matches', () => {
+  it('does not let an old ticker advance the newest-first cursor', () => {
+    const first = search(defaults)
+    expect(first.map((contract) => contract.id)).toEqual(['title-1', 'title-2'])
+
+    const second = search({ ...defaults, beforeTime: first[1].createdTime })
+    expect(second.map((contract) => contract.id)).toEqual([
+      'title-3',
+      'title-4',
+    ])
+
+    const third = search({ ...defaults, beforeTime: second[1].createdTime })
+    expect(third.map((contract) => contract.id)).toEqual([
+      'title-5',
+      'ticker-only',
+    ])
+  })
+
+  it('returns every match exactly once across offset pages', () => {
+    const pages = [0, 2, 4].flatMap((offset) => search({ ...defaults, offset }))
+    expect(pages.map((contract) => contract.id)).toEqual([
+      ...titles.map((contract) => contract.id),
+      ticker.id,
+    ])
+    expect(search({ ...defaults, offset: 6 })).toEqual([])
+  })
+
+  it('preserves relevance priority without losing displaced title matches', () => {
+    const pagination = { ...defaults, sort: 'score' }
+    expect(search(pagination).map((contract) => contract.id)).toEqual([
+      'title-1',
+      'ticker-only',
+    ])
+    const rest = [2, 4].flatMap((offset) => search({ ...pagination, offset }))
+    expect(rest.map((contract) => contract.id)).toEqual([
+      'title-2',
+      'title-3',
+      'title-4',
+      'title-5',
+    ])
+  })
+
+  it('ignores the offset when a time cursor is supplied', () => {
+    const pagination = { ...defaults, offset: 40, beforeTime: 9 }
+    expect(getSearchQueryPagination(pagination)).toEqual({
+      limit: 2,
+      offset: 0,
+    })
+    expect(search(pagination).map((contract) => contract.id)).toEqual([
+      'title-3',
+      'title-4',
+    ])
+  })
+
+  it('deduplicates a market that matches both its ticker and its title', () => {
+    const page = getSearchResultPage([ticker, ticker, ...titles], {
+      ...defaults,
+      sort: 'score',
+      limit: 10,
+    })
+    expect(page.map((contract) => contract.id)).toEqual([
+      ...titles.map((contract) => contract.id),
+      ticker.id,
+    ])
+  })
+
+  it('respects ascending display order after selecting an offset page', () => {
+    const page = getSearchResultPage([ticker, ...titles], {
+      ...defaults,
+      sort: 'close-date',
+      offset: 1,
+      order: 'asc',
+    })
+    expect(page.map((contract) => contract.id)).toEqual(['title-2', 'title-1'])
+  })
+})

--- a/backend/shared/src/helpers/search-pagination.test.ts
+++ b/backend/shared/src/helpers/search-pagination.test.ts
@@ -1,81 +1,169 @@
 import { Contract } from 'common/contract'
 import {
+  SearchSort,
   getSearchQueryPagination,
   getSearchResultPage,
+  sortLikeSql,
 } from './search-pagination'
 
-const market = (id: string, createdTime: number) =>
-  ({ id, createdTime } as Contract)
+const market = (
+  id: string,
+  createdTime: number,
+  importanceScore = 0,
+  uniqueBettorCount = 0
+) =>
+  ({
+    id,
+    createdTime,
+    importanceScore,
+    uniqueBettorCount,
+  } as unknown as Contract)
 
-const ticker = market('ticker-only', 1)
-const titles = Array.from({ length: 5 }, (_, i) =>
-  market(`title-${i + 1}`, 10 - i)
-)
-
-const defaults = {
-  limit: 2,
-  offset: 0,
-  sort: 'newest',
-  sortCallback: (contract: Contract) => contract.createdTime,
-  order: 'desc' as const,
+// The `score` sort as the database and getSearchSort both define it.
+const score: SearchSort = {
+  keys: (c) => [c.importanceScore, c.uniqueBettorCount],
+  directions: [
+    { order: 'desc', nullsFirst: true },
+    { order: 'desc', nullsFirst: true },
+  ],
+}
+const newest: SearchSort = {
+  keys: (c) => [c.createdTime],
+  directions: [{ order: 'desc', nullsFirst: true }],
 }
 
-// Simulate the existing per-type SQL lookups: each filters by the cursor and
-// applies its own limit/offset before the API merges the returned matches.
-const search = (pagination: typeof defaults & { beforeTime?: number }) => {
+type Pagination = {
+  limit: number
+  offset: number
+  beforeTime?: number
+  sort: string
+  ordering: SearchSort
+}
+
+// Simulates the per-tier SQL lookups: each tier is filtered by the cursor,
+// ordered exactly as the database orders it (the same total order, id
+// tiebreak included) and cut at the query's limit/offset, before the API
+// merges the tiers in relevance order and cuts the page.
+const search = (tiers: Contract[][], pagination: Pagination) => {
   const query = getSearchQueryPagination(pagination)
-  const candidates = [[ticker], titles, titles].flatMap((matches) =>
-    matches
-      .filter(
-        (contract) =>
+  const candidates = tiers.flatMap((tier) =>
+    sortLikeSql(
+      tier.filter(
+        (c) =>
           pagination.beforeTime === undefined ||
-          contract.createdTime < pagination.beforeTime
-      )
-      .slice(query.offset, query.offset + query.limit)
+          c.createdTime < pagination.beforeTime
+      ),
+      pagination.ordering,
+      (c) => c
+    ).slice(query.offset, query.offset + query.limit)
   )
   return getSearchResultPage(candidates, pagination)
 }
 
+const ids = (contracts: Contract[]) => contracts.map((c) => c.id)
+
+// Every offset page in turn, as an infinite-scrolling client requests them.
+const walkOffsetPages = (tiers: Contract[][], pagination: Pagination) => {
+  const pages: string[][] = []
+  for (let offset = 0; ; offset += pagination.limit) {
+    const page = ids(search(tiers, { ...pagination, offset }))
+    if (page.length === 0) return pages
+    pages.push(page)
+  }
+}
+
+describe('sortLikeSql', () => {
+  it('ranks by each key in turn, in its own direction, then by id', () => {
+    const rows = [
+      market('c', 1, 0, 50),
+      market('b', 1, 0.5, 1),
+      market('a', 1, 0.5, 1),
+      market('d', 1, 0.9, 0),
+      market('e', 1, 0, 40),
+    ]
+    expect(ids(sortLikeSql(rows, score, (c) => c))).toEqual([
+      'd',
+      'a',
+      'b',
+      'c',
+      'e',
+    ])
+  })
+
+  it('places nulls where Postgres does for the direction', () => {
+    const rows = [market('a', 1, 0.2), market('b', 1, NaN), market('c', 1, 0.7)]
+    const nullsFirst: SearchSort = {
+      keys: (c) => [c.importanceScore],
+      directions: [{ order: 'desc', nullsFirst: true }],
+    }
+    const nullsLast: SearchSort = {
+      keys: (c) => [c.importanceScore],
+      directions: [{ order: 'desc', nullsFirst: false }],
+    }
+    expect(ids(sortLikeSql(rows, nullsFirst, (c) => c))).toEqual([
+      'b',
+      'c',
+      'a',
+    ])
+    expect(ids(sortLikeSql(rows, nullsLast, (c) => c))).toEqual(['c', 'a', 'b'])
+  })
+
+  it('scales numeric keys by the weight, so an answer match counts half', () => {
+    const matches = [
+      { data: market('answer', 1, 0.8), type: 'answer' },
+      { data: market('title', 1, 0.5), type: 'title' },
+      { data: market('weak', 1, 0.3), type: 'title' },
+    ]
+    const sorted = sortLikeSql(
+      matches,
+      score,
+      (m) => m.data,
+      (m) => (m.type === 'answer' ? 0.5 : 1)
+    )
+    expect(sorted.map((m) => m.data.id)).toEqual(['title', 'answer', 'weak'])
+  })
+})
+
 describe('search pagination across ticker and title matches', () => {
+  const ticker = market('ticker-only', 1)
+  const titles = Array.from({ length: 5 }, (_, i) =>
+    market(`title-${i + 1}`, 10 - i)
+  )
+  const defaults: Pagination = {
+    limit: 2,
+    offset: 0,
+    sort: 'newest',
+    ordering: newest,
+  }
+
   it('does not let an old ticker advance the newest-first cursor', () => {
-    const first = search(defaults)
-    expect(first.map((contract) => contract.id)).toEqual(['title-1', 'title-2'])
+    const tiers = [[ticker], titles, titles]
+    const first = search(tiers, defaults)
+    expect(ids(first)).toEqual(['title-1', 'title-2'])
 
-    const second = search({ ...defaults, beforeTime: first[1].createdTime })
-    expect(second.map((contract) => contract.id)).toEqual([
-      'title-3',
-      'title-4',
-    ])
+    const second = search(tiers, {
+      ...defaults,
+      beforeTime: first[1].createdTime,
+    })
+    expect(ids(second)).toEqual(['title-3', 'title-4'])
 
-    const third = search({ ...defaults, beforeTime: second[1].createdTime })
-    expect(third.map((contract) => contract.id)).toEqual([
-      'title-5',
-      'ticker-only',
-    ])
+    const third = search(tiers, {
+      ...defaults,
+      beforeTime: second[1].createdTime,
+    })
+    expect(ids(third)).toEqual(['title-5', 'ticker-only'])
   })
 
   it('returns every match exactly once across offset pages', () => {
-    const pages = [0, 2, 4].flatMap((offset) => search({ ...defaults, offset }))
-    expect(pages.map((contract) => contract.id)).toEqual([
-      ...titles.map((contract) => contract.id),
-      ticker.id,
-    ])
-    expect(search({ ...defaults, offset: 6 })).toEqual([])
+    const pages = walkOffsetPages([[ticker], titles, titles], defaults)
+    expect(pages.flat()).toEqual([...ids(titles), ticker.id])
   })
 
   it('preserves relevance priority without losing displaced title matches', () => {
-    const pagination = { ...defaults, sort: 'score' }
-    expect(search(pagination).map((contract) => contract.id)).toEqual([
-      'title-1',
-      'ticker-only',
-    ])
-    const rest = [2, 4].flatMap((offset) => search({ ...pagination, offset }))
-    expect(rest.map((contract) => contract.id)).toEqual([
-      'title-2',
-      'title-3',
-      'title-4',
-      'title-5',
-    ])
+    const pagination = { ...defaults, sort: 'score', ordering: score }
+    const pages = walkOffsetPages([[ticker], titles, titles], pagination)
+    expect(pages[0]).toEqual(['ticker-only', 'title-1'])
+    expect(pages.flat()).toEqual(['ticker-only', ...ids(titles)])
   })
 
   it('ignores the offset when a time cursor is supplied', () => {
@@ -84,7 +172,7 @@ describe('search pagination across ticker and title matches', () => {
       limit: 2,
       offset: 0,
     })
-    expect(search(pagination).map((contract) => contract.id)).toEqual([
+    expect(ids(search([[ticker], titles, titles], pagination))).toEqual([
       'title-3',
       'title-4',
     ])
@@ -94,21 +182,62 @@ describe('search pagination across ticker and title matches', () => {
     const page = getSearchResultPage([ticker, ticker, ...titles], {
       ...defaults,
       sort: 'score',
+      ordering: score,
       limit: 10,
     })
-    expect(page.map((contract) => contract.id)).toEqual([
-      ...titles.map((contract) => contract.id),
-      ticker.id,
-    ])
+    // Every key ties, so ids decide the order — on both sides.
+    expect(ids(page)).toEqual([ticker.id, ...ids(titles)])
   })
 
   it('respects ascending display order after selecting an offset page', () => {
+    const ascending: SearchSort = {
+      keys: (c) => [c.createdTime],
+      directions: [{ order: 'asc', nullsFirst: false }],
+    }
     const page = getSearchResultPage([ticker, ...titles], {
       ...defaults,
       sort: 'close-date',
+      ordering: ascending,
       offset: 1,
-      order: 'asc',
     })
-    expect(page.map((contract) => contract.id)).toEqual(['title-2', 'title-1'])
+    expect(ids(page)).toEqual(['title-2', 'title-1'])
+  })
+})
+
+describe('search pagination when SQL and JS must agree on the order', () => {
+  // The score sort's database order: importance first, then bettor count.
+  // A popular zero-importance market therefore sorts BELOW every scored one,
+  // and the merge must not rank it any other way.
+  const scored = [
+    market('hot', 1, 0.9, 1),
+    market('warm', 1, 0.5, 1),
+    market('mild', 1, 0.2, 3),
+  ]
+  const popularButUnscored = [
+    market('crowd', 1, 0, 50),
+    market('busy', 1, 0, 40),
+  ]
+  const all = [...scored, ...popularButUnscored]
+  const pagination: Pagination = {
+    limit: 2,
+    offset: 0,
+    sort: 'score',
+    ordering: score,
+  }
+
+  it('pages plain title matches without repeating or skipping any', () => {
+    const pages = walkOffsetPages([all], pagination)
+    expect(pages).toEqual([['hot', 'warm'], ['mild', 'crowd'], ['busy']])
+  })
+
+  it('keeps the same guarantee when the tiers overlap', () => {
+    const pages = walkOffsetPages([all, scored, popularButUnscored], pagination)
+    expect(pages.flat()).toEqual(['hot', 'warm', 'mild', 'crowd', 'busy'])
+  })
+
+  it('breaks exact ties by id on both sides, so ties cannot reorder', () => {
+    const ties = ['d', 'b', 'a', 'c', 'e'].map((id) => market(id, 1, 0, 0))
+    const pages = walkOffsetPages([ties, [...ties].reverse()], pagination)
+    expect(pages).toEqual([['a', 'b'], ['c', 'd'], ['e']])
   })
 })

--- a/backend/shared/src/helpers/search-pagination.ts
+++ b/backend/shared/src/helpers/search-pagination.ts
@@ -1,5 +1,19 @@
 import { Contract } from 'common/contract'
-import { orderBy, uniqBy } from 'lodash'
+import { uniqBy } from 'lodash'
+
+// One `order by` expression of a search sort, evaluated in JS.
+export type SearchSortValue = number | string | null | undefined
+export type SearchSortDirection = { order: 'asc' | 'desc'; nullsFirst: boolean }
+
+// A search sort as BOTH sides must apply it: the SQL `order by` that fetches
+// each match tier, and the JS that merges those tiers into a page. Keys are
+// compared in order, each in its own direction with its own null placement,
+// and a tie in all of them falls through to the contract id — the same total
+// order the SQL clause ends with (see getSearchContractSortSQL).
+export type SearchSort = {
+  keys: (contract: Contract) => SearchSortValue[]
+  directions: SearchSortDirection[]
+}
 
 type SearchPagination = {
   limit: number
@@ -17,24 +31,82 @@ export const getSearchQueryPagination = (pagination: SearchPagination) => ({
   offset: 0,
 })
 
+const isNull = (value: SearchSortValue) =>
+  value == null || (typeof value === 'number' && Number.isNaN(value))
+
+const compareValues = (
+  a: SearchSortValue,
+  b: SearchSortValue,
+  { order, nullsFirst }: SearchSortDirection
+) => {
+  if (isNull(a) || isNull(b)) {
+    if (isNull(a) && isNull(b)) return 0
+    return (isNull(a) ? -1 : 1) * (nullsFirst ? 1 : -1)
+  }
+  const [left, right] = [a, b] as (number | string)[]
+  if (left === right) return 0
+  return (left < right ? -1 : 1) * (order === 'asc' ? 1 : -1)
+}
+
+/**
+ * Sort exactly as the SQL that fetched the rows does.
+ *
+ * Each match tier arrives as a prefix of its own SQL ordering, and a page is
+ * cut from the JS merge of those prefixes. That cut is only the page the
+ * database would have produced if JS ranks rows the way SQL does — a JS key
+ * that disagrees with SQL (the score sort once ranked zero-importance markets
+ * by bettor count among scored ones, which SQL never does) lets a row fetched
+ * for a later page leapfrog rows already shown, so one market repeats and
+ * another is never seen. `getWeight` scales a match's numeric keys (answer
+ * matches count half); string keys are left alone.
+ */
+export const sortLikeSql = <T>(
+  items: T[],
+  sort: SearchSort,
+  getContract: (item: T) => Contract,
+  getWeight: (item: T) => number = () => 1
+) => {
+  const lastDirection = sort.directions[sort.directions.length - 1]
+  const keyed = items.map((item) => {
+    const contract = getContract(item)
+    const weight = getWeight(item)
+    return {
+      item,
+      id: contract.id,
+      keys: sort
+        .keys(contract)
+        .map((value) => (typeof value === 'number' ? value * weight : value)),
+    }
+  })
+  keyed.sort((a, b) => {
+    for (let i = 0; i < a.keys.length; i++) {
+      const result = compareValues(
+        a.keys[i],
+        b.keys[i],
+        sort.directions[i] ?? lastDirection
+      )
+      if (result !== 0) return result
+    }
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  })
+  return keyed.map(({ item }) => item)
+}
+
 export const getSearchResultPage = (
   matchesInRelevanceOrder: Contract[],
-  pagination: SearchPagination & {
-    sort: string
-    sortCallback: (contract: Contract) => number
-    order: 'asc' | 'desc'
-  }
+  pagination: SearchPagination & { sort: string; ordering: SearchSort }
 ) => {
-  const { limit, sort, sortCallback, order } = pagination
+  const { limit, sort, ordering } = pagination
   const offset = getResultOffset(pagination)
   const matches = uniqBy(matchesInRelevanceOrder, 'id')
+  const order = (contracts: Contract[]) =>
+    sortLikeSql(contracts, ordering, (contract) => contract)
   // The newest-first cursor is the last result's createdTime. Relevance
   // cannot put an older ticker hit on this page ahead of newer title hits,
   // or the next cursor will skip those titles entirely.
-  if (sort === 'newest')
-    return orderBy(matches, sortCallback, order).slice(offset, offset + limit)
+  if (sort === 'newest') return order(matches).slice(offset, offset + limit)
 
   // Other sorts use offsets and retain the existing relevance priority for
   // page membership, then display that page in the requested sort order.
-  return orderBy(matches.slice(offset, offset + limit), sortCallback, order)
+  return order(matches.slice(offset, offset + limit))
 }

--- a/backend/shared/src/helpers/search-pagination.ts
+++ b/backend/shared/src/helpers/search-pagination.ts
@@ -1,0 +1,40 @@
+import { Contract } from 'common/contract'
+import { orderBy, uniqBy } from 'lodash'
+
+type SearchPagination = {
+  limit: number
+  offset: number
+  beforeTime?: number
+}
+
+const getResultOffset = ({ offset, beforeTime }: SearchPagination) =>
+  beforeTime ? 0 : offset
+
+// Each lookup must include the candidates that earlier pages consumed from
+// any match type. Applying the offset independently skips displaced matches.
+export const getSearchQueryPagination = (pagination: SearchPagination) => ({
+  limit: getResultOffset(pagination) + pagination.limit,
+  offset: 0,
+})
+
+export const getSearchResultPage = (
+  matchesInRelevanceOrder: Contract[],
+  pagination: SearchPagination & {
+    sort: string
+    sortCallback: (contract: Contract) => number
+    order: 'asc' | 'desc'
+  }
+) => {
+  const { limit, sort, sortCallback, order } = pagination
+  const offset = getResultOffset(pagination)
+  const matches = uniqBy(matchesInRelevanceOrder, 'id')
+  // The newest-first cursor is the last result's createdTime. Relevance
+  // cannot put an older ticker hit on this page ahead of newer title hits,
+  // or the next cursor will skip those titles entirely.
+  if (sort === 'newest')
+    return orderBy(matches, sortCallback, order).slice(offset, offset + limit)
+
+  // Other sorts use offsets and retain the existing relevance priority for
+  // page membership, then display that page in the requested sort order.
+  return orderBy(matches.slice(offset, offset + limit), sortCallback, order)
+}

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -531,6 +531,18 @@ design notes, and oracle-latency risks live in
 `backend/scripts/perp-launch-preflight.ts` at each rollout phase; the operational
 sequence and rollback are in `perps-launch-runbook.md`.
 
+**Tickers.** Every perp carries a `ticker` (`BTC`, `TRUMP`, `SPYx`): the
+badge in front of its title shows it in place of the word "Perpetual", the
+`/perps` hub labels rows with it, and search matches it (`data->>'ticker'`,
+which is why it is stored on the contract rather than only mapped in client
+code). The canonical assignment is `PERP_FEED_TICKERS` in
+`common/src/perps/ticker.ts`, keyed by feed id; `create-perp` stamps it and
+refuses another name for a feed listed there, the launch manifest requires an
+entry for every launch feed, and the preflight fails a launch market whose
+stored ticker disagrees. `backend/scripts/backfill-perp-tickers.ts` (dry-run
+by default, `--apply` to write) stamps markets created before the field
+existed.
+
 ## Scheduler
 
 - `update-oracle-feeds.ts` fires **every 5 seconds** (croner handles

--- a/backend/shared/src/perps/launch-manifest.ts
+++ b/backend/shared/src/perps/launch-manifest.ts
@@ -2,6 +2,11 @@ import { HOUSE_LIQUIDITY_PROVIDER_ID } from 'common/antes'
 import { MAX_QUESTION_LENGTH } from 'common/contract'
 import { DAY_MS, HOUR_MS, MINUTE_MS, YEAR_MS } from 'common/util/time'
 import { getOracleAttribution } from 'common/perps/oracle-attribution'
+import {
+  PERP_TICKER_MAX_LENGTH,
+  getPerpFeedTicker,
+  isValidPerpTicker,
+} from 'common/perps/ticker'
 
 import {
   BTC_USD_FEED_ID,
@@ -521,7 +526,20 @@ const collectDefinitionErrors = (
     )
   if (/\bperpetual\b/i.test(market.question))
     errors.push(
-      `${market.feedId} repeats "perpetual" in its title; the market type is rendered separately`
+      `${market.feedId} repeats "perpetual" in its title; the ticker and market type are rendered separately`
+    )
+  // The ticker is what the title badge shows in place of the market type,
+  // what the /perps hub labels the row with, and what search matches, so a
+  // launch feed without one would launch unlabelled. It lives in `common`
+  // (the web renders it), not in this definition — see common/perps/ticker.
+  const ticker = getPerpFeedTicker(market.feedId)
+  if (!ticker)
+    errors.push(
+      `${market.feedId} has no canonical ticker in PERP_FEED_TICKERS (common/perps/ticker.ts)`
+    )
+  else if (!isValidPerpTicker(ticker))
+    errors.push(
+      `${market.feedId} ticker "${ticker}" is not one alphanumeric token of at most ${PERP_TICKER_MAX_LENGTH} characters starting with a letter`
     )
   if (
     market.requiresSourceAsOf !==

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -10,6 +10,11 @@ import { PrivateUser } from 'common/user'
 import { buildArray, filterDefined } from 'common/util/array'
 import { MINUTE_MS } from 'common/util/time'
 import { constructPrefixTsQuery } from 'shared/helpers/search'
+import {
+  SearchSort,
+  SearchSortDirection,
+  SearchSortValue,
+} from 'shared/helpers/search-pagination'
 import { getContractPrivacyWhereSQLFilter } from 'shared/supabase/contracts'
 import { createSupabaseDirectClient } from 'shared/supabase/init'
 import {
@@ -693,19 +698,37 @@ function getSearchContractWhereSQL(args: {
   ]
 }
 
+type SortOrder = 'ASC' | 'ASC NULLS LAST' | 'DESC' | 'DESC NULLS LAST'
 type SortFields = Record<
   string,
   {
     sql: string
-    sortCallback: (c: Contract) => number
-    order: 'ASC' | 'ASC NULLS LAST' | 'DESC' | 'DESC NULLS LAST'
+    // `order` applies to the LAST expression of `sql`, as in the clause.
+    order: SortOrder
+    // The JS evaluation of `sql`, which the search API uses to merge the
+    // fetched match tiers and cut a page (see sortLikeSql in
+    // shared/helpers/search-pagination). It must rank rows exactly as the
+    // database does: a single-expression sort gives `sortCallback`; a sort
+    // whose `sql` has several expressions gives one key per expression in
+    // `sortKeys`, with each expression's direction in `keyDirections`.
+    sortCallback?: (c: Contract) => number
+    sortKeys?: (c: Contract) => SearchSortValue[]
+    keyDirections?: SearchSortDirection[]
   }
 >
 export const sortFields: SortFields = {
   score: {
     sql: `importance_score::numeric desc, unique_bettor_count`,
-    sortCallback: (c: Contract) =>
-      c.importanceScore > 0 ? c.importanceScore : c.uniqueBettorCount,
+    // Term for term what `sql` says. A single callback that fell back to the
+    // bettor count when importance was zero ranked popular zero-importance
+    // markets above scored ones — an order the database never produces, and
+    // one that made pages repeat and skip markets once the tiers were
+    // over-fetched (see sortLikeSql).
+    sortKeys: (c: Contract) => [c.importanceScore, c.uniqueBettorCount],
+    keyDirections: [
+      { order: 'desc', nullsFirst: true },
+      { order: 'desc', nullsFirst: true },
+    ],
     order: 'DESC',
   },
   'daily-score': {
@@ -789,17 +812,26 @@ export const sortFields: SortFields = {
   },
   'bounty-amount': {
     sql: "COALESCE((contracts.data->>'bountyLeft')::numeric, -1)",
-    sortCallback: (c: Contract) => ('bountyLeft' in c && c.bountyLeft) || -1,
+    sortCallback: (c: Contract) =>
+      ('bountyLeft' in c ? c.bountyLeft : -1) ?? -1,
     order: 'DESC',
   },
   'prob-descending': {
     sql: "resolution DESC, (contracts.data->>'prob')::numeric",
-    sortCallback: (c: Contract) => ('prob' in c && c.prob) || 0,
+    sortKeys: (c: Contract) => [c.resolution, 'prob' in c ? c.prob : null],
+    keyDirections: [
+      { order: 'desc', nullsFirst: true },
+      { order: 'desc', nullsFirst: false },
+    ],
     order: 'DESC NULLS LAST',
   },
   'prob-ascending': {
     sql: "resolution DESC, (contracts.data->>'prob')::numeric",
-    sortCallback: (c: Contract) => ('prob' in c && c.prob) || 0,
+    sortKeys: (c: Contract) => [c.resolution, 'prob' in c ? c.prob : null],
+    keyDirections: [
+      { order: 'desc', nullsFirst: true },
+      { order: 'asc', nullsFirst: false },
+    ],
     order: 'ASC',
   },
   'prob-50': {
@@ -810,7 +842,25 @@ export const sortFields: SortFields = {
   },
 }
 function getSearchContractSortSQL(sort: string) {
-  return `${sortFields[sort].sql} ${sortFields[sort].order}`
+  // The id tiebreak makes the sort a total order, so `limit n` and
+  // `limit 2n` return consistent prefixes and the JS side (sortLikeSql) can
+  // reproduce the order exactly — pagination across the merged match tiers
+  // depends on both.
+  return `${sortFields[sort].sql} ${sortFields[sort].order}, contracts.id`
+}
+
+// Postgres puts nulls first for DESC and last for ASC unless told otherwise.
+const parseSortOrder = (order: SortOrder): SearchSortDirection => ({
+  order: order.startsWith('DESC') ? 'desc' : 'asc',
+  nullsFirst: order === 'DESC',
+})
+
+/** The JS twin of getSearchContractSortSQL(sort). */
+export const getSearchSort = (sort: string): SearchSort => {
+  const { sortCallback, sortKeys, keyDirections, order } = sortFields[sort]
+  if (sortKeys) return { keys: sortKeys, directions: keyDirections ?? [] }
+  if (!sortCallback) throw new Error(`Search sort ${sort} has no JS ordering`)
+  return { keys: (c) => [sortCallback(c)], directions: [parseSortOrder(order)] }
 }
 
 const loadScoreThresholds = async (threshold: number) => {

--- a/backend/shared/src/supabase/search-contracts.ts
+++ b/backend/shared/src/supabase/search-contracts.ts
@@ -3,6 +3,7 @@ import { DiscoveryExperimentVariant } from 'common/discovery-experiment'
 import { PROD_MANIFOLD_LOVE_GROUP_SLUG } from 'common/envs/constants'
 import { GROUP_SCORE_PRIOR, nicheBlendTopicScoreSql } from 'common/feed'
 import { getPerpBackingPool } from 'common/perps/amm'
+import { isPerpTickerSearchTerm } from 'common/perps/ticker'
 import { tsToMillis } from 'common/supabase/utils'
 import { answerCostTiers, getTierIndexFromLiquidity } from 'common/tier'
 import { PrivateUser } from 'common/user'
@@ -330,6 +331,8 @@ export type SearchTypes =
   | 'description'
   | 'prefix'
   | 'answer'
+  // Perp tickers, matched on data->>'ticker' (no tsvector covers them).
+  | 'ticker'
 
 // Full-text search finds nothing unless the user guesses a word that is
 // literally in the question, so a near miss lands on "only nothingness"
@@ -522,6 +525,20 @@ export function getSearchContractSQL(
 
     whereSql,
     term.length && [
+      // A perp's ticker ("BTC", "SPYx") is stored in data->>'ticker', which
+      // no tsvector column sees, so it gets its own lookup: perps are a
+      // handful of rows behind the non-binary outcome_type index, and a
+      // prefix match on that set is what makes "BT" find BTC as you type.
+      // The API asks for this type only when the term could be a ticker;
+      // the guard here keeps the shared builder from ever interpolating a
+      // wildcard from a term it did not vet.
+      searchType === 'ticker' &&
+        (isPerpTickerSearchTerm(term)
+          ? where(
+              `outcome_type = 'PERP' and contracts.data->>'ticker' ilike $1`,
+              [`${term.trim()}%`]
+            )
+          : where('false')),
       searchType === 'prefix' &&
         where(
           `question_fts @@ to_tsquery('english_extended', $1)`,

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -14,6 +14,11 @@ import { MAX_ID_LENGTH } from 'common/group'
 import { MAX_MULTI_NUMERIC_ANSWERS } from 'common/multi-numeric'
 import { MIN_PERP_LEVERAGE, PERP_MIN_CLOSE_FRACTION } from 'common/perps/amm'
 import {
+  PERP_TICKER_MAX_LENGTH,
+  PERP_TICKER_PATTERN,
+  getPerpTicker,
+} from 'common/perps/ticker'
+import {
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeBps,
   getPerpTakerFeeImpact,
@@ -105,6 +110,9 @@ export type LiteMarket = {
   // number — and it is the input a client needs to size a trade.
   takerFeeApiBps?: number
   resolvedOraclePrice?: number
+  // The market's short on-site identifier ("BTC", "TRUMP"): the label the
+  // /perps hub and the title badge show, and what search matches on.
+  ticker?: string
 }
 export type ApiAnswer = Omit<
   Answer & {
@@ -252,6 +260,7 @@ export function toLiteMarket(
           takerFeeImpact: getPerpTakerFeeImpact(contract),
           takerFeeApiBps: getPerpEffectiveTakerFeeBps(contract, true),
           resolvedOraclePrice: contract.resolvedOraclePrice,
+          ticker: getPerpTicker(contract),
         }
       : {}),
 
@@ -591,6 +600,16 @@ export const updateMarketProps = z
     homePageScoreAdjustment: z.number().gte(-1).lte(1).nullable().optional(),
     homePageScoreAdjustmentDays: z.number().int().positive().optional(),
     creatorBannedFromBetting: z.boolean().optional(),
+    // Perp markets only, admin only; a feed named in PERP_FEED_TICKERS
+    // accepts only its canonical ticker (see update-market).
+    ticker: z
+      .string()
+      .max(PERP_TICKER_MAX_LENGTH)
+      .regex(
+        PERP_TICKER_PATTERN,
+        'A ticker is one alphanumeric token that starts with a letter'
+      )
+      .optional(),
   })
   .strict()
 
@@ -663,6 +682,18 @@ export const createPerpSchema = z.object({
   visibility: z.enum(VISIBILITIES).optional(),
   groupIds: z.array(z.string().min(1).max(MAX_ID_LENGTH)).optional(),
   oracleFeedId: z.string().min(1).max(200),
+  // Short on-site identifier shown in place of the market type ("BTC").
+  // Omitted = the feed's canonical ticker (PERP_FEED_TICKERS), else one
+  // derived from the feed id; a feed that has a canonical ticker rejects any
+  // other value, so the label can't drift between markets on one feed.
+  ticker: z
+    .string()
+    .max(PERP_TICKER_MAX_LENGTH)
+    .regex(
+      PERP_TICKER_PATTERN,
+      'A ticker is one alphanumeric token that starts with a letter'
+    )
+    .optional(),
   maxLeverage: z.number().gt(1).lte(100),
   maxFundingRate: z.number().gt(0).lt(1),
   fundingSensitivity: z.number().gt(0).lte(100),

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1380,6 +1380,9 @@ export const API = (_apiTypeCheck = {
       updatePeriodMs: number | null
       marketCreationEnabled: boolean
       description: string | null
+      // Canonical ticker (PERP_FEED_TICKERS); null for a feed nobody has
+      // named, where the form may choose one.
+      ticker: string | null
       launchLatencyRisk: string | null
       launchRecommendation: {
         question: string

--- a/common/src/contract-seo.ts
+++ b/common/src/contract-seo.ts
@@ -8,6 +8,7 @@ import { sortAnswers } from './answer'
 import { getFormattedExpectedValue } from './multi-numeric'
 import { getFormattedExpectedDate } from './multi-date'
 import { formatPrice, inferPriceDecimals } from './perps/format'
+import { getPerpTicker } from './perps/ticker'
 
 export const getContractOGProps = (
   contract: Contract
@@ -66,7 +67,9 @@ export const getContractOGProps = (
     resolution,
     topAnswer: topAnswer?.text,
     bountyLeft: bountyLeft,
-    ...(outcomeType === 'PERP' ? { outcomeType } : {}),
+    ...(contract.outcomeType === 'PERP'
+      ? { outcomeType: contract.outcomeType, perpTicker: getPerpTicker(contract) }
+      : {}),
     ...(perpPrice === undefined ? {} : { perpPrice }),
   }
 }
@@ -84,6 +87,7 @@ export type OgCardProps = {
   bountyLeft?: string // number
   outcomeType?: 'PERP'
   perpPrice?: string
+  perpTicker?: string
   points?: string // base64ified points
 }
 

--- a/common/src/contract-seo.ts
+++ b/common/src/contract-seo.ts
@@ -68,7 +68,10 @@ export const getContractOGProps = (
     topAnswer: topAnswer?.text,
     bountyLeft: bountyLeft,
     ...(contract.outcomeType === 'PERP'
-      ? { outcomeType: contract.outcomeType, perpTicker: getPerpTicker(contract) }
+      ? {
+          outcomeType: contract.outcomeType,
+          perpTicker: getPerpTicker(contract),
+        }
       : {}),
     ...(perpPrice === undefined ? {} : { perpPrice }),
   }

--- a/common/src/contract.ts
+++ b/common/src/contract.ts
@@ -324,6 +324,14 @@ export type Perp = {
   // economics of open positions. Missing on pre-period contracts = hourly.
   // Read via getFundingPeriodMs (common/perps/funding), never directly.
   fundingPeriodMs?: number
+  // Short on-site identifier ("BTC", "TRUMP") shown in front of the title in
+  // place of the market type, used as the row label on /perps, and matched
+  // by search — which is why it is stored here rather than only mapped in
+  // client code. Canonical per feed in PERP_FEED_TICKERS (common/perps/
+  // ticker); stamped by create-perp, and absent on markets created before it
+  // existed until backfill-perp-tickers.ts runs. Read via getPerpTicker
+  // (common/perps/ticker), never directly, so those rows still get a label.
+  ticker?: string
   resolution?: 'MKT' | 'CANCEL'
 }
 

--- a/common/src/perps/ticker.test.ts
+++ b/common/src/perps/ticker.test.ts
@@ -1,0 +1,105 @@
+import {
+  PERP_FEED_TICKERS,
+  PERP_TICKER_MAX_LENGTH,
+  derivePerpTicker,
+  getPerpFeedTicker,
+  getPerpTicker,
+  isPerpTickerSearchTerm,
+  isValidPerpTicker,
+} from './ticker'
+
+describe('isValidPerpTicker', () => {
+  it('accepts one alphanumeric token that starts with a letter', () => {
+    expect(isValidPerpTicker('BTC')).toBe(true)
+    expect(isValidPerpTicker('SPYx')).toBe(true)
+    expect(isValidPerpTicker('UKCO2')).toBe(true)
+    expect(isValidPerpTicker('A')).toBe(true)
+    expect(isValidPerpTicker('ABCDEFGH')).toBe(true)
+  })
+
+  it('rejects spaces, symbols, bare numbers, empties and overlong labels', () => {
+    expect(isValidPerpTicker('')).toBe(false)
+    expect(isValidPerpTicker('BTC USD')).toBe(false)
+    expect(isValidPerpTicker('$BTC')).toBe(false)
+    expect(isValidPerpTicker('BTC-USD')).toBe(false)
+    expect(isValidPerpTicker('2026')).toBe(false)
+    expect(isValidPerpTicker('ABCDEFGHI')).toBe(false)
+    expect(isValidPerpTicker(' BTC')).toBe(false)
+  })
+})
+
+describe('PERP_FEED_TICKERS', () => {
+  it('names every feed with a valid ticker', () => {
+    for (const [feedId, ticker] of Object.entries(PERP_FEED_TICKERS)) {
+      expect([feedId, isValidPerpTicker(ticker)]).toEqual([feedId, true])
+      expect(ticker.length).toBeLessThanOrEqual(PERP_TICKER_MAX_LENGTH)
+    }
+  })
+
+  it('never gives two feeds the same ticker, even ignoring case', () => {
+    const tickers = Object.values(PERP_FEED_TICKERS).map((t) =>
+      t.toLowerCase()
+    )
+    expect(new Set(tickers).size).toBe(tickers.length)
+  })
+
+  it('keeps the launch tickers the hub has always shown', () => {
+    expect(getPerpFeedTicker('btc-usd')).toBe('BTC')
+    expect(getPerpFeedTicker('trump-approval-rating')).toBe('TRUMP')
+    expect(getPerpFeedTicker('spyx-usd')).toBe('SPYx')
+    expect(getPerpFeedTicker('nonexistent-feed')).toBeUndefined()
+    expect(getPerpFeedTicker(undefined)).toBeUndefined()
+  })
+})
+
+describe('derivePerpTicker', () => {
+  it('uses the leading segment of the feed id, upper-cased and capped', () => {
+    expect(derivePerpTicker('btc-usd')).toBe('BTC')
+    expect(derivePerpTicker('votehub-generic-ballot-2026')).toBe('VOTEHU')
+    expect(derivePerpTicker('eth')).toBe('ETH')
+  })
+
+  it('always yields something a badge can show', () => {
+    expect(derivePerpTicker('')).toBe('PERP')
+    expect(derivePerpTicker('2026-midterms')).toBe('MIDTER')
+    expect(derivePerpTicker('$$$-usd')).toBe('PERP')
+    expect(isValidPerpTicker(derivePerpTicker('s&p500-usd'))).toBe(true)
+  })
+})
+
+describe('getPerpTicker', () => {
+  it('prefers the stored ticker, which is what search matches', () => {
+    expect(
+      getPerpTicker({ ticker: 'BTC2', oracleFeedId: 'btc-usd', slug: 'x' })
+    ).toBe('BTC2')
+  })
+
+  it('falls back to the canonical map for rows stored before the field', () => {
+    expect(getPerpTicker({ oracleFeedId: 'crypto-fear-greed' })).toBe('FEAR')
+    expect(getPerpTicker({ ticker: '', oracleFeedId: 'gldx-usd' })).toBe(
+      'GLDx'
+    )
+  })
+
+  it('derives a label for a feed nobody has named', () => {
+    expect(getPerpTicker({ oracleFeedId: 'eth-usd' })).toBe('ETH')
+    expect(getPerpTicker({ slug: 'some-prototype-market' })).toBe('SOME')
+    expect(getPerpTicker({})).toBe('PERP')
+  })
+})
+
+describe('isPerpTickerSearchTerm', () => {
+  it('accepts a single token a trader might type for a ticker', () => {
+    expect(isPerpTickerSearchTerm('btc')).toBe(true)
+    expect(isPerpTickerSearchTerm('BT')).toBe(true)
+    expect(isPerpTickerSearchTerm('  spyx ')).toBe(true)
+  })
+
+  it('rejects multi-word queries, numbers and anything longer than a ticker', () => {
+    expect(isPerpTickerSearchTerm('trump approval')).toBe(false)
+    expect(isPerpTickerSearchTerm('2026')).toBe(false)
+    expect(isPerpTickerSearchTerm('')).toBe(false)
+    expect(isPerpTickerSearchTerm('perpetuals')).toBe(false)
+    expect(isPerpTickerSearchTerm('https://manifold.markets/x')).toBe(false)
+  })
+})

--- a/common/src/perps/ticker.test.ts
+++ b/common/src/perps/ticker.test.ts
@@ -37,9 +37,7 @@ describe('PERP_FEED_TICKERS', () => {
   })
 
   it('never gives two feeds the same ticker, even ignoring case', () => {
-    const tickers = Object.values(PERP_FEED_TICKERS).map((t) =>
-      t.toLowerCase()
-    )
+    const tickers = Object.values(PERP_FEED_TICKERS).map((t) => t.toLowerCase())
     expect(new Set(tickers).size).toBe(tickers.length)
   })
 
@@ -62,7 +60,8 @@ describe('derivePerpTicker', () => {
   it('always yields something a badge can show', () => {
     expect(derivePerpTicker('')).toBe('PERP')
     expect(derivePerpTicker('2026-midterms')).toBe('MIDTER')
-    expect(derivePerpTicker('$$$-usd')).toBe('PERP')
+    expect(derivePerpTicker('$$$-usd')).toBe('USD')
+    expect(derivePerpTicker('$$$')).toBe('PERP')
     expect(isValidPerpTicker(derivePerpTicker('s&p500-usd'))).toBe(true)
   })
 })
@@ -76,9 +75,7 @@ describe('getPerpTicker', () => {
 
   it('falls back to the canonical map for rows stored before the field', () => {
     expect(getPerpTicker({ oracleFeedId: 'crypto-fear-greed' })).toBe('FEAR')
-    expect(getPerpTicker({ ticker: '', oracleFeedId: 'gldx-usd' })).toBe(
-      'GLDx'
-    )
+    expect(getPerpTicker({ ticker: '', oracleFeedId: 'gldx-usd' })).toBe('GLDx')
   })
 
   it('derives a label for a feed nobody has named', () => {

--- a/common/src/perps/ticker.ts
+++ b/common/src/perps/ticker.ts
@@ -33,7 +33,10 @@ export const PERP_FEED_TICKERS: Readonly<Record<string, string>> = {
   'vance-favorability': 'VANCE',
   'crypto-fear-greed': 'FEAR',
   'openrouter-open-weight-share': 'OPENW',
-  'openrouter-anthropic-share': 'ANTH',
+  // The product, not the company: this is the share of OpenRouter tokens
+  // going to Claude models. ANTH is reserved for the Anthropic pre-IPO price
+  // ticker.
+  'openrouter-anthropic-share': 'CLAUDE',
   'openrouter-chinese-lab-share': 'CNLAB',
   'spyx-usd': 'SPYx',
   'qqqx-usd': 'QQQx',

--- a/common/src/perps/ticker.ts
+++ b/common/src/perps/ticker.ts
@@ -1,0 +1,77 @@
+// The ticker: the short on-site identifier a perp market goes by ("BTC",
+// "TRUMP", "SPYx"). It is what the /perps hub labels rows with, what the
+// badge in front of a perp's title shows in place of its market type, and
+// what search matches on (contracts.data->>'ticker'), so it must be STORED
+// on the contract, not only computed here: a label that exists only in
+// client code is invisible to search and to API consumers.
+//
+// PERP_FEED_TICKERS is the canonical assignment, keyed by the stable oracle
+// feed id (never inferred from a renameable question). It lives in `common`
+// rather than beside the launch manifest because the web renders it: a
+// contract that predates the stored field still gets the right label from
+// this map until backfill-perp-tickers.ts stamps it. create-perp refuses a
+// different ticker for a feed named here, the launch manifest requires an
+// entry for every launch feed, and the preflight fails a launch market whose
+// stored ticker disagrees.
+
+export const PERP_TICKER_MAX_LENGTH = 8
+
+// One alphanumeric token, starting with a letter. A single token is what
+// makes it usable as a search term and as a label that never wraps; the
+// leading letter keeps a bare number from ever reading as a ticker. Case is
+// the admin's choice ("SPYx" follows the xStocks naming); matching is
+// case-insensitive everywhere.
+export const PERP_TICKER_PATTERN = /^[A-Za-z][A-Za-z0-9]{0,7}$/
+
+export const isValidPerpTicker = (ticker: string) =>
+  ticker.length <= PERP_TICKER_MAX_LENGTH && PERP_TICKER_PATTERN.test(ticker)
+
+export const PERP_FEED_TICKERS: Readonly<Record<string, string>> = {
+  'btc-usd': 'BTC',
+  'trump-approval-rating': 'TRUMP',
+  'votehub-generic-ballot-2026': 'BALLOT',
+  'vance-favorability': 'VANCE',
+  'crypto-fear-greed': 'FEAR',
+  'openrouter-open-weight-share': 'OPENW',
+  'openrouter-anthropic-share': 'ANTH',
+  'openrouter-chinese-lab-share': 'CNLAB',
+  'spyx-usd': 'SPYx',
+  'qqqx-usd': 'QQQx',
+  'nvdax-usd': 'NVDAx',
+  'gldx-usd': 'GLDx',
+  // Retired feed (see the note in backend/shared/src/oracle-feeds.ts). Its
+  // settled market page still renders the badge, so it keeps its name.
+  'uk-grid-carbon': 'UKCO2',
+}
+
+export const getPerpFeedTicker = (feedId: string | undefined) =>
+  feedId ? PERP_FEED_TICKERS[feedId] : undefined
+
+// Last resort for a market on a feed nobody has named: the feed id's leading
+// segment, so a new perp is merely unglamorous until someone adds a line to
+// PERP_FEED_TICKERS, never broken.
+export const derivePerpTicker = (feedIdOrSlug: string) => {
+  const head = feedIdOrSlug.split('-')[0].replace(/[^A-Za-z0-9]/g, '')
+  const letters = head.replace(/^[0-9]+/, '')
+  return letters.toUpperCase().slice(0, 6) || 'PERP'
+}
+
+// The label to render. Prefers what is stored on the contract (which is what
+// search matches), then the canonical map, then the derived fallback — so a
+// row from before the field existed and a row whose feed nobody named both
+// still get a label.
+export const getPerpTicker = (contract: {
+  ticker?: string
+  oracleFeedId?: string
+  slug?: string
+}) =>
+  contract.ticker ||
+  getPerpFeedTicker(contract.oracleFeedId) ||
+  derivePerpTicker(contract.oracleFeedId ?? contract.slug ?? '')
+
+// Whether a search term could be (the start of) a ticker. Every prefix of a
+// valid ticker is itself a valid ticker, so the same pattern answers both
+// "is this a ticker" and "could this be one being typed" — and a multi-word
+// query never is, so search skips the ticker lookup for it entirely.
+export const isPerpTickerSearchTerm = (term: string) =>
+  isValidPerpTicker(term.trim())

--- a/common/src/perps/ticker.ts
+++ b/common/src/perps/ticker.ts
@@ -51,9 +51,13 @@ export const getPerpFeedTicker = (feedId: string | undefined) =>
 // segment, so a new perp is merely unglamorous until someone adds a line to
 // PERP_FEED_TICKERS, never broken.
 export const derivePerpTicker = (feedIdOrSlug: string) => {
-  const head = feedIdOrSlug.split('-')[0].replace(/[^A-Za-z0-9]/g, '')
-  const letters = head.replace(/^[0-9]+/, '')
-  return letters.toUpperCase().slice(0, 6) || 'PERP'
+  for (const segment of feedIdOrSlug.split('-')) {
+    // Drop anything that can't be in a ticker, and a leading run of digits
+    // so "2026-midterms" reads MIDTER rather than a bare year.
+    const head = segment.replace(/[^A-Za-z0-9]/g, '').replace(/^[0-9]+/, '')
+    if (head) return head.toUpperCase().slice(0, 6)
+  }
+  return 'PERP'
 }
 
 // The label to render. Prefers what is stored on the contract (which is what

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -1905,9 +1905,13 @@ inside the `limit` cap.
 
 Create a perp market. Admin-only; documented for completeness. Takes the
 market question and description, an `oracleFeedId` from the registered feeds,
-and the risk parameters `maxLeverage`, `maxFundingRate`,
-`fundingSensitivity`, `maxOraclePriceAgeMs`, `subsidyLong`, and
-`subsidyShort`. Returns the created market as a `LiteMarket`.
+an optional `ticker` (the market's short identifier, e.g. `BTC`: one
+alphanumeric token of at most 8 characters, shown in place of the market type
+and matched by search; a feed that already has a canonical ticker accepts only
+that one, and it is the default when omitted), and the risk parameters
+`maxLeverage`, `maxFundingRate`, `fundingSensitivity`, `maxOraclePriceAgeMs`,
+`subsidyLong`, and `subsidyShort`. Returns the created market as a
+`LiteMarket`; perp markets carry their `ticker` there.
 
 ## Websockets
 

--- a/perps-launch-runbook.md
+++ b/perps-launch-runbook.md
@@ -209,6 +209,17 @@ links and embeddings. Use `--apply` only for prototypes that will be retained;
 topic attachment updates market ranking time, so do not mutate a market that
 will immediately be recreated.
 
+Markets created before the stored ticker existed need it stamped, or search
+cannot find them by ticker and the preflight fails their launch-ticker check:
+
+```powershell
+npx.cmd ts-node backfill-perp-tickers.ts
+npx.cmd ts-node backfill-perp-tickers.ts --apply
+```
+
+It writes only `ticker` (no ranking-time bump), settled markets included, and
+leaves any market on a feed missing from `PERP_FEED_TICKERS` alone.
+
 ## Unlisted smoke pass
 
 Create only the manifest feeds as unlisted. Required topic tags are

--- a/web/components/bet/user-bets-table.tsx
+++ b/web/components/bet/user-bets-table.tsx
@@ -787,7 +787,7 @@ function BetsTable(props: {
                         {(contract as Contract).outcomeType === 'PERP' && (
                           <PerpMarketBadge
                             contract={contract as Contract}
-                            className="mr-1 align-middle"
+                            className="mr-1"
                           />
                         )}
                         {contract.question}

--- a/web/components/bet/user-bets-table.tsx
+++ b/web/components/bet/user-bets-table.tsx
@@ -785,7 +785,7 @@ function BetsTable(props: {
                         )}
                       >
                         {(contract as Contract).outcomeType === 'PERP' && (
-                          <PerpMarketBadge className="mr-1 align-middle" />
+                          <PerpMarketBadge contract={contract as Contract} className="mr-1 align-middle" />
                         )}
                         {contract.question}
                       </Link>

--- a/web/components/bet/user-bets-table.tsx
+++ b/web/components/bet/user-bets-table.tsx
@@ -785,7 +785,10 @@ function BetsTable(props: {
                         )}
                       >
                         {(contract as Contract).outcomeType === 'PERP' && (
-                          <PerpMarketBadge contract={contract as Contract} className="mr-1 align-middle" />
+                          <PerpMarketBadge
+                            contract={contract as Contract}
+                            className="mr-1 align-middle"
+                          />
                         )}
                         {contract.question}
                       </Link>

--- a/web/components/contract/contract-info-dialog.tsx
+++ b/web/components/contract/contract-info-dialog.tsx
@@ -1,6 +1,7 @@
 import { formatTimeWithTimezone } from 'client-common/lib/time'
 import clsx from 'clsx'
 import { ELASTICITY_BET_AMOUNT } from 'common/calculate-metrics'
+import { getPerpTicker } from 'common/perps/ticker'
 import { Contract, PerpContract, contractPool } from 'common/contract'
 import {
   ENV_CONFIG,
@@ -105,8 +106,8 @@ export const Stats = (props: {
   const typeDisplay =
     outcomeType === 'BINARY'
       ? 'YES / NO'
-      : outcomeType === 'PERP'
-      ? 'Perpetual'
+      : contract.outcomeType === 'PERP'
+      ? `Perpetual · ${getPerpTicker(contract)}`
       : outcomeType === 'MULTIPLE_CHOICE'
       ? 'Multiple choice'
       : outcomeType === 'BOUNTIED_QUESTION'

--- a/web/components/contract/contract-mention.tsx
+++ b/web/components/contract/contract-mention.tsx
@@ -49,7 +49,7 @@ export function ContractMention(props: {
         aria-hidden
         className="mr-1 inline h-[1em] w-[1em] stroke-indigo-700 align-text-bottom dark:stroke-white"
       />
-      {isPerp && <PerpMarketBadge className="mr-1 align-bottom" />}
+      {isPerp && <PerpMarketBadge contract={contract} className="mr-1 align-bottom" />}
       <span
         className={clsx(
           'break-anywhere group-hover/mention:text-primary-500 group-focus/mention:text-primary-500 text-primary-800  mr-0.5 whitespace-normal font-medium transition-colors',

--- a/web/components/contract/contract-mention.tsx
+++ b/web/components/contract/contract-mention.tsx
@@ -49,9 +49,7 @@ export function ContractMention(props: {
         aria-hidden
         className="mr-1 inline h-[1em] w-[1em] stroke-indigo-700 align-text-bottom dark:stroke-white"
       />
-      {isPerp && (
-        <PerpMarketBadge contract={contract} className="mr-1 align-bottom" />
-      )}
+      {isPerp && <PerpMarketBadge contract={contract} className="mr-1" />}
       <span
         className={clsx(
           'break-anywhere group-hover/mention:text-primary-500 group-focus/mention:text-primary-500 text-primary-800  mr-0.5 whitespace-normal font-medium transition-colors',

--- a/web/components/contract/contract-mention.tsx
+++ b/web/components/contract/contract-mention.tsx
@@ -49,7 +49,9 @@ export function ContractMention(props: {
         aria-hidden
         className="mr-1 inline h-[1em] w-[1em] stroke-indigo-700 align-text-bottom dark:stroke-white"
       />
-      {isPerp && <PerpMarketBadge contract={contract} className="mr-1 align-bottom" />}
+      {isPerp && (
+        <PerpMarketBadge contract={contract} className="mr-1 align-bottom" />
+      )}
       <span
         className={clsx(
           'break-anywhere group-hover/mention:text-primary-500 group-focus/mention:text-primary-500 text-primary-800  mr-0.5 whitespace-normal font-medium transition-colors',

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -320,7 +320,7 @@ export function ContractPageContent(props: ContractParams) {
                     )}
                     <VisibilityIcon contract={props.contract} />{' '}
                     {isPerp && (
-                      <PerpMarketBadge className="mr-1 align-middle" />
+                      <PerpMarketBadge contract={liveContract} className="mr-1 align-middle" />
                     )}
                     {props.contract.question}
                   </span>

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -320,7 +320,10 @@ export function ContractPageContent(props: ContractParams) {
                     )}
                     <VisibilityIcon contract={props.contract} />{' '}
                     {isPerp && (
-                      <PerpMarketBadge contract={liveContract} className="mr-1 align-middle" />
+                      <PerpMarketBadge
+                        contract={liveContract}
+                        className="mr-1 align-middle"
+                      />
                     )}
                     {props.contract.question}
                   </span>

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -322,7 +322,7 @@ export function ContractPageContent(props: ContractParams) {
                     {isPerp && (
                       <PerpMarketBadge
                         contract={liveContract}
-                        className="mr-1 align-middle"
+                        className="mr-1"
                       />
                     )}
                     {props.contract.question}

--- a/web/components/contract/contracts-table.tsx
+++ b/web/components/contract/contracts-table.tsx
@@ -577,7 +577,7 @@ function ContractQuestion(props: {
         )}
         <VisibilityIcon className="mr-1" contract={contract} />
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1" />
         )}
         {removeEmojis(contract.question)}
       </span>

--- a/web/components/contract/contracts-table.tsx
+++ b/web/components/contract/contracts-table.tsx
@@ -568,7 +568,7 @@ function ContractQuestion(props: {
         )}
         <VisibilityIcon className="mr-1" contract={contract} />
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
         )}
         {removeEmojis(contract.question)}
       </span>

--- a/web/components/contract/editable-question-title.tsx
+++ b/web/components/contract/editable-question-title.tsx
@@ -64,7 +64,7 @@ export const EditableQuestionTitle = (props: {
   ) : (
     <div className="group text-xl font-medium sm:text-2xl">
       {prefix && (
-        <span className="mr-2 inline-flex align-middle">{prefix}</span>
+        <span className="mr-2 inline-flex align-baseline">{prefix}</span>
       )}
       {contract.question}
       {canEdit && (

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -250,7 +250,7 @@ export function FeedContractCard(props: {
             style={{ fontWeight: 500 }}
           >
             <VisibilityIcon contract={contract} />{' '}
-            {isPerp && <PerpMarketBadge className="mr-1 align-middle" />}
+            {isPerp && <PerpMarketBadge contract={contract} className="mr-1 align-middle" />}
             {removeEmojis(contract.question)}
           </Link>
           {contract.outcomeType !== 'MULTIPLE_CHOICE' && (

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -250,7 +250,12 @@ export function FeedContractCard(props: {
             style={{ fontWeight: 500 }}
           >
             <VisibilityIcon contract={contract} />{' '}
-            {isPerp && <PerpMarketBadge contract={contract} className="mr-1 align-middle" />}
+            {isPerp && (
+              <PerpMarketBadge
+                contract={contract}
+                className="mr-1 align-middle"
+              />
+            )}
             {removeEmojis(contract.question)}
           </Link>
           {contract.outcomeType !== 'MULTIPLE_CHOICE' && (

--- a/web/components/contract/feed-contract-card.tsx
+++ b/web/components/contract/feed-contract-card.tsx
@@ -250,12 +250,7 @@ export function FeedContractCard(props: {
             style={{ fontWeight: 500 }}
           >
             <VisibilityIcon contract={contract} />{' '}
-            {isPerp && (
-              <PerpMarketBadge
-                contract={contract}
-                className="mr-1 align-middle"
-              />
-            )}
+            {isPerp && <PerpMarketBadge contract={contract} className="mr-1" />}
             {removeEmojis(contract.question)}
           </Link>
           {contract.outcomeType !== 'MULTIPLE_CHOICE' && (

--- a/web/components/contract/related-contracts-widget.tsx
+++ b/web/components/contract/related-contracts-widget.tsx
@@ -151,7 +151,7 @@ const SidebarRelatedContractCard = memo(function (props: {
         )}
       >
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1" />
         )}
         {question}
       </div>
@@ -230,7 +230,7 @@ const RelatedContractCard = memo(function (props: {
         )}
       >
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1" />
         )}
         {question}
       </div>

--- a/web/components/contract/related-contracts-widget.tsx
+++ b/web/components/contract/related-contracts-widget.tsx
@@ -151,7 +151,7 @@ const SidebarRelatedContractCard = memo(function (props: {
         )}
       >
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
         )}
         {question}
       </div>
@@ -230,7 +230,7 @@ const RelatedContractCard = memo(function (props: {
         )}
       >
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
         )}
         {question}
       </div>

--- a/web/components/dashboard/dashboard-market-card.tsx
+++ b/web/components/dashboard/dashboard-market-card.tsx
@@ -304,7 +304,7 @@ export function DashboardMarketCard({
       {/* Question title */}
       <div className="px-5 pt-3">
         <p className="text-ink-900 line-clamp-2 text-lg font-semibold leading-snug">
-          {perpContract && <PerpMarketBadge className="mr-1 align-middle" />}
+          {perpContract && <PerpMarketBadge contract={perpContract} className="mr-1 align-middle" />}
           {contract.question}
         </p>
       </div>

--- a/web/components/dashboard/dashboard-market-card.tsx
+++ b/web/components/dashboard/dashboard-market-card.tsx
@@ -304,7 +304,12 @@ export function DashboardMarketCard({
       {/* Question title */}
       <div className="px-5 pt-3">
         <p className="text-ink-900 line-clamp-2 text-lg font-semibold leading-snug">
-          {perpContract && <PerpMarketBadge contract={perpContract} className="mr-1 align-middle" />}
+          {perpContract && (
+            <PerpMarketBadge
+              contract={perpContract}
+              className="mr-1 align-middle"
+            />
+          )}
           {contract.question}
         </p>
       </div>

--- a/web/components/dashboard/dashboard-market-card.tsx
+++ b/web/components/dashboard/dashboard-market-card.tsx
@@ -305,10 +305,7 @@ export function DashboardMarketCard({
       <div className="px-5 pt-3">
         <p className="text-ink-900 line-clamp-2 text-lg font-semibold leading-snug">
           {perpContract && (
-            <PerpMarketBadge
-              contract={perpContract}
-              className="mr-1 align-middle"
-            />
+            <PerpMarketBadge contract={perpContract} className="mr-1" />
           )}
           {contract.question}
         </p>

--- a/web/components/dashboard/horizontal-dashboard-card.tsx
+++ b/web/components/dashboard/horizontal-dashboard-card.tsx
@@ -125,7 +125,10 @@ export function HorizontalDashboardCard(props: {
         >
           <VisibilityIcon contract={contract} />{' '}
           {contract.outcomeType === 'PERP' && (
-            <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
+            <PerpMarketBadge
+              contract={contract}
+              className="mr-1 align-middle"
+            />
           )}
           {contract.question}
         </Link>

--- a/web/components/dashboard/horizontal-dashboard-card.tsx
+++ b/web/components/dashboard/horizontal-dashboard-card.tsx
@@ -125,7 +125,7 @@ export function HorizontalDashboardCard(props: {
         >
           <VisibilityIcon contract={contract} />{' '}
           {contract.outcomeType === 'PERP' && (
-            <PerpMarketBadge className="mr-1 align-middle" />
+            <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
           )}
           {contract.question}
         </Link>

--- a/web/components/dashboard/horizontal-dashboard-card.tsx
+++ b/web/components/dashboard/horizontal-dashboard-card.tsx
@@ -125,10 +125,7 @@ export function HorizontalDashboardCard(props: {
         >
           <VisibilityIcon contract={contract} />{' '}
           {contract.outcomeType === 'PERP' && (
-            <PerpMarketBadge
-              contract={contract}
-              className="mr-1 align-middle"
-            />
+            <PerpMarketBadge contract={contract} className="mr-1" />
           )}
           {contract.question}
         </Link>

--- a/web/components/editor/contract-mention/contract-mention-list.tsx
+++ b/web/components/editor/contract-mention/contract-mention-list.tsx
@@ -66,7 +66,7 @@ const MentionList = forwardRef((props: SuggestionProps<Contract>, ref) => {
               key={contract.id}
             >
               <Avatar avatarUrl={contract.creatorAvatarUrl} size="xs" />
-              {isPerp && <PerpMarketBadge />}
+              {isPerp && <PerpMarketBadge contract={contract} />}
               <span className="min-w-0 flex-1 truncate text-left">
                 {contract.question}
               </span>

--- a/web/components/feed/activity-card.tsx
+++ b/web/components/feed/activity-card.tsx
@@ -172,10 +172,7 @@ export const ActivityCard = memo(function ActivityCard(props: {
         >
           <VisibilityIcon contract={contract} />{' '}
           {contract.outcomeType === 'PERP' && (
-            <PerpMarketBadge
-              contract={contract}
-              className="mr-1 align-middle"
-            />
+            <PerpMarketBadge contract={contract} className="mr-1" />
           )}
           {removeEmojis(contract.question)}
         </Link>

--- a/web/components/feed/activity-card.tsx
+++ b/web/components/feed/activity-card.tsx
@@ -172,7 +172,10 @@ export const ActivityCard = memo(function ActivityCard(props: {
         >
           <VisibilityIcon contract={contract} />{' '}
           {contract.outcomeType === 'PERP' && (
-            <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
+            <PerpMarketBadge
+              contract={contract}
+              className="mr-1 align-middle"
+            />
           )}
           {removeEmojis(contract.question)}
         </Link>

--- a/web/components/feed/activity-card.tsx
+++ b/web/components/feed/activity-card.tsx
@@ -172,7 +172,7 @@ export const ActivityCard = memo(function ActivityCard(props: {
         >
           <VisibilityIcon contract={contract} />{' '}
           {contract.outcomeType === 'PERP' && (
-            <PerpMarketBadge className="mr-1 align-middle" />
+            <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
           )}
           {removeEmojis(contract.question)}
         </Link>

--- a/web/components/og/og-market.tsx
+++ b/web/components/og/og-market.tsx
@@ -19,6 +19,7 @@ export function OgMarket(props: OgCardProps) {
     bountyLeft,
     outcomeType,
     perpPrice,
+    perpTicker,
   } = props
   const isPerp = outcomeType === 'PERP'
   const probabilityAsFloat = probability
@@ -105,7 +106,7 @@ export function OgMarket(props: OgCardProps) {
           (isPerp || probability || numericValue || resolution) && (
             <div className="absolute bottom-0 mb-4 mt-8 flex w-full flex-row justify-center self-center text-2xl text-white">
               {isPerp ? (
-                <PerpValue price={perpPrice} />
+                <PerpValue price={perpPrice} ticker={perpTicker} />
               ) : probabilityAsFloat && !resolution ? (
                 <>
                   <div
@@ -140,13 +141,15 @@ export function OgMarket(props: OgCardProps) {
   )
 }
 
-function PerpValue(props: { price?: string }) {
-  const { price } = props
+function PerpValue(props: { price?: string; ticker?: string }) {
+  const { price, ticker } = props
 
   return (
     <div className="flex flex-col items-center justify-center text-black">
       {price && <span className="text-3xl">{price}</span>}
-      <span className={price ? 'text-xl' : 'text-3xl'}>Perpetual market</span>
+      <span className={price ? 'text-xl' : 'text-3xl'}>
+        {ticker ? `${ticker} perpetual market` : 'Perpetual market'}
+      </span>
     </div>
   )
 }

--- a/web/components/perps/perp-market-badge.tsx
+++ b/web/components/perps/perp-market-badge.tsx
@@ -2,21 +2,21 @@ import clsx from 'clsx'
 import { Contract } from 'common/contract'
 import { getPerpTicker } from 'common/perps/ticker'
 
-// Light mode is a soft tinted chip; dark mode mirrors that cleanliness as a
-// solid filled chip (translucent washes read muddy on dark canvases).
-export const PERP_MARKET_BADGE_CLASS =
-  'border-primary-300 bg-primary-100 text-primary-700 dark:border-transparent dark:bg-primary-600 dark:text-white inline-flex h-5 shrink-0 items-center justify-center rounded-md border px-1.5 font-mono text-[11px] font-bold leading-none'
+// The ticker as the /perps hub prints it: bold blue monospace at the size of
+// the text it sits in, no chip. In front of a title it reads as the first
+// word of the line; on the market page it is also the explainer's trigger.
+export const PERP_TICKER_CLASS =
+  'text-primary-600 dark:text-primary-400 font-mono font-bold'
 
-// The chip in front of a perp's title. It shows the market's ticker ("BTC",
-// "TRUMP") — the same handle the /perps hub labels rows with — rather than
-// the word "Perpetual": the type is identical across every one of them, the
-// ticker is what tells them apart. The type survives as the hover title.
+// "Badge" is historical — this is a plain label now — but every list and
+// card that puts a ticker in front of a perp's question goes through here.
+// The market type survives as the hover title.
 export function PerpTickerBadge(props: { ticker: string; className?: string }) {
   const { ticker, className } = props
 
   return (
     <span
-      className={clsx(PERP_MARKET_BADGE_CLASS, className)}
+      className={clsx(PERP_TICKER_CLASS, className)}
       title="Perpetual market"
     >
       {ticker}

--- a/web/components/perps/perp-market-badge.tsx
+++ b/web/components/perps/perp-market-badge.tsx
@@ -1,14 +1,39 @@
 import clsx from 'clsx'
+import { Contract } from 'common/contract'
+import { getPerpTicker } from 'common/perps/ticker'
 
 // Light mode is a soft tinted chip; dark mode mirrors that cleanliness as a
 // solid filled chip (translucent washes read muddy on dark canvases).
 export const PERP_MARKET_BADGE_CLASS =
-  'border-primary-300 bg-primary-100 text-primary-700 dark:border-transparent dark:bg-primary-600 dark:text-white inline-flex h-5 shrink-0 items-center justify-center rounded-md border px-1.5 text-[11px] font-semibold leading-none'
+  'border-primary-300 bg-primary-100 text-primary-700 dark:border-transparent dark:bg-primary-600 dark:text-white inline-flex h-5 shrink-0 items-center justify-center rounded-md border px-1.5 font-mono text-[11px] font-bold leading-none'
 
-export function PerpMarketBadge(props: { className?: string }) {
-  const { className } = props
+// The chip in front of a perp's title. It shows the market's ticker ("BTC",
+// "TRUMP") — the same handle the /perps hub labels rows with — rather than
+// the word "Perpetual": the type is identical across every one of them, the
+// ticker is what tells them apart. The type survives as the hover title.
+export function PerpTickerBadge(props: { ticker: string; className?: string }) {
+  const { ticker, className } = props
 
   return (
-    <span className={clsx(PERP_MARKET_BADGE_CLASS, className)}>Perpetual</span>
+    <span
+      className={clsx(PERP_MARKET_BADGE_CLASS, className)}
+      title="Perpetual market"
+    >
+      {ticker}
+    </span>
+  )
+}
+
+// Renders nothing for a non-perp, so a call site can hand over whatever
+// contract it holds; the `isPerp` guard most of them keep is not load-bearing.
+export function PerpMarketBadge(props: {
+  contract: Contract
+  className?: string
+}) {
+  const { contract, className } = props
+  if (contract.mechanism !== 'perp') return null
+
+  return (
+    <PerpTickerBadge ticker={getPerpTicker(contract)} className={className} />
   )
 }

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -14,7 +14,7 @@ import { useUser } from 'web/hooks/use-user'
 
 import { Col } from '../layout/col'
 import { Modal, MODAL_CLASS, SCROLLABLE_MODAL_CLASS } from '../layout/modal'
-import { PERP_MARKET_BADGE_CLASS } from './perp-market-badge'
+import { PERP_TICKER_CLASS } from './perp-market-badge'
 
 export function PerpMarketExplainer(props: {
   // The explainer quotes THIS market's live settings (fees, leverage cap)
@@ -37,8 +37,9 @@ export function PerpMarketExplainer(props: {
       <button
         type="button"
         className={clsx(
-          PERP_MARKET_BADGE_CLASS,
-          'hover:bg-primary-200 focus-visible:ring-primary-500 dark:hover:bg-primary-900/70 h-7 cursor-pointer gap-1 px-2.5 text-xs transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1',
+          PERP_TICKER_CLASS,
+          // Title-sized like the label everywhere else; the (i) scales with it.
+          'hover:text-primary-500 focus-visible:ring-primary-500 inline-flex cursor-pointer items-center gap-1 rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1',
           className
         )}
         aria-haspopup="dialog"
@@ -47,7 +48,7 @@ export function PerpMarketExplainer(props: {
         onClick={() => setOpen(true)}
       >
         {ticker}
-        <InformationCircleIcon aria-hidden className="h-4 w-4" />
+        <InformationCircleIcon aria-hidden className="h-[0.8em] w-[0.8em]" />
       </button>
       <Modal
         open={open}

--- a/web/components/perps/perp-market-explainer.tsx
+++ b/web/components/perps/perp-market-explainer.tsx
@@ -6,6 +6,7 @@ import {
   formatFeePctApprox,
   perpFeeScheduleSummary,
 } from 'common/perps/format'
+import { getPerpTicker } from 'common/perps/ticker'
 import { formatNumber } from 'common/util/format'
 import Link from 'next/link'
 import { ReactNode, useState } from 'react'
@@ -26,6 +27,10 @@ export function PerpMarketExplainer(props: {
 }) {
   const { contract, className } = props
   const [open, setOpen] = useState(false)
+  // The button reads "[TICKER] (i)": the ticker is the market's handle on
+  // /perps and in search, and the (i) is the invitation to learn what a
+  // perpetual market is. The word itself moved into the label and the modal.
+  const ticker = getPerpTicker(contract)
 
   return (
     <>
@@ -38,10 +43,10 @@ export function PerpMarketExplainer(props: {
         )}
         aria-haspopup="dialog"
         aria-expanded={open}
-        aria-label="What are perpetual markets?"
+        aria-label={`${ticker}: how this perpetual market works`}
         onClick={() => setOpen(true)}
       >
-        Perpetual
+        {ticker}
         <InformationCircleIcon aria-hidden className="h-4 w-4" />
       </button>
       <Modal

--- a/web/components/profile/user-liked-contracts-button.tsx
+++ b/web/components/profile/user-liked-contracts-button.tsx
@@ -1,11 +1,12 @@
 import { XIcon } from '@heroicons/react/outline'
+import { getPerpTicker } from 'common/perps/ticker'
 import { User } from 'common/user'
 import Link from 'next/link'
 import { memo, useEffect, useState } from 'react'
 import { TextButton } from 'web/components/buttons/text-button'
 import { Col } from 'web/components/layout/col'
 import { Modal } from 'web/components/layout/modal'
-import { PerpMarketBadge } from 'web/components/perps/perp-market-badge'
+import { PerpTickerBadge } from 'web/components/perps/perp-market-badge'
 import { Row } from 'web/components/layout/row'
 import { Input } from 'web/components/widgets/input'
 import { withTracking } from 'web/lib/service/analytics'
@@ -78,7 +79,14 @@ export const UserLikedContractsButton = memo(
                       className={'text-primary-700 line-clamp-2 text-sm'}
                     >
                       {contract.outcome_type === 'PERP' && (
-                        <PerpMarketBadge className="mr-1 align-middle" />
+                        <PerpTickerBadge
+                          ticker={getPerpTicker({
+                            ticker: contract.ticker ?? undefined,
+                            oracleFeedId: contract.oracle_feed_id ?? undefined,
+                            slug: contract.slug ?? undefined,
+                          })}
+                          className="mr-1 align-middle"
+                        />
                       )}
                       {contract.question}
                     </Link>

--- a/web/components/profile/user-liked-contracts-button.tsx
+++ b/web/components/profile/user-liked-contracts-button.tsx
@@ -85,7 +85,7 @@ export const UserLikedContractsButton = memo(
                             oracleFeedId: contract.oracle_feed_id ?? undefined,
                             slug: contract.slug ?? undefined,
                           })}
-                          className="mr-1 align-middle"
+                          className="mr-1"
                         />
                       )}
                       {contract.question}

--- a/web/components/simple-contract-row.tsx
+++ b/web/components/simple-contract-row.tsx
@@ -37,7 +37,7 @@ export function SimpleContractRow(props: {
         )}
       >
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1" />
         )}
         {contract.question}
       </div>

--- a/web/components/simple-contract-row.tsx
+++ b/web/components/simple-contract-row.tsx
@@ -37,7 +37,7 @@ export function SimpleContractRow(props: {
         )}
       >
         {contract.outcomeType === 'PERP' && (
-          <PerpMarketBadge className="mr-1 align-middle" />
+          <PerpMarketBadge contract={contract} className="mr-1 align-middle" />
         )}
         {contract.question}
       </div>

--- a/web/components/tv/tv-display.tsx
+++ b/web/components/tv/tv-display.tsx
@@ -106,7 +106,7 @@ export function TVDisplay(props: {
           <Col className="mb-2 p-4 md:pb-8 lg:px-8">
             <Row className="justify-between gap-4">
               <Row className="items-center gap-2 text-xl font-medium sm:text-2xl">
-                {perpContract && <PerpMarketBadge />}
+                {perpContract && <PerpMarketBadge contract={perpContract} />}
                 <Link
                   href={`/${contract.creatorUsername}/${contract.slug}`}
                   target="_blank"

--- a/web/lib/supabase/reactions.ts
+++ b/web/lib/supabase/reactions.ts
@@ -32,14 +32,28 @@ export async function getLikedContracts(userId: string) {
   const contracts = await run(
     db
       .from('contracts')
-      .select('id, question, slug, outcome_type')
+      // The perp badge needs the ticker (and the feed id it falls back on);
+      // pulled as scalar JSON paths rather than loading every liked
+      // contract's full data blob for the sake of a few perps.
+      .select(
+        'id, question, slug, outcome_type, ticker:data->>ticker, oracle_feed_id:data->>oracleFeedId'
+      )
       .in(
         'id',
         reacts.data.map((r) => r.content_id)
       )
   )
 
-  return contracts.data
+  return contracts.data as unknown as LikedContractRow[]
+}
+
+export type LikedContractRow = {
+  id: string
+  question: string | null
+  slug: string | null
+  outcome_type: string | null
+  ticker: string | null
+  oracle_feed_id: string | null
 }
 
 export async function getLikedContractsCount(userId: string) {

--- a/web/pages/admin/create-perp.tsx
+++ b/web/pages/admin/create-perp.tsx
@@ -3,6 +3,11 @@ import { toast } from 'react-hot-toast'
 import { XIcon } from '@heroicons/react/solid'
 import { Group } from 'common/group'
 import { fundingPeriodNoun, fundingPeriodUnit } from 'common/perps/funding'
+import {
+  PERP_TICKER_MAX_LENGTH,
+  derivePerpTicker,
+  isValidPerpTicker,
+} from 'common/perps/ticker'
 import { DAY_MS, HOUR_MS, MINUTE_MS, YEAR_MS } from 'common/util/time'
 import { Button } from 'web/components/buttons/button'
 import { Col } from 'web/components/layout/col'
@@ -24,6 +29,7 @@ export default function AdminCreatePerpPage() {
     question: '',
     description: '',
     oracleFeedId: '',
+    ticker: '',
     maxLeverage: 10,
     // Annualized max funding rate as a percentage (e.g. 50 means 50%/yr).
     maxFundingRateAnnualPct: 50,
@@ -44,6 +50,7 @@ export default function AdminCreatePerpPage() {
       updatePeriodMs: number | null
       marketCreationEnabled: boolean
       description: string | null
+      ticker: string | null
       launchLatencyRisk: string | null
       launchRecommendation: {
         question: string
@@ -110,6 +117,19 @@ export default function AdminCreatePerpPage() {
   const update = <K extends keyof typeof form>(k: K, v: (typeof form)[K]) =>
     setForm((f) => ({ ...f, [k]: v }))
 
+  // The ticker follows the feed: a feed named in PERP_FEED_TICKERS has exactly
+  // one (the API rejects any other), an unnamed one gets a derived default the
+  // admin can edit. Recomputed whenever the feed changes so a label typed for
+  // a previous choice can't be submitted for the new one.
+  useEffect(() => {
+    const feedId = form.oracleFeedId.trim()
+    const canonical = knownFeeds.find((f) => f.id === feedId)?.ticker
+    setForm((f) => ({
+      ...f,
+      ticker: feedId ? canonical ?? derivePerpTicker(feedId) : '',
+    }))
+  }, [form.oracleFeedId, knownFeeds])
+
   const subsidyTotal = form.subsidyLong + form.subsidyShort
 
   // The engine stores maxFundingRate per FUNDING PERIOD, and the period is
@@ -135,6 +155,7 @@ export default function AdminCreatePerpPage() {
     hasCompleteLaunchRecommendation &&
     launchRecommendation?.creatorAuthorized === false
   const feedCreationDisabled = selectedFeed?.marketCreationEnabled === false
+  const canonicalTicker = selectedFeed?.ticker ?? null
   const unregisteredFeed =
     feedCreationDisabled && selectedFeed?.updatePeriodMs == null
   const fundingPeriodMs = selectedFeed?.updatePeriodMs
@@ -213,12 +234,19 @@ export default function AdminCreatePerpPage() {
       )
       return
     }
+    if (!isValidPerpTicker(form.ticker.trim())) {
+      toast.error(
+        `Ticker must be one alphanumeric token of at most ${PERP_TICKER_MAX_LENGTH} characters, starting with a letter.`
+      )
+      return
+    }
     setSubmitting(true)
     try {
       const res = await api('create-perp', {
         question: form.question,
         description: form.description || undefined,
         oracleFeedId: form.oracleFeedId.trim(),
+        ticker: form.ticker.trim(),
         maxLeverage: form.maxLeverage,
         maxFundingRate: maxFundingRatePerPeriod,
         fundingSensitivity: form.fundingSensitivity,
@@ -403,6 +431,27 @@ export default function AdminCreatePerpPage() {
                 )}
               </div>
             )}
+          </div>
+
+          <div>
+            <span className="text-ink-700 mb-2 block text-sm font-medium">
+              Ticker
+            </span>
+            <Input
+              type="text"
+              value={form.ticker}
+              onChange={(e) => update('ticker', e.target.value)}
+              required
+              disabled={canonicalTicker != null}
+              maxLength={PERP_TICKER_MAX_LENGTH}
+              className="w-full max-w-[12rem] font-mono"
+              placeholder="e.g. BTC"
+            />
+            <p className="text-ink-500 mt-1 text-xs">
+              {canonicalTicker != null
+                ? 'Canonical for this feed (PERP_FEED_TICKERS in common/perps/ticker.ts); every market on the feed shows it.'
+                : `Shown in front of the title in place of the market type, used as the label on /perps, and matched by search. One alphanumeric token of at most ${PERP_TICKER_MAX_LENGTH} characters, starting with a letter. To make it canonical for the feed, add it to PERP_FEED_TICKERS.`}
+            </p>
           </div>
 
           <div>

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -565,7 +565,7 @@ function PerpContractSmolView(props: {
         rel="noreferrer"
         className="hover:text-primary-700 mt-1 flex min-w-0 items-start gap-2 text-lg font-semibold leading-tight transition-colors"
       >
-        <PerpMarketBadge className="mt-0.5" />
+        <PerpMarketBadge contract={contract} className="mt-0.5" />
         <span className="line-clamp-2">{contract.question}</span>
       </a>
 

--- a/web/pages/embed/[username]/[contractSlug].tsx
+++ b/web/pages/embed/[username]/[contractSlug].tsx
@@ -565,7 +565,7 @@ function PerpContractSmolView(props: {
         rel="noreferrer"
         className="hover:text-primary-700 mt-1 flex min-w-0 items-start gap-2 text-lg font-semibold leading-tight transition-colors"
       >
-        <PerpMarketBadge contract={contract} className="mt-0.5" />
+        <PerpMarketBadge contract={contract} />
         <span className="line-clamp-2">{contract.question}</span>
       </a>
 

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -25,6 +25,7 @@ import {
 } from 'common/perps/format'
 import { useIsClient } from 'web/hooks/use-is-client'
 import { getPerpTakerFeeBps } from 'common/perps/fees'
+import { getPerpTicker } from 'common/perps/ticker'
 import {
   fundingPeriodNoun,
   fundingPeriodUnit,
@@ -119,30 +120,6 @@ export async function getStaticProps() {
 
 // ---------------------------------------------------------------------------
 // Display helpers
-
-// Tickers, keyed by the stable oracle feed id (same reasoning as
-// ORACLE_TICK_DECORATIONS: never infer a label from a renameable question).
-// Unknown feeds fall back to the feed id's leading segment, so a new perp is
-// merely unglamorous until someone adds a line here, never broken.
-const FEED_TICKERS: Record<string, string> = {
-  'btc-usd': 'BTC',
-  'trump-approval-rating': 'TRUMP',
-  'votehub-generic-ballot-2026': 'BALLOT',
-  'vance-favorability': 'VANCE',
-  'crypto-fear-greed': 'FEAR',
-  'openrouter-open-weight-share': 'OPENW',
-  'openrouter-anthropic-share': 'ANTH',
-  'openrouter-chinese-lab-share': 'CNLAB',
-  'spyx-usd': 'SPYx',
-  'qqqx-usd': 'QQQx',
-  'nvdax-usd': 'NVDAx',
-  'gldx-usd': 'GLDx',
-  'uk-grid-carbon': 'UKCO2',
-}
-
-const tickerOf = (c: PerpContract) =>
-  FEED_TICKERS[c.oracleFeedId ?? ''] ??
-  (c.oracleFeedId ?? c.slug).split('-')[0].toUpperCase().slice(0, 6)
 
 const PERCENT_FEEDS = new Set([
   'trump-approval-rating',
@@ -906,7 +883,7 @@ const YourPositions = (props: {
               className="hover:bg-canvas-50 grid grid-cols-[3.25rem_minmax(0,1fr)_auto] items-center gap-x-2 px-3 py-2 text-left"
             >
               <span className="text-ink-900 truncate font-mono text-sm font-bold">
-                {tickerOf(contract)}
+                {getPerpTicker(contract)}
               </span>
               <Col className="min-w-0 gap-0.5">
                 <Row className="items-center gap-1.5 text-xs">
@@ -1054,7 +1031,7 @@ const RecentActivity = (props: {
                     </span>
                   )}{' '}
                   <span className="text-ink-900 font-mono font-semibold">
-                    {tickerOf(contract)}
+                    {getPerpTicker(contract)}
                   </span>
                   {closing && e.pnl != null && Math.abs(e.pnl) >= 0.5 && (
                     <>
@@ -1128,7 +1105,7 @@ const TopMover = (props: {
         onFocus={() => warmChart(best!.contract)}
         className="hover:bg-canvas-50 -mx-1 flex items-baseline gap-1.5 rounded px-1 text-left font-mono text-lg font-semibold tabular-nums"
       >
-        <span className="text-ink-900">{tickerOf(best.contract)}</span>
+        <span className="text-ink-900">{getPerpTicker(best.contract)}</span>
         <ChangeLabel change={best.change} className="text-lg font-semibold" />
       </button>
     </Col>
@@ -1289,7 +1266,7 @@ const TickerItem = (props: {
       className="hover:bg-canvas-50 inline-flex items-center gap-2 px-4 text-sm"
     >
       <span className="text-ink-900 font-mono font-semibold">
-        {tickerOf(contract)}
+        {getPerpTicker(contract)}
       </span>
       <span
         className={clsx(
@@ -1613,7 +1590,7 @@ const Terminal = (props: {
                   : 'border-ink-200 text-ink-600 hover:bg-canvas-50 dark:border-ink-300'
               )}
             >
-              {tickerOf(c)}
+              {getPerpTicker(c)}
             </button>
           )
         })}
@@ -1623,7 +1600,7 @@ const Terminal = (props: {
         <Col className="min-w-0 gap-1">
           <Row className="items-baseline gap-3">
             <span className="text-primary-600 dark:text-primary-400 font-mono text-xl font-bold">
-              {tickerOf(contract)}
+              {getPerpTicker(contract)}
             </span>
             <span className="text-ink-900 truncate text-lg font-medium">
               {contract.question}
@@ -1955,7 +1932,7 @@ const WatchRow = (props: {
           selected ? 'text-primary-600 dark:text-primary-400' : 'text-ink-900'
         )}
       >
-        {tickerOf(contract)}
+        {getPerpTicker(contract)}
       </span>
       <span
         className={clsx(
@@ -2013,7 +1990,7 @@ const RelatedMarkets = (props: {
           Related
         </span>
         <span className="text-primary-600 dark:text-primary-400 font-mono text-xs font-bold">
-          {tickerOf(perp)}
+          {getPerpTicker(perp)}
         </span>
         <span className="text-ink-500 truncate text-xs">
           {topics.slice(0, 3).map(topicLabel).join(' · ')}
@@ -2520,7 +2497,7 @@ const MarketParameters = (props: { contract: PerpContract }) => {
           This market
         </span>
         <span className="text-primary-600 dark:text-primary-400 font-mono text-xs font-bold">
-          {tickerOf(contract)}
+          {getPerpTicker(contract)}
         </span>
       </Row>
       <Col className="divide-ink-200 dark:divide-ink-300 divide-y">


### PR DESCRIPTION
## Summary
Perp markets get a stored `ticker` (`BTC`, `TRUMP`, `SPYx`). It replaces the "Perpetual" chip in front of a perp's title, is what the `/perps` hub already labels rows with, and search now finds a perp by it.

## Key changes

- **Ticker module** (`common/src/perps/ticker.ts`): `PERP_FEED_TICKERS` is the canonical feed-id → ticker map (moved out of the `/perps` page so the web and backend share it), plus validation (`isValidPerpTicker`), a derived fallback (`derivePerpTicker`), `getPerpTicker()` (stored value → canonical map → fallback) and `isPerpTickerSearchTerm()`.
- **Stored on the contract**: `Perp.ticker` in contract data, exposed on perp `LiteMarket`s. `create-perp` stamps it and refuses another ticker for a feed named in the map; `update-market` accepts `ticker` for admins on perps under the same rule; `get-known-oracle-feeds` returns it so the admin create form can prefill.
- **Search**: a single-token query also runs a cheap `ticker` lookup (`outcome_type = 'PERP' and data->>'ticker' ilike 'term%'`) merged ahead of the lexical tiers, so `btc` or `BT` finds the Bitcoin perp. Multi-word queries skip it.
- **Search pagination** (`shared/helpers/search-pagination.ts`): each tier fetches `offset + limit` rows and the merged, deduplicated list is paged once, so a title match displaced from page one by a ticker hit still appears on page two; under newest-first the page is ordered by `createdTime` before slicing so the `beforeTime` cursor cannot skip newer titles. For that cut to be the page the database would produce, JS must rank rows exactly as SQL does: every sort now ends with a `contracts.id` tiebreak in SQL, multi-expression sorts (`score`, `prob-*`) are mirrored key for key in JS with per-key direction and null placement (`getSearchSort`), and `sortLikeSql` applies that order to both the similar-relevance merge and the page. Regression tests cover the zero-importance case, overlapping tiers, and exact ties.
- **UI**: `PerpTickerBadge` / `PerpMarketBadge` render the ticker as bold blue monospace text at the size of the surrounding text (the same treatment as the `/perps` hub), no chip. On the market page the explainer trigger reads `TICKER (i)` and opens the same explainer. The market info dialog shows `Perpetual · TICKER`; the OG card says `TICKER perpetual market`. Every list, card, mention, embed and TV call site passes its contract.
- **Launch tooling**: the launch manifest requires a canonical ticker for every launch feed; the preflight fails a launch market whose stored ticker is missing or wrong; `backend/scripts/backfill-perp-tickers.ts` (dry-run by default, `--apply` to write) stamps markets created before the field existed. README, runbook and API docs updated.

## After deploy

Run the backfill once. Existing perps already render the right ticker via the map fallback, but search matches only the stored value:

```
yarn ts-node backfill-perp-tickers.ts
yarn ts-node backfill-perp-tickers.ts --apply
```

No database migration; the field lives in the contract's JSON data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JndK9U59cZDe3DWRjkrj8