### PR TITLE
fix(perps): recover hung feed polls and quiet expected trade errors

### DIFF
--- a/backend/scheduler/src/jobs/update-oracle-feeds.ts
+++ b/backend/scheduler/src/jobs/update-oracle-feeds.ts
@@ -14,6 +14,11 @@ import {
 import { log } from 'shared/utils'
 import { applyOraclePointToLivePerps } from 'shared/perps/apply-oracle-point'
 import { FAST_TICK_ORACLE_BOUNDS } from 'shared/perps/oracle-tick-bounds'
+import {
+  createOracleFeedDispatcher,
+  OraclePollAbandonedError,
+  OraclePollProgress,
+} from 'shared/oracle-feed-dispatcher'
 
 // The fast oracle tick (fires every 2s, modeled on sports-live). For each
 // `fast` feed in the registry that is due to be polled:
@@ -32,10 +37,8 @@ import { FAST_TICK_ORACLE_BOUNDS } from 'shared/perps/oracle-tick-bounds'
 // xStocks on the same job that is a live regression of this file's purpose —
 // their adapter waits on an RPC node (1.5s timeout), so one hanging request
 // would push BTC's interval out exactly when the mark is moving. The
-// per-feed
-// in-flight guard below is a strictly finer-grained `protect`: it still
-// prevents a feed from stacking on ITSELF, without coupling feeds to each
-// other.
+// per-feed dispatcher gives each feed one active polling slot. A deadline
+// releases a hung slot; unfinished work stays counted until it settles.
 export async function updateOracleFeeds() {
   const pg = createSupabaseDirectClient()
   const now = Date.now()
@@ -43,87 +46,20 @@ export async function updateOracleFeeds() {
   for (const feed of ORACLE_FEEDS) {
     if (feed.cadence === 'fast') {
       if (isPollDue(feed.id, feed.pollPeriodMs, now))
-        dispatch(feed.id, () => tickOneFeed(pg, feed))
+        dispatcher.dispatch(feed.id, (progress) =>
+          tickOneFeed(pg, feed, progress)
+        )
     } else if (isPollDue(feed.id, DAILY_PROBE_PERIOD_MS, now)) {
-      dispatch(feed.id, () => probeDailyFeedStaleness(pg, feed))
+      dispatcher.dispatch(feed.id, (progress) =>
+        probeDailyFeedStaleness(pg, feed, progress)
+      )
     }
   }
-
-  alertOnStuckFeeds(now)
 }
 
-// Per-feed poll throttle. The cron fires at the rate the FASTEST feed wants
-// (5s, for BTC); every other feed opts down via pollPeriodMs, so raising the
-// tick rate for one source does not raise it for all of them. State is
-// in-memory — a scheduler restart polls everything once immediately, which is
-// the correct bias: fresher marks, and staleness alerting re-arms at once.
-const lastPollAttempt: Record<string, number> = {}
-/** Start time of the run currently in flight, or absent when idle. */
-const inFlightSince: Record<string, number> = {}
-/** Last time a stuck feed was reported, to keep the alert to once a period. */
-const lastStuckAlert: Record<string, number> = {}
-
-// How overdue an in-flight run must be before it is treated as stuck. Every
-// fetch adapter is bounded (AbortSignal.timeout), but the DB work behind
-// runOracleUpdate is not, and an advisory-lock wait or a pool starvation can
-// last far longer than any poll period.
-const STUCK_GRACE_MS = 2 * MINUTE_MS
-const STUCK_ALERT_INTERVAL_MS = 5 * MINUTE_MS
-
-/**
- * Because dispatch skips a feed while its previous run is in flight, a promise
- * that never settles takes that feed permanently dark — silently, since the
- * staleness check lives INSIDE the work that is no longer running. The job
- * itself keeps reporting success either way: `updateOracleFeeds` returns after
- * dispatching, so `scheduler_info.last_end_time` is now a dispatcher heartbeat
- * and says nothing about whether feed work completes. (`perp-launch-preflight`
- * reads that column as a liveness signal; it still correctly means "the job is
- * firing", which is what it checks.) This is the compensating signal.
- *
- * `update-perps` would also catch it hourly for feeds with a live market; this
- * reports in minutes and covers feeds that have no market yet.
- */
-const alertOnStuckFeeds = (now: number) => {
-  for (const feedId of Object.keys(inFlightSince)) {
-    const startedAt = inFlightSince[feedId]
-    if (startedAt == null) continue
-    const age = now - startedAt
-    if (age < STUCK_GRACE_MS) continue
-    if (now - (lastStuckAlert[feedId] ?? 0) < STUCK_ALERT_INTERVAL_MS) continue
-    lastStuckAlert[feedId] = now
-    log.error(
-      `[oracle-feeds] ${feedId}: poll has been in flight for ${Math.round(
-        age / 1000
-      )}s and is blocking its own next run — the feed is effectively dark`
-    )
-  }
-}
-
-/**
- * Start a feed's work without blocking the cron run, at most once at a time.
- *
- * Skipping while in-flight is what replaces croner's `protect` at feed
- * granularity: a source slower than its own poll period falls back to running
- * as often as it can finish, rather than piling up overlapping fetches.
- *
- * The attempt is stamped here, before the work starts, so a source that hangs
- * to its fetch timeout does not earn an immediate retry on the next firing.
- * `tickOneFeed` and `probeDailyFeedStaleness` both catch internally and never
- * reject; the `.catch` is a backstop so a future edit that lets one throw
- * cannot become an unhandled rejection that takes the scheduler down.
- */
-const dispatch = (feedId: string, run: () => Promise<void>) => {
-  if (inFlightSince[feedId] != null) return
-  const startedAt = Date.now()
-  inFlightSince[feedId] = startedAt
-  lastPollAttempt[feedId] = startedAt
-  void run()
-    .catch((err) => log.error(`[oracle-feeds] ${feedId}: unhandled — ${err}`))
-    .finally(() => {
-      delete inFlightSince[feedId]
-      delete lastStuckAlert[feedId]
-    })
-}
+// Each feed recovers its polling slot after a deadline, while abandoned
+// work stays counted against the process-wide limit until it settles.
+const dispatcher = createOracleFeedDispatcher(log)
 
 // The daily feeds' staleness probe is a read-only indexed lookup, but it has
 // no reason to run 12x a minute; it can only alert once an hour anyway.
@@ -159,7 +95,7 @@ const isPollDue = (
   // behavior), so a registry addition can never accidentally go silent.
   if (periodMs == null || !Number.isFinite(periodMs) || periodMs <= 0)
     return true
-  const last = lastPollAttempt[feedId]
+  const last = dispatcher.lastAttemptAt(feedId)
   if (last == null) return true
   // Cap at half the period too, so a period shorter than one tick cannot be
   // swallowed by the tolerance and turn into "poll on every firing".
@@ -214,14 +150,17 @@ const lastStaleAlert: Record<string, number> = {}
 
 const probeDailyFeedStaleness = async (
   pg: SupabaseDirectClient,
-  feed: OracleFeedDef
+  feed: OracleFeedDef,
+  progress: OraclePollProgress
 ) => {
   try {
+    progress.checkpoint('daily:read-latest-point')
     const row = await pg.oneOrNone<{ ts: string }>(
       `select ts from oracle_prices
        where feed_id = $1 order by ts desc limit 1`,
       [feed.id]
     )
+    progress.checkpoint('daily:check-staleness')
     const latestTs = row ? new Date(row.ts).getTime() : null
     const stale = latestTs == null || Date.now() - latestTs > feed.staleAfterMs
     if (!stale) return
@@ -234,12 +173,18 @@ const probeDailyFeedStaleness = async (
       } exceeds staleAfterMs=${feed.staleAfterMs}`
     )
   } catch (err) {
+    if (err instanceof OraclePollAbandonedError) return
     log.error(`[oracle-feeds] ${feed.id}: staleness probe failed — ${err}`)
   }
 }
 
-const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
+const tickOneFeed = async (
+  pg: SupabaseDirectClient,
+  feed: OracleFeedDef,
+  progress: OraclePollProgress
+) => {
   try {
+    progress.checkpoint('read-latest-point')
     const prevRow = await pg.oneOrNone<{ ts: string; price: number | string }>(
       `select ts, price from oracle_prices
        where feed_id = $1 order by ts desc limit 1`,
@@ -257,7 +202,9 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
       // block that finalized after its successor. Row growth is bounded by
       // the source's block cadence, not the tick rate, so shouldWrite's
       // dedupe isn't needed here.
+      progress.checkpoint('fetch-recent')
       const points = await feed.fetchRecent()
+      progress.checkpoint('validate-points')
       const valid: { ts: number; price: number }[] = []
       for (const point of points) {
         const rejection = validateOraclePoint(feed, null, point)
@@ -278,13 +225,16 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
             `[oracle-feeds] ${feed.id}: rejected ambiguous batch — ${normalized.reason}`
           )
         } else {
+          progress.checkpoint('insert-points')
           await insertOraclePrices(pg, feed.id, normalized.points)
           const newest = normalized.points[normalized.points.length - 1]
           if (newest && (!latest || newest.ts > latest.ts)) latest = newest
         }
       }
     } else if (feed.fetchLatest) {
+      progress.checkpoint('fetch-latest')
       const point = await feed.fetchLatest()
+      progress.checkpoint('validate-point')
       if (point) {
         const rejection = validateOraclePoint(feed, prev, point)
         if (rejection) {
@@ -294,12 +244,14 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
             ).toISOString()} — ${rejection}`
           )
         } else if (shouldWrite(feed, prev, point)) {
+          progress.checkpoint('insert-point')
           await insertOraclePrices(pg, feed.id, [point])
           latest = point
         }
       }
     }
 
+    progress.checkpoint('check-feed-health')
     // Feed health. Fast feeds are launch-critical, so silence is an incident
     // even with no live market attached (this is what would have caught the
     // dev feed that froze unnoticed for 19 days).
@@ -331,9 +283,11 @@ const tickOneFeed = async (pg: SupabaseDirectClient, feed: OracleFeedDef) => {
       pg,
       feed.id,
       latestPoint,
-      FAST_TICK_ORACLE_BOUNDS
+      FAST_TICK_ORACLE_BOUNDS,
+      progress
     )
   } catch (err) {
+    if (err instanceof OraclePollAbandonedError) return
     log.error(`[oracle-feeds] ${feed.id}: tick failed — ${err}`)
   }
 }

--- a/backend/shared/src/oracle-feed-dispatcher.test.ts
+++ b/backend/shared/src/oracle-feed-dispatcher.test.ts
@@ -1,0 +1,178 @@
+import {
+  createOracleFeedDispatcher,
+  MAX_ABANDONED_POLLS_PER_FEED,
+  MAX_OUTSTANDING_ORACLE_POLLS,
+  ORACLE_POLL_DEADLINE_MS,
+  OraclePollProgress,
+} from './oracle-feed-dispatcher'
+
+const deferred = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+const flush = async () => {
+  for (let i = 0; i < 12; i++) await Promise.resolve()
+}
+const setup = () => {
+  const log = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  return { ...createOracleFeedDispatcher(log), log }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+afterEach(() => {
+  jest.clearAllTimers()
+  jest.useRealTimers()
+})
+
+it('prevents overlap on one feed while other feeds keep polling', async () => {
+  const dispatcher = setup()
+  const pending = deferred()
+  const sameFeed = jest.fn(async () => undefined)
+  const otherFeed = jest.fn(async () => undefined)
+  expect(dispatcher.dispatch('btc', () => pending.promise)).toBe(true)
+  expect(dispatcher.dispatch('btc', sameFeed)).toBe(false)
+  expect(dispatcher.dispatch('spy', otherFeed)).toBe(true)
+  await flush()
+  expect(otherFeed).toHaveBeenCalledTimes(1)
+  expect(sameFeed).not.toHaveBeenCalled()
+  pending.resolve()
+  await flush()
+  expect(dispatcher.dispatch('btc', sameFeed)).toBe(true)
+  await flush()
+  jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+  expect(dispatcher.log.error).not.toHaveBeenCalled()
+})
+
+it.each(['synchronous', 'asynchronous'])(
+  'releases the slot after a %s failure',
+  async (kind) => {
+    const dispatcher = setup()
+    dispatcher.dispatch('btc', () => {
+      if (kind === 'synchronous') throw new Error('source failed')
+      return Promise.reject(new Error('source failed'))
+    })
+    await flush()
+    expect(dispatcher.log.error).toHaveBeenCalledTimes(1)
+    expect(dispatcher.dispatch('btc', async () => undefined)).toBe(true)
+    await flush()
+    jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+    expect(dispatcher.log.error).toHaveBeenCalledTimes(1)
+  }
+)
+
+it('rearms a hung feed and prevents its late read from starting a write', async () => {
+  const dispatcher = setup()
+  const read = deferred()
+  const replacement = deferred()
+  const write = jest.fn()
+  dispatcher.dispatch('btc', async (progress) => {
+    progress.checkpoint('read-latest-point')
+    await read.promise
+    progress.checkpoint('insert-point')
+    write()
+  })
+  await flush()
+  jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+  expect(dispatcher.log.error).toHaveBeenCalledWith(
+    expect.stringContaining('phase "read-latest-point"')
+  )
+  expect(dispatcher.dispatch('btc', () => replacement.promise)).toBe(true)
+  await flush()
+  read.resolve()
+  await flush()
+  expect(write).not.toHaveBeenCalled()
+  expect(dispatcher.log.error).toHaveBeenCalledTimes(1)
+  // Settling the retired run must not release the replacement's busy flag.
+  expect(dispatcher.dispatch('btc', async () => undefined)).toBe(false)
+  replacement.resolve()
+  await flush()
+  expect(dispatcher.dispatch('btc', async () => undefined)).toBe(true)
+})
+
+it('keeps progress attached to the replacement when retired work resumes', async () => {
+  const dispatcher = setup()
+  const first = deferred()
+  const second = deferred()
+  let oldProgress!: OraclePollProgress
+  dispatcher.dispatch('btc', async (progress) => {
+    oldProgress = progress
+    progress.checkpoint('old-read')
+    await first.promise
+  })
+  await flush()
+  jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+  dispatcher.dispatch('btc', async (progress) => {
+    progress.checkpoint('replacement-read')
+    await second.promise
+  })
+  await flush()
+  oldProgress.setPhase('late-notification')
+  first.resolve()
+  await flush()
+  jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+  expect(dispatcher.log.error).toHaveBeenLastCalledWith(
+    expect.stringContaining('phase "replacement-read"')
+  )
+})
+
+it('stops accumulating unfinished work on a single feed and recovers when it settles', async () => {
+  const dispatcher = setup()
+  const pending = Array.from({ length: MAX_ABANDONED_POLLS_PER_FEED }, deferred)
+  for (const poll of pending) {
+    expect(dispatcher.dispatch('btc', () => poll.promise)).toBe(true)
+    await flush()
+    jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+  }
+  const replacement = jest.fn(async () => undefined)
+  expect(dispatcher.dispatch('btc', replacement)).toBe(false)
+  const errors = dispatcher.log.error.mock.calls.length
+  expect(dispatcher.dispatch('btc', replacement)).toBe(false)
+  expect(dispatcher.log.error).toHaveBeenCalledTimes(errors)
+  expect(dispatcher.dispatch('spy', async () => undefined)).toBe(true)
+  pending[0].resolve()
+  await flush()
+  expect(dispatcher.dispatch('btc', replacement)).toBe(true)
+  await flush()
+  expect(replacement).toHaveBeenCalledTimes(1)
+})
+
+it('reserves an exact process limit before dispatch, including runs not yet timed out', async () => {
+  const dispatcher = setup()
+  const pending = Array.from({ length: MAX_OUTSTANDING_ORACLE_POLLS }, deferred)
+  pending.forEach((poll, i) => {
+    expect(dispatcher.dispatch('feed-' + i, () => poll.promise)).toBe(true)
+  })
+  const extra = jest.fn(async () => undefined)
+  expect(dispatcher.dispatch('extra', extra)).toBe(false)
+  await flush()
+  jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+  // Abandoning frees polling slots, not the underlying resource reservations.
+  expect(dispatcher.dispatch('extra', extra)).toBe(false)
+  expect(extra).not.toHaveBeenCalled()
+  expect(dispatcher.log.error).toHaveBeenLastCalledWith(
+    expect.stringContaining('extra: refusing to poll')
+  )
+  pending[0].resolve()
+  await flush()
+  expect(dispatcher.dispatch('extra', extra)).toBe(true)
+  await flush()
+  expect(extra).toHaveBeenCalledTimes(1)
+})
+
+it('clears the deadline when a slow but bounded poll finishes', async () => {
+  const dispatcher = setup()
+  const pending = deferred()
+  dispatcher.dispatch('btc', () => pending.promise)
+  await flush()
+  jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS - 1)
+  pending.resolve()
+  await flush()
+  jest.advanceTimersByTime(1)
+  expect(dispatcher.log.error).not.toHaveBeenCalled()
+  expect(dispatcher.dispatch('btc', async () => undefined)).toBe(true)
+})

--- a/backend/shared/src/oracle-feed-dispatcher.ts
+++ b/backend/shared/src/oracle-feed-dispatcher.ts
@@ -1,0 +1,132 @@
+// A hung promise must not own a feed's polling slot forever. Retired work
+// remains counted until it really settles: checkpoints stop its next step,
+// but cannot cancel a database statement or a shared source request in flight.
+export const ORACLE_POLL_DEADLINE_MS = 60_000
+export const MAX_ABANDONED_POLLS_PER_FEED = 3
+// Includes BOTH active and abandoned polls, reserved before starting work.
+// The scheduler's DB pool has 40 connections; each poll does sequential work.
+export const MAX_OUTSTANDING_ORACLE_POLLS = 20
+const REFUSAL_LOG_INTERVAL_MS = 5 * 60_000
+
+export class OraclePollAbandonedError extends Error {
+  constructor() {
+    super('Oracle poll was abandoned after its deadline')
+  }
+}
+
+export type OraclePollProgress = {
+  /** Before starting another read/write; throws if this run was abandoned. */
+  checkpoint: (phase: string) => void
+  /** Track completion of an already committed update without cancelling it. */
+  setPhase: (phase: string) => void
+}
+
+type Poll = { phase: string; abandoned: boolean }
+
+export const createOracleFeedDispatcher = (log: {
+  info: (message: string) => void
+  warn: (message: string) => void
+  error: (message: string) => void
+}) => {
+  const active = new Map<string, Poll>()
+  const outstanding = new Set<Poll>()
+  const abandonedByFeed = new Map<string, number>()
+  const lastAttempt = new Map<string, number>()
+  const lastRefusalLog = new Map<
+    string,
+    { at: number; hasAbandoned: boolean }
+  >()
+
+  const dispatch = (
+    feedId: string,
+    run: (progress: OraclePollProgress) => Promise<void>
+  ): boolean => {
+    if (active.has(feedId)) return false
+    const abandoned = abandonedByFeed.get(feedId) ?? 0
+    if (
+      abandoned >= MAX_ABANDONED_POLLS_PER_FEED ||
+      outstanding.size >= MAX_OUTSTANDING_ORACLE_POLLS
+    ) {
+      const now = Date.now()
+      const lastLog = lastRefusalLog.get(feedId)
+      const hasAbandoned = outstanding.size > active.size
+      if (
+        lastLog == null ||
+        now - lastLog.at >= REFUSAL_LOG_INTERVAL_MS ||
+        (hasAbandoned && !lastLog.hasAbandoned)
+      ) {
+        lastRefusalLog.set(feedId, { at: now, hasAbandoned })
+        const message = `[oracle-feeds] ${feedId}: refusing to poll; ${abandoned} abandoned on this feed, ${outstanding.size} outstanding in this process.`
+        if (hasAbandoned)
+          log.error(
+            `${message} Polling resumes when work settles; restart the scheduler if it remains stuck.`
+          )
+        else log.warn(message)
+      }
+      return false
+    }
+
+    const poll: Poll = { phase: 'dispatch', abandoned: false }
+    active.set(feedId, poll)
+    outstanding.add(poll)
+    lastAttempt.set(feedId, Date.now())
+    lastRefusalLog.delete(feedId)
+    // Progress belongs to this run, so a late completion cannot relabel its
+    // replacement. Checkpoints deliberately do not abandon a transaction:
+    // an update already committed must still publish its quote and notify.
+    const progress: OraclePollProgress = {
+      checkpoint: (phase) => {
+        if (poll.abandoned) throw new OraclePollAbandonedError()
+        poll.phase = phase
+      },
+      setPhase: (phase) => {
+        poll.phase = phase
+      },
+    }
+    const timer = setTimeout(() => {
+      poll.abandoned = true
+      active.delete(feedId)
+      abandonedByFeed.set(feedId, (abandonedByFeed.get(feedId) ?? 0) + 1)
+      log.error(
+        `[oracle-feeds] ${feedId}: poll has been in flight for ${
+          ORACLE_POLL_DEADLINE_MS / 1000
+        }s in phase "${
+          poll.phase
+        }"; re-armed the feed, but the unfinished work is still counted (${
+          outstanding.size
+        } outstanding).`
+      )
+    }, ORACLE_POLL_DEADLINE_MS)
+    timer.unref?.()
+
+    // Also catches a callback that throws before returning its promise.
+    void Promise.resolve()
+      .then(() => run(progress))
+      .catch((error: unknown) => {
+        if (!(error instanceof OraclePollAbandonedError))
+          log.error(
+            `[oracle-feeds] ${feedId}: unhandled poll failure: ${error}`
+          )
+      })
+      .finally(() => {
+        clearTimeout(timer)
+        outstanding.delete(poll)
+        if (poll.abandoned) {
+          const remaining = (abandonedByFeed.get(feedId) ?? 1) - 1
+          if (remaining === 0) abandonedByFeed.delete(feedId)
+          else abandonedByFeed.set(feedId, remaining)
+          log.info(
+            `[oracle-feeds] ${feedId}: abandoned poll settled; ${remaining} still outstanding on this feed`
+          )
+        } else {
+          active.delete(feedId)
+        }
+      })
+    return true
+  }
+
+  return {
+    dispatch,
+    lastAttemptAt: (feedId: string) => lastAttempt.get(feedId),
+  }
+}

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -146,7 +146,7 @@ urgently need is a worse failure than any it would prevent.
 
 Partial closes are rate-limited per user (60/hour); full closes are **never**
 rate-limited, for the same reason. The limit exists because the 1% minimum is a
-fraction of the current *remainder*, so repeated 1% closes decay geometrically
+fraction of the current _remainder_, so repeated 1% closes decay geometrically
 rather than terminating: from an M$100 cost basis it takes ~917 of them to
 reach the dust floor, and more on a larger position.
 
@@ -442,6 +442,30 @@ rows exist.** Clear them first (top up the deficit side, let a tick apply, or
 clear the field directly) or roll the scheduler back with it.
 
 ## Oracle feeds
+
+### Recovery from a stuck poll
+
+Each oracle feed owns one polling slot. After 60 seconds, the dispatcher logs
+the step that stalled and releases that slot for the next scheduled attempt.
+The regular scheduler heartbeat only proves dispatch is running; the
+`[oracle-feeds]` deadline log is the signal for an individual hung feed.
+
+An abandoned poll stays counted until its underlying work settles. Checkpoints
+stop it before another read, source fetch, price insert, or contract update.
+An oracle transaction already started finishes atomically, and a committed
+result still publishes its quote and notifications. Existing fetch timeouts
+and the shared Solana request are unchanged.
+
+There can be at most three abandoned polls per feed and twenty outstanding
+polls (active plus abandoned) in the process. At either limit, new attempts are
+refused and logged; late completion releases capacity. If unfinished work
+never settles, the affected feed still needs a scheduler restart. This bounds
+accumulation rather than claiming to cancel a database query already running.
+
+These controls apply to oracle polling and daily feed staleness probes.
+Hourly funding and the source-publishing jobs retain their existing behavior.
+
+### Registry
 
 `backend/shared/src/oracle-feeds.ts` is the registry of known feeds: cadence
 (`fast` | `daily`), sanity bounds, staleness threshold, and the required

--- a/backend/shared/src/perps/apply-oracle-point.test.ts
+++ b/backend/shared/src/perps/apply-oracle-point.test.ts
@@ -1,0 +1,157 @@
+import { PerpContract } from 'common/contract'
+import { notifyPerpOracleResult } from 'shared/notifications/perps'
+import {
+  createOracleFeedDispatcher,
+  ORACLE_POLL_DEADLINE_MS,
+} from 'shared/oracle-feed-dispatcher'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { applyOraclePointToLivePerps } from './apply-oracle-point'
+import { runOracleUpdate } from './engine'
+import { FAST_TICK_ORACLE_BOUNDS } from './oracle-tick-bounds'
+import { publishPerpQuote } from './publish-perp-quote'
+
+jest.mock('shared/notifications/perps', () => ({
+  notifyPerpOracleResult: jest.fn(),
+}))
+jest.mock('./engine', () => ({ runOracleUpdate: jest.fn() }))
+jest.mock('./publish-perp-quote', () => ({ publishPerpQuote: jest.fn() }))
+jest.mock('shared/utils', () => ({
+  log: Object.assign(jest.fn(), {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+const flush = async () => {
+  for (let i = 0; i < 16; i++) await Promise.resolve()
+}
+const point = { ts: 2000, price: 101 }
+const stored = {
+  ts: new Date(point.ts).toISOString(),
+  price: point.price,
+  source_ts: null,
+}
+const result = {
+  liquidated: [],
+  adlAdjusted: [],
+  adlSettled: [],
+  adlFactorLong: 1,
+  adlFactorShort: 1,
+  poolLongBefore: 100,
+  poolLongAfter: 100,
+  poolShortBefore: 100,
+  poolShortAfter: 100,
+}
+const setup = () => {
+  const readPoint = jest.fn(async () => stored)
+  const readContracts = jest.fn(async () =>
+    ['first', 'second'].map((id) => ({
+      data: {
+        id,
+        slug: id,
+        oraclePrice: 100,
+        oraclePriceTime: 1000,
+        maxOraclePriceAgeMs: 120_000,
+      } as PerpContract,
+    }))
+  )
+  const pg = {
+    oneOrNone: readPoint,
+    manyOrNone: readContracts,
+  } as unknown as SupabaseDirectClient
+  const log = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+  const dispatcher = createOracleFeedDispatcher(log)
+  return { pg, readPoint, readContracts, dispatcher, log }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.clearAllMocks()
+  jest.mocked(runOracleUpdate).mockResolvedValue(result)
+  jest.mocked(notifyPerpOracleResult).mockResolvedValue(undefined)
+})
+afterEach(() => {
+  jest.clearAllTimers()
+  jest.useRealTimers()
+})
+
+it('does not start the next database read when an abandoned lookup returns', async () => {
+  const { pg, readPoint, readContracts, dispatcher, log } = setup()
+  const pending = deferred<typeof stored>()
+  readPoint.mockImplementationOnce(() => pending.promise)
+  dispatcher.dispatch('btc', (progress) =>
+    applyOraclePointToLivePerps(
+      pg,
+      'btc',
+      point,
+      FAST_TICK_ORACLE_BOUNDS,
+      progress
+    )
+  )
+  await flush()
+  jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+  pending.resolve(stored)
+  await flush()
+  expect(readContracts).not.toHaveBeenCalled()
+  expect(runOracleUpdate).not.toHaveBeenCalled()
+  expect(log.error).toHaveBeenCalledTimes(1)
+  expect(log.error).toHaveBeenCalledWith(
+    expect.stringContaining('apply:read-stored-point')
+  )
+})
+
+it.each(['transaction', 'notification'])(
+  'finishes a committed result after a slow %s, then stops before the next contract',
+  async (phase) => {
+    const { pg, dispatcher, log } = setup()
+    const pending = deferred<void>()
+    if (phase === 'transaction')
+      jest.mocked(runOracleUpdate).mockImplementationOnce(async () => {
+        await pending.promise
+        return result
+      })
+    else
+      jest
+        .mocked(notifyPerpOracleResult)
+        .mockImplementationOnce(() => pending.promise)
+    dispatcher.dispatch('btc', (progress) =>
+      applyOraclePointToLivePerps(
+        pg,
+        'btc',
+        point,
+        FAST_TICK_ORACLE_BOUNDS,
+        progress
+      )
+    )
+    await flush()
+    jest.advanceTimersByTime(ORACLE_POLL_DEADLINE_MS)
+    pending.resolve()
+    await flush()
+    expect(runOracleUpdate).toHaveBeenCalledTimes(1)
+    expect(publishPerpQuote).toHaveBeenCalledTimes(1)
+    expect(notifyPerpOracleResult).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalledTimes(1)
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        phase === 'transaction'
+          ? 'apply:runOracleUpdate(first)'
+          : 'apply:notify(first)'
+      )
+    )
+  }
+)
+
+it('lets an unbounded publisher finish every contract', async () => {
+  const { pg } = setup()
+  await applyOraclePointToLivePerps(pg, 'btc', point)
+  expect(runOracleUpdate).toHaveBeenCalledTimes(2)
+  expect(notifyPerpOracleResult).toHaveBeenCalledTimes(2)
+})

--- a/backend/shared/src/perps/apply-oracle-point.ts
+++ b/backend/shared/src/perps/apply-oracle-point.ts
@@ -13,6 +13,10 @@ import {
 import { publishPerpQuote } from 'shared/perps/publish-perp-quote'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 import { log } from 'shared/utils'
+import {
+  OraclePollAbandonedError,
+  OraclePollProgress,
+} from 'shared/oracle-feed-dispatcher'
 
 /**
  * How far a contract's executable mark may fall behind the feed before a
@@ -22,9 +26,8 @@ import { log } from 'shared/utils'
  * alert always lands BEFORE the market freezes at that threshold, whatever it
  * is set to. This is the signal nothing else provides: feed staleness reads
  * oracle_prices, which the publisher has already written by the time apply
- * runs, and the stuck-feed detector reads inFlightSince, which is clear
- * because the poll itself completed. Both stay green while a single contract
- * silently stops tracking the price it executes against.
+ * runs, and the poll deadline sees a completed run. Both stay green while a
+ * single contract silently stops tracking the price it executes against.
  */
 const APPLICATION_LAG_ALERT_FRACTION = 0.5
 
@@ -45,7 +48,9 @@ export const applyOraclePointToLivePerps = async (
    * which must wait for the apply rather than abandon it — see
    * OracleUpdateBounds.
    */
-  bounds?: OracleUpdateBounds
+  bounds?: OracleUpdateBounds,
+  /** Fast-poll checkpoints; other publishers finish their complete update. */
+  progress?: OraclePollProgress
 ) => {
   const pointRejection = validateBasicOraclePoint(point)
   if (pointRejection) {
@@ -57,6 +62,7 @@ export const applyOraclePointToLivePerps = async (
   // The database row is the published source of truth. INSERT ... DO NOTHING
   // can lose a same-timestamp race, so never execute against the caller's value
   // until it matches the immutable row that actually won.
+  progress?.checkpoint('apply:read-stored-point')
   const stored = await pg.oneOrNone<{
     ts: string
     price: number | string
@@ -96,6 +102,7 @@ export const applyOraclePointToLivePerps = async (
       }`
     )
 
+  progress?.checkpoint('apply:read-live-contracts')
   const rows = await pg.manyOrNone<{ data: PerpContract }>(
     `select data from contracts
      where mechanism = 'perp'
@@ -104,20 +111,11 @@ export const applyOraclePointToLivePerps = async (
     [feedId]
   )
 
-  // NOTE: the bounds here are per-statement and per-lock, not a deadline for
-  // the whole run. Contracts are applied sequentially, and pool checkout, the
-  // query above, and notifications all sit outside them, so one slow contract
-  // can still hold a feed in-flight past a tick — the in-flight guard then
-  // skips that firing, which is degraded but correct.
-  //
-  // A run-wide budget was tried and removed: it can only bind when a feed
-  // backs more than one market, which none currently do, and skipping
-  // contracts by wall-clock in an unordered result set starves whichever ones
-  // sort last. Doing it properly needs oldest-first ordering (or rotation),
-  // escalation for contracts that keep getting skipped, and a deadline
-  // propagated from dispatch. That belongs with the change that first puts two
-  // markets on one feed, not here.
+  // Statement/lock limits bound each engine transaction. Fast-poll
+  // checkpoints also stop abandoned runs before their next read or contract.
+  // Already-started transactions finish atomically and deliver their results.
   for (const { data: contract } of rows) {
+    progress?.checkpoint(`apply:check-contract(${contract.slug})`)
     const currentPoint =
       contract.oraclePriceTime == null
         ? null
@@ -142,6 +140,7 @@ export const applyOraclePointToLivePerps = async (
     }
 
     try {
+      progress?.checkpoint(`apply:runOracleUpdate(${contract.slug})`)
       const result = await runOracleUpdate(
         contract.id,
         persistedPoint.price,
@@ -150,6 +149,10 @@ export const applyOraclePointToLivePerps = async (
         bounds
       )
       if (!result) continue
+
+      // The update committed. Even if the poll's deadline passed while it
+      // ran, finish its quote/notifications; stop before the next contract.
+      progress?.setPhase(`apply:publishQuote(${contract.slug})`)
 
       if (result.solvencyHalt) {
         // The tick committed its PRICE but not its state, and halted trading.
@@ -191,6 +194,7 @@ export const applyOraclePointToLivePerps = async (
       })
 
       try {
+        progress?.setPhase(`apply:notify(${contract.slug})`)
         await notifyPerpOracleResult(pg, contract, persistedPoint.price, result)
       } catch (err) {
         // The price transition is already committed. Notification delivery
@@ -200,6 +204,7 @@ export const applyOraclePointToLivePerps = async (
         )
       }
     } catch (err) {
+      if (err instanceof OraclePollAbandonedError) throw err
       // One malformed/contended contract must not leave every other market on
       // the same feed trading against a stale cached price.
       const message = `[oracle-feeds] ${contract.slug}: failed to apply ${feedId} @ ${persistedPoint.ts}: ${err}`

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -68,6 +68,7 @@ import { removeUndefinedProps } from 'common/util/object'
 import { randomStringRegex } from 'common/util/random'
 import { UserBan } from 'common/user'
 import { runTxnOutsideBetQueue } from 'shared/txn/run-txn'
+import { isExpectedPerpTradeError } from 'shared/perps/trade-errors'
 import {
   SupabaseDirectClient,
   SupabaseTransaction,
@@ -167,6 +168,15 @@ const runPerpTransaction = <T>(
   maxAttempts = PERP_TX_MAX_ATTEMPTS,
   options?: TransactionRetryOptions
 ): Promise<T> => runTransactionWithRetries(fn, maxAttempts, options)
+
+// A rejected trade is an expected user-visible outcome. Keep scheduled
+// operations and 5xx failures on the default ERROR path.
+const runTradeTransaction = <T>(
+  fn: (pgTrans: SupabaseTransaction) => Promise<T>
+): Promise<T> =>
+  runPerpTransaction(fn, PERP_TX_MAX_ATTEMPTS, {
+    isExpectedError: isExpectedPerpTradeError,
+  })
 
 const buildState = (
   contract: PerpContract,
@@ -529,7 +539,7 @@ export const openOrAddPosition = async (
   if (maxFee !== undefined && (!Number.isFinite(maxFee) || maxFee < 0))
     throw new APIError(400, 'maxFee must be a finite non-negative number')
 
-  return runPerpTransaction(async (pgTrans) => {
+  return runTradeTransaction(async (pgTrans) => {
     if (idempotencyKey) {
       const stored = await getIdempotentEvent(
         pgTrans,
@@ -1215,7 +1225,7 @@ export const closePosition = async (
       'Closing part of a position requires the expected position size'
     )
 
-  return runPerpTransaction(async (pgTrans) => {
+  return runTradeTransaction(async (pgTrans) => {
     if (idempotencyKey) {
       const stored = await getIdempotentEvent(
         pgTrans,

--- a/backend/shared/src/perps/trade-errors.test.ts
+++ b/backend/shared/src/perps/trade-errors.test.ts
@@ -1,0 +1,85 @@
+import { APIError } from 'common/api/utils'
+import { log } from 'shared/monitoring/log'
+import { runTransactionWithRetries } from 'shared/transact-with-retries'
+import { isExpectedPerpTradeError } from './trade-errors'
+
+jest.mock('shared/monitoring/log', () => ({
+  log: Object.assign(jest.fn(), { warn: jest.fn(), error: jest.fn() }),
+}))
+jest.mock('shared/supabase/init', () => ({
+  SERIAL_MODE: {},
+  createSupabaseDirectClient: () => ({
+    tx: (_options: unknown, callback: () => Promise<unknown>) => callback(),
+  }),
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+it('logs a stale-price trade rejection once at WARN and returns the original error', async () => {
+  const error = new APIError(400, 'Oracle feed is stale')
+  const trade = jest.fn(async () => {
+    throw error
+  })
+  await expect(
+    runTransactionWithRetries(trade, 8, {
+      isExpectedError: isExpectedPerpTradeError,
+    })
+  ).rejects.toBe(error)
+  expect(trade).toHaveBeenCalledTimes(1)
+  expect(log.warn).toHaveBeenCalledWith(
+    expect.stringContaining('Oracle feed is stale')
+  )
+  expect(log.error).not.toHaveBeenCalled()
+})
+
+it.each([500, 503] as const)(
+  'keeps a trade failure with status %s at ERROR',
+  async (code) => {
+    const error = new APIError(code, 'Engine cannot complete the trade')
+    await expect(
+      runTransactionWithRetries(
+        async () => {
+          throw error
+        },
+        8,
+        {
+          isExpectedError: isExpectedPerpTradeError,
+        }
+      )
+    ).rejects.toBe(error)
+    expect(log.error).toHaveBeenCalledTimes(1)
+    expect(log.warn).not.toHaveBeenCalled()
+  }
+)
+
+it('does not downgrade a scheduled operation that rejects the same input', async () => {
+  const error = new APIError(400, 'Invalid oracle transition')
+  await expect(
+    runTransactionWithRetries(async () => {
+      throw error
+    }, 8)
+  ).rejects.toBe(error)
+  expect(log.error).toHaveBeenCalledTimes(1)
+  expect(log.warn).not.toHaveBeenCalled()
+})
+
+it('does not mistake an unrelated error carrying a numeric code for a trade rejection', async () => {
+  const error = Object.assign(new Error('Unexpected library failure'), {
+    code: 400,
+  })
+  await expect(
+    runTransactionWithRetries(
+      async () => {
+        throw error
+      },
+      8,
+      {
+        isExpectedError: isExpectedPerpTradeError,
+      }
+    )
+  ).rejects.toBe(error)
+  expect(log.error).toHaveBeenCalledTimes(1)
+  expect(log.warn).not.toHaveBeenCalled()
+})

--- a/backend/shared/src/perps/trade-errors.ts
+++ b/backend/shared/src/perps/trade-errors.ts
@@ -1,0 +1,6 @@
+import { APIError } from 'common/api/utils'
+
+// Used only by user-initiated trades. The same 4xx from a scheduled oracle,
+// funding or resolution operation is unexpected and must remain an error.
+export const isExpectedPerpTradeError = (error: unknown) =>
+  error instanceof APIError && error.code >= 400 && error.code < 500


### PR DESCRIPTION
A feed fetch or database promise that never settles currently keeps that feed's polling slot occupied indefinitely, even while sibling feeds and the scheduler heartbeat look healthy. This releases the slot after 60 seconds and reports the exact step that stalled, allowing the next scheduled poll to try again.

Expected 4xx rejections from opening/closing a perp are also logged at WARN. User responses and retry rules are unchanged; 5xx failures and errors from scheduled operations remain ERROR.

### Recovery and limits

- Reserve capacity before dispatch: at most **20 outstanding polls across the process**, including active and abandoned work, and **3 abandoned polls per feed**.
- Keep abandoned work counted until its underlying promise actually settles. A late completion cannot clear or relabel the replacement's polling slot.
- Checkpoints stop retired polls before their next read, fetch, price insertion, or contract update.
- A transaction already started finishes atomically; a committed update still publishes its quote and delivers notifications.
- Source adapters retain their existing timeouts and shared Solana request. The deadline does **not** cancel in-flight database queries. If enough operations remain stuck indefinitely, polling is refused and logged until work settles or the scheduler is restarted.

Supersedes #4017 on current main. This carries forward recovery/diagnostics and expected-rejection logging; existing solvency handling, conversion-score improvements, lock budgets, and alert thresholds are preserved.

### Validation

- Common: **48 suites / 1,014 tests passed**.
- Shared: **14 suites / 106 tests passed**, including **17 new regression cases** covering never-settling and late-settling work, exact resource limits, retained notifications, and log severity.
- `tsc -b backend/api backend/scheduler --force` passed.
- ESLint on changed shared TypeScript files, Prettier on all changed files, and `git diff --check` passed.

### Automated checks

[GitHub CI passed](https://github.com/manifoldmarkets/manifold/actions/runs/34193606404): build, all typechecks, lint, formatting, and tests.

The [Vercel dev-project preview](https://vercel.com/mantic/dev/F553P5M7TVba2b1dh76vbnDkyUGY) compiled successfully, then failed prerendering the unchanged `/admin/reports` page: `.reports[0].reporter.entitlements[0].expiresTime` is `undefined` and cannot be serialized by `getStaticProps`. This PR changes no web files; that preview failure is outside this perp change.

### Deploy

No migration. Deploy API first, fully rolled out, then `scheduler-perps` from the same SHA. No production deployment performed by this PR.
