### PR TITLE
fix(perps): stop treating a lagging MNX node as a feed outage

### DIFF
--- a/backend/shared/src/mnx.test.ts
+++ b/backend/shared/src/mnx.test.ts
@@ -133,12 +133,17 @@ it('pins identity and chronology across missing/disabled intervals', () => {
     first
   )
   expect(conflicting.feeds[spec.feedId].health.reason).toMatch(/immutable/)
+  // A lagging load-balanced node is not an incident: keep the prior
+  // observation and stay available rather than withdrawing the feed.
   const older = parseMnxSnapshot(
     [market({ mark_price_timestamp: new Date(now - 1).toISOString() })],
     now,
     first
   )
-  expect(older.feeds[spec.feedId].health.reason).toMatch(/regressed/)
+  expect(older.feeds[spec.feedId].health.status).toBe('available')
+  expect(older.feeds[spec.feedId].health.reason).toBeUndefined()
+  expect(older.feeds[spec.feedId].point).toEqual(first.feeds[spec.feedId].point)
+  expect(older.feeds[spec.feedId].marketId).toBe(11)
   const recovered = parseMnxSnapshot([market()], now + MINUTE_MS, missing)
   expect(recovered.feeds[spec.feedId].health.checkedAt).toBe(now + MINUTE_MS)
   expect(recovered.feeds[spec.feedId].point?.ts).toBe(now + MINUTE_MS)

--- a/backend/shared/src/mnx.ts
+++ b/backend/shared/src/mnx.ts
@@ -133,8 +133,33 @@ export const parseMnxSnapshot = (
       // authoritative. Revalidate this tolerance if MNX changes its encoding.
       if (Math.abs(price - market.mark_price) > Math.max(1e-8, price * 1e-12))
         throw new Error('MNX numeric and exact mark prices disagree')
-      if (prior?.point && ts < prior.point.sourceTs!)
-        throw new Error('MNX source timestamp regressed')
+      // A stamp older than one we have already seen is NOT a provider fault.
+      // MNX serves /v0/markets from load-balanced nodes that lag each other by
+      // up to a minute, so consecutive polls routinely retrieve an older
+      // observation than the last one (reproduced 2026-09-11: GOOGL read
+      // 21:59:12 then 21:58:11 four seconds later). Treating that as an
+      // incident marked every instrument unavailable and paged hourly.
+      //
+      // Carry the prior observation forward instead, exactly as the
+      // fetchLatest feeds do in update-oracle-feeds' shouldWrite (`point.ts <=
+      // prev.ts` → skip, silently). A served response is the liveness signal;
+      // staleness is decided by the maxAgeMs gate above and by the failure
+      // budget in publish-oracle-observation, not by whether the number moved.
+      if (prior?.point && ts < prior.point.sourceTs!) {
+        feeds[spec.feedId] = {
+          ...prior,
+          ...identity,
+          health: {
+            checkedAt: fetchedAt,
+            status: 'available',
+            expiresAt: Math.min(
+              fetchedAt + ORACLE_HEALTH_MAX_AGE_MS,
+              prior.point.sourceTs! + spec.maxAgeMs
+            ),
+          },
+        }
+        continue
+      }
       if (
         prior?.point &&
         ts === prior.point.sourceTs &&

--- a/backend/shared/src/perps/publish-oracle-observation.test.ts
+++ b/backend/shared/src/perps/publish-oracle-observation.test.ts
@@ -106,7 +106,6 @@ it('refreshes health at a flat price and writes the normal heartbeat when due', 
 })
 
 it.each([
-  ['regression', { ...point, sourceTs: point.sourceTs + 1 }],
   ['same-source conflict', { ...point, price: 2105 }],
   ['same-observation conflict', { ...point, price: 2105, ts: now + 1 }],
 ])('never publishes a %s over immutable history', async (_name, previous) => {
@@ -119,6 +118,27 @@ it.each([
   await publishOracleObservation(pg, feed, { point: incoming, health })
   expect(insertOraclePrices).not.toHaveBeenCalled()
   expect(applyOraclePointToLivePerps).not.toHaveBeenCalled()
+})
+
+// A provider served from load-balanced nodes hands back observations that lag
+// each other, so a poll can retrieve a stamp older than one already published.
+// That is "nothing new", not an incident: keep the published point, keep the
+// feed available, and do not spend the failure budget that pages at five
+// minutes. Only an identical stamp carrying a DIFFERENT price is corruption.
+it('carries the published point forward when a lagging node serves an older stamp', async () => {
+  const published = { ...point, sourceTs: point.sourceTs + 60_000 }
+  const { pg } = database({ ...published, ts: now - 1000 })
+  await publishOracleObservation(pg, feed, { point, health })
+  expect(insertOraclePrices).not.toHaveBeenCalled()
+  expect(applyOraclePointToLivePerps).toHaveBeenCalledWith(
+    pg,
+    feed.id,
+    expect.objectContaining({ sourceTs: published.sourceTs }),
+    undefined,
+    health
+  )
+  expect(log.error).not.toHaveBeenCalled()
+  expect(log.warn).not.toHaveBeenCalled()
 })
 
 it('refuses a malformed point through the shared registry bounds', async () => {

--- a/backend/shared/src/perps/publish-oracle-observation.ts
+++ b/backend/shared/src/perps/publish-oracle-observation.ts
@@ -201,15 +201,30 @@ export const publishOracleObservation = async (
       }
       const rejection = validateOraclePoint(feed, previous, point)
       if (rejection) throw new InvalidOracleObservation(rejection)
+      // An older provider stamp is "nothing new", not an incident. Providers
+      // served from load-balanced nodes hand out observations that lag each
+      // other, so a poll can retrieve a stamp older than one already
+      // published (MNX, reproduced 2026-09-11: GOOGL read 21:59:12 then
+      // 21:58:11 four seconds later). Keep the published point, exactly as
+      // the `point.ts < previous.ts` branch above already does, rather than
+      // withdrawing availability and paging on a healthy feed.
+      //
+      // A CONFLICT at an identical stamp is still corruption and still fails
+      // closed: same immutable observation, two different prices.
       if (
         previous?.sourceTs != null &&
         point.sourceTs != null &&
-        (point.sourceTs < previous.sourceTs ||
-          (point.sourceTs === previous.sourceTs &&
-            point.price !== previous.price))
+        point.sourceTs < previous.sourceTs
+      )
+        return previous
+      if (
+        previous?.sourceTs != null &&
+        point.sourceTs != null &&
+        point.sourceTs === previous.sourceTs &&
+        point.price !== previous.price
       )
         throw new InvalidOracleObservation(
-          'Provider source timestamp regressed or conflicts with published history'
+          'Provider source timestamp conflicts with published history'
         )
       // Price changes and flat-price heartbeats follow the normal fast-tick rule.
       if (


### PR DESCRIPTION
## What

Two checks treated an older provider `sourceTs` as corruption:

- `parseMnxSnapshot` threw `'MNX source timestamp regressed'`
- `publishOracleObservation` threw `InvalidOracleObservation` on the same condition

Either one withdraws availability for the instrument and spends the failure budget that pages after five minutes. Both now carry the prior observation forward instead.

## Why

MNX serves `/v0/markets` from load-balanced nodes that lag each other by up to a minute, so consecutive polls routinely retrieve an observation older than one already seen.

Reproduced directly against the provider on 2026-09-11 — GOOGL read `21:59:12`, then `21:58:11` four seconds later.

In prod this marked all 16 MNX instruments unavailable and paged hourly per feed. The persisted rows showed every *accepted* write advancing normally: the throw only ever fired on observations that were then discarded. It also dropped real points — the equity feeds averaged 63–83s between writes against a 60s source cadence, with 9–31 gaps over 100s each.

## The rule this restores

A served response is the liveness signal. Staleness is "no update for a period", decided by the per-instrument `maxAgeMs` gate and the fetch-failure budget — not by whether the number moved.

This is already what every other feed does. `update-oracle-feeds`' `shouldWrite` skips an older point silently (`point.ts <= prev.ts` → `return false`) and writes a heartbeat at `staleAfterMs / 2` so a flat price can't trip the freshness gate. The MNX observation path had inverted that, requiring an *advancing provider stamp* as proof of life — which a quiet market cannot supply. H100 tracks an hourly index and legitimately holds one value for 75 minutes when nobody trades it.

## Still fails closed

- An identical `sourceTs` carrying a **different** price throws at both sites — that's genuine corruption.
- The `maxAgeMs` staleness gate is untouched (`mnx.ts:124`), and the H100 test still pins hour-old → available, day-old → unavailable.
- `expiresAt` is anchored to the *prior* observation's `sourceTs`, not to `fetchedAt`, so repeated lagging reads cannot keep a genuinely dead feed alive.

## Testing

- `backend/shared` suite: 187 passed / 20 suites
- `tsc -p backend/shared` clean
- Rewrote the `mnx.test.ts` case that pinned `/regressed/` (it asserted the behaviour this PR corrects); dropped the `'regression'` row from the `it.each` in `publish-oracle-observation.test.ts`; added a positive test that a lagging node keeps the feed available, applies the retained point, and logs nothing. Both conflict cases kept as-is.

## Notes

No user impact today — there are currently zero perp contracts on any `mnx-*` feed, so `applyOracleFeedUnavailability` was iterating an empty set. This is a pager and data-quality fix.

Zero file overlap with #4062; that branch already contains current `main`, so it picks this up on a routine rebase.