### PR TITLE
docs(guidelines): add a duplicate markets policy

### DIFF
--- a/web/components/guidelines-search.tsx
+++ b/web/components/guidelines-search.tsx
@@ -160,7 +160,7 @@ export const GUIDELINES_SEARCH_INDEX: SearchEntry[] = [
   {
     page: 'Market Policies',
     section: 'Duplicate markets',
-    text: 'duplicate duplicates same question already exists splitting liquidity pool thinner arbitrage bots unranked deboosted delisted resolved n/a no trading importance score fine market creation ban similar markets shown at creation title match differing resolution criteria timeframe source bulk farming league points bonuses',
+    text: 'duplicate duplicates same question already exists splitting liquidity pool thinner arbitrage bots unranked deboosted delisted resolved n/a no trading importance score fine market creation ban similar markets shown at creation title match differing resolution criteria timeframe source creator reliability biased unreliable unresponsive judgement call ambiguous impartial bulk farming league points bonuses',
     href: '/community-guidelines/market-policies#duplicate-markets',
   },
   {
@@ -178,13 +178,13 @@ export const GUIDELINES_SEARCH_INDEX: SearchEntry[] = [
   {
     page: 'Running a Market',
     section: 'Check for an existing market first',
-    text: 'duplicate existing market check before creating similar markets shown create page splits liquidity arbitrage bots bet on existing add liquidity unranked deboosted delisted resolved n/a no trading fine market creation ban',
+    text: 'duplicate existing market check before creating similar markets shown create page splits liquidity arbitrage bots bet on existing add liquidity unranked deboosted delisted resolved n/a no trading fine market creation ban creator reliability biased unresponsive ambiguous',
     href: '/community-guidelines/running-a-market#check-for-an-existing-market',
   },
   {
     page: 'Moderation Guidelines',
     section: 'Handling duplicate markets',
-    text: 'duplicate markets mod playbook what counts unrank rather than unlist traders already bet repeat offender mod alert fine bulk farming spam market control ban newer market better link both',
+    text: 'duplicate markets mod playbook what counts unrank rather than unlist traders already bet creator reliability biased unresponsive ambiguous judgement call sore loser price repeat offender mod alert fine bulk farming spam market control ban newer market better link both',
     href: '/community-guidelines/moderation-guidelines-internal#handling-duplicate-markets',
   },
   {

--- a/web/components/guidelines-search.tsx
+++ b/web/components/guidelines-search.tsx
@@ -160,7 +160,7 @@ export const GUIDELINES_SEARCH_INDEX: SearchEntry[] = [
   {
     page: 'Market Policies',
     section: 'Duplicate markets',
-    text: 'duplicate duplicates same question already exists splitting liquidity pool thinner arbitrage bots unranked deboosted delisted resolved n/a no trading importance score fine market creation ban similar markets shown at creation title match differing resolution criteria timeframe source creator reliability biased unreliable unresponsive judgement call ambiguous impartial bulk farming league points bonuses',
+    text: 'duplicate duplicates same question already exists splitting liquidity pool thinner arbitrage bots unranked deboosted delisted resolved n/a no trading importance score fine market creation ban similar markets shown at creation title match differing resolution criteria timeframe source creator reliability biased unreliable unresponsive judgement call ambiguous impartial mass creation at scale one line explanation new market instead of updating criteria not a duplicate league points bonuses',
     href: '/community-guidelines/market-policies#duplicate-markets',
   },
   {

--- a/web/components/guidelines-search.tsx
+++ b/web/components/guidelines-search.tsx
@@ -159,9 +159,9 @@ export const GUIDELINES_SEARCH_INDEX: SearchEntry[] = [
   },
   {
     page: 'Market Policies',
-    section: 'Subsidized',
-    text: 'subsidized mana unique trader 50 traders cap 10000 liquidity subsidy house unsubsidized unlisted self-referential random gambling spam low quality duplicate',
-    href: '/community-guidelines/market-policies#subsidized',
+    section: 'Duplicate markets',
+    text: 'duplicate duplicates same question already exists splitting liquidity pool thinner arbitrage bots unranked deboosted delisted resolved n/a no trading importance score fine market creation ban similar markets shown at creation title match differing resolution criteria timeframe source bulk farming league points bonuses',
+    href: '/community-guidelines/market-policies#duplicate-markets',
   },
   {
     page: 'Market Policies',
@@ -174,6 +174,18 @@ export const GUIDELINES_SEARCH_INDEX: SearchEntry[] = [
     section: 'A note on third-party platforms',
     text: 'metaculus tournament questions community prediction hidden terms of service external forecasting topics twitter data breach',
     href: '/community-guidelines/market-policies#third-party-platforms',
+  },
+  {
+    page: 'Running a Market',
+    section: 'Check for an existing market first',
+    text: 'duplicate existing market check before creating similar markets shown create page splits liquidity arbitrage bots bet on existing add liquidity unranked deboosted delisted resolved n/a no trading fine market creation ban',
+    href: '/community-guidelines/running-a-market#check-for-an-existing-market',
+  },
+  {
+    page: 'Moderation Guidelines',
+    section: 'Handling duplicate markets',
+    text: 'duplicate markets mod playbook what counts unrank rather than unlist traders already bet repeat offender mod alert fine bulk farming spam market control ban newer market better link both',
+    href: '/community-guidelines/moderation-guidelines-internal#handling-duplicate-markets',
   },
   {
     page: 'Market Policies',

--- a/web/pages/community-guidelines/market-policies.tsx
+++ b/web/pages/community-guidelines/market-policies.tsx
@@ -95,6 +95,17 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
             </li>
             <li>It isn't predicting anything</li>
             <li>It can never be resolved or could only ever resolve one way</li>
+            <li>
+              It's a{' '}
+              <a
+                href="#duplicate-markets"
+                className="text-primary-500 underline"
+              >
+                duplicate
+              </a>{' '}
+              of an existing market with no meaningful difference in resolution
+              criteria
+            </li>
           </ul>
           <p className="text-ink-600 mt-3 text-sm">
             If you're not sure why your market is unranked, ask in{' '}
@@ -144,6 +155,15 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
             </li>
             <li>Low-quality non-predictive markets</li>
             <li>
+              Duplicate markets created repeatedly or in bulk — see{' '}
+              <a
+                href="#duplicate-markets"
+                className="text-primary-500 underline"
+              >
+                Duplicate markets
+              </a>
+            </li>
+            <li>
               Markets designed to harvest or redistribute Manifold bonuses
             </li>
             <li>
@@ -176,6 +196,66 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
               service
             </li>
           </ul>
+        </div>
+
+        <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
+          <h2
+            id="duplicate-markets"
+            className="text-ink-1000 text-xl font-semibold"
+          >
+            Duplicate markets
+          </h2>
+          <p className="text-ink-700 mt-3">
+            Only create a market that already exists if there's a real reason to
+            — most often materially different resolution criteria, a different
+            timeframe, or a different resolution source. Otherwise you're
+            splitting the liquidity across two markets, which makes both of them
+            thinner, worse priced, and easier for bots to pick off. It's better
+            for arbitrage bots and worse for everyone else.
+          </p>
+          <p className="text-ink-700 mt-3">
+            When you type a title on the create page, Manifold automatically
+            searches for similar open markets and lists them right there. If
+            near-identical markets are shown to you before you hit create, "I
+            didn't know it existed" isn't much of a defense — check the existing
+            one first, and bet on it or add liquidity to it instead.
+          </p>
+          <p className="text-ink-700 mt-3">
+            If you do have a good reason, say so in the description. A one-line
+            note explaining how yours differs from the existing market is
+            usually enough to make it clear this was deliberate.
+          </p>
+          <p className="text-ink-700 mt-3">What happens to duplicates:</p>
+          <ul className="text-ink-700 mt-2 list-disc space-y-2 pl-5">
+            <li>
+              A duplicate with no meaningful difference from an existing market
+              may be unranked, so it no longer counts toward{' '}
+              <Link
+                href="/community-guidelines/leagues"
+                className="text-primary-500 underline"
+              >
+                Leagues
+              </Link>
+              , and significantly deboosted so it stops surfacing in browse and
+              feeds. If no real trading has occurred on it yet, it may instead
+              be delisted outright or resolved N/A.
+            </li>
+            <li>
+              Creating duplicates repeatedly, or after being warned, may result
+              in a fine.
+            </li>
+            <li>
+              Creating them in bulk, or to farm bonuses, league points, or
+              engagement, may result in the markets being unlisted or deleted
+              and a market creation ban.
+            </li>
+          </ul>
+          <p className="text-ink-600 mt-3 text-sm">
+            Duplicating your own market to reset it or to escape an inconvenient
+            position is treated the same way. If your market needs new criteria,
+            update the description and comment on it rather than starting a
+            second one.
+          </p>
         </div>
 
         <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">

--- a/web/pages/community-guidelines/market-policies.tsx
+++ b/web/pages/community-guidelines/market-policies.tsx
@@ -155,7 +155,7 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
             </li>
             <li>Low-quality non-predictive markets</li>
             <li>
-              Duplicate markets created repeatedly or in bulk — see{' '}
+              Duplicate markets, especially created repeatedly or at scale — see{' '}
               <a
                 href="#duplicate-markets"
                 className="text-primary-500 underline"
@@ -206,45 +206,36 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
             Duplicate markets
           </h2>
           <p className="text-ink-700 mt-3">
-            Only create a market that already exists if there's a real reason to
-            — most often materially different resolution criteria, a different
-            timeframe, a different resolution source, or a well-founded concern
-            about who's resolving the original. Otherwise you're splitting the
-            liquidity across two markets, which makes both of them thinner,
-            worse priced, and easier for bots to pick off. It's better for
-            arbitrage bots and worse for everyone else.
+            Duplicate markets split the liquidity across two markets, making
+            both of them thinner, worse priced, and easier for bots to pick off.
+            It's better for arbitrage bots and worse for everyone else.
           </p>
           <p className="text-ink-700 mt-3">
-            When you type a title on the create page, Manifold automatically
-            searches for similar open markets and lists them right there. If
-            near-identical markets are shown to you before you hit create, "I
-            didn't know it existed" isn't much of a defense — check the existing
-            one first, and bet on it or add liquidity to it instead.
+            Only create a market that already exists if there's a real reason
+            to. Reasons include:
           </p>
-          <p className="text-ink-700 mt-3">
-            Who is resolving can itself be a legitimate reason. Where a market
-            leaves real room for interpretation — insufficient criteria, or an
-            outcome that comes down to a judgement call — a creator who holds a
-            position, has a track record of resolving their own markets in their
-            favour, or is unresponsive is a genuine risk to traders, and a
-            better-specified version run by someone impartial is worth having.
-            Try to fix the original first: ask the creator to tighten the
-            criteria, or tag @mods. If that goes nowhere, write your version
-            with criteria specific enough that the resolution isn't a judgement
-            call, and say plainly in the description that it exists to remove
-            the ambiguity.
+          <ul className="text-ink-700 mt-2 list-disc space-y-2 pl-5">
+            <li>Materially different resolution criteria</li>
+            <li>A different timeframe</li>
+            <li>A different resolution source</li>
+            <li>A well-founded concern about who's resolving the original</li>
+          </ul>
+          <p className="text-ink-700 mt-4">
+            Who is resolving can itself be a legitimate reason. If a market
+            leaves real room for interpretation:
           </p>
-          <p className="text-ink-700 mt-3">
-            This isn't a licence to re-run any market you disagree with. A
-            creator resolving a clear-cut market against your position isn't
-            unreliable — they're right. Duplicating an unambiguous market
-            because you don't like where it's heading is treated as a plain
-            duplicate.
-          </p>
-          <p className="text-ink-700 mt-3">
-            If you do have a good reason, say so in the description. A one-line
-            note explaining how yours differs from the existing market is
-            usually enough to make it clear this was deliberate.
+          <ul className="text-ink-700 mt-2 list-disc space-y-2 pl-5">
+            <li>Insufficient criteria</li>
+            <li>A judgement call</li>
+            <li>A creator holding a position</li>
+            <li>A creator has a track record of resolutions in their favour</li>
+            <li>A creator is unresponsive</li>
+          </ul>
+          <p className="text-ink-700 mt-4">
+            This policy is primarily to discourage the mass creation of
+            duplicate markets. A one line explanation in the description is
+            usually sufficient to show that the duplicate was deliberate and had
+            a reason behind it.
           </p>
           <p className="text-ink-700 mt-3">What happens to duplicates:</p>
           <ul className="text-ink-700 mt-2 list-disc space-y-2 pl-5">
@@ -257,25 +248,19 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
               >
                 Leagues
               </Link>
-              , and significantly deboosted so it stops surfacing in browse and
-              feeds. If no real trading has occurred on it yet, it may instead
-              be delisted outright or resolved N/A.
+              , significantly deboosted so that it stops surfacing in browse or
+              feeds, unlisted, or resolved N/A.
             </li>
             <li>
               Creating duplicates repeatedly, or after being warned, may result
-              in a fine.
-            </li>
-            <li>
-              Creating them in bulk, or to farm bonuses, league points, or
-              engagement, may result in the markets being unlisted or deleted
-              and a market creation ban.
+              in a fine or a market creation ban.
             </li>
           </ul>
-          <p className="text-ink-600 mt-3 text-sm">
-            Duplicating your own market to reset it or to escape an inconvenient
-            position is treated the same way. If your market needs new criteria,
-            update the description and comment on it rather than starting a
-            second one.
+          <p className="text-ink-700 mt-4">
+            If you feel that your own market no longer reflects the original
+            intention, we actually encourage you to create a new market instead
+            of materially updating the criteria on the original. This is not a
+            duplicate.
           </p>
         </div>
 

--- a/web/pages/community-guidelines/market-policies.tsx
+++ b/web/pages/community-guidelines/market-policies.tsx
@@ -208,10 +208,11 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
           <p className="text-ink-700 mt-3">
             Only create a market that already exists if there's a real reason to
             — most often materially different resolution criteria, a different
-            timeframe, or a different resolution source. Otherwise you're
-            splitting the liquidity across two markets, which makes both of them
-            thinner, worse priced, and easier for bots to pick off. It's better
-            for arbitrage bots and worse for everyone else.
+            timeframe, a different resolution source, or a well-founded concern
+            about who's resolving the original. Otherwise you're splitting the
+            liquidity across two markets, which makes both of them thinner,
+            worse priced, and easier for bots to pick off. It's better for
+            arbitrage bots and worse for everyone else.
           </p>
           <p className="text-ink-700 mt-3">
             When you type a title on the create page, Manifold automatically
@@ -219,6 +220,26 @@ export default function CommunityGuidelinesMarketPoliciesPage() {
             near-identical markets are shown to you before you hit create, "I
             didn't know it existed" isn't much of a defense — check the existing
             one first, and bet on it or add liquidity to it instead.
+          </p>
+          <p className="text-ink-700 mt-3">
+            Who is resolving can itself be a legitimate reason. Where a market
+            leaves real room for interpretation — insufficient criteria, or an
+            outcome that comes down to a judgement call — a creator who holds a
+            position, has a track record of resolving their own markets in their
+            favour, or is unresponsive is a genuine risk to traders, and a
+            better-specified version run by someone impartial is worth having.
+            Try to fix the original first: ask the creator to tighten the
+            criteria, or tag @mods. If that goes nowhere, write your version
+            with criteria specific enough that the resolution isn't a judgement
+            call, and say plainly in the description that it exists to remove
+            the ambiguity.
+          </p>
+          <p className="text-ink-700 mt-3">
+            This isn't a licence to re-run any market you disagree with. A
+            creator resolving a clear-cut market against your position isn't
+            unreliable — they're right. Duplicating an unambiguous market
+            because you don't like where it's heading is treated as a plain
+            duplicate.
           </p>
           <p className="text-ink-700 mt-3">
             If you do have a good reason, say so in the description. A one-line

--- a/web/pages/community-guidelines/moderation-guidelines-internal.tsx
+++ b/web/pages/community-guidelines/moderation-guidelines-internal.tsx
@@ -392,6 +392,27 @@ export default function ModerationGuidelinesInternalPage() {
             </li>
           </ul>
           <p className="text-ink-700 mt-3">
+            Creator reliability is a legitimate reason to duplicate, and worth
+            checking before you unrank anything. Where the original leaves real
+            room for interpretation — thin criteria, or a judgement call at
+            resolution — and the creator holds a position, has previously
+            resolved their own ambiguous markets in their favour, or has gone
+            unresponsive, a tighter version run by someone impartial is a
+            reasonable thing for a trader to build. Leave it ranked, and treat
+            the original as the market with the problem: it's usually a
+            candidate for a takeover or criteria clarification rather than the
+            new one being a candidate for unranking.
+          </p>
+          <p className="text-ink-700 mt-3">
+            Hold that reason to a real standard, though — "I don't trust the
+            creator" is the natural cover story for someone who just doesn't
+            like the price. Ask whether the original is genuinely ambiguous, and
+            whether they tried to fix it first by asking the creator or tagging
+            @mods. If the original resolves cleanly on its stated criteria and
+            the complaint is really about the direction it's moving, it's a
+            plain duplicate.
+          </p>
+          <p className="text-ink-700 mt-3">
             Don't act on duplicates where the newer market is clearly the better
             one — better criteria, better sourced, more traders — just because
             it came second. In that case leave both ranked and comment linking

--- a/web/pages/community-guidelines/moderation-guidelines-internal.tsx
+++ b/web/pages/community-guidelines/moderation-guidelines-internal.tsx
@@ -413,6 +413,13 @@ export default function ModerationGuidelinesInternalPage() {
             plain duplicate.
           </p>
           <p className="text-ink-700 mt-3">
+            A creator remaking their own market because the original no longer
+            reflects what they meant to ask is not a duplicate — that's the
+            behaviour we ask for over materially rewriting criteria traders have
+            already bet on. Check the old market gets closed out or N/A'd rather
+            than left running alongside the new one.
+          </p>
+          <p className="text-ink-700 mt-3">
             Don't act on duplicates where the newer market is clearly the better
             one — better criteria, better sourced, more traders — just because
             it came second. In that case leave both ranked and comment linking

--- a/web/pages/community-guidelines/moderation-guidelines-internal.tsx
+++ b/web/pages/community-guidelines/moderation-guidelines-internal.tsx
@@ -347,6 +347,66 @@ export default function ModerationGuidelinesInternalPage() {
 
         <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
           <h2
+            id="handling-duplicate-markets"
+            className="text-ink-1000 text-xl font-semibold"
+          >
+            Handling duplicate markets
+          </h2>
+          <p className="text-ink-700 mt-3">
+            Treat a market as a duplicate when an existing open market asks
+            substantially the same question and there's no meaningful difference
+            in resolution criteria, timeframe, or resolution source. A different
+            wording of the same question is still a duplicate. A genuinely
+            different bar — a different date, threshold, or source — is not.
+          </p>
+          <p className="text-ink-700 mt-3">
+            Duplicates aren't a moral failing, they're a liquidity problem: two
+            markets on one question are both thinner and easier for arbitrage
+            bots to farm. Default to fixing the market state rather than
+            punishing the creator.
+          </p>
+          <p className="text-ink-700 mt-3">Which lever to pull:</p>
+          <ul className="text-ink-700 mt-2 list-disc space-y-2 pl-5">
+            <li>
+              <span className="font-medium">First instance, good faith:</span>{' '}
+              comment linking the original, and unrank the duplicate. Point the
+              creator at the older market. If no real trading has occurred on it
+              yet, ask them to N/A it themselves — if they don't, delist it or
+              resolve it N/A directly, since nobody's position is affected.
+            </li>
+            <li>
+              <span className="font-medium">Duplicate with traders:</span>{' '}
+              unrank rather than unlist — unlisting strands people who've
+              already bet. Link the two markets in comments on both.
+            </li>
+            <li>
+              <span className="font-medium">Repeat offender:</span> mod alert
+              citing the previous instance, then a fine. Loop in the community
+              manager once you're issuing fines for a pattern.
+            </li>
+            <li>
+              <span className="font-medium">Bulk or farming:</span> duplicates
+              created in volume, or aimed at league points, bonuses, or
+              engagement, are spam — unlist or delete, and apply a market
+              control ban. Escalate as with any other market abuse.
+            </li>
+          </ul>
+          <p className="text-ink-700 mt-3">
+            Don't act on duplicates where the newer market is clearly the better
+            one — better criteria, better sourced, more traders — just because
+            it came second. In that case leave both ranked and comment linking
+            them, or ask the original creator whether they want to N/A theirs.
+          </p>
+          <p className="text-ink-600 mt-3 text-sm">
+            The create page already surfaces similar open markets as a creator
+            types their title, so a near-identical title is usually careless
+            rather than unlucky. Worth saying in the alert — it's the reason "I
+            didn't know" doesn't hold up.
+          </p>
+        </div>
+
+        <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
+          <h2
             id="when-to-escalate"
             className="text-ink-1000 text-xl font-semibold"
           >

--- a/web/pages/community-guidelines/running-a-market.tsx
+++ b/web/pages/community-guidelines/running-a-market.tsx
@@ -66,6 +66,43 @@ export default function CommunityGuidelinesRunningAMarketPage() {
 
         <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
           <h2
+            id="check-for-an-existing-market"
+            className="text-ink-1000 text-xl font-semibold"
+          >
+            Check for an existing market first
+          </h2>
+          <p className="text-ink-700 mt-3">
+            Before you create, look at whether someone has already asked the
+            same question. As you type a title, Manifold searches for similar
+            open markets and shows them to you on the create page — read that
+            list rather than clicking past it.
+          </p>
+          <p className="text-ink-700 mt-3">
+            Only make a second market if there's an actual reason to: different
+            resolution criteria, timeframe, or source. Duplicating a question
+            that already exists just splits the liquidity across both markets,
+            which makes them worse priced for humans and better for arbitrage
+            bots. If you want the question to be bigger, bet on the existing
+            market or add liquidity to it — that's the version of this that
+            actually helps.
+          </p>
+          <p className="text-ink-700 mt-3">
+            Duplicates with no meaningful difference may be unranked and
+            significantly deboosted — or outright delisted or resolved N/A if no
+            real trading has occurred — and creating them repeatedly or in bulk
+            can result in a fine or a market creation ban. See{' '}
+            <Link
+              href="/community-guidelines/market-policies#duplicate-markets"
+              className="text-primary-500 underline"
+            >
+              Duplicate markets
+            </Link>
+            .
+          </p>
+        </div>
+
+        <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">
+          <h2
             id="trade-in-good-faith"
             className="text-ink-1000 text-xl font-semibold"
           >

--- a/web/pages/community-guidelines/running-a-market.tsx
+++ b/web/pages/community-guidelines/running-a-market.tsx
@@ -62,6 +62,19 @@ export default function CommunityGuidelinesRunningAMarketPage() {
             shifting criteria are the most common source of disputes on the
             platform.
           </p>
+          <p className="text-ink-700 mt-3">
+            That's for clarifying what you already meant. If the change is
+            material enough that traders bet on a different question than the
+            one you'd now be resolving, start a new market instead — that isn't
+            a duplicate, and it's the option we'd rather you took. See{' '}
+            <Link
+              href="/community-guidelines/market-policies#duplicate-markets"
+              className="text-primary-500 underline"
+            >
+              Duplicate markets
+            </Link>
+            .
+          </p>
         </div>
 
         <div className="border-ink-200 bg-canvas-0 mt-6 rounded-xl border-2 p-6">

--- a/web/pages/community-guidelines/running-a-market.tsx
+++ b/web/pages/community-guidelines/running-a-market.tsx
@@ -79,12 +79,14 @@ export default function CommunityGuidelinesRunningAMarketPage() {
           </p>
           <p className="text-ink-700 mt-3">
             Only make a second market if there's an actual reason to: different
-            resolution criteria, timeframe, or source. Duplicating a question
-            that already exists just splits the liquidity across both markets,
-            which makes them worse priced for humans and better for arbitrage
-            bots. If you want the question to be bigger, bet on the existing
-            market or add liquidity to it — that's the version of this that
-            actually helps.
+            resolution criteria, timeframe, or source — or a well-founded
+            concern about who's resolving the original, where it's genuinely
+            ambiguous and the creator is biased or unresponsive. Duplicating a
+            question that already exists just splits the liquidity across both
+            markets, which makes them worse priced for humans and better for
+            arbitrage bots. If you want the question to be bigger, bet on the
+            existing market or add liquidity to it — that's the version of this
+            that actually helps.
           </p>
           <p className="text-ink-700 mt-3">
             Duplicates with no meaningful difference may be unranked and


### PR DESCRIPTION
## Why

We had **no rule against duplicate markets anywhere in the guidelines**. The only trace of the concept was a keyword in the search index pointing at a `#subsidized` section that had already been deleted from the page â€” so a mod warning a creator that they're splitting the liquidity pool had nothing to link to.

This writes the rule down, with real consequences attached.

## What

**Market Policies â€” new "Duplicate markets" section** (canonical statement)

- Why it's a problem: splitting liquidity across two markets makes both thinner and worse priced â€” better for arbitrage bots, worse for humans.
- When a second market is legitimate: materially different resolution criteria, timeframe, or resolution source — **or a well-founded concern about who's resolving the original**. Say so in the description.
- **Creator reliability** as a reason: where a market genuinely leaves room for interpretation (thin criteria, or a judgement call at resolution) and the creator holds a position, has form for resolving their own ambiguous markets in their favour, or is unresponsive, a better-specified version run by someone impartial is worth having. Bounded so it isn't a catch-all — try to fix the original first (ask the creator, tag @mods), write criteria specific enough that resolution isn't a judgement call, and note in the description that it exists to remove the ambiguity. A creator resolving an *unambiguous* market against your position isn't unreliable, and re-running that is still a plain duplicate.
- Notes that the create page already lists similar open markets as you type a title, so near-identical titles aren't really an accident.
- Consequences, escalating:
  - unranked (no Leagues credit) and significantly deboosted;
  - **delisted outright or resolved N/A where no real trading has occurred**;
  - fine for repeats or after a warning;
  - unlisting/deletion plus a market creation ban for bulk creation or farming bonuses, league points, or engagement.
- Covers re-creating your own market to reset it or escape a position.
- Cross-referencing bullets added to the Ranked criteria list and the unlist/N/A/delete list.

**Running a Market â€” "Check for an existing market first"**

Creator-facing norm: read the similar-markets list on the create page, and if you want the question to be bigger, bet on the existing market or add liquidity to it instead.

**Moderation Guidelines â€” "Handling duplicate markets"**

Mod playbook: what counts as a duplicate (rewording the same question still counts; a different date/threshold/source doesn't), and which lever for which case. Two judgment calls worth reviewing:

- **Unrank rather than unlist once a duplicate has traders** â€” unlisting strands people who already bet. Delist or N/A freely when nobody's position is affected.
- **Don't penalise the newer market when it's clearly the better one** (better criteria, better sourced, more traders) purely for coming second.
- **Check the creator-reliability claim rather than accepting it** — "I don't trust the creator" is the natural cover story for someone who dislikes the price. Where the concern is real, it's the *original* that needs a takeover or criteria clarification, not the new market that needs unranking.

**Search index**

Replaces the dead `#subsidized` entry and adds entries for the three new sections. Running a Market and the Moderation Guidelines previously had *no* search entries at all â€” these are their first, so those pages remain otherwise unindexed.


## Testing

Docs-only, no behaviour change. `tsc --noEmit` clean, prettier applied.

