### PR TITLE
Share quote refresh bursts and revalidate maker balances

### DIFF
--- a/client-common/src/hooks/use-bets.ts
+++ b/client-common/src/hooks/use-bets.ts
@@ -10,6 +10,7 @@ import {
 import { useEffectCheckEquality } from './use-effect-check-equality'
 import { useEvent } from './use-event'
 import { usePersistentInMemoryState } from './use-persistent-in-memory-state'
+import { createRequestDeduper } from 'common/util/promise'
 
 export function useBetsOnce(
   api: (params: APIParams<'bets'>) => Promise<APIResponse<'bets'>>,
@@ -214,6 +215,24 @@ export const applyLimitOrderUpdates = (bets: LimitBet[]) => {
   }
 }
 
+// Every panel on a market page mounts its own useUnfilledBets, and they all
+// want the same request at the same moment — on load, on tab refocus, on
+// reconnect. One request between them rather than N identical ones.
+const dedupeUnfilledBetsFetch = createRequestDeduper<LimitBet[]>()
+
+const fetchUnfilledBets = (
+  contractId: string,
+  triggerKey: string,
+  api: (params: APIParams<'bets'>) => Promise<APIResponse<'bets'>>
+) =>
+  // The trigger is part of the key so a reconnect mid-request doesn't get
+  // handed the snapshot taken before the socket dropped.
+  dedupeUnfilledBetsFetch(`${contractId}|${triggerKey}`, () =>
+    api({ contractId, kinds: 'open-limit', order: 'asc' }).then(
+      (bets) => bets as LimitBet[]
+    )
+  )
+
 export const useUnfilledBets = (
   contractId: string,
   api: (params: APIParams<'bets'>) => Promise<APIResponse<'bets'>>,
@@ -244,11 +263,14 @@ export const useUnfilledBets = (
   const reconnectCount = useWebsocketReconnectCount()
 
   useEffect(() => {
-    if (enabled)
-      api({ contractId, kinds: 'open-limit', order: 'asc' }).then((bets) =>
-        // Reset bets instead of adding to existing, since we want to exclude those recently filled/cancelled.
-        setBets(openOrdersOnly(bets as LimitBet[]))
-      )
+    // Skip while the tab is hidden — we refetch on the way back. Matches
+    // useContractBets, and stops a backgrounded tab firing a request when it
+    // loses focus.
+    if (!enabled || !isPageVisible) return
+    fetchUnfilledBets(contractId, `${reconnectCount}`, api)
+      // Reset bets instead of adding to existing, since we want to exclude those recently filled/cancelled.
+      .then((bets) => setBets(openOrdersOnly(bets)))
+      .catch((e) => console.error('Failed to load limit orders', e))
   }, [enabled, contractId, isPageVisible, reconnectCount])
 
   // Local updates (e.g. you cancelling one of your own orders) reach every
@@ -289,50 +311,79 @@ export const useUnfilledBetsAndBalanceByUserId = (
   const unfilledBets =
     useUnfilledBets(contractId, api, useIsPageVisible, { enabled: true }) ?? []
   const userIds = uniq(unfilledBets.map((b) => b.userId))
-  const balances = useUserBalances(userIds, usersApi, useIsPageVisible) ?? []
-
-  const balanceByUserId = Object.fromEntries(
-    balances.map(({ id, balance }) => [id, balance])
+  const balanceByUserId = useUserBalances(
+    contractId,
+    userIds,
+    usersApi,
+    useIsPageVisible
   )
+
   return { unfilledBets, balanceByUserId }
 }
 
 const useUserBalances = (
+  cacheKey: string,
   userIds: string[],
   api: (
     params: APIParams<'users/by-id/balance'>
   ) => Promise<APIResponse<'users/by-id/balance'>>,
   useIsPageVisible: () => boolean
 ) => {
-  const [users, setUsers] = usePersistentInMemoryState<
-    { id: string; balance: number }[]
-  >([], `user-balances-${userIds.join('-')}`)
+  // Keyed by the contract rather than by the set of makers. Keying by the set
+  // minted a new cache entry every time anyone posted an order, and — because
+  // a changed key resets the state to its initial value — briefly emptied the
+  // balances. An unknown balance counts as unlimited in computeFills, so for
+  // the length of the refetch every maker looked fully funded.
+  const [balances, setBalances] = usePersistentInMemoryState<
+    Record<string, number>
+  >({}, `user-balances-${cacheKey}`)
   const isPageVisible = useIsPageVisible()
+  const reconnectCount = useWebsocketReconnectCount()
 
-  // Load initial data
+  const fetchBalances = useEvent(async (ids: string[]) => {
+    if (!ids.length) return
+    try {
+      const users = await api({ ids })
+      setBalances((prev) => ({
+        ...prev,
+        ...Object.fromEntries(users.map(({ id, balance }) => [id, balance])),
+      }))
+    } catch (e) {
+      console.error('Failed to load maker balances', e)
+    }
+  })
+
+  // Ask only for makers we haven't seen. The subscriptions below keep the ones
+  // we hold current, so a new order from a new account no longer refetches the
+  // balance of every other maker in the book.
+  const missingIds = userIds.filter((id) => balances[id] === undefined)
+  const missingKey = missingIds.join(',')
+
   useEffect(() => {
-    if (!userIds.length || !isPageVisible) return
-    api({ ids: userIds }).then((users) => {
-      setUsers(users)
-    })
-  }, [userIds.join(','), isPageVisible])
+    if (!isPageVisible) return
+    fetchBalances(missingIds)
+  }, [missingKey, isPageVisible])
 
-  // Subscribe to updates
+  // Balances can have moved while the socket was down, and those updates
+  // aren't replayed.
+  useEffect(() => {
+    if (!isPageVisible || !reconnectCount) return
+    fetchBalances(userIds)
+  }, [reconnectCount])
+
   useApiSubscription({
     topics: userIds.map((id) => `user/${id}`),
     onBroadcast: ({ data }) => {
       const { user } = data as { user: Partial<User> }
-      if (!user) return
-      const prevUser = users.find((u) => u.id === user.id)
-      if (!prevUser) return
-      setUsers((prevUsers) => {
-        return prevUsers.map((prevU) =>
-          prevU.id === user.id ? { ...prevU, ...user } : prevU
-        )
-      })
+      const { id, balance } = user ?? {}
+      if (id === undefined || balance === undefined) return
+      setBalances((prev) =>
+        // Only track balances we actually asked for.
+        prev[id] === undefined ? prev : { ...prev, [id]: balance }
+      )
     },
     enabled: userIds.length > 0 && isPageVisible,
   })
 
-  return users
+  return balances
 }

--- a/client-common/src/hooks/use-bets.ts
+++ b/client-common/src/hooks/use-bets.ts
@@ -1,6 +1,7 @@
 import { APIParams, APIResponse } from 'common/api/schema'
 import { Bet, isOpenLimitOrder, LimitBet } from 'common/bet'
 import { createLiveSnapshot } from 'common/util/live-snapshot'
+import { createRequestDeduper } from 'common/util/promise'
 import { User } from 'common/user'
 import { groupBy, sortBy, uniq, uniqBy } from 'lodash'
 import {
@@ -181,6 +182,7 @@ export const useSubscribeGlobalBets = (options?: APIParams<'bets'>) => {
 // Each contract has one observable snapshot. A confirmed cancel changes the
 // cache itself, including when no quote panel is mounted. Live updates are
 // retained only while a snapshot request is in flight; no tombstone TTL is needed.
+const dedupeRefresh = createRequestDeduper<void>('burst')
 const createOrderBook = () =>
   createLiveSnapshot<LimitBet>((bets) =>
     sortBy(
@@ -229,14 +231,14 @@ export const useUnfilledBets = (
 
   const refresh = useEvent(() => {
     if (!enabled || !isPageVisible) return
-    book
-      .refresh(
+    dedupeRefresh(`orders:${contractId}:${reconnectCount}`, () =>
+      book.refresh(
         () =>
           api({ contractId, kinds: 'open-limit', order: 'asc' }) as Promise<
             LimitBet[]
           >
       )
-      .catch((e) => console.error('Failed to load limit orders', e))
+    ).catch((e) => console.error('Failed to load limit orders', e))
   })
   useEffect(refresh, [enabled, book, contractId, isPageVisible, reconnectCount])
 
@@ -272,50 +274,77 @@ export const useUnfilledBetsAndBalanceByUserId = (
   const unfilledBets =
     useUnfilledBets(contractId, api, useIsPageVisible, { enabled: true }) ?? []
   const userIds = uniq(unfilledBets.map((b) => b.userId))
-  const balances = useUserBalances(userIds, usersApi, useIsPageVisible) ?? []
-
-  const balanceByUserId = Object.fromEntries(
-    balances.map(({ id, balance }) => [id, balance])
+  const balanceByUserId = useUserBalances(
+    contractId,
+    userIds,
+    usersApi,
+    useIsPageVisible
   )
   return { unfilledBets, balanceByUserId }
 }
 
+type MakerBalance = { id: string; balance: number }
+const balancesByContract = new Map<
+  string,
+  ReturnType<typeof createLiveSnapshot<MakerBalance>>
+>()
+const getBalances = (contractId: string) => {
+  if (typeof window === 'undefined') return createLiveSnapshot<MakerBalance>()
+  let store = balancesByContract.get(contractId)
+  if (!store) {
+    store = createLiveSnapshot<MakerBalance>()
+    balancesByContract.set(contractId, store)
+  }
+  return store
+}
+
 const useUserBalances = (
+  contractId: string,
   userIds: string[],
   api: (
     params: APIParams<'users/by-id/balance'>
   ) => Promise<APIResponse<'users/by-id/balance'>>,
   useIsPageVisible: () => boolean
 ) => {
-  const [users, setUsers] = usePersistentInMemoryState<
-    { id: string; balance: number }[]
-  >([], `user-balances-${userIds.join('-')}`)
+  const store = useMemo(() => getBalances(contractId), [contractId])
+  const users = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    getServerSnapshot
+  )
   const isPageVisible = useIsPageVisible()
-
-  // Load initial data
-  useEffect(() => {
-    if (!userIds.length || !isPageVisible) return
-    api({ ids: userIds }).then((users) => {
-      setUsers(users)
-    })
-  }, [userIds.join(','), isPageVisible])
-
-  // Subscribe to updates
-  useApiSubscription({
-    topics: userIds.map((id) => `user/${id}`),
-    onBroadcast: ({ data }) => {
-      const { user } = data as { user: Partial<User> }
-      if (!user) return
-      const prevUser = users.find((u) => u.id === user.id)
-      if (!prevUser) return
-      setUsers((prevUsers) => {
-        return prevUsers.map((prevU) =>
-          prevU.id === user.id ? { ...prevU, ...user } : prevU
-        )
+  const reconnectCount = useWebsocketReconnectCount()
+  const ids = [...userIds].sort()
+  const idsKey = ids.join(',')
+  const refresh = useEvent(() => {
+    if (!isPageVisible || !ids.length) return
+    dedupeRefresh(`balances:${contractId}:${idsKey}:${reconnectCount}`, () =>
+      store.refresh(async () => {
+        const users = await api({ ids })
+        const byId = new Map(users.map((user) => [user.id, user.balance]))
+        // Missing/deleted users cannot fund a fill. Retry them on the next
+        // mount, refocus, reconnect, or maker-set change, like every other id.
+        return ids.map((id) => ({ id, balance: byId.get(id) ?? 0 }))
       })
-    },
-    enabled: userIds.length > 0 && isPageVisible,
+    ).catch((e) => console.error('Failed to load maker balances', e))
   })
-
-  return users
+  // Preserve known balances while revalidating. "Known" does not mean fresh:
+  // subscriptions stop while hidden and when a maker leaves the book.
+  useEffect(refresh, [store, contractId, idsKey, isPageVisible, reconnectCount])
+  useApiSubscription({
+    topics: ids.map((id) => `user/${id}`),
+    enabled: ids.length > 0 && isPageVisible,
+    onSubscribed: refresh,
+    onBroadcast: ({ data }) => {
+      const { id, balance } = (data.user ?? {}) as Partial<User>
+      if (id !== undefined && balance !== undefined && ids.includes(id))
+        store.update([{ id, balance }])
+    },
+  })
+  return useMemo(() => {
+    const byId = new Map(users?.map((user) => [user.id, user.balance]))
+    // computeFills interprets undefined as unlimited. Until a maker's balance
+    // arrives, omit its liquidity from the quote rather than inventing funding.
+    return Object.fromEntries(userIds.map((id) => [id, byId.get(id) ?? 0]))
+  }, [users, idsKey])
 }

--- a/common/src/api/cache.test.ts
+++ b/common/src/api/cache.test.ts
@@ -5,4 +5,7 @@ it('bypasses caches for open orders without changing historical bets', () => {
   expect(isUncachedQuoteRead('bets', { contractId: 'market' })).toBe(false)
   expect(isUncachedQuoteRead('unrelated', { kinds: 'open-limit' })).toBe(false)
   expect(isUncachedQuoteRead('markets-by-ids', { ids: ['market'] })).toBe(true)
+  expect(isUncachedQuoteRead('users/by-id/balance', { ids: ['maker'] })).toBe(
+    true
+  )
 })

--- a/common/src/api/cache.ts
+++ b/common/src/api/cache.ts
@@ -5,4 +5,5 @@ export const isUncachedQuoteRead = (
   params: Record<string, unknown>
 ) =>
   (path === 'bets' && params.kinds === 'open-limit') ||
-  path === 'markets-by-ids'
+  path === 'markets-by-ids' ||
+  path === 'users/by-id/balance'

--- a/common/src/util/promise.test.ts
+++ b/common/src/util/promise.test.ts
@@ -1,6 +1,16 @@
 import { createRequestDeduper } from './promise'
 
 describe('createRequestDeduper', () => {
+  it('burst mode starts a new read after the current microtask even while the old read is pending', async () => {
+    const dedupe = createRequestDeduper<string>('burst')
+    const read = jest.fn(() => new Promise<string>(() => {}))
+    const first = dedupe('key', read)
+    expect(dedupe('key', read)).toBe(first)
+    await Promise.resolve()
+    expect(dedupe('key', read)).not.toBe(first)
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+
   const deferred = <T>() => {
     let resolve!: (value: T) => void
     let reject!: (err: unknown) => void

--- a/common/src/util/promise.test.ts
+++ b/common/src/util/promise.test.ts
@@ -1,0 +1,74 @@
+import { createRequestDeduper } from './promise'
+
+describe('createRequestDeduper', () => {
+  const deferred = <T>() => {
+    let resolve!: (value: T) => void
+    let reject!: (err: unknown) => void
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    return { promise, resolve, reject }
+  }
+
+  it('makes one request for callers arriving while it is in flight', async () => {
+    const dedupe = createRequestDeduper<string>()
+    const pending = deferred<string>()
+    const makeRequest = jest.fn(() => pending.promise)
+
+    const first = dedupe('key', makeRequest)
+    const second = dedupe('key', makeRequest)
+
+    expect(makeRequest).toHaveBeenCalledTimes(1)
+    expect(second).toBe(first)
+
+    pending.resolve('orders')
+    expect(await first).toBe('orders')
+    expect(await second).toBe('orders')
+  })
+
+  it('keeps different keys apart', () => {
+    const dedupe = createRequestDeduper<string>()
+    const makeRequest = jest.fn(() => deferred<string>().promise)
+
+    dedupe('contract-a', makeRequest)
+    dedupe('contract-b', makeRequest)
+
+    expect(makeRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('makes a fresh request once the previous one settles', async () => {
+    const dedupe = createRequestDeduper<string>()
+    const makeRequest = jest.fn(() => Promise.resolve('orders'))
+
+    await dedupe('key', makeRequest)
+    await dedupe('key', makeRequest)
+
+    // Otherwise this would be a cache, and a panel opening later would be
+    // handed a stale order book.
+    expect(makeRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not wedge the key after a failure', async () => {
+    const dedupe = createRequestDeduper<string>()
+    const failing = jest.fn(() => Promise.reject(new Error('nope')))
+
+    await expect(dedupe('key', failing)).rejects.toThrow('nope')
+
+    const succeeding = jest.fn(() => Promise.resolve('orders'))
+    expect(await dedupe('key', succeeding)).toBe('orders')
+  })
+
+  it('gives every waiter the failure', async () => {
+    const dedupe = createRequestDeduper<string>()
+    const pending = deferred<string>()
+    const makeRequest = jest.fn(() => pending.promise)
+
+    const first = dedupe('key', makeRequest)
+    const second = dedupe('key', makeRequest)
+    pending.reject(new Error('nope'))
+
+    await expect(first).rejects.toThrow('nope')
+    await expect(second).rejects.toThrow('nope')
+  })
+})

--- a/common/src/util/promise.ts
+++ b/common/src/util/promise.ts
@@ -80,7 +80,9 @@ export const mapAsync = <T, U>(
  * burst of callers wanting the same thing at the same moment makes one request
  * between them. The entry is dropped as soon as it settles: this dedupes, it
  * does not cache, so a caller arriving afterwards still gets fresh data. */
-export const createRequestDeduper = <T>() => {
+export const createRequestDeduper = <T>(
+  scope: 'in-flight' | 'burst' = 'in-flight'
+) => {
   const inFlight = new Map<string, Promise<T>>()
 
   return (key: string, makeRequest: () => Promise<T>) => {
@@ -92,7 +94,10 @@ export const createRequestDeduper = <T>() => {
     const clear = () => {
       if (inFlight.get(key) === request) inFlight.delete(key)
     }
-    request.then(clear, clear)
+    // Burst mode joins callers from the current batch of effects only. A later
+    // visibility/reconnect event must start a new read even if this one hangs.
+    if (scope === 'burst') queueMicrotask(clear)
+    else request.then(clear, clear)
     return request
   }
 }

--- a/common/src/util/promise.ts
+++ b/common/src/util/promise.ts
@@ -75,3 +75,24 @@ export const mapAsync = <T, U>(
     else doWork()
   })
 }
+
+/** Collapses concurrent requests for the same key onto a single promise, so a
+ * burst of callers wanting the same thing at the same moment makes one request
+ * between them. The entry is dropped as soon as it settles: this dedupes, it
+ * does not cache, so a caller arriving afterwards still gets fresh data. */
+export const createRequestDeduper = <T>() => {
+  const inFlight = new Map<string, Promise<T>>()
+
+  return (key: string, makeRequest: () => Promise<T>) => {
+    const existing = inFlight.get(key)
+    if (existing) return existing
+
+    const request = makeRequest()
+    inFlight.set(key, request)
+    const clear = () => {
+      if (inFlight.get(key) === request) inFlight.delete(key)
+    }
+    request.then(clear, clear)
+    return request
+  }
+}

--- a/web/hooks/use-order-book.test.tsx
+++ b/web/hooks/use-order-book.test.tsx
@@ -3,6 +3,7 @@ import { act, create, ReactTestRenderer } from 'react-test-renderer'
 import { LimitBet } from 'common/bet'
 import {
   useUnfilledBets,
+  useUnfilledBetsAndBalanceByUserId,
   applyLimitOrderUpdates,
 } from 'client-common/hooks/use-bets'
 
@@ -192,4 +193,137 @@ it('expires an idle order without waiting for another render or event', async ()
   } finally {
     jest.useRealTimers()
   }
+})
+
+async function mountBalances(
+  read: (params: {
+    ids: string[]
+  }) => Promise<{ id: string; balance: number }[]>,
+  n = 1,
+  id = `balances-${nextId++}`
+) {
+  const latest: ReturnType<typeof useUnfilledBetsAndBalanceByUserId>[] = []
+  const readOrders = jest.fn(async () => [order(id)])
+  function Consumer({ i }: { i: number }) {
+    latest[i] = useUnfilledBetsAndBalanceByUserId(
+      id,
+      readOrders,
+      read,
+      () => mockVisible
+    )
+    return null
+  }
+  const render = () => (
+    <>
+      {Array.from({ length: n }, (_, i) => (
+        <Consumer key={i} i={i} />
+      ))}
+    </>
+  )
+  await act(async () => {
+    root = create(render())
+  })
+  return {
+    id,
+    latest,
+    readOrders,
+    update: async () => act(async () => root!.update(render())),
+    broadcast: async (topic: string, data: any) =>
+      act(async () => {
+        for (const sub of mockSubscriptions)
+          if (sub.topics.includes(topic)) sub.onBroadcast({ data })
+      }),
+    reconnect: async () =>
+      act(async () => {
+        mockGeneration++
+        for (const listener of mockReconnectListeners) listener(mockGeneration)
+      }),
+  }
+}
+
+it('deduplicates mounted consumers without reusing an old request after refocus', async () => {
+  const read = jest.fn(async () => [{ id: 'maker', balance: 100 }])
+  const m = await mountBalances(read, 3)
+  expect(m.readOrders).toHaveBeenCalledTimes(1)
+  expect(read).toHaveBeenCalledTimes(1)
+  mockVisible = false
+  await m.update()
+  mockVisible = true
+  await m.update()
+  expect(m.readOrders).toHaveBeenCalledTimes(2)
+  expect(read).toHaveBeenCalledTimes(2)
+})
+
+it('refreshes known balances after hidden reconnects, refocus, and remount', async () => {
+  let balance = 100
+  const read = jest.fn(async () => [{ id: 'maker', balance }])
+  const m = await mountBalances(read)
+  mockVisible = false
+  await m.update()
+  balance = 0
+  await m.reconnect()
+  expect(read).toHaveBeenCalledTimes(1)
+  mockVisible = true
+  await m.update()
+  expect(m.latest[0].balanceByUserId.maker).toBe(0)
+  await act(async () => root!.unmount())
+  root = undefined
+  balance = 5
+  const later = await mountBalances(read, 1, m.id)
+  expect(later.latest[0].balanceByUserId.maker).toBe(5)
+})
+
+it('retains a known empty balance when an unseen maker appears', async () => {
+  const pending = deferred<{ id: string; balance: number }[]>()
+  let calls = 0
+  const m = await mountBalances(() =>
+    ++calls === 1
+      ? Promise.resolve([{ id: 'maker', balance: 0 }])
+      : pending.promise
+  )
+  await m.broadcast(`contract/${m.id}/orders`, {
+    bets: [order(m.id, 'b', { userId: 'new-maker' })],
+  })
+  expect(m.latest[0].balanceByUserId).toEqual({ maker: 0, 'new-maker': 0 })
+  await act(async () =>
+    pending.resolve([
+      { id: 'maker', balance: 0 },
+      { id: 'new-maker', balance: 20 },
+    ])
+  )
+  expect(m.latest[0].balanceByUserId).toEqual({ maker: 0, 'new-maker': 20 })
+})
+
+it('does not let an old balance response overwrite recovery or live updates', async () => {
+  const old = deferred<{ id: string; balance: number }[]>()
+  const fresh = deferred<{ id: string; balance: number }[]>()
+  let calls = 0
+  const m = await mountBalances(() =>
+    ++calls === 1 ? old.promise : fresh.promise
+  )
+  await m.reconnect()
+  await m.broadcast('user/maker', { user: { id: 'maker', balance: 0 } })
+  await act(async () => fresh.resolve([{ id: 'maker', balance: 50 }]))
+  await act(async () => old.resolve([{ id: 'maker', balance: 100 }]))
+  expect(m.latest[0].balanceByUserId.maker).toBe(0)
+})
+
+it('treats omitted makers as unfunded and accepts their later websocket updates', async () => {
+  const m = await mountBalances(async () => [])
+  expect(m.latest[0].balanceByUserId.maker).toBe(0)
+  await m.broadcast('user/maker', { user: { id: 'maker', balance: 25 } })
+  expect(m.latest[0].balanceByUserId.maker).toBe(25)
+})
+
+it('refreshes a returning maker after its subscription was removed', async () => {
+  let balance = 100
+  const read = jest.fn(async () => [{ id: 'maker', balance }])
+  const m = await mountBalances(read)
+  await m.broadcast(`contract/${m.id}/orders`, {
+    bets: [order(m.id, 'a', { isCancelled: true })],
+  })
+  balance = 0
+  await m.broadcast(`contract/${m.id}/orders`, { bets: [order(m.id, 'b')] })
+  expect(read).toHaveBeenCalledTimes(2)
+  expect(m.latest[0].balanceByUserId.maker).toBe(0)
 })


### PR DESCRIPTION
**Stack 3 of 4**, based on #4068.

Multiple consumers now share one order-book refresh and one identical maker-balance refresh within a burst of effects. Burst entries clear at the next microtask, so a later refocus or reconnect starts a new read even if the previous read is still pending. Reconnect generations also remain in the key.

Maker balances use a shared per-contract snapshot. Known balances remain visible while revalidating, but all current makers refresh on mount, refocus, reconnect, subscription acknowledgment, and maker-set changes. This fixes stale balances after hidden tabs, remounts, and returning makers. Refresh generations and live-update overlays prevent late reads from overwriting observed updates.

Unknown or omitted makers contribute zero funding until a balance arrives; `computeFills` would otherwise interpret an undefined balance as unlimited. Omitted makers retry on subsequent refresh triggers, and websocket updates are accepted for them. Successful snapshots retain the requested maker set rather than accumulating every historical maker. Balance reads bypass HTTP/browser caches.

Corrections to the original rationale:
- Having a cached balance does not mean it stayed current while its subscription was absent.
- Deduplicating fetches is not a guarantee of lower total traffic: recovery adds requests. A tested burst of three consumers uses one book request and one balance request, versus three of each without sharing. Initial acknowledgments and recovery can add further bursts.

Tests cover burst counts, refocus during a pending read, hidden reconnects, remounts, returning makers, missing makers, new maker loading, and stale balance responses.

Validation of the completed stack: full web typecheck passes; common/shared TypeScript builds pass; all 1,186 common tests and 20 React hook/rendering tests pass. New code passes lint. Existing lint findings are identical to current main. The API typecheck still reports two implicit-any errors in unchanged files (`helpers/on-create-market.ts:133` and `stripe-endpoints.ts:330`). No production trade or live outage was exercised.