### PR TITLE
Reconcile quote inputs after acknowledged websocket recovery

### DIFF
--- a/client-common/src/hooks/use-api-subscription.ts
+++ b/client-common/src/hooks/use-api-subscription.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useEvent } from './use-event'
 import { getWebsocketUrl } from 'common/api/utils'
 import { ServerMessage } from 'common/api/websockets'
 import { APIRealtimeClient } from 'common/api/websocket-client'
@@ -13,25 +14,33 @@ export type SubscriptionOptions = {
   onBroadcast: (msg: ServerMessage<'broadcast'>) => void
   onError?: (err: Error) => void
   enabled?: boolean
+  onSubscribed?: () => void
 }
 
 export function useApiSubscription(opts: SubscriptionOptions) {
+  const onBroadcast = useEvent(opts.onBroadcast)
+  const onSubscribed = useEvent(() => opts.onSubscribed?.())
   useEffect(() => {
     const ws = client
     if (ws != null && (opts.enabled ?? true)) {
-      ws.subscribe(opts.topics, opts.onBroadcast).catch(opts.onError)
+      let active = true
+      ws.subscribe(opts.topics, onBroadcast)
+        .then(() => {
+          if (active && ws.state === WebSocket.OPEN) onSubscribed()
+        })
+        .catch(opts.onError ?? console.error)
       return () => {
-        ws.unsubscribe(opts.topics, opts.onBroadcast).catch(opts.onError)
+        active = false
+        ws.unsubscribe(opts.topics, onBroadcast).catch(
+          opts.onError ?? console.error
+        )
       }
     }
   }, [opts.enabled, JSON.stringify(opts.topics)])
 }
 
-/** Counts how many times the websocket has come back after dropping. Add it to
- * a fetch effect's dependencies to reconcile after an outage: we resubscribe on
- * reconnect but the broadcasts sent while we were away are gone for good, so
- * cached server state is silently stale until something refetches it. Costs one
- * request per reconnect, not per message. */
+/** Connection generation, incremented after subscriptions are acknowledged.
+ * Includes the first successful connection, which can follow a stale HTTP read. */
 export function useWebsocketReconnectCount() {
   const [count, setCount] = useState(client?.reconnectCount ?? 0)
 

--- a/client-common/src/hooks/use-api-subscription.ts
+++ b/client-common/src/hooks/use-api-subscription.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { getWebsocketUrl } from 'common/api/utils'
 import { ServerMessage } from 'common/api/websockets'
 import { APIRealtimeClient } from 'common/api/websocket-client'
@@ -25,4 +25,22 @@ export function useApiSubscription(opts: SubscriptionOptions) {
       }
     }
   }, [opts.enabled, JSON.stringify(opts.topics)])
+}
+
+/** Counts how many times the websocket has come back after dropping. Add it to
+ * a fetch effect's dependencies to reconcile after an outage: we resubscribe on
+ * reconnect but the broadcasts sent while we were away are gone for good, so
+ * cached server state is silently stale until something refetches it. Costs one
+ * request per reconnect, not per message. */
+export function useWebsocketReconnectCount() {
+  const [count, setCount] = useState(client?.reconnectCount ?? 0)
+
+  useEffect(() => {
+    if (client == null) return
+    // A reconnect can happen between render and this effect running.
+    setCount(client.reconnectCount)
+    return client.onReconnect(setCount)
+  }, [])
+
+  return count
 }

--- a/client-common/src/hooks/use-batched-getter.ts
+++ b/client-common/src/hooks/use-batched-getter.ts
@@ -1,5 +1,6 @@
 import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-in-memory-state'
-import { useEffect } from 'react'
+import { SetStateAction, useEffect, useRef } from 'react'
+import { useEvent } from './use-event'
 import { Contract } from 'common/contract'
 import { Reaction } from 'common/reaction'
 import { DisplayUser } from 'common/api/user-types'
@@ -11,7 +12,10 @@ export const pendingRequests: {
   userId?: string
 }[] = []
 
-export const pendingCallbacks: Map<string, ((data: any) => void)[]> = new Map()
+export const pendingCallbacks: Map<
+  string,
+  ((data: any, error?: unknown) => void)[]
+> = new Map()
 
 type FilterCallback<T> = (data: T[], id: string) => T | undefined
 
@@ -22,6 +26,13 @@ export const executeBatchQuery = debounce(async (handlers: QueryHandlers) => {
   const batchPromises = requestsToProcess.map(
     async ({ queryType, ids, userId }) => {
       if (!ids.size) return
+      const callbacksById = new Map(
+        Array.from(ids, (id) => {
+          const callbacks = pendingCallbacks.get(key(queryType, id)) ?? []
+          pendingCallbacks.delete(key(queryType, id))
+          return [id, callbacks] as const
+        })
+      )
 
       try {
         const handler = handlers[queryType as keyof QueryHandlers]
@@ -33,12 +44,14 @@ export const executeBatchQuery = debounce(async (handlers: QueryHandlers) => {
         const data = await handler({ ids, userId })
 
         ids.forEach((id) => {
-          const callbacks = pendingCallbacks.get(key(queryType, id)) || []
-          pendingCallbacks.delete(key(queryType, id))
+          const callbacks = callbacksById.get(id) ?? []
           const filteredData = filtersByQueryType[queryType](data, id)
           callbacks.forEach((callback) => callback(filteredData))
         })
       } catch (error) {
+        for (const callbacks of callbacksById.values()) {
+          callbacks.forEach((callback) => callback(undefined, error))
+        }
         console.error(`Error fetching batch data for ${queryType}:`, error)
       }
     }
@@ -91,15 +104,38 @@ export const useBatchedGetter = <T>(
   id: string,
   initialValue: T,
   enabled = true,
-  userId?: string
+  userId?: string,
+  refreshKey = 0
 ) => {
   const key = `${queryType}-${id}`
-  const [state, setState] = usePersistentInMemoryState<T>(initialValue, key)
+  const [state, saveState] = usePersistentInMemoryState<T>(initialValue, key)
+  const liveUpdates = useRef<SetStateAction<T>[] | undefined>(undefined)
+  const setState = useEvent((update: SetStateAction<T>) => {
+    liveUpdates.current?.push(update)
+    saveState(update)
+  })
 
   const MAX_BATCH_SIZE = 38
 
   useEffect(() => {
     if (!enabled) return
+    let active = true
+    const updates: SetStateAction<T>[] = []
+    liveUpdates.current = updates
+    const receive = (value: T, error?: unknown) => {
+      if (!active) return
+      liveUpdates.current = undefined
+      if (error) return
+      saveState(
+        updates.reduce<T>(
+          (current, update) =>
+            typeof update === 'function'
+              ? (update as (prev: T) => T)(current)
+              : update,
+          value
+        )
+      )
+    }
 
     // Find the latest batch for this query type
     let currentBatch = pendingRequests.findLast(
@@ -121,14 +157,16 @@ export const useBatchedGetter = <T>(
     if (!pendingCallbacks.has(key)) {
       pendingCallbacks.set(key, [])
     }
-    pendingCallbacks.get(key)!.push(setState)
+    pendingCallbacks.get(key)!.push(receive)
 
     executeBatchQuery(handlers)
 
     return () => {
+      active = false
+      if (liveUpdates.current === updates) liveUpdates.current = undefined
       const callbacks = pendingCallbacks.get(key)
       if (callbacks) {
-        const index = callbacks.indexOf(setState)
+        const index = callbacks.indexOf(receive)
         if (index > -1) {
           callbacks.splice(index, 1)
         }
@@ -137,7 +175,7 @@ export const useBatchedGetter = <T>(
         }
       }
     }
-  }, [queryType, id, enabled, userId])
+  }, [queryType, id, enabled, userId, refreshKey])
 
   return [state, setState] as const
 }

--- a/client-common/src/hooks/use-bets.ts
+++ b/client-common/src/hooks/use-bets.ts
@@ -3,7 +3,10 @@ import { Bet, isOpenLimitOrder, LimitBet } from 'common/bet'
 import { User } from 'common/user'
 import { groupBy, sortBy, uniq, uniqBy } from 'lodash'
 import { Dispatch, SetStateAction, useEffect, useMemo } from 'react'
-import { useApiSubscription } from './use-api-subscription'
+import {
+  useApiSubscription,
+  useWebsocketReconnectCount,
+} from './use-api-subscription'
 import { useEffectCheckEquality } from './use-effect-check-equality'
 import { useEvent } from './use-event'
 import { usePersistentInMemoryState } from './use-persistent-in-memory-state'
@@ -236,6 +239,9 @@ export const useUnfilledBets = (
   })
 
   const isPageVisible = useIsPageVisible()
+  // Resubscribing after an outage doesn't replay the order updates we missed
+  // while the socket was down, so reconcile whenever it comes back.
+  const reconnectCount = useWebsocketReconnectCount()
 
   useEffect(() => {
     if (enabled)
@@ -243,7 +249,7 @@ export const useUnfilledBets = (
         // Reset bets instead of adding to existing, since we want to exclude those recently filled/cancelled.
         setBets(openOrdersOnly(bets as LimitBet[]))
       )
-  }, [enabled, contractId, isPageVisible])
+  }, [enabled, contractId, isPageVisible, reconnectCount])
 
   // Local updates (e.g. you cancelling one of your own orders) reach every
   // other panel on the page through here rather than over the network.

--- a/client-common/src/hooks/use-bets.ts
+++ b/client-common/src/hooks/use-bets.ts
@@ -10,7 +10,10 @@ import {
   useMemo,
   useSyncExternalStore,
 } from 'react'
-import { useApiSubscription } from './use-api-subscription'
+import {
+  useApiSubscription,
+  useWebsocketReconnectCount,
+} from './use-api-subscription'
 import { useEffectCheckEquality } from './use-effect-check-equality'
 import { useEvent } from './use-event'
 import { usePersistentInMemoryState } from './use-persistent-in-memory-state'
@@ -222,8 +225,9 @@ export const useUnfilledBets = (
     getServerSnapshot
   )
   const isPageVisible = useIsPageVisible()
+  const reconnectCount = useWebsocketReconnectCount()
 
-  useEffect(() => {
+  const refresh = useEvent(() => {
     if (!enabled || !isPageVisible) return
     book
       .refresh(
@@ -233,9 +237,11 @@ export const useUnfilledBets = (
           >
       )
       .catch((e) => console.error('Failed to load limit orders', e))
-  }, [enabled, book, contractId, isPageVisible])
+  })
+  useEffect(refresh, [enabled, book, contractId, isPageVisible, reconnectCount])
 
   useApiSubscription({
+    onSubscribed: refresh,
     enabled,
     topics: [`contract/${contractId}/orders`],
     onBroadcast: ({ data }) => book.update(data.bets as LimitBet[]),

--- a/client-common/src/hooks/use-contract-updates.ts
+++ b/client-common/src/hooks/use-contract-updates.ts
@@ -5,9 +5,11 @@ import { Answer } from 'common/answer'
 import { uniqBy } from 'lodash'
 export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
   initial: C,
-  setContract: (value: SetStateAction<C>) => void
+  setContract: (value: SetStateAction<C>) => void,
+  onSubscribed?: () => void
 ) => {
   useApiSubscription({
+    onSubscribed,
     topics: [`contract/${initial.id}/new-answer`],
     enabled: 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
     onBroadcast: ({ data }) => {
@@ -27,6 +29,7 @@ export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
   })
 
   useApiSubscription({
+    onSubscribed,
     topics: [`contract/${initial.id}/updated-answers`],
     enabled: 'mechanism' in initial && initial.mechanism === 'cpmm-multi-1',
     onBroadcast: ({ data }) => {
@@ -69,6 +72,7 @@ export const useContractUpdates = <C extends Contract | Pick<Contract, 'id'>>(
   })
 
   useApiSubscription({
+    onSubscribed,
     topics: [`contract/${initial.id}`],
     onBroadcast: ({ data }) => {
       setContract((contract) => {

--- a/common/src/api/cache.test.ts
+++ b/common/src/api/cache.test.ts
@@ -4,4 +4,5 @@ it('bypasses caches for open orders without changing historical bets', () => {
   expect(isUncachedQuoteRead('bets', { kinds: 'open-limit' })).toBe(true)
   expect(isUncachedQuoteRead('bets', { contractId: 'market' })).toBe(false)
   expect(isUncachedQuoteRead('unrelated', { kinds: 'open-limit' })).toBe(false)
+  expect(isUncachedQuoteRead('markets-by-ids', { ids: ['market'] })).toBe(true)
 })

--- a/common/src/api/cache.ts
+++ b/common/src/api/cache.ts
@@ -3,4 +3,6 @@
 export const isUncachedQuoteRead = (
   path: string,
   params: Record<string, unknown>
-) => path === 'bets' && params.kinds === 'open-limit'
+) =>
+  (path === 'bets' && params.kinds === 'open-limit') ||
+  path === 'markets-by-ids'

--- a/common/src/api/websocket-client.test.ts
+++ b/common/src/api/websocket-client.test.ts
@@ -1,163 +1,174 @@
 import { APIRealtimeClient } from './websocket-client'
 
-// Minimal stand-in for the browser WebSocket, driven by hand so tests can open,
-// drop and reopen the connection deterministically.
 class FakeWebSocket {
   static readonly CONNECTING = 0
   static readonly OPEN = 1
   static readonly CLOSING = 2
   static readonly CLOSED = 3
   static instances: FakeWebSocket[] = []
-
   readyState = FakeWebSocket.CONNECTING
   sent: any[] = []
-  onopen: ((ev: any) => void) | null = null
+  onopen: ((ev: any) => unknown) | null = null
   onclose: ((ev: any) => void) | null = null
   onerror: ((ev: any) => void) | null = null
   onmessage: ((ev: any) => void) | null = null
   onSend?: (msg: any) => void
-
   constructor(public url: string) {
     FakeWebSocket.instances.push(this)
   }
-
   send(data: string) {
     const msg = JSON.parse(data)
     this.sent.push(msg)
     this.onSend?.(msg)
   }
-
-  close(_code?: number, _reason?: string) {
-    this.readyState = FakeWebSocket.CLOSED
+  close(code = 1000) {
+    this.dropped(code)
   }
-
-  // Test controls.
   opened() {
     this.readyState = FakeWebSocket.OPEN
-    this.onopen?.({})
+    return this.onopen?.({})
   }
-
   dropped(code = 1006) {
     this.readyState = FakeWebSocket.CLOSED
     this.onclose?.({ code, reason: '' })
   }
-
-  get subscribeTopics() {
-    return this.sent
-      .filter((m) => m.type === 'subscribe')
-      .flatMap((m) => m.topics as string[])
+  failed() {
+    this.onerror?.({})
+    this.dropped()
   }
 }
 
-describe('APIRealtimeClient reconnects', () => {
+describe('APIRealtimeClient recovery', () => {
   let client: APIRealtimeClient
-
-  const latestSocket = () =>
+  const latest = () =>
     FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
-
-  // The client waits for an ack on every message it sends; without one the
-  // txn times out and logs. Ack immediately so tests stay quiet.
-  const autoAck = (socket: FakeWebSocket) => {
-    socket.onSend = (msg) => {
-      if (msg.txid != null) {
-        client.receiveMessage({ type: 'ack', txid: msg.txid, success: true })
-      }
+  const ack = (msg: any) =>
+    client.receiveMessage({ type: 'ack', txid: msg.txid, success: true })
+  const connect = async () => {
+    latest().onSend = (msg) => {
+      Promise.resolve().then(() => ack(msg))
     }
+    await latest().opened()
   }
-
-  const connect = () => {
-    const socket = latestSocket()
-    autoAck(socket)
-    socket.opened()
-    return socket
+  const advance = async (ms: number) => {
+    jest.advanceTimersByTime(ms)
+    for (let i = 0; i < 8; i++) await Promise.resolve()
   }
-
   beforeEach(() => {
     jest.useFakeTimers()
+    jest.spyOn(Math, 'random').mockReturnValue(1)
+    jest.spyOn(console, 'error').mockImplementation(() => {})
     FakeWebSocket.instances = []
     ;(global as any).WebSocket = FakeWebSocket
     client = new APIRealtimeClient('ws://test')
   })
-
   afterEach(() => {
     client.close()
     jest.clearAllTimers()
     jest.useRealTimers()
+    jest.restoreAllMocks()
     delete (global as any).WebSocket
   })
-
-  it('does not count the first connection as a reconnect', () => {
+  it('reconciles the first successful connection and subsequent connections', async () => {
     const listener = jest.fn()
     client.onReconnect(listener)
-
-    connect()
-
-    expect(client.reconnectCount).toBe(0)
-    expect(listener).not.toHaveBeenCalled()
-  })
-
-  it('counts each time the socket comes back', () => {
-    const listener = jest.fn()
-    client.onReconnect(listener)
-    connect()
-
-    latestSocket().dropped()
-    jest.advanceTimersByTime(5000)
-    connect()
-
-    expect(client.reconnectCount).toBe(1)
-    expect(listener).toHaveBeenCalledWith(1)
-
-    latestSocket().dropped()
-    jest.advanceTimersByTime(5000)
-    connect()
-
-    expect(client.reconnectCount).toBe(2)
+    await connect()
+    expect(listener).toHaveBeenLastCalledWith(1)
+    latest().dropped()
+    await advance(5000)
+    await connect()
     expect(listener).toHaveBeenLastCalledWith(2)
   })
-
-  it('has already asked to resubscribe by the time listeners run', () => {
-    connect()
-    client.subscribe(['contract/abc/orders'], jest.fn())
-
-    let topicsWhenNotified: string[] = []
-    client.onReconnect(() => {
-      topicsWhenNotified = latestSocket().subscribeTopics
-    })
-
-    latestSocket().dropped()
-    jest.advanceTimersByTime(5000)
-    connect()
-
-    // Otherwise a refetch could snapshot the server before our topics are back
-    // on, and miss anything that changed in between.
-    expect(topicsWhenNotified).toContain('contract/abc/orders')
-  })
-
-  it('stops notifying once the listener unsubscribes', () => {
-    const listener = jest.fn()
-    const unsubscribe = client.onReconnect(listener)
-    connect()
-
-    unsubscribe()
-    latestSocket().dropped()
-    jest.advanceTimersByTime(5000)
-    connect()
-
-    expect(client.reconnectCount).toBe(1)
-    expect(listener).not.toHaveBeenCalled()
-  })
-
-  it('does not count a deliberate close as a reconnect', () => {
+  it('waits for subscription acknowledgment before notifying', async () => {
+    await client.subscribe(['contract/a/orders'], jest.fn())
     const listener = jest.fn()
     client.onReconnect(listener)
-    connect()
-
-    // 1000 is a normal on-purpose closure, so the client stays down.
-    latestSocket().dropped(1000)
-    jest.advanceTimersByTime(5000)
-
+    const opened = latest().opened()
+    expect(listener).not.toHaveBeenCalled()
+    ack(latest().sent[0])
+    await opened
+    expect(listener).toHaveBeenCalledWith(1)
+  })
+  it('recovers from initial failures and coalesces error then close', async () => {
+    latest().failed()
+    await advance(5000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    await connect()
+    expect(client.reconnectCount).toBe(1)
+  })
+  it('registers and unregisters every topic, preserving other consumers', async () => {
+    await connect()
+    const first = jest.fn(),
+      second = jest.fn()
+    await client.subscribe(['a', 'b', 'c'], first)
+    await client.subscribe(['b'], second)
+    expect(Array.from(client.subscriptions.keys())).toEqual(['a', 'b', 'c'])
+    await client.unsubscribe(['a', 'b', 'c'], first)
+    expect(Array.from(client.subscriptions.keys())).toEqual(['b'])
+    expect(client.subscriptions.get('b')).toEqual([second])
+    expect(latest().sent.at(-1).topics).toEqual(['a', 'c'])
+  })
+  it('makes concurrent consumers wait for the same pending subscription', async () => {
+    await connect()
+    latest().onSend = undefined
+    const first = client.subscribe(['a'], jest.fn())
+    const ready = jest.fn()
+    const second = client.subscribe(['a'], jest.fn()).then(ready)
+    await Promise.resolve()
+    expect(ready).not.toHaveBeenCalled()
+    ack(latest().sent.at(-1))
+    await Promise.all([first, second])
+    expect(ready).toHaveBeenCalledTimes(1)
+  })
+  it('does not announce readiness when the socket closes before acknowledgment', async () => {
+    await client.subscribe(['a'], jest.fn())
+    const opened = latest().opened()
+    latest().dropped()
+    await opened
+    expect(client.reconnectCount).toBe(0)
+    await advance(5000)
+    await connect()
+    expect(client.reconnectCount).toBe(1)
+  })
+  it('reconnects after heartbeat timeout with only one retry timer', async () => {
+    await connect()
+    latest().onSend = undefined
+    await advance(15_000)
+    expect(latest().readyState).toBe(FakeWebSocket.CLOSED)
+    await advance(5000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+  })
+  it('backs off repeated failures and caps the delay', async () => {
+    latest().failed()
+    await advance(5000)
+    latest().failed()
+    await advance(9999)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    await advance(1)
+    expect(FakeWebSocket.instances).toHaveLength(3)
+    latest().failed()
+    await advance(20_000)
+    latest().failed()
+    await advance(30_000)
+    expect(FakeWebSocket.instances).toHaveLength(5)
+  })
+  it('jitters retries and cancels them on deliberate close', async () => {
+    jest.mocked(Math.random).mockReturnValue(0)
+    latest().failed()
+    await advance(999)
     expect(FakeWebSocket.instances).toHaveLength(1)
+    await advance(1)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    latest().failed()
+    client.close()
+    await advance(60_000)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+  })
+  it('stops notifying an unsubscribed listener', async () => {
+    const listener = jest.fn()
+    const unsubscribe = client.onReconnect(listener)
+    unsubscribe()
+    await connect()
     expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/common/src/api/websocket-client.test.ts
+++ b/common/src/api/websocket-client.test.ts
@@ -1,0 +1,163 @@
+import { APIRealtimeClient } from './websocket-client'
+
+// Minimal stand-in for the browser WebSocket, driven by hand so tests can open,
+// drop and reopen the connection deterministically.
+class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+  static instances: FakeWebSocket[] = []
+
+  readyState = FakeWebSocket.CONNECTING
+  sent: any[] = []
+  onopen: ((ev: any) => void) | null = null
+  onclose: ((ev: any) => void) | null = null
+  onerror: ((ev: any) => void) | null = null
+  onmessage: ((ev: any) => void) | null = null
+  onSend?: (msg: any) => void
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string) {
+    const msg = JSON.parse(data)
+    this.sent.push(msg)
+    this.onSend?.(msg)
+  }
+
+  close(_code?: number, _reason?: string) {
+    this.readyState = FakeWebSocket.CLOSED
+  }
+
+  // Test controls.
+  opened() {
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.({})
+  }
+
+  dropped(code = 1006) {
+    this.readyState = FakeWebSocket.CLOSED
+    this.onclose?.({ code, reason: '' })
+  }
+
+  get subscribeTopics() {
+    return this.sent
+      .filter((m) => m.type === 'subscribe')
+      .flatMap((m) => m.topics as string[])
+  }
+}
+
+describe('APIRealtimeClient reconnects', () => {
+  let client: APIRealtimeClient
+
+  const latestSocket = () =>
+    FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+
+  // The client waits for an ack on every message it sends; without one the
+  // txn times out and logs. Ack immediately so tests stay quiet.
+  const autoAck = (socket: FakeWebSocket) => {
+    socket.onSend = (msg) => {
+      if (msg.txid != null) {
+        client.receiveMessage({ type: 'ack', txid: msg.txid, success: true })
+      }
+    }
+  }
+
+  const connect = () => {
+    const socket = latestSocket()
+    autoAck(socket)
+    socket.opened()
+    return socket
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    FakeWebSocket.instances = []
+    ;(global as any).WebSocket = FakeWebSocket
+    client = new APIRealtimeClient('ws://test')
+  })
+
+  afterEach(() => {
+    client.close()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    delete (global as any).WebSocket
+  })
+
+  it('does not count the first connection as a reconnect', () => {
+    const listener = jest.fn()
+    client.onReconnect(listener)
+
+    connect()
+
+    expect(client.reconnectCount).toBe(0)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('counts each time the socket comes back', () => {
+    const listener = jest.fn()
+    client.onReconnect(listener)
+    connect()
+
+    latestSocket().dropped()
+    jest.advanceTimersByTime(5000)
+    connect()
+
+    expect(client.reconnectCount).toBe(1)
+    expect(listener).toHaveBeenCalledWith(1)
+
+    latestSocket().dropped()
+    jest.advanceTimersByTime(5000)
+    connect()
+
+    expect(client.reconnectCount).toBe(2)
+    expect(listener).toHaveBeenLastCalledWith(2)
+  })
+
+  it('has already asked to resubscribe by the time listeners run', () => {
+    connect()
+    client.subscribe(['contract/abc/orders'], jest.fn())
+
+    let topicsWhenNotified: string[] = []
+    client.onReconnect(() => {
+      topicsWhenNotified = latestSocket().subscribeTopics
+    })
+
+    latestSocket().dropped()
+    jest.advanceTimersByTime(5000)
+    connect()
+
+    // Otherwise a refetch could snapshot the server before our topics are back
+    // on, and miss anything that changed in between.
+    expect(topicsWhenNotified).toContain('contract/abc/orders')
+  })
+
+  it('stops notifying once the listener unsubscribes', () => {
+    const listener = jest.fn()
+    const unsubscribe = client.onReconnect(listener)
+    connect()
+
+    unsubscribe()
+    latestSocket().dropped()
+    jest.advanceTimersByTime(5000)
+    connect()
+
+    expect(client.reconnectCount).toBe(1)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('does not count a deliberate close as a reconnect', () => {
+    const listener = jest.fn()
+    client.onReconnect(listener)
+    connect()
+
+    // 1000 is a normal on-purpose closure, so the client stays down.
+    latestSocket().dropped(1000)
+    jest.advanceTimersByTime(5000)
+
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/common/src/api/websocket-client.ts
+++ b/common/src/api/websocket-client.ts
@@ -153,9 +153,8 @@ export class APIRealtimeClient {
       }
       clearInterval(this.heartbeat)
 
-      // mqp: we might need to change how the txn stuff works if we ever want to
-      // implement "wait until i am subscribed, and then do something" in a component.
-      // right now it cannot be reliably used to detect that in the presence of reconnects
+      // Acknowledgments belong to this connection. Recovery establishes new
+      // subscriptions before announcing the next connection generation.
       for (const txn of Array.from(this.txns.values())) {
         clearTimeout(txn.timeout)
         txn.reject(new Error('Websocket was closed.'))
@@ -241,13 +240,13 @@ export class APIRealtimeClient {
         this.txns.set(txid, { resolve, reject, timeout })
         this.ws.send(JSON.stringify({ type, txid, ...data }))
       }).catch((error) => {
-        // If this is a heartbeat message that failed, trigger reconnection
+        // A failed ping or subscription leaves this connection unusable.
         if (
           (type === 'ping' || type === 'subscribe') &&
           this.ws === socket &&
           !this.stopped
         ) {
-          console.error('Heartbeat failed, attempting to reconnect:', error)
+          console.error('Websocket request failed, attempting to reconnect:', error)
           socket.close()
           this.waitAndReconnect()
         }

--- a/common/src/api/websocket-client.ts
+++ b/common/src/api/websocket-client.ts
@@ -55,11 +55,13 @@ export class APIRealtimeClient {
   subscriptions: Map<string, BroadcastHandler[]>
   connectTimeout?: NodeJS.Timeout
   heartbeat?: NodeJS.Timeout
-  /** Incremented each time the socket comes back after dropping. Resubscribing
+  /** Incremented after each successful connection and resubscription. Resubscribing
    * doesn't backfill the broadcasts sent while we were away, so anything
    * caching server state should watch this and refetch. */
   reconnectCount: number
-  private hasConnected: boolean
+  private stopped = false
+  private reconnectAttempt = 0
+  private subscriptionRequests = new Map<string, Promise<void>>()
   private reconnectListeners: Set<(count: number) => void>
 
   constructor(url: string) {
@@ -68,7 +70,6 @@ export class APIRealtimeClient {
     this.txns = new Map()
     this.subscriptions = new Map()
     this.reconnectCount = 0
-    this.hasConnected = false
     this.reconnectListeners = new Set()
     this.connect()
   }
@@ -86,6 +87,7 @@ export class APIRealtimeClient {
   }
 
   close() {
+    this.stopped = true
     if (this.heartbeat) {
       clearInterval(this.heartbeat)
       this.heartbeat = undefined
@@ -97,45 +99,54 @@ export class APIRealtimeClient {
   connect() {
     // you may wish to refer to https://websockets.spec.whatwg.org/
     // in order to check the semantics of events etc.
-    this.ws = new WebSocket(this.url)
+    const socket = new WebSocket(this.url)
+    this.ws = socket
     this.ws.onmessage = (ev) => {
       this.receiveMessage(JSON.parse(ev.data))
     }
     this.ws.onerror = (ev) => {
       console.error('API websocket error: ', ev)
-      // this can fire without an onclose if this is the first time we ever try
-      // to connect, so we need to turn on our reconnect in that case
+      // Browser errors are followed by close. The timer guard coalesces both.
       this.waitAndReconnect()
     }
-    this.ws.onopen = (_ev) => {
-      if (VERBOSE_LOGGING) {
-        console.info('API websocket opened.')
-      }
-      if (this.heartbeat) {
-        clearInterval(this.heartbeat)
-      }
+    this.ws.onopen = async () => {
+      clearTimeout(this.connectTimeout)
+      this.connectTimeout = undefined
+      clearInterval(this.heartbeat)
       this.heartbeat = setInterval(
-        async () => this.sendMessage('ping', {}).catch(console.error),
+        () => this.sendMessage('ping', {}).catch(console.error),
         HEARTBEAT_MS
       )
-      if (this.subscriptions.size > 0) {
-        this.sendMessage('subscribe', {
-          topics: Array.from(this.subscriptions.keys()),
-        }).catch(console.error)
-      }
-      // Only after the first connection: on the first one there is nothing to
-      // have missed, and subscribers have just fetched their initial state.
-      // Notify after asking to resubscribe so a refetch can't snapshot the
-      // server before our topics are back on.
-      if (this.hasConnected) {
+      try {
+        if (this.subscriptions.size > 0) {
+          const topics = Array.from(this.subscriptions.keys())
+          const request = this.sendMessage('subscribe', { topics })
+          for (const topic of topics)
+            this.subscriptionRequests.set(topic, request)
+          await request
+        }
+        if (
+          this.stopped ||
+          this.ws !== socket ||
+          socket.readyState !== WebSocket.OPEN
+        )
+          return
+        this.reconnectAttempt = 0
+        // Also reconcile the first successful connection: the initial HTTP
+        // read may have completed before this socket (or its retries) opened.
         this.reconnectCount++
-        for (const listener of Array.from(this.reconnectListeners)) {
+        for (const listener of Array.from(this.reconnectListeners))
           listener(this.reconnectCount)
+      } catch (error) {
+        console.error('Failed to restore websocket subscriptions', error)
+        if (!this.stopped && this.ws === socket) {
+          socket.close()
+          this.waitAndReconnect()
         }
       }
-      this.hasConnected = true
     }
     this.ws.onclose = (ev) => {
+      if (this.ws !== socket) return
       // note that if the connection closes due to an error, onerror fires and then this
       if (VERBOSE_LOGGING) {
         console.info(`API websocket closed with code=${ev.code}: ${ev.reason}`)
@@ -159,11 +170,16 @@ export class APIRealtimeClient {
   }
 
   waitAndReconnect() {
-    if (this.connectTimeout == null) {
+    if (!this.stopped && this.connectTimeout == null) {
+      const cap = Math.min(
+        30_000,
+        RECONNECT_WAIT_MS * 2 ** Math.min(this.reconnectAttempt++, 3)
+      )
+      const delay = 1000 + Math.random() * (cap - 1000)
       this.connectTimeout = setTimeout(() => {
         this.connectTimeout = undefined
         this.connect()
-      }, RECONNECT_WAIT_MS)
+      }, delay)
     }
   }
 
@@ -214,6 +230,7 @@ export class APIRealtimeClient {
     if (VERBOSE_LOGGING) {
       console.info(`> Outgoing API websocket ${type} message: `, data)
     }
+    const socket = this.ws
     if (this.state === WebSocket.OPEN) {
       return new Promise<void>((resolve, reject) => {
         const txid = this.txid++
@@ -225,9 +242,13 @@ export class APIRealtimeClient {
         this.ws.send(JSON.stringify({ type, txid, ...data }))
       }).catch((error) => {
         // If this is a heartbeat message that failed, trigger reconnection
-        if (type === 'ping') {
+        if (
+          (type === 'ping' || type === 'subscribe') &&
+          this.ws === socket &&
+          !this.stopped
+        ) {
           console.error('Heartbeat failed, attempting to reconnect:', error)
-          this.ws.close()
+          socket.close()
           this.waitAndReconnect()
         }
         throw error // Re-throw the error for other message types
@@ -244,31 +265,39 @@ export class APIRealtimeClient {
   }
 
   async subscribe(topics: string[], handler: BroadcastHandler) {
+    const added: string[] = []
     for (const topic of topics) {
-      let existingHandlers = this.subscriptions.get(topic)
-      if (existingHandlers == null) {
-        this.subscriptions.set(topic, (existingHandlers = [handler]))
-        return await this.sendMessage('subscribe', { topics: [topic] })
-      } else {
-        existingHandlers.push(handler)
+      const existing = this.subscriptions.get(topic)
+      if (existing) existing.push(handler)
+      else {
+        this.subscriptions.set(topic, [handler])
+        added.push(topic)
       }
     }
+    if (added.length) {
+      const request = this.sendMessage('subscribe', { topics: added })
+      for (const topic of added) this.subscriptionRequests.set(topic, request)
+    }
+    // A second consumer of a topic must also wait for its pending subscribe.
+    await Promise.all(
+      topics.map((topic) => this.subscriptionRequests.get(topic))
+    )
   }
 
   async unsubscribe(topics: string[], handler: BroadcastHandler) {
+    const removed: string[] = []
     for (const topic of topics) {
-      const existingHandlers = this.subscriptions.get(topic)
-      if (existingHandlers == null) {
-        console.error(`Subscription mapping busted -- ${topic} handlers null.`)
-      } else {
-        const remainingHandlers = existingHandlers.filter((h) => h != handler)
-        if (remainingHandlers.length > 0) {
-          this.subscriptions.set(topic, remainingHandlers)
-        } else {
-          this.subscriptions.delete(topic)
-          return await this.sendMessage('unsubscribe', { topics: [topic] })
-        }
+      const remaining = (this.subscriptions.get(topic) ?? []).filter(
+        (h) => h !== handler
+      )
+      if (remaining.length) this.subscriptions.set(topic, remaining)
+      else {
+        this.subscriptions.delete(topic)
+        this.subscriptionRequests.delete(topic)
+        removed.push(topic)
       }
     }
+    if (removed.length)
+      await this.sendMessage('unsubscribe', { topics: removed })
   }
 }

--- a/common/src/api/websocket-client.ts
+++ b/common/src/api/websocket-client.ts
@@ -55,13 +55,30 @@ export class APIRealtimeClient {
   subscriptions: Map<string, BroadcastHandler[]>
   connectTimeout?: NodeJS.Timeout
   heartbeat?: NodeJS.Timeout
+  /** Incremented each time the socket comes back after dropping. Resubscribing
+   * doesn't backfill the broadcasts sent while we were away, so anything
+   * caching server state should watch this and refetch. */
+  reconnectCount: number
+  private hasConnected: boolean
+  private reconnectListeners: Set<(count: number) => void>
 
   constructor(url: string) {
     this.url = url
     this.txid = 0
     this.txns = new Map()
     this.subscriptions = new Map()
+    this.reconnectCount = 0
+    this.hasConnected = false
+    this.reconnectListeners = new Set()
     this.connect()
+  }
+
+  /** Returns an unsubscribe function. */
+  onReconnect(listener: (count: number) => void) {
+    this.reconnectListeners.add(listener)
+    return () => {
+      this.reconnectListeners.delete(listener)
+    }
   }
 
   get state() {
@@ -106,6 +123,17 @@ export class APIRealtimeClient {
           topics: Array.from(this.subscriptions.keys()),
         }).catch(console.error)
       }
+      // Only after the first connection: on the first one there is nothing to
+      // have missed, and subscribers have just fetched their initial state.
+      // Notify after asking to resubscribe so a refetch can't snapshot the
+      // server before our topics are back on.
+      if (this.hasConnected) {
+        this.reconnectCount++
+        for (const listener of Array.from(this.reconnectListeners)) {
+          listener(this.reconnectCount)
+        }
+      }
+      this.hasConnected = true
     }
     this.ws.onclose = (ev) => {
       // note that if the connection closes due to an error, onerror fires and then this

--- a/web/hooks/use-batched-getter.test.tsx
+++ b/web/hooks/use-batched-getter.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { act, create, ReactTestRenderer } from 'react-test-renderer'
+import {
+  executeBatchQuery,
+  useBatchedGetter,
+} from 'client-common/hooks/use-batched-getter'
+
+const deferred = () => {
+  let resolve!: (values: any[]) => void
+  const promise = new Promise<any[]>((yes) => {
+    resolve = yes
+  })
+  return { promise, resolve }
+}
+let root: ReactTestRenderer
+let id = 0
+beforeEach(() => {
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+})
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  executeBatchQuery.cancel()
+})
+
+async function mount(read: () => Promise<any[]>) {
+  const market = `batch-${id++}`
+  let latest: any,
+    setValue: any,
+    refreshKey = 0
+  function Consumer() {
+    ;[latest, setValue] = useBatchedGetter(
+      { markets: read },
+      'markets',
+      market,
+      { id: market, pool: 0 },
+      true,
+      undefined,
+      refreshKey
+    )
+    return null
+  }
+  await act(async () => {
+    root = create(<Consumer />)
+  })
+  return {
+    market,
+    latest: () => latest,
+    setValue: async (value: any) => act(async () => setValue(value)),
+    refresh: async () => {
+      refreshKey++
+      await act(async () => root.update(<Consumer />))
+    },
+    dispatch: () => {
+      executeBatchQuery.flush()
+    },
+  }
+}
+
+it('does not deliver an old batch response to callbacks added during that read', async () => {
+  const old = deferred(),
+    fresh = deferred()
+  let calls = 0
+  const m = await mount(() => (++calls === 1 ? old.promise : fresh.promise))
+  m.dispatch()
+  await m.refresh()
+  m.dispatch()
+  await act(async () => fresh.resolve([{ id: m.market, pool: 2 }]))
+  await act(async () => old.resolve([{ id: m.market, pool: 1 }]))
+  expect(m.latest().pool).toBe(2)
+})
+
+it('replays live pool changes over the fetched market snapshot', async () => {
+  const read = deferred()
+  const m = await mount(() => read.promise)
+  m.dispatch()
+  await m.setValue((prev: any) => ({ ...prev, pool: 3 }))
+  await act(async () =>
+    read.resolve([{ id: m.market, pool: 1, title: 'Fresh title' }])
+  )
+  expect(m.latest()).toEqual({ id: m.market, pool: 3, title: 'Fresh title' })
+})
+
+it('keeps the last value on failure and can retry', async () => {
+  const log = jest.spyOn(console, 'error').mockImplementation(() => {})
+  let calls = 0
+  const m = await mount(async () => {
+    if (++calls === 1) throw new Error('offline')
+    return [{ id: m.market, pool: 9 }]
+  })
+  await act(async () => {
+    m.dispatch()
+  })
+  expect(m.latest().pool).toBe(0)
+  await m.refresh()
+  await act(async () => {
+    m.dispatch()
+  })
+  expect(m.latest().pool).toBe(9)
+  log.mockRestore()
+})

--- a/web/hooks/use-batched-getter.test.tsx
+++ b/web/hooks/use-batched-getter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { act, create, ReactTestRenderer } from 'react-test-renderer'
 import {
   executeBatchQuery,

--- a/web/hooks/use-contract.ts
+++ b/web/hooks/use-contract.ts
@@ -4,7 +4,10 @@ import { getContract, getContracts } from 'common/supabase/contracts'
 import { getPublicContractIdsInTopics } from 'web/lib/supabase/contracts'
 import { useEffectCheckEquality } from './use-effect-check-equality'
 import { difference, uniqBy } from 'lodash'
-import { useApiSubscription } from 'client-common/hooks/use-api-subscription'
+import {
+  useApiSubscription,
+  useWebsocketReconnectCount,
+} from 'client-common/hooks/use-api-subscription'
 import { useIsPageVisible } from './use-page-visible'
 import { api } from 'web/lib/api/api'
 import { db } from 'web/lib/supabase/db'
@@ -96,15 +99,21 @@ export function useLiveAllNewContracts(limit: number) {
 
 export function useLiveContract<C extends Contract = Contract>(initial: C): C {
   const isPageVisible = useIsPageVisible()
+  const reconnectCount = useWebsocketReconnectCount()
+  const [subscriptionCount, setSubscriptionCount] = useState(0)
   // ian: Batching is helpful on pages like /browse
   const [contract, setContract] = useBatchedGetter<C>(
     queryHandlers,
     'markets',
     initial.id,
     initial,
-    isPageVisible
+    isPageVisible,
+    undefined,
+    reconnectCount + subscriptionCount
   )
 
-  useContractUpdates(initial, setContract)
+  useContractUpdates(initial, setContract, () => {
+    if (isPageVisible) setSubscriptionCount((count) => count + 1)
+  })
   return contract ?? initial
 }

--- a/web/hooks/use-order-book.test.tsx
+++ b/web/hooks/use-order-book.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { act, create, ReactTestRenderer } from 'react-test-renderer'
 import { LimitBet } from 'common/bet'
 import {
@@ -11,7 +10,7 @@ let mockGeneration = 0
 const mockReconnectListeners = new Set<(count: number) => void>()
 const mockSubscriptions = new Set<any>()
 jest.mock('client-common/hooks/use-api-subscription', () => {
-  const React = require('react')
+  const React = jest.requireActual('react')
   return {
     useWebsocketReconnectCount: () => {
       const [count, setCount] = React.useState(mockGeneration)

--- a/web/hooks/use-order-book.test.tsx
+++ b/web/hooks/use-order-book.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react'
+import { act, create, ReactTestRenderer } from 'react-test-renderer'
+import { LimitBet } from 'common/bet'
+import {
+  useUnfilledBets,
+  applyLimitOrderUpdates,
+} from 'client-common/hooks/use-bets'
+
+let mockVisible = true
+let mockGeneration = 0
+const mockReconnectListeners = new Set<(count: number) => void>()
+const mockSubscriptions = new Set<any>()
+jest.mock('client-common/hooks/use-api-subscription', () => {
+  const React = require('react')
+  return {
+    useWebsocketReconnectCount: () => {
+      const [count, setCount] = React.useState(mockGeneration)
+      React.useEffect(() => {
+        mockReconnectListeners.add(setCount)
+        return () => mockReconnectListeners.delete(setCount)
+      }, [])
+      return count
+    },
+    useApiSubscription: (options: any) => {
+      React.useEffect(() => {
+        if (options.enabled === false) return
+        mockSubscriptions.add(options)
+        return () => mockSubscriptions.delete(options)
+      }, [options.enabled, JSON.stringify(options.topics)])
+    },
+  }
+})
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((yes) => {
+    resolve = yes
+  })
+  return { promise, resolve }
+}
+const order = (contractId: string, id = 'a', fields: Partial<LimitBet> = {}) =>
+  ({
+    id,
+    contractId,
+    userId: 'maker',
+    createdTime: 1,
+    isFilled: false,
+    isCancelled: false,
+    ...fields,
+  } as LimitBet)
+let nextId = 0
+let root: ReactTestRenderer | undefined
+beforeEach(() => {
+  ;(globalThis as any).window = {}
+  ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+  mockVisible = true
+  mockGeneration = 0
+})
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  root = undefined
+  delete (globalThis as any).window
+})
+
+async function mount(
+  read: () => Promise<LimitBet[]>,
+  id = `market-${nextId++}`,
+  n = 1
+) {
+  const latest: (LimitBet[] | undefined)[] = []
+  let contractId = id
+  function Consumer({ i }: { i: number }) {
+    latest[i] = useUnfilledBets(contractId, read, () => mockVisible)
+    return null
+  }
+  const render = () => (
+    <>
+      {Array.from({ length: n }, (_, i) => (
+        <Consumer key={i} i={i} />
+      ))}
+    </>
+  )
+  await act(async () => {
+    root = create(render())
+  })
+  return {
+    id,
+    latest,
+    update: async (id = contractId) => {
+      contractId = id
+      await act(async () => root!.update(render()))
+    },
+    broadcast: async (bets: LimitBet[]) =>
+      act(async () => {
+        for (const sub of mockSubscriptions)
+          if (sub.topics.includes(`contract/${contractId}/orders`))
+            sub.onBroadcast({ data: { bets } })
+      }),
+    reconnect: async () =>
+      act(async () => {
+        mockGeneration++
+        for (const listener of mockReconnectListeners) listener(mockGeneration)
+      }),
+  }
+}
+
+it('shares a confirmed cancel across mounted consumers and later mounts', async () => {
+  const id = `market-${nextId++}`
+  const m = await mount(async () => [order(id)], id, 2)
+  await act(async () =>
+    applyLimitOrderUpdates([order(id, 'a', { isCancelled: true })])
+  )
+  expect(m.latest).toEqual([[], []])
+  await act(async () => root!.unmount())
+  root = undefined
+  const later = await mount(() => new Promise(() => {}), id)
+  expect(later.latest[0]).toEqual([])
+})
+
+it('keeps live additions and cancellations when the initial request finishes', async () => {
+  const read = deferred<LimitBet[]>()
+  const m = await mount(() => read.promise)
+  await m.broadcast([order(m.id, 'a', { isCancelled: true }), order(m.id, 'b')])
+  await act(async () => read.resolve([order(m.id)]))
+  expect(m.latest[0]?.map((b) => b.id)).toEqual(['b'])
+})
+
+it('ignores a request from before reconnect even if it finishes last', async () => {
+  const old = deferred<LimitBet[]>(),
+    fresh = deferred<LimitBet[]>()
+  let calls = 0
+  const m = await mount(() => (++calls === 1 ? old.promise : fresh.promise))
+  await m.reconnect()
+  await act(async () => fresh.resolve([]))
+  await act(async () => old.resolve([order(m.id)]))
+  expect(m.latest[0]).toEqual([])
+})
+
+it('starts a fresh request after refocus instead of reusing the pending pre-hide read', async () => {
+  const old = deferred<LimitBet[]>()
+  let calls = 0
+  const m = await mount(() =>
+    ++calls === 1 ? old.promise : Promise.resolve([])
+  )
+  mockVisible = false
+  await m.update()
+  expect(calls).toBe(1)
+  mockVisible = true
+  await m.update()
+  expect(calls).toBe(2)
+  await act(async () => old.resolve([order(m.id)]))
+  expect(m.latest[0]).toEqual([])
+})
+
+it('does not write a previous market response into a new market', async () => {
+  const old = deferred<LimitBet[]>()
+  let calls = 0
+  const m = await mount(() =>
+    ++calls === 1 ? old.promise : Promise.resolve([])
+  )
+  await m.update(`other-${nextId++}`)
+  await act(async () => old.resolve([order(m.id)]))
+  expect(m.latest[0]).toEqual([])
+})
+
+it('refreshes after the subscription acknowledgment', async () => {
+  let calls = 0
+  const m = await mount(async () => {
+    calls++
+    return []
+  })
+  await act(async () => {
+    for (const sub of mockSubscriptions)
+      if (sub.topics.includes(`contract/${m.id}/orders`)) sub.onSubscribed?.()
+  })
+  expect(calls).toBe(2)
+})
+
+it('expires an idle order without waiting for another render or event', async () => {
+  jest.useFakeTimers()
+  try {
+    const id = `market-${nextId++}`
+    const m = await mount(
+      async () => [order(id, 'a', { expiresAt: Date.now() + 1000 })],
+      id
+    )
+    expect(m.latest[0]).toHaveLength(1)
+    await act(async () => {
+      jest.advanceTimersByTime(1000)
+    })
+    expect(m.latest[0]).toEqual([])
+  } finally {
+    jest.useRealTimers()
+  }
+})

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+  rootDir: '..',
+  roots: ['<rootDir>/web', '<rootDir>/client-common', '<rootDir>/common'],
+  roots: ['<rootDir>/web', '<rootDir>/client-common', '<rootDir>/common'],
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/web/**/*.test.tsx'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+        diagnostics: false,
+        tsconfig: {
+          target: 'es2022',
+          module: 'commonjs',
+          jsx: 'react-jsx',
+          esModuleInterop: true,
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^common/(.*)$': '<rootDir>/common/src/$1',
+    '^client-common/(.*)$': '<rootDir>/client-common/src/$1',
+    '^web/(.*)$': '<rootDir>/web/$1',
+    '^react$': require.resolve('react'),
+  },
+}

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   rootDir: '..',
   roots: ['<rootDir>/web', '<rootDir>/client-common', '<rootDir>/common'],
-  roots: ['<rootDir>/web', '<rootDir>/client-common', '<rootDir>/common'],
   testEnvironment: 'node',
   testMatch: ['<rootDir>/web/**/*.test.tsx'],
   transform: {

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "test": "jest --config jest.config.js",
     "serve": "next dev",
     "ts-watch": "tsc --watch --noEmit --incremental --preserveWatchOutput --pretty 2>&1 | grep -v 'node_modules'",
     "dev": "concurrently -n NEXT,TS -c magenta,cyan \"yarn serve\" \"yarn ts-watch\"",
@@ -90,6 +91,7 @@
     "@types/react": "18.0.25",
     "@types/react-color": "3.0.11",
     "@types/react-dom": "18.0.9",
+    "@types/react-test-renderer": "19.0.0",
     "@types/string-similarity": "4.0.0",
     "autoprefixer": "10.2.6",
     "concurrently": "8.2.2",
@@ -101,6 +103,7 @@
     "postcss": "8.4.31",
     "prettier-plugin-sql": "0.14.0",
     "prettier-plugin-tailwindcss": "^0.2.1",
+    "react-test-renderer": "19.0.1",
     "tailwindcss": "3.3.3",
     "tsc-files": "1.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7731,6 +7731,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-19.0.0.tgz#4cdeace7561bf359ee167f51704f420c07d4bd8d"
+  integrity sha512-qDVnNybqFm2eZKJ4jD34EvRd6VHD67KjgnWaEMM0Id9L22EpWe3nOSVKHWL1XWRCxUWe3lhXwlEeCKD1BlJCQA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@18.0.25":
   version "18.0.25"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
@@ -16762,6 +16769,11 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-is@^19.0.1:
+  version "19.3.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.3.0.tgz#716028d67e9993d23a2d353c6d08a3c1ef2bbeb4"
+  integrity sha512-UpMYezM4v5/18F28aC66AEsjXIgE02kyEMH6yLdgLXu/UTfa1Ntwck/nNLrbqJsEXW7gPb0coNO9FQse9WTovA==
+
 react-masonry-css@1.0.16:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/react-masonry-css/-/react-masonry-css-1.0.16.tgz#72b28b4ae3484e250534700860597553a10f1a2c"
@@ -16793,6 +16805,14 @@ react-snowfall@2.2.0:
   integrity sha512-dRk7vEHq/ZUOG+JHk2k/hH3HmliOWGXr4rKRDeW4mjWuHeI1r5h0Lc1r2jnTtUS1im702d6tCmNGymlNTdhXYg==
   dependencies:
     react-fast-compare "^3.2.2"
+
+react-test-renderer@19.0.1:
+  version "19.0.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.0.1.tgz#833801bc1a828c4ea8eba427698a6db6ebfd4104"
+  integrity sha512-V+jkFF2latFw911oS+GpSrUlY/kN7d5opKAyEts8QckcCKsVWF/qHFKR0tuacepOOia0YLfc3VavIm5iIzpTEA==
+  dependencies:
+    react-is "^19.0.1"
+    scheduler "^0.25.0"
 
 react-twitter-embed@4.0.4:
   version "4.0.4"


### PR DESCRIPTION
**Stack 2 of 4**, based on #4067.

A socket resubscription does not replay missed updates. Quote inputs now refresh after acknowledged subscriptions, including the first successful connection and newly subscribed topics. Market pools and answers refresh too, through the existing batched getter.

The realtime client registers and unregisters every requested topic, waits for pending subscriptions shared by multiple consumers, and uses jittered exponential retry delays capped at 30 seconds. Tests cover delayed acknowledgments, initial failure, error followed by close, heartbeat timeout, multiple topics, concurrent subscribers, backoff, and deliberate shutdown.

The batched getter associates responses with the callbacks present at dispatch, ignores obsolete consumers, and replays intervening live updates over the fetched snapshot. Market snapshot reads bypass HTTP/browser caches.

Corrections to the original rationale:
- An initial HTTP read can precede even the first successful socket connection, so the first connection can require reconciliation.
- Sending a subscription is not proof the server has installed it; acknowledgment is required.
- Request volume is per active contract and consumer trigger, not necessarily one request per tab. #4069 collapses effect bursts, but neither PR guarantees a net reduction for every usage pattern.

This PR also adds a repeatable React hook test setup (`yarn workspace web test --runInBand`).

Validation of the completed stack: full web typecheck passes; common/shared TypeScript builds pass; all 1,186 common tests and 20 React hook/rendering tests pass. New code passes lint. Existing lint findings are identical to current main. The API typecheck still reports two implicit-any errors in unchanged files (`helpers/on-create-market.ts:133` and `stripe-endpoints.ts:330`). No production trade or live outage was exercised.