### PR TITLE
fix(elections): feature the Republican-v-independent Idaho Senate market

### DIFF
--- a/web/public/data/senate-state-data.ts
+++ b/web/public/data/senate-state-data.ts
@@ -154,7 +154,20 @@ export const senate2026: StateElectionMarket[] = [
   // Binary market — YES = Republican wins, which getPartyProbs handles.
   { state: 'FL', slug: 'will-a-republican-win-the-us-senate' },
   { state: 'GA', slug: 'which-party-will-win-the-2026-us-se' },
-  { state: 'ID', slug: 'which-party-will-win-the-2026-idaho' },
+  // ID: another race with no Democrat on the ballot. David Roth won the
+  // Democratic nomination, then withdrew in July once independent former state
+  // rep Todd Achilles entered with Democratic leaders' backing — so it is
+  // Jim Risch (R) v. Achilles (I). The superseded market still lists
+  // "Republicans | Democrats"; this one lists "Republicans | Independent".
+  //
+  // otherParty folds Achilles into the Democratic side for colouring only.
+  // Without it getPartyProbs sees no Democratic answer, hits its
+  // `!hasDem || !hasRep` guard, and greys Idaho out entirely.
+  {
+    state: 'ID',
+    slug: 'which-party-will-win-the-2026-idaho-2PNUOhCEyR',
+    otherParty: 'Democratic Party',
+  },
   { state: 'IL', slug: 'which-party-will-win-the-2026-illin' },
   { state: 'IA', slug: 'which-party-will-win-the-2026-iowa' },
   { state: 'KS', slug: 'which-party-will-win-the-2026-kansa' },


### PR DESCRIPTION
Same shape as the Montana fix in #4047. Split out because that PR had already merged when this was written.

Idaho has **no Democrat on the ballot**. David Roth won the Democratic nomination, then withdrew in July once independent former state rep **Todd Achilles** entered with Democratic leaders' backing. The race is **Jim Risch (R) v. Achilles (I)**.

| market | answers | traders | liquidity | last bet |
|---|---|---|---|---|
| current map entry | `Republicans 95% \| Democrats 5%` | 7 | 200 | 25 Jul |
| **TheDucksFan's replacement** | `Republicans 95% \| Independent 5%` | 11 | **1,200** | today |

Same creator — they superseded their own market once the race changed shape.

### It needs `otherParty`

`getPartyProbs` requires both major parties present (`!hasDem || !hasRep`) so a one-sided market can't fake max certainty. The new market has **no Democratic answer at all**, so pointing at it naively greys Idaho out.

`otherParty: 'Democratic Party'` folds Achilles into the Democratic side for colouring only — precisely the case the field was added for: "a race where the only viable non-major candidate caucuses with one side". Confirmed it's still wired up for 2026: both `senate-state.tsx` and `senate-bar.tsx` pass the `senate2026` entry into `probToColor`.

Verified by replicating the function against the live answers:

```
ID today, no otherParty : GREY (undefined)
ID with otherParty      : dem 0.05 / rep 0.95 / other 0.00
ID after rename to names: dem 0.05 / rep 0.95 / other 0.00
```

That last line matters: it's robust to renaming the answers to `Jim Risch (R)` / `Todd Achilles (I)`, so **there's no deploy-order dependency here** — unlike Montana, this can merge before or after the answers are reformatted.

### Pattern worth noting

Three Democratic-backed independents now: Bodnar (MT), Achilles (ID), and Osborn (NE), already documented in this file. The two-party map assumption keeps failing the same way. `otherParty` handles it but is manual per state — if a fourth appears it may be worth detecting rather than curating.

`tsc` and `eslint` clean. One-line data change plus comment; nothing rendered differently except Idaho's map colour and which market its card opens.
