### PR TITLE
Fix Browse discovery tracking and failed-search recovery

### DIFF
--- a/web/components/profile/user-contracts-list.tsx
+++ b/web/components/profile/user-contracts-list.tsx
@@ -10,6 +10,7 @@ import {
   LoadingContractResults,
   NoMoreResults,
   QUERY_KEY,
+  SearchErrorNotice,
   useSearchQueryState,
   useSearchResults,
 } from 'web/components/search'
@@ -60,14 +61,21 @@ export function UserContractsList(props: {
     defaultSweepies: '2',
   })
 
-  const { contracts, loading, shouldLoadMore, loadMoreContracts, posts } =
-    useSearchResults({
-      persistPrefix,
-      searchParams: params,
-      includeUsersAndTopics: false,
-      isReady,
-      additionalFilter: { creatorId: creator.id },
-    })
+  const {
+    contracts,
+    loading,
+    searchError,
+    retrySearch,
+    shouldLoadMore,
+    loadMoreContracts,
+    posts,
+  } = useSearchResults({
+    persistPrefix,
+    searchParams: params,
+    includeUsersAndTopics: false,
+    isReady,
+    additionalFilter: { creatorId: creator.id },
+  })
 
   const query = params[QUERY_KEY]
   const setQuery = (query: string) => updateParams({ [QUERY_KEY]: query })
@@ -158,7 +166,12 @@ export function UserContractsList(props: {
         />
       </Col>
       <Col className="w-full">
-        {loading && !contracts && !posts ? (
+        {searchError && (
+          <SearchErrorNotice onRetry={retrySearch} loading={loading} />
+        )}
+        {searchError && !contracts?.length && !posts?.length ? null : loading &&
+          !contracts &&
+          !posts ? (
           <LoadingContractResults />
         ) : (!contracts || contracts.length === 0) &&
           (!posts || posts.length === 0) ? (
@@ -180,9 +193,11 @@ export function UserContractsList(props: {
               searchParams={params}
               hideAvatars={true}
             />
-            <LoadMoreUntilNotVisible loadMore={loadMoreContracts} />
+            {!searchError && (
+              <LoadMoreUntilNotVisible loadMore={loadMoreContracts} />
+            )}
             {shouldLoadMore && <LoadingContractResults />}
-            {!shouldLoadMore && (
+            {!shouldLoadMore && !searchError && (
               <NoMoreResults params={params} onChange={updateParams} />
             )}
           </>

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -249,6 +249,8 @@ export type SearchState = {
 
 type SearchProps = {
   persistPrefix: string
+  // Analytics identity is stable even when browser storage is account-scoped.
+  discoverySourceComponent?: 'search'
   defaultSort?: Sort
   defaultFilter?: Filter
   defaultContractType?: ContractTypeType
@@ -325,6 +327,7 @@ export function Search(props: SearchProps) {
     highlightContractIds,
     headerClassName,
     persistPrefix,
+    discoverySourceComponent,
     isWholePage,
     useUrlParams,
     autoFocus,
@@ -416,6 +419,8 @@ export function Search(props: SearchProps) {
     users,
     topics,
     loading,
+    searchError,
+    retrySearch,
     shouldLoadMore,
     loadMoreContracts,
     refreshContracts,
@@ -423,6 +428,7 @@ export function Search(props: SearchProps) {
     discoveryTracking,
   } = useSearchResults({
     persistPrefix,
+    discoverySourceComponent,
     searchParams: searchParams,
     includeUsersAndTopics: showSearchTypes,
     isReady: isReady && discoveryVariant !== undefined,
@@ -979,8 +985,32 @@ export function Search(props: SearchProps) {
           </Col>
         )}
 
+        {searchError && (
+          <Col role="alert" className="text-ink-700 my-6 items-center gap-3">
+            <span>Questions couldn’t load. Please try again.</span>
+            <Row className="gap-2">
+              <Button
+                color="gray-outline"
+                onClick={retrySearch}
+                loading={loading}
+              >
+                Retry
+              </Button>
+              {selectedForYou && (
+                <Button
+                  color="gray-outline"
+                  onClick={() => onChange({ fy: '0' })}
+                >
+                  Browse All
+                </Button>
+              )}
+            </Row>
+          </Col>
+        )}
         {!contracts && !posts ? (
-          <LoadingContractResults />
+          searchError ? null : (
+            <LoadingContractResults />
+          )
         ) : contracts?.length === 0 && posts?.length === 0 ? (
           emptyContractsState
         ) : (
@@ -1000,9 +1030,11 @@ export function Search(props: SearchProps) {
                 discoveryTracking={discoveryTracking}
               />
             ) : null}
-            <LoadMoreUntilNotVisible loadMore={loadMoreContracts} />
+            {!searchError && (
+              <LoadMoreUntilNotVisible loadMore={loadMoreContracts} />
+            )}
             {shouldLoadMore && <LoadingContractResults />}
-            {!shouldLoadMore && (
+            {!shouldLoadMore && !searchError && (
               <NoMoreResults params={searchParams} onChange={onChange} />
             )}
           </>
@@ -1099,6 +1131,7 @@ const FRESH_SEARCH_CHANGED_STATE: SearchState = {
 
 export const useSearchResults = (props: {
   persistPrefix: string
+  discoverySourceComponent?: 'search'
   searchParams: SearchParams
   includeUsersAndTopics: boolean
   isReady: boolean
@@ -1109,6 +1142,9 @@ export const useSearchResults = (props: {
 }) => {
   const {
     persistPrefix,
+    discoverySourceComponent = persistPrefix === 'search'
+      ? 'search'
+      : undefined,
     searchParams,
     isReady,
     discoveryVariant,
@@ -1119,13 +1155,17 @@ export const useSearchResults = (props: {
   // The treatment still applies to every Search instance, but the primary
   // experiment scorecard is Browse-only. Avoid multiplying user_events write
   // volume for embedded/topic search instances that the analysis excludes.
-  const trackDiscoveryExperiment = persistPrefix === 'search'
+  const trackDiscoveryExperiment = discoverySourceComponent !== undefined
 
   const [state, setState] = usePersistentInMemoryState<SearchState>(
     FRESH_SEARCH_CHANGED_STATE,
     `${persistPrefix}-supabase-contract-search`
   )
   const [loading, setLoading] = useState(false)
+  const [failedSearch, setFailedSearch] = useState<{
+    key: string
+    fresh: boolean
+  }>()
   const [lastSearchParams, setLastSearchParams] =
     usePersistentInMemoryState<SearchParams | null>(
       null,
@@ -1225,6 +1265,10 @@ export const useSearchResults = (props: {
         !contractsOnly && props.includeUsersAndTopics
 
       if (freshQuery || state.shouldLoadMore) {
+        const requestSearchKey = serializedSearchParams
+        // Keep a failed load-more observer unmounted until its retry finishes,
+        // so remounting it cannot start a duplicate request at the same offset.
+        if (failedSearch?.key === requestSearchKey) setLoading(true)
         const discoveryResultSetId = freshQuery
           ? randomString(16)
           : state.discoveryResultSetId ?? randomString(16)
@@ -1329,6 +1373,7 @@ export const useSearchResults = (props: {
 
             clearTimeout(timeoutId)
             finishFreshRequest()
+            setFailedSearch(undefined)
             setLoading(false)
             return shouldLoadMore
           }
@@ -1347,7 +1392,7 @@ export const useSearchResults = (props: {
               resultSetId: discoveryResultSetId,
               variant: discoveryVariant,
               assignmentSource: discoveryAssignmentSource,
-              sourceComponent: persistPrefix,
+              sourceComponent: discoverySourceComponent,
               surface: discoverySurface,
               page: discoveryPage,
               isFresh: !!freshQuery,
@@ -1601,7 +1646,7 @@ export const useSearchResults = (props: {
                 resultSetId: discoveryResultSetId,
                 variant: discoveryVariant,
                 assignmentSource: discoveryAssignmentSource,
-                sourceComponent: persistPrefix,
+                sourceComponent: discoverySourceComponent,
                 surface: discoverySurface,
                 page: discoveryPage,
                 isFresh: !!freshQuery,
@@ -1642,6 +1687,7 @@ export const useSearchResults = (props: {
 
             clearTimeout(timeoutId)
             finishFreshRequest()
+            setFailedSearch(undefined)
             setLoading(false)
 
             return shouldLoadMore
@@ -1663,7 +1709,7 @@ export const useSearchResults = (props: {
                 requestAttemptId: discoveryRequestAttemptId,
                 variant: discoveryVariant,
                 assignmentSource: discoveryAssignmentSource,
-                sourceComponent: persistPrefix,
+                sourceComponent: discoverySourceComponent,
                 surface: discoverySurface,
                 page: discoveryPage,
                 isFresh: !!freshQuery,
@@ -1687,7 +1733,7 @@ export const useSearchResults = (props: {
               requestAttemptId: discoveryRequestAttemptId,
               variant: discoveryVariant,
               assignmentSource: discoveryAssignmentSource,
-              sourceComponent: persistPrefix,
+              sourceComponent: discoverySourceComponent,
               surface: discoverySurface,
               page: discoveryPage,
               isFresh: !!freshQuery,
@@ -1699,6 +1745,7 @@ export const useSearchResults = (props: {
             })
           }
           console.error('Error fetching search results:', error)
+          setFailedSearch({ key: requestSearchKey, fresh: !!freshQuery })
           setLoading(false)
         }
       }
@@ -1794,7 +1841,7 @@ export const useSearchResults = (props: {
 
   const stateAssignmentKey = state.discoveryAssignmentKey
   const discoveryTracking: DiscoveryResultTracking | undefined =
-    trackDiscoveryExperiment &&
+    discoverySourceComponent &&
     stateAssignmentKey &&
     state.discoveryResultSetId &&
     discoveryPresentationId &&
@@ -1814,7 +1861,7 @@ export const useSearchResults = (props: {
           presentationId: discoveryPresentationId,
           variant: state.discoveryVariant,
           source: state.discoveryAssignmentSource,
-          sourceComponent: persistPrefix,
+          sourceComponent: discoverySourceComponent,
           surface: state.discoverySurface,
           semanticEligible: state.discoverySemanticEligible,
           semanticMarketCount: state.discoverySemanticMarketCount,
@@ -1824,12 +1871,19 @@ export const useSearchResults = (props: {
         }
       : undefined
 
+  const searchError = failedSearch?.key === serializedSearchParams
   return {
     contracts,
     users: hasCurrentResults ? state.users : undefined,
     topics: hasCurrentResults ? state.topics : undefined,
     loading,
-    shouldLoadMore: hasCurrentResults ? state.shouldLoadMore : true,
+    searchError,
+    retrySearch: () => querySearchResults(failedSearch?.fresh ?? true),
+    shouldLoadMore: searchError
+      ? false
+      : hasCurrentResults
+      ? state.shouldLoadMore
+      : true,
     loadMoreContracts: () => querySearchResults(false, true),
     refreshContracts: () => querySearchResults(true, true),
     posts: hasCurrentResults ? state.posts : undefined,

--- a/web/components/search.tsx
+++ b/web/components/search.tsx
@@ -986,26 +986,13 @@ export function Search(props: SearchProps) {
         )}
 
         {searchError && (
-          <Col role="alert" className="text-ink-700 my-6 items-center gap-3">
-            <span>Questions couldn’t load. Please try again.</span>
-            <Row className="gap-2">
-              <Button
-                color="gray-outline"
-                onClick={retrySearch}
-                loading={loading}
-              >
-                Retry
-              </Button>
-              {selectedForYou && (
-                <Button
-                  color="gray-outline"
-                  onClick={() => onChange({ fy: '0' })}
-                >
-                  Browse All
-                </Button>
-              )}
-            </Row>
-          </Col>
+          <SearchErrorNotice
+            onRetry={retrySearch}
+            loading={loading}
+            onBrowseAll={
+              selectedForYou ? () => onChange({ fy: '0' }) : undefined
+            }
+          />
         )}
         {!contracts && !posts ? (
           searchError ? null : (
@@ -1072,6 +1059,29 @@ export const LoadingContractResults = () => {
       <LoadingContractRow />
       <LoadingContractRow />
       <LoadingContractRow />
+    </Col>
+  )
+}
+
+export const SearchErrorNotice = (props: {
+  onRetry: () => void
+  loading: boolean
+  onBrowseAll?: () => void
+}) => {
+  const { onRetry, loading, onBrowseAll } = props
+  return (
+    <Col role="alert" className="text-ink-700 my-6 items-center gap-3">
+      <span>Questions couldn’t load. Please try again.</span>
+      <Row className="gap-2">
+        <Button color="gray-outline" onClick={onRetry} loading={loading}>
+          Retry
+        </Button>
+        {onBrowseAll && (
+          <Button color="gray-outline" onClick={onBrowseAll}>
+            Browse All
+          </Button>
+        )}
+      </Row>
     </Col>
   )
 }
@@ -1759,6 +1769,9 @@ export const useSearchResults = (props: {
     // change. Advance the generation before checking for a controller.
     paramsGeneration.current++
     requestId.current++
+    // Pagination retries also set loading, but have no fresh controller.
+    // Their stale completion cannot clear the busy state after invalidation.
+    setLoading(false)
     const controller = freshRequestAbortController.current
     if (!controller) return
 
@@ -1767,7 +1780,6 @@ export const useSearchResults = (props: {
     // required by the new params.
     freshRequestAbortController.current = undefined
     controller.abort()
-    setLoading(false)
   })
 
   const serializedSearchParams = JSON.stringify({

--- a/web/pages/browse/index.tsx
+++ b/web/pages/browse/index.tsx
@@ -68,6 +68,7 @@ export function BrowsePageContent() {
         showTopicsFilterPills
         showHotTopics
         persistPrefix={browseDefault.persistPrefix}
+        discoverySourceComponent="search"
         onBrowseModeChange={browseDefault.rememberMode}
         autoFocus={autoFocus}
         additionalFilter={{


### PR DESCRIPTION
Browse could display loading placeholders indefinitely after its first market request failed. It also stopped recording Discovery request/result/exposure/click events after #4041 changed the page's storage prefix from `search` to `browse-v1-<account>`: the tracking gate still required `persistPrefix === 'search'`, and the scorecard only accepts `sourceComponent = search`.

Browse and profile searches now show an error and Retry after a failed request. For You also offers Browse All. Pagination errors preserve earlier rows, hide the load-more observer until recovery, and retry the failed offset or cursor. Profile errors no longer display an empty result or “No more results.” Superseding a pagination retry clears its busy state, so typing and clearing a query cannot leave Retry disabled after a stale response.

Errors belong to the current query/account; cancelled or superseded requests cannot overwrite its state. Browse explicitly supplies the stable analytics source `search` independently of its account-scoped storage key, restoring tracking in both arms while leaving embedded searches outside the scorecard.

## Incident and rollout

An API availability incident was reported separately. Both defects repaired here reproduce with synthetic API fixtures, independently of that incident's cause. This PR restores experiment tracking and gives users a recovery path after a failed request; backend availability remediation is separate. Ranking, assignment, default eligibility, and pending-request timeouts are unchanged.

Web-only deployment through normal Vercel merge flow; no API, scheduler, or migration change. The For You bubble and remembered opt-out remain available. After deployment, the operator must confirm request → result/error → exposure/click events reach the scorecard with `sourceComponent = search`, verify both arms, and establish a new clean measurement window. The previous September 7–21 efficacy window is invalid because request denominators were not recorded for updated Browse clients; old-client events cannot reconstruct the missing population. See the [experiment plan](https://app.notion.com/p/3d354492ea7a818b832ccfa8472b716b?pvs=204).

## Validation

- Seven browser regression scenarios passed using real React, the actual search hook, profile component, and shared error notice with synthetic API fixtures and network access blocked. Covered both experiment arms, first-request recovery, pagination retry invalidation with stale success and failure, profile initial/pagination recovery, and embedded-search exclusion.
- Targeted hook fixtures passed for retrying the same offset, preserving loaded rows, clearing superseded retry loading, and stable analytics identity.
- 85 existing common tests passed across Discovery assignment, Browse defaults, search request coordination, and result ordering.
- Web TypeScript check passed with verification-only mappings to this branch's source and shared dependency types.
- Changed-file ESLint and Prettier passed. Local ESLint normalized line-ending handling and retained the existing autofocus exception.
- `git diff --check` passed.
- Hosted CI has been queued for `7fad3efbcaeb16a786a8ac7431097451c9b5b682`; the new commit's hosted checks and deployment preview still need to finish.

No browser test scaffold or dependencies are added to the product.
