### PR TITLE
fix(elections): feature the right markets for Montana and Idaho (independent candidates)

### DIFF
--- a/backend/scripts/rename-election-market-answers.ts
+++ b/backend/scripts/rename-election-market-answers.ts
@@ -220,6 +220,28 @@ const SENATE_PARTY_MARKETS: Group[] = [
   },
 ]
 
+/**
+ * Montana is a candidate market, not a party market, so it is listed
+ * separately: the point of tagging its answers is purely so getPartyProbs can
+ * colour the state, NOT to relabel a party line. Seth Bodnar is an
+ * INDEPENDENT — Jon Tester-backed, and the actual competitive alternative to
+ * Alme — so he is tagged (I) and lands in getPartyProbs's "other" bucket
+ * rather than being miscounted as a Democrat.
+ */
+const MONTANA_THREE_WAY: Group = {
+  contractId: 'tydQt5d26u',
+  label: 'MT Senate (three-way)',
+  renames: [
+    { id: 'lPtldCU006', from: 'Kurt Alme', to: 'Kurt Alme (R)' },
+    {
+      id: 'RSCc0lpsNt',
+      from: 'Alani Bankhead',
+      to: 'Alani Bankhead (D)',
+    },
+    { id: 'L5dSc92I5L', from: 'Seth Bodnar', to: 'Seth Bodnar (I)' },
+  ],
+}
+
 const GROUPS: Group[] = [
   {
     contractId: 'sqUzOZN8Cs',
@@ -227,6 +249,7 @@ const GROUPS: Group[] = [
     renames: HOUSE_DISTRICTS,
   },
   ...SENATE_PARTY_MARKETS,
+  MONTANA_THREE_WAY,
 ]
 
 runScript(async ({ pg }) => {

--- a/web/components/us-elections/contracts/party-panel/party-panel.tsx
+++ b/web/components/us-elections/contracts/party-panel/party-panel.tsx
@@ -85,9 +85,18 @@ export function PartyPanel(props: {
   const republicanAnswer = answers.find((a) => isRepublicanAnswer(a.text))
   const democraticAnswer = answers.find((a) => isDemocraticAnswer(a.text))
 
-  // Only when the answers name candidates — on a market still labelled
-  // "Democratic party" the note would state the obvious.
-  const namesCandidates = answers.some((a) => isCandidateLabelledAnswer(a.text))
+  // Two conditions, both required.
+  //
+  // The answers must name candidates — on a market still labelled "Democratic
+  // party" the note would state the obvious. AND the market must actually be a
+  // party market: this panel also renders genuine candidate markets (Montana's
+  // three-way, where Seth Bodnar runs as an independent), and telling a reader
+  // those resolve by party would be flatly wrong. Keying off the question is
+  // crude but fails safe — an unrecognised wording hides a true note rather
+  // than showing a false one.
+  const namesCandidates =
+    answers.some((a) => isCandidateLabelledAnswer(a.text)) &&
+    /which\s+party/i.test(contract.question)
 
   let democratToRepublicanRatio = 0.5
   if (republicanAnswer && democraticAnswer) {

--- a/web/public/data/senate-state-data.ts
+++ b/web/public/data/senate-state-data.ts
@@ -165,7 +165,14 @@ export const senate2026: StateElectionMarket[] = [
   { state: 'MI', slug: 'which-party-will-win-the-2026-michi' },
   { state: 'MN', slug: 'which-party-will-win-the-2026-senat-RLNdnAsdEg' },
   { state: 'MS', slug: 'which-party-will-win-the-2026-missi' },
-  { state: 'MT', slug: 'which-party-will-win-the-2026-monta' },
+  // MT: a three-way race the party markets cannot express. Steve Daines (R)
+  // withdrew minutes before the filing deadline and endorsed Kurt Alme (R);
+  // the Democratic nominee is Alani Bankhead; and the competitive alternative
+  // is Seth Bodnar, running as an INDEPENDENT with Jon Tester's backing. The
+  // party market here is "Republicans 97% / Democrats 3%" with no Other line,
+  // so a Bodnar win would N/A it — and it hides the only interesting contest.
+  // This candidate market carries all three plus Other.
+  { state: 'MT', slug: 'who-will-win-the-2026-montana-senat' },
   // NE: front-runner is independent Dan Osborn, who reads as "other" on the
   // map rather than a party color — known imperfection of reusing this market.
   { state: 'NE', slug: 'which-party-will-win-the-2026-nebra' },
@@ -196,7 +203,6 @@ export const senateCandidates2026: StateElectionMarket[] = [
   { state: 'MN', slug: 'who-will-win-minnesotas-2026-senate' },
   { state: 'OH', slug: 'who-will-win-the-2026-united-states' },
   { state: 'IA', slug: 'who-will-win-the-2026-united-states-u09U0PqQSn' },
-  { state: 'MT', slug: 'who-will-the-2026-montana-senate-el' },
 ]
 
 export interface CurrentSenateState {


### PR DESCRIPTION
Montana is not a two-party race, and both markets the page was using are structurally unable to say so.

Steve Daines (R) withdrew minutes before the filing deadline and endorsed **Kurt Alme (R)**. **Alani Bankhead (D)** is the Democratic nominee, at ~2%. The actual competitive alternative is **Seth Bodnar**, running as an **independent** with Jon Tester's backing, at ~7%.

| market | answers | traders | liquidity |
|---|---|---|---|
| party market *(current map entry)* | `Republicans 97% \| Democrats 3%` | 22 | 200 |
| candidate market *(current "who's running")* | `Kurt Alme 95% \| Seth Bodnar 5%` | 29 | 1,000 |
| **Tetraspace's** | `Kurt Alme 90% \| Seth Bodnar 7% \| Alani Bankhead 2% \| Other 1%` | 11 | **2,000** |

The party market has no `Other` line, so a Bodnar win would N/A it — and it hides the only interesting contest behind a 97/3 party split. The head-to-head omits the Democratic nominee entirely and would also N/A on a surprise. Only the third carries all three candidates plus `Other`.

Points the state at that market and drops the now-redundant candidate-card entry. It has less volume (11 traders / 1.2k vs 22 / 20k) but more liquidity (2,000 vs 200), and correctness beats volume when the alternatives cannot represent the race at all.

### A note that would have become a lie

The "Resolves by party, not by candidate" caveat from #4042 was gated purely on the answers naming candidates — which is also true of a *genuine* candidate market. Left alone, this panel would have told Montana readers that their candidate market settles on party.

It now additionally requires the question to be a "which party" question. Verified against the real questions: fires on all six renamed party markets, hides on `"Who will win the 2026 Montana senate election?"`. Crude, but it fails safe — an unrecognised wording hides a true note rather than showing a false one.

### Bodnar is tagged `(I)`, not `(D)`

The script tags Montana's answers so `getPartyProbs` can colour the state. Bodnar gets `(I)`, which matches neither `DEM_TAG` nor `REP_TAG` and so lands in the "other" bucket rather than being miscounted as a Democrat. Result: rep .90 / dem .02 / other .08.

This is the same failure mode already documented for Nebraska (Dan Osborn) — Montana is now a second instance, and worth remembering as a pattern rather than a one-off.

### ⚠️ Deploy order — opposite of last time

**Run the script for Montana first, then merge this.**

Renaming Tetraspace's answers has no visible effect today, because nothing references that market yet. Merging first would point the map at an untagged candidate market and grey Montana out until the script ran. Doing it in this order there is no gap at all.

`tsc` and `eslint` clean. Not viewed in a browser.
