### PR TITLE
Drop cancelled limit orders from price-impact calculations

### DIFF
--- a/backend/api/src/app.ts
+++ b/backend/api/src/app.ts
@@ -1,3 +1,4 @@
+import { isUncachedQuoteRead } from 'common/api/cache'
 import { API, type APIPath } from 'common/api/schema'
 import { APIError, pathWithPrefix } from 'common/api/utils'
 import { randomString } from 'common/util/random'
@@ -22,9 +23,11 @@ export const allowCorsUnrestricted: RequestHandler = cors({
   maxAge: 86400, // 24 hours
 })
 
-function cacheController(policy?: string): RequestHandler {
-  return (_req, res, next) => {
-    if (policy) res.appendHeader('Cache-Control', policy)
+function cacheController(path: string, policy?: string): RequestHandler {
+  return (req, res, next) => {
+    if (isUncachedQuoteRead(path, req.query)) {
+      res.setHeader('Cache-Control', 'no-store')
+    } else if (policy) res.appendHeader('Cache-Control', policy)
     next()
   }
 }
@@ -145,7 +148,7 @@ app.options('*', allowCorsUnrestricted)
 
 Object.entries(handlers).forEach(([path, handler]) => {
   const api = API[path as APIPath]
-  const cache = cacheController((api as any).cache)
+  const cache = cacheController(path, (api as any).cache)
   const url = '/' + pathWithPrefix(path as APIPath)
 
   const apiRoute = [

--- a/client-common/src/hooks/use-bets.ts
+++ b/client-common/src/hooks/use-bets.ts
@@ -1,8 +1,15 @@
 import { APIParams, APIResponse } from 'common/api/schema'
 import { Bet, isOpenLimitOrder, LimitBet } from 'common/bet'
+import { createLiveSnapshot } from 'common/util/live-snapshot'
 import { User } from 'common/user'
 import { groupBy, sortBy, uniq, uniqBy } from 'lodash'
-import { Dispatch, SetStateAction, useEffect, useMemo } from 'react'
+import {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from 'react'
 import { useApiSubscription } from './use-api-subscription'
 import { useEffectCheckEquality } from './use-effect-check-equality'
 import { useEvent } from './use-event'
@@ -168,46 +175,36 @@ export const useSubscribeGlobalBets = (options?: APIParams<'bets'>) => {
   return newBets
 }
 
-// Filling and cancelling a limit order are both terminal, so once we've seen an
-// order close we can keep it out of every order book we hold, even if a request
-// that was already in flight comes back still reporting it as open.
-const CLOSED_ORDER_MEMORY_MS = 30 * 60 * 1000
-const CLOSED_ORDER_PRUNE_SIZE = 500
-const closedOrderTimes = new Map<string, number>()
-
-const rememberClosedOrders = (bets: LimitBet[], now: number) => {
-  for (const bet of bets) {
-    if (!isOpenLimitOrder(bet, now)) closedOrderTimes.set(bet.id, now)
-  }
-  if (closedOrderTimes.size <= CLOSED_ORDER_PRUNE_SIZE) return
-  for (const [id, closedAt] of closedOrderTimes) {
-    if (closedAt < now - CLOSED_ORDER_MEMORY_MS) closedOrderTimes.delete(id)
-  }
-}
-
-const openOrdersOnly = (bets: LimitBet[]) => {
-  const now = Date.now()
-  return bets.filter(
-    (bet) => isOpenLimitOrder(bet, now) && !closedOrderTimes.has(bet.id)
+// Each contract has one observable snapshot. A confirmed cancel changes the
+// cache itself, including when no quote panel is mounted. Live updates are
+// retained only while a snapshot request is in flight; no tombstone TTL is needed.
+const createOrderBook = () =>
+  createLiveSnapshot<LimitBet>((bets) =>
+    sortBy(
+      bets.filter((bet) => isOpenLimitOrder(bet)),
+      'createdTime'
+    )
   )
+const orderBooks = new Map<string, ReturnType<typeof createOrderBook>>()
+const getOrderBook = (contractId: string) => {
+  // Never share mutable market state between SSR requests.
+  if (typeof window === 'undefined') return createOrderBook()
+  let book = orderBooks.get(contractId)
+  if (!book) {
+    book = createOrderBook()
+    orderBooks.set(contractId, book)
+  }
+  return book
 }
+const getServerSnapshot = () => undefined
 
-type LimitOrderListener = (bets: LimitBet[]) => void
-const unfilledBetListeners = new Map<string, Set<LimitOrderListener>>()
-
-/** Push limit order updates straight into every mounted `useUnfilledBets`,
- * without waiting for the websocket to echo them back. Cancel an order and the
- * order book the bet and sell panels price against drops it immediately, so
- * they stop quoting a counterparty that has gone. */
+/** Apply confirmed mutations to the same snapshot every quote panel reads. */
 export const applyLimitOrderUpdates = (bets: LimitBet[]) => {
-  if (bets.length === 0) return
-  rememberClosedOrders(bets, Date.now())
-  for (const [contractId, contractBets] of Object.entries(
+  for (const [contractId, updates] of Object.entries(
     groupBy(bets, 'contractId')
   )) {
-    for (const listener of unfilledBetListeners.get(contractId) ?? []) {
-      listener(contractBets)
-    }
+    // With no cached book, a later mount starts from a fresh server read.
+    orderBooks.get(contractId)?.update(updates)
   }
 }
 
@@ -215,61 +212,47 @@ export const useUnfilledBets = (
   contractId: string,
   api: (params: APIParams<'bets'>) => Promise<APIResponse<'bets'>>,
   useIsPageVisible: () => boolean,
-  options?: {
-    enabled?: boolean
-  }
+  options?: { enabled?: boolean }
 ) => {
   const { enabled = true } = options ?? {}
-
-  const [bets, setBets] = usePersistentInMemoryState<LimitBet[] | undefined>(
-    undefined,
-    `unfilled-bets-${contractId}`
+  const book = useMemo(() => getOrderBook(contractId), [contractId])
+  const bets = useSyncExternalStore(
+    book.subscribe,
+    book.getSnapshot,
+    getServerSnapshot
   )
-
-  const addBets = useEvent((newBets: LimitBet[]) => {
-    rememberClosedOrders(newBets, Date.now())
-    setBets((bets) =>
-      openOrdersOnly(
-        sortBy(uniqBy([...newBets, ...(bets ?? [])], 'id'), 'createdTime')
-      )
-    )
-  })
-
   const isPageVisible = useIsPageVisible()
 
   useEffect(() => {
-    if (enabled)
-      api({ contractId, kinds: 'open-limit', order: 'asc' }).then((bets) =>
-        // Reset bets instead of adding to existing, since we want to exclude those recently filled/cancelled.
-        setBets(openOrdersOnly(bets as LimitBet[]))
+    if (!enabled || !isPageVisible) return
+    book
+      .refresh(
+        () =>
+          api({ contractId, kinds: 'open-limit', order: 'asc' }) as Promise<
+            LimitBet[]
+          >
       )
-  }, [enabled, contractId, isPageVisible])
-
-  // Local updates (e.g. you cancelling one of your own orders) reach every
-  // other panel on the page through here rather than over the network.
-  useEffect(() => {
-    if (!enabled) return
-    const listeners =
-      unfilledBetListeners.get(contractId) ?? new Set<LimitOrderListener>()
-    unfilledBetListeners.set(contractId, listeners)
-    listeners.add(addBets)
-    return () => {
-      listeners.delete(addBets)
-      if (listeners.size === 0) unfilledBetListeners.delete(contractId)
-    }
-  }, [enabled, contractId, addBets])
+      .catch((e) => console.error('Failed to load limit orders', e))
+  }, [enabled, book, contractId, isPageVisible])
 
   useApiSubscription({
     enabled,
     topics: [`contract/${contractId}/orders`],
-    onBroadcast: ({ data }) => {
-      addBets(data.bets as LimitBet[])
-    },
+    onBroadcast: ({ data }) => book.update(data.bets as LimitBet[]),
   })
 
-  // A panel that mounts after a cancel starts from the in-memory cache, which
-  // can still be holding the order that was just cancelled.
-  return useMemo(() => bets && openOrdersOnly(bets), [bets])
+  useEffect(() => {
+    if (!enabled || !bets?.length) return
+    const expiry = Math.min(...bets.map((b) => b.expiresAt ?? Infinity))
+    if (!Number.isFinite(expiry)) return
+    const timer = setTimeout(
+      book.normalize,
+      Math.min(2 ** 31 - 1, Math.max(0, expiry - Date.now()))
+    )
+    return () => clearTimeout(timer)
+  }, [enabled, book, bets])
+
+  return bets
 }
 
 export const useUnfilledBetsAndBalanceByUserId = (

--- a/client-common/src/hooks/use-bets.ts
+++ b/client-common/src/hooks/use-bets.ts
@@ -1,10 +1,11 @@
 import { APIParams, APIResponse } from 'common/api/schema'
-import { Bet, LimitBet } from 'common/bet'
+import { Bet, isOpenLimitOrder, LimitBet } from 'common/bet'
 import { User } from 'common/user'
-import { sortBy, uniq, uniqBy } from 'lodash'
-import { Dispatch, SetStateAction, useEffect } from 'react'
+import { groupBy, sortBy, uniq, uniqBy } from 'lodash'
+import { Dispatch, SetStateAction, useEffect, useMemo } from 'react'
 import { useApiSubscription } from './use-api-subscription'
 import { useEffectCheckEquality } from './use-effect-check-equality'
+import { useEvent } from './use-event'
 import { usePersistentInMemoryState } from './use-persistent-in-memory-state'
 
 export function useBetsOnce(
@@ -167,6 +168,49 @@ export const useSubscribeGlobalBets = (options?: APIParams<'bets'>) => {
   return newBets
 }
 
+// Filling and cancelling a limit order are both terminal, so once we've seen an
+// order close we can keep it out of every order book we hold, even if a request
+// that was already in flight comes back still reporting it as open.
+const CLOSED_ORDER_MEMORY_MS = 30 * 60 * 1000
+const CLOSED_ORDER_PRUNE_SIZE = 500
+const closedOrderTimes = new Map<string, number>()
+
+const rememberClosedOrders = (bets: LimitBet[], now: number) => {
+  for (const bet of bets) {
+    if (!isOpenLimitOrder(bet, now)) closedOrderTimes.set(bet.id, now)
+  }
+  if (closedOrderTimes.size <= CLOSED_ORDER_PRUNE_SIZE) return
+  for (const [id, closedAt] of closedOrderTimes) {
+    if (closedAt < now - CLOSED_ORDER_MEMORY_MS) closedOrderTimes.delete(id)
+  }
+}
+
+const openOrdersOnly = (bets: LimitBet[]) => {
+  const now = Date.now()
+  return bets.filter(
+    (bet) => isOpenLimitOrder(bet, now) && !closedOrderTimes.has(bet.id)
+  )
+}
+
+type LimitOrderListener = (bets: LimitBet[]) => void
+const unfilledBetListeners = new Map<string, Set<LimitOrderListener>>()
+
+/** Push limit order updates straight into every mounted `useUnfilledBets`,
+ * without waiting for the websocket to echo them back. Cancel an order and the
+ * order book the bet and sell panels price against drops it immediately, so
+ * they stop quoting a counterparty that has gone. */
+export const applyLimitOrderUpdates = (bets: LimitBet[]) => {
+  if (bets.length === 0) return
+  rememberClosedOrders(bets, Date.now())
+  for (const [contractId, contractBets] of Object.entries(
+    groupBy(bets, 'contractId')
+  )) {
+    for (const listener of unfilledBetListeners.get(contractId) ?? []) {
+      listener(contractBets)
+    }
+  }
+}
+
 export const useUnfilledBets = (
   contractId: string,
   api: (params: APIParams<'bets'>) => Promise<APIResponse<'bets'>>,
@@ -182,29 +226,38 @@ export const useUnfilledBets = (
     `unfilled-bets-${contractId}`
   )
 
-  const addBets = (newBets: LimitBet[]) => {
-    setBets((bets) => {
-      return sortBy(
-        uniqBy([...newBets, ...(bets ?? [])], 'id'),
-        'createdTime'
-      ).filter(
-        (bet) =>
-          !bet.isFilled &&
-          !bet.isCancelled &&
-          (!bet.expiresAt || bet.expiresAt > Date.now())
+  const addBets = useEvent((newBets: LimitBet[]) => {
+    rememberClosedOrders(newBets, Date.now())
+    setBets((bets) =>
+      openOrdersOnly(
+        sortBy(uniqBy([...newBets, ...(bets ?? [])], 'id'), 'createdTime')
       )
-    })
-  }
+    )
+  })
 
   const isPageVisible = useIsPageVisible()
 
   useEffect(() => {
     if (enabled)
-      api({ contractId, kinds: 'open-limit', order: 'asc' }).then(
+      api({ contractId, kinds: 'open-limit', order: 'asc' }).then((bets) =>
         // Reset bets instead of adding to existing, since we want to exclude those recently filled/cancelled.
-        (bets) => setBets(bets as LimitBet[])
+        setBets(openOrdersOnly(bets as LimitBet[]))
       )
   }, [enabled, contractId, isPageVisible])
+
+  // Local updates (e.g. you cancelling one of your own orders) reach every
+  // other panel on the page through here rather than over the network.
+  useEffect(() => {
+    if (!enabled) return
+    const listeners =
+      unfilledBetListeners.get(contractId) ?? new Set<LimitOrderListener>()
+    unfilledBetListeners.set(contractId, listeners)
+    listeners.add(addBets)
+    return () => {
+      listeners.delete(addBets)
+      if (listeners.size === 0) unfilledBetListeners.delete(contractId)
+    }
+  }, [enabled, contractId, addBets])
 
   useApiSubscription({
     enabled,
@@ -214,7 +267,9 @@ export const useUnfilledBets = (
     },
   })
 
-  return bets
+  // A panel that mounts after a cancel starts from the in-memory cache, which
+  // can still be holding the order that was just cancelled.
+  return useMemo(() => bets && openOrdersOnly(bets), [bets])
 }
 
 export const useUnfilledBetsAndBalanceByUserId = (

--- a/client-common/src/lib/api.ts
+++ b/client-common/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { isUncachedQuoteRead } from 'common/api/cache'
 import { API, APIParams, APIPath, APIResponse } from 'common/api/schema'
 import {
   BaseApiCallOptions,
@@ -52,6 +53,6 @@ export async function apiWithAuth<P extends APIPath>(
     pathProps.method,
     auth,
     params,
-    options
+    isUncachedQuoteRead(path, params) ? { ...options, cache: 'no-store' } : options
   )) as Promise<APIResponse<P>>
 }

--- a/common/src/api/cache.test.ts
+++ b/common/src/api/cache.test.ts
@@ -1,0 +1,7 @@
+import { isUncachedQuoteRead } from './cache'
+
+it('bypasses caches for open orders without changing historical bets', () => {
+  expect(isUncachedQuoteRead('bets', { kinds: 'open-limit' })).toBe(true)
+  expect(isUncachedQuoteRead('bets', { contractId: 'market' })).toBe(false)
+  expect(isUncachedQuoteRead('unrelated', { kinds: 'open-limit' })).toBe(false)
+})

--- a/common/src/api/cache.ts
+++ b/common/src/api/cache.ts
@@ -1,0 +1,6 @@
+/** Quote inputs must come from the origin, including on post-mutation reads.
+ * Use the same policy for browser requests and API response headers. */
+export const isUncachedQuoteRead = (
+  path: string,
+  params: Record<string, unknown>
+) => path === 'bets' && params.kinds === 'open-limit'

--- a/common/src/bet.ts
+++ b/common/src/bet.ts
@@ -105,3 +105,9 @@ export type maker = {
 }
 
 export const getNewBetId = () => nanoid(12)
+
+// A limit order can still be matched against only while it has unfilled amount
+// left, hasn't been cancelled, and hasn't expired. Cancelling and filling are
+// both terminal: an order that fails this can never become open again.
+export const isOpenLimitOrder = (bet: LimitBet, now = Date.now()) =>
+  !bet.isFilled && !bet.isCancelled && (!bet.expiresAt || bet.expiresAt > now)

--- a/common/src/calculate-cpmm.test.ts
+++ b/common/src/calculate-cpmm.test.ts
@@ -1,10 +1,13 @@
+import { LimitBet } from './bet'
 import {
   addCpmmLiquidity,
   calculateCpmmPurchase,
   calculateCpmmShares,
+  computeFills,
   CpmmState,
   getCpmmOutcomeProbabilityAfterBet,
   getCpmmProbability,
+  getCpmmProbabilityAfterSale,
   removeCpmmLiquidity,
 } from './calculate-cpmm'
 import { noFees } from './fees'
@@ -189,6 +192,118 @@ describe('CPMM Calculations', () => {
       expect(finalPool.YES).toBeCloseTo(initialPool.YES, 5)
       expect(finalPool.NO).toBeCloseTo(initialPool.NO, 5)
       expect(finalP).toBeCloseTo(initialP, 5)
+    })
+  })
+
+  describe('open limit orders', () => {
+    const makeLimitOrder = (overrides: Partial<LimitBet> = {}): LimitBet => ({
+      id: 'limit-order',
+      userId: 'maker',
+      contractId: 'contract',
+      createdTime: 0,
+      amount: 0,
+      shares: 0,
+      outcome: 'YES',
+      limitProb: 0.5,
+      orderAmount: 10000,
+      isFilled: false,
+      isCancelled: false,
+      fills: [],
+      probBefore: 0.5,
+      probAfter: 0.5,
+      fees: noFees,
+      isRedemption: false,
+      ...overrides,
+    })
+
+    const state: CpmmState = {
+      pool: { YES: 10000, NO: 10000 },
+      p: 0.5,
+      collectedFees: noFees,
+    }
+    const balanceByUserId = { maker: 100000 }
+
+    it('matches a buyer against an open order', () => {
+      const { makers } = computeFills(
+        state,
+        'NO',
+        1000,
+        undefined,
+        [makeLimitOrder()],
+        balanceByUserId
+      )
+      expect(makers).toHaveLength(1)
+    })
+
+    it('ignores a cancelled order', () => {
+      const { makers } = computeFills(
+        state,
+        'NO',
+        1000,
+        undefined,
+        [makeLimitOrder({ isCancelled: true })],
+        balanceByUserId
+      )
+      expect(makers).toHaveLength(0)
+    })
+
+    it('ignores a filled order', () => {
+      const { makers } = computeFills(
+        state,
+        'NO',
+        1000,
+        undefined,
+        [makeLimitOrder({ isFilled: true })],
+        balanceByUserId
+      )
+      expect(makers).toHaveLength(0)
+    })
+
+    it('ignores an expired order', () => {
+      const { makers } = computeFills(
+        state,
+        'NO',
+        1000,
+        undefined,
+        [makeLimitOrder({ expiresAt: Date.now() - 1000 })],
+        balanceByUserId
+      )
+      expect(makers).toHaveLength(0)
+    })
+
+    it('cancelling your own order moves the price your sale would make', () => {
+      const shares = 2000
+      const order = makeLimitOrder()
+
+      // The order is big enough to absorb the whole sale at its limit price.
+      const withOpenOrder = getCpmmProbabilityAfterSale(
+        state,
+        shares,
+        'YES',
+        [order],
+        balanceByUserId
+      )
+      expect(withOpenOrder).toBeCloseTo(0.5, 6)
+
+      const withoutOrders = getCpmmProbabilityAfterSale(
+        state,
+        shares,
+        'YES',
+        [],
+        balanceByUserId
+      )
+      expect(withoutOrders).toBeLessThan(0.5)
+
+      // Once cancelled it can't be the counterparty any more, so the sale has
+      // to move the pool just as it would with an empty order book.
+      const withCancelledOrder = getCpmmProbabilityAfterSale(
+        state,
+        shares,
+        'YES',
+        [{ ...order, isCancelled: true }],
+        balanceByUserId
+      )
+      expect(withCancelledOrder).toBeCloseTo(withoutOrders, 6)
     })
   })
 })

--- a/common/src/calculate-cpmm.ts
+++ b/common/src/calculate-cpmm.ts
@@ -1,5 +1,5 @@
 import { groupBy, mapValues, minBy, omitBy, sortBy, sum, sumBy } from 'lodash'
-import { fill, LimitBet } from './bet'
+import { fill, isOpenLimitOrder, LimitBet } from './bet'
 import { Fees, getFeesSplit, getTakerFee, noFees } from './fees'
 import { LiquidityProvision } from './liquidity-provision'
 import { binarySearch } from './util/algos'
@@ -229,9 +229,11 @@ export const computeFills = (
     : limit
 
   const sortedBets = sortBy(
+    // Callers are meant to hand us only open orders, but a client's cached
+    // order book can lag behind a cancel or a fill. Never quote a price
+    // against an order that isn't there any more.
     unfilledBets.filter(
-      (bet) =>
-        bet.outcome !== outcome && (bet.expiresAt ? bet.expiresAt > now : true)
+      (bet) => bet.outcome !== outcome && isOpenLimitOrder(bet, now)
     ),
     (bet) => (outcome === 'YES' ? bet.limitProb : -bet.limitProb),
     (bet) => bet.createdTime

--- a/common/src/util/api.ts
+++ b/common/src/util/api.ts
@@ -1,3 +1,4 @@
+import { isUncachedQuoteRead } from 'common/api/cache'
 import { API, APIParams, APIPath, APIResponse } from 'common/api/schema'
 import { APIError, ErrorCode, getApiUrl } from 'common/api/utils'
 import { forEach } from 'lodash'
@@ -19,7 +20,8 @@ export function unauthedApi<P extends APIPath>(path: P, params: APIParams<P>) {
     formatApiUrlWithParams(path, params),
     API[path].method,
     params,
-    null
+    null,
+    isUncachedQuoteRead(path, params) ? { cache: 'no-store' } : undefined
   ) as Promise<APIResponse<P>>
 }
 

--- a/common/src/util/live-snapshot.test.ts
+++ b/common/src/util/live-snapshot.test.ts
@@ -1,0 +1,82 @@
+import { createLiveSnapshot } from './live-snapshot'
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason: Error) => void
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+type Order = { id: string; closed?: boolean; amount?: number }
+const book = () =>
+  createLiveSnapshot<Order>((orders) => orders.filter((o) => !o.closed))
+
+it('keeps cancellations received during a snapshot read', async () => {
+  const store = book()
+  const read = deferred<Order[]>()
+  const done = store.refresh(() => read.promise)
+  store.update([{ id: 'a', closed: true }])
+  read.resolve([{ id: 'a' }])
+  await done
+  expect(store.getSnapshot()).toEqual([])
+})
+
+it('updates the shared cache even with no mounted subscribers', async () => {
+  const store = book()
+  await store.refresh(async () => [{ id: 'a' }])
+  store.update([{ id: 'a', closed: true }])
+  // No TTL or separate stale copy can resurrect this order on a later mount.
+  expect(store.getSnapshot()).toEqual([])
+})
+
+it('ignores an older response that finishes after a newer refresh', async () => {
+  const store = book()
+  const old = deferred<Order[]>()
+  const done = store.refresh(() => old.promise)
+  await store.refresh(async () => [])
+  old.resolve([{ id: 'cancelled-offline' }])
+  await done
+  expect(store.getSnapshot()).toEqual([])
+})
+
+it('preserves new and partially filled orders received during a read', async () => {
+  const store = book()
+  const read = deferred<Order[]>()
+  const done = store.refresh(() => read.promise)
+  store.update([{ id: 'a', amount: 25 }, { id: 'b' }])
+  read.resolve([{ id: 'a', amount: 0 }])
+  await done
+  expect(store.getSnapshot()).toEqual([{ id: 'a', amount: 25 }, { id: 'b' }])
+})
+
+it('keeps the last snapshot on failure, ignores obsolete reads, and allows retry', async () => {
+  const store = book()
+  store.update([{ id: 'a' }])
+  const old = deferred<Order[]>()
+  const done = store.refresh(() => old.promise)
+  await expect(
+    store.refresh(async () => {
+      throw new Error('offline')
+    })
+  ).rejects.toThrow('offline')
+  old.resolve([{ id: 'obsolete' }])
+  await done
+  expect(store.getSnapshot()).toEqual([{ id: 'a' }])
+  await store.refresh(async () => [{ id: 'fresh' }])
+  expect(store.getSnapshot()).toEqual([{ id: 'fresh' }])
+})
+
+it('notifies all subscribers and stops after unsubscribe', () => {
+  const store = book()
+  const first = jest.fn(),
+    second = jest.fn()
+  const unsubscribe = store.subscribe(first)
+  store.subscribe(second)
+  store.update([{ id: 'a' }])
+  unsubscribe()
+  store.update([{ id: 'a', closed: true }])
+  expect(first).toHaveBeenCalledTimes(1)
+  expect(second).toHaveBeenCalledTimes(2)
+})

--- a/common/src/util/live-snapshot.ts
+++ b/common/src/util/live-snapshot.ts
@@ -1,0 +1,49 @@
+/** A shared snapshot with ordered refreshes and an overlay of live updates.
+ * Updates received during a read win over that read. Starting a newer read
+ * makes every older response obsolete, even if the newer read fails. */
+export function createLiveSnapshot<T extends { id: string }>(
+  normalize: (values: T[]) => T[] = (values) => values
+) {
+  let snapshot: T[] | undefined
+  let generation = 0
+  let updates: Map<string, T> | undefined
+  const listeners = new Set<() => void>()
+
+  const publish = (values: T[]) => {
+    snapshot = normalize(values)
+    // React can subscribe or unsubscribe while a listener runs.
+    for (const listener of Array.from(listeners)) listener()
+  }
+  const merge = (values: T[], changes: T[]) =>
+    Array.from(new Map([...values, ...changes].map((v) => [v.id, v])).values())
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    update: (changes: T[]) => {
+      for (const value of changes) updates?.set(value.id, value)
+      publish(merge(snapshot ?? [], changes))
+    },
+    // Used to remove orders when their expiry time is reached.
+    normalize: () => {
+      if (snapshot) publish(snapshot)
+    },
+    refresh: async (read: () => Promise<T[]>) => {
+      const current = ++generation
+      updates = new Map()
+      try {
+        const values = await read()
+        if (generation === current) {
+          publish(merge(values, Array.from(updates?.values() ?? [])))
+        }
+      } finally {
+        if (generation === current) updates = undefined
+      }
+    },
+  }
+}

--- a/web/components/bet/order-book.tsx
+++ b/web/components/bet/order-book.tsx
@@ -19,6 +19,7 @@ import { getFormattedMappedValue } from 'common/pseudo-numeric'
 import { formatPercent } from 'common/util/format'
 import { groupBy, keyBy, sortBy, sumBy, uniq } from 'lodash'
 import { useState } from 'react'
+import toast from 'react-hot-toast'
 import { useUser } from 'web/hooks/use-user'
 import { useDisplayUserById, useUsers } from 'web/hooks/use-user-supabase'
 import { api } from 'web/lib/api/api'
@@ -149,11 +150,18 @@ export function OrderTable(props: {
       const results = await Promise.allSettled(
         limitBets
           .filter((b) => !b.isCancelled)
-          .map((bet) => api('bet/cancel/:betId', { betId: bet.id }))
+          .map(async (bet) => {
+            const cancelled = await api('bet/cancel/:betId', { betId: bet.id })
+            applyLimitOrderUpdates([cancelled])
+          })
       )
-      applyLimitOrderUpdates(
-        results.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : []))
-      )
+      const failures = results.filter((r) => r.status === 'rejected').length
+      if (failures)
+        toast.error(
+          `Could not cancel ${failures} order${
+            failures === 1 ? '' : 's'
+          }. Please retry.`
+        )
     } finally {
       setIsCancelling(false)
     }
@@ -302,6 +310,9 @@ function OrderRow(props: {
       applyLimitOrderUpdates([
         await api('bet/cancel/:betId', { betId: bet.id }),
       ])
+    } catch (e) {
+      console.error('Failed to cancel order', e)
+      toast.error('Could not cancel this order. Please retry.')
     } finally {
       setIsCancelling(false)
     }

--- a/web/components/bet/order-book.tsx
+++ b/web/components/bet/order-book.tsx
@@ -1,4 +1,5 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/outline'
+import { applyLimitOrderUpdates } from 'client-common/hooks/use-bets'
 import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
 import { getCountdownString } from 'client-common/lib/time'
 import clsx from 'clsx'
@@ -144,12 +145,18 @@ export function OrderTable(props: {
   const [isCancelling, setIsCancelling] = useState(false)
   const onCancel = async () => {
     setIsCancelling(true)
-    await Promise.all(
-      limitBets
-        .filter((b) => !b.isCancelled)
-        .map((bet) => api('bet/cancel/:betId', { betId: bet.id }))
-    )
-    setIsCancelling(false)
+    try {
+      const results = await Promise.allSettled(
+        limitBets
+          .filter((b) => !b.isCancelled)
+          .map((bet) => api('bet/cancel/:betId', { betId: bet.id }))
+      )
+      applyLimitOrderUpdates(
+        results.flatMap((r) => (r.status === 'fulfilled' ? [r.value] : []))
+      )
+    } finally {
+      setIsCancelling(false)
+    }
   }
 
   // If showAnswers is true and we have answers, group bets by answerId
@@ -288,8 +295,16 @@ function OrderRow(props: {
 
   const onCancel = async () => {
     setIsCancelling(true)
-    await api('bet/cancel/:betId', { betId: bet.id })
-    setIsCancelling(false)
+    try {
+      // Drop the order from the shared order book right away so the bet and
+      // sell panels stop pricing against it, rather than waiting on the
+      // websocket to tell us what we already know.
+      applyLimitOrderUpdates([
+        await api('bet/cancel/:betId', { betId: bet.id }),
+      ])
+    } finally {
+      setIsCancelling(false)
+    }
   }
   const isCashContract = contract.token === 'CASH'
   const expired = bet.expiresAt && bet.expiresAt < Date.now()


### PR DESCRIPTION
Cancelling a limit order must remove it from every quote, including a panel opened after the cancellation and a request that was already in flight.

The matching guard rejects cancelled, filled, and expired counterparties. Server order queries already filter the closed flags; the guard also protects stale client inputs.

The client now has one observable order-book snapshot per contract. Confirmed mutations update that snapshot even without mounted consumers. Refreshes discard superseded responses and preserve live updates received during the read. This replaces the closed-order TTL map and the separate copies in the persistent-state hook. Mutable snapshots are not shared between SSR requests. An expiry timer also removes orders from idle panels.

Open-order reads bypass browser and HTTP response caches. Cancel-all applies each successful response immediately and reports partial failures; a single failed cancel also reports an error. Updates happen after API confirmation.

The branch includes current main and preserves the original PR commit. The later PRs remain based on this branch.

Validation of the completed stack: full web typecheck passes; common/shared TypeScript builds pass; all 1,186 common tests and 20 React hook/rendering tests pass. New code passes lint. Existing lint findings are identical to current main. The API typecheck still reports two implicit-any errors in unchanged files (`helpers/on-create-market.ts:133` and `stripe-endpoints.ts:330`). No production trade or live outage was exercised.