### PR TITLE
fix(perps): show the profit ladder when adding to a held position

### DIFF
--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -241,9 +241,12 @@ above is preserved. The position tracks its cumulative opening fees in
 `takerFeeCostBasis` (kept separate from margin so leverage/liquidation math
 is untouched), and every user-facing PnL number — the position card, close
 receipts, portfolio metrics, period metrics, and the trade panel's profit
-ladder (`getPerpPriceForUserFacingPnl` solves for the price at which that
-PnL reaches a target, so each tier is net of the fee and agrees with the
-card) — subtracts it: a fresh position starts at PnL = −fee. Admins tune
+ladder (`getPerpProfitScenarios`, via `getPerpPriceForUserFacingPnl`, solves
+for the price at which that PnL reaches each tier, so every tier is net of the
+fee and agrees with the card; the ladder is built on the row the trade RESULTS
+in, so on an add it covers the merged position — held margin and fees included,
+the only base the card can show — and drops any tier the row already exceeds
+at the mark) — subtracts it: a fresh position starts at PnL = −fee. Admins tune
 both knobs live per market via `update-perp-config` (base 0 disables the
 flat part, impact 0 the size part); contracts created before the fields
 existed default to base 10 / impact 0 at trade time.

--- a/common/src/perps/pnl.test.ts
+++ b/common/src/perps/pnl.test.ts
@@ -1,8 +1,15 @@
-import { applyFunding, computeFundingRate, getPositionValue } from './amm'
+import {
+  applyFunding,
+  computeFundingRate,
+  getPositionValue,
+  openPosition,
+} from './amm'
+import { accruePerpPositionTakerFee } from './fees'
 import {
   fundingPerPeriod,
   getPerpPositionTotalCost,
   getPerpPriceForUserFacingPnl,
+  getPerpProfitScenarios,
   getUserFacingPnl,
   getUserFacingPnlFromPayout,
   getUserFacingPnlPercent,
@@ -169,5 +176,139 @@ describe('getPerpPriceForUserFacingPnl', () => {
         1_000
       )
     ).toBeUndefined()
+  })
+})
+
+describe('getPerpProfitScenarios', () => {
+  const tiers = [0.25, 0.5, 1] as const
+  // A fresh M$100 open at 10× from a mark of 100, paying a M$1 fee.
+  const fresh = makePosition('long', {
+    size: 1_000,
+    costBasis: 100,
+    originalCostBasis: 100,
+    takerFeeCostBasis: 1,
+    entryPrice: 100,
+  })
+
+  it('prices every tier net of the fee on both sides, as the card will show', () => {
+    for (const direction of ['long', 'short'] as const) {
+      const position = { ...fresh, direction }
+      const scenarios = getPerpProfitScenarios(position, 100, tiers)
+      expect(scenarios.map((s) => s.ret)).toEqual([...tiers])
+      for (const { ret, price, pnl } of scenarios) {
+        // The base is the whole cash committed: margin + fee.
+        expect(pnl).toBeCloseTo(ret * 101, 10)
+        expect(getUserFacingPnl(position, price)).toBeCloseTo(pnl, 10)
+        expect(getUserFacingPnlPercent(position, price)).toBeCloseTo(ret, 10)
+        // A profit scenario is a favourable move from the mark.
+        expect(direction === 'long' ? price > 100 : price < 100).toBe(true)
+      }
+    }
+  })
+
+  it('reduces to entry·(1 ± r/ℓ) when there is no fee', () => {
+    const noFee = { ...fresh, takerFeeCostBasis: 0 }
+    const longPrices = getPerpProfitScenarios(noFee, 100, tiers).map(
+      (s) => s.price
+    )
+    const shortPrices = getPerpProfitScenarios(
+      { ...noFee, direction: 'short' as const },
+      100,
+      tiers
+    ).map((s) => s.price)
+    expect(longPrices).toHaveLength(3)
+    expect(shortPrices).toHaveLength(3)
+    tiers.forEach((ret, i) => {
+      expect(longPrices[i]).toBeCloseTo(100 * (1 + ret / 10), 10)
+      expect(shortPrices[i]).toBeCloseTo(100 * (1 - ret / 10), 10)
+    })
+  })
+
+  it('prices an add on the merged row the position card will show', () => {
+    // Held: M$100 long at 5× from 50 with M$1 of fees, now marked at 60
+    // (+M$100 unrealized). Add M$50 at 4× at the mark for a M$0.50 fee,
+    // merged exactly as the engine merges it.
+    const held = makePosition('long', {
+      size: 500,
+      costBasis: 100,
+      originalCostBasis: 100,
+      takerFeeCostBasis: 1,
+      entryPrice: 50,
+      leverage: 5,
+    })
+    const opened = openPosition(
+      { pool: { L: 100, S: 100 }, positions: [held] },
+      'u',
+      'c',
+      'long',
+      50,
+      4,
+      60,
+      held
+    )
+    const merged = accruePerpPositionTakerFee(
+      opened.state,
+      opened.position,
+      0.5
+    ).position
+    expect(merged.size).toBe(700)
+    expect(merged.originalCostBasis).toBe(150)
+    expect(merged.takerFeeCostBasis).toBe(1.5)
+    expect(merged.entryPrice).toBeCloseTo(52.5, 10)
+
+    // At the mark the merged row already reads +98.5 on 151.5 committed
+    // (+65%), so +25% and +50% would be losses from here: only +100% is a
+    // profit scenario, and it is a +100% on the WHOLE row.
+    expect(getUserFacingPnlPercent(merged, 60)).toBeCloseTo(98.5 / 151.5, 10)
+    const scenarios = getPerpProfitScenarios(merged, 60, tiers)
+    expect(scenarios.map((s) => s.ret)).toEqual([1])
+    const [{ price, pnl }] = scenarios
+    expect(pnl).toBeCloseTo(151.5, 10)
+    expect(price).toBeGreaterThan(60)
+    expect(price).toBeCloseTo(63.975, 10)
+    expect(getUserFacingPnl(merged, price)).toBeCloseTo(151.5, 10)
+    expect(getUserFacingPnlPercent(merged, price)).toBeCloseTo(1, 10)
+
+    // Past every tier, there is nothing left to show.
+    expect(getPerpProfitScenarios(merged, 80, tiers)).toEqual([])
+  })
+
+  it('drops tiers a short has already passed the same way', () => {
+    // 10× short from 100 with no fee, marked at 94: +25% (at 97.5) and +50%
+    // (at 95) sit ABOVE the mark, i.e. would be losses; +100% (at 90) stands.
+    const short = makePosition('short', {
+      size: 1_000,
+      costBasis: 100,
+      originalCostBasis: 100,
+      takerFeeCostBasis: 0,
+      entryPrice: 100,
+    })
+    const scenarios = getPerpProfitScenarios(short, 94, tiers)
+    expect(scenarios.map((s) => s.ret)).toEqual([1])
+    expect(scenarios[0].price).toBeCloseTo(90, 10)
+  })
+
+  it('fails closed on inputs it cannot price', () => {
+    expect(getPerpProfitScenarios(fresh, Number.NaN, tiers)).toEqual([])
+    expect(getPerpProfitScenarios(fresh, 0, tiers)).toEqual([])
+    expect(getPerpProfitScenarios({ ...fresh, size: 0 }, 100, tiers)).toEqual(
+      []
+    )
+    expect(
+      getPerpProfitScenarios(
+        { ...fresh, takerFeeCostBasis: Number.NaN },
+        100,
+        tiers
+      )
+    ).toEqual([])
+    expect(getPerpProfitScenarios(fresh, 100, [0, -1, Number.NaN])).toEqual([])
+    // A 1× short's +100% would need a price of 0.
+    expect(
+      getPerpProfitScenarios(
+        { ...fresh, direction: 'short', size: 100, takerFeeCostBasis: 0 },
+        100,
+        [1]
+      )
+    ).toEqual([])
   })
 })

--- a/common/src/perps/pnl.ts
+++ b/common/src/perps/pnl.ts
@@ -79,20 +79,26 @@ export const getPerpPositionTotalCost = (
 ) => getValidatedPerpPositionTotalCost(position) ?? 0
 
 /**
+ * The fields the PnL solvers read: a stored row, or a preview of the row a
+ * trade would produce.
+ */
+export type PerpPnlPositionInput = Pick<
+  PerpPosition,
+  | 'direction'
+  | 'size'
+  | 'costBasis'
+  | 'originalCostBasis'
+  | 'takerFeeCostBasis'
+  | 'entryPrice'
+>
+
+/**
  * Oracle/close price required to reach a user-facing PnL target. The target
  * is net of all opening/add fees already paid; future funding is necessarily
  * excluded. Returns undefined when the inputs cannot describe a valid target.
  */
 export const getPerpPriceForUserFacingPnl = (
-  position: Pick<
-    PerpPosition,
-    | 'direction'
-    | 'size'
-    | 'costBasis'
-    | 'originalCostBasis'
-    | 'takerFeeCostBasis'
-    | 'entryPrice'
-  >,
+  position: PerpPnlPositionInput,
   targetPnl: number
 ): number | undefined => {
   const { direction, size, costBasis, entryPrice } = position
@@ -120,6 +126,56 @@ export const getPerpPriceForUserFacingPnl = (
   return Number.isFinite(targetPrice) && targetPrice > 0
     ? targetPrice
     : undefined
+}
+
+export type PerpProfitScenario = {
+  /** Net return on the cash committed: margin plus opening/add fees. */
+  ret: number
+  /** Oracle price at which the position card reads exactly +ret. */
+  price: number
+  /** User-facing PnL at that price — ret × the cash committed. */
+  pnl: number
+}
+
+/**
+ * The trade panel's profit ladder for the position a trade RESULTS in: the
+ * row the position card will show once the trade lands. Each tier is a NET
+ * return on the cash committed to that row — margin plus every opening/add
+ * fee, the denominator of getUserFacingPnlPercent — so at the solved price
+ * the card reads exactly "+ret%" and exactly `pnl`.
+ *
+ * On a fresh open (or the new leg of a flip) the row is just the tranche. On
+ * an ADD it is the merged row, held margin and fees included — the only base
+ * the card can show, and why this takes a position rather than a margin: a
+ * "+25% on the tranche" target would mix the tranche's cash with the merged
+ * entry price. A tier the row already exceeds at the mark is dropped, since
+ * reaching it from here is a loss, not a profit scenario (only an add can
+ * start past one; a fresh row starts at −fee). Closing is free; future
+ * funding is unknowable here and excluded. Fails closed (empty) on a mark
+ * or row it cannot price.
+ */
+export const getPerpProfitScenarios = (
+  position: PerpPnlPositionInput,
+  markPrice: number,
+  returnTiers: readonly number[]
+): PerpProfitScenario[] => {
+  const totalCost = getValidatedPerpPositionTotalCost(position)
+  if (
+    totalCost === undefined ||
+    totalCost <= 0 ||
+    !Number.isFinite(markPrice) ||
+    markPrice <= 0
+  )
+    return []
+  return returnTiers.flatMap((ret) => {
+    if (!Number.isFinite(ret) || ret <= 0) return []
+    const pnl = ret * totalCost
+    const price = getPerpPriceForUserFacingPnl(position, pnl)
+    if (price === undefined) return []
+    const isFavourableMove =
+      position.direction === 'long' ? price > markPrice : price < markPrice
+    return isFavourableMove ? [{ ret, price, pnl }] : []
+  })
 }
 
 /**

--- a/web/components/perps/perp-bet-panel.tsx
+++ b/web/components/perps/perp-bet-panel.tsx
@@ -35,7 +35,9 @@ import {
 } from 'common/perps/funding'
 import {
   fundingPerPeriod,
-  getPerpPriceForUserFacingPnl,
+  getPerpPositionTotalCost,
+  getPerpProfitScenarios,
+  PerpPnlPositionInput,
 } from 'common/perps/pnl'
 import {
   formatFeePct,
@@ -313,6 +315,25 @@ export const PerpBetPanel = (props: {
     !Number.isFinite(feeGrossDepth) ||
     (!!myPosition && !Number.isFinite(myPositionValue)) ||
     !Number.isFinite(openFee)
+  // The position this trade RESULTS in — the row the position card will show
+  // once it lands — which the profit ladder is built on. A fresh open (or a
+  // flip's new leg) is just this tranche at the mark. An add merges the
+  // tranche into the held row exactly as the engine does (openPosition, then
+  // accruePerpPositionTakerFee): size and both cost bases sum, the entry
+  // price is the merged one previewed above, and the fee accrues onto the
+  // fee basis. The ladder describes this row rather than the tranche because
+  // the card can only ever show the merged position — a "+25% on the
+  // tranche" target would mix the tranche's cash with the merged entry
+  // price, which is why adds used to get no ladder at all.
+  const heldForAdd = isAddPreview && notional > 0 ? myPosition : null
+  const resultingPosition: PerpPnlPositionInput = {
+    direction,
+    size: (heldForAdd?.size ?? 0) + notional,
+    costBasis: (heldForAdd?.costBasis ?? 0) + marginAmount,
+    originalCostBasis: (heldForAdd?.originalCostBasis ?? 0) + marginAmount,
+    takerFeeCostBasis: (heldForAdd?.takerFeeCostBasis ?? 0) + openFee,
+    entryPrice: preview.entryPrice,
+  }
   // Price protection sent with the trade: the engine rejects rather than
   // charges if the authoritative fee exceeds this. The band is the DISPLAYED
   // fee plus PERP_FEE_SLIPPAGE_BPS of notional — see perpMaxFeeFor for why it
@@ -639,7 +660,8 @@ export const PerpBetPanel = (props: {
       </Col>
 
       <StatsGrid
-        direction={direction}
+        resultingPosition={resultingPosition}
+        markPrice={price}
         notional={notional}
         margin={marginAmount}
         entryPrice={preview.entryPrice}
@@ -807,8 +829,9 @@ const LeverageSlider = (props: {
 }
 
 // Profit tiers shown in the scenario ladder: each is a +r NET return on the
-// cash committed to this new position (margin + opening fee) — the same base
-// the position card's percentage uses, so the two agree at the target price.
+// cash committed to the position the trade results in (margin + opening/add
+// fees; the whole merged row on an add) — the same base the position card's
+// percentage uses, so the two agree at the target price.
 const RETURN_TIERS = [0.25, 0.5, 1] as const
 
 const formatPoolShare = (share: number) => {
@@ -828,7 +851,13 @@ const SizeFeeWhyTooltip = () => (
 )
 
 const StatsGrid = (props: {
-  direction: 'long' | 'short'
+  // The position this trade results in — the row the position card will
+  // show once it lands — which the profit ladder is built on. Just the
+  // tranche on an open or flip; the merged row on an add.
+  resultingPosition: PerpPnlPositionInput
+  // Current oracle price. A tier only counts as a profit scenario when it
+  // takes a favourable move from here.
+  markPrice: number
   notional: number
   margin: number
   entryPrice: number
@@ -843,8 +872,8 @@ const StatsGrid = (props: {
   // The contract's frozen funding period — labels are per-hour on fast
   // feeds, per-day on daily ones.
   fundingPeriodMs: number
-  // True when adding to a held position: entryPrice/leverage/liqPrice
-  // describe the merged result, so the labels say so.
+  // True when adding to a held position: entryPrice/leverage/liqPrice and
+  // the profit ladder describe the merged result, so the labels say so.
   isAddPreview?: boolean
   // Open-side taker fee for THIS trade. Closing is free, so this is the
   // whole round-trip cost. The effective rate is base + size: positions
@@ -863,7 +892,8 @@ const StatsGrid = (props: {
   feePreviewInvalid: boolean
 }) => {
   const {
-    direction,
+    resultingPosition,
+    markPrice,
     notional,
     margin,
     entryPrice,
@@ -894,42 +924,23 @@ const StatsGrid = (props: {
   const feeExceedsMargin =
     margin > 0 && fee >= margin * PERP_MAX_FEE_SHARE_OF_MARGIN
 
-  // Add previews are hidden on purpose: `margin` is the new tranche but
-  // entryPrice describes the merged position, so a "+25% on margin" target
-  // would mix two bases. Defining return for an add is a product decision.
-  const canShowScenarios =
-    !isAddPreview &&
-    !feePreviewInvalid &&
-    Number.isFinite(entryPrice) &&
-    entryPrice > 0 &&
-    margin > 0 &&
-    notional > 0
+  // Hidden while the fee cannot be quoted (every tier is net of it) and until
+  // a trade is configured; getPerpProfitScenarios fails closed on the rest.
+  const canShowScenarios = !feePreviewInvalid && margin > 0 && notional > 0
 
-  // Solve for the price at which the position's user-facing PnL — the number
-  // the position card will show, net of the opening fee — reaches +r of the
-  // cash committed. The base is margin + fee, the same denominator the card's
-  // percentage uses (getUserFacingPnlPercent), so at the solved price the
-  // card reads exactly "+r%" and exactly this mana profit. Without the fee
-  // this is the familiar entry·(1 ± r/ℓ); with it the target sits further
-  // out, so the ladder no longer promises a profit the card would then
-  // report as smaller. Closing is free; future funding remains unknowable
-  // here (and is called out below).
+  // Each tier is the price at which the position's user-facing PnL — the
+  // number the position card will show, net of the opening fee — reaches +r
+  // of the cash committed to the position this trade results in. That base
+  // (margin + fees) is the same denominator the card's percentage uses
+  // (getUserFacingPnlPercent), so at the solved price the card reads exactly
+  // "+r%" and exactly this mana profit. Without the fee this is the familiar
+  // entry·(1 ± r/ℓ); with it the target sits further out, so the ladder
+  // never promises a profit the card would then report as smaller. On an add
+  // the row is the merged position (see resultingPosition), so the ladder
+  // covers the whole position and is captioned as such below. Closing is
+  // free; future funding remains unknowable here (and is called out below).
   const scenarios = canShowScenarios
-    ? RETURN_TIERS.flatMap((ret) => {
-        const pnl = ret * (margin + fee)
-        const price = getPerpPriceForUserFacingPnl(
-          {
-            direction,
-            size: notional,
-            costBasis: margin,
-            originalCostBasis: margin,
-            takerFeeCostBasis: fee,
-            entryPrice,
-          },
-          pnl
-        )
-        return price === undefined ? [] : [{ ret, price, pnl }]
-      })
+    ? getPerpProfitScenarios(resultingPosition, markPrice, RETURN_TIERS)
     : []
 
   const periodPct = marketFundingRate * 100
@@ -1072,6 +1083,16 @@ const StatsGrid = (props: {
                   </span>
                 </Row>
               ))}
+              {isAddPreview && (
+                <span className="text-ink-400 text-xs leading-tight">
+                  Whole {resultingPosition.direction} position after this add —{' '}
+                  {formatMoneyPrecise(
+                    getPerpPositionTotalCost(resultingPosition)
+                  )}{' '}
+                  committed including what you already hold — so it matches what
+                  the position card will show.
+                </span>
+              )}
               {(paysFunding || earnsFunding) && (
                 <span className="text-ink-400 text-xs leading-tight">
                   {paysFunding


### PR DESCRIPTION
## Summary

Reported as "perps showing profit scenarios for short, but not for long positions". The trade panel's **profit scenarios** ladder was hidden for any trade that *adds* to a position you already hold. Hold a long and the Long tab is an add (no ladder) while the Short tab is a flip, which previews as a fresh open (ladder shown). Hold a short and it reverses. The price math itself was never wrong; it is direction-symmetric.

The gate was deliberate when the fee-aware ladder landed in #4005: a "+25% on the tranche" target would mix the tranche's cash with the merged position's entry price, so adds were dropped rather than given a definition. This PR gives them one.

**Fix:** the ladder is now built on the position the trade *results in*, i.e. the row the position card will show once the trade lands:

- **Fresh open, or the new leg of a flip:** just this tranche. Numbers are identical to today.
- **Add:** the merged row, held margin and fees included, merged exactly as the engine merges it (`openPosition`, then `accruePerpPositionTakerFee`). Each tier is still a net return on that row's total cash committed, so at the solved price the position card reads exactly "+r%".

## Behaviour changelog

| Situation | Before | After |
|---|---|---|
| No position, Long or Short tab | Ladder shown | Unchanged |
| Hold a long, Long tab (add) | **No ladder** | Ladder on the merged position, with a caption |
| Hold a long, Short tab (flip) | Ladder for the new leg | Unchanged |
| Hold a short, Short tab (add) | **No ladder** | Ladder on the merged position, with a caption |
| Hold a short, Long tab (flip) | Ladder for the new leg | Unchanged |
| Add where the merged row is already past a tier at the mark | n/a | That tier is dropped; past all three, the toggle is hidden |
| Margin blank or 0, or fee unpriceable | Hidden | Unchanged |

Details of the add case:

- **Base.** "+25%" means the position card will read +25% on the *whole* position: profit = 0.25 × (existing margin + existing fees + new margin + this trade's fee). The caption states that total.
- **Price.** Solved on the merged row: size = held + new notional, entry = the "New avg. entry" shown two rows up, cost bases summed, fee basis plus this trade's fee.
- **Dropped tiers.** If the merged row already reads, say, +65% at the current mark, reaching +25% or +50% would be a *loss* from here, so those rows are dropped and only +100% shows. A fresh row starts at minus the fee, so this can only ever happen on an add.
- **Caption** under the rows, e.g. "Whole long position after this add — Ṁ151.50 committed including what you already hold — so it matches what the position card will show."
- The funding note below the ladder is unchanged.

## Code changelog

- `common/src/perps/pnl.ts`
  - New `getPerpProfitScenarios(position, markPrice, tiers)`: pure, fails closed on anything it cannot price, and drops tiers that are not a favourable move from the mark. It owns the ladder math so it can be unit-tested.
  - New exported types `PerpPnlPositionInput` (the fields the solvers read; now also the parameter type of `getPerpPriceForUserFacingPnl`, no behaviour change) and `PerpProfitScenario`.
- `web/components/perps/perp-bet-panel.tsx`
  - Builds `resultingPosition` next to the fee preview: the tranche, or the merged row on an add.
  - `StatsGrid` takes `resultingPosition` and `markPrice` instead of `direction`; the `!isAddPreview` gate is gone; the scenario math is delegated to the helper; the add caption is new.
  - Both the market page and the `/perps` hub render this panel, so both get the fix.
- `common/src/perps/pnl.test.ts`: five new tests, listed below.
- `backend/shared/src/perps/README.md`: the fee section's description of the ladder updated to match.

No engine, API, schema, fee, or position-card changes. 4 files, +276 / −55.

## Automated tests

`getPerpProfitScenarios`:

1. **Both sides:** every tier's profit is r × (margin + fee), the card's PnL and percent at the returned price equal the tier exactly, and the price is a favourable move from the mark.
2. **No fee:** prices reduce to the familiar entry·(1 ± r/ℓ).
3. **Add:** a held long merged via `openPosition` + `accruePerpPositionTakerFee`; asserts the merged row's fields, that only +100% survives when the row is already +65% at the mark, the exact price (63.975), and that the card reads exactly +100% there. Past every tier returns nothing.
4. **Short:** passed tiers are dropped the same way (a price above the mark is unfavourable for a short).
5. **Fails closed:** NaN or zero mark, zero size, NaN fee basis, non-positive tiers, and a short whose target would need a price of 0.

## Manual test plan

Any perp market page, or the `/perps` hub. The bet panel is the Long / Short buttons.

1. **Reproduce on main first (optional):** open a small long, then check the Long tab: no "Show profit scenarios". Short tab: present.
2. **No position:** Long and Short tabs each show the toggle; open it and note the three rows. These numbers must be identical before and after this PR, since the fresh-open path is untouched.
3. **Add to a long:** with a long held, the Long tab reads "Add to long", the stats read "New avg. entry" / "New liquidation", and the toggle is now present. Open it and check:
   - three rows plus the caption;
   - each profit equals r × the committed figure in the caption, to the cent;
   - prices increase down the rows and all sit above the current oracle price;
   - the committed figure equals the card's Margin + this margin + fees (this trade's Fee row, plus fees paid on earlier opens or adds).
4. **Flip:** the Short tab while holding a long is a flip; the ladder describes the new leg only (new margin + fee), unchanged from today.
5. **Past a tier:** with a long that already shows at least +25% on the position card, add a small tranche. The +25% row is gone (and +50% / +100% if those are passed too); if all three are passed the toggle is absent. Increase the added margin: as the merged percentage dilutes, rows reappear.
6. **Short side:** mirror steps 3 to 5 with a short; ladder prices must sit below the mark and decrease down the rows.
7. **Edge cases:** margin blank or 0 shows no toggle. A 1× short with no position has no +100% row (it would need a price of 0; pre-existing behaviour).
8. **Layout:** the caption wraps cleanly at phone width and in dark mode; check the `/perps` hub panel too.

I could not run the app in this environment, so the visual pass is on the tester.

## Decisions to assess

1. **Merged-row basis for adds** rather than "this tranche's own profit". Chosen because the card can only ever show the merged position, and the panel already labels an add's entry and liquidation as merged. A tranche-only reading would give smaller, additive numbers that the card would never display.
2. **Dropping passed tiers**, including hiding the toggle when all three are passed. The alternative is keeping them with a "below current price" marker.
3. **Caption copy and length.**
4. **Column header** stays "profit"; on an add it is the whole position's profit, which the caption explains.

## Verification run locally

- `yarn build:ci`, `yarn typecheck` (web, api, scheduler), `yarn lint` (common, api, shared), `yarn format:check`, `yarn test` (common: 913 tests, shared: 51): all green.
- ESLint on the changed web file with `--max-warnings=0`: clean. Whole-web lint reports 214 pre-existing errors in unrelated files; CI does not run it.
- The branch merges cleanly onto current `main`.

## Follow-up (not in this PR)

A user asked for a "type a price, see the profit" calculator. It fits as a fourth, free-form row of this ladder and as a collapsible on the position card, sharing this helper. To be proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3BF1oT7q12q5Nt3G78XAe

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3BF1oT7q12q5Nt3G78XAe)_