### PR TITLE
Allow MNX title edits and update market copy templates

### DIFF
--- a/backend/api/src/update-market.ts
+++ b/backend/api/src/update-market.ts
@@ -1,7 +1,8 @@
 import { JSONContent } from '@tiptap/core'
 import { APIError, APIHandler } from 'api/helpers/endpoint'
 import { Contract } from 'common/contract'
-import { isAdminId, isModId } from 'common/envs/constants'
+import { ENV, isAdminId, isModId } from 'common/envs/constants'
+import { isMnxOwnedPerp } from 'common/perps/creator-accounts'
 import { getPerpFeedTicker } from 'common/perps/ticker'
 import { DAY_MS } from 'common/util/time'
 import { buildArray } from 'common/util/array'
@@ -61,6 +62,9 @@ export const updateMarket: APIHandler<'market/:contractId/update'> =
         : undefined
     if (
       launchDefinition &&
+      // MNX owns its display copy. The creator/mod permission check above
+      // still applies; oracle feed and ticker cannot be changed by the partner.
+      !isMnxOwnedPerp(contract, ENV) &&
       question !== undefined &&
       question !== launchDefinition.question
     )

--- a/backend/scripts/create-mnx-perps.ts
+++ b/backend/scripts/create-mnx-perps.ts
@@ -80,7 +80,7 @@ if (require.main === module)
       )!.recommended
       return {
         question: spec.question,
-        description: `${spec.description}\n\nSource: ${spec.url}\nIf MNX ends this instrument, trading pauses pending administrative settlement; it will not automatically roll into a replacement.`,
+        description: spec.description,
         oracleFeedId: spec.feedId,
         ticker: getPerpFeedTicker(spec.feedId),
         creatorAccount,

--- a/backend/scripts/perp-launch-preflight.ts
+++ b/backend/scripts/perp-launch-preflight.ts
@@ -10,7 +10,10 @@ import {
   getPerpOpenInterestCapacity,
   assertPerpStateSolvent,
 } from 'common/perps/amm'
-import { isPerpCreatorAccountAllowed } from 'common/perps/creator-accounts'
+import {
+  isMnxOwnedPerp,
+  isPerpCreatorAccountAllowed,
+} from 'common/perps/creator-accounts'
 import { isPerpEscrowBalanced } from 'common/perps/escrow'
 import { shouldApplyFunding } from 'common/perps/funding'
 import { getOracleFreshness, getPerpOracleFreshness } from 'common/perps/oracle'
@@ -660,10 +663,15 @@ export const auditPerpLaunch = async (pg: SupabaseDirectClient) => {
 
       if (definition) {
         const expectedCreatorId = getPerpLaunchCreatorId(environment)
+        const editableTitle = isMnxOwnedPerp(contract, environment)
         report(
-          contract.question === definition.question ? 'PASS' : 'FAIL',
+          editableTitle || contract.question === definition.question
+            ? 'PASS'
+            : 'FAIL',
           `market ${contract.slug} launch title`,
-          contract.question === definition.question
+          editableTitle
+            ? `MNX-owned display title: "${contract.question}"`
+            : contract.question === definition.question
             ? definition.question
             : `stored="${contract.question}", expected="${definition.question}"; the ticker and market type are rendered separately`
         )

--- a/backend/scripts/perp-launch-preflight.ts
+++ b/backend/scripts/perp-launch-preflight.ts
@@ -40,7 +40,7 @@ import { log } from 'shared/utils'
 import { runScript } from './run-script'
 
 type Phase = 'feeds' | 'unlisted' | 'rollout' | 'public'
-type Level = 'PASS' | 'WARN' | 'FAIL'
+type Level = 'PASS' | 'INFO' | 'WARN' | 'FAIL'
 
 type FeedSnapshot = {
   feedId: string
@@ -664,15 +664,14 @@ export const auditPerpLaunch = async (pg: SupabaseDirectClient) => {
       if (definition) {
         const expectedCreatorId = getPerpLaunchCreatorId(environment)
         const editableTitle = isMnxOwnedPerp(contract, environment)
+        const matchesTitle = contract.question === definition.question
         report(
-          editableTitle || contract.question === definition.question
-            ? 'PASS'
-            : 'FAIL',
+          matchesTitle ? 'PASS' : editableTitle ? 'INFO' : 'FAIL',
           `market ${contract.slug} launch title`,
-          editableTitle
-            ? `MNX-owned display title: "${contract.question}"`
-            : contract.question === definition.question
+          matchesTitle
             ? definition.question
+            : editableTitle
+            ? `stored="${contract.question}", template="${definition.question}"; MNX-owned display titles are editable`
             : `stored="${contract.question}", expected="${definition.question}"; the ticker and market type are rendered separately`
         )
         // The ticker is what the badge shows in place of "Perpetual" and

--- a/backend/scripts/update-mnx-market-copy.ts
+++ b/backend/scripts/update-mnx-market-copy.ts
@@ -1,0 +1,172 @@
+// Preview the partner's metadata templates, then apply with an explicit editor.
+// Run with the normal script credentials and matching Firebase project:
+//   NEXT_PUBLIC_FIREBASE_ENV=PROD yarn ts-node update-mnx-market-copy.ts
+//   NEXT_PUBLIC_FIREBASE_ENV=PROD yarn ts-node update-mnx-market-copy.ts --apply --editor-id=USER_ID
+
+import { isEqual } from 'lodash'
+import { Contract } from 'common/contract'
+import { ENV } from 'common/envs/constants'
+import { getMnxCreatorId, isMnxOwnedPerp } from 'common/perps/creator-accounts'
+import { MNX_INSTRUMENTS, getMnxInstrument } from 'common/perps/mnx'
+import { getPerpFeedTicker } from 'common/perps/ticker'
+import { getLocalEnv } from 'shared/init-admin'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { revalidateContractStaticProps } from 'shared/utils'
+
+const getCopy = (contract: Contract) => ({
+  question: contract.question,
+  description: contract.description,
+  ticker: contract.mechanism === 'perp' ? contract.ticker : undefined,
+})
+
+const readMarkets = async (pg: SupabaseDirectClient, lock = false) =>
+  pg.map<Contract>(
+    `select data from contracts
+     where creator_id = $1 and mechanism = 'perp'
+       and resolution_time is null
+       and data->>'oracleFeedId' = any($2::text[])
+     order by id ${lock ? 'for update' : ''}`,
+    [getMnxCreatorId(ENV), MNX_INSTRUMENTS.map((i) => i.feedId)],
+    (row) => row.data
+  )
+
+const run = async (apply: boolean, editorId: string | undefined) => {
+  if (!['DEV', 'PROD'].includes(process.env.NEXT_PUBLIC_FIREBASE_ENV ?? ''))
+    throw new Error('Set NEXT_PUBLIC_FIREBASE_ENV explicitly to DEV or PROD')
+  if (ENV !== getLocalEnv())
+    throw new Error('Select the matching Firebase project')
+  if (!getMnxCreatorId(ENV))
+    throw new Error(`MNX has no configured creator in ${ENV}`)
+  if (apply && !editorId)
+    throw new Error('--apply requires --editor-id=USER_ID')
+
+  const { runScript } = await import('./run-script')
+  await runScript(async ({ pg }) => {
+    if (editorId) {
+      const editor = await pg.oneOrNone<{ id: string }>(
+        'select id from users where id = $1',
+        [editorId]
+      )
+      if (!editor) throw new Error('The edit-history user does not exist')
+    }
+
+    const contracts = await readMarkets(pg)
+    if (!contracts.length) throw new Error('No live MNX-owned markets found')
+    const feeds = new Set<string>()
+    const plans = contracts.map((contract) => {
+      if (
+        contract.mechanism !== 'perp' ||
+        contract.outcomeType !== 'PERP' ||
+        contract.isResolved ||
+        !isMnxOwnedPerp(contract, ENV)
+      )
+        throw new Error(`Unexpected market identity: ${contract.id}`)
+      const spec = getMnxInstrument(contract.oracleFeedId)!
+      if (feeds.has(spec.feedId))
+        throw new Error(`Multiple live MNX-owned markets for ${spec.feedId}`)
+      feeds.add(spec.feedId)
+      const ticker = getPerpFeedTicker(spec.feedId)
+      if (!ticker) throw new Error(`No canonical ticker for ${spec.feedId}`)
+      const before = getCopy(contract)
+      const after = {
+        question: spec.question,
+        description: {
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: spec.description }],
+            },
+          ],
+        },
+        ticker,
+      }
+      const updatedKeys = (Object.keys(after) as (keyof typeof after)[]).filter(
+        (key) => !isEqual(before[key], after[key])
+      )
+      return { contract, before, after, updatedKeys }
+    })
+    const changed = plans.filter((plan) => plan.updatedKeys.length)
+    console.log(
+      `${ENV}: ${apply ? 'APPLY' : 'DRY RUN'}, ${changed.length} edits`
+    )
+    for (const { contract, before, after } of changed)
+      console.log(
+        JSON.stringify({ id: contract.id, slug: contract.slug, before, after })
+      )
+    console.log(
+      `Found ${contracts.length} of ${MNX_INSTRUMENTS.length} registered instruments.`
+    )
+    if (!apply) return
+
+    await pg.tx(async (tx) => {
+      await tx.none("set local lock_timeout = '5s'")
+      const locked = await readMarkets(tx, true)
+      if (
+        !isEqual(
+          locked.map((contract) => contract.id),
+          contracts.map((contract) => contract.id)
+        )
+      )
+        throw new Error('The MNX market cohort changed; rerun the preview')
+      for (const { contract, before, after, updatedKeys } of changed) {
+        const current = locked.find((c) => c.id === contract.id)!
+        if (
+          !isMnxOwnedPerp(current, ENV) ||
+          current.isResolved ||
+          current.outcomeType !== 'PERP' ||
+          current.mechanism !== 'perp' ||
+          contract.mechanism !== 'perp' ||
+          current.oracleFeedId !== contract.oracleFeedId ||
+          !isEqual(getCopy(current), before)
+        )
+          throw new Error(`Market ${contract.id} changed; rerun the preview`)
+        await tx.none(
+          `insert into contract_edits (contract_id, editor_id, data, updated_keys)
+           values ($1, $2, $3, $4)`,
+          [contract.id, editorId, current, updatedKeys]
+        )
+        // Merge only the requested metadata; never write back a stale price,
+        // pool, position, visibility, slug, or other trading state.
+        await tx.none(
+          'update contracts set data = data || $2::jsonb where id = $1',
+          [contract.id, { ...after, lastUpdatedTime: Date.now() }]
+        )
+      }
+    })
+
+    const verified = await readMarkets(pg)
+    for (const { contract, after } of plans) {
+      const current = verified.find((c) => c.id === contract.id)
+      if (!current || !isEqual(getCopy(current), after))
+        throw new Error(`Verification failed for ${contract.id}`)
+      // Refresh even on a no-op retry, in case an earlier run committed but
+      // failed before refreshing the pages.
+      await revalidateContractStaticProps(current)
+    }
+    console.log(
+      `Applied ${changed.length} edits and verified ${plans.length} markets.`
+    )
+  })
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2)
+  if (
+    args.some((arg) => arg !== '--apply' && !arg.startsWith('--editor-id=')) ||
+    args.filter((arg) => arg === '--apply').length > 1 ||
+    args.filter((arg) => arg.startsWith('--editor-id=')).length > 1
+  )
+    throw new Error('Expected [--apply --editor-id=USER_ID]')
+  run(
+    args.includes('--apply'),
+    args
+      .find((arg) => arg.startsWith('--editor-id='))
+      ?.slice('--editor-id='.length)
+  ).catch((error) => {
+    console.error(
+      error instanceof Error ? error.message : 'Metadata update failed'
+    )
+    process.exit(1)
+  })
+}

--- a/backend/shared/jest.config.js
+++ b/backend/shared/jest.config.js
@@ -1,11 +1,18 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 const { pathsToModuleNameMapper } = require('ts-jest')
 const { compilerOptions } = require('./tsconfig')
+// API handler regressions run in this suite alongside the script regressions.
+const paths = Object.assign({}, compilerOptions.paths, {
+  'api/*': ['../api/src/*'],
+})
 
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { baseUrl: __dirname, paths } }],
+  },
+  moduleNameMapper: pathsToModuleNameMapper(paths, {
     prefix: '<rootDir>/',
   }),
   testMatch: ['**/*.test.ts'],

--- a/backend/shared/src/perps/preflight-cohort.test.ts
+++ b/backend/shared/src/perps/preflight-cohort.test.ts
@@ -217,6 +217,15 @@ it('accepts the pinned MNX partner as creator of MNX-feed markets only', async (
   expect(log).toHaveBeenCalledWith(
     '[PASS] market mnx-anthropic-mark launch creator: MNX partner account @MNX (mnx-user)'
   )
+  expect(log).toHaveBeenCalledWith(
+    '[PASS] market mnx-anthropic-mark launch title: MNX-owned display title: "fixture"'
+  )
+  expect(log.error).toHaveBeenCalledWith(
+    expect.stringContaining('[FAIL] market btc-usd launch title:')
+  )
+  expect(log.error).toHaveBeenCalledWith(
+    expect.stringContaining('[FAIL] market mnx-anthropic-mark launch ticker:')
+  )
   expect(log.error).toHaveBeenCalledWith(
     expect.stringContaining(
       '[FAIL] market btc-usd launch creator: creator mnx-user is not an allowed creator account for btc-usd (MxyCh2xvsFMFywwjg3Az0w4xP5B3)'

--- a/backend/shared/src/perps/preflight-cohort.test.ts
+++ b/backend/shared/src/perps/preflight-cohort.test.ts
@@ -2,6 +2,7 @@ import { SupabaseDirectClient } from '../supabase/init'
 import { log } from '../utils'
 import { HOUR_MS, MINUTE_MS } from 'common/util/time'
 import { PerpContract } from 'common/contract'
+import { MNX_INSTRUMENTS } from 'common/perps/mnx'
 jest.mock('../../../scripts/run-script', () => ({ runScript: jest.fn() }))
 jest.mock('../init-admin', () => ({ getLocalEnv: () => 'DEV' }))
 jest.mock('../mnx', () => ({
@@ -138,7 +139,10 @@ const partnerRow = {
 // Runs the MNX-cohort feeds audit with the partner id pinned for DEV. The
 // preflight is loaded in an isolated registry, so the pin is applied by a
 // mock factory on that registry's copy of the module.
-const auditWithPinnedPartner = async (partnerExists: boolean) => {
+const auditWithPinnedPartner = async (
+  partnerExists: boolean,
+  mnxTitle = 'fixture'
+) => {
   process.argv = ['node', 'preflight', '--phase=feeds', '--cohort=mnx']
   jest.doMock('./creator-accounts', () => {
     const actual = jest.requireActual('./creator-accounts')
@@ -162,7 +166,7 @@ const auditWithPinnedPartner = async (partnerExists: boolean) => {
         slug: feedId,
         oracleFeedId: feedId,
         mechanism: 'perp',
-        question: 'fixture',
+        question: feedId === 'btc-usd' ? 'fixture' : mnxTitle,
         creatorId: 'mnx-user',
         token: 'MANA',
         oraclePrice: feedId === 'btc-usd' ? 100000 : 2104,
@@ -218,7 +222,16 @@ it('accepts the pinned MNX partner as creator of MNX-feed markets only', async (
     '[PASS] market mnx-anthropic-mark launch creator: MNX partner account @MNX (mnx-user)'
   )
   expect(log).toHaveBeenCalledWith(
-    '[PASS] market mnx-anthropic-mark launch title: MNX-owned display title: "fixture"'
+    '[INFO] market mnx-anthropic-mark launch title: stored="fixture", template="Anthropic IPO Market Cap (MNX)"; MNX-owned display titles are editable'
+  )
+  expect(log).not.toHaveBeenCalledWith(
+    expect.stringContaining('[PASS] market mnx-anthropic-mark launch title:')
+  )
+  expect(log.warn).not.toHaveBeenCalledWith(
+    expect.stringContaining('market mnx-anthropic-mark launch title')
+  )
+  expect(log.error).not.toHaveBeenCalledWith(
+    expect.stringContaining('market mnx-anthropic-mark launch title')
   )
   expect(log.error).toHaveBeenCalledWith(
     expect.stringContaining('[FAIL] market btc-usd launch title:')
@@ -230,6 +243,19 @@ it('accepts the pinned MNX partner as creator of MNX-feed markets only', async (
     expect.stringContaining(
       '[FAIL] market btc-usd launch creator: creator mnx-user is not an allowed creator account for btc-usd (MxyCh2xvsFMFywwjg3Az0w4xP5B3)'
     )
+  )
+})
+
+it('reports a matching MNX launch title as PASS', async () => {
+  const title = MNX_INSTRUMENTS.find(
+    (instrument) => instrument.feedId === 'mnx-anthropic-mark'
+  )!.question
+  await auditWithPinnedPartner(true, title)
+  expect(log).toHaveBeenCalledWith(
+    `[PASS] market mnx-anthropic-mark launch title: ${title}`
+  )
+  expect(log).not.toHaveBeenCalledWith(
+    expect.stringContaining('[INFO] market mnx-anthropic-mark launch title:')
   )
 })
 

--- a/backend/shared/src/perps/update-market-copy.test.ts
+++ b/backend/shared/src/perps/update-market-copy.test.ts
@@ -1,0 +1,164 @@
+import { API, ValidatedAPIParams } from 'common/api/schema'
+import { PerpContract } from 'common/contract'
+import { ENV, ENV_CONFIG } from 'common/envs/constants'
+import { MNX_CREATOR_IDS } from 'common/perps/creator-accounts'
+import { MNX_INSTRUMENTS } from 'common/perps/mnx'
+import { recordContractEdit } from '../record-contract-edit'
+import { updateContract } from '../supabase/contracts'
+import { getContract } from '../utils'
+
+// Exercise the API handler through the shared test runner, as the preflight
+// tests exercise scripts. Request validation and permission checks are real;
+// persistence, rich-text sanitizing, and the HTTP wrapper are mocked.
+jest.mock('api/helpers/endpoint', () => ({
+  APIError: jest.requireActual('common/api/utils').APIError,
+}))
+jest.mock('../../../api/src/helpers/rate-limit', () => ({
+  onlyUsersWhoCanPerformAction: (_action: string, handler: unknown) => handler,
+}))
+jest.mock('../analytics', () => ({ trackPublicEvent: jest.fn() }))
+jest.mock('../audit-events', () => ({ trackAuditEvent: jest.fn() }))
+jest.mock('../record-contract-edit', () => ({ recordContractEdit: jest.fn() }))
+jest.mock('../supabase/contracts', () => ({ updateContract: jest.fn() }))
+jest.mock('../utils', () => ({
+  getContract: jest.fn(),
+  sanitizeJsonContent: (content: unknown) => content,
+  revalidateContractStaticProps: jest.fn(),
+  log: Object.assign(jest.fn(), { warn: jest.fn(), error: jest.fn() }),
+}))
+jest.mock('../supabase/init', () => ({
+  createSupabaseDirectClient: () => ({}),
+  pgp: jest.requireActual('pg-promise')(),
+}))
+
+const { updateMarket } = jest.requireActual(
+  '../../../api/src/update-market'
+) as {
+  updateMarket: (
+    body: ValidatedAPIParams<'market/:contractId/update'>,
+    auth: { uid: string }
+  ) => Promise<{ result: { success: boolean }; continue: () => Promise<void> }>
+}
+const mnxId = 'mnx-partner'
+const description = {
+  type: 'doc',
+  content: [
+    { type: 'paragraph', content: [{ type: 'text', text: 'MNX mark price.' }] },
+  ],
+}
+const ids = { ...MNX_CREATOR_IDS }
+let contract: PerpContract
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  MNX_CREATOR_IDS[ENV] = mnxId
+  contract = {
+    id: 'mnx-market',
+    creatorId: mnxId,
+    creatorUsername: 'RenamedPartner',
+    mechanism: 'perp',
+    outcomeType: 'PERP',
+    oracleFeedId: MNX_INSTRUMENTS[0].feedId,
+    ticker: MNX_INSTRUMENTS[0].symbol,
+    question: MNX_INSTRUMENTS[0].question,
+  } as PerpContract
+  jest.mocked(getContract).mockImplementation(async () => contract)
+})
+afterEach(() => Object.assign(MNX_CREATOR_IDS, ids))
+
+const edit = async (
+  fields: Omit<ValidatedAPIParams<'market/:contractId/update'>, 'contractId'>,
+  userId = mnxId
+) =>
+  updateMarket(
+    API['market/:contractId/update'].props.parse({
+      contractId: contract.id,
+      ...fields,
+    }),
+    { uid: userId }
+  )
+
+it('lets the pinned MNX owner edit title and description and records both edits', async () => {
+  const result = await edit({
+    question: 'Anthropic valuation',
+    descriptionJson: JSON.stringify(description),
+  })
+  expect(result.result.success).toBe(true)
+  expect(updateContract).toHaveBeenCalledWith(
+    {},
+    contract.id,
+    expect.objectContaining({
+      question: 'Anthropic valuation',
+      description,
+    })
+  )
+  const patch = jest.mocked(updateContract).mock.calls[0][2]
+  expect(patch).not.toHaveProperty('oracleFeedId')
+  expect(patch).not.toHaveProperty('ticker')
+  await result.continue()
+  expect(recordContractEdit).toHaveBeenCalledWith(contract, mnxId, [
+    'question',
+    'description',
+  ])
+})
+
+it('retains description-only editing through the existing creator API', async () => {
+  await edit({ descriptionJson: JSON.stringify(description) })
+  expect(updateContract).toHaveBeenCalledWith(
+    {},
+    contract.id,
+    expect.objectContaining({ description })
+  )
+})
+
+it('lets an admin edit the display title of an MNX-owned market', async () => {
+  await expect(
+    edit({ question: 'Partner title' }, ENV_CONFIG.adminIds[0])
+  ).resolves.toMatchObject({ result: { success: true } })
+})
+
+it.each([
+  { question: 'Unauthorized title' },
+  { descriptionJson: JSON.stringify(description) },
+])('refuses another user editing MNX copy: %j', async (fields) => {
+  await expect(edit(fields, 'someone-else')).rejects.toThrow('admin or mod')
+  expect(updateContract).not.toHaveBeenCalled()
+})
+
+it('does not grant MNX access to another owner’s market', async () => {
+  contract.creatorId = 'another-owner'
+  await expect(edit({ question: 'New title' })).rejects.toThrow('admin or mod')
+  expect(updateContract).not.toHaveBeenCalled()
+})
+
+it.each([
+  { creatorId: 'house', oracleFeedId: MNX_INSTRUMENTS[0].feedId },
+  { creatorId: mnxId, oracleFeedId: 'btc-usd' },
+])(
+  'retains canonical titles outside MNX-owned MNX feeds: %j',
+  async (fields) => {
+    Object.assign(contract, fields)
+    await expect(
+      edit({ question: 'New title' }, ENV_CONFIG.adminIds[0])
+    ).rejects.toThrow('The launch title')
+    expect(updateContract).not.toHaveBeenCalled()
+  }
+)
+
+it('does not grant title exceptions when the partner is unconfigured', async () => {
+  MNX_CREATOR_IDS[ENV] = undefined
+  await expect(edit({ question: 'New title' })).rejects.toThrow(
+    'The launch title'
+  )
+  expect(updateContract).not.toHaveBeenCalled()
+})
+
+it('still refuses ticker changes by MNX', async () => {
+  await expect(edit({ ticker: 'NEW' })).rejects.toThrow('Only admins')
+  expect(updateContract).not.toHaveBeenCalled()
+})
+
+it('still rejects attempts to retarget the oracle feed', async () => {
+  await expect(edit({ oracleFeedId: 'btc-usd' } as never)).rejects.toThrow()
+  expect(updateContract).not.toHaveBeenCalled()
+})

--- a/common/src/perps/creator-accounts.ts
+++ b/common/src/perps/creator-accounts.ts
@@ -1,4 +1,5 @@
 import { getMnxInstrument } from './mnx'
+import type { Contract } from '../contract'
 
 // Accounts a PERP can be created under. The selection is the market's creator
 // in every sense the engine knows: it pays the backing at creation and
@@ -32,6 +33,18 @@ export const MNX_CREATOR_IDS: Record<'DEV' | 'PROD', string | undefined> = {
 
 export const getMnxCreatorId = (environment: 'DEV' | 'PROD') =>
   MNX_CREATOR_IDS[environment]
+
+// Partner-owned market copy is editable; feed identity is still fixed. Use
+// the same ownership test in the update API and the launch audit.
+export const isMnxOwnedPerp = (
+  contract: Pick<Contract, 'mechanism' | 'creatorId'> & {
+    oracleFeedId?: string
+  },
+  environment: 'DEV' | 'PROD'
+) =>
+  contract.mechanism === 'perp' &&
+  contract.creatorId === getMnxCreatorId(environment) &&
+  !!getMnxInstrument(contract.oracleFeedId)
 
 // A partner may only own markets on its own feeds: MNX-owned BTC markets would
 // route house backing to a third party for a product it has nothing to do

--- a/common/src/perps/mnx.ts
+++ b/common/src/perps/mnx.ts
@@ -53,13 +53,17 @@ export const MNX_INSTRUMENTS = instruments.map(
       minPrice,
       maxPrice,
       question: valuation
-        ? `${name} — MNX valuation futures price (USD billions)`
-        : `${name} — MNX mark price (${symbol}, USD)`,
-      description: valuation
-        ? `Tracks the MNX ${name} valuation futures mark price, in billions of US dollars. This is a futures price, not a stock price or a confirmed current company valuation. MNX's contract references market capitalization after IPO, or the last public valuation if no listing happens before 2028.`
+        ? `${name} IPO Market Cap (MNX)`
         : category === 'compute'
-        ? 'Tracks the MNX H100 rental-price mark in USD. MNX references the SemiAnalysis H100 Selected Spot Rental Price Index. This measures GPU rental prices, not the purchase price of a GPU.'
-        : `Tracks the MNX ${symbol} market mark price in USD. This is the price of the MNX derivative; it can differ from the underlying share price.`,
+        ? 'H100 GPU rental price (MNX)'
+        : `${name} (MNX)`,
+      description: valuation
+        ? `Tracks MNX futures contract on ${name}'s market capitalization after IPO — or its last public valuation if no listing happens before 2028 — in billions of US dollars.`
+        : category === 'compute'
+        ? 'Tracks the MNX perpetual on the rental price of NVIDIA H100 GPUs, as measured by the SemiAnalysis H100 Selected Spot Rental Price Index.'
+        : `Tracks the MNX perpetual on one share of ${
+            symbol === 'SNDK' ? 'Sandisk Corporation' : name
+          } (${symbol}).`,
     }
   }
 )

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -10,6 +10,13 @@ and resolved markets. Stats are refreshed from the database with **Refresh stats
 backing, open interest, active traders, 24-hour margin volume, opening fees, and
 oracle health. Fees are added to the backing pools. Stats cannot be manually edited.
 
+To edit a market's title or description, open its market link while signed in
+as MNX. Use the pencil beside the title or **Edit description** below the
+description. Both are editable on MNX-owned markets; the oracle feed and ticker
+remain fixed. Title editing requires the updated API deployment. Description
+editing already uses the existing creator permissions. The launch audit accepts
+custom MNX-owned titles while still checking the feed, ticker, and owner.
+
 Select live markets, or use **Manage** on one market:
 
 - **Add liquidity:** choose long, short, or both. The entered amount is **per

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -69,7 +69,15 @@ New MNX markets use the partner's category templates: `[Company] IPO Market Cap
 price (MNX)` for compute. Descriptions come from the same instrument registry;
 canonical display tickers remain unchanged (including `ANTH`, `SNDK`, and `H100`).
 The market's oracle attribution continues to link to MNX independently of its
-editable description.
+editable description. A fixed notice beside that source explains that if MNX
+ends the instrument, trading pauses pending administrative settlement and does
+not automatically roll into a replacement. Deploy the web change before running
+the copy backfill so this notice stays visible when descriptions are replaced.
+
+The launch preflight reports an edited MNX-owned title as `INFO`, printing both
+the stored title and the template. Matching titles still report `PASS`; title
+mismatches on other markets still fail. An edited MNX title does not require a
+warning override.
 
 To apply the templates to existing live MNX-owned markets, use
 `backend/scripts/update-mnx-market-copy.ts` with the normal script credentials,

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -63,3 +63,22 @@ and verifies the fees and creator in each response. The MNX identity remains
 pinned by environment in `common/src/perps/creator-accounts.ts` (re-exported from
 the existing shared module); usernames do not grant management access. DEV stays
 unconfigured until it has its own verified partner account.
+
+New MNX markets use the partner's category templates: `[Company] IPO Market Cap
+(MNX)` for valuation futures, `[Company] (MNX)` for equities, and `H100 GPU rental
+price (MNX)` for compute. Descriptions come from the same instrument registry;
+canonical display tickers remain unchanged (including `ANTH`, `SNDK`, and `H100`).
+The market's oracle attribution continues to link to MNX independently of its
+editable description.
+
+To apply the templates to existing live MNX-owned markets, use
+`backend/scripts/update-mnx-market-copy.ts` with the normal script credentials,
+`NEXT_PUBLIC_FIREBASE_ENV` explicitly set to `PROD`, and the matching Firebase
+project selected. Run without arguments to preview the before/after metadata;
+then add `--apply --editor-id=USER_ID` using the operator's Manifold user ID for
+edit history. This writes titles, descriptions, and canonical tickers together
+with their edit history in one transaction, verifies the stored metadata, and
+revalidates the market pages. It refuses concurrent metadata or cohort changes,
+skips resolved markets, and targets only the pinned MNX owner and registered MNX
+feeds. Trading settings and balances are unaffected. Merging the PR does not
+run this backfill.

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -241,6 +241,13 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
         feedId={contract.oracleFeedId}
         asOfTime={contract.oracleSourceTime}
       />
+      {/* Keep settlement behavior visible even when MNX edits its description. */}
+      {getMnxInstrument(contract.oracleFeedId) && (
+        <p className="text-ink-500 text-sm">
+          If MNX ends this instrument, trading pauses pending administrative
+          settlement; it will not automatically roll into a replacement.
+        </p>
+      )}
 
       {contract.isResolved ? (
         <div className="border-primary-200 bg-primary-50 text-ink-700 dark:bg-primary-900/20 rounded-lg border px-4 py-3 text-sm">


### PR DESCRIPTION
﻿MNX currently gets a 400 when saving a new title for a market it owns because the API requires the exact launch-manifest title. Allow display-title edits on registered MNX feeds owned by the pinned MNX account. Creator/moderator permissions and fixed feed/ticker checks still apply. Descriptions are already editable through the market page.

The launch preflight reports matching titles as PASS and edited MNX-owned titles as INFO, including both the stored and template text. Other title mismatches still fail. This makes edits visible without requiring a warning override.

Update the 16 registered MNX instruments to the partner's copy templates: `[Company] IPO Market Cap (MNX)` for valuation futures, `[Company] (MNX)` for equities, and `H100 GPU rental price (MNX)` for compute. Anthropic, Sandisk, and H100 use the requested descriptions exactly; the other instruments use their category template. Creation uses those descriptions directly. Canonical display tickers, provider identities, price units, and oracle attribution remain intact.

The descriptions intentionally omit the duplicate source URL and settlement paragraph. The source link remains in the fixed oracle attribution, and the market overview now preserves the settlement notice beside it: if MNX ends the instrument, trading pauses pending administrative settlement and does not automatically roll into a replacement. Description edits and the backfill cannot remove that notice.

Add `backend/scripts/update-mnx-market-copy.ts`, a one-time backfill using the same `runScript` credentials and environment checks as `create-mnx-perps.ts`. It previews by default, targets existing unresolved markets owned by the pinned MNX account on registered feeds, and requires `--apply --editor-id=USER_ID` to write. It locks target rows, rejects concurrent metadata/cohort changes, records previous market data in `contract_edits` in the same transaction, verifies stored copy, and refreshes market pages. Trading settings, balances, and slugs are unchanged. The operator will run this locally; it has not been applied to production.

The shared Jest runner resolves API imports so the handler regressions exercise the real update handler.

Validation:
- Initial implementation: all 216 shared tests and 35 common MNX, API market-types, and MNX-management tests passed; common/shared/API builds and targeted checks of both MNX scripts passed.
- Review fixes: all 22 preflight and update-handler regression tests passed, including matching/edited titles and retained feed/ticker restrictions.
- Web TypeScript check, changed-file ESLint and Prettier, and `git diff --check` passed.
- The full legacy scripts project has unrelated errors in older scripts and dependency declarations.

Deploy the API for self-service title editing. Deploy the web change before running the metadata backfill so the settlement notice remains visible when descriptions are replaced. Merging does not run the backfill.

From `backend/scripts` on this branch, with the same PROD credentials and selected Firebase project used for creation:

```powershell
$env:NEXT_PUBLIC_FIREBASE_ENV = 'PROD'
yarn ts-node update-mnx-market-copy.ts
yarn ts-node update-mnx-market-copy.ts --apply --editor-id=YOUR_MANIFOLD_USER_ID
```
