### PR TITLE
Use MNX account for liquidity added from admin/mnx

### DIFF
--- a/backend/api/src/add-perp-subsidy.ts
+++ b/backend/api/src/add-perp-subsidy.ts
@@ -1,44 +1,24 @@
-import { requirePerpManager } from 'shared/perps/management-auth'
-import { createSupabaseDirectClient } from 'shared/supabase/init'
-import { addPerpPoolSubsidy } from 'shared/perps/engine'
+import { addManagedPerpSubsidy } from 'shared/perps/manage-subsidy'
 import { log } from 'shared/utils'
 import { broadcastUpdatedContract } from 'shared/websockets/helpers'
-import { APIError, APIHandler } from './helpers/endpoint'
+import { APIHandler } from './helpers/endpoint'
 
-// The signed-in manager pays from their own balance; all state checks (unresolved, MANA
-// token, escrow invariant) and locking live in the engine.
+// Funding and authorization are checked together under the engine's contract lock.
 export const addPerpSubsidy: APIHandler<'add-perp-subsidy'> = async (
   body,
   auth
 ) => {
-  if (
-    body.expectedManagerId !== undefined &&
-    body.expectedManagerId !== auth.uid
-  )
-    throw new APIError(
-      409,
-      'The paying account changed. Sign back in before retrying.'
-    )
-  await requirePerpManager(createSupabaseDirectClient(), auth.uid)
   const { contractId, side, amount } = body
 
-  const { contract, poolLong, poolShort, replayed } = await addPerpPoolSubsidy(
-    contractId,
-    auth.uid,
-    side,
-    amount,
-    {
-      idempotencyKey: body.idempotencyKey,
-      authorize: async (tx, contract) => {
-        await requirePerpManager(tx, auth.uid, contract)
-      },
-    }
-  )
+  const { contract, poolLong, poolShort, replayed, funderId } =
+    await addManagedPerpSubsidy(body, auth.uid)
   if (!replayed)
     log(
       `perp manager ${auth.uid} added M$${
         amount * (side === 'both' ? 2 : 1)
-      } to ${side} pools on ${contract.slug}: L=${poolLong} S=${poolShort}`
+      } from ${funderId} to ${side} pools on ${
+        contract.slug
+      }: L=${poolLong} S=${poolShort}`
     )
   broadcastUpdatedContract(contract.visibility, {
     id: contractId,

--- a/backend/shared/src/perps/manage-subsidy.ts
+++ b/backend/shared/src/perps/manage-subsidy.ts
@@ -1,0 +1,52 @@
+import type { ValidatedAPIParams } from 'common/api/schema'
+import { APIError } from 'common/api/utils'
+import { ENV } from 'common/envs/constants'
+import { getMnxCreatorId } from 'common/perps/creator-accounts'
+import { getMnxInstrument } from 'common/perps/mnx'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+import { addPerpPoolSubsidy } from './engine'
+import { requirePerpManager } from './management-auth'
+
+export const addManagedPerpSubsidy = async (
+  body: ValidatedAPIParams<'add-perp-subsidy'>,
+  managerId: string
+) => {
+  if (
+    body.expectedManagerId !== undefined &&
+    body.expectedManagerId !== managerId
+  )
+    throw new APIError(
+      409,
+      'The signed-in account changed. Sign back in before retrying.'
+    )
+  await requirePerpManager(createSupabaseDirectClient(), managerId)
+  const funderId =
+    body.fundingAccount === 'mnx' ? getMnxCreatorId(ENV) : managerId
+  if (!funderId) throw new APIError(403, 'The MNX account is not configured.')
+
+  const result = await addPerpPoolSubsidy(
+    body.contractId,
+    funderId,
+    body.side,
+    body.amount,
+    {
+      idempotencyKey: body.idempotencyKey,
+      authorize: async (tx, contract) => {
+        await requirePerpManager(tx, managerId, contract)
+        if (body.fundingAccount === 'mnx') {
+          // Even admins may only spend MNX funds on its own registered feeds.
+          if (
+            contract.creatorId !== funderId ||
+            !getMnxInstrument(contract.oracleFeedId)
+          )
+            throw new APIError(
+              403,
+              'MNX funds can only be added to MNX-owned MNX markets.'
+            )
+          await requirePerpManager(tx, funderId, contract)
+        }
+      },
+    }
+  )
+  return { ...result, funderId }
+}

--- a/backend/shared/src/perps/management.test.ts
+++ b/backend/shared/src/perps/management.test.ts
@@ -12,6 +12,7 @@ import { runTxnOutsideBetQueue } from 'shared/txn/run-txn'
 import { getContract } from 'shared/utils'
 import { addPerpPoolSubsidy } from './engine'
 import { setPerpConfig } from './manage-config'
+import { addManagedPerpSubsidy } from './manage-subsidy'
 import { requirePerpManager } from './management-auth'
 
 jest.mock('shared/utils', () => ({
@@ -46,8 +47,13 @@ const mnx = 'mnx-test'
 const ids = { ...MNX_CREATOR_IDS }
 let contract: PerpContract
 let balance: number
+let adminBalance: number
+let mnxAccountData: {
+  userDeleted?: boolean
+  isBannedFromPosting?: boolean
+} | null
 let ledger: number
-let receipts: { amount: number; side: string; key: string }[]
+let receipts: { fromId: string; amount: number; side: string; key: string }[]
 let locked: boolean
 const tx = {
   one: jest.fn(),
@@ -60,6 +66,8 @@ beforeEach(() => {
   jest.clearAllMocks()
   MNX_CREATOR_IDS[ENV] = mnx
   balance = 1000
+  adminBalance = 1000
+  mnxAccountData = {}
   ledger = 200
   receipts = []
   locked = false
@@ -123,18 +131,29 @@ beforeEach(() => {
         return convert ? convert(row) : row
       }
       if (query.includes('from users')) {
-        const row = { id: values[0], username: 'RenamedMNX', balance, data: {} }
+        if (values[0] === mnx && mnxAccountData === null) return null
+        const row = {
+          id: values[0],
+          username: values[0] === mnx ? 'RenamedMNX' : 'Admin',
+          balance: values[0] === mnx ? balance : adminBalance,
+          data: values[0] === mnx ? mnxAccountData : {},
+        }
         return convert ? convert(row) : row
       }
       if (query.includes('from txns'))
-        return receipts.find((r) => r.key === values[2]) ?? null
+        return (
+          receipts.find((r) => r.fromId === values[0] && r.key === values[2]) ??
+          null
+        )
       throw new Error(`Unexpected query ${query}`)
     })
   jest.mocked(runTxnOutsideBetQueue).mockImplementation(async (_tx, txn) => {
     expect(locked).toBe(true)
-    balance -= txn.amount
+    if (txn.fromId === mnx) balance -= txn.amount
+    else adminBalance -= txn.amount
     ledger += txn.amount
     receipts.push({
+      fromId: txn.fromId,
       amount: txn.amount,
       side: txn.data!.side,
       key: txn.data!.idempotencyKey,
@@ -148,6 +167,102 @@ const authorize = async (pg: SupabaseTransaction, c: PerpContract) => {
   await requirePerpManager(pg, mnx, c)
 }
 const options = { idempotencyKey: 'abcdefghjk', authorize }
+
+const mnxSubsidyRequest = {
+  contractId: 'c1',
+  side: 'both' as const,
+  amount: 50,
+  fundingAccount: 'mnx' as const,
+  idempotencyKey: 'abcdefghjk',
+}
+
+it.each([mnx, ENV_CONFIG.adminIds[0]])(
+  'debits only MNX when %s applies a dashboard contribution, including on retry',
+  async (managerId) => {
+    adminBalance = 0
+    const body = { ...mnxSubsidyRequest, expectedManagerId: managerId }
+    await expect(addManagedPerpSubsidy(body, managerId)).resolves.toMatchObject(
+      {
+        funderId: mnx,
+        poolLong: 150,
+        poolShort: 150,
+      }
+    )
+    await expect(addManagedPerpSubsidy(body, managerId)).resolves.toMatchObject(
+      {
+        replayed: true,
+      }
+    )
+    expect(balance).toBe(900)
+    expect(adminBalance).toBe(0)
+    expect(runTxnOutsideBetQueue).toHaveBeenCalledTimes(1)
+    expect(runTxnOutsideBetQueue).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({ fromId: mnx, amount: 100 })
+    )
+  }
+)
+
+it('does not fall back to the admin balance when MNX cannot cover the combined cost', async () => {
+  balance = 75
+  await expect(
+    addManagedPerpSubsidy(mnxSubsidyRequest, ENV_CONFIG.adminIds[0])
+  ).rejects.toThrow('Insufficient balance')
+  expect(adminBalance).toBe(1000)
+  expect(runTxnOutsideBetQueue).not.toHaveBeenCalled()
+})
+
+it.each([
+  { creatorId: 'different-owner' },
+  { oracleFeedId: 'btc-usd' },
+  { oracleFeedId: 'mnx-not-registered' },
+])('refuses admin spending of MNX funds on a market with %j', async (patch) => {
+  contract = { ...contract, ...patch }
+  await expect(
+    addManagedPerpSubsidy(mnxSubsidyRequest, ENV_CONFIG.adminIds[0])
+  ).rejects.toThrow('MNX-owned MNX markets')
+  expect(locked).toBe(true)
+  expect(runTxnOutsideBetQueue).not.toHaveBeenCalled()
+})
+
+it.each([null, { userDeleted: true }, { isBannedFromPosting: true }])(
+  'refuses an unavailable MNX funding account: %j',
+  async (data) => {
+    mnxAccountData = data
+    await expect(
+      addManagedPerpSubsidy(mnxSubsidyRequest, ENV_CONFIG.adminIds[0])
+    ).rejects.toThrow('active, unbanned')
+    expect(runTxnOutsideBetQueue).not.toHaveBeenCalled()
+  }
+)
+
+it('requires a configured MNX account and an authorized, unchanged manager', async () => {
+  await expect(
+    addManagedPerpSubsidy(mnxSubsidyRequest, 'unrelated-user')
+  ).rejects.toThrow('Only admins')
+  await expect(
+    addManagedPerpSubsidy(
+      { ...mnxSubsidyRequest, expectedManagerId: mnx },
+      ENV_CONFIG.adminIds[0]
+    )
+  ).rejects.toThrow('signed-in account changed')
+  MNX_CREATOR_IDS[ENV] = undefined
+  await expect(
+    addManagedPerpSubsidy(mnxSubsidyRequest, ENV_CONFIG.adminIds[0])
+  ).rejects.toThrow('not configured')
+  expect(runTxnOutsideBetQueue).not.toHaveBeenCalled()
+})
+
+it('preserves personal funding for existing non-dashboard subsidy callers', async () => {
+  contract.creatorId = 'house'
+  contract.oracleFeedId = 'btc-usd'
+  await addManagedPerpSubsidy(
+    { ...mnxSubsidyRequest, fundingAccount: undefined },
+    ENV_CONFIG.adminIds[0]
+  )
+  expect(balance).toBe(1000)
+  expect(adminBalance).toBe(900)
+})
 
 it('funds both sides in one transaction and debits the combined cost exactly once', async () => {
   expect(

--- a/common/src/api/schema.ts
+++ b/common/src/api/schema.ts
@@ -1275,7 +1275,8 @@ export const API = (_apiTypeCheck = {
     returns: {} as MnxDashboard,
     props: z.object({}).strict(),
   },
-  // The signed-in manager pays. For 'both', amount is added to EACH side.
+  // Defaults to the signed-in manager; the MNX dashboard uses MNX funds.
+  // For 'both', amount is added to EACH side.
   // A request key makes retrying a dashboard operation safe after a timeout.
   'add-perp-subsidy': {
     method: 'POST',
@@ -1286,6 +1287,7 @@ export const API = (_apiTypeCheck = {
       .object({
         contractId: z.string().min(1),
         side: z.enum(['long', 'short', 'both']),
+        fundingAccount: z.enum(['mnx']).optional(),
         expectedManagerId: z.string().min(1).optional(),
         amount: z.number().finite().gt(0).lte(1_000_000),
         idempotencyKey: z

--- a/common/src/perps/mnx-management.test.ts
+++ b/common/src/perps/mnx-management.test.ts
@@ -85,6 +85,7 @@ const batch = (id = 'batch1'): MnxBatch => ({
       contractId,
       side: 'both',
       amount: 10,
+      fundingAccount: 'mnx',
       idempotencyKey: 'abcdefghjk',
     },
   })),
@@ -137,6 +138,37 @@ it('sends no payment if saving the retry keys fails or the account unmounts', as
   ).rejects.toThrow('Storage full')
   await runMnxBatch(batch(), jest.fn(), send, () => false)
   expect(send).not.toHaveBeenCalled()
+})
+
+it('keeps legacy personal-account requests for reconciliation without sending or changing their payer', async () => {
+  const legacy = batch()
+  for (const item of legacy.items)
+    if (item.kind === 'liquidity') delete item.params.fundingAccount
+  legacy.items[0].status = 'done'
+  const send = jest.fn()
+  const result = await runMnxBatch(legacy, jest.fn(), send, () => true)
+  expect(send).not.toHaveBeenCalled()
+  expect(result.items.map((item) => item.status)).toEqual([
+    'done',
+    'error',
+    'pending',
+  ])
+  expect(result.items[1].error).toContain('Check its payment results')
+  expect(result.items.map((item) => item.params)).toEqual(
+    legacy.items.map((item) => item.params)
+  )
+})
+
+it('accepts MNX funding but rejects arbitrary funding accounts in the subsidy API', () => {
+  const props = API['add-perp-subsidy'].props
+  const params = { contractId: 'c', side: 'both', amount: 50 }
+  expect(props.safeParse(params).success).toBe(true)
+  expect(props.safeParse({ ...params, fundingAccount: 'mnx' }).success).toBe(
+    true
+  )
+  expect(
+    props.safeParse({ ...params, fundingAccount: 'another-user' }).success
+  ).toBe(false)
 })
 
 it('marks the batch in progress for other tabs while sending and clears it when the run ends', async () => {

--- a/common/src/perps/mnx-management.ts
+++ b/common/src/perps/mnx-management.ts
@@ -228,7 +228,14 @@ export const runMnxBatch = async (
         runningAt: Date.now(),
       })
       try {
-        await send(current.items[index])
+        const item = current.items[index]
+        // Old receipts are keyed to the original payer. Changing their funding
+        // account on retry could debit MNX for an already-committed payment.
+        if (item.kind === 'liquidity' && item.params.fundingAccount !== 'mnx')
+          throw new Error(
+            'This saved contribution used the signed-in account. Check its payment results and finish the batch before creating a new MNX-funded contribution.'
+          )
+        await send(item)
       } catch (error) {
         persist(
           withItem(index, {

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -14,8 +14,9 @@ Select live markets, or use **Manage** on one market:
 
 - **Add liquidity:** choose long, short, or both. The entered amount is **per
   market, per selected side**. For example, M$1,000 to both sides of 16 markets
-  costs M$32,000. The signed-in account pays, including when that account is an
-  admin. Contributions do not create withdrawable LP shares; remaining backing
+  costs M$32,000. The configured MNX account always pays, including when an
+  admin applies the batch. The form checks and displays MNX's available balance.
+  Contributions do not create withdrawable LP shares; remaining backing
   belongs to the market creator at settlement.
 - **Trading rules:** change web/API opening fees, the size-impact coefficient,
   leverage cap, funding cap/sensitivity, or the maximum oracle mark age. Blank
@@ -44,6 +45,10 @@ show a batch while it is being applied and cannot retry or finish it until the
 run ends, or about a minute after a tab was closed mid-run. Rule edits check the
 previewed settings and record their audit history in the same database
 transaction as the update.
+
+Saved liquidity batches from before MNX account funding cannot be retried here.
+Check their payment results and finish the old batch before creating a new
+contribution; switching an old request to MNX could make a second payment.
 
 New MNX-feed markets default to **10 bps web, 20 bps API, impact 10**. These are
 opening fees on notional; 20 bps is 0.20%, plus the size-dependent fee. The impact

--- a/web/components/perps/mnx-dashboard.tsx
+++ b/web/components/perps/mnx-dashboard.tsx
@@ -189,10 +189,18 @@ export function MnxDashboardView({
         throw new Error(
           'Enter between 0 and 1,000,000 mana per side, greater than zero.'
         )
-      if (mode === 'liquidity' && totalCost > data.payer.balance)
-        throw new Error(
-          `@${data.payer.username} needs ${mana(totalCost)} to fund this batch.`
-        )
+      if (mode === 'liquidity') {
+        if (!data.account)
+          throw new Error(
+            'The MNX account is not configured or is unavailable.'
+          )
+        if (totalCost > data.account.balance)
+          throw new Error(
+            `@${data.account.username} needs ${mana(
+              totalCost
+            )} to fund this batch.`
+          )
+      }
       const changedTargets =
         mode === 'visibility'
           ? targets.filter(({ contract }) => contract.visibility !== visibility)
@@ -222,6 +230,7 @@ export function MnxDashboardView({
                 contractId: contract.id,
                 side,
                 amount: Number(amount),
+                fundingAccount: 'mnx',
                 idempotencyKey: randomString(),
                 expectedManagerId: data.payer.id,
               },
@@ -551,7 +560,7 @@ export function MnxDashboardView({
                     0
                   )
                 )}{' '}
-                from @{data.payer.username}
+                from the MNX account (@{data.account?.username})
               </p>
               <p className="text-ink-600 mt-1 text-sm">
                 This adds backing, with no withdrawable LP shares. Remaining
@@ -703,8 +712,15 @@ export function MnxDashboardView({
                   {Number.isFinite(Number(amount)) ? mana(Number(amount)) : '—'}
                 </p>
                 <p className="text-ink-500 mt-3 text-sm">
-                  Paid by <b>@{data.payer.username}</b> ·{' '}
-                  {mana(data.payer.balance)} available
+                  {data.account ? (
+                    <>
+                      Paid by the MNX account (<b>@{data.account.username}</b>)
+                      {' · '}
+                      {mana(data.account.balance)} available
+                    </>
+                  ) : (
+                    'The MNX account is not configured or is unavailable.'
+                  )}
                 </p>
                 <p className="text-ink-500 mt-2 text-xs">
                   Backing is committed to the markets. This does not buy LP
@@ -835,6 +851,7 @@ export function MnxDashboardView({
                 !ready ||
                 !targets.length ||
                 refreshing ||
+                (mode === 'liquidity' && !data.account) ||
                 (mode === 'visibility' &&
                   targets.every(
                     ({ contract }) => contract.visibility === visibility


### PR DESCRIPTION
﻿Adding liquidity from `/admin/mnx` now always charges the configured MNX account, including when an admin applies the batch. The form checks MNX's balance and identifies MNX as the payer in the contribution preview.

The server only allows MNX funds on MNX-owned markets with registered MNX feeds, retains manager authorization and idempotent payments, and never falls back to the admin's balance. Existing saved personal-account batches remain available for reconciliation but cannot be retried with a different payer. Other subsidy callers retain their existing personal funding behavior.

Validation:
- 45 focused dashboard, subsidy, and authorization tests passed.
- Common/shared build and web/API type checks passed.
- Changed-file ESLint, Prettier, and `git diff --check` passed.
