### PR TITLE
Let PERPs be owned by the MNX partner account

### DIFF
--- a/backend/api/src/create-perp.ts
+++ b/backend/api/src/create-perp.ts
@@ -32,7 +32,10 @@ import { camelCase, first, uniqBy } from 'lodash'
 import { createSupabaseDirectClient, pgp } from 'shared/supabase/init'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { getMinTradingMarkAgeMs, getOracleFeed } from 'shared/oracle-feeds'
-import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
+import {
+  getPerpCreatorAccountMismatch,
+  resolvePerpCreatorAccount,
+} from 'shared/perps/creator-accounts'
 import { assertPerpEscrowBalance } from 'shared/perps/escrow'
 import {
   ALL_PERP_LAUNCH_MARKETS,
@@ -152,10 +155,13 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
 
   const pg = createSupabaseDirectClient()
   const creator = await resolvePerpCreatorAccount(creatorAccount, ENV, pg)
-  if (!creator.user)
+  const creatorProblem = creator.user
+    ? getPerpCreatorAccountMismatch(creator)
+    : creator.reason
+  if (!creator.user || creatorProblem)
     throw new APIError(
       400,
-      `Cannot create as ${PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]}: ${creator.reason}.`
+      `Cannot create as ${PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]}: ${creatorProblem}.`
     )
   const user = creator.user
   if (user.balance < totalSubsidy)

--- a/backend/api/src/create-perp.ts
+++ b/backend/api/src/create-perp.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_PERP_CREATOR_ACCOUNT,
+  PERP_CREATOR_ACCOUNT_LABELS,
+  getAllowedPerpCreatorAccounts,
+  isPerpCreatorAccountAllowed,
+} from 'common/perps/creator-accounts'
 import { getMnxInstrument } from 'common/perps/mnx'
 import { OracleFeedHealth } from 'common/perps/oracle-health'
 import { fetchMnxSnapshot, requireMnxReady } from 'shared/mnx'
@@ -26,6 +32,7 @@ import { camelCase, first, uniqBy } from 'lodash'
 import { createSupabaseDirectClient, pgp } from 'shared/supabase/init'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { getMinTradingMarkAgeMs, getOracleFeed } from 'shared/oracle-feeds'
+import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
 import { assertPerpEscrowBalance } from 'shared/perps/escrow'
 import {
   ALL_PERP_LAUNCH_MARKETS,
@@ -38,7 +45,7 @@ import { runTxnOutsideBetQueue } from 'shared/txn/run-txn'
 import { addGroupToContract } from 'shared/update-group-contracts-internal'
 import { broadcastNewContract } from 'shared/websockets/helpers'
 import { convertUser } from 'common/supabase/users'
-import { getUser, htmlToRichText, log } from 'shared/utils'
+import { htmlToRichText, log } from 'shared/utils'
 import { APIError, APIHandler } from './helpers/endpoint'
 import { assertPerpExposureIncreaseEnabled } from './helpers/perp-trading-mode'
 
@@ -86,6 +93,7 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
     subsidyShort,
     takerFeeBps,
     takerFeeImpact,
+    creatorAccount = DEFAULT_PERP_CREATOR_ACCOUNT,
   } = body
 
   const totalSubsidy = subsidyLong + subsidyShort
@@ -99,10 +107,25 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
   const launchDefinition = ALL_PERP_LAUNCH_MARKETS.find(
     (market) => market.feedId === oracleFeedId
   )
-  if (launchDefinition && auth.uid !== getPerpLaunchCreatorId(ENV))
+  // The owner is a selected account, never the calling admin: it pays the
+  // backing and residual backing returns to it at settlement. Spending that
+  // balance (its own, or the partner's on the partner's behalf) is reserved
+  // for the official Manifold account, so a personal admin session cannot
+  // create a PERP under either name. Every creation-enabled feed is a launch
+  // feed today, so this is the same gate the launch manifest always had.
+  if (auth.uid !== getPerpLaunchCreatorId(ENV))
     throw new APIError(
       403,
-      'Launch PERPs must be created by the official Manifold account because residual backing returns to the creator.'
+      'PERPs must be created by the official Manifold account: the selected creator account pays the backing and residual backing returns to it.'
+    )
+  if (!isPerpCreatorAccountAllowed(creatorAccount, oracleFeedId))
+    throw new APIError(
+      400,
+      `${
+        PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]
+      } cannot own a market on ${oracleFeedId}; allowed creator accounts: ${getAllowedPerpCreatorAccounts(
+        oracleFeedId
+      ).join(', ')}.`
     )
   if (launchDefinition && question !== launchDefinition.question)
     throw new APIError(
@@ -127,12 +150,23 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
   const ticker =
     canonicalTicker ?? requestedTicker ?? derivePerpTicker(oracleFeedId)
 
-  const user = await getUser(auth.uid)
-  if (!user) throw new APIError(404, 'User not found')
-  if (user.balance < totalSubsidy)
-    throw new APIError(403, `Balance must be at least ${totalSubsidy}.`)
-
   const pg = createSupabaseDirectClient()
+  const creator = await resolvePerpCreatorAccount(creatorAccount, ENV, pg)
+  if (!creator.user)
+    throw new APIError(
+      400,
+      `Cannot create as ${PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]}: ${creator.reason}.`
+    )
+  const user = creator.user
+  if (user.balance < totalSubsidy)
+    throw new APIError(
+      403,
+      `${PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]} (@${
+        user.username
+      }) pays the backing and has M${Math.floor(
+        user.balance
+      )}; it must hold at least M${totalSubsidy}.`
+    )
 
   // Implicit feed existence check: at least one oracle_prices row must exist.
   const oracle = await pg.oneOrNone<{
@@ -378,7 +412,7 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
     )
     await tx.none(contractQuery)
 
-    // Creator pays the subsidy into the contract pools.
+    // The selected creator account pays the subsidy into the contract pools.
     await runTxnOutsideBetQueue(tx, {
       fromId: user.id,
       fromType: 'USER',

--- a/backend/api/src/get-known-oracle-feeds.ts
+++ b/backend/api/src/get-known-oracle-feeds.ts
@@ -9,7 +9,10 @@ import {
 import { getPerpFeedTicker } from 'common/perps/ticker'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { getOracleFeed, ORACLE_FEEDS } from 'shared/oracle-feeds'
-import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
+import {
+  getPerpCreatorAccountMismatch,
+  resolvePerpCreatorAccount,
+} from 'shared/perps/creator-accounts'
 import {
   ALL_PERP_LAUNCH_MARKETS,
   getPerpLaunchCreatorId,
@@ -78,7 +81,9 @@ export const getKnownOracleFeeds: APIHandler<'get-known-oracle-feeds'> = async (
         label: PERP_CREATOR_ACCOUNT_LABELS[resolved.account],
         allowed: isPerpCreatorAccountAllowed(resolved.account, id),
         username: resolved.user?.username ?? null,
-        unavailableReason: resolved.user ? null : resolved.reason,
+        unavailableReason: resolved.user
+          ? getPerpCreatorAccountMismatch(resolved)
+          : resolved.reason,
       })),
     }
   })

--- a/backend/api/src/get-known-oracle-feeds.ts
+++ b/backend/api/src/get-known-oracle-feeds.ts
@@ -1,9 +1,15 @@
 import { sortBy, uniq } from 'lodash'
 
 import { ENV } from 'common/envs/constants'
+import {
+  PERP_CREATOR_ACCOUNT_LABELS,
+  PERP_CREATOR_ACCOUNTS,
+  isPerpCreatorAccountAllowed,
+} from 'common/perps/creator-accounts'
 import { getPerpFeedTicker } from 'common/perps/ticker'
 import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
 import { getOracleFeed, ORACLE_FEEDS } from 'shared/oracle-feeds'
+import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
 import {
   ALL_PERP_LAUNCH_MARKETS,
   getPerpLaunchCreatorId,
@@ -20,6 +26,15 @@ export const getKnownOracleFeeds: APIHandler<'get-known-oracle-feeds'> = async (
   const rows = await pg.manyOrNone<{ feed_id: string }>(
     `select distinct feed_id from oracle_prices order by feed_id asc`
   )
+  // Resolve each selectable owner once: the form greys out an account that
+  // does not exist here (DEV may have no partner account) with the reason,
+  // instead of letting create-perp reject the submission.
+  const creatorAccounts = await Promise.all(
+    PERP_CREATOR_ACCOUNTS.map((account) =>
+      resolvePerpCreatorAccount(account, ENV, pg)
+    )
+  )
+  const callerAuthorized = auth.uid === getPerpLaunchCreatorId(ENV)
   // Include the registry independently of stored history: a disabled feed must
   // remain blocked in the form even before its first point is written. Also
   // retain price-only ids so the form can explain why they cannot back a
@@ -54,9 +69,17 @@ export const getKnownOracleFeeds: APIHandler<'get-known-oracle-feeds'> = async (
             requiredTopicNames: launch.requiredTopics.map(
               (topic) => topic.name
             ),
-            creatorAuthorized: auth.uid === getPerpLaunchCreatorId(ENV),
+            creatorAuthorized: callerAuthorized,
           }
         : null,
+      callerAuthorized,
+      creatorAccounts: creatorAccounts.map((resolved) => ({
+        account: resolved.account,
+        label: PERP_CREATOR_ACCOUNT_LABELS[resolved.account],
+        allowed: isPerpCreatorAccountAllowed(resolved.account, id),
+        username: resolved.user?.username ?? null,
+        unavailableReason: resolved.user ? null : resolved.reason,
+      })),
     }
   })
 }

--- a/backend/scripts/create-mnx-perps.ts
+++ b/backend/scripts/create-mnx-perps.ts
@@ -10,7 +10,10 @@ import { MNX_INSTRUMENTS } from 'common/perps/mnx'
 import { getPerpFeedTicker } from 'common/perps/ticker'
 import { HOUR_MS, YEAR_MS } from 'common/util/time'
 import { getLocalEnv } from 'shared/init-admin'
-import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
+import {
+  getPerpCreatorAccountMismatch,
+  resolvePerpCreatorAccount,
+} from 'shared/perps/creator-accounts'
 import {
   getPerpLaunchCreatorId,
   MNX_LAUNCH_MARKETS,
@@ -97,11 +100,13 @@ if (require.main === module)
       0
     )
     const callerId = getPerpLaunchCreatorId(ENV)
+    const ownerLabel = PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]
     const owner = await resolvePerpCreatorAccount(creatorAccount, ENV, pg)
-    if (!owner.user)
-      throw new Error(
-        `Cannot create as ${PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]}: ${owner.reason}`
-      )
+    const ownerProblem = owner.user
+      ? getPerpCreatorAccountMismatch(owner)
+      : owner.reason
+    if (!owner.user || ownerProblem)
+      throw new Error(`Cannot create as ${ownerLabel}: ${ownerProblem}`)
     log(
       JSON.stringify(
         {
@@ -157,6 +162,53 @@ if (require.main === module)
     })
     if (!me.ok || (await me.json()).id !== callerId)
       throw new Error('API key does not belong to the official creator')
+    // An API that predates the creator selector strips the unknown field and
+    // creates every market under the caller with a 200, so a successful
+    // response proves nothing. Require the API to advertise the option for
+    // each feed, agree on who the account is, and then check every created
+    // market's creator before moving to the next.
+    const feedsResponse = await fetch(getApiUrl('get-known-oracle-feeds'), {
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!feedsResponse.ok)
+      throw new Error(
+        `get-known-oracle-feeds failed: HTTP ${feedsResponse.status}`
+      )
+    const knownFeeds: {
+      id: string
+      callerAuthorized?: boolean
+      creatorAccounts?: {
+        account: string
+        allowed: boolean
+        username: string | null
+        unavailableReason: string | null
+      }[]
+    }[] = await feedsResponse.json()
+    for (const body of bodies) {
+      const feed = knownFeeds.find((f) => f.id === body.oracleFeedId)
+      const option = feed?.creatorAccounts?.find(
+        (a) => a.account === creatorAccount
+      )
+      if (!feed?.creatorAccounts || !option)
+        throw new Error(
+          `The API at ${apiUrl.host} predates the creator account selector (no creator accounts reported for ${body.oracleFeedId}); deploy it before creating with --creator`
+        )
+      if (feed.callerAuthorized === false)
+        throw new Error(
+          'The API does not accept this key as the official creator'
+        )
+      if (!option.allowed || option.unavailableReason)
+        throw new Error(
+          `${ownerLabel} cannot own ${body.oracleFeedId} on the API: ${
+            option.unavailableReason ?? 'not allowed on this feed'
+          }`
+        )
+      if (option.username !== owner.user.username)
+        throw new Error(
+          `The API resolves ${ownerLabel} to @${option.username} but this script to @${owner.user.username}; reconcile MNX_CREATOR_IDS before creating`
+        )
+    }
     for (const body of bodies) {
       const response = await fetch(getApiUrl('create-perp'), {
         method: 'POST',
@@ -170,5 +222,9 @@ if (require.main === module)
         )
       const market = await response.json()
       log(`Created unlisted ${body.oracleFeedId}: ${market.id}`)
+      if (market.creatorId !== owner.user.id)
+        throw new Error(
+          `${market.id} was created under creator ${market.creatorId}, not ${ownerLabel} (${owner.user.id}). Stop and audit before retrying.`
+        )
     }
   })

--- a/backend/scripts/create-mnx-perps.ts
+++ b/backend/scripts/create-mnx-perps.ts
@@ -1,9 +1,16 @@
 import { getApiUrl } from 'common/api/utils'
 import { ENV, ENV_CONFIG } from 'common/envs/constants'
+import {
+  DEFAULT_PERP_CREATOR_ACCOUNT,
+  PERP_CREATOR_ACCOUNT_LABELS,
+  PERP_CREATOR_ACCOUNTS,
+  PerpCreatorAccount,
+} from 'common/perps/creator-accounts'
 import { MNX_INSTRUMENTS } from 'common/perps/mnx'
 import { getPerpFeedTicker } from 'common/perps/ticker'
 import { HOUR_MS, YEAR_MS } from 'common/util/time'
 import { getLocalEnv } from 'shared/init-admin'
+import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
 import {
   getPerpLaunchCreatorId,
   MNX_LAUNCH_MARKETS,
@@ -14,9 +21,20 @@ import { runScript } from './run-script'
 
 // Default: inspect and print, with no writes. --apply only creates UNLISTED
 // markets via the normal authenticated API in the explicitly selected environment.
+// --creator=mnx makes the MNX partner account the owner (it pays the backing
+// and receives the residual); the API key must still belong to the official
+// Manifold creator, which is the only caller create-perp accepts.
 if (require.main === module)
   runScript(async ({ pg }) => {
     const apply = process.argv.includes('--apply')
+    const creatorAccount = (process.argv
+      .find((arg) => arg.startsWith('--creator='))
+      ?.slice('--creator='.length) ??
+      DEFAULT_PERP_CREATOR_ACCOUNT) as PerpCreatorAccount
+    if (!PERP_CREATOR_ACCOUNTS.includes(creatorAccount))
+      throw new Error(
+        `Unknown --creator; expected one of ${PERP_CREATOR_ACCOUNTS.join(', ')}`
+      )
     if (
       !['DEV', 'PROD'].includes(process.env.NEXT_PUBLIC_FIREBASE_ENV ?? '') ||
       ENV !== getLocalEnv()
@@ -61,6 +79,7 @@ if (require.main === module)
         description: `${spec.description}\n\nSource: ${spec.url}\nIf MNX ends this instrument, trading pauses pending administrative settlement; it will not automatically roll into a replacement.`,
         oracleFeedId: spec.feedId,
         ticker: getPerpFeedTicker(spec.feedId),
+        creatorAccount,
         visibility: 'unlisted' as const,
         maxLeverage: Math.min(recommended.maxLeverage, ready.maxLeverage!),
         subsidyLong: recommended.subsidyLong,
@@ -77,19 +96,23 @@ if (require.main === module)
       (sum, body) => sum + body.subsidyLong + body.subsidyShort,
       0
     )
-    const creatorId = getPerpLaunchCreatorId(ENV)
-    const creator = await pg.one<{ balance: number }>(
-      `select balance from users where id = $1`,
-      [creatorId]
-    )
+    const callerId = getPerpLaunchCreatorId(ENV)
+    const owner = await resolvePerpCreatorAccount(creatorAccount, ENV, pg)
+    if (!owner.user)
+      throw new Error(
+        `Cannot create as ${PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]}: ${owner.reason}`
+      )
     log(
       JSON.stringify(
         {
           environment: ENV,
           apply,
-          creatorId,
+          callerId,
+          creatorAccount,
+          creatorId: owner.user.id,
+          creatorUsername: owner.user.username,
           backingRequired: total,
-          available: creator.balance,
+          available: owner.user.balance,
           markets: bodies,
           unavailable,
         },
@@ -105,8 +128,14 @@ if (require.main === module)
       process.exitCode = 1
     }
     if (!apply || !bodies.length) return
-    if (Number(creator.balance) < total)
-      throw new Error(`Insufficient backing: need M${total}`)
+    if (Number(owner.user.balance) < total)
+      throw new Error(
+        `Insufficient backing: ${
+          PERP_CREATOR_ACCOUNT_LABELS[creatorAccount]
+        } (@${owner.user.username}) has M${Math.floor(
+          owner.user.balance
+        )} and needs M${total}`
+      )
     const key = process.env.MANIFOLD_API_KEY
     if (!key)
       throw new Error('MANIFOLD_API_KEY for the official creator is required')
@@ -126,7 +155,7 @@ if (require.main === module)
       headers,
       signal: AbortSignal.timeout(10_000),
     })
-    if (!me.ok || (await me.json()).id !== creatorId)
+    if (!me.ok || (await me.json()).id !== callerId)
       throw new Error('API key does not belong to the official creator')
     for (const body of bodies) {
       const response = await fetch(getApiUrl('create-perp'), {

--- a/backend/scripts/perp-launch-preflight.ts
+++ b/backend/scripts/perp-launch-preflight.ts
@@ -28,7 +28,10 @@ import {
   getPerpLaunchTopicSlug,
 } from 'shared/perps/launch-manifest'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
-import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
+import {
+  getMnxCreatorId,
+  resolvePerpCreatorAccount,
+} from 'shared/perps/creator-accounts'
 import { getLocalEnv } from 'shared/init-admin'
 import { log } from 'shared/utils'
 import { runScript } from './run-script'
@@ -598,22 +601,28 @@ export const auditPerpLaunch = async (pg: SupabaseDirectClient) => {
     )
     const excludedIds = new Set<string>(PERP_LAUNCH_EXCLUDED_FEED_IDS)
     // A launch market's owner is one of the selectable creator accounts, not
-    // only the manifest's official id: the MNX partner may own MNX feeds. A
-    // missing partner account narrows the allowed set instead of failing —
-    // DEV need not have one.
+    // only the manifest's official id: the pinned MNX partner id may own MNX
+    // feeds. Ownership is judged by the id alone so a renamed partner keeps
+    // its markets; an unconfigured id (DEV need not have one) narrows the
+    // allowed set, while a configured id whose row is missing, deleted or
+    // banned is worth an explicit --allow-warning.
+    const partnerId = getMnxCreatorId(environment)
     const partner = await resolvePerpCreatorAccount('mnx', environment, pg)
+    const partnerLabel = partner.user
+      ? `MNX partner account @${partner.user.username} (${partner.user.id})`
+      : `MNX partner account ${partnerId}`
     report(
-      'PASS',
+      !partnerId || partner.user ? 'PASS' : 'WARN',
       'creator accounts',
-      partner.user
+      !partnerId
         ? `official ${environment} account ${getPerpLaunchCreatorId(
             environment
-          )}; MNX partner @${partner.user.username} (${
-            partner.user.id
-          }) may own MNX feeds`
-        : `official ${environment} account ${getPerpLaunchCreatorId(
+          )} only; MNX partner not configured for ${environment}`
+        : partner.user
+        ? `official ${environment} account ${getPerpLaunchCreatorId(
             environment
-          )} only; MNX partner unavailable (${partner.reason})`
+          )}; ${partnerLabel} may own MNX feeds`
+        : `${partnerLabel} may own MNX feeds but ${partner.reason}`
     )
 
     for (const contract of contracts) {
@@ -680,13 +689,10 @@ export const auditPerpLaunch = async (pg: SupabaseDirectClient) => {
           [expectedCreatorId, `official ${environment} Manifold account`],
         ])
         if (
-          partner.user &&
+          partnerId &&
           isPerpCreatorAccountAllowed('mnx', contract.oracleFeedId)
         )
-          allowedCreators.set(
-            partner.user.id,
-            `MNX partner account @${partner.user.username}`
-          )
+          allowedCreators.set(partnerId, partnerLabel)
         const ownerLabel = allowedCreators.get(contract.creatorId)
         report(
           ownerLabel ? 'PASS' : 'FAIL',

--- a/backend/scripts/perp-launch-preflight.ts
+++ b/backend/scripts/perp-launch-preflight.ts
@@ -10,6 +10,7 @@ import {
   getPerpOpenInterestCapacity,
   assertPerpStateSolvent,
 } from 'common/perps/amm'
+import { isPerpCreatorAccountAllowed } from 'common/perps/creator-accounts'
 import { isPerpEscrowBalanced } from 'common/perps/escrow'
 import { shouldApplyFunding } from 'common/perps/funding'
 import { getOracleFreshness, getPerpOracleFreshness } from 'common/perps/oracle'
@@ -27,6 +28,7 @@ import {
   getPerpLaunchTopicSlug,
 } from 'shared/perps/launch-manifest'
 import { getOracleFeed, validateOraclePoint } from 'shared/oracle-feeds'
+import { resolvePerpCreatorAccount } from 'shared/perps/creator-accounts'
 import { getLocalEnv } from 'shared/init-admin'
 import { log } from 'shared/utils'
 import { runScript } from './run-script'
@@ -595,6 +597,24 @@ export const auditPerpLaunch = async (pg: SupabaseDirectClient) => {
       rows.map((row) => [row.data.id, row.token])
     )
     const excludedIds = new Set<string>(PERP_LAUNCH_EXCLUDED_FEED_IDS)
+    // A launch market's owner is one of the selectable creator accounts, not
+    // only the manifest's official id: the MNX partner may own MNX feeds. A
+    // missing partner account narrows the allowed set instead of failing —
+    // DEV need not have one.
+    const partner = await resolvePerpCreatorAccount('mnx', environment, pg)
+    report(
+      'PASS',
+      'creator accounts',
+      partner.user
+        ? `official ${environment} account ${getPerpLaunchCreatorId(
+            environment
+          )}; MNX partner @${partner.user.username} (${
+            partner.user.id
+          }) may own MNX feeds`
+        : `official ${environment} account ${getPerpLaunchCreatorId(
+            environment
+          )} only; MNX partner unavailable (${partner.reason})`
+    )
 
     for (const contract of contracts) {
       const nativeToken = tokenByContractId.get(contract.id)
@@ -656,12 +676,29 @@ export const auditPerpLaunch = async (pg: SupabaseDirectClient) => {
                 contract.ticker ? `"${contract.ticker}"` : 'none'
               }, expected="${expectedTicker}"; run backfill-perp-tickers.ts --apply`
         )
+        const allowedCreators = new Map([
+          [expectedCreatorId, `official ${environment} Manifold account`],
+        ])
+        if (
+          partner.user &&
+          isPerpCreatorAccountAllowed('mnx', contract.oracleFeedId)
+        )
+          allowedCreators.set(
+            partner.user.id,
+            `MNX partner account @${partner.user.username}`
+          )
+        const ownerLabel = allowedCreators.get(contract.creatorId)
         report(
-          contract.creatorId === expectedCreatorId ? 'PASS' : 'FAIL',
+          ownerLabel ? 'PASS' : 'FAIL',
           `market ${contract.slug} launch creator`,
-          contract.creatorId === expectedCreatorId
-            ? `official ${environment} Manifold account`
-            : `creator ${contract.creatorId} is not the required official account ${expectedCreatorId}; residual backing returns to the creator`
+          ownerLabel ??
+            `creator ${
+              contract.creatorId
+            } is not an allowed creator account for ${
+              contract.oracleFeedId
+            } (${Array.from(allowedCreators.keys()).join(
+              ', '
+            )}); residual backing returns to the creator`
         )
         const discovery = await pg.one<{
           group_slugs: string[]

--- a/backend/scripts/perp-launch-preflight.ts
+++ b/backend/scripts/perp-launch-preflight.ts
@@ -676,7 +676,7 @@ export const auditPerpLaunch = async (pg: SupabaseDirectClient) => {
                 contract.ticker ? `"${contract.ticker}"` : 'none'
               }, expected="${expectedTicker}"; run backfill-perp-tickers.ts --apply`
         )
-        const allowedCreators = new Map([
+        const allowedCreators = new Map<string, string>([
           [expectedCreatorId, `official ${environment} Manifold account`],
         ])
         if (

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -65,10 +65,14 @@ Endpoints are registered in `backend/api/src/routes.ts` and schemas live in
 - `POST /create-perp` (admin) — creates a new perp market. Launch-manifest
   feeds automatically receive their environment-specific required topic; the
   admin form defaults to unlisted and can apply the full reviewed launch
-  recommendation in one click. Launch feeds require the environment's official
-  Manifold creator account because residual backing returns to the creator.
-  New markets preserve their per-side initial backing for later preflight
-  auditing.
+  recommendation in one click. The caller must be the environment's official
+  Manifold account; the market's owner is the `creatorAccount` selection
+  (`common/src/perps/creator-accounts.ts`): `manifold` (default, the official
+  account) or `mnx` (the verified `@MNX` partner account, accepted only on MNX
+  feeds). The selected account pays the backing at creation and receives the
+  residual pool at settlement, so a partner owner must already hold the
+  backing. New markets preserve their per-side initial backing for later
+  preflight auditing.
 - `POST /place-perp-trade` — opens or adds to a position.
 - `POST /close-perp-position` — closes all of a position, or the
   `fraction` of it given (see Partial closes).
@@ -616,8 +620,11 @@ for feeds requiring a provider observation.
 Use `publish-mnx-now.ts` to inspect readiness or publish immediately (`--apply`);
 a fresh process bypasses the scheduler's in-memory backoff. Backfill and creation
 scripts are dry-run-first and environment-checked in DEV and PROD. Creation
-uses the MNX manifest recommendations, the official creator and unlisted
-visibility. New markets start paused until their first atomic live tick.
+uses the MNX manifest recommendations, the official creator as caller and
+unlisted visibility; `--creator=mnx` makes the `@MNX` partner account the
+owner (it must hold the backing, and the preflight accepts it as the creator
+of MNX-feed markets only). New markets start paused until their first atomic
+live tick.
 The 3× recommendation is advisory; creation permits lower leverage and enforces
 MNX's supported leverage as a ceiling. Provider margin changes never freeze an
 existing feed. MNX derivatives are the defined price target: valuation futures

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -69,10 +69,13 @@ Endpoints are registered in `backend/api/src/routes.ts` and schemas live in
   Manifold account; the market's owner is the `creatorAccount` selection
   (`common/src/perps/creator-accounts.ts`): `manifold` (default, the official
   account) or `mnx` (the verified `@MNX` partner account, accepted only on MNX
-  feeds). The selected account pays the backing at creation and receives the
-  residual pool at settlement, so a partner owner must already hold the
-  backing. New markets preserve their per-side initial backing for later
-  preflight auditing.
+  feeds). Both are pinned by user id per environment (`MNX_CREATOR_IDS` in
+  `backend/shared/src/perps/creator-accounts.ts`); MNX stays unavailable
+  where no id is configured, and creation refuses a pinned id whose account
+  no longer carries the `MNX` name. The selected account pays the backing at
+  creation and receives the residual pool at settlement, so a partner owner
+  must already hold the backing. New markets preserve their per-side initial
+  backing for later preflight auditing.
 - `POST /place-perp-trade` — opens or adds to a position.
 - `POST /close-perp-position` — closes all of a position, or the
   `fraction` of it given (see Partial closes).
@@ -623,8 +626,11 @@ scripts are dry-run-first and environment-checked in DEV and PROD. Creation
 uses the MNX manifest recommendations, the official creator as caller and
 unlisted visibility; `--creator=mnx` makes the `@MNX` partner account the
 owner (it must hold the backing, and the preflight accepts it as the creator
-of MNX-feed markets only). New markets start paused until their first atomic
-live tick.
+of MNX-feed markets only). Before any write the script requires the API to
+advertise the creator option for every feed and agree on the owner, and it
+checks each created market's `creatorId`, because an older API silently
+strips the field. New markets start paused until their first atomic live
+tick.
 The 3× recommendation is advisory; creation permits lower leverage and enforces
 MNX's supported leverage as a ceiling. Provider margin changes never freeze an
 existing feed. MNX derivatives are the defined price target: valuation futures

--- a/backend/shared/src/perps/creator-accounts.test.ts
+++ b/backend/shared/src/perps/creator-accounts.test.ts
@@ -1,0 +1,80 @@
+import { SupabaseDirectClient } from '../supabase/init'
+import { resolvePerpCreatorAccount } from './creator-accounts'
+import { getPerpLaunchCreatorId } from './launch-manifest'
+
+const row = (overrides: Record<string, unknown>) => ({
+  id: 'mnx-user',
+  username: 'MNX',
+  name: 'MNX',
+  balance: 0,
+  cash_balance: 0,
+  spice_balance: 0,
+  total_deposits: 0,
+  total_cash_deposits: 0,
+  created_time: '2026-01-01T00:00:00Z',
+  data: {},
+  ...overrides,
+})
+
+const clientReturning = (
+  result: Record<string, unknown> | null,
+  calls: { sql: string; values: unknown[] }[] = []
+) =>
+  ({
+    oneOrNone: jest.fn(
+      async (sql: string, values: unknown[], cb?: (r: unknown) => unknown) => {
+        calls.push({ sql, values })
+        return cb ? cb(result) : result
+      }
+    ),
+  } as unknown as SupabaseDirectClient)
+
+it('pins the official account by environment id', async () => {
+  const calls: { sql: string; values: unknown[] }[] = []
+  const pg = clientReturning(
+    row({ id: getPerpLaunchCreatorId('PROD'), username: 'ManifoldMarkets' }),
+    calls
+  )
+  const resolved = await resolvePerpCreatorAccount('manifold', 'PROD', pg)
+  expect(resolved.user?.id).toBe(getPerpLaunchCreatorId('PROD'))
+  expect(calls[0].sql).toContain('where id = $1')
+  expect(calls[0].values).toEqual([getPerpLaunchCreatorId('PROD')])
+})
+
+it('looks the partner up by username and explains a missing account', async () => {
+  const calls: { sql: string; values: unknown[] }[] = []
+  const found = await resolvePerpCreatorAccount(
+    'mnx',
+    'DEV',
+    clientReturning(row({}), calls)
+  )
+  expect(found.user?.id).toBe('mnx-user')
+  expect(calls[0].sql).toContain('where username = $1')
+  expect(calls[0].values).toEqual(['MNX'])
+
+  const missing = await resolvePerpCreatorAccount(
+    'mnx',
+    'DEV',
+    clientReturning(null)
+  )
+  expect(missing.user).toBeNull()
+  expect(missing.reason).toBe('no @MNX account exists in DEV')
+})
+
+it('refuses a deleted or banned owner', async () => {
+  const banned = await resolvePerpCreatorAccount(
+    'mnx',
+    'PROD',
+    clientReturning(row({ isBannedFromPosting: true }))
+  )
+  expect(banned.user).toBeNull()
+  expect(banned.reason).toBe('MNX (@MNX) is banned')
+
+  const deleted = await resolvePerpCreatorAccount(
+    'mnx',
+    'PROD',
+    clientReturning(row({ data: { userDeleted: true } }))
+  )
+  expect(deleted.user).toBeNull()
+  expect(deleted.reason).toBe('MNX (@MNX) is deleted')
+})

--- a/backend/shared/src/perps/creator-accounts.test.ts
+++ b/backend/shared/src/perps/creator-accounts.test.ts
@@ -1,5 +1,9 @@
 import { SupabaseDirectClient } from '../supabase/init'
-import { resolvePerpCreatorAccount } from './creator-accounts'
+import {
+  getPerpCreatorAccountMismatch,
+  MNX_CREATOR_IDS,
+  resolvePerpCreatorAccount,
+} from './creator-accounts'
 import { getPerpLaunchCreatorId } from './launch-manifest'
 
 const row = (overrides: Record<string, unknown>) => ({
@@ -29,6 +33,9 @@ const clientReturning = (
     ),
   } as unknown as SupabaseDirectClient)
 
+const configured = { ...MNX_CREATOR_IDS }
+afterEach(() => Object.assign(MNX_CREATOR_IDS, configured))
+
 it('pins the official account by environment id', async () => {
   const calls: { sql: string; values: unknown[] }[] = []
   const pg = clientReturning(
@@ -41,34 +48,49 @@ it('pins the official account by environment id', async () => {
   expect(calls[0].values).toEqual([getPerpLaunchCreatorId('PROD')])
 })
 
-it('looks the partner up by username and explains a missing account', async () => {
+it('keeps the partner unavailable until an id is configured', async () => {
+  MNX_CREATOR_IDS.DEV = undefined
+  const pg = clientReturning(row({}))
+  const missing = await resolvePerpCreatorAccount('mnx', 'DEV', pg)
+  expect(missing.user).toBeNull()
+  expect(missing.reason).toBe(
+    'no MNX account id is configured for DEV (MNX_CREATOR_IDS in backend/shared/src/perps/creator-accounts.ts)'
+  )
+  expect(pg.oneOrNone).not.toHaveBeenCalled()
+})
+
+it('resolves the partner by its pinned id, never by username', async () => {
+  MNX_CREATOR_IDS.PROD = 'mnx-user'
   const calls: { sql: string; values: unknown[] }[] = []
   const found = await resolvePerpCreatorAccount(
     'mnx',
-    'DEV',
+    'PROD',
     clientReturning(row({}), calls)
   )
   expect(found.user?.id).toBe('mnx-user')
-  expect(calls[0].sql).toContain('where username = $1')
-  expect(calls[0].values).toEqual(['MNX'])
+  expect(calls[0].sql).toContain('where id = $1')
+  expect(calls[0].sql).not.toContain('username')
+  expect(calls[0].values).toEqual(['mnx-user'])
+  expect(getPerpCreatorAccountMismatch(found)).toBeNull()
 
-  const missing = await resolvePerpCreatorAccount(
+  const gone = await resolvePerpCreatorAccount(
     'mnx',
-    'DEV',
+    'PROD',
     clientReturning(null)
   )
-  expect(missing.user).toBeNull()
-  expect(missing.reason).toBe('no @MNX account exists in DEV')
+  expect(gone.user).toBeNull()
+  expect(gone.reason).toBe('MNX account mnx-user does not exist in PROD')
 })
 
 it('refuses a deleted or banned owner', async () => {
+  MNX_CREATOR_IDS.PROD = 'mnx-user'
   const banned = await resolvePerpCreatorAccount(
     'mnx',
     'PROD',
     clientReturning(row({ isBannedFromPosting: true }))
   )
   expect(banned.user).toBeNull()
-  expect(banned.reason).toBe('MNX (@MNX) is banned')
+  expect(banned.reason).toBe('MNX (@MNX, mnx-user) is banned')
 
   const deleted = await resolvePerpCreatorAccount(
     'mnx',
@@ -76,5 +98,24 @@ it('refuses a deleted or banned owner', async () => {
     clientReturning(row({ data: { userDeleted: true } }))
   )
   expect(deleted.user).toBeNull()
-  expect(deleted.reason).toBe('MNX (@MNX) is deleted')
+  expect(deleted.reason).toBe('MNX (@MNX, mnx-user) is deleted')
+})
+
+it('flags a pinned id whose account no longer carries the partner name', async () => {
+  MNX_CREATOR_IDS.PROD = 'mnx-user'
+  const renamed = await resolvePerpCreatorAccount(
+    'mnx',
+    'PROD',
+    clientReturning(row({ username: 'SomeoneElse' }))
+  )
+  expect(renamed.user?.id).toBe('mnx-user')
+  expect(getPerpCreatorAccountMismatch(renamed)).toBe(
+    'configured MNX partner account mnx-user is now @SomeoneElse, not @MNX; confirm MNX_CREATOR_IDS before creating'
+  )
+  const official = await resolvePerpCreatorAccount(
+    'manifold',
+    'PROD',
+    clientReturning(row({ id: getPerpLaunchCreatorId('PROD'), username: 'X' }))
+  )
+  expect(getPerpCreatorAccountMismatch(official)).toBeNull()
 })

--- a/backend/shared/src/perps/creator-accounts.ts
+++ b/backend/shared/src/perps/creator-accounts.ts
@@ -8,42 +8,57 @@ import { User } from 'common/user'
 import { SupabaseDirectClient } from 'shared/supabase/init'
 import { getPerpLaunchCreatorId } from './launch-manifest'
 
+type Environment = 'DEV' | 'PROD'
+
+// The partner is identified by user id, never by username: usernames can be
+// changed and are not reserved, so resolving @MNX at request time would let a
+// rename strand its existing markets and let whoever reclaims the old name
+// become the partner. Fill an environment in from
+//   select id, username from users where username = 'MNX'
+// and leave it undefined to keep MNX unavailable there (the form greys the
+// option out and create-perp refuses it).
+export const MNX_CREATOR_IDS: Record<Environment, string | undefined> = {
+  DEV: undefined,
+  PROD: undefined,
+}
+
+export const getMnxCreatorId = (environment: Environment) =>
+  MNX_CREATOR_IDS[environment]
+
 export type PerpCreatorAccountResolution =
   | { account: PerpCreatorAccount; user: User; reason?: undefined }
   | { account: PerpCreatorAccount; user: null; reason: string }
 
 // Maps a creator-account choice to the user row that will pay the backing and
 // own the market. Plain queries (no shared/utils) so scripts and the preflight
-// can call this with a bare client. The official account is pinned by id per
-// environment; the partner is looked up by username because its id is not.
+// can call this with a bare client. Both accounts are pinned by id per
+// environment; nothing here trusts a username.
 export const resolvePerpCreatorAccount = async (
   account: PerpCreatorAccount,
-  environment: 'DEV' | 'PROD',
+  environment: Environment,
   pg: SupabaseDirectClient
 ): Promise<PerpCreatorAccountResolution> => {
   const label = PERP_CREATOR_ACCOUNT_LABELS[account]
-  const user =
+  const id =
     account === 'manifold'
-      ? await pg.oneOrNone(
-          `select * from users where id = $1 limit 1`,
-          [getPerpLaunchCreatorId(environment)],
-          convertUser
-        )
-      : await pg.oneOrNone(
-          `select * from users where username = $1 limit 1`,
-          [MNX_CREATOR_USERNAME],
-          convertUser
-        )
+      ? getPerpLaunchCreatorId(environment)
+      : getMnxCreatorId(environment)
+  if (!id)
+    return {
+      account,
+      user: null,
+      reason: `no ${label} account id is configured for ${environment} (MNX_CREATOR_IDS in backend/shared/src/perps/creator-accounts.ts)`,
+    }
+  const user = await pg.oneOrNone(
+    `select * from users where id = $1 limit 1`,
+    [id],
+    convertUser
+  )
   if (!user)
     return {
       account,
       user: null,
-      reason:
-        account === 'manifold'
-          ? `the official ${environment} Manifold account ${getPerpLaunchCreatorId(
-              environment
-            )} does not exist`
-          : `no @${MNX_CREATOR_USERNAME} account exists in ${environment}`,
+      reason: `${label} account ${id} does not exist in ${environment}`,
     }
   // A deleted or banned owner cannot be paid the residual or trusted with the
   // badge; refuse rather than create a market nobody can settle to.
@@ -51,9 +66,22 @@ export const resolvePerpCreatorAccount = async (
     return {
       account,
       user: null,
-      reason: `${label} (@${user.username}) is ${
+      reason: `${label} (@${user.username}, ${id}) is ${
         user.userDeleted ? 'deleted' : 'banned'
       }`,
     }
   return { account, user }
 }
+
+// Creation moves money to and from the pinned account, so an id that no
+// longer carries the partner's name is refused until someone confirms it is
+// still the right account. Read-only paths (the preflight) trust the id alone,
+// so a rename never invalidates markets the partner already owns.
+export const getPerpCreatorAccountMismatch = (
+  resolution: PerpCreatorAccountResolution
+) =>
+  resolution.user &&
+  resolution.account === 'mnx' &&
+  resolution.user.username !== MNX_CREATOR_USERNAME
+    ? `configured MNX partner account ${resolution.user.id} is now @${resolution.user.username}, not @${MNX_CREATOR_USERNAME}; confirm MNX_CREATOR_IDS before creating`
+    : null

--- a/backend/shared/src/perps/creator-accounts.ts
+++ b/backend/shared/src/perps/creator-accounts.ts
@@ -19,7 +19,7 @@ type Environment = 'DEV' | 'PROD'
 // option out and create-perp refuses it).
 export const MNX_CREATOR_IDS: Record<Environment, string | undefined> = {
   DEV: undefined,
-  PROD: undefined,
+  PROD: '0YOMCbJas0UqJdlrqKe1MrQewrF2',
 }
 
 export const getMnxCreatorId = (environment: Environment) =>

--- a/backend/shared/src/perps/creator-accounts.ts
+++ b/backend/shared/src/perps/creator-accounts.ts
@@ -1,0 +1,59 @@
+import {
+  MNX_CREATOR_USERNAME,
+  PERP_CREATOR_ACCOUNT_LABELS,
+  PerpCreatorAccount,
+} from 'common/perps/creator-accounts'
+import { convertUser } from 'common/supabase/users'
+import { User } from 'common/user'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { getPerpLaunchCreatorId } from './launch-manifest'
+
+export type PerpCreatorAccountResolution =
+  | { account: PerpCreatorAccount; user: User; reason?: undefined }
+  | { account: PerpCreatorAccount; user: null; reason: string }
+
+// Maps a creator-account choice to the user row that will pay the backing and
+// own the market. Plain queries (no shared/utils) so scripts and the preflight
+// can call this with a bare client. The official account is pinned by id per
+// environment; the partner is looked up by username because its id is not.
+export const resolvePerpCreatorAccount = async (
+  account: PerpCreatorAccount,
+  environment: 'DEV' | 'PROD',
+  pg: SupabaseDirectClient
+): Promise<PerpCreatorAccountResolution> => {
+  const label = PERP_CREATOR_ACCOUNT_LABELS[account]
+  const user =
+    account === 'manifold'
+      ? await pg.oneOrNone(
+          `select * from users where id = $1 limit 1`,
+          [getPerpLaunchCreatorId(environment)],
+          convertUser
+        )
+      : await pg.oneOrNone(
+          `select * from users where username = $1 limit 1`,
+          [MNX_CREATOR_USERNAME],
+          convertUser
+        )
+  if (!user)
+    return {
+      account,
+      user: null,
+      reason:
+        account === 'manifold'
+          ? `the official ${environment} Manifold account ${getPerpLaunchCreatorId(
+              environment
+            )} does not exist`
+          : `no @${MNX_CREATOR_USERNAME} account exists in ${environment}`,
+    }
+  // A deleted or banned owner cannot be paid the residual or trusted with the
+  // badge; refuse rather than create a market nobody can settle to.
+  if (user.userDeleted || user.isBannedFromPosting)
+    return {
+      account,
+      user: null,
+      reason: `${label} (@${user.username}) is ${
+        user.userDeleted ? 'deleted' : 'banned'
+      }`,
+    }
+  return { account, user }
+}

--- a/backend/shared/src/perps/preflight-cohort.test.ts
+++ b/backend/shared/src/perps/preflight-cohort.test.ts
@@ -122,13 +122,38 @@ it.each(
   }
 )
 
-it('accepts the MNX partner account as creator of MNX-feed markets only', async () => {
+const partnerRow = {
+  id: 'mnx-user',
+  username: 'MNX',
+  name: 'MNX',
+  balance: 0,
+  cash_balance: 0,
+  spice_balance: 0,
+  total_deposits: 0,
+  total_cash_deposits: 0,
+  created_time: '2026-01-01T00:00:00Z',
+  data: {},
+}
+
+// Runs the MNX-cohort feeds audit with the partner id pinned for DEV. The
+// preflight is loaded in an isolated registry, so the pin is applied by a
+// mock factory on that registry's copy of the module.
+const auditWithPinnedPartner = async (partnerExists: boolean) => {
   process.argv = ['node', 'preflight', '--phase=feeds', '--cohort=mnx']
-  let audit!: (pg: SupabaseDirectClient) => Promise<void>
-  jest.isolateModules(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    audit = require('../../../scripts/perp-launch-preflight').auditPerpLaunch
+  jest.doMock('./creator-accounts', () => {
+    const actual = jest.requireActual('./creator-accounts')
+    actual.MNX_CREATOR_IDS.DEV = 'mnx-user'
+    return actual
   })
+  let audit!: (pg: SupabaseDirectClient) => Promise<void>
+  try {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      audit = require('../../../scripts/perp-launch-preflight').auditPerpLaunch
+    })
+  } finally {
+    jest.dontMock('./creator-accounts')
+  }
   const now = Date.now()
   const contracts = ['btc-usd', 'mnx-anthropic-mark'].map(
     (feedId) =>
@@ -153,18 +178,6 @@ it('accepts the MNX partner account as creator of MNX-feed markets only', async 
         createdTime: now,
       } as unknown as PerpContract)
   )
-  const partnerRow = {
-    id: 'mnx-user',
-    username: 'MNX',
-    name: 'MNX',
-    balance: 0,
-    cash_balance: 0,
-    spice_balance: 0,
-    total_deposits: 0,
-    total_cash_deposits: 0,
-    created_time: '2026-01-01T00:00:00Z',
-    data: {},
-  }
   const pg = {
     manyOrNone: jest.fn(async (sql: string) => {
       if (sql.includes('select data, token from contracts'))
@@ -172,8 +185,13 @@ it('accepts the MNX partner account as creator of MNX-feed markets only', async 
       return []
     }),
     oneOrNone: jest.fn(
-      async (sql: string, _values?: unknown[], cb?: (r: unknown) => unknown) =>
-        sql.includes('where username = $1') && cb ? cb(partnerRow) : null
+      async (sql: string, values?: unknown[], cb?: (r: unknown) => unknown) =>
+        partnerExists &&
+        sql.includes('from users where id = $1') &&
+        values?.[0] === 'mnx-user' &&
+        cb
+          ? cb(partnerRow)
+          : null
     ),
     one: jest.fn(async (sql: string) =>
       sql.includes('from txns')
@@ -184,15 +202,34 @@ it('accepts the MNX partner account as creator of MNX-feed markets only', async 
   await expect(audit(pg as unknown as SupabaseDirectClient)).rejects.toThrow(
     /preflight failed/
   )
+  expect(pg.oneOrNone).not.toHaveBeenCalledWith(
+    expect.stringContaining('username'),
+    expect.anything(),
+    expect.anything()
+  )
+}
+
+it('accepts the pinned MNX partner as creator of MNX-feed markets only', async () => {
+  await auditWithPinnedPartner(true)
   expect(log).toHaveBeenCalledWith(
-    '[PASS] creator accounts: official DEV account MxyCh2xvsFMFywwjg3Az0w4xP5B3; MNX partner @MNX (mnx-user) may own MNX feeds'
+    '[PASS] creator accounts: official DEV account MxyCh2xvsFMFywwjg3Az0w4xP5B3; MNX partner account @MNX (mnx-user) may own MNX feeds'
   )
   expect(log).toHaveBeenCalledWith(
-    '[PASS] market mnx-anthropic-mark launch creator: MNX partner account @MNX'
+    '[PASS] market mnx-anthropic-mark launch creator: MNX partner account @MNX (mnx-user)'
   )
   expect(log.error).toHaveBeenCalledWith(
     expect.stringContaining(
       '[FAIL] market btc-usd launch creator: creator mnx-user is not an allowed creator account for btc-usd (MxyCh2xvsFMFywwjg3Az0w4xP5B3)'
     )
+  )
+})
+
+it('keeps markets owned by the pinned id valid when its row cannot be resolved', async () => {
+  await auditWithPinnedPartner(false)
+  expect(log.warn).toHaveBeenCalledWith(
+    '[WARN] creator accounts [warning-key=creator-accounts]: MNX partner account mnx-user may own MNX feeds but MNX account mnx-user does not exist in DEV'
+  )
+  expect(log).toHaveBeenCalledWith(
+    '[PASS] market mnx-anthropic-mark launch creator: MNX partner account mnx-user'
   )
 })

--- a/backend/shared/src/perps/preflight-cohort.test.ts
+++ b/backend/shared/src/perps/preflight-cohort.test.ts
@@ -121,3 +121,78 @@ it.each(
     }
   }
 )
+
+it('accepts the MNX partner account as creator of MNX-feed markets only', async () => {
+  process.argv = ['node', 'preflight', '--phase=feeds', '--cohort=mnx']
+  let audit!: (pg: SupabaseDirectClient) => Promise<void>
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    audit = require('../../../scripts/perp-launch-preflight').auditPerpLaunch
+  })
+  const now = Date.now()
+  const contracts = ['btc-usd', 'mnx-anthropic-mark'].map(
+    (feedId) =>
+      ({
+        id: feedId,
+        slug: feedId,
+        oracleFeedId: feedId,
+        mechanism: 'perp',
+        question: 'fixture',
+        creatorId: 'mnx-user',
+        token: 'MANA',
+        oraclePrice: feedId === 'btc-usd' ? 100000 : 2104,
+        oraclePriceTime: now,
+        maxOraclePriceAgeMs: 5 * MINUTE_MS,
+        fundingPeriodMs: HOUR_MS,
+        maxLeverage: 3,
+        maxFundingRate: 0.0001,
+        fundingSensitivity: 1,
+        poolLong: 25000,
+        poolShort: 25000,
+        initialSubsidy: 50000,
+        createdTime: now,
+      } as unknown as PerpContract)
+  )
+  const partnerRow = {
+    id: 'mnx-user',
+    username: 'MNX',
+    name: 'MNX',
+    balance: 0,
+    cash_balance: 0,
+    spice_balance: 0,
+    total_deposits: 0,
+    total_cash_deposits: 0,
+    created_time: '2026-01-01T00:00:00Z',
+    data: {},
+  }
+  const pg = {
+    manyOrNone: jest.fn(async (sql: string) => {
+      if (sql.includes('select data, token from contracts'))
+        return contracts.map((data) => ({ data, token: 'MANA' }))
+      return []
+    }),
+    oneOrNone: jest.fn(
+      async (sql: string, _values?: unknown[], cb?: (r: unknown) => unknown) =>
+        sql.includes('where username = $1') && cb ? cb(partnerRow) : null
+    ),
+    one: jest.fn(async (sql: string) =>
+      sql.includes('from txns')
+        ? { balance: 0 }
+        : { group_slugs: [], has_embedding: false, count: 0 }
+    ),
+  }
+  await expect(audit(pg as unknown as SupabaseDirectClient)).rejects.toThrow(
+    /preflight failed/
+  )
+  expect(log).toHaveBeenCalledWith(
+    '[PASS] creator accounts: official DEV account MxyCh2xvsFMFywwjg3Az0w4xP5B3; MNX partner @MNX (mnx-user) may own MNX feeds'
+  )
+  expect(log).toHaveBeenCalledWith(
+    '[PASS] market mnx-anthropic-mark launch creator: MNX partner account @MNX'
+  )
+  expect(log.error).toHaveBeenCalledWith(
+    expect.stringContaining(
+      '[FAIL] market btc-usd launch creator: creator mnx-user is not an allowed creator account for btc-usd (MxyCh2xvsFMFywwjg3Az0w4xP5B3)'
+    )
+  )
+})

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -14,6 +14,7 @@ import { DOMAIN } from 'common/envs/constants'
 import { MAX_ID_LENGTH } from 'common/group'
 import { MAX_MULTI_NUMERIC_ANSWERS } from 'common/multi-numeric'
 import { MIN_PERP_LEVERAGE, PERP_MIN_CLOSE_FRACTION } from 'common/perps/amm'
+import { PERP_CREATOR_ACCOUNTS } from 'common/perps/creator-accounts'
 import {
   PERP_TICKER_MAX_LENGTH,
   PERP_TICKER_PATTERN,
@@ -719,6 +720,12 @@ export const createPerpSchema = z.object({
   // platform default (see PERP_TAKER_FEE_IMPACT_DEFAULT); stamped like
   // takerFeeBps above.
   takerFeeImpact: z.number().min(0).max(PERP_TAKER_FEE_IMPACT_MAX).optional(),
+  // Which account owns the market. The owner pays the backing now and is paid
+  // the residual pool at settlement, so the caller must be the official
+  // Manifold account either way (it spends its own balance or acts for the
+  // partner). Omitted = 'manifold' (the handler owns the default, as with
+  // visibility); a partner is accepted only on its own feeds.
+  creatorAccount: z.enum(PERP_CREATOR_ACCOUNTS).optional(),
 })
 
 export const placePerpTradeSchema = z.object({

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -37,6 +37,7 @@ import { CandidateBet } from 'common/new-bet'
 import { Headline } from 'common/news'
 import { PERIODS } from 'common/period'
 import type { PerpTradeActivity } from 'common/perps/activity'
+import { PerpCreatorAccount } from 'common/perps/creator-accounts'
 import {
   PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_IMPACT_MAX,
@@ -1396,6 +1397,20 @@ export const API = (_apiTypeCheck = {
         requiredTopicNames: string[]
         creatorAuthorized: boolean
       } | null
+      // Whether the caller may create on this feed at all: only the official
+      // Manifold account can, because it either pays the backing itself or
+      // acts for a partner account (see createPerpSchema.creatorAccount).
+      callerAuthorized: boolean
+      // Every selectable owner, in display order. `allowed` is feed policy
+      // (a partner owns only its own feeds); `unavailableReason` is set when
+      // the account cannot be resolved in this environment.
+      creatorAccounts: {
+        account: PerpCreatorAccount
+        label: string
+        allowed: boolean
+        username: string | null
+        unavailableReason: string | null
+      }[]
     }[],
     props: z.object({}).strict(),
   },

--- a/common/src/perps/creator-accounts.test.ts
+++ b/common/src/perps/creator-accounts.test.ts
@@ -1,0 +1,36 @@
+import { VERIFIED_USERNAMES } from '../envs/constants'
+import {
+  DEFAULT_PERP_CREATOR_ACCOUNT,
+  getAllowedPerpCreatorAccounts,
+  isPerpCreatorAccountAllowed,
+  MNX_CREATOR_USERNAME,
+  PERP_CREATOR_ACCOUNT_LABELS,
+  PERP_CREATOR_ACCOUNTS,
+} from './creator-accounts'
+import { MNX_INSTRUMENTS } from './mnx'
+
+it('defaults to the official Manifold account and labels every option', () => {
+  expect(DEFAULT_PERP_CREATOR_ACCOUNT).toBe('manifold')
+  expect(PERP_CREATOR_ACCOUNTS[0]).toBe('manifold')
+  for (const account of PERP_CREATOR_ACCOUNTS)
+    expect(PERP_CREATOR_ACCOUNT_LABELS[account]).toMatch(/\S/)
+})
+
+it('lets MNX own markets on every MNX feed and nothing else', () => {
+  for (const instrument of MNX_INSTRUMENTS) {
+    expect(getAllowedPerpCreatorAccounts(instrument.feedId)).toEqual([
+      'manifold',
+      'mnx',
+    ])
+    expect(isPerpCreatorAccountAllowed('mnx', instrument.feedId)).toBe(true)
+  }
+  for (const feedId of ['btc-usd', 'spyx-usd', 'not-a-feed', undefined]) {
+    expect(getAllowedPerpCreatorAccounts(feedId)).toEqual(['manifold'])
+    expect(isPerpCreatorAccountAllowed('mnx', feedId)).toBe(false)
+    expect(isPerpCreatorAccountAllowed('manifold', feedId)).toBe(true)
+  }
+})
+
+it('resolves the partner by a verified username so the badge renders', () => {
+  expect(VERIFIED_USERNAMES).toContain(MNX_CREATOR_USERNAME)
+})

--- a/common/src/perps/creator-accounts.ts
+++ b/common/src/perps/creator-accounts.ts
@@ -1,0 +1,34 @@
+import { getMnxInstrument } from './mnx'
+
+// Accounts a PERP can be created under. The selection is the market's creator
+// in every sense the engine knows: it pays the backing at creation and
+// receives the residual pool at settlement (PERP_RESOLVE_RESIDUAL is paid to
+// contract.creatorId). Personal admin accounts are deliberately not on the
+// list — see PERP_LAUNCH_CREATOR_IDS for why the house account is the default.
+export const PERP_CREATOR_ACCOUNTS = ['manifold', 'mnx'] as const
+export type PerpCreatorAccount = (typeof PERP_CREATOR_ACCOUNTS)[number]
+
+export const DEFAULT_PERP_CREATOR_ACCOUNT: PerpCreatorAccount = 'manifold'
+
+export const PERP_CREATOR_ACCOUNT_LABELS: Record<PerpCreatorAccount, string> = {
+  manifold: 'Manifold (official account)',
+  mnx: 'MNX',
+}
+
+// The partner account is resolved by username at request time because its id
+// differs per environment (and DEV may not have one at all). The name is in
+// VERIFIED_USERNAMES, so the badge shows on markets it owns.
+export const MNX_CREATOR_USERNAME = 'MNX'
+
+// A partner may only own markets on its own feeds: MNX-owned BTC markets would
+// route house backing to a third party for a product it has nothing to do
+// with. The official account may own anything.
+export const getAllowedPerpCreatorAccounts = (
+  feedId: string | undefined
+): readonly PerpCreatorAccount[] =>
+  getMnxInstrument(feedId) ? PERP_CREATOR_ACCOUNTS : ['manifold']
+
+export const isPerpCreatorAccountAllowed = (
+  account: PerpCreatorAccount,
+  feedId: string | undefined
+) => getAllowedPerpCreatorAccounts(feedId).includes(account)

--- a/perps-launch-runbook.md
+++ b/perps-launch-runbook.md
@@ -201,6 +201,7 @@ npx.cmd ts-node publish-mnx-now.ts --apply
 npx.cmd ts-node perp-launch-preflight.ts --cohort=mnx --phase=feeds
 npx.cmd ts-node create-mnx-perps.ts
 npx.cmd ts-node create-mnx-perps.ts --apply
+npx.cmd ts-node create-mnx-perps.ts --creator=mnx            # MNX-owned variant (dry run)
 npx.cmd ts-node perp-launch-preflight.ts --cohort=mnx --phase=unlisted --allow-warning=external-alert-policies
 ```
 
@@ -217,7 +218,12 @@ instrument is unavailable. It exits nonzero on unavailable/rejected publication.
 Repair discovery prerequisites with
 `backfill-perp-launch-discovery.ts --cohort=mnx` (dry run), then `--apply`.
 Creation requires `MANIFOLD_API_KEY` belonging to the environment's official
-Manifold creator and sufficient backing (M800,000 for all sixteen). It prints
+Manifold creator and sufficient backing (M800,000 for all sixteen). By default
+the official account owns the markets; `--creator=mnx` makes the verified
+`@MNX` partner account the owner instead, in which case that account must hold
+the backing (the owner pays it at creation and receives the residual pool at
+settlement) while the API key stays the official creator's. The admin form
+offers the same choice as its **Creator account** selector. It prints
 per-instrument readiness and exact request bodies, refuses a partially ready
 apply before any creation, and checks duplicates before applying; reruns skip existing
 markets. Do not run these commands until ready to perform their indicated writes.
@@ -364,10 +370,13 @@ Keep that redesign separate from the capped day-one launch.
    announcement QA; generated iframe URLs must target that deployed
    environment, not localhost.
 
-Sign in as the environment's official Manifold account; residual backing
-returns to the creator at settlement, and both the form and API reject another
-admin for launch feeds. Confirm that account has at least M100,000 available
-before creation. The form defaults to unlisted. For each manifest feed, click
+Sign in as the environment's official Manifold account; both the form and API
+reject any other admin, because the selected creator account's balance is
+spent. The **Creator account** selector defaults to the official account and
+offers `@MNX` on MNX feeds only; whichever is selected pays the backing and
+receives the residual at settlement. Confirm that account has at least
+M100,000 available before creation. The form defaults to unlisted. For each
+manifest feed, click
 **Apply launch recommendation**; it sets leverage, annual funding cap,
 sensitivity, oracle-age tolerance, per-side backing, and unlisted visibility.
 The API automatically attaches the required DEV/PROD topic atomically.

--- a/perps-launch-runbook.md
+++ b/perps-launch-runbook.md
@@ -222,8 +222,12 @@ Manifold creator and sufficient backing (M800,000 for all sixteen). By default
 the official account owns the markets; `--creator=mnx` makes the verified
 `@MNX` partner account the owner instead, in which case that account must hold
 the backing (the owner pays it at creation and receives the residual pool at
-settlement) while the API key stays the official creator's. The admin form
-offers the same choice as its **Creator account** selector. It prints
+settlement) while the API key stays the official creator's. The partner's user
+id must first be pinned for the environment in `MNX_CREATOR_IDS`
+(`backend/shared/src/perps/creator-accounts.ts`); until then the option is
+unavailable everywhere. The script refuses to apply against an API that does
+not advertise the option and verifies each created market's creator. The
+admin form offers the same choice as its **Creator account** selector. It prints
 per-instrument readiness and exact request bodies, refuses a partially ready
 apply before any creation, and checks duplicates before applying; reruns skip existing
 markets. Do not run these commands until ready to perform their indicated writes.

--- a/web/pages/admin/create-perp.tsx
+++ b/web/pages/admin/create-perp.tsx
@@ -2,6 +2,12 @@ import { useState, useEffect } from 'react'
 import { toast } from 'react-hot-toast'
 import { XIcon } from '@heroicons/react/solid'
 import { Group } from 'common/group'
+import {
+  DEFAULT_PERP_CREATOR_ACCOUNT,
+  PERP_CREATOR_ACCOUNT_LABELS,
+  PERP_CREATOR_ACCOUNTS,
+  PerpCreatorAccount,
+} from 'common/perps/creator-accounts'
 import { fundingPeriodNoun, fundingPeriodUnit } from 'common/perps/funding'
 import {
   PERP_TICKER_MAX_LENGTH,
@@ -15,6 +21,7 @@ import { Page } from 'web/components/layout/page'
 import { Row } from 'web/components/layout/row'
 import { NoSEO } from 'web/components/NoSEO'
 import { TopicSelector } from 'web/components/topics/topic-selector'
+import { ChoicesToggleGroup } from 'web/components/widgets/choices-toggle-group'
 import { Input } from 'web/components/widgets/input'
 import { Title } from 'web/components/widgets/title'
 import { useAdmin } from 'web/hooks/use-admin'
@@ -30,6 +37,9 @@ export default function AdminCreatePerpPage() {
     description: '',
     oracleFeedId: '',
     ticker: '',
+    // Who owns the market: pays the backing now, receives the residual pool
+    // at settlement. The house account unless a partner feed says otherwise.
+    creatorAccount: DEFAULT_PERP_CREATOR_ACCOUNT as PerpCreatorAccount,
     maxLeverage: 10,
     // Annualized max funding rate as a percentage (e.g. 50 means 50%/yr).
     maxFundingRateAnnualPct: 50,
@@ -63,6 +73,16 @@ export default function AdminCreatePerpPage() {
         requiredTopicNames: string[]
         creatorAuthorized: boolean
       } | null
+      // Optional so the page stays usable against an API that predates the
+      // creator selector during a rolling deploy (see creatorSelectorSupported).
+      callerAuthorized?: boolean
+      creatorAccounts?: {
+        account: PerpCreatorAccount
+        label: string
+        allowed: boolean
+        username: string | null
+        unavailableReason: string | null
+      }[]
     }[]
   >([])
   const [feedLatest, setFeedLatest] = useState<{
@@ -130,6 +150,19 @@ export default function AdminCreatePerpPage() {
     }))
   }, [form.oracleFeedId, knownFeeds])
 
+  // A partner may only own its own feeds, so a choice made for one feed can't
+  // survive switching to another where it is not allowed.
+  useEffect(() => {
+    const feedId = form.oracleFeedId.trim()
+    const accounts = knownFeeds.find((f) => f.id === feedId)?.creatorAccounts
+    if (!accounts) return
+    setForm((f) =>
+      accounts.some((a) => a.account === f.creatorAccount && a.allowed)
+        ? f
+        : { ...f, creatorAccount: DEFAULT_PERP_CREATOR_ACCOUNT }
+    )
+  }, [form.oracleFeedId, knownFeeds])
+
   const subsidyTotal = form.subsidyLong + form.subsidyShort
 
   // The engine stores maxFundingRate per FUNDING PERIOD, and the period is
@@ -154,6 +187,36 @@ export default function AdminCreatePerpPage() {
   const launchCreatorUnauthorized =
     hasCompleteLaunchRecommendation &&
     launchRecommendation?.creatorAuthorized === false
+  // Older API responses carry no creator accounts. 'manifold' then means what
+  // it always meant (the caller, which the API requires to be the official
+  // account), but a partner selection must not be sent to an API that would
+  // silently create the market under the caller instead.
+  const creatorSelectorSupported =
+    selectedFeed == null || Array.isArray(selectedFeed.creatorAccounts)
+  const creatorAccounts =
+    selectedFeed?.creatorAccounts ??
+    PERP_CREATOR_ACCOUNTS.map((account) => ({
+      account,
+      label: PERP_CREATOR_ACCOUNT_LABELS[account],
+      allowed: account === DEFAULT_PERP_CREATOR_ACCOUNT,
+      username: null,
+      unavailableReason: null,
+    }))
+  const selectedCreator = creatorAccounts.find(
+    (a) => a.account === form.creatorAccount
+  )
+  const creatorBlockedReason =
+    selectedFeed != null &&
+    !creatorSelectorSupported &&
+    form.creatorAccount !== DEFAULT_PERP_CREATOR_ACCOUNT
+      ? 'Redeploy the current API before creating a market owned by another account.'
+      : selectedCreator && !selectedCreator.allowed
+      ? `${selectedCreator.label} cannot own a market on this feed.`
+      : selectedCreator?.unavailableReason
+      ? `${selectedCreator.label} is unavailable: ${selectedCreator.unavailableReason}.`
+      : null
+  const callerUnauthorized =
+    launchCreatorUnauthorized || selectedFeed?.callerAuthorized === false
   const feedCreationDisabled = selectedFeed?.marketCreationEnabled === false
   const canonicalTicker = selectedFeed?.ticker ?? null
   const unregisteredFeed =
@@ -228,10 +291,12 @@ export default function AdminCreatePerpPage() {
       toast.error('Redeploy the current API before creating this launch feed.')
       return
     }
-    if (launchCreatorUnauthorized) {
-      toast.error(
-        'Sign in as the official Manifold account to create a launch PERP.'
-      )
+    if (callerUnauthorized) {
+      toast.error('Sign in as the official Manifold account to create a PERP.')
+      return
+    }
+    if (creatorBlockedReason) {
+      toast.error(creatorBlockedReason)
       return
     }
     if (!isValidPerpTicker(form.ticker.trim())) {
@@ -247,6 +312,7 @@ export default function AdminCreatePerpPage() {
         description: form.description || undefined,
         oracleFeedId: form.oracleFeedId.trim(),
         ticker: form.ticker.trim(),
+        creatorAccount: form.creatorAccount,
         maxLeverage: form.maxLeverage,
         maxFundingRate: maxFundingRatePerPeriod,
         fundingSensitivity: form.fundingSensitivity,
@@ -420,11 +486,12 @@ export default function AdminCreatePerpPage() {
                           : 'Current form differs.'}
                       </span>
                     </Row>
-                    {launchCreatorUnauthorized && (
+                    {callerUnauthorized && (
                       <p className="text-scarlet-700 mt-2 font-semibold">
-                        Sign in as the official Manifold account. Residual
-                        backing returns to the market creator, so another admin
-                        cannot create this launch feed.
+                        Sign in as the official Manifold account. The creator
+                        account below pays the backing and receives the
+                        residual at settlement, so another admin cannot
+                        create this market under either name.
                       </p>
                     )}
                   </>
@@ -452,6 +519,46 @@ export default function AdminCreatePerpPage() {
                 ? 'Canonical for this feed (PERP_FEED_TICKERS in common/perps/ticker.ts); every market on the feed shows it.'
                 : `Shown in front of the title in place of the market type, used as the label on /perps, and matched by search. One alphanumeric token of at most ${PERP_TICKER_MAX_LENGTH} characters, starting with a letter. To make it canonical for the feed, add it to PERP_FEED_TICKERS.`}
             </p>
+          </div>
+
+          <div>
+            <span className="text-ink-700 mb-2 block text-sm font-medium">
+              Creator account
+            </span>
+            <ChoicesToggleGroup
+              currentChoice={form.creatorAccount}
+              choicesMap={Object.fromEntries(
+                creatorAccounts.map((a) => [
+                  a.username ? `${a.label} · @${a.username}` : a.label,
+                  a.account,
+                ])
+              )}
+              disabledOptions={creatorAccounts
+                .filter((a) => !a.allowed || a.unavailableReason)
+                .map((a) => a.account)}
+              setChoice={(choice) =>
+                update('creatorAccount', choice as PerpCreatorAccount)
+              }
+            />
+            <p className="text-ink-500 mt-1 text-xs">
+              The selected account is the market's creator: it pays the backing
+              at creation and receives the residual pool at settlement, and its
+              name and badge show on the market. MNX can only own markets on
+              MNX feeds; the official Manifold account can own any feed.
+            </p>
+            {creatorBlockedReason && (
+              <p className="text-scarlet-700 mt-1 text-xs">
+                {creatorBlockedReason}
+              </p>
+            )}
+            {selectedFeed != null &&
+              !callerUnauthorized &&
+              selectedFeed.callerAuthorized == null && (
+                <p className="text-scarlet-700 mt-1 text-xs">
+                  This API predates the creator selector; redeploy it before
+                  relying on the options above.
+                </p>
+              )}
           </div>
 
           <div>
@@ -548,7 +655,10 @@ export default function AdminCreatePerpPage() {
               onChange={(v) => update('subsidyShort', v)}
               step={100}
               min={1}
-              hint={`Total ${subsidyTotal} paid by you at creation. Use symmetric pools for launch unless observed flow and stress tests support a deliberate skew.`}
+              hint={`Total ${subsidyTotal} paid by ${
+                selectedCreator?.label ??
+                PERP_CREATOR_ACCOUNT_LABELS[form.creatorAccount]
+              } at creation. Use symmetric pools for launch unless observed flow and stress tests support a deliberate skew.`}
             />
           </Row>
 
@@ -571,7 +681,8 @@ export default function AdminCreatePerpPage() {
                 feedRegistryStatus !== 'ready' ||
                 feedCreationDisabled ||
                 launchApiOutOfDate ||
-                launchCreatorUnauthorized
+                callerUnauthorized ||
+                creatorBlockedReason != null
               }
             >
               Create perp

--- a/web/pages/admin/create-perp.tsx
+++ b/web/pages/admin/create-perp.tsx
@@ -489,9 +489,9 @@ export default function AdminCreatePerpPage() {
                     {callerUnauthorized && (
                       <p className="text-scarlet-700 mt-2 font-semibold">
                         Sign in as the official Manifold account. The creator
-                        account below pays the backing and receives the
-                        residual at settlement, so another admin cannot
-                        create this market under either name.
+                        account below pays the backing and receives the residual
+                        at settlement, so another admin cannot create this
+                        market under either name.
                       </p>
                     )}
                   </>
@@ -543,8 +543,8 @@ export default function AdminCreatePerpPage() {
             <p className="text-ink-500 mt-1 text-xs">
               The selected account is the market's creator: it pays the backing
               at creation and receives the residual pool at settlement, and its
-              name and badge show on the market. MNX can only own markets on
-              MNX feeds; the official Manifold account can own any feed.
+              name and badge show on the market. MNX can only own markets on MNX
+              feeds; the official Manifold account can own any feed.
             </p>
             {creatorBlockedReason && (
               <p className="text-scarlet-700 mt-1 text-xs">

--- a/web/pages/admin/create-perp.tsx
+++ b/web/pages/admin/create-perp.tsx
@@ -215,6 +215,30 @@ export default function AdminCreatePerpPage() {
       : selectedCreator?.unavailableReason
       ? `${selectedCreator.label} is unavailable: ${selectedCreator.unavailableReason}.`
       : null
+  // Every greyed-out option explains itself in place: a disabled toggle cannot
+  // be selected to reveal why, so the reason for each one is listed below.
+  const creatorApiOutOfDate = selectedFeed != null && !creatorSelectorSupported
+  const disabledCreatorReasons = creatorApiOutOfDate
+    ? []
+    : creatorAccounts.flatMap((a) =>
+        !a.allowed
+          ? [
+              {
+                account: a.account,
+                reason: selectedFeed
+                  ? `${a.label} cannot own a market on this feed.`
+                  : `${a.label} is only available on MNX feeds; choose the feed first.`,
+              },
+            ]
+          : a.unavailableReason
+          ? [
+              {
+                account: a.account,
+                reason: `${a.label} is unavailable: ${a.unavailableReason}.`,
+              },
+            ]
+          : []
+      )
   const callerUnauthorized =
     launchCreatorUnauthorized || selectedFeed?.callerAuthorized === false
   const feedCreationDisabled = selectedFeed?.marketCreationEnabled === false
@@ -546,19 +570,24 @@ export default function AdminCreatePerpPage() {
               name and badge show on the market. MNX can only own markets on MNX
               feeds; the official Manifold account can own any feed.
             </p>
-            {creatorBlockedReason && (
+            {disabledCreatorReasons.map(({ account, reason }) => (
+              <p
+                key={account}
+                className={
+                  account === form.creatorAccount
+                    ? 'text-scarlet-700 mt-1 text-xs'
+                    : 'text-ink-500 mt-1 text-xs'
+                }
+              >
+                {reason}
+              </p>
+            ))}
+            {creatorApiOutOfDate && (
               <p className="text-scarlet-700 mt-1 text-xs">
-                {creatorBlockedReason}
+                This API predates the creator selector; redeploy it before
+                relying on the options above.
               </p>
             )}
-            {selectedFeed != null &&
-              !callerUnauthorized &&
-              selectedFeed.callerAuthorized == null && (
-                <p className="text-scarlet-700 mt-1 text-xs">
-                  This API predates the creator selector; redeploy it before
-                  relying on the options above.
-                </p>
-              )}
           </div>
 
           <div>


### PR DESCRIPTION
Follow-up to #4055: lets a PERP be owned by the MNX partner account instead of the official Manifold account.

## What changes

- **Creator account selector** on `/admin/create-perp`: "Manifold (official account)" (default) or "MNX". MNX is only selectable on MNX feeds; every greyed-out option lists its reason in place (not allowed on this feed, no id configured for the environment, account missing/banned/deleted, or pinned id renamed), and the form refuses to send a partner selection to an API that predates the selector.
- **`create-perp` API** accepts `creatorAccount: 'manifold' | 'mnx'` (omitted = `manifold`). The selected account is the market's creator in every sense the engine already has: it is stored as `creatorId`, it **pays the backing** at creation, and it **receives the residual pool** at settlement (`PERP_RESOLVE_RESIDUAL` goes to `contract.creatorId`). A deleted or banned owner is refused. A partner is only accepted on its own feeds.
- **Pinned identity**: both accounts are resolved by user id per environment. The partner's ids live in `MNX_CREATOR_IDS` (`backend/shared/src/perps/creator-accounts.ts`), PROD pinned to `0YOMCbJas0UqJdlrqKe1MrQewrF2`, verified against https://api.manifold.markets/v0/user/by-id/0YOMCbJas0UqJdlrqKe1MrQewrF2 as `@MNX`. DEV remains unset, so MNX is unavailable there until a DEV account id is configured. Usernames are never used to identify the account; creation additionally refuses a pinned id whose account no longer carries the `MNX` name, while the read-only preflight trusts the id alone so a rename never invalidates existing markets.
- **Caller gate**: the caller must be the environment's official Manifold account for every creation, since it either spends its own balance or acts for the partner. Every creation-enabled feed is already a launch feed, so this is the same gate the launch manifest always enforced; the message now says why.
- **`get-known-oracle-feeds`** reports `callerAuthorized` and the per-feed `creatorAccounts` (label, allowed, resolved username, unavailable reason) so the form can explain instead of letting the API reject.
- **Preflight** accepts the pinned MNX id as creator of MNX-feed markets only, reports the resolved accounts in one line, and WARNs (allow-warning key `creator-accounts`) when a configured id cannot be resolved.
- **`create-mnx-perps.ts --creator=mnx`** creates the cohort under the partner account (dry-run first, as before). Before any write in apply mode it requires the API to advertise the creator option for every feed and to resolve the owner to the same account, and it verifies each created market's `creatorId`, because an older API strips the unknown field and would create under the caller with a 200. The API key must still belong to the official creator; the backing check runs against the selected owner's balance.
- README and runbook updated to describe the selector, the pinned ids and the money semantics.

## Semantics to confirm

The owner pays the backing and receives the residual. Creating as MNX therefore requires the `@MNX` account to hold the backing first (M50,000 per market at the launch recommendation). This keeps the engine's "residual returns to the creator" rule and avoids house backing silently flowing to a partner at settlement. If the intended model is instead "Manifold funds, MNX is the displayed owner", say so and the subsidy source can be split from the creator in a follow-up.

## Before using it

- The production MNX account id is configured and ships with the normal API deployment. Configure a separate DEV id if a partner account exists there; otherwise the DEV option stays greyed out.
- No new endpoints, migrations, jobs, or changes to trading, funding, or oracle code.

## Tests

- `common/src/perps/creator-accounts.test.ts`: allowed accounts per feed, default, labels, verified username.
- `backend/shared/src/perps/creator-accounts.test.ts`: resolver by pinned id (never username), unconfigured, missing, banned, deleted, renamed-id mismatch.
- `backend/shared/src/perps/preflight-cohort.test.ts`: pinned MNX id passes on an MNX feed and fails on BTC; markets owned by the pinned id stay valid when its row cannot be resolved (WARN instead of FAIL).

Local validation: the suites above pass; `tsc -b` for common, shared and api is clean; web `tsc --noEmit` is clean; eslint and prettier pass on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QN3FVJM3sL9sVxrckDfa1G
