### PR TITLE
Make admin reports static props JSON-serializable

### DIFF
--- a/web/pages/admin/reports.tsx
+++ b/web/pages/admin/reports.tsx
@@ -29,8 +29,9 @@ export async function getStaticProps() {
     const reports = await getReports({ limit: PAGE_SIZE })
     // Direct database lookups can leave nested undefined fields (e.g. optional
     // entitlement expiry/metadata), which Next.js rejects in static props.
+    const serializedReports: LiteReport[] = JSON.parse(JSON.stringify(reports))
     return {
-      props: { reports: JSON.parse(JSON.stringify(reports)) },
+      props: { reports: serializedReports },
       revalidate: 60,
     }
   } catch (e) {

--- a/web/pages/admin/reports.tsx
+++ b/web/pages/admin/reports.tsx
@@ -27,7 +27,12 @@ const PAGE_SIZE = 20
 export async function getStaticProps() {
   try {
     const reports = await getReports({ limit: PAGE_SIZE })
-    return { props: { reports }, revalidate: 60 }
+    // Direct database lookups can leave nested undefined fields (e.g. optional
+    // entitlement expiry/metadata), which Next.js rejects in static props.
+    return {
+      props: { reports: JSON.parse(JSON.stringify(reports)) },
+      revalidate: 60,
+    }
   } catch (e) {
     console.error(e)
     return { props: { reports: [] }, revalidate: 60 }


### PR DESCRIPTION
`/admin/reports` can fail Next.js static-props validation when database lookups return nested undefined values, including entitlement `expiresTime` and `metadata`.

Normalize the reports through JSON serialization before returning static props, with an explicit `LiteReport[]` type so the inferred props do not become `any`. The existing report fetch, 60-second revalidation, and fetch-error fallback are preserved.

Validation:
- Five fixture-based checks exercised the page's actual `getStaticProps` function with Next.js 16.0.7's serializer: permanent entitlements, missing metadata, other nested optional fields, empty reports, and fetch failures. Invalid fixtures reproduce the original serializer errors; normalized props pass without mutating the inputs.
- A TypeScript compiler check confirms the inferred reports prop is `LiteReport[]`.
- Changed-file ESLint, Prettier, and `git diff --check` passed.
- At head `7b000c763`, GitHub typecheck/lint/format/tests, the [DEV preview](https://vercel.com/mantic/dev/Add6f53sEygQ1jpVRcJwd3UMJj3Y), and the [PROD preview](https://vercel.com/mantic/prod/5ok2QWFh562oVRZ2h3NFq7SLZBBG) all passed. No full local web build was run.
