### PR TITLE
Add MNX management dashboard and 20 bps API launch fees

### DIFF
--- a/backend/api/src/add-perp-subsidy.ts
+++ b/backend/api/src/add-perp-subsidy.ts
@@ -1,28 +1,45 @@
-import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
+import { requirePerpManager } from 'shared/perps/management-auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { addPerpPoolSubsidy } from 'shared/perps/engine'
 import { log } from 'shared/utils'
 import { broadcastUpdatedContract } from 'shared/websockets/helpers'
-import { APIHandler } from './helpers/endpoint'
+import { APIError, APIHandler } from './helpers/endpoint'
 
-// Admin-only escrow top-up of one side's backing pool on a live perp. The
-// admin pays from their own balance; all state checks (unresolved, MANA
+// The signed-in manager pays from their own balance; all state checks (unresolved, MANA
 // token, escrow invariant) and locking live in the engine.
 export const addPerpSubsidy: APIHandler<'add-perp-subsidy'> = async (
   body,
   auth
 ) => {
-  throwErrorIfNotAdmin(auth.uid)
+  if (
+    body.expectedManagerId !== undefined &&
+    body.expectedManagerId !== auth.uid
+  )
+    throw new APIError(
+      409,
+      'The paying account changed. Sign back in before retrying.'
+    )
+  await requirePerpManager(createSupabaseDirectClient(), auth.uid)
   const { contractId, side, amount } = body
 
-  const { contract, poolLong, poolShort } = await addPerpPoolSubsidy(
+  const { contract, poolLong, poolShort, replayed } = await addPerpPoolSubsidy(
     contractId,
     auth.uid,
     side,
-    amount
+    amount,
+    {
+      idempotencyKey: body.idempotencyKey,
+      authorize: async (tx, contract) => {
+        await requirePerpManager(tx, auth.uid, contract)
+      },
+    }
   )
-  log(
-    `admin ${auth.uid} added M$${amount} ${side} pool subsidy on ${contract.slug}: L=${poolLong} S=${poolShort}`
-  )
+  if (!replayed)
+    log(
+      `perp manager ${auth.uid} added M$${
+        amount * (side === 'both' ? 2 : 1)
+      } to ${side} pools on ${contract.slug}: L=${poolLong} S=${poolShort}`
+    )
   broadcastUpdatedContract(contract.visibility, {
     id: contractId,
     poolLong,

--- a/backend/api/src/create-perp.ts
+++ b/backend/api/src/create-perp.ts
@@ -4,7 +4,7 @@ import {
   getAllowedPerpCreatorAccounts,
   isPerpCreatorAccountAllowed,
 } from 'common/perps/creator-accounts'
-import { getMnxInstrument } from 'common/perps/mnx'
+import { getMnxInstrument, MNX_DEFAULT_FEES } from 'common/perps/mnx'
 import { OracleFeedHealth } from 'common/perps/oracle-health'
 import { fetchMnxSnapshot, requireMnxReady } from 'shared/mnx'
 import { advisoryLockQuery } from 'shared/perps/queries'
@@ -95,6 +95,7 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
     subsidyLong,
     subsidyShort,
     takerFeeBps,
+    takerFeeApiBps,
     takerFeeImpact,
     creatorAccount = DEFAULT_PERP_CREATOR_ACCOUNT,
   } = body
@@ -338,8 +339,21 @@ export const createPerp: APIHandler<'create-perp'> = async (body, auth) => {
       // Stamp the resolved values so a later change to the platform defaults
       // cannot silently rewrite this market's economics (same reasoning as
       // fundingPeriodMs above).
-      takerFeeBps: takerFeeBps ?? PERP_TAKER_FEE_BPS_DEFAULT,
-      takerFeeImpact: takerFeeImpact ?? PERP_TAKER_FEE_IMPACT_DEFAULT,
+      takerFeeBps:
+        takerFeeBps ??
+        (getMnxInstrument(oracleFeedId)
+          ? MNX_DEFAULT_FEES.takerFeeBps
+          : PERP_TAKER_FEE_BPS_DEFAULT),
+      takerFeeApiBps:
+        takerFeeApiBps ??
+        (getMnxInstrument(oracleFeedId)
+          ? MNX_DEFAULT_FEES.takerFeeApiBps
+          : undefined),
+      takerFeeImpact:
+        takerFeeImpact ??
+        (getMnxInstrument(oracleFeedId)
+          ? MNX_DEFAULT_FEES.takerFeeImpact
+          : PERP_TAKER_FEE_IMPACT_DEFAULT),
       fundingPeriodMs,
       poolLong: subsidyLong,
       poolShort: subsidyShort,

--- a/backend/api/src/get-known-oracle-feeds.ts
+++ b/backend/api/src/get-known-oracle-feeds.ts
@@ -55,6 +55,7 @@ export const getKnownOracleFeeds: APIHandler<'get-known-oracle-feeds'> = async (
     )
     return {
       id,
+      supportsApiTakerFee: true,
       updatePeriodMs: feed?.updatePeriodMs ?? null,
       marketCreationEnabled: feed?.marketCreationEnabled ?? false,
       description: feed?.description ?? null,

--- a/backend/api/src/get-mnx-dashboard.ts
+++ b/backend/api/src/get-mnx-dashboard.ts
@@ -1,0 +1,88 @@
+import { PerpContract } from 'common/contract'
+import { ENV } from 'common/envs/constants'
+import { MNX_INSTRUMENTS } from 'common/perps/mnx'
+import { convertContract } from 'common/supabase/contracts'
+import { convertUser } from 'common/supabase/users'
+import { DAY_MS } from 'common/util/time'
+import { getMinTradingMarkAgeMs, getOracleFeed } from 'shared/oracle-feeds'
+import { getMnxCreatorId } from 'shared/perps/creator-accounts'
+import { requirePerpManager } from 'shared/perps/management-auth'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { APIHandler } from './helpers/endpoint'
+
+export const getMnxDashboard: APIHandler<'get-mnx-dashboard'> = async (
+  _,
+  auth
+) => {
+  const pg = createSupabaseDirectClient()
+  const payer = await requirePerpManager(pg, auth.uid)
+  const ownerId = getMnxCreatorId(ENV)
+  const account = ownerId
+    ? await pg.oneOrNone(
+        'select * from users where id = $1',
+        [ownerId],
+        convertUser
+      )
+    : null
+  const asOf = Date.now()
+  const rows = await pg.manyOrNone(
+    `select * from contracts
+      where mechanism = 'perp' and creator_id = $1
+        and data->>'oracleFeedId' = any($2)
+      order by created_time`,
+    [ownerId ?? null, MNX_INSTRUMENTS.map((i) => i.feedId)]
+  )
+  const contracts = rows.map(convertContract) as PerpContract[]
+  const ids = contracts.map((c) => c.id)
+  const [positions, activity] = await Promise.all([
+    pg.manyOrNone<{
+      contract_id: string
+      traders: number
+      long_oi: number
+      short_oi: number
+    }>(
+      `select contract_id, count(distinct user_id)::int as traders,
+              coalesce(sum(size) filter (where direction = 'long'), 0)::float8 as long_oi,
+              coalesce(sum(size) filter (where direction = 'short'), 0)::float8 as short_oi
+         from contract_perp_positions where contract_id = any($1) and size > 0
+         group by contract_id`,
+      [ids]
+    ),
+    pg.manyOrNone<{ contract_id: string; volume: number; fees: number }>(
+      `select contract_id,
+              coalesce(sum(abs(original_cost_basis_delta)), 0)::float8 as volume,
+              coalesce(sum((data->>'fee')::float8), 0)::float8 as fees
+         from contract_perp_events
+        where contract_id = any($1) and applied_ts >= $2 and applied_ts <= $3
+          and event_type in ('open', 'add', 'close')
+        group by contract_id`,
+      [ids, new Date(asOf - DAY_MS), new Date(asOf)]
+    ),
+  ])
+  const summary = (user: typeof payer) => ({
+    id: user.id,
+    username: user.username,
+    balance: user.balance,
+  })
+  return {
+    asOf,
+    account: account ? summary(account) : null,
+    payer: summary(payer),
+    markets: contracts.map((contract) => {
+      const book = positions.find((p) => p.contract_id === contract.id)
+      const trades = activity.find((a) => a.contract_id === contract.id)
+      const feed = getOracleFeed(contract.oracleFeedId)
+      return {
+        contract,
+        activeTraders: book?.traders ?? 0,
+        openInterestLong: book?.long_oi ?? 0,
+        openInterestShort: book?.short_oi ?? 0,
+        volume24Hours: trades?.volume ?? 0,
+        fees24Hours: trades?.fees ?? 0,
+        minOraclePriceAgeMs: feed
+          ? getMinTradingMarkAgeMs(feed)
+          : contract.maxOraclePriceAgeMs,
+      }
+    }),
+  }
+}

--- a/backend/api/src/routes.ts
+++ b/backend/api/src/routes.ts
@@ -76,6 +76,7 @@ import { placePerpTrade } from './place-perp-trade'
 import { closePerpPosition } from './close-perp-position'
 import { updatePerpConfig } from './update-perp-config'
 import { addPerpSubsidy } from './add-perp-subsidy'
+import { getMnxDashboard } from './get-mnx-dashboard'
 import {
   getModelClassifications,
   setModelClassification,
@@ -460,6 +461,7 @@ export const handlers: { [k in APIPath]: APIHandler<k> } = {
   'close-perp-position': closePerpPosition,
   'update-perp-config': updatePerpConfig,
   'add-perp-subsidy': addPerpSubsidy,
+  'get-mnx-dashboard': getMnxDashboard,
   'get-model-classifications': getModelClassifications,
   'set-model-classification': setModelClassification,
   'get-openrouter-lab-classifications': getOpenRouterLabClassifications,

--- a/backend/api/src/update-perp-config.ts
+++ b/backend/api/src/update-perp-config.ts
@@ -1,174 +1,33 @@
-import {
-  getPerpEffectiveTakerFeeBps,
-  getPerpTakerFeeBps,
-  getPerpTakerFeeImpact,
-} from 'common/perps/fees'
-import { getMinTradingMarkAgeMs, getOracleFeed } from 'shared/oracle-feeds'
-import { removeUndefinedProps } from 'common/util/object'
-import { throwErrorIfNotAdmin } from 'shared/helpers/auth'
-import { recordContractEdit } from 'shared/record-contract-edit'
-import { updateContract } from 'shared/supabase/contracts'
-import { createSupabaseDirectClient } from 'shared/supabase/init'
-import { getContract, log, revalidateContractStaticProps } from 'shared/utils'
+import { getPerpEffectiveTakerFeeBps } from 'common/perps/fees'
+import { getPerpConfig } from 'common/perps/management'
+import { setPerpConfig } from 'shared/perps/manage-config'
+import { log, revalidateContractStaticProps } from 'shared/utils'
 import { broadcastUpdatedContract } from 'shared/websockets/helpers'
-import { APIError, APIHandler } from './helpers/endpoint'
+import { APIHandler } from './helpers/endpoint'
 
-// Admin-only live tuning of a perp's risk config. Takes effect with no
-// deploy or restart: the engine re-reads the contract inside every trade and
-// funding transaction under the advisory lock.
-// - maxLeverage: lowering the cap only constrains new opens and adds —
-//   leverage is checked at trade time, never retroactively — so existing
-//   positions above a lowered cap are grandfathered and a cut can never
-//   force-close or liquidate anyone by itself.
-// - maxFundingRate: applies from the NEXT funding event. It is the
-//   per-PERIOD cap on the imbalance haircut, so on an hourly market 0.02
-//   means up to 2% of the crowded side's positions per hour at full
-//   imbalance. The schema keeps it inside assertPerpFundingConfig's (0, 1)
-//   domain; a value at or above 1 would make every funding tick fail closed.
-// - takerFeeBps: open-side fee on notional (closing is free, so this is the
-//   round-trip cost), applied to the NEXT open or add. 0 disables. The
-//   schema keeps it inside assertPerpTakerFeeConfig's [0, 100] domain;
-//   outside it the engine fail-closes every trade.
-// - takerFeeApiBps: base fee for API-KEY opens, applied as
-//   max(takerFeeBps, takerFeeApiBps) from the NEXT open or add. Unset or 0
-//   = API pays the web base. Its own wider [0, 300] domain — it prices
-//   hostile bot flow (the 2026-08-19/20 BTC drain was all API-key trades).
-// - takerFeeImpact: size-impact coefficient of the fee (marginal rate is
-//   base + takerFeeImpact·(share of pool)² bps, integrated over the added
-//   notional — see calcPerpSizeFee; NOT the paper's k, which is
-//   fundingSensitivity). 0 keeps the fee flat at whichever base the channel
-//   selected. Applied to the NEXT open or add; the schema keeps it inside
-//   assertPerpTakerFeeConfig's [0, PERP_TAKER_FEE_IMPACT_MAX] domain.
-// - maxOraclePriceAgeMs: the age at which the engine stops accepting trades
-//   AND closes against the cached mark. Lowering it is the direct lever on
-//   latency arbitrage — every stale-mark window a bot can trade is bounded by
-//   this number, not by the tick rate. It is floored at the feed's own cadence
-//   (getMinTradingMarkAgeMs), because a gate tighter than a couple of update
-//   periods would pause the market between perfectly healthy ticks. Note it
-//   pauses honest closes too, so tighten it with the feed's observed
-//   reliability in hand rather than by taste.
 export const updatePerpConfig: APIHandler<'update-perp-config'> = async (
   body,
   auth
 ) => {
-  throwErrorIfNotAdmin(auth.uid)
-  const {
-    contractId,
-    maxLeverage,
-    maxFundingRate,
-    takerFeeBps,
-    takerFeeApiBps,
-    takerFeeImpact,
-    maxOraclePriceAgeMs,
-  } = body
-
-  const pg = createSupabaseDirectClient()
-  const contract = await getContract(pg, contractId)
-  if (!contract) throw new APIError(404, `Contract ${contractId} not found`)
-  if (contract.mechanism !== 'perp')
-    throw new APIError(400, 'Only perp markets have a perp risk config')
-  if (contract.isResolved)
-    throw new APIError(403, 'Cannot update a resolved market')
-
-  if (takerFeeImpact !== undefined)
-    log(
-      `admin ${auth.uid} set takerFeeImpact on ${
-        contract.slug
-      }: ${getPerpTakerFeeImpact(contract)} -> ${takerFeeImpact}`
-    )
-  if (maxOraclePriceAgeMs !== undefined) {
-    const feedDef = getOracleFeed(contract.oracleFeedId)
-    if (!feedDef)
-      throw new APIError(
-        400,
-        `Contract ${contractId} references unknown feed "${contract.oracleFeedId}"`
-      )
-    const minMarkAgeMs = getMinTradingMarkAgeMs(feedDef)
-    if (maxOraclePriceAgeMs < minMarkAgeMs)
-      throw new APIError(
-        400,
-        `maxOraclePriceAgeMs ${maxOraclePriceAgeMs} is below feed "${contract.oracleFeedId}" update cadence (min ${minMarkAgeMs}ms) — the market would pause between healthy ticks`
-      )
-  }
-
-  // What an API-key open will ACTUALLY be charged once max(base, api) is
-  // applied. Echoing the submitted value alone is misleading: a rate at or
-  // below the base is a silent no-op, and with no GET for perp config and no
-  // admin-UI row, this response is the only feedback the operator gets.
-  const nextTakerFeeBps = takerFeeBps ?? getPerpTakerFeeBps(contract)
-  const effectiveTakerFeeApiBps = getPerpEffectiveTakerFeeBps(
-    {
-      takerFeeBps: nextTakerFeeBps,
-      takerFeeApiBps: takerFeeApiBps ?? contract.takerFeeApiBps,
-    },
-    true
+  const updated = await setPerpConfig(body, auth.uid)
+  log(
+    `perp manager ${auth.uid} updated ${updated.slug}`,
+    getPerpConfig(updated)
   )
-
-  const lastUpdatedTime = Date.now()
-  const patch = removeUndefinedProps({
-    maxLeverage,
-    maxFundingRate,
-    takerFeeBps,
-    takerFeeApiBps,
-    takerFeeImpact,
-    maxOraclePriceAgeMs,
-    lastUpdatedTime,
+  broadcastUpdatedContract(updated.visibility, {
+    id: updated.id,
+    ...getPerpConfig(updated),
+    lastUpdatedTime: updated.lastUpdatedTime,
   })
-  await updateContract(pg, contractId, patch)
-  if (maxLeverage !== undefined)
-    log(
-      `admin ${auth.uid} set maxLeverage on ${contract.slug}: ${contract.maxLeverage} -> ${maxLeverage}`
-    )
-  if (maxFundingRate !== undefined)
-    log(
-      `admin ${auth.uid} set maxFundingRate on ${contract.slug}: ${contract.maxFundingRate} -> ${maxFundingRate}`
-    )
-  if (takerFeeBps !== undefined)
-    log(
-      `admin ${auth.uid} set takerFeeBps on ${
-        contract.slug
-      }: ${getPerpTakerFeeBps(contract)} -> ${takerFeeBps}`
-    )
-  if (takerFeeApiBps !== undefined)
-    log(
-      `admin ${auth.uid} set takerFeeApiBps on ${contract.slug}: ${
-        contract.takerFeeApiBps ?? 'unset'
-      } -> ${takerFeeApiBps} (API opens will pay ${effectiveTakerFeeApiBps} bps${
-        effectiveTakerFeeApiBps !== takerFeeApiBps
-          ? ` — the ${nextTakerFeeBps} bps base is higher, so this value has no effect`
-          : ''
-      })`
-    )
-  if (maxOraclePriceAgeMs !== undefined)
-    log(
-      `admin ${auth.uid} set maxOraclePriceAgeMs on ${contract.slug}: ${contract.maxOraclePriceAgeMs} -> ${maxOraclePriceAgeMs}`
-    )
-  broadcastUpdatedContract(contract.visibility, { id: contractId, ...patch })
-
-  const editedFields = Object.keys(
-    removeUndefinedProps({
-      maxLeverage,
-      maxFundingRate,
-      takerFeeBps,
-      takerFeeApiBps,
-      takerFeeImpact,
-      maxOraclePriceAgeMs,
-    })
-  )
   return {
     result: {
       success: true as const,
-      maxLeverage: maxLeverage ?? contract.maxLeverage,
-      maxFundingRate: maxFundingRate ?? contract.maxFundingRate,
-      takerFeeBps: nextTakerFeeBps,
-      takerFeeApiBps: takerFeeApiBps ?? contract.takerFeeApiBps ?? null,
-      effectiveTakerFeeApiBps,
-      takerFeeImpact: takerFeeImpact ?? getPerpTakerFeeImpact(contract),
-      maxOraclePriceAgeMs: maxOraclePriceAgeMs ?? contract.maxOraclePriceAgeMs,
+      ...getPerpConfig(updated),
+      takerFeeApiBps: updated.takerFeeApiBps ?? null,
+      effectiveTakerFeeApiBps: getPerpEffectiveTakerFeeBps(updated, true),
     },
     continue: async () => {
-      await recordContractEdit(contract, auth.uid, editedFields)
-      await revalidateContractStaticProps(contract)
+      await revalidateContractStaticProps(updated)
     },
   }
 }

--- a/backend/scripts/create-mnx-perps.ts
+++ b/backend/scripts/create-mnx-perps.ts
@@ -6,6 +6,7 @@ import {
   PERP_CREATOR_ACCOUNTS,
   PerpCreatorAccount,
 } from 'common/perps/creator-accounts'
+import { getPerpEffectiveTakerFeeBps } from 'common/perps/fees'
 import { MNX_INSTRUMENTS, MNX_DEFAULT_FEES } from 'common/perps/mnx'
 import { getPerpFeedTicker } from 'common/perps/ticker'
 import { HOUR_MS, YEAR_MS } from 'common/util/time'
@@ -232,9 +233,11 @@ if (require.main === module)
         throw new Error(
           `${market.id} was created under creator ${market.creatorId}, not ${ownerLabel} (${owner.user.id}). Stop and audit before retrying.`
         )
+      // The API publishes the API-channel rate it will actually charge,
+      // max(web, api), not the configured value.
       if (
         market.takerFeeBps !== body.takerFeeBps ||
-        market.takerFeeApiBps !== body.takerFeeApiBps ||
+        market.takerFeeApiBps !== getPerpEffectiveTakerFeeBps(body, true) ||
         market.takerFeeImpact !== body.takerFeeImpact
       )
         throw new Error(

--- a/backend/scripts/create-mnx-perps.ts
+++ b/backend/scripts/create-mnx-perps.ts
@@ -6,7 +6,7 @@ import {
   PERP_CREATOR_ACCOUNTS,
   PerpCreatorAccount,
 } from 'common/perps/creator-accounts'
-import { MNX_INSTRUMENTS } from 'common/perps/mnx'
+import { MNX_INSTRUMENTS, MNX_DEFAULT_FEES } from 'common/perps/mnx'
 import { getPerpFeedTicker } from 'common/perps/ticker'
 import { HOUR_MS, YEAR_MS } from 'common/util/time'
 import { getLocalEnv } from 'shared/init-admin'
@@ -84,6 +84,7 @@ if (require.main === module)
         ticker: getPerpFeedTicker(spec.feedId),
         creatorAccount,
         visibility: 'unlisted' as const,
+        ...MNX_DEFAULT_FEES,
         maxLeverage: Math.min(recommended.maxLeverage, ready.maxLeverage!),
         subsidyLong: recommended.subsidyLong,
         subsidyShort: recommended.subsidyShort,
@@ -178,6 +179,7 @@ if (require.main === module)
     const knownFeeds: {
       id: string
       callerAuthorized?: boolean
+      supportsApiTakerFee?: boolean
       creatorAccounts?: {
         account: string
         allowed: boolean
@@ -193,6 +195,10 @@ if (require.main === module)
       if (!feed?.creatorAccounts || !option)
         throw new Error(
           `The API at ${apiUrl.host} predates the creator account selector (no creator accounts reported for ${body.oracleFeedId}); deploy it before creating with --creator`
+        )
+      if (feed.supportsApiTakerFee !== true)
+        throw new Error(
+          'The API does not support explicit API-channel creation fees. Deploy the current backend before creating MNX markets.'
         )
       if (feed.callerAuthorized === false)
         throw new Error(
@@ -225,6 +231,14 @@ if (require.main === module)
       if (market.creatorId !== owner.user.id)
         throw new Error(
           `${market.id} was created under creator ${market.creatorId}, not ${ownerLabel} (${owner.user.id}). Stop and audit before retrying.`
+        )
+      if (
+        market.takerFeeBps !== body.takerFeeBps ||
+        market.takerFeeApiBps !== body.takerFeeApiBps ||
+        market.takerFeeImpact !== body.takerFeeImpact
+      )
+        throw new Error(
+          `${market.id} was created with different fees than requested. Deploy the current backend and correct this market in /admin/mnx before continuing.`
         )
     }
   })

--- a/backend/shared/src/perps/creator-accounts.test.ts
+++ b/backend/shared/src/perps/creator-accounts.test.ts
@@ -54,7 +54,7 @@ it('keeps the partner unavailable until an id is configured', async () => {
   const missing = await resolvePerpCreatorAccount('mnx', 'DEV', pg)
   expect(missing.user).toBeNull()
   expect(missing.reason).toBe(
-    'no MNX account id is configured for DEV (MNX_CREATOR_IDS in backend/shared/src/perps/creator-accounts.ts)'
+    'no MNX account id is configured for DEV (MNX_CREATOR_IDS in common/src/perps/creator-accounts.ts)'
   )
   expect(pg.oneOrNone).not.toHaveBeenCalled()
 })

--- a/backend/shared/src/perps/creator-accounts.ts
+++ b/backend/shared/src/perps/creator-accounts.ts
@@ -1,5 +1,6 @@
 import {
   MNX_CREATOR_USERNAME,
+  getMnxCreatorId,
   PERP_CREATOR_ACCOUNT_LABELS,
   PerpCreatorAccount,
 } from 'common/perps/creator-accounts'
@@ -10,20 +11,8 @@ import { getPerpLaunchCreatorId } from './launch-manifest'
 
 type Environment = 'DEV' | 'PROD'
 
-// The partner is identified by user id, never by username: usernames can be
-// changed and are not reserved, so resolving @MNX at request time would let a
-// rename strand its existing markets and let whoever reclaims the old name
-// become the partner. Fill an environment in from
-//   select id, username from users where username = 'MNX'
-// and leave it undefined to keep MNX unavailable there (the form greys the
-// option out and create-perp refuses it).
-export const MNX_CREATOR_IDS: Record<Environment, string | undefined> = {
-  DEV: undefined,
-  PROD: '0YOMCbJas0UqJdlrqKe1MrQewrF2',
-}
-
-export const getMnxCreatorId = (environment: Environment) =>
-  MNX_CREATOR_IDS[environment]
+// Kept as re-exports for scripts and preflight consumers.
+export { MNX_CREATOR_IDS, getMnxCreatorId } from 'common/perps/creator-accounts'
 
 export type PerpCreatorAccountResolution =
   | { account: PerpCreatorAccount; user: User; reason?: undefined }

--- a/backend/shared/src/perps/creator-accounts.ts
+++ b/backend/shared/src/perps/creator-accounts.ts
@@ -36,7 +36,7 @@ export const resolvePerpCreatorAccount = async (
     return {
       account,
       user: null,
-      reason: `no ${label} account id is configured for ${environment} (MNX_CREATOR_IDS in backend/shared/src/perps/creator-accounts.ts)`,
+      reason: `no ${label} account id is configured for ${environment} (MNX_CREATOR_IDS in common/src/perps/creator-accounts.ts)`,
     }
   const user = await pg.oneOrNone(
     `select * from users where id = $1 limit 1`,

--- a/backend/shared/src/perps/engine.ts
+++ b/backend/shared/src/perps/engine.ts
@@ -179,7 +179,8 @@ const buildState = (
 
 const loadStateForUpdate = async (
   pgTrans: SupabaseTransaction,
-  contractId: string
+  contractId: string,
+  allowResolved = false
 ): Promise<LoadedState> => {
   // `select pg_advisory_xact_lock(...)` returns a row (void column), so
   // .none() would throw "No return data was expected". .one() is correct.
@@ -209,7 +210,7 @@ const loadStateForUpdate = async (
   }
   if (contract.mechanism !== 'perp')
     throw new APIError(400, `Contract ${contractId} is not a perp`)
-  if (contract.isResolved)
+  if (contract.isResolved && !allowResolved)
     throw new APIError(400, `Contract ${contractId} is resolved`)
 
   const positionRows = await pgTrans.any(
@@ -1570,26 +1571,70 @@ export const closePosition = async (
 export const addPerpPoolSubsidy = async (
   contractId: string,
   funderId: string,
-  side: PerpDirection,
-  amount: number
+  side: PerpDirection | 'both',
+  amount: number,
+  options?: {
+    idempotencyKey?: string
+    authorize?: (
+      tx: SupabaseTransaction,
+      contract: PerpContract
+    ) => Promise<void>
+  }
 ) => {
   if (!Number.isFinite(amount) || amount <= 0)
     throw new APIError(400, 'amount must be a finite positive number')
 
+  assertIdempotencyKey(options?.idempotencyKey)
+  const total = amount * (side === 'both' ? 2 : 1)
+
   return runPerpTransaction(async (pgTrans) => {
-    // Rejects resolved markets and non-MANA tokens, and serializes against
-    // every other engine writer on this contract.
-    const { contract, state } = await loadStateForUpdate(pgTrans, contractId)
+    // Serialize against every other engine writer. Permit reading a resolved
+    // contract only to recover a committed request; new payments are refused
+    // below, before any debit. Non-MANA tokens are always rejected.
+    const { contract, state } = await loadStateForUpdate(
+      pgTrans,
+      contractId,
+      true
+    )
+
+    await options?.authorize?.(pgTrans, contract)
+    // The contract lock serializes duplicate requests. The ledger entry and
+    // pool change commit together; txns.data has a legacy extra data level.
+    if (options?.idempotencyKey) {
+      const prior = await pgTrans.oneOrNone<{ amount: number; side: string }>(
+        `select amount, data->'data'->>'side' as side from txns
+          where from_id = $1 and to_id = $2 and category = 'ADD_SUBSIDY'
+            and token = 'M$' and from_type = 'USER' and to_type = 'CONTRACT'
+            and data->'data'->>'idempotencyKey' = $3 limit 1`,
+        [funderId, contractId, options.idempotencyKey]
+      )
+      if (prior) {
+        if (Number(prior.amount) !== total || prior.side !== side)
+          throw new APIError(
+            409,
+            'This subsidy request key was already used for a different amount or side.'
+          )
+        return {
+          contract,
+          poolLong: state.pool.L,
+          poolShort: state.pool.S,
+          replayed: true,
+        }
+      }
+    }
+
+    if (contract.isResolved)
+      throw new APIError(400, `Contract ${contractId} is resolved`)
 
     const funder = await pgTrans.oneOrNone<{ id: string; balance: number }>(
       `select id, balance from users where id = $1 for update`,
       [funderId]
     )
     if (!funder) throw new APIError(404, `User ${funderId} not found`)
-    if (!Number.isFinite(funder.balance) || funder.balance < amount)
+    if (!Number.isFinite(funder.balance) || funder.balance < total)
       throw new APIError(
         403,
-        `Insufficient balance: needed ${amount}, have ${funder.balance}`
+        `Insufficient balance: needed ${total}, have ${funder.balance}`
       )
 
     await assertPerpEscrowBalance(pgTrans, contractId, state.pool)
@@ -1600,14 +1645,20 @@ export const addPerpPoolSubsidy = async (
       fromType: 'USER',
       toId: contractId,
       toType: 'CONTRACT',
-      amount,
+      amount: total,
       token: 'M$',
-      data: { side, reason: 'perp-pool-subsidy' },
+      data: {
+        side,
+        reason: 'perp-pool-subsidy',
+        ...(options?.idempotencyKey
+          ? { idempotencyKey: options.idempotencyKey }
+          : {}),
+      },
     })
 
     const pool = {
-      L: state.pool.L + (side === 'long' ? amount : 0),
-      S: state.pool.S + (side === 'short' ? amount : 0),
+      L: state.pool.L + (side === 'long' || side === 'both' ? amount : 0),
+      S: state.pool.S + (side === 'short' || side === 'both' ? amount : 0),
     }
     await assertPerpEscrowBalance(pgTrans, contractId, pool)
 
@@ -1621,7 +1672,7 @@ export const addPerpPoolSubsidy = async (
       })
     )
 
-    return { contract, poolLong: pool.L, poolShort: pool.S }
+    return { contract, poolLong: pool.L, poolShort: pool.S, replayed: false }
   })
 }
 

--- a/backend/shared/src/perps/manage-config.ts
+++ b/backend/shared/src/perps/manage-config.ts
@@ -59,9 +59,13 @@ export const setPerpConfig = async (
     await requirePerpManager(tx, userId, contract)
     if (contract.isResolved)
       throw new APIError(403, 'Cannot update a resolved market')
+    // A replay of an already-applied patch is successful, without a second
+    // edit. Compare the stored fields, not the defaults they resolve to: an
+    // explicit default must still be stamped onto an unset or out-of-range
+    // field, or the market keeps failing closed (or follows a later default
+    // change) while the dashboard reports success.
+    if (keys.every((key) => patch[key] === contract[key])) return contract
     const current = getPerpConfig(contract)
-    // A replay of an already-applied patch is successful, without a second edit.
-    if (keys.every((key) => patch[key] === current[key])) return contract
     for (const [key, value] of Object.entries(expectedConfig ?? {})) {
       if (value !== undefined && current[key as keyof typeof current] !== value)
         throw new APIError(

--- a/backend/shared/src/perps/manage-config.ts
+++ b/backend/shared/src/perps/manage-config.ts
@@ -1,0 +1,124 @@
+import { getPerpConfig, PerpConfigPatch } from 'common/perps/management'
+import { getMnxInstrument } from 'common/perps/mnx'
+import { PerpContract } from 'common/contract'
+import { convertContract } from 'common/supabase/contracts'
+import { removeUndefinedProps } from 'common/util/object'
+import { fetchMnxSnapshot, requireMnxReady } from 'shared/mnx'
+import { getMinTradingMarkAgeMs, getOracleFeed } from 'shared/oracle-feeds'
+import { requirePerpManager } from 'shared/perps/management-auth'
+import { advisoryLockQuery, mergeContractDataQuery } from 'shared/perps/queries'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { runTransactionWithRetries } from 'shared/transact-with-retries'
+import { getContract } from 'shared/utils'
+import { APIError } from 'common/api/utils'
+import type { ValidatedAPIParams } from 'common/api/schema'
+
+// Config edits serialize with trades, funding, and settlement. Fees apply to
+// subsequent opens/adds; funding changes apply to the next funding event.
+// Lower leverage caps grandfather existing positions. Freshness gates affect
+// closes too, and may never go below the provider's cadence floor.
+export const setPerpConfig = async (
+  body: ValidatedAPIParams<'update-perp-config'>,
+  userId: string
+): Promise<PerpContract> => {
+  const { contractId, expectedConfig, expectedManagerId, ...fields } = body
+  if (expectedManagerId !== undefined && expectedManagerId !== userId)
+    throw new APIError(
+      409,
+      'The signed-in account changed. Sign back in before retrying.'
+    )
+  const patch = removeUndefinedProps(fields)
+  const keys = Object.keys(patch) as (keyof PerpConfigPatch)[]
+  const pg = createSupabaseDirectClient()
+  await requirePerpManager(pg, userId)
+  const before = await getContract(pg, contractId)
+  if (!before) throw new APIError(404, `Contract ${contractId} not found`)
+  if (before.mechanism !== 'perp')
+    throw new APIError(400, 'Only perp markets have a perp risk config')
+  await requirePerpManager(pg, userId, before)
+
+  // Fetch before taking the database lock. Reducing leverage remains possible
+  // during a provider outage; increases require the same capability as creation.
+  const snapshot =
+    getMnxInstrument(before.oracleFeedId) &&
+    patch.maxLeverage !== undefined &&
+    patch.maxLeverage > before.maxLeverage
+      ? await fetchMnxSnapshot()
+      : null
+
+  const updated = await runTransactionWithRetries(async (tx) => {
+    await tx.one(advisoryLockQuery(contractId))
+    const contract = await tx.oneOrNone(
+      'select * from contracts where id = $1 for update',
+      [contractId],
+      convertContract
+    )
+    if (!contract) throw new APIError(404, `Contract ${contractId} not found`)
+    if (contract.mechanism !== 'perp')
+      throw new APIError(400, 'Only perp markets have a perp risk config')
+    await requirePerpManager(tx, userId, contract)
+    if (contract.isResolved)
+      throw new APIError(403, 'Cannot update a resolved market')
+    const current = getPerpConfig(contract)
+    // A replay of an already-applied patch is successful, without a second edit.
+    if (keys.every((key) => patch[key] === current[key])) return contract
+    for (const [key, value] of Object.entries(expectedConfig ?? {})) {
+      if (value !== undefined && current[key as keyof typeof current] !== value)
+        throw new APIError(
+          409,
+          'Market rules changed since this preview. Refresh and review again.'
+        )
+    }
+    if (
+      patch.maxLeverage !== undefined &&
+      patch.maxLeverage > contract.maxLeverage &&
+      getMnxInstrument(contract.oracleFeedId)
+    ) {
+      if (!snapshot)
+        throw new APIError(
+          409,
+          'Leverage changed since this request. Refresh and review again.'
+        )
+      let supported: number
+      try {
+        supported = requireMnxReady(snapshot, contract.oracleFeedId)
+          .supportedLeverage!
+      } catch (error) {
+        throw new APIError(
+          400,
+          error instanceof Error ? error.message : String(error)
+        )
+      }
+      if (
+        !Number.isFinite(supported) ||
+        supported <= 1 ||
+        patch.maxLeverage > supported
+      )
+        throw new APIError(
+          400,
+          `MNX currently supports at most ${supported}x leverage on this feed.`
+        )
+    }
+    if (patch.maxOraclePriceAgeMs !== undefined) {
+      const feed = getOracleFeed(contract.oracleFeedId)
+      if (!feed) throw new APIError(400, 'Unknown oracle feed')
+      const min = getMinTradingMarkAgeMs(feed)
+      if (patch.maxOraclePriceAgeMs < min)
+        throw new APIError(
+          400,
+          `Oracle age must be at least ${min / 1000} seconds for this feed.`
+        )
+    }
+    const changes = { ...patch, lastUpdatedTime: Date.now() }
+    await tx.one(mergeContractDataQuery(contractId, changes))
+    // Audit is committed with the edit, so a post-response failure cannot lose it.
+    await tx.none(
+      `insert into contract_edits (contract_id, editor_id, data, updated_keys)
+       values ($1, $2, $3, $4)`,
+      [contractId, userId, contract, keys]
+    )
+    return { ...contract, ...changes } as PerpContract
+  }, 8)
+
+  return updated
+}

--- a/backend/shared/src/perps/management-auth.test.ts
+++ b/backend/shared/src/perps/management-auth.test.ts
@@ -1,0 +1,57 @@
+import { PerpContract } from 'common/contract'
+import { ENV, ENV_CONFIG } from 'common/envs/constants'
+import { MNX_CREATOR_IDS } from 'common/perps/creator-accounts'
+import { isPerpManager, requirePerpManager } from './management-auth'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+
+const mnxId = 'mnx-test-id'
+const ids = { ...MNX_CREATOR_IDS }
+beforeEach(() => {
+  MNX_CREATOR_IDS[ENV] = mnxId
+})
+afterEach(() => Object.assign(MNX_CREATOR_IDS, ids))
+const own = {
+  creatorId: mnxId,
+  oracleFeedId: 'mnx-openai-mark',
+} as PerpContract
+
+it('limits the partner to its own registered MNX feeds, including after renames', () => {
+  expect(isPerpManager(mnxId, own)).toBe(true)
+  expect(isPerpManager(mnxId, { ...own, creatorId: 'someone-else' })).toBe(
+    false
+  )
+  expect(isPerpManager(mnxId, { ...own, oracleFeedId: 'btc-usd' })).toBe(false)
+  expect(
+    isPerpManager(mnxId, { ...own, oracleFeedId: 'mnx-not-registered' })
+  ).toBe(false)
+  expect(
+    isPerpManager('username-squatter', { ...own, creatorUsername: 'MNX' })
+  ).toBe(false)
+  expect(isPerpManager(ENV_CONFIG.adminIds[0], own)).toBe(true)
+  MNX_CREATOR_IDS[ENV] = undefined
+  expect(isPerpManager(mnxId)).toBe(false)
+})
+
+it.each([null, { userDeleted: true }, { isBannedFromPosting: true }])(
+  'refuses unavailable manager accounts: %j',
+  async (data) => {
+    const pg = {
+      oneOrNone: jest.fn(async (_q, _p, convert) =>
+        convert(
+          data === null ? null : { id: mnxId, username: 'RenamedPartner', data }
+        )
+      ),
+    } as unknown as SupabaseDirectClient
+    await expect(requirePerpManager(pg, mnxId, own)).rejects.toThrow(
+      'active, unbanned'
+    )
+  }
+)
+
+it('rejects an unauthorized caller before looking up any account data', async () => {
+  const pg = { oneOrNone: jest.fn() } as unknown as SupabaseDirectClient
+  await expect(requirePerpManager(pg, 'other', own)).rejects.toThrow(
+    'Only admins'
+  )
+  expect(pg.oneOrNone).not.toHaveBeenCalled()
+})

--- a/backend/shared/src/perps/management-auth.ts
+++ b/backend/shared/src/perps/management-auth.ts
@@ -1,0 +1,35 @@
+import { APIError } from 'common/api/utils'
+import type { PerpContract } from 'common/contract'
+import { ENV, isAdminId } from 'common/envs/constants'
+import { getMnxInstrument } from 'common/perps/mnx'
+import { convertUser } from 'common/supabase/users'
+import type { SupabaseDirectClient } from 'shared/supabase/init'
+import { getMnxCreatorId } from './creator-accounts'
+
+// Identity is pinned by environment, never inferred from a username or badge.
+export const isPerpManager = (userId: string, contract?: PerpContract) =>
+  isAdminId(userId) ||
+  (userId === getMnxCreatorId(ENV) &&
+    (!contract ||
+      (contract.creatorId === userId &&
+        !!getMnxInstrument(contract.oracleFeedId))))
+
+export const requirePerpManager = async (
+  pg: Pick<SupabaseDirectClient, 'oneOrNone'>,
+  userId: string,
+  contract?: PerpContract
+) => {
+  if (!isPerpManager(userId, contract))
+    throw new APIError(
+      403,
+      'Only admins and the MNX account managing its own MNX markets may do this.'
+    )
+  const user = await pg.oneOrNone(
+    'select * from users where id = $1',
+    [userId],
+    convertUser
+  )
+  if (!user || user.userDeleted || user.isBannedFromPosting)
+    throw new APIError(403, 'An active, unbanned manager account is required.')
+  return user
+}

--- a/backend/shared/src/perps/management.test.ts
+++ b/backend/shared/src/perps/management.test.ts
@@ -1,0 +1,302 @@
+import { PerpContract } from 'common/contract'
+import { ENV, ENV_CONFIG } from 'common/envs/constants'
+import { MNX_CREATOR_IDS } from 'common/perps/creator-accounts'
+import { getPerpConfig } from 'common/perps/management'
+import { fetchMnxSnapshot, requireMnxReady } from 'shared/mnx'
+import {
+  createSupabaseDirectClient,
+  SupabaseTransaction,
+} from 'shared/supabase/init'
+import { runTransactionWithRetries } from 'shared/transact-with-retries'
+import { runTxnOutsideBetQueue } from 'shared/txn/run-txn'
+import { getContract } from 'shared/utils'
+import { addPerpPoolSubsidy } from './engine'
+import { setPerpConfig } from './manage-config'
+import { requirePerpManager } from './management-auth'
+
+jest.mock('shared/utils', () => ({
+  log: Object.assign(jest.fn(), { error: jest.fn(), warn: jest.fn() }),
+  getContract: jest.fn(),
+}))
+jest.mock('shared/transact-with-retries', () => ({
+  runTransactionWithRetries: jest.fn(),
+}))
+jest.mock('shared/txn/run-txn', () => ({ runTxnOutsideBetQueue: jest.fn() }))
+jest.mock('shared/mnx', () => ({
+  fetchMnxSnapshot: jest.fn(),
+  requireMnxReady: jest.fn(),
+}))
+jest.mock('shared/oracle-feeds', () => ({
+  getOracleFeed: () => ({}),
+  getMinTradingMarkAgeMs: () => 120_000,
+}))
+jest.mock('shared/supabase/init', () => ({
+  createSupabaseDirectClient: jest.fn(),
+  pgp: jest.requireActual('pg-promise')(),
+}))
+jest.mock('./queries', () => ({
+  ...jest.requireActual('./queries'),
+  advisoryLockQuery: (id: string) => `lock:${id}`,
+  selectContractForUpdateQuery: (id: string) => `contract:${id}`,
+  selectPositionsForUpdateQuery: (id: string) => `positions:${id}`,
+  mergeContractDataQuery: (_id: string, patch: unknown) => ({ patch }),
+}))
+
+const mnx = 'mnx-test'
+const ids = { ...MNX_CREATOR_IDS }
+let contract: PerpContract
+let balance: number
+let ledger: number
+let receipts: { amount: number; side: string; key: string }[]
+let locked: boolean
+const tx = {
+  one: jest.fn(),
+  oneOrNone: jest.fn(),
+  any: jest.fn(),
+  none: jest.fn(),
+} as unknown as SupabaseTransaction
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  MNX_CREATOR_IDS[ENV] = mnx
+  balance = 1000
+  ledger = 200
+  receipts = []
+  locked = false
+  contract = {
+    id: 'c1',
+    creatorId: mnx,
+    mechanism: 'perp',
+    token: 'MANA',
+    oracleFeedId: 'mnx-openai-mark',
+    slug: 'mnx-openai',
+    poolLong: 100,
+    poolShort: 100,
+    maxLeverage: 3,
+    maxFundingRate: 0.001,
+    fundingSensitivity: 1,
+    maxOraclePriceAgeMs: 300000,
+    takerFeeBps: 10,
+    takerFeeApiBps: 30,
+    takerFeeImpact: 10,
+  } as PerpContract
+  jest
+    .mocked(createSupabaseDirectClient)
+    .mockReturnValue(
+      tx as unknown as ReturnType<typeof createSupabaseDirectClient>
+    )
+  jest.mocked(getContract).mockImplementation(async () => contract)
+  jest
+    .mocked(runTransactionWithRetries)
+    .mockImplementation(async (fn) => fn(tx))
+  jest
+    .mocked(fetchMnxSnapshot)
+    .mockResolvedValue({ fetchedAt: Date.now(), feeds: {}, markets: [] })
+  jest
+    .mocked(requireMnxReady)
+    .mockReturnValue({ supportedLeverage: 4 } as ReturnType<
+      typeof requireMnxReady
+    >)
+  jest.mocked(tx.any).mockResolvedValue([])
+  jest.mocked(tx.one).mockImplementation(async (query: any) => {
+    if (typeof query === 'string' && query.startsWith('lock:')) {
+      locked = true
+      return {}
+    }
+    if (query.patch) {
+      expect(locked).toBe(true)
+      contract = { ...contract, ...query.patch }
+      return {}
+    }
+    if (query.includes('as balance')) return { balance: ledger }
+    throw new Error(`Unexpected query ${query}`)
+  })
+  jest
+    .mocked(tx.oneOrNone)
+    .mockImplementation(async (query: any, values: any, convert?: any) => {
+      if (
+        query.startsWith('contract:') ||
+        query.startsWith('select * from contracts')
+      ) {
+        expect(locked).toBe(true)
+        const row = { data: contract, token: contract.token }
+        return convert ? convert(row) : row
+      }
+      if (query.includes('from users')) {
+        const row = { id: values[0], username: 'RenamedMNX', balance, data: {} }
+        return convert ? convert(row) : row
+      }
+      if (query.includes('from txns'))
+        return receipts.find((r) => r.key === values[2]) ?? null
+      throw new Error(`Unexpected query ${query}`)
+    })
+  jest.mocked(runTxnOutsideBetQueue).mockImplementation(async (_tx, txn) => {
+    expect(locked).toBe(true)
+    balance -= txn.amount
+    ledger += txn.amount
+    receipts.push({
+      amount: txn.amount,
+      side: txn.data!.side,
+      key: txn.data!.idempotencyKey,
+    })
+    return {} as Awaited<ReturnType<typeof runTxnOutsideBetQueue>>
+  })
+})
+afterEach(() => Object.assign(MNX_CREATOR_IDS, ids))
+
+const authorize = async (pg: SupabaseTransaction, c: PerpContract) => {
+  await requirePerpManager(pg, mnx, c)
+}
+const options = { idempotencyKey: 'abcdefghjk', authorize }
+
+it('funds both sides in one transaction and debits the combined cost exactly once', async () => {
+  expect(
+    await addPerpPoolSubsidy('c1', mnx, 'both', 50, options)
+  ).toMatchObject({ poolLong: 150, poolShort: 150 })
+  expect(balance).toBe(900)
+  expect(ledger).toBe(300)
+  expect(runTxnOutsideBetQueue).toHaveBeenCalledTimes(1)
+  await addPerpPoolSubsidy('c1', mnx, 'both', 50, options)
+  expect(balance).toBe(900)
+  expect(runTxnOutsideBetQueue).toHaveBeenCalledTimes(1)
+})
+
+it.each(['long', 'short'] as const)(
+  'still supports a %s-only contribution',
+  async (side) => {
+    await addPerpPoolSubsidy('c1', mnx, side, 50, options)
+    expect(contract.poolLong).toBe(side === 'long' ? 150 : 100)
+    expect(contract.poolShort).toBe(side === 'short' ? 150 : 100)
+    expect(balance).toBe(950)
+  }
+)
+
+it('checks the combined balance and ownership under the contract lock before paying', async () => {
+  balance = 75
+  await expect(
+    addPerpPoolSubsidy('c1', mnx, 'both', 50, options)
+  ).rejects.toThrow('Insufficient balance')
+  balance = 1000
+  contract.creatorId = 'different-owner'
+  await expect(
+    addPerpPoolSubsidy('c1', mnx, 'both', 50, options)
+  ).rejects.toThrow('Only admins')
+  expect(runTxnOutsideBetQueue).not.toHaveBeenCalled()
+})
+
+it('rejects a reused key with a different amount or side', async () => {
+  await addPerpPoolSubsidy('c1', mnx, 'both', 50, options)
+  await expect(
+    addPerpPoolSubsidy('c1', mnx, 'both', 60, options)
+  ).rejects.toThrow('different amount or side')
+  await expect(
+    addPerpPoolSubsidy('c1', mnx, 'long', 100, options)
+  ).rejects.toThrow('different amount or side')
+  expect(runTxnOutsideBetQueue).toHaveBeenCalledTimes(1)
+})
+
+it('recovers a committed payment after settlement, while refusing new payments to resolved markets', async () => {
+  await addPerpPoolSubsidy('c1', mnx, 'both', 50, options)
+  contract.isResolved = true
+  balance = 0
+  await expect(
+    addPerpPoolSubsidy('c1', mnx, 'both', 50, options)
+  ).resolves.toMatchObject({ poolLong: 150 })
+  await expect(
+    addPerpPoolSubsidy('c1', mnx, 'both', 50, {
+      ...options,
+      idempotencyKey: 'abcdefghjm',
+    })
+  ).rejects.toThrow('resolved')
+  expect(runTxnOutsideBetQueue).toHaveBeenCalledTimes(1)
+})
+
+it('fails closed on escrow mismatch and does not debit the manager', async () => {
+  ledger = 0
+  await expect(
+    addPerpPoolSubsidy('c1', mnx, 'long', 50, options)
+  ).rejects.toThrow('escrow invariant')
+  expect(runTxnOutsideBetQueue).not.toHaveBeenCalled()
+})
+
+it('updates the partner rules with an audit record inside the same transaction', async () => {
+  const expectedConfig = getPerpConfig(contract)
+  const result = await setPerpConfig(
+    {
+      contractId: 'c1',
+      takerFeeApiBps: 20,
+      fundingSensitivity: 2,
+      expectedConfig,
+    },
+    mnx
+  )
+  expect(result.takerFeeApiBps).toBe(20)
+  expect(result.fundingSensitivity).toBe(2)
+  expect(tx.none).toHaveBeenCalledWith(
+    expect.stringContaining('insert into contract_edits'),
+    expect.arrayContaining(['c1', mnx])
+  )
+  // Lost response: the exact desired config is already present.
+  await setPerpConfig(
+    {
+      contractId: 'c1',
+      takerFeeApiBps: 20,
+      fundingSensitivity: 2,
+      expectedConfig,
+    },
+    mnx
+  )
+  expect(tx.none).toHaveBeenCalledTimes(1)
+})
+
+it('refuses a stale preview without overwriting another operator', async () => {
+  const expectedConfig = getPerpConfig(contract)
+  contract.takerFeeBps = 15
+  await expect(
+    setPerpConfig({ contractId: 'c1', takerFeeApiBps: 20, expectedConfig }, mnx)
+  ).rejects.toThrow('changed since this preview')
+  expect(tx.none).not.toHaveBeenCalled()
+})
+
+it('preserves provider limits and refuses freshness settings below the cadence floor', async () => {
+  await expect(
+    setPerpConfig({ contractId: 'c1', maxLeverage: 5 }, mnx)
+  ).rejects.toThrow('at most 4x')
+  await expect(
+    setPerpConfig({ contractId: 'c1', maxOraclePriceAgeMs: 1000 }, mnx)
+  ).rejects.toThrow('at least 120')
+  expect(tx.none).not.toHaveBeenCalled()
+})
+
+it('can reduce leverage during an MNX outage and keeps admin access to other perps', async () => {
+  jest.mocked(fetchMnxSnapshot).mockRejectedValue(new Error('provider offline'))
+  await expect(
+    setPerpConfig({ contractId: 'c1', maxLeverage: 2 }, mnx)
+  ).resolves.toMatchObject({ maxLeverage: 2 })
+  expect(fetchMnxSnapshot).not.toHaveBeenCalled()
+  contract.oracleFeedId = 'btc-usd'
+  contract.creatorId = 'house'
+  await expect(
+    setPerpConfig(
+      { contractId: 'c1', takerFeeApiBps: 20 },
+      ENV_CONFIG.adminIds[0]
+    )
+  ).resolves.toMatchObject({ takerFeeApiBps: 20 })
+  await expect(
+    setPerpConfig({ contractId: 'c1', takerFeeApiBps: 30 }, mnx)
+  ).rejects.toThrow('Only admins')
+})
+
+it('refuses account switches and resolved-market rule edits', async () => {
+  await expect(
+    setPerpConfig(
+      { contractId: 'c1', maxLeverage: 2, expectedManagerId: 'other' },
+      mnx
+    )
+  ).rejects.toThrow('signed-in account changed')
+  contract.isResolved = true
+  await expect(
+    setPerpConfig({ contractId: 'c1', maxLeverage: 2 }, mnx)
+  ).rejects.toThrow('resolved')
+  expect(tx.none).not.toHaveBeenCalled()
+})

--- a/backend/shared/src/perps/management.test.ts
+++ b/backend/shared/src/perps/management.test.ts
@@ -300,3 +300,22 @@ it('refuses account switches and resolved-market rule edits', async () => {
   ).rejects.toThrow('resolved')
   expect(tx.none).not.toHaveBeenCalled()
 })
+
+it('stamps an explicit default onto an unset or out-of-range field instead of skipping it as a replay', async () => {
+  // Out of range, so the engine fails closed on every trade while the value
+  // resolves to the default of 10: exactly what an operator sends to repair it.
+  contract.takerFeeBps = 150
+  delete contract.takerFeeImpact
+  await expect(
+    setPerpConfig({ contractId: 'c1', takerFeeBps: 10, takerFeeImpact: 0 }, mnx)
+  ).resolves.toMatchObject({ takerFeeBps: 10, takerFeeImpact: 0 })
+  expect(contract.takerFeeBps).toBe(10)
+  expect(contract.takerFeeImpact).toBe(0)
+  expect(tx.none).toHaveBeenCalledTimes(1)
+  // Now the same request really is a replay.
+  await setPerpConfig(
+    { contractId: 'c1', takerFeeBps: 10, takerFeeImpact: 0 },
+    mnx
+  )
+  expect(tx.none).toHaveBeenCalledTimes(1)
+})

--- a/common/src/api/market-types.test.ts
+++ b/common/src/api/market-types.test.ts
@@ -343,19 +343,24 @@ function getLiteMarket(overrides: Partial<LiteMarket> = {}): LiteMarket {
 
 describe('update-perp-config props', () => {
   // The schema lives in schema.ts, but its refine is the kind of guard that
-  // silently rots: every optional field has to be listed, and forgetting one
+  // silently rots: every tunable field has to count, and forgetting one
   // makes a request that sets ONLY that field fail as "nothing to update".
   // maxOraclePriceAgeMs shipped that way and would have rejected the exact
   // call the change existed to enable.
   const props = API['update-perp-config'].props
-
-  const optionalFields = Object.keys(
-    (props as unknown as { _def: { schema: z.ZodObject<z.ZodRawShape> } })._def
-      .schema.shape
-  ).filter((k) => k !== 'contractId')
+  const shape = (
+    props as unknown as { _def: { schema: z.ZodObject<z.ZodRawShape> } }
+  )._def.schema.shape
+  // Optimistic checks of what the operator reviewed. They change nothing, so
+  // a request carrying only these must still count as "nothing to update".
+  const previewFields = ['expectedConfig', 'expectedManagerId']
+  const tunableFields = Object.keys(shape).filter(
+    (k) => k !== 'contractId' && !previewFields.includes(k)
+  )
 
   it('enumerates the tunable fields, so the loop below cannot pass vacuously', () => {
-    expect(optionalFields.sort()).toEqual([
+    expect(tunableFields.sort()).toEqual([
+      'fundingSensitivity',
       'maxFundingRate',
       'maxLeverage',
       'maxOraclePriceAgeMs',
@@ -363,18 +368,23 @@ describe('update-perp-config props', () => {
       'takerFeeBps',
       'takerFeeImpact',
     ])
+    // A new field must be classified as tunable or preview, never ignored.
+    expect(Object.keys(shape).filter((k) => previewFields.includes(k))).toEqual(
+      previewFields
+    )
   })
 
   it('accepts each tunable field on its own', () => {
     const sample: Record<string, number> = {
       maxLeverage: 10,
       maxFundingRate: 0.02,
+      fundingSensitivity: 5,
       takerFeeBps: 10,
       takerFeeImpact: 90,
       takerFeeApiBps: 30,
       maxOraclePriceAgeMs: 10_000,
     }
-    for (const field of optionalFields) {
+    for (const field of tunableFields) {
       expect(sample[field]).toBeDefined() // keeps this test honest as fields are added
       const parsed = props.safeParse({
         contractId: 'c1',
@@ -386,6 +396,13 @@ describe('update-perp-config props', () => {
 
   it('still rejects a request that changes nothing', () => {
     expect(props.safeParse({ contractId: 'c1' }).success).toBe(false)
+    expect(
+      props.safeParse({
+        contractId: 'c1',
+        expectedConfig: { maxLeverage: 10 },
+        expectedManagerId: 'u1',
+      }).success
+    ).toBe(false)
   })
 
   it('rejects an out-of-bounds takerFeeImpact at the schema', () => {

--- a/common/src/api/market-types.ts
+++ b/common/src/api/market-types.ts
@@ -24,6 +24,7 @@ import {
   getPerpEffectiveTakerFeeBps,
   getPerpTakerFeeBps,
   getPerpTakerFeeImpact,
+  PERP_TAKER_FEE_API_BPS_MAX,
   PERP_TAKER_FEE_IMPACT_MAX,
 } from 'common/perps/fees'
 import { getMappedValue } from 'common/pseudo-numeric'
@@ -711,13 +712,17 @@ export const createPerpSchema = z.object({
   subsidyLong: z.number().gt(0),
   subsidyShort: z.number().gt(0),
   // Open-side taker fee in bps of notional (closing is free). Omitted = the
-  // platform default (see PERP_TAKER_FEE_BPS_DEFAULT); the handler stamps
+  // feed default (MNX_DEFAULT_FEES for MNX, PERP_TAKER_FEE_BPS_DEFAULT
+  // otherwise); the handler stamps
   // the resolved value so later default changes cannot rewrite an existing
   // market's economics.
   takerFeeBps: z.number().min(0).max(100).optional(),
+  // API-key opens use max(web base, API base). MNX defaults to 20 bps;
+  // other feeds inherit the web base when this is omitted.
+  takerFeeApiBps: z.number().min(0).max(PERP_TAKER_FEE_API_BPS_MAX).optional(),
   // Size-impact coefficient of the taker fee (marginal rate is
   // takerFeeBps + takerFeeImpact·(share of pool)² bps). Omitted = the
-  // platform default (see PERP_TAKER_FEE_IMPACT_DEFAULT); stamped like
+  // feed default (10 on MNX, PERP_TAKER_FEE_IMPACT_DEFAULT otherwise); stamped like
   // takerFeeBps above.
   takerFeeImpact: z.number().min(0).max(PERP_TAKER_FEE_IMPACT_MAX).optional(),
   // Which account owns the market. The owner pays the backing now and is paid

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1,4 +1,6 @@
 import { PerpSuggestion } from '../perps/suggestion'
+import { MnxDashboard, perpConfigFields } from 'common/perps/management'
+import { randomStringRegex } from 'common/util/random'
 import type { BrowsePersonalization } from 'common/browse-personalization'
 import { MAX_ANSWER_LENGTH, type Answer } from 'common/answer'
 import { coerceBoolean, contentSchema } from 'common/api/zod-types'
@@ -38,10 +40,6 @@ import { Headline } from 'common/news'
 import { PERIODS } from 'common/period'
 import type { PerpTradeActivity } from 'common/perps/activity'
 import { PerpCreatorAccount } from 'common/perps/creator-accounts'
-import {
-  PERP_TAKER_FEE_API_BPS_MAX,
-  PERP_TAKER_FEE_IMPACT_MAX,
-} from 'common/perps/fees'
 import { PerpQuote, perpQuoteSchema } from 'common/perps/quote'
 import {
   LivePortfolioMetrics,
@@ -1231,7 +1229,7 @@ export const API = (_apiTypeCheck = {
       })
       .strict(),
   },
-  // Admin-only live risk tuning; undocumented deliberately — internal
+  // Admin / MNX-owner live risk tuning; undocumented deliberately — internal
   // operator tooling, not part of the public perp API surface.
   'update-perp-config': {
     method: 'POST',
@@ -1241,6 +1239,7 @@ export const API = (_apiTypeCheck = {
       success: true
       maxLeverage: number
       maxFundingRate: number
+      fundingSensitivity: number
       takerFeeBps: number
       takerFeeImpact: number
       // Configured API-channel base rate, or null when API trades pay the
@@ -1252,67 +1251,32 @@ export const API = (_apiTypeCheck = {
       effectiveTakerFeeApiBps: number
       maxOraclePriceAgeMs: number
     },
-    props: z
-      .object({
+    props: perpConfigFields
+      .extend({
         contractId: z.string().min(1),
-        // Same bounds as createPerpSchema. maxFundingRate must stay inside
-        // the engine's assertPerpFundingConfig domain (0, 1) — at >= 1 the
-        // funding tick fail-closes and the market stops funding entirely.
-        maxLeverage: z.number().gt(1).lte(100).optional(),
-        maxFundingRate: z.number().gt(0).lt(1).optional(),
-        // Open-side BASE taker fee in bps of notional (closing is free);
-        // 0 disables. Bounds match assertPerpTakerFeeConfig — outside them
-        // the engine fail-closes every trade. This caps the base only: the
-        // size-dependent total (base + takerFeeImpact·share² marginal) is
-        // intentionally uncapped.
-        takerFeeBps: z.number().min(0).max(100).optional(),
-        // Size-impact coefficient of the taker fee (NOT the paper's k —
-        // that is fundingSensitivity). 0 keeps the fee flat at the base.
-        // Bounds match assertPerpTakerFeeConfig.
-        takerFeeImpact: z
-          .number()
-          .min(0)
-          .max(PERP_TAKER_FEE_IMPACT_MAX)
-          .optional(),
-        // Base rate for API-KEY opens only, applied as max(takerFeeBps,
-        // takerFeeApiBps) — it can raise the API channel's rate, never
-        // discount it. 0 (or unset) = API pays the web base. Wider cap than
-        // the web base on purpose: it prices hostile bot flow (see
-        // PERP_TAKER_FEE_API_BPS_MAX).
-        takerFeeApiBps: z
-          .number()
-          .min(0)
-          .max(PERP_TAKER_FEE_API_BPS_MAX)
-          .optional(),
-        // How old the executable mark may be before the engine refuses trades
-        // and closes. Tunable live because the right value depends on how
-        // reliably the feed is actually ticking, which is an operational fact
-        // rather than a design-time one. The handler enforces the feed's
-        // cadence floor; a value below it would freeze the market between
-        // healthy updates.
-        maxOraclePriceAgeMs: z.number().int().positive().optional(),
+        // Optimistic check of the values the operator reviewed. Trades do not
+        // change these, so normal activity does not invalidate the preview.
+        expectedConfig: perpConfigFields.optional(),
+        expectedManagerId: z.string().min(1).optional(),
       })
       .strict()
       .refine(
-        // Every optional field above must appear here. Omitting one makes a
-        // request that sets ONLY that field fail as "nothing to update",
-        // which is both baffling and invisible until someone tries it in
-        // prod — maxOraclePriceAgeMs shipped that way.
         (p) =>
-          p.maxLeverage !== undefined ||
-          p.maxFundingRate !== undefined ||
-          p.takerFeeBps !== undefined ||
-          p.takerFeeImpact !== undefined ||
-          p.takerFeeApiBps !== undefined ||
-          p.maxOraclePriceAgeMs !== undefined,
+          Object.keys(perpConfigFields.shape).some(
+            (key) => p[key as keyof typeof perpConfigFields.shape] !== undefined
+          ),
         { message: 'Provide at least one field to update' }
       ),
   },
-  // Admin-only escrow top-up of one side's backing pool on a live perp.
-  // Ops tool for restoring margin cover (a side's pool can fall below its
-  // side's aggregate cost basis when realized profits were paid against
-  // opposing unrealized losses that later recovered — see the UK carbon
-  // incident 2026-08-07). The funder pays from their own balance.
+  'get-mnx-dashboard': {
+    method: 'GET',
+    visibility: 'undocumented',
+    authed: true,
+    returns: {} as MnxDashboard,
+    props: z.object({}).strict(),
+  },
+  // The signed-in manager pays. For 'both', amount is added to EACH side.
+  // A request key makes retrying a dashboard operation safe after a timeout.
   'add-perp-subsidy': {
     method: 'POST',
     visibility: 'undocumented',
@@ -1321,8 +1285,14 @@ export const API = (_apiTypeCheck = {
     props: z
       .object({
         contractId: z.string().min(1),
-        side: z.enum(['long', 'short']),
-        amount: z.number().gt(0).lte(1_000_000),
+        side: z.enum(['long', 'short', 'both']),
+        expectedManagerId: z.string().min(1).optional(),
+        amount: z.number().finite().gt(0).lte(1_000_000),
+        idempotencyKey: z
+          .string()
+          .regex(randomStringRegex)
+          .length(10)
+          .optional(),
       })
       .strict(),
   },
@@ -1379,6 +1349,8 @@ export const API = (_apiTypeCheck = {
     // daily feed would understate the cap 24x.
     returns: [] as {
       id: string
+      // Capability probe for scripts that explicitly set the API-channel fee.
+      supportsApiTakerFee: boolean
       updatePeriodMs: number | null
       marketCreationEnabled: boolean
       description: string | null

--- a/common/src/perps/creator-accounts.ts
+++ b/common/src/perps/creator-accounts.ts
@@ -15,10 +15,23 @@ export const PERP_CREATOR_ACCOUNT_LABELS: Record<PerpCreatorAccount, string> = {
   mnx: 'MNX',
 }
 
-// The partner account is resolved by username at request time because its id
-// differs per environment (and DEV may not have one at all). The name is in
-// VERIFIED_USERNAMES, so the badge shows on markets it owns.
+// Display name only; authorization uses the immutable per-environment id.
 export const MNX_CREATOR_USERNAME = 'MNX'
+
+// The partner is identified by user id, never by username: usernames can be
+// changed and are not reserved, so resolving @MNX at request time would let a
+// rename strand its existing markets and let whoever reclaims the old name
+// become the partner. Fill an environment in from
+//   select id, username from users where username = 'MNX'
+// and leave it undefined to keep MNX unavailable there (the form greys the
+// option out and create-perp refuses it).
+export const MNX_CREATOR_IDS: Record<'DEV' | 'PROD', string | undefined> = {
+  DEV: undefined,
+  PROD: '0YOMCbJas0UqJdlrqKe1MrQewrF2',
+}
+
+export const getMnxCreatorId = (environment: 'DEV' | 'PROD') =>
+  MNX_CREATOR_IDS[environment]
 
 // A partner may only own markets on its own feeds: MNX-owned BTC markets would
 // route house backing to a third party for a product it has nothing to do

--- a/common/src/perps/management.ts
+++ b/common/src/perps/management.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod'
+import type { PerpContract } from '../contract'
+import {
+  getPerpEffectiveTakerFeeBps,
+  getPerpTakerFeeBps,
+  getPerpTakerFeeImpact,
+  PERP_TAKER_FEE_API_BPS_MAX,
+  PERP_TAKER_FEE_IMPACT_MAX,
+} from './fees'
+
+// Shared by the API and dashboard; omitted fields are left unchanged.
+export const perpConfigFields = z
+  .object({
+    maxLeverage: z.number().finite().gt(1).lte(100).optional(),
+    maxFundingRate: z.number().finite().gt(0).lt(1).optional(),
+    fundingSensitivity: z.number().finite().gt(0).lte(100).optional(),
+    takerFeeBps: z.number().finite().min(0).max(100).optional(),
+    takerFeeApiBps: z
+      .number()
+      .finite()
+      .min(0)
+      .max(PERP_TAKER_FEE_API_BPS_MAX)
+      .optional(),
+    takerFeeImpact: z
+      .number()
+      .finite()
+      .min(0)
+      .max(PERP_TAKER_FEE_IMPACT_MAX)
+      .optional(),
+    maxOraclePriceAgeMs: z.number().int().positive().optional(),
+  })
+  .strict()
+
+export type PerpConfigPatch = z.infer<typeof perpConfigFields>
+export const getPerpConfig = (contract: PerpContract) => ({
+  maxLeverage: contract.maxLeverage,
+  maxFundingRate: contract.maxFundingRate,
+  fundingSensitivity: contract.fundingSensitivity,
+  takerFeeBps: getPerpTakerFeeBps(contract),
+  takerFeeApiBps: contract.takerFeeApiBps ?? 0,
+  takerFeeImpact: getPerpTakerFeeImpact(contract),
+  maxOraclePriceAgeMs: contract.maxOraclePriceAgeMs,
+})
+
+export type MnxDashboardMarket = {
+  contract: PerpContract
+  activeTraders: number
+  openInterestLong: number
+  openInterestShort: number
+  volume24Hours: number
+  fees24Hours: number
+  minOraclePriceAgeMs: number
+}
+
+export type MnxDashboard = {
+  asOf: number
+  account: { id: string; username: string; balance: number } | null
+  payer: { id: string; username: string; balance: number }
+  markets: MnxDashboardMarket[]
+}
+
+export const getEffectiveApiFee = (contract: PerpContract) =>
+  getPerpEffectiveTakerFeeBps(contract, true)

--- a/common/src/perps/mnx-management.test.ts
+++ b/common/src/perps/mnx-management.test.ts
@@ -1,7 +1,17 @@
 import { API } from '../api/schema'
 import { PerpContract } from '../contract'
 import { HOUR_MS, YEAR_MS } from '../util/time'
-import { buildMnxRulePatch, MnxBatch, runMnxBatch } from './mnx-management'
+import {
+  buildMnxRulePatch,
+  isMnxBatchInProgress,
+  MNX_BATCH_STALE_MS,
+  MnxBatch,
+  MnxBatchStorage,
+  readMnxBatches,
+  removeMnxBatch,
+  runMnxBatch,
+  saveMnxBatch,
+} from './mnx-management'
 import { MNX_DEFAULT_FEES } from './mnx'
 
 const contract = { fundingPeriodMs: HOUR_MS } as PerpContract
@@ -25,6 +35,13 @@ it('leaves blank fields unchanged but preserves explicit zero fees', () => {
   expect(() => buildMnxRulePatch({}, contract)).toThrow('at least one')
   expect(buildMnxRulePatch({ oracleAgeSeconds: '4500' }, contract)).toEqual({
     maxOraclePriceAgeMs: 4_500_000,
+  })
+})
+
+it('rounds a fractional mark age to whole milliseconds', () => {
+  // 1.005 * 1000 is 1004.9999999999999 in floating point.
+  expect(buildMnxRulePatch({ oracleAgeSeconds: '1.005' }, contract)).toEqual({
+    maxOraclePriceAgeMs: 1005,
   })
 })
 
@@ -55,16 +72,17 @@ it('allows each rule independently and rejects an empty update or client-only fi
   ).toBe(false)
 })
 
-const batch = (): MnxBatch => ({
-  version: 1,
+const batch = (id = 'batch1'): MnxBatch => ({
+  version: 2,
+  id,
   actorId: 'mnx',
   createdAt: 1,
-  items: ['a', 'b', 'c'].map((id) => ({
+  items: ['a', 'b', 'c'].map((contractId) => ({
     kind: 'liquidity',
-    title: id,
+    title: contractId,
     status: 'pending',
     params: {
-      contractId: id,
+      contractId,
       side: 'both',
       amount: 10,
       idempotencyKey: 'abcdefghjk',
@@ -119,4 +137,81 @@ it('sends no payment if saving the retry keys fails or the account unmounts', as
   ).rejects.toThrow('Storage full')
   await runMnxBatch(batch(), jest.fn(), send, () => false)
   expect(send).not.toHaveBeenCalled()
+})
+
+it('marks the batch in progress for other tabs while sending and clears it when the run ends', async () => {
+  const saved: MnxBatch[] = []
+  const send = jest
+    .fn()
+    .mockResolvedValueOnce({})
+    .mockRejectedValueOnce(new Error('Lost response'))
+  const last = await runMnxBatch(
+    batch(),
+    (b) => {
+      saved.push(b)
+    },
+    send,
+    () => true
+  )
+  const during = saved.slice(0, -1)
+  expect(during.length).toBeGreaterThan(0)
+  expect(during.every((b) => isMnxBatchInProgress(b, b.runningAt!))).toBe(true)
+  expect(last.runningAt).toBeUndefined()
+  expect(saved[saved.length - 1]).toEqual(last)
+  // A tab that crashed mid-run stops blocking the others once its mark is stale.
+  const crashed = { ...last, runningAt: 1_000_000 }
+  expect(
+    isMnxBatchInProgress(crashed, 1_000_000 + MNX_BATCH_STALE_MS - 1)
+  ).toBe(true)
+  expect(isMnxBatchInProgress(crashed, 1_000_000 + MNX_BATCH_STALE_MS)).toBe(
+    false
+  )
+})
+
+const fakeStorage = (): MnxBatchStorage => {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    key: (index) => [...map.keys()][index] ?? null,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value)
+    },
+    removeItem: (key) => {
+      map.delete(key)
+    },
+  }
+}
+
+it('saves every batch under its own entry, so finishing one never discards another', () => {
+  const storage = fakeStorage()
+  saveMnxBatch(storage, 'DEV', { ...batch('newer'), createdAt: 2 })
+  saveMnxBatch(storage, 'DEV', batch('older'))
+  saveMnxBatch(storage, 'PROD', batch('other-env'))
+  saveMnxBatch(storage, 'DEV', { ...batch('other-account'), actorId: 'admin' })
+  expect(readMnxBatches(storage, 'DEV', 'mnx').map((b) => b.id)).toEqual([
+    'older',
+    'newer',
+  ])
+  removeMnxBatch(storage, 'DEV', batch('newer'))
+  expect(readMnxBatches(storage, 'DEV', 'mnx').map((b) => b.id)).toEqual([
+    'older',
+  ])
+  expect(readMnxBatches(storage, 'PROD', 'mnx').map((b) => b.id)).toEqual([
+    'other-env',
+  ])
+  expect(readMnxBatches(storage, 'DEV', 'admin').map((b) => b.id)).toEqual([
+    'other-account',
+  ])
+})
+
+it('refuses to start over a saved batch it cannot read', () => {
+  const storage = fakeStorage()
+  saveMnxBatch(storage, 'DEV', batch())
+  storage.setItem('mnx-batch-v2:DEV:mnx:legacy', '{"version":1,"items":[]}')
+  expect(() => readMnxBatches(storage, 'DEV', 'mnx')).toThrow(
+    'could not be read'
+  )
 })

--- a/common/src/perps/mnx-management.test.ts
+++ b/common/src/perps/mnx-management.test.ts
@@ -1,0 +1,122 @@
+import { API } from '../api/schema'
+import { PerpContract } from '../contract'
+import { HOUR_MS, YEAR_MS } from '../util/time'
+import { buildMnxRulePatch, MnxBatch, runMnxBatch } from './mnx-management'
+import { MNX_DEFAULT_FEES } from './mnx'
+
+const contract = { fundingPeriodMs: HOUR_MS } as PerpContract
+
+it('converts an annual funding percentage separately for each market period', () => {
+  expect(buildMnxRulePatch({ annualFunding: '100' }, contract)).toEqual({
+    maxFundingRate: HOUR_MS / YEAR_MS,
+  })
+  expect(
+    buildMnxRulePatch(
+      { annualFunding: '100' },
+      { ...contract, fundingPeriodMs: 24 * HOUR_MS }
+    )
+  ).toEqual({ maxFundingRate: (24 * HOUR_MS) / YEAR_MS })
+})
+
+it('leaves blank fields unchanged but preserves explicit zero fees', () => {
+  expect(
+    buildMnxRulePatch({ takerFeeBps: '0', maxLeverage: ' ' }, contract)
+  ).toEqual({ takerFeeBps: 0 })
+  expect(() => buildMnxRulePatch({}, contract)).toThrow('at least one')
+  expect(buildMnxRulePatch({ oracleAgeSeconds: '4500' }, contract)).toEqual({
+    maxOraclePriceAgeMs: 4_500_000,
+  })
+})
+
+it.each([
+  { maxLeverage: '1' },
+  { annualFunding: '0' },
+  { takerFeeApiBps: '301' },
+  { takerFeeImpact: 'Infinity' },
+  { fundingSensitivity: '0' },
+])('rejects invalid rules %j before making a preview', (form) => {
+  expect(() => buildMnxRulePatch(form, contract)).toThrow()
+})
+
+it('allows each rule independently and rejects an empty update or client-only fields', () => {
+  const shape = API['update-perp-config'].props
+  for (const patch of [
+    { ...MNX_DEFAULT_FEES },
+    { maxLeverage: 3 },
+    { fundingSensitivity: 1 },
+    { maxFundingRate: 0.001 },
+    { maxOraclePriceAgeMs: 4500000 },
+  ])
+    expect(shape.safeParse({ contractId: 'c', ...patch }).success).toBe(true)
+  expect(shape.safeParse({ contractId: 'c' }).success).toBe(false)
+  expect(
+    shape.safeParse({ contractId: 'c', maxLeverage: 3, creatorId: 'attacker' })
+      .success
+  ).toBe(false)
+})
+
+const batch = (): MnxBatch => ({
+  version: 1,
+  actorId: 'mnx',
+  createdAt: 1,
+  items: ['a', 'b', 'c'].map((id) => ({
+    kind: 'liquidity',
+    title: id,
+    status: 'pending',
+    params: {
+      contractId: id,
+      side: 'both',
+      amount: 10,
+      idempotencyKey: 'abcdefghjk',
+    },
+  })),
+})
+
+it('stops at a lost response, then skips successes and retries with the SAME payment key', async () => {
+  const saved: MnxBatch[] = []
+  const save = (b: MnxBatch) => {
+    saved.push(b)
+  }
+  const send = jest
+    .fn()
+    .mockResolvedValueOnce({})
+    .mockRejectedValueOnce(new Error('Lost response'))
+  const first = await runMnxBatch(batch(), save, send, () => true)
+  expect(first.items.map((i) => i.status)).toEqual(['done', 'error', 'pending'])
+  expect(saved[0].items.map((i) => i.status)).toEqual([
+    'pending',
+    'pending',
+    'pending',
+  ])
+  const retry = jest.fn().mockResolvedValue({})
+  const last = await runMnxBatch(
+    JSON.parse(JSON.stringify(first)),
+    save,
+    retry,
+    () => true
+  )
+  expect(retry.mock.calls.map(([item]) => item.params.contractId)).toEqual([
+    'b',
+    'c',
+  ])
+  expect(retry.mock.calls[0][0].params.idempotencyKey).toBe(
+    send.mock.calls[1][0].params.idempotencyKey
+  )
+  expect(last.items.every((i) => i.status === 'done')).toBe(true)
+})
+
+it('sends no payment if saving the retry keys fails or the account unmounts', async () => {
+  const send = jest.fn()
+  await expect(
+    runMnxBatch(
+      batch(),
+      () => {
+        throw new Error('Storage full')
+      },
+      send,
+      () => true
+    )
+  ).rejects.toThrow('Storage full')
+  await runMnxBatch(batch(), jest.fn(), send, () => false)
+  expect(send).not.toHaveBeenCalled()
+})

--- a/common/src/perps/mnx-management.ts
+++ b/common/src/perps/mnx-management.ts
@@ -1,24 +1,35 @@
 import { APIParams } from 'common/api/schema'
 import { PerpContract } from 'common/contract'
+import {
+  PERP_TAKER_FEE_API_BPS_MAX,
+  PERP_TAKER_FEE_BPS_MAX,
+  PERP_TAKER_FEE_IMPACT_MAX,
+} from 'common/perps/fees'
 import { getFundingPeriodMs } from 'common/perps/funding'
 import { PerpConfigPatch, perpConfigFields } from 'common/perps/management'
 import { YEAR_MS } from 'common/util/time'
 
 export const MNX_RULE_FIELDS = [
-  { key: 'takerFeeBps', label: 'Web base fee', unit: 'bps', min: 0, max: 100 },
+  {
+    key: 'takerFeeBps',
+    label: 'Web base fee',
+    unit: 'bps',
+    min: 0,
+    max: PERP_TAKER_FEE_BPS_MAX,
+  },
   {
     key: 'takerFeeApiBps',
     label: 'API base fee',
     unit: 'bps',
     min: 0,
-    max: 300,
+    max: PERP_TAKER_FEE_API_BPS_MAX,
   },
   {
     key: 'takerFeeImpact',
     label: 'Size-impact coefficient',
     unit: '',
     min: 0,
-    max: 100,
+    max: PERP_TAKER_FEE_IMPACT_MAX,
   },
   {
     key: 'maxLeverage',
@@ -65,7 +76,8 @@ export const buildMnxRulePatch = (
       patch.maxFundingRate =
         ((value / 100) * getFundingPeriodMs(contract)) / YEAR_MS
     else if (key === 'oracleAgeSeconds')
-      patch.maxOraclePriceAgeMs = value * 1000
+      // 1.005 * 1000 is not an integer in floating point.
+      patch.maxOraclePriceAgeMs = Math.round(value * 1000)
     else patch[key] = value
   }
   if (!Object.keys(patch).length)
@@ -89,10 +101,92 @@ export type MnxBatchItem = {
   | { kind: 'rules'; params: APIParams<'update-perp-config'> }
 )
 export type MnxBatch = {
-  version: 1
+  version: 2
+  id: string
   actorId: string
   createdAt: number
+  // Set while a tab is applying the batch, refreshed before every request.
+  // Other tabs treat it as abandoned after MNX_BATCH_STALE_MS.
+  runningAt?: number
   items: MnxBatchItem[]
+}
+
+// A client waits this long for one response before giving up on it.
+export const MNX_REQUEST_TIMEOUT_MS = 30_000
+// Longer than one request, so a live run in another tab is never mistaken
+// for a crashed one.
+export const MNX_BATCH_STALE_MS = 2 * MNX_REQUEST_TIMEOUT_MS
+
+export const isMnxBatchInProgress = (batch: MnxBatch, now: number) =>
+  batch.runningAt !== undefined && now - batch.runningAt < MNX_BATCH_STALE_MS
+
+// The subset of Storage the batch persistence uses, so it can be tested
+// without a DOM and swapped for another store.
+export type MnxBatchStorage = {
+  readonly length: number
+  key(index: number): string | null
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+// Every batch gets its own entry: finishing or retrying one batch must never
+// overwrite or delete another tab's batch, whose entry is the only record of
+// the payment request IDs that make a retry safe.
+export const mnxBatchKeyPrefix = (env: string, actorId: string) =>
+  `mnx-batch-v2:${env}:${actorId}:`
+export const mnxBatchKey = (
+  env: string,
+  batch: Pick<MnxBatch, 'actorId' | 'id'>
+) => mnxBatchKeyPrefix(env, batch.actorId) + batch.id
+
+export const saveMnxBatch = (
+  storage: MnxBatchStorage,
+  env: string,
+  batch: MnxBatch
+) => storage.setItem(mnxBatchKey(env, batch), JSON.stringify(batch))
+
+export const removeMnxBatch = (
+  storage: MnxBatchStorage,
+  env: string,
+  batch: Pick<MnxBatch, 'actorId' | 'id'>
+) => storage.removeItem(mnxBatchKey(env, batch))
+
+const parseMnxBatch = (raw: string | null, actorId: string) => {
+  try {
+    const batch = JSON.parse(raw ?? '') as MnxBatch
+    return batch.version === 2 &&
+      typeof batch.id === 'string' &&
+      batch.actorId === actorId &&
+      Array.isArray(batch.items)
+      ? batch
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+// Every unfinished batch this account saved, oldest first. Throws if one
+// cannot be read: the operator must keep it for recovery rather than start a
+// batch that would pay again.
+export const readMnxBatches = (
+  storage: MnxBatchStorage,
+  env: string,
+  actorId: string
+) => {
+  const prefix = mnxBatchKeyPrefix(env, actorId)
+  const batches: MnxBatch[] = []
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i)
+    if (!key?.startsWith(prefix)) continue
+    const batch = parseMnxBatch(storage.getItem(key), actorId)
+    if (!batch || mnxBatchKey(env, batch) !== key)
+      throw new Error(
+        'A saved MNX batch could not be read. Keep it for recovery before starting another batch.'
+      )
+    batches.push(batch)
+  }
+  return batches.sort((a, b) => a.createdAt - b.createdAt)
 }
 
 // Stop on the first error. Persist BEFORE each request and after each result.
@@ -103,34 +197,51 @@ export const runMnxBatch = async (
   send: (item: MnxBatchItem) => Promise<unknown>,
   isActive: () => boolean
 ) => {
-  let current = { ...batch, items: batch.items.map((i) => ({ ...i })) }
-  const update = (index: number, changes: Partial<MnxBatchItem>) => {
-    current = {
-      ...current,
-      items: current.items.map((item, i) =>
-        i === index ? ({ ...item, ...changes } as MnxBatchItem) : item
-      ),
-    }
+  let current: MnxBatch = {
+    ...batch,
+    items: batch.items.map((i) => ({ ...i })),
   }
-  for (let index = 0; index < current.items.length; index++) {
-    if (!isActive()) break
-    if (current.items[index].status === 'done') continue
-    update(index, { status: 'pending', error: undefined })
+  // Every save receives a fresh object, so React state and earlier saves are
+  // never mutated by a later pass.
+  const persist = (changes: Partial<MnxBatch>) => {
+    current = { ...current, ...changes }
     save(current)
-    try {
-      await send(current.items[index])
-      update(index, { status: 'done' })
-    } catch (error) {
-      update(index, {
-        status: 'error',
-        error: error instanceof Error ? error.message : String(error),
+  }
+  const withItem = (index: number, changes: Partial<MnxBatchItem>) => ({
+    items: current.items.map((item, i) =>
+      i === index ? ({ ...item, ...changes } as MnxBatchItem) : item
+    ),
+  })
+  try {
+    for (let index = 0; index < current.items.length; index++) {
+      if (!isActive()) break
+      if (current.items[index].status === 'done') continue
+      persist({
+        ...withItem(index, { status: 'pending', error: undefined }),
+        runningAt: Date.now(),
       })
-      save(current)
-      break
+      try {
+        await send(current.items[index])
+      } catch (error) {
+        persist(
+          withItem(index, {
+            status: 'error',
+            error: error instanceof Error ? error.message : String(error),
+          })
+        )
+        break
+      }
+      persist(withItem(index, { status: 'done' }))
     }
-    save(current)
-    // Never mutate a React state object or a saved preview on the next pass.
-    current = { ...current, items: [...current.items] }
+  } finally {
+    if (current.runningAt !== undefined) {
+      current = { ...current, runningAt: undefined }
+      try {
+        save(current)
+      } catch {
+        // Results were already saved; the marker expires on its own.
+      }
+    }
   }
   return current
 }

--- a/common/src/perps/mnx-management.ts
+++ b/common/src/perps/mnx-management.ts
@@ -1,0 +1,136 @@
+import { APIParams } from 'common/api/schema'
+import { PerpContract } from 'common/contract'
+import { getFundingPeriodMs } from 'common/perps/funding'
+import { PerpConfigPatch, perpConfigFields } from 'common/perps/management'
+import { YEAR_MS } from 'common/util/time'
+
+export const MNX_RULE_FIELDS = [
+  { key: 'takerFeeBps', label: 'Web base fee', unit: 'bps', min: 0, max: 100 },
+  {
+    key: 'takerFeeApiBps',
+    label: 'API base fee',
+    unit: 'bps',
+    min: 0,
+    max: 300,
+  },
+  {
+    key: 'takerFeeImpact',
+    label: 'Size-impact coefficient',
+    unit: '',
+    min: 0,
+    max: 100,
+  },
+  {
+    key: 'maxLeverage',
+    label: 'Maximum leverage',
+    unit: '×',
+    min: 1.01,
+    max: 100,
+  },
+  { key: 'annualFunding', label: 'Annualized funding cap', unit: '%', min: 0 },
+  {
+    key: 'fundingSensitivity',
+    label: 'Funding sensitivity',
+    unit: '',
+    min: 0.01,
+    max: 100,
+  },
+  {
+    key: 'oracleAgeSeconds',
+    label: 'Maximum mark age',
+    unit: 'seconds',
+    min: 1,
+  },
+] as const
+export type RuleField = (typeof MNX_RULE_FIELDS)[number]['key']
+export type MnxRuleForm = Partial<Record<RuleField, string>>
+
+export const ruleValue = (contract: PerpContract, key: RuleField) =>
+  key === 'annualFunding'
+    ? (contract.maxFundingRate * YEAR_MS * 100) / getFundingPeriodMs(contract)
+    : key === 'oracleAgeSeconds'
+    ? contract.maxOraclePriceAgeMs / 1000
+    : contract[key] ?? 0
+
+export const buildMnxRulePatch = (
+  form: MnxRuleForm,
+  contract: PerpContract
+): PerpConfigPatch => {
+  const patch: PerpConfigPatch = {}
+  for (const { key, label } of MNX_RULE_FIELDS) {
+    if (!form[key]?.trim()) continue
+    const value = Number(form[key])
+    if (!Number.isFinite(value)) throw new Error(`${label} must be a number.`)
+    if (key === 'annualFunding')
+      patch.maxFundingRate =
+        ((value / 100) * getFundingPeriodMs(contract)) / YEAR_MS
+    else if (key === 'oracleAgeSeconds')
+      patch.maxOraclePriceAgeMs = value * 1000
+    else patch[key] = value
+  }
+  if (!Object.keys(patch).length)
+    throw new Error('Enter at least one rule to change.')
+  const parsed = perpConfigFields.safeParse(patch)
+  if (!parsed.success)
+    throw new Error(
+      parsed.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ')
+    )
+  return parsed.data
+}
+
+export type MnxBatchItem = {
+  title: string
+  status: 'pending' | 'done' | 'error'
+  error?: string
+} & (
+  | { kind: 'liquidity'; params: APIParams<'add-perp-subsidy'> }
+  | { kind: 'rules'; params: APIParams<'update-perp-config'> }
+)
+export type MnxBatch = {
+  version: 1
+  actorId: string
+  createdAt: number
+  items: MnxBatchItem[]
+}
+
+// Stop on the first error. Persist BEFORE each request and after each result.
+// A crash between a commit and saving 'done' replays the same request key.
+export const runMnxBatch = async (
+  batch: MnxBatch,
+  save: (batch: MnxBatch) => void,
+  send: (item: MnxBatchItem) => Promise<unknown>,
+  isActive: () => boolean
+) => {
+  let current = { ...batch, items: batch.items.map((i) => ({ ...i })) }
+  const update = (index: number, changes: Partial<MnxBatchItem>) => {
+    current = {
+      ...current,
+      items: current.items.map((item, i) =>
+        i === index ? ({ ...item, ...changes } as MnxBatchItem) : item
+      ),
+    }
+  }
+  for (let index = 0; index < current.items.length; index++) {
+    if (!isActive()) break
+    if (current.items[index].status === 'done') continue
+    update(index, { status: 'pending', error: undefined })
+    save(current)
+    try {
+      await send(current.items[index])
+      update(index, { status: 'done' })
+    } catch (error) {
+      update(index, {
+        status: 'error',
+        error: error instanceof Error ? error.message : String(error),
+      })
+      save(current)
+      break
+    }
+    save(current)
+    // Never mutate a React state object or a saved preview on the next pass.
+    current = { ...current, items: [...current.items] }
+  }
+  return current
+}

--- a/common/src/perps/mnx.ts
+++ b/common/src/perps/mnx.ts
@@ -3,6 +3,13 @@ import { HOUR_MS, MINUTE_MS } from '../util/time'
 export const MNX_API_URL = 'https://api.app.mnx.fi/v0'
 export const MNX_POLL_MS = 2_000
 
+// Opening fees in bps of notional; impact is the size-fee coefficient.
+export const MNX_DEFAULT_FEES = {
+  takerFeeBps: 10,
+  takerFeeApiBps: 20,
+  takerFeeImpact: 10,
+} as const
+
 // Stable provider IDs and explicit feed IDs prevent silently rolling a delisted
 // instrument into a new market. Bounds are in the displayed units and reject
 // gross scaling mistakes; currency identity is pinned separately (USD vs HKD

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -31,8 +31,12 @@ in place. **Retry remaining** skips completed markets. The browser saves payment
 request IDs before sending, and the backend recognizes those IDs under the
 contract lock, so a timeout/reload can be retried without charging twice. A
 restored batch never resumes automatically. Keep the saved batch until uncertain
-results are reconciled; starting a new batch creates new payments. Rule edits
-check the previewed settings and record their audit history in the same database
+results are reconciled; starting a new batch creates new payments. Each batch is
+saved under its own browser entry, so **Finish batch** removes only that batch
+and can never discard one that another tab is still applying. Other open tabs
+show a batch while it is being applied and cannot retry or finish it until the
+run ends, or about a minute after a tab was closed mid-run. Rule edits check the
+previewed settings and record their audit history in the same database
 transaction as the update.
 
 New MNX-feed markets default to **10 bps web, 20 bps API, impact 10**. These are

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -1,0 +1,48 @@
+# MNX market management
+
+Open `/admin/mnx` while signed in as the configured MNX account or an admin.
+There is also a link on `/perps` for those accounts and on the admin index.
+Deploy the API and web changes before using the dashboard. No database migration
+is required. Merging or deploying does not create, fund, or reprice any markets.
+
+The dashboard lists MNX-owned markets on registered MNX feeds, including unlisted
+and resolved markets. Stats are refreshed from the database with **Refresh stats**:
+backing, open interest, active traders, 24-hour margin volume, opening fees, and
+oracle health. Fees are added to the backing pools. Stats cannot be manually edited.
+
+Select live markets, or use **Manage** on one market:
+
+- **Add liquidity:** choose long, short, or both. The entered amount is **per
+  market, per selected side**. For example, M$1,000 to both sides of 16 markets
+  costs M$32,000. The signed-in account pays, including when that account is an
+  admin. Contributions do not create withdrawable LP shares; remaining backing
+  belongs to the market creator at settlement.
+- **Trading rules:** change web/API opening fees, the size-impact coefficient,
+  leverage cap, funding cap/sensitivity, or the maximum oracle mark age. Blank
+  fields stay unchanged. Funding is entered as an annualized percentage and
+  converted using each market's own funding period. API base fees cannot go
+  below the web base. Lower leverage caps affect new opens/adds, and increases
+  on MNX feeds require current provider support. Oracle age also gates closes
+  and cannot be reduced below the feed's cadence floor.
+
+Review the market list, changes, and total contribution, then apply. Markets are
+processed sequentially; a failure stops the batch and leaves earlier successes
+in place. **Retry remaining** skips completed markets. The browser saves payment
+request IDs before sending, and the backend recognizes those IDs under the
+contract lock, so a timeout/reload can be retried without charging twice. A
+restored batch never resumes automatically. Keep the saved batch until uncertain
+results are reconciled; starting a new batch creates new payments. Rule edits
+check the previewed settings and record their audit history in the same database
+transaction as the update.
+
+New MNX-feed markets default to **10 bps web, 20 bps API, impact 10**. These are
+opening fees on notional; 20 bps is 0.20%, plus the size-dependent fee. The impact
+coefficient is not a flat 10% fee. Existing markets keep their settings until an
+operator applies a change, such as **Use MNX fee preset** in the dashboard.
+
+Creation remains in `backend/scripts/create-mnx-perps.ts`. The script now sends
+these fees explicitly, checks the API's creation-fee capability before any write,
+and verifies the fees and creator in each response. The MNX identity remains
+pinned by environment in `common/src/perps/creator-accounts.ts` (re-exported from
+the existing shared module); usernames do not grant management access. DEV stays
+unconfigured until it has its own verified partner account.

--- a/web/components/perps/mnx-dashboard.tsx
+++ b/web/components/perps/mnx-dashboard.tsx
@@ -1,0 +1,801 @@
+import clsx from 'clsx'
+import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+import { ENV } from 'common/envs/constants'
+import {
+  getPerpConfig,
+  getEffectiveApiFee,
+  MnxDashboard,
+  MnxDashboardMarket,
+} from 'common/perps/management'
+import {
+  MNX_DEFAULT_FEES,
+  MNX_INSTRUMENTS,
+  getMnxInstrument,
+} from 'common/perps/mnx'
+import { getPerpOracleFreshness } from 'common/perps/oracle'
+import { randomString } from 'common/util/random'
+import { Button } from 'web/components/buttons/button'
+import { Input } from 'web/components/widgets/input'
+import { api } from 'web/lib/api/api'
+import {
+  buildMnxRulePatch,
+  MNX_RULE_FIELDS,
+  MnxBatch,
+  MnxBatchItem,
+  MnxRuleForm,
+  ruleValue,
+  runMnxBatch,
+} from 'common/perps/mnx-management'
+
+const number = (value: number) =>
+  new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value)
+const mana = (value: number) => `M$${number(value)}`
+const panel = 'border-ink-200 bg-canvas-0 rounded-xl border'
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error)
+
+export function MnxDashboardView({
+  data,
+  refresh,
+  refreshing,
+}: {
+  data: MnxDashboard
+  refresh: () => Promise<void>
+  refreshing: boolean
+}) {
+  const [selected, setSelected] = useState<string[]>([])
+  const [mode, setMode] = useState<'liquidity' | 'rules'>('liquidity')
+  const [side, setSide] = useState<'both' | 'long' | 'short'>('both')
+  const [amount, setAmount] = useState('')
+  const [rules, setRules] = useState<MnxRuleForm>({})
+  const [preview, setPreview] = useState<MnxBatch>()
+  const [batch, setBatch] = useState<MnxBatch>()
+  const [running, setRunning] = useState(false)
+  const [ready, setReady] = useState(false)
+  const [error, setError] = useState<string>()
+  const [acknowledge, setAcknowledge] = useState(false)
+  const active = useRef(true)
+  const busy = useRef(false)
+  const editor = useRef<HTMLDivElement>(null)
+  const storageKey = `mnx-management-v1:${ENV}:${data.payer.id}`
+  useEffect(() => {
+    active.current = true
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (stored) {
+        const previous = JSON.parse(stored) as MnxBatch
+        if (
+          previous.version !== 1 ||
+          previous.actorId !== data.payer.id ||
+          !Array.isArray(previous.items)
+        )
+          throw new Error(
+            'The saved MNX batch could not be read. Keep it for recovery before starting another batch.'
+          )
+        setBatch(previous)
+      }
+      setReady(true)
+    } catch (error) {
+      setError(errorMessage(error))
+    }
+    return () => {
+      active.current = false
+    }
+  }, [storageKey, data.payer.id])
+
+  const live = data.markets.filter(({ contract }) => !contract.isResolved)
+  const targets = live.filter(({ contract }) => selected.includes(contract.id))
+  const missing = MNX_INSTRUMENTS.filter(
+    (i) => !live.some((m) => m.contract.oracleFeedId === i.feedId)
+  )
+  const sum = (fn: (m: MnxDashboardMarket) => number) =>
+    live.reduce((total, m) => total + fn(m), 0)
+  const totalCost = Number(amount) * (side === 'both' ? 2 : 1) * targets.length
+  const locked = !!batch || !!preview || running
+  const one = targets.length === 1 ? targets[0].contract : undefined
+
+  const saveBatch = (next: MnxBatch) => {
+    // If storage fails, runMnxBatch stops before sending another paid request.
+    localStorage.setItem(storageKey, JSON.stringify(next))
+    if (active.current)
+      setBatch({ ...next, items: next.items.map((i) => ({ ...i })) })
+  }
+  const execute = async (next: MnxBatch) => {
+    if (busy.current || next.actorId !== data.payer.id) return
+    busy.current = true
+    setRunning(true)
+    setError(undefined)
+    try {
+      saveBatch(next)
+      setPreview(undefined)
+      await runMnxBatch(
+        next,
+        saveBatch,
+        async (item) => {
+          const controller = new AbortController()
+          const timeout = setTimeout(() => controller.abort(), 30_000)
+          try {
+            return item.kind === 'liquidity'
+              ? await api('add-perp-subsidy', item.params, {
+                  signal: controller.signal,
+                })
+              : await api('update-perp-config', item.params, {
+                  signal: controller.signal,
+                })
+          } finally {
+            clearTimeout(timeout)
+          }
+        },
+        () => active.current
+      )
+    } catch (error) {
+      if (active.current) setError(errorMessage(error))
+    } finally {
+      busy.current = false
+      if (active.current) {
+        setRunning(false)
+        await refresh()
+      }
+    }
+  }
+  const review = () => {
+    setError(undefined)
+    try {
+      if (!targets.length) throw new Error('Select at least one live market.')
+      if (
+        mode === 'liquidity' &&
+        (!Number.isFinite(Number(amount)) ||
+          Number(amount) <= 0 ||
+          Number(amount) > 1_000_000)
+      )
+        throw new Error(
+          'Enter between 0 and 1,000,000 mana per side, greater than zero.'
+        )
+      if (mode === 'liquidity' && totalCost > data.payer.balance)
+        throw new Error(
+          `@${data.payer.username} needs ${mana(totalCost)} to fund this batch.`
+        )
+      const items: MnxBatchItem[] = targets.map(
+        ({ contract, minOraclePriceAgeMs }) => {
+          const base = {
+            title:
+              getMnxInstrument(contract.oracleFeedId)?.symbol ??
+              contract.question,
+            status: 'pending' as const,
+          }
+          if (mode === 'liquidity')
+            return {
+              ...base,
+              kind: 'liquidity',
+              params: {
+                contractId: contract.id,
+                side,
+                amount: Number(amount),
+                idempotencyKey: randomString(),
+                expectedManagerId: data.payer.id,
+              },
+            }
+          const patch = buildMnxRulePatch(rules, contract)
+          if (
+            patch.maxOraclePriceAgeMs !== undefined &&
+            patch.maxOraclePriceAgeMs < minOraclePriceAgeMs
+          )
+            throw new Error(
+              `${base.title} needs a mark age of at least ${number(
+                minOraclePriceAgeMs / 1000
+              )} seconds.`
+            )
+          return {
+            ...base,
+            kind: 'rules',
+            params: {
+              contractId: contract.id,
+              ...patch,
+              expectedConfig: getPerpConfig(contract),
+              expectedManagerId: data.payer.id,
+            },
+          }
+        }
+      )
+      setPreview({
+        version: 1,
+        actorId: data.payer.id,
+        createdAt: Date.now(),
+        items,
+      })
+    } catch (error) {
+      setError(errorMessage(error))
+    }
+  }
+  const finish = () => {
+    try {
+      localStorage.removeItem(storageKey)
+      setBatch(undefined)
+      setAcknowledge(false)
+      setSelected([])
+      setError(undefined)
+    } catch (error) {
+      setError(errorMessage(error))
+    }
+  }
+  const toggle = (id: string) =>
+    setSelected((ids) =>
+      ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id]
+    )
+
+  return (
+    <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-col gap-6 p-4 pb-12 sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-primary-600 text-xs font-semibold uppercase tracking-widest">
+            Partner console · {ENV}
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+            MNX markets
+          </h1>
+          <p className="text-ink-500 mt-2 text-sm">
+            Backing, activity, and trading rules in one place.
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-2">
+          <Button
+            color="gray-outline"
+            onClick={refresh}
+            disabled={refreshing || running}
+          >
+            {refreshing ? 'Refreshing…' : 'Refresh stats'}
+          </Button>
+          <span className="text-ink-500 text-xs">
+            Snapshot {new Date(data.asOf).toLocaleTimeString()}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+        <Stat
+          label="MNX available balance"
+          value={data.account ? mana(data.account.balance) : 'Not configured'}
+          note={`${live.length} live · ${missing.length} feeds without an MNX market`}
+        />
+        <Stat
+          label="Total backing"
+          value={mana(sum((m) => m.contract.poolLong + m.contract.poolShort))}
+          note="Long and short pools combined"
+        />
+        <Stat
+          label="Open interest"
+          value={mana(sum((m) => m.openInterestLong + m.openInterestShort))}
+          note="Leveraged notional across live markets"
+        />
+        <Stat
+          label="24h trading activity"
+          value={mana(sum((m) => m.volume24Hours))}
+          note={`${mana(sum((m) => m.fees24Hours))} fees added to backing`}
+        />
+      </div>
+
+      <section className={panel} aria-label="MNX markets">
+        <div className="flex flex-wrap items-center justify-between gap-3 p-4">
+          <div>
+            <h2 className="font-semibold">Your markets</h2>
+            <p className="text-ink-500 text-xs">
+              Volume is margin opened and closed; fees are charged on opening
+              notional.
+            </p>
+          </div>
+          <Button
+            size="xs"
+            color="gray-outline"
+            disabled={locked || !live.length}
+            onClick={() =>
+              setSelected(
+                targets.length === live.length
+                  ? []
+                  : live.map((m) => m.contract.id)
+              )
+            }
+          >
+            {targets.length === live.length && live.length
+              ? 'Clear selection'
+              : 'Select all live'}
+          </Button>
+        </div>
+        {data.markets.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="text-ink-500 bg-canvas-50 border-ink-200 border-y text-xs">
+                <tr>
+                  <th className="p-3">
+                    <span className="sr-only">Select</span>
+                  </th>
+                  <th className="py-3 pr-4">Market / oracle</th>
+                  <th className="py-3 pr-4">Backing · L / S</th>
+                  <th className="py-3 pr-4">Open interest</th>
+                  <th className="py-3 pr-4">24h volume / fees</th>
+                  <th className="py-3 pr-4">Fees · web / API</th>
+                  <th className="p-3">
+                    <span className="sr-only">Manage</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-ink-100 divide-y">
+                {data.markets.map((market) => {
+                  const c = market.contract
+                  const config = getPerpConfig(c)
+                  const health = getPerpOracleFreshness(c, data.asOf)
+                  const halted = c.solvencyHaltTime != null
+                  const status = c.isResolved
+                    ? 'Resolved'
+                    : halted
+                    ? 'Trading halted'
+                    : health.status === 'fresh'
+                    ? 'Oracle healthy'
+                    : 'Oracle stale'
+                  return (
+                    <tr
+                      key={c.id}
+                      className={clsx(
+                        selected.includes(c.id) && 'bg-primary-50/50'
+                      )}
+                    >
+                      <td className="p-3">
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${
+                            getMnxInstrument(c.oracleFeedId)?.symbol
+                          }`}
+                          checked={selected.includes(c.id)}
+                          disabled={locked || c.isResolved}
+                          onChange={() => toggle(c.id)}
+                        />
+                      </td>
+                      <td className="py-4 pr-4">
+                        <Link
+                          href={`/${c.creatorUsername}/${c.slug}`}
+                          className="text-primary-700 font-semibold hover:underline"
+                        >
+                          {getMnxInstrument(c.oracleFeedId)?.symbol}
+                        </Link>
+                        <div className="text-ink-500 whitespace-nowrap text-xs">
+                          ${number(c.oraclePrice)}
+                          {getMnxInstrument(c.oracleFeedId)?.category ===
+                          'valuation'
+                            ? 'B'
+                            : ''}{' '}
+                          · {c.visibility}
+                        </div>
+                        <div
+                          title={c.solvencyHaltReason ?? health.reason}
+                          className={clsx(
+                            'mt-1 whitespace-nowrap text-xs',
+                            c.isResolved
+                              ? 'text-ink-500'
+                              : halted || health.status !== 'fresh'
+                              ? 'text-amber-700'
+                              : 'text-teal-600'
+                          )}
+                        >
+                          {status}
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap py-4 pr-4 tabular-nums">
+                        <div>{mana(c.poolLong)}</div>
+                        <div className="text-ink-500">{mana(c.poolShort)}</div>
+                      </td>
+                      <td className="whitespace-nowrap py-4 pr-4 tabular-nums">
+                        <div>
+                          {mana(
+                            market.openInterestLong + market.openInterestShort
+                          )}
+                        </div>
+                        <div className="text-ink-500 text-xs">
+                          {market.activeTraders} active traders
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap py-4 pr-4 tabular-nums">
+                        <div>{mana(market.volume24Hours)}</div>
+                        <div className="text-ink-500 text-xs">
+                          {mana(market.fees24Hours)} fees
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap py-4 pr-4 tabular-nums">
+                        <div>
+                          {config.takerFeeBps} / {getEffectiveApiFee(c)} bps
+                        </div>
+                        <div className="text-ink-500 text-xs">
+                          Impact {config.takerFeeImpact} · {c.maxLeverage}× cap
+                        </div>
+                      </td>
+                      <td className="p-3">
+                        <Button
+                          size="xs"
+                          color="gray-outline"
+                          disabled={locked || c.isResolved}
+                          onClick={() => {
+                            setSelected([c.id])
+                            setMode('rules')
+                            setRules({})
+                            editor.current?.scrollIntoView({
+                              behavior: 'smooth',
+                              block: 'start',
+                            })
+                          }}
+                        >
+                          Manage
+                        </Button>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="text-ink-500 border-ink-100 border-t px-6 py-10 text-center">
+            No MNX-owned markets yet. Markets created by the MNX launch script
+            will appear here.
+          </div>
+        )}
+        {missing.length > 0 && (
+          <details className="border-ink-100 border-t p-4 text-sm">
+            <summary className="text-ink-500 cursor-pointer">
+              {missing.length} feeds without a live MNX-owned market
+            </summary>
+            <p className="mt-2">{missing.map((i) => i.symbol).join(' · ')}</p>
+            <p className="text-ink-500 mt-2 text-xs">
+              Creation still uses the launch script and its funding checks.
+              Markets owned by other accounts are excluded from this dashboard.
+            </p>
+          </details>
+        )}
+      </section>
+
+      {error && (
+        <div
+          role="alert"
+          className="bg-scarlet-50 text-scarlet-700 rounded-lg p-4 text-sm"
+        >
+          {error}
+        </div>
+      )}
+
+      {batch ? (
+        <section className={`${panel} p-5`} aria-live="polite">
+          <h2 className="font-semibold">
+            {running ? 'Applying batch…' : 'Batch results'} ·{' '}
+            {batch.items.filter((i) => i.status === 'done').length}/
+            {batch.items.length} complete
+          </h2>
+          <p className="text-ink-500 mt-1 text-sm">
+            Completed markets are skipped on retry. Remaining liquidity requests
+            keep their original request IDs.
+          </p>
+          <ul className="my-4 space-y-2 text-sm">
+            {batch.items.map((item) => (
+              <li key={item.params.contractId}>
+                <b>{item.title}</b> ·{' '}
+                {item.status === 'done'
+                  ? 'Done'
+                  : item.status === 'error'
+                  ? 'Needs attention'
+                  : 'Pending'}
+                {item.error && (
+                  <p className="text-scarlet-600 break-words">{item.error}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+          {!running && batch.items.some((i) => i.status !== 'done') && (
+            <>
+              <Button onClick={() => execute(batch)}>Retry remaining</Button>
+              <label className="text-ink-500 my-4 flex items-start gap-2 text-sm">
+                <input
+                  className="mt-1"
+                  type="checkbox"
+                  checked={acknowledge}
+                  onChange={(e) => setAcknowledge(e.target.checked)}
+                />
+                I have checked any uncertain results and want to end this batch
+                without retrying. A new liquidity batch would make new payments.
+              </label>
+            </>
+          )}
+          <Button
+            color="gray-outline"
+            disabled={
+              running ||
+              (batch.items.some((i) => i.status !== 'done') && !acknowledge)
+            }
+            onClick={finish}
+          >
+            Finish batch
+          </Button>
+        </section>
+      ) : preview ? (
+        <section className={`${panel} p-5`}>
+          <h2 className="text-lg font-semibold">
+            Review{' '}
+            {preview.items.length === 1
+              ? 'market change'
+              : `${preview.items.length} market changes`}
+          </h2>
+          <p className="text-ink-500 mt-1 text-sm">
+            Applying as @{data.payer.username}. Markets are processed one at a
+            time; the batch stops if one fails.
+          </p>
+          {preview.items[0]?.kind === 'liquidity' && (
+            <div className="bg-primary-50 my-4 rounded-lg p-4">
+              <p className="text-primary-800 text-xl font-semibold">
+                {mana(
+                  preview.items.reduce(
+                    (total, item) =>
+                      total +
+                      (item.kind === 'liquidity'
+                        ? item.params.amount *
+                          (item.params.side === 'both' ? 2 : 1)
+                        : 0),
+                    0
+                  )
+                )}{' '}
+                from @{data.payer.username}
+              </p>
+              <p className="text-ink-600 mt-1 text-sm">
+                This adds backing, with no withdrawable LP shares. Remaining
+                backing goes to the market creator at settlement.
+              </p>
+            </div>
+          )}
+          <ul className="divide-ink-100 my-4 divide-y">
+            {preview.items.map((item) => {
+              const c = data.markets.find(
+                (m) => m.contract.id === item.params.contractId
+              )!.contract
+              return (
+                <li key={c.id} className="py-3 text-sm">
+                  <b>{item.title}</b>
+                  {item.kind === 'liquidity' ? (
+                    <p className="text-ink-600">
+                      {mana(item.params.amount)} to{' '}
+                      {item.params.side === 'both'
+                        ? 'each side'
+                        : `the ${item.params.side} side`}
+                    </p>
+                  ) : (
+                    <>
+                      <div className="text-ink-600 mt-1 flex flex-wrap gap-x-6 gap-y-1">
+                        {MNX_RULE_FIELDS.filter(({ key }) =>
+                          rules[key]?.trim()
+                        ).map(({ key, label, unit }) => (
+                          <span key={key}>
+                            {label}:{' '}
+                            {number(
+                              ruleValue({ ...c, ...getPerpConfig(c) }, key)
+                            )}{' '}
+                            →{' '}
+                            <b>
+                              {number(ruleValue({ ...c, ...item.params }, key))}
+                              {unit}
+                            </b>
+                          </span>
+                        ))}
+                      </div>
+                      <p className="text-ink-500 mt-1">
+                        Effective API base:{' '}
+                        {getEffectiveApiFee({ ...c, ...item.params })} bps
+                      </p>
+                    </>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+          <div className="flex gap-3">
+            <Button onClick={() => execute(preview)} disabled={running}>
+              Apply {preview.items.length === 1 ? 'change' : 'batch'}
+            </Button>
+            <Button color="gray-outline" onClick={() => setPreview(undefined)}>
+              Back to editing
+            </Button>
+          </div>
+        </section>
+      ) : (
+        <section ref={editor} className={`${panel} scroll-mt-4 p-5`}>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold">
+                Manage{' '}
+                {targets.length === 1
+                  ? getMnxInstrument(one?.oracleFeedId)?.symbol
+                  : `${targets.length} selected markets`}
+              </h2>
+              <p className="text-ink-500 mt-1 text-sm">
+                Select one market for individual changes, or several for a bulk
+                update.
+              </p>
+            </div>
+            <div className="bg-canvas-50 flex gap-1 rounded-lg p-1">
+              {(['liquidity', 'rules'] as const).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setMode(tab)}
+                  className={clsx(
+                    'rounded-md px-3 py-2 text-sm',
+                    mode === tab
+                      ? 'bg-canvas-0 text-primary-700 shadow-sm'
+                      : 'text-ink-500'
+                  )}
+                >
+                  {tab === 'liquidity' ? 'Add liquidity' : 'Trading rules'}
+                </button>
+              ))}
+            </div>
+          </div>
+          {mode === 'liquidity' ? (
+            <div className="mt-5 grid gap-5 md:grid-cols-2">
+              <div className="flex flex-col gap-4">
+                <label className="text-sm font-medium">
+                  Pool side
+                  <select
+                    value={side}
+                    onChange={(e) => setSide(e.target.value as typeof side)}
+                    className="border-ink-300 bg-canvas-0 mt-2 w-full rounded-md border p-2.5"
+                  >
+                    <option value="both">Both sides equally</option>
+                    <option value="long">Long only</option>
+                    <option value="short">Short only</option>
+                  </select>
+                </label>
+                <label
+                  htmlFor="mnx-liquidity-amount"
+                  className="text-sm font-medium"
+                >
+                  Mana per market, per selected side
+                  <Input
+                    className="mt-2 w-full"
+                    type="number"
+                    min={0}
+                    max={1_000_000}
+                    id="mnx-liquidity-amount"
+                    step="any"
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value)}
+                    placeholder="e.g. 1,000"
+                  />
+                </label>
+              </div>
+              <div className="bg-canvas-50 rounded-lg p-4">
+                <p className="text-ink-500 text-xs uppercase tracking-wide">
+                  Total contribution
+                </p>
+                <p className="mt-2 text-2xl font-semibold">
+                  {Number.isFinite(totalCost) && totalCost >= 0
+                    ? mana(totalCost)
+                    : '—'}
+                </p>
+                <p className="text-ink-600 mt-2 text-sm">
+                  {targets.length} markets ×{' '}
+                  {side === 'both' ? '2 sides' : '1 side'} ×{' '}
+                  {Number.isFinite(Number(amount)) ? mana(Number(amount)) : '—'}
+                </p>
+                <p className="text-ink-500 mt-3 text-sm">
+                  Paid by <b>@{data.payer.username}</b> ·{' '}
+                  {mana(data.payer.balance)} available
+                </p>
+                <p className="text-ink-500 mt-2 text-xs">
+                  Backing is committed to the markets. This does not buy LP
+                  shares or a right to withdraw.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-5">
+              <div className="bg-canvas-50 mb-5 flex flex-wrap items-center justify-between gap-3 rounded-lg p-3">
+                <p className="text-ink-600 text-sm">
+                  MNX starting fees: 10 bps web · 20 bps API · impact 10
+                </p>
+                <Button
+                  size="xs"
+                  color="gray-outline"
+                  onClick={() =>
+                    setRules((r) => ({
+                      ...r,
+                      ...Object.fromEntries(
+                        Object.entries(MNX_DEFAULT_FEES).map(([k, v]) => [
+                          k,
+                          String(v),
+                        ])
+                      ),
+                    }))
+                  }
+                >
+                  Use MNX fee preset
+                </Button>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {MNX_RULE_FIELDS.map(({ key, label, unit, ...bounds }) => (
+                  <label
+                    key={key}
+                    htmlFor={`mnx-rule-${key}`}
+                    className="text-sm font-medium"
+                  >
+                    {label}
+                    {unit ? ` (${unit})` : ''}
+                    <Input
+                      className="mt-2 w-full"
+                      type="number"
+                      {...bounds}
+                      id={`mnx-rule-${key}`}
+                      step="any"
+                      value={rules[key] ?? ''}
+                      onChange={(e) =>
+                        setRules({ ...rules, [key]: e.target.value })
+                      }
+                      placeholder={
+                        one
+                          ? `Current: ${number(
+                              ruleValue({ ...one, ...getPerpConfig(one) }, key)
+                            )}`
+                          : 'Leave unchanged'
+                      }
+                    />
+                  </label>
+                ))}
+              </div>
+              <div className="text-ink-500 mt-4 space-y-2 text-xs">
+                <p>
+                  Blank fields stay unchanged. API base is the higher of the web
+                  and API rates. 20 bps = 0.20% of opening notional, plus the
+                  size-impact fee. Closing is free.
+                </p>
+                <p>
+                  The annualized funding cap is converted using each market’s
+                  funding period; it is a maximum, not a promised yield. Lower
+                  leverage caps apply to new opens and adds. Increasing MNX
+                  leverage requires current provider support.
+                </p>
+                <p>
+                  Maximum mark age also gates closes. The strictest minimum
+                  among selected feeds is{' '}
+                  {number(
+                    Math.max(0, ...targets.map((m) => m.minOraclePriceAgeMs)) /
+                      1000
+                  )}{' '}
+                  seconds.
+                </p>
+              </div>
+            </div>
+          )}
+          <div className="border-ink-100 mt-5 border-t pt-4">
+            <Button
+              onClick={review}
+              disabled={!ready || !targets.length || refreshing}
+            >
+              Review {mode === 'liquidity' ? 'contribution' : 'rule changes'}
+            </Button>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  note,
+}: {
+  label: string
+  value: string
+  note: string
+}) {
+  return (
+    <div className={`${panel} p-4`}>
+      <p className="text-ink-500 text-xs">{label}</p>
+      <p className="mt-2 break-words text-xl font-semibold tabular-nums">
+        {value}
+      </p>
+      <p className="text-ink-500 mt-2 text-xs">{note}</p>
+    </div>
+  )
+}

--- a/web/components/perps/mnx-dashboard.tsx
+++ b/web/components/perps/mnx-dashboard.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
+import { contractPath } from 'common/contract'
 import { ENV } from 'common/envs/constants'
 import {
   getPerpConfig,
@@ -20,16 +21,22 @@ import { Input } from 'web/components/widgets/input'
 import { api } from 'web/lib/api/api'
 import {
   buildMnxRulePatch,
+  isMnxBatchInProgress,
+  MNX_REQUEST_TIMEOUT_MS,
   MNX_RULE_FIELDS,
   MnxBatch,
   MnxBatchItem,
   MnxRuleForm,
+  mnxBatchKeyPrefix,
+  readMnxBatches,
+  removeMnxBatch,
   ruleValue,
   runMnxBatch,
+  saveMnxBatch,
 } from 'common/perps/mnx-management'
 
-const number = (value: number) =>
-  new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value)
+const formatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 })
+const number = (value: number) => formatter.format(value)
 const mana = (value: number) => `M$${number(value)}`
 const panel = 'border-ink-200 bg-canvas-0 rounded-xl border'
 const errorMessage = (error: unknown) =>
@@ -50,39 +57,48 @@ export function MnxDashboardView({
   const [amount, setAmount] = useState('')
   const [rules, setRules] = useState<MnxRuleForm>({})
   const [preview, setPreview] = useState<MnxBatch>()
-  const [batch, setBatch] = useState<MnxBatch>()
-  const [running, setRunning] = useState(false)
+  // Every unfinished batch this account saved, in this or another tab.
+  const [batches, setBatches] = useState<MnxBatch[]>([])
+  const [runningId, setRunningId] = useState<string>()
   const [ready, setReady] = useState(false)
   const [error, setError] = useState<string>()
-  const [acknowledge, setAcknowledge] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
   const active = useRef(true)
   const busy = useRef(false)
   const editor = useRef<HTMLDivElement>(null)
-  const storageKey = `mnx-management-v1:${ENV}:${data.payer.id}`
+  const prefix = mnxBatchKeyPrefix(ENV, data.payer.id)
   useEffect(() => {
     active.current = true
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const previous = JSON.parse(stored) as MnxBatch
-        if (
-          previous.version !== 1 ||
-          previous.actorId !== data.payer.id ||
-          !Array.isArray(previous.items)
-        )
-          throw new Error(
-            'The saved MNX batch could not be read. Keep it for recovery before starting another batch.'
-          )
-        setBatch(previous)
+    const load = () => {
+      try {
+        setBatches(readMnxBatches(localStorage, ENV, data.payer.id))
+        setNow(Date.now())
+        setReady(true)
+      } catch (error) {
+        setReady(false)
+        setError(errorMessage(error))
       }
-      setReady(true)
-    } catch (error) {
-      setError(errorMessage(error))
     }
+    load()
+    // Another tab saved, retried, or finished one of this account's batches.
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === null || event.key.startsWith(prefix)) load()
+    }
+    window.addEventListener('storage', onStorage)
     return () => {
       active.current = false
+      window.removeEventListener('storage', onStorage)
     }
-  }, [storageKey, data.payer.id])
+  }, [prefix, data.payer.id])
+  // A batch another tab is applying unlocks here once its marker goes stale.
+  const watching = batches.some(
+    (b) => b.id !== runningId && isMnxBatchInProgress(b, now)
+  )
+  useEffect(() => {
+    if (!watching) return
+    const timer = setInterval(() => setNow(Date.now()), 5_000)
+    return () => clearInterval(timer)
+  }, [watching])
 
   const live = data.markets.filter(({ contract }) => !contract.isResolved)
   const targets = live.filter(({ contract }) => selected.includes(contract.id))
@@ -92,49 +108,61 @@ export function MnxDashboardView({
   const sum = (fn: (m: MnxDashboardMarket) => number) =>
     live.reduce((total, m) => total + fn(m), 0)
   const totalCost = Number(amount) * (side === 'both' ? 2 : 1) * targets.length
-  const locked = !!batch || !!preview || running
+  const locked = batches.length > 0 || !!preview || !!runningId
   const one = targets.length === 1 ? targets[0].contract : undefined
 
   const saveBatch = (next: MnxBatch) => {
     // If storage fails, runMnxBatch stops before sending another paid request.
-    localStorage.setItem(storageKey, JSON.stringify(next))
+    saveMnxBatch(localStorage, ENV, next)
     if (active.current)
-      setBatch({ ...next, items: next.items.map((i) => ({ ...i })) })
+      setBatches((prev) =>
+        prev.some((b) => b.id === next.id)
+          ? prev.map((b) => (b.id === next.id ? next : b))
+          : [...prev, next]
+      )
+  }
+  const send = async (item: MnxBatchItem) => {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), MNX_REQUEST_TIMEOUT_MS)
+    try {
+      return item.kind === 'liquidity'
+        ? await api('add-perp-subsidy', item.params, {
+            signal: controller.signal,
+          })
+        : await api('update-perp-config', item.params, {
+            signal: controller.signal,
+          })
+    } catch (error) {
+      if (controller.signal.aborted)
+        throw new Error(
+          `No response after ${
+            MNX_REQUEST_TIMEOUT_MS / 1000
+          } seconds. The request may still have gone through; Retry remaining is safe and reuses the same request ID.`
+        )
+      throw error
+    } finally {
+      clearTimeout(timeout)
+    }
   }
   const execute = async (next: MnxBatch) => {
     if (busy.current || next.actorId !== data.payer.id) return
+    if (isMnxBatchInProgress(next, Date.now())) {
+      setError('Another tab is applying this batch. Wait for it to finish.')
+      return
+    }
     busy.current = true
-    setRunning(true)
+    setRunningId(next.id)
     setError(undefined)
     try {
       saveBatch(next)
       setPreview(undefined)
-      await runMnxBatch(
-        next,
-        saveBatch,
-        async (item) => {
-          const controller = new AbortController()
-          const timeout = setTimeout(() => controller.abort(), 30_000)
-          try {
-            return item.kind === 'liquidity'
-              ? await api('add-perp-subsidy', item.params, {
-                  signal: controller.signal,
-                })
-              : await api('update-perp-config', item.params, {
-                  signal: controller.signal,
-                })
-          } finally {
-            clearTimeout(timeout)
-          }
-        },
-        () => active.current
-      )
+      await runMnxBatch(next, saveBatch, send, () => active.current)
     } catch (error) {
       if (active.current) setError(errorMessage(error))
     } finally {
       busy.current = false
       if (active.current) {
-        setRunning(false)
+        setRunningId(undefined)
         await refresh()
       }
     }
@@ -199,7 +227,8 @@ export function MnxDashboardView({
         }
       )
       setPreview({
-        version: 1,
+        version: 2,
+        id: randomString(),
         actorId: data.payer.id,
         createdAt: Date.now(),
         items,
@@ -208,11 +237,12 @@ export function MnxDashboardView({
       setError(errorMessage(error))
     }
   }
-  const finish = () => {
+  const finish = (batch: MnxBatch) => {
     try {
-      localStorage.removeItem(storageKey)
-      setBatch(undefined)
-      setAcknowledge(false)
+      // Only this batch's own entry: a batch another tab is applying, or has
+      // not reconciled yet, keeps its request IDs.
+      removeMnxBatch(localStorage, ENV, batch)
+      setBatches((prev) => prev.filter((b) => b.id !== batch.id))
       setSelected([])
       setError(undefined)
     } catch (error) {
@@ -242,7 +272,7 @@ export function MnxDashboardView({
           <Button
             color="gray-outline"
             onClick={refresh}
-            disabled={refreshing || running}
+            disabled={refreshing || !!runningId}
           >
             {refreshing ? 'Refreshing…' : 'Refresh stats'}
           </Button>
@@ -352,7 +382,7 @@ export function MnxDashboardView({
                       </td>
                       <td className="py-4 pr-4">
                         <Link
-                          href={`/${c.creatorUsername}/${c.slug}`}
+                          href={contractPath(c)}
                           className="text-primary-700 font-semibold hover:underline"
                         >
                           {getMnxInstrument(c.oracleFeedId)?.symbol}
@@ -460,58 +490,19 @@ export function MnxDashboardView({
         </div>
       )}
 
-      {batch ? (
-        <section className={`${panel} p-5`} aria-live="polite">
-          <h2 className="font-semibold">
-            {running ? 'Applying batch…' : 'Batch results'} ·{' '}
-            {batch.items.filter((i) => i.status === 'done').length}/
-            {batch.items.length} complete
-          </h2>
-          <p className="text-ink-500 mt-1 text-sm">
-            Completed markets are skipped on retry. Remaining liquidity requests
-            keep their original request IDs.
-          </p>
-          <ul className="my-4 space-y-2 text-sm">
-            {batch.items.map((item) => (
-              <li key={item.params.contractId}>
-                <b>{item.title}</b> ·{' '}
-                {item.status === 'done'
-                  ? 'Done'
-                  : item.status === 'error'
-                  ? 'Needs attention'
-                  : 'Pending'}
-                {item.error && (
-                  <p className="text-scarlet-600 break-words">{item.error}</p>
-                )}
-              </li>
-            ))}
-          </ul>
-          {!running && batch.items.some((i) => i.status !== 'done') && (
-            <>
-              <Button onClick={() => execute(batch)}>Retry remaining</Button>
-              <label className="text-ink-500 my-4 flex items-start gap-2 text-sm">
-                <input
-                  className="mt-1"
-                  type="checkbox"
-                  checked={acknowledge}
-                  onChange={(e) => setAcknowledge(e.target.checked)}
-                />
-                I have checked any uncertain results and want to end this batch
-                without retrying. A new liquidity batch would make new payments.
-              </label>
-            </>
-          )}
-          <Button
-            color="gray-outline"
-            disabled={
-              running ||
-              (batch.items.some((i) => i.status !== 'done') && !acknowledge)
+      {batches.length > 0 ? (
+        batches.map((batch) => (
+          <BatchResults
+            key={batch.id}
+            batch={batch}
+            running={runningId === batch.id}
+            elsewhere={
+              runningId !== batch.id && isMnxBatchInProgress(batch, now)
             }
-            onClick={finish}
-          >
-            Finish batch
-          </Button>
-        </section>
+            onRetry={() => execute(batch)}
+            onFinish={() => finish(batch)}
+          />
+        ))
       ) : preview ? (
         <section className={`${panel} p-5`}>
           <h2 className="text-lg font-semibold">
@@ -591,7 +582,7 @@ export function MnxDashboardView({
             })}
           </ul>
           <div className="flex gap-3">
-            <Button onClick={() => execute(preview)} disabled={running}>
+            <Button onClick={() => execute(preview)} disabled={!!runningId}>
               Apply {preview.items.length === 1 ? 'change' : 'batch'}
             </Button>
             <Button color="gray-outline" onClick={() => setPreview(undefined)}>
@@ -797,5 +788,83 @@ function Stat({
       </p>
       <p className="text-ink-500 mt-2 text-xs">{note}</p>
     </div>
+  )
+}
+
+function BatchResults({
+  batch,
+  running,
+  elsewhere,
+  onRetry,
+  onFinish,
+}: {
+  batch: MnxBatch
+  running: boolean
+  // Another tab is applying this batch right now.
+  elsewhere: boolean
+  onRetry: () => void
+  onFinish: () => void
+}) {
+  const [acknowledge, setAcknowledge] = useState(false)
+  const unfinished = batch.items.some((i) => i.status !== 'done')
+  return (
+    <section className={`${panel} p-5`} aria-live="polite">
+      <h2 className="font-semibold">
+        {running
+          ? 'Applying batch…'
+          : elsewhere
+          ? 'Applying in another tab…'
+          : 'Batch results'}{' '}
+        · {batch.items.filter((i) => i.status === 'done').length}/
+        {batch.items.length} complete
+      </h2>
+      <p className="text-ink-500 mt-1 text-sm">
+        Completed markets are skipped on retry. Remaining liquidity requests
+        keep their original request IDs.
+      </p>
+      {elsewhere && (
+        <p className="text-ink-500 mt-1 text-sm">
+          Another tab or window is applying this batch. If that tab was closed
+          mid-run, this unlocks within a minute.
+        </p>
+      )}
+      <ul className="my-4 space-y-2 text-sm">
+        {batch.items.map((item) => (
+          <li key={item.params.contractId}>
+            <b>{item.title}</b> ·{' '}
+            {item.status === 'done'
+              ? 'Done'
+              : item.status === 'error'
+              ? 'Needs attention'
+              : 'Pending'}
+            {item.error && (
+              <p className="text-scarlet-600 break-words">{item.error}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+      {!running && !elsewhere && unfinished && (
+        <>
+          <Button onClick={onRetry}>Retry remaining</Button>
+          <label className="text-ink-500 my-4 flex items-start gap-2 text-sm">
+            <input
+              className="mt-1"
+              type="checkbox"
+              checked={acknowledge}
+              onChange={(e) => setAcknowledge(e.target.checked)}
+            />
+            I have checked any uncertain results and want to end this batch
+            without retrying. A new liquidity batch would make new payments.
+          </label>
+        </>
+      )}
+      <Button
+        color="gray-outline"
+        disabled={running || elsewhere || (unfinished && !acknowledge)}
+        onClick={onFinish}
+      >
+        Finish batch
+      </Button>
+    </section>
   )
 }

--- a/web/pages/admin/index.tsx
+++ b/web/pages/admin/index.tsx
@@ -92,6 +92,7 @@ export default function AdminPage() {
         />
         <LabCard title="⚽ sports markets" href="/admin/sports" />
         <LabCard title="📈 create perp market" href="/admin/create-perp" />
+        <LabCard title="MNX partner dashboard" href="/admin/mnx" />
         <LabCard
           title="🧭 OpenRouter classifications"
           href="/admin/model-classifications"

--- a/web/pages/admin/mnx.tsx
+++ b/web/pages/admin/mnx.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Page } from 'web/components/layout/page'
+import { NoSEO } from 'web/components/NoSEO'
+import { useUser } from 'web/hooks/use-user'
+import { useRedirectIfSignedOut } from 'web/hooks/use-redirect-if-signed-out'
+import { api } from 'web/lib/api/api'
+import type { MnxDashboard } from 'common/perps/management'
+import { MnxDashboardView } from 'web/components/perps/mnx-dashboard'
+
+export default function MnxPage() {
+  useRedirectIfSignedOut()
+  const user = useUser()
+  return (
+    <Page trackPageView="MNX dashboard">
+      <NoSEO />
+      {user ? (
+        <MnxPageContent key={user.id} userId={user.id} />
+      ) : (
+        <p className="p-8">Sign in to manage MNX markets.</p>
+      )}
+    </Page>
+  )
+}
+
+function MnxPageContent({ userId }: { userId: string }) {
+  const [data, setData] = useState<MnxDashboard>()
+  const [error, setError] = useState<string>()
+  const [refreshing, setRefreshing] = useState(false)
+  const active = useRef(true)
+  const refresh = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      const next = await api('get-mnx-dashboard', {}, { cache: 'no-store' })
+      if (active.current && next.payer.id === userId) {
+        setData(next)
+        setError(undefined)
+      }
+    } catch (error) {
+      if (active.current)
+        setError(error instanceof Error ? error.message : String(error))
+    } finally {
+      if (active.current) setRefreshing(false)
+    }
+  }, [userId])
+  useEffect(() => {
+    active.current = true
+    void refresh()
+    return () => {
+      active.current = false
+    }
+  }, [refresh])
+  return (
+    <>
+      {error && (
+        <p
+          role="alert"
+          className="bg-scarlet-50 text-scarlet-700 m-4 rounded-lg p-4"
+        >
+          {error}{' '}
+          <button className="underline" onClick={refresh}>
+            Retry
+          </button>
+        </p>
+      )}
+      {data ? (
+        <MnxDashboardView
+          data={data}
+          refresh={refresh}
+          refreshing={refreshing}
+        />
+      ) : (
+        !error && <p className="p-8">Loading MNX markets…</p>
+      )}
+    </>
+  )
+}

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -11,6 +11,7 @@ import { PerpPosition } from 'common/perps/position'
 import { getDisplayProbability } from 'common/calculate'
 import { Contract, PerpContract, contractPath } from 'common/contract'
 import {
+  ENV,
   PERPS_SKIP_ORACLE_FRESHNESS,
   isAdminId,
   isModId,
@@ -25,6 +26,7 @@ import {
 } from 'common/perps/format'
 import { useIsClient } from 'web/hooks/use-is-client'
 import { getPerpTakerFeeBps } from 'common/perps/fees'
+import { getMnxCreatorId } from 'common/perps/creator-accounts'
 import { getPerpTicker } from 'common/perps/ticker'
 import {
   fundingPeriodNoun,
@@ -708,6 +710,14 @@ export default function PerpsPage(props: { perps: Contract[] }) {
               </a>
             </div>
           </Col>
+          {user && (isAdminId(user.id) || user.id === getMnxCreatorId(ENV)) && (
+            <Link
+              href="/admin/mnx"
+              className="text-primary-600 text-sm hover:underline"
+            >
+              Manage MNX markets
+            </Link>
+          )}
           <div className="sm:divide-ink-200 sm:dark:divide-ink-300 grid w-full grid-cols-2 gap-x-6 gap-y-3 sm:flex sm:w-auto sm:divide-x">
             <Stat label="24h volume" amount={stats.volume24h} />
             <Stat label="Open interest" amount={stats.openInterest} />


### PR DESCRIPTION
MNX currently needs scripts and admin-only API calls to manage its perpetual markets. Add /admin/mnx for the pinned MNX account and admins, with portfolio statistics, per-market editing, and bulk liquidity/rule updates.

- Set new MNX-feed markets to 10 bps web, 20 bps API, and impact 10. The launch script sends and verifies those fees and checks backend capability before creating anything. Existing markets change only when an operator applies a patch.
- Show backing, open interest, active traders, 24-hour margin volume/fees, oracle health, and missing feeds. Add links from /perps and the admin index.
- Let MNX edit only its own markets on registered MNX feeds. Both MNX and admins can change leverage, funding, fees, and freshness limits; leverage increases must fit current MNX provider support. Rule edits lock the contract, check the previewed config, and commit audit records atomically.
- Fund one or both sides from the signed-in account. Both sides of one market are funded atomically. Bulk operations stop on the first failure, save progress locally, and reuse payment request IDs across retries/reloads. Completed markets are skipped. The preview identifies the payer and total cost.

No migration is needed. Deploy the API and web changes before using the dashboard or updated creation script. Merge/deployment performs no market writes. Usage and retry behavior are documented in docs/mnx-dashboard.md.

Validation: 211 tests passed (120 common fee/funding/MNX tests and 91 shared perp tests), including 27 new management tests. Common/shared/API TypeScript builds and web typecheck passed; eslint and canonical LF prettier checks passed for all changed code. The money-management tests were rerun after the final replay-log adjustment. A fixture-only Next preview compiled and returned HTTP 200 with all 16 market rows and the expected management controls. Browser control was unavailable, so desktop/mobile visual verification remains outstanding. No live-market mutations or payments were performed.
