### PR TITLE
Show direct limit fills and other-answer quote dependencies

### DIFF
--- a/client-common/src/lib/bet.ts
+++ b/client-common/src/lib/bet.ts
@@ -86,8 +86,8 @@ export const getLimitBetReturns = (
         .concat(otherBetResults.flatMap((r) => r.makers.map((m) => m.bet)))
         .concat(newBetResult.ordersToCancel)
         .concat(otherBetResults.flatMap((r) => r.ordersToCancel))
-      // Only the answer being bought — see getSaleResultMultiSumsToOne.
-      limitOrderFill = getLimitOrderFill(newBetResult.makers)
+      // Keep other-answer dependencies separate from shares of this answer.
+      limitOrderFill = getLimitOrderFill(newBetResult.makers, otherBetResults.flatMap((r) => r.makers))
       fees = addObjects(
         newBetResult.totalFees,
         otherBetResults.reduce(

--- a/client-common/src/lib/bet.ts
+++ b/client-common/src/lib/bet.ts
@@ -2,7 +2,7 @@ import {
   CPMM_ARBITRAGE_ERROR_PREFIX,
   getCpmmProbability,
 } from 'common/calculate-cpmm'
-import { LimitBet } from 'common/bet'
+import { getLimitOrderFill, LimitBet, LimitOrderFill } from 'common/bet'
 import { Answer } from 'common/answer'
 import { noFees } from 'common/fees'
 import { calculateCpmmMultiArbitrageBet } from 'common/calculate-cpmm-arbitrage'
@@ -68,6 +68,7 @@ export const getLimitBetReturns = (
   let shares = 0
   let fees = noFees
   let betDeps: LimitBet[] = []
+  let limitOrderFill: LimitOrderFill = { shares: 0, orderCount: 0 }
   let probAfter = 0
   let calculationError: string | undefined = undefined
   try {
@@ -90,6 +91,8 @@ export const getLimitBetReturns = (
         .concat(otherBetResults.flatMap((r) => r.makers.map((m) => m.bet)))
         .concat(newBetResult.ordersToCancel)
         .concat(otherBetResults.flatMap((r) => r.ordersToCancel))
+      // Only the answer being bought — see getSaleResultMultiSumsToOne.
+      limitOrderFill = getLimitOrderFill(newBetResult.makers)
       fees = addObjects(
         newBetResult.totalFees,
         otherBetResults.reduce(
@@ -115,6 +118,7 @@ export const getLimitBetReturns = (
       shares = result.shares
       fees = result.fees
       betDeps = result.makers.map((m) => m.bet).concat(result.ordersToCancel)
+      limitOrderFill = getLimitOrderFill(result.makers)
       probAfter = result.probAfter
     }
   } catch (err: any) {
@@ -142,6 +146,7 @@ export const getLimitBetReturns = (
     currentReturn,
     fees,
     betDeps,
+    limitOrderFill,
     probAfter,
     limitProb,
     prob,

--- a/common/src/bet.ts
+++ b/common/src/bet.ts
@@ -109,12 +109,25 @@ export const getNewBetId = () => nanoid(12)
 /** How much of a trade is absorbed by resting limit orders rather than by the
  * pool. This is the part of a quote that moves when someone posts or cancels an
  * order, so it's worth showing rather than folding silently into the total. */
-export const getLimitOrderFill = (makers: maker[]) => ({
+export type LimitOrderFill = {
+  shares: number
+  orderCount: number
+  otherAnswerOrderCount?: number
+}
+
+export const getLimitOrderFill = (
+  makers: maker[],
+  otherAnswerMakers: maker[] = []
+): LimitOrderFill => ({
   shares: sumBy(makers, 'shares'),
   orderCount: uniqBy(makers, (m) => m.bet.id).length,
+  ...(otherAnswerMakers.length
+    ? {
+        otherAnswerOrderCount: uniqBy(otherAnswerMakers, (m) => m.bet.id)
+          .length,
+      }
+    : {}),
 })
-
-export type LimitOrderFill = ReturnType<typeof getLimitOrderFill>
 
 // A limit order can still be matched against only while it has unfilled amount
 // left, hasn't been cancelled, and hasn't expired. Cancelling and filling are

--- a/common/src/bet.ts
+++ b/common/src/bet.ts
@@ -1,4 +1,4 @@
-import { groupBy, mapValues } from 'lodash'
+import { groupBy, mapValues, sumBy, uniqBy } from 'lodash'
 import { Fees } from './fees'
 import { maxMinBin } from './chart'
 import { nanoid } from 'common/util/random'
@@ -105,6 +105,16 @@ export type maker = {
 }
 
 export const getNewBetId = () => nanoid(12)
+
+/** How much of a trade is absorbed by resting limit orders rather than by the
+ * pool. This is the part of a quote that moves when someone posts or cancels an
+ * order, so it's worth showing rather than folding silently into the total. */
+export const getLimitOrderFill = (makers: maker[]) => ({
+  shares: sumBy(makers, 'shares'),
+  orderCount: uniqBy(makers, (m) => m.bet.id).length,
+})
+
+export type LimitOrderFill = ReturnType<typeof getLimitOrderFill>
 
 // A limit order can still be matched against only while it has unfilled amount
 // left, hasn't been cancelled, and hasn't expired. Cancelling and filling are

--- a/common/src/calculate-cpmm.test.ts
+++ b/common/src/calculate-cpmm.test.ts
@@ -1,7 +1,8 @@
-import { LimitBet } from './bet'
+import { getLimitOrderFill, LimitBet } from './bet'
 import {
   addCpmmLiquidity,
   calculateCpmmPurchase,
+  calculateCpmmSale,
   calculateCpmmShares,
   computeFills,
   CpmmState,
@@ -269,6 +270,60 @@ describe('CPMM Calculations', () => {
         balanceByUserId
       )
       expect(makers).toHaveLength(0)
+    })
+
+    it('reports how much of a trade rests on limit orders', () => {
+      const orders = [
+        makeLimitOrder({ id: 'a' }),
+        makeLimitOrder({ id: 'b', createdTime: 1 }),
+      ]
+      const { makers, takers } = computeFills(
+        state,
+        'NO',
+        1000,
+        undefined,
+        orders,
+        balanceByUserId
+      )
+      const fill = getLimitOrderFill(makers)
+
+      // The first order is deep enough to take the whole trade on its own.
+      expect(fill.orderCount).toBe(1)
+      expect(fill.shares).toBeGreaterThan(0)
+      expect(fill.shares).toBeCloseTo(
+        takers.reduce((total, taker) => total + taker.shares, 0),
+        6
+      )
+    })
+
+    it('reports no limit order fill once the orders are cancelled', () => {
+      const { makers, takers } = computeFills(
+        state,
+        'NO',
+        1000,
+        undefined,
+        [makeLimitOrder({ isCancelled: true })],
+        balanceByUserId
+      )
+
+      // The trade still happens, but entirely against the pool.
+      expect(takers.length).toBeGreaterThan(0)
+      expect(getLimitOrderFill(makers)).toEqual({ shares: 0, orderCount: 0 })
+    })
+
+    it('measures the limit order fill in the shares being sold', () => {
+      const shares = 2000
+      const { makers } = calculateCpmmSale(
+        state,
+        shares,
+        'YES',
+        [makeLimitOrder()],
+        balanceByUserId
+      )
+
+      // The sell panel shows this against the size of the sale, so the two have
+      // to be the same unit — the order absorbs the sale whole here.
+      expect(getLimitOrderFill(makers).shares).toBeCloseTo(shares, 6)
     })
 
     it('cancelling your own order moves the price your sale would make', () => {

--- a/common/src/limit-order-fill.test.ts
+++ b/common/src/limit-order-fill.test.ts
@@ -1,0 +1,73 @@
+import { LimitBet } from './bet'
+import { Answer } from './answer'
+import { MultiContract } from './contract'
+import { noFees } from './fees'
+import { getSaleResultMultiSumsToOne } from './sell-bet'
+
+it('reports other-answer order dependencies without counting their shares as sold shares', () => {
+  const answers = ['a', 'b', 'c'].map(
+    (id) =>
+      ({
+        id,
+        contractId: 'multi',
+        poolYes: 20000,
+        poolNo: 10000,
+        prob: 1 / 3,
+        createdTime: 0,
+        text: id,
+        userId: 'creator',
+      } as Answer)
+  )
+  const contract = {
+    id: 'multi',
+    mechanism: 'cpmm-multi-1',
+    shouldAnswersSumToOne: true,
+    answers,
+    collectedFees: noFees,
+  } as MultiContract
+  const orders = ['b', 'c'].map(
+    (id) =>
+      ({
+        id: `order-${id}`,
+        contractId: 'multi',
+        userId: `maker-${id}`,
+        answerId: id,
+        createdTime: 1,
+        amount: 0,
+        shares: 0,
+        outcome: 'NO',
+        orderAmount: 10000,
+        limitProb: 1 / 3,
+        isFilled: false,
+        isCancelled: false,
+        fills: [],
+        probBefore: 1 / 3,
+        probAfter: 1 / 3,
+        fees: noFees,
+        isRedemption: false,
+      } as LimitBet)
+  )
+  const withOrders = getSaleResultMultiSumsToOne(
+    contract,
+    'a',
+    2000,
+    'YES',
+    orders,
+    { 'maker-b': 100000, 'maker-c': 100000 }
+  )
+  const withoutOrders = getSaleResultMultiSumsToOne(
+    contract,
+    'a',
+    2000,
+    'YES',
+    [],
+    {}
+  )
+  expect(withOrders.saleValue).toBeGreaterThan(withoutOrders.saleValue)
+  expect(withOrders.limitOrderFill).toEqual({
+    shares: 0,
+    orderCount: 0,
+    otherAnswerOrderCount: 2,
+  })
+  expect(withoutOrders.limitOrderFill).toEqual({ shares: 0, orderCount: 0 })
+})

--- a/common/src/sell-bet.ts
+++ b/common/src/sell-bet.ts
@@ -1,4 +1,4 @@
-import { Bet, LimitBet } from './bet'
+import { Bet, getLimitOrderFill, LimitBet } from './bet'
 import {
   calculateCpmmMultiSumsToOneSale,
   calculateCpmmSale,
@@ -319,6 +319,7 @@ export const getSaleResult = (
     probChange,
     fees,
     makers,
+    limitOrderFill: getLimitOrderFill(wholeMakers),
   }
 }
 
@@ -365,5 +366,9 @@ export const getSaleResultMultiSumsToOne = (
     probChange,
     fees,
     makers,
+    // Only the answer being sold. The arbitrage legs on the other answers also
+    // match orders, but counting their shares here would read as if they were
+    // part of this sale.
+    limitOrderFill: getLimitOrderFill(newBetResult.makers),
   }
 }

--- a/common/src/sell-bet.ts
+++ b/common/src/sell-bet.ts
@@ -366,9 +366,11 @@ export const getSaleResultMultiSumsToOne = (
     probChange,
     fees,
     makers,
-    // Only the answer being sold. The arbitrage legs on the other answers also
-    // match orders, but counting their shares here would read as if they were
-    // part of this sale.
-    limitOrderFill: getLimitOrderFill(newBetResult.makers),
+    // Other-answer orders also affect the quote, but their shares are not
+    // shares of the answer being sold. Report their order count separately.
+    limitOrderFill: getLimitOrderFill(
+      newBetResult.makers,
+      otherBetResults.flatMap((r) => r.makers)
+    ),
   }
 }

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -69,6 +69,7 @@ import { AmountInput, BuyAmountInput } from '../widgets/amount-input'
 import { ChoicesToggleGroup } from '../widgets/choices-toggle-group'
 import { SliderColor } from '../widgets/slider'
 import { Tooltip } from '../widgets/tooltip'
+import { LimitOrderFillRow } from './limit-order-fill-row'
 import LimitOrderPanel from './limit-order-panel'
 import { MoneyDisplay } from './money-display'
 import {
@@ -457,6 +458,8 @@ export const BuyPanelBody = (
     probAfter: newProbAfter,
     currentReturn,
     betDeps,
+    limitOrderFill,
+    shares: filledShares,
     limitProb,
     prob,
     calculationError,
@@ -945,6 +948,11 @@ export const BuyPanelBody = (
                     </span>
                   </Row>
                 </Row>
+                <LimitOrderFillRow
+                  fill={limitOrderFill}
+                  totalShares={filledShares}
+                  isCashContract={isCashContract}
+                />
               </Col>
             </Row>
           </>

--- a/web/components/bet/bet-panel.tsx
+++ b/web/components/bet/bet-panel.tsx
@@ -967,9 +967,9 @@ export const BuyPanelBody = (
                   </Row>
                 </Row>
                 <LimitOrderFillRow
+                  contract={contract}
                   fill={limitOrderFill}
                   totalShares={filledShares}
-                  isCashContract={isCashContract}
                 />
               </Col>
             </Row>

--- a/web/components/bet/limit-order-fill-row.test.tsx
+++ b/web/components/bet/limit-order-fill-row.test.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Contract } from 'common/contract'
+import { LimitOrderFillRow } from './limit-order-fill-row'
+
+jest.mock('../widgets/info-tooltip', () => ({
+  InfoTooltip: ({ text }: { text: string }) => <span title={text} />,
+}))
+const contract = { outcomeType: 'BINARY', token: 'MANA' } as Contract
+
+it('uses the same stock units for the fill and total', () => {
+  const html = renderToStaticMarkup(
+    <LimitOrderFillRow
+      contract={{ ...contract, outcomeType: 'STONK' } as Contract}
+      fill={{ shares: 1000, orderCount: 1 }}
+      totalShares={2000}
+    />
+  )
+  expect(html).toContain('0.22 of 0.43 shares')
+  expect(html).not.toContain('1,000')
+})
+
+it('does not label a positive tiny fill as zero shares', () => {
+  const html = renderToStaticMarkup(
+    <LimitOrderFillRow
+      contract={contract}
+      fill={{ shares: 0.9, orderCount: 1 }}
+      totalShares={2000}
+    />
+  )
+  expect(html).toContain('&lt; 1 of 2,000 shares')
+  const cash = renderToStaticMarkup(
+    <LimitOrderFillRow
+      contract={{ ...contract, token: 'CASH' }}
+      fill={{ shares: 0.004, orderCount: 1 }}
+      totalShares={2000}
+    />
+  )
+  expect(cash).toContain('&lt; 0.01 of 2,000.00 shares')
+})
+
+it('shows dependencies on other answers even with no direct limit fill', () => {
+  const html = renderToStaticMarkup(
+    <LimitOrderFillRow
+      contract={contract}
+      fill={{ shares: 0, orderCount: 0, otherAnswerOrderCount: 2 }}
+      totalShares={2000}
+    />
+  )
+  expect(html).toContain('Other-answer limit orders')
+  expect(html).toContain('2 orders')
+  expect(html).toContain('on other answers')
+  expect(html).toContain('may differ')
+  expect(html).not.toContain('0 of')
+})
+
+it('hides the row for a quote entirely against pools', () => {
+  expect(
+    renderToStaticMarkup(
+      <LimitOrderFillRow
+        contract={contract}
+        fill={{ shares: 0, orderCount: 0 }}
+      />
+    )
+  ).toBe('')
+})

--- a/web/components/bet/limit-order-fill-row.tsx
+++ b/web/components/bet/limit-order-fill-row.tsx
@@ -1,0 +1,41 @@
+import { LimitOrderFill } from 'common/bet'
+import { formatShares } from 'common/util/format'
+import { Row } from '../layout/row'
+import { InfoTooltip } from '../widgets/info-tooltip'
+
+/** Shows how much of a quote rests on other people's limit orders rather than
+ * on the pool. Without it, the order book's contribution is invisible: the
+ * numbers just move when an order is posted, taken or cancelled, and there's
+ * nothing on screen to say why. */
+export function LimitOrderFillRow(props: {
+  fill: LimitOrderFill
+  isCashContract: boolean
+  /** Shares in the trade overall, to show the limit order share against. */
+  totalShares?: number
+}) {
+  const { fill, isCashContract, totalShares } = props
+  const { shares, orderCount } = fill
+
+  if (shares <= 0 || orderCount === 0) return null
+
+  const showTotal = totalShares !== undefined && totalShares > shares
+
+  return (
+    <Row className="items-center justify-between">
+      <span className="text-ink-500">
+        Filled by limit orders{' '}
+        <InfoTooltip
+          text={`${orderCount} resting ${
+            orderCount === 1 ? 'order takes' : 'orders take'
+          } part of this trade instead of the pool. If ${
+            orderCount === 1 ? 'it is' : 'they are'
+          } cancelled or taken first, your price moves.`}
+        />
+      </span>
+      <span className="text-ink-600 tabular-nums">
+        {formatShares(shares, isCashContract)}
+        {showTotal && ` of ${formatShares(totalShares, isCashContract)}`} shares
+      </span>
+    </Row>
+  )
+}

--- a/web/components/bet/limit-order-fill-row.tsx
+++ b/web/components/bet/limit-order-fill-row.tsx
@@ -1,40 +1,64 @@
 import { LimitOrderFill } from 'common/bet'
+import { Contract } from 'common/contract'
+import { getStonkDisplayShares } from 'common/stonk'
 import { formatShares } from 'common/util/format'
 import { Row } from '../layout/row'
 import { InfoTooltip } from '../widgets/info-tooltip'
 
-/** Shows how much of a quote rests on other people's limit orders rather than
- * on the pool. Without it, the order book's contribution is invisible: the
- * numbers just move when an order is posted, taken or cancelled, and there's
- * nothing on screen to say why. */
+/** Keep the units consistent with the panel, including fractional stock shares. */
+const displayShares = (shares: number, contract: Contract) => {
+  if (contract.outcomeType === 'STONK') {
+    const displayed = getStonkDisplayShares(contract, shares, 2)
+    return displayed > 0
+      ? `${displayed}`
+      : `< ${getStonkDisplayShares(contract, 1, 2)}`
+  }
+  const isCash = contract.token === 'CASH'
+  if (shares < (isCash ? 0.01 : 1)) return isCash ? '< 0.01' : '< 1'
+  return formatShares(shares, isCash)
+}
+
 export function LimitOrderFillRow(props: {
   fill: LimitOrderFill
-  isCashContract: boolean
-  /** Shares in the trade overall, to show the limit order share against. */
+  contract: Contract
+  /** Shares filled immediately, excluding any new resting limit order. */
   totalShares?: number
 }) {
-  const { fill, isCashContract, totalShares } = props
-  const { shares, orderCount } = fill
+  const { fill, contract, totalShares } = props
+  const { shares, orderCount, otherAnswerOrderCount = 0 } = fill
+  const hasDirectFill = shares > 0 && orderCount > 0
+  if (!hasDirectFill && otherAnswerOrderCount === 0) return null
 
-  if (shares <= 0 || orderCount === 0) return null
-
-  const showTotal = totalShares !== undefined && totalShares > shares
+  const filled = displayShares(shares, contract)
+  const total =
+    totalShares === undefined ? undefined : displayShares(totalShares, contract)
+  const showTotal =
+    totalShares !== undefined && totalShares > shares && total !== filled
+  const directText = hasDirectFill
+    ? `This quote matches ${orderCount} resting ${
+        orderCount === 1 ? 'order' : 'orders'
+      } for this outcome. `
+    : ''
+  const otherText = otherAnswerOrderCount
+    ? `${hasDirectFill ? 'It also' : 'This quote'} depends on ${otherAnswerOrderCount} resting ${
+        otherAnswerOrderCount === 1 ? 'order' : 'orders'
+      } on other answers. `
+    : ''
 
   return (
     <Row className="items-center justify-between">
       <span className="text-ink-500">
-        Filled by limit orders{' '}
+        {hasDirectFill ? 'Filled by limit orders' : 'Other-answer limit orders'}{' '}
         <InfoTooltip
-          text={`${orderCount} resting ${
-            orderCount === 1 ? 'order takes' : 'orders take'
-          } part of this trade instead of the pool. If ${
-            orderCount === 1 ? 'it is' : 'they are'
-          } cancelled or taken first, your price moves.`}
+          text={`${directText}${otherText}Orders can change before your trade executes; the final price may differ.`}
         />
       </span>
       <span className="text-ink-600 tabular-nums">
-        {formatShares(shares, isCashContract)}
-        {showTotal && ` of ${formatShares(totalShares, isCashContract)}`} shares
+        {hasDirectFill
+          ? `${filled}${showTotal ? ` of ${total}` : ''} shares`
+          : `${otherAnswerOrderCount} ${
+              otherAnswerOrderCount === 1 ? 'order' : 'orders'
+            }`}
       </span>
     </Row>
   )

--- a/web/components/bet/limit-order-fill-row.tsx
+++ b/web/components/bet/limit-order-fill-row.tsx
@@ -40,7 +40,9 @@ export function LimitOrderFillRow(props: {
       } for this outcome. `
     : ''
   const otherText = otherAnswerOrderCount
-    ? `${hasDirectFill ? 'It also' : 'This quote'} depends on ${otherAnswerOrderCount} resting ${
+    ? `${
+        hasDirectFill ? 'It also' : 'This quote'
+      } depends on ${otherAnswerOrderCount} resting ${
         otherAnswerOrderCount === 1 ? 'order' : 'orders'
       } on other answers. `
     : ''

--- a/web/components/bet/money-display.tsx
+++ b/web/components/bet/money-display.tsx
@@ -1,4 +1,6 @@
+import { animated } from '@react-spring/web'
 import { formatWithToken } from 'common/util/format'
+import { useAnimatedNumber } from 'web/hooks/use-animated-number'
 import { NumberDisplayType } from '../widgets/token-number'
 
 export function MoneyDisplay(props: {
@@ -8,17 +10,40 @@ export function MoneyDisplay(props: {
 }) {
   const { amount, isCashContract = false, numberType } = props
 
+  return <>{formatAmount(amount, isCashContract, numberType)}</>
+}
+
+/** Counts to the new value instead of snapping to it, the way the market
+ * probability does. A quote can move while you're looking at it — someone
+ * cancels an order, or takes the one you were about to trade against — and a
+ * number that changes silently is a number nobody notices changing. */
+export function AnimatedMoneyDisplay(props: {
+  amount: number
+  isCashContract?: boolean
+  numberType?: NumberDisplayType
+}) {
+  const { amount, isCashContract = false, numberType } = props
+  const spring = useAnimatedNumber(Number.isFinite(amount) ? amount : 0)
+
+  return (
+    <animated.span>
+      {spring.to((value) => formatAmount(value, isCashContract, numberType))}
+    </animated.span>
+  )
+}
+
+function formatAmount(
+  amount: number,
+  isCashContract: boolean,
+  numberType: NumberDisplayType | undefined
+) {
   const toDecimal =
     numberType === 'toDecimal' ? (isCashContract ? 4 : 2) : undefined
 
-  return (
-    <>
-      {formatWithToken({
-        amount: amount,
-        token: isCashContract ? 'CASH' : 'M$',
-        toDecimal: toDecimal,
-        short: numberType === 'short',
-      })}
-    </>
-  )
+  return formatWithToken({
+    amount,
+    token: isCashContract ? 'CASH' : 'M$',
+    toDecimal,
+    short: numberType === 'short',
+  })
 }

--- a/web/components/bet/money-display.tsx
+++ b/web/components/bet/money-display.tsx
@@ -1,6 +1,4 @@
-import { animated } from '@react-spring/web'
 import { formatWithToken } from 'common/util/format'
-import { useAnimatedNumber } from 'web/hooks/use-animated-number'
 import { NumberDisplayType } from '../widgets/token-number'
 
 export function MoneyDisplay(props: {
@@ -10,40 +8,17 @@ export function MoneyDisplay(props: {
 }) {
   const { amount, isCashContract = false, numberType } = props
 
-  return <>{formatAmount(amount, isCashContract, numberType)}</>
-}
-
-/** Counts to the new value instead of snapping to it, the way the market
- * probability does. A quote can move while you're looking at it — someone
- * cancels an order, or takes the one you were about to trade against — and a
- * number that changes silently is a number nobody notices changing. */
-export function AnimatedMoneyDisplay(props: {
-  amount: number
-  isCashContract?: boolean
-  numberType?: NumberDisplayType
-}) {
-  const { amount, isCashContract = false, numberType } = props
-  const spring = useAnimatedNumber(Number.isFinite(amount) ? amount : 0)
-
-  return (
-    <animated.span>
-      {spring.to((value) => formatAmount(value, isCashContract, numberType))}
-    </animated.span>
-  )
-}
-
-function formatAmount(
-  amount: number,
-  isCashContract: boolean,
-  numberType: NumberDisplayType | undefined
-) {
   const toDecimal =
     numberType === 'toDecimal' ? (isCashContract ? 4 : 2) : undefined
 
-  return formatWithToken({
-    amount,
-    token: isCashContract ? 'CASH' : 'M$',
-    toDecimal,
-    short: numberType === 'short',
-  })
+  return (
+    <>
+      {formatWithToken({
+        amount: amount,
+        token: isCashContract ? 'CASH' : 'M$',
+        toDecimal: toDecimal,
+        short: numberType === 'short',
+      })}
+    </>
+  )
 }

--- a/web/components/bet/sell-panel.tsx
+++ b/web/components/bet/sell-panel.tsx
@@ -36,7 +36,7 @@ import { Row } from '../layout/row'
 import { Spacer } from '../layout/spacer'
 import { AmountInput } from '../widgets/amount-input'
 import { LimitOrderFillRow } from './limit-order-fill-row'
-import { AnimatedMoneyDisplay, MoneyDisplay } from './money-display'
+import { MoneyDisplay } from './money-display'
 
 export function SellPanel(props: {
   contract: CPMMContract | MultiContract
@@ -296,7 +296,7 @@ export function SellPanel(props: {
           <Row className="items-center justify-between">
             <span className="text-ink-500">Sale value</span>
             <span className="text-ink-900 tabular-nums">
-              <AnimatedMoneyDisplay
+              <MoneyDisplay
                 amount={saleValue + totalFees}
                 isCashContract={isCashContract}
               />
@@ -343,9 +343,9 @@ export function SellPanel(props: {
         </Row>
 
         <LimitOrderFillRow
+          contract={contract}
           fill={limitOrderFill}
           totalShares={sellQuantity}
-          isCashContract={isCashContract}
         />
 
         <div className="border-ink-200 my-2 border-t" />
@@ -353,7 +353,7 @@ export function SellPanel(props: {
         <Row className="items-center justify-between">
           <span className="text-ink-900 font-medium">Payout</span>
           <span className="text-ink-900 text-lg font-semibold tabular-nums">
-            <AnimatedMoneyDisplay
+            <MoneyDisplay
               amount={netProceeds}
               isCashContract={isCashContract}
             />

--- a/web/components/bet/sell-panel.tsx
+++ b/web/components/bet/sell-panel.tsx
@@ -2,7 +2,7 @@ import { useUnfilledBetsAndBalanceByUserId } from 'client-common/hooks/use-bets'
 import clsx from 'clsx'
 import { Answer } from 'common/answer'
 import { APIError } from 'common/api/utils'
-import { LimitBet } from 'common/bet'
+import { LimitBet, LimitOrderFill } from 'common/bet'
 import { getCpmmProbability } from 'common/calculate-cpmm'
 import {
   CPMMContract,
@@ -34,7 +34,8 @@ import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 import { Spacer } from '../layout/spacer'
 import { AmountInput } from '../widgets/amount-input'
-import { MoneyDisplay } from './money-display'
+import { LimitOrderFillRow } from './limit-order-fill-row'
+import { AnimatedMoneyDisplay, MoneyDisplay } from './money-display'
 
 export function SellPanel(props: {
   contract: CPMMContract | MultiContract
@@ -196,8 +197,9 @@ export function SellPanel(props: {
   let fees: Fees
   let cpmmState
   let makers: LimitBet[]
+  let limitOrderFill: LimitOrderFill
   if (isMultiSumsToOne) {
-    ;({ initialProb, cpmmState, saleValue, fees, makers } =
+    ;({ initialProb, cpmmState, saleValue, fees, makers, limitOrderFill } =
       getSaleResultMultiSumsToOne(
         contract,
         answerId!,
@@ -207,14 +209,15 @@ export function SellPanel(props: {
         balanceByUserId
       ))
   } else {
-    ;({ initialProb, cpmmState, saleValue, fees, makers } = getSaleResult(
-      contract,
-      sellQuantity,
-      sharesOutcome,
-      unfilledBets,
-      balanceByUserId,
-      answer
-    ))
+    ;({ initialProb, cpmmState, saleValue, fees, makers, limitOrderFill } =
+      getSaleResult(
+        contract,
+        sellQuantity,
+        sharesOutcome,
+        unfilledBets,
+        balanceByUserId,
+        answer
+      ))
   }
   betDeps.current = makers
   const totalFees = getFeeTotal(fees)
@@ -294,7 +297,7 @@ export function SellPanel(props: {
           <Row className="items-center justify-between">
             <span className="text-ink-500">Sale value</span>
             <span className="text-ink-900 tabular-nums">
-              <MoneyDisplay
+              <AnimatedMoneyDisplay
                 amount={saleValue + totalFees}
                 isCashContract={isCashContract}
               />
@@ -340,12 +343,18 @@ export function SellPanel(props: {
           </span>
         </Row>
 
+        <LimitOrderFillRow
+          fill={limitOrderFill}
+          totalShares={sellQuantity}
+          isCashContract={isCashContract}
+        />
+
         <div className="border-ink-200 my-2 border-t" />
 
         <Row className="items-center justify-between">
           <span className="text-ink-900 font-medium">Payout</span>
           <span className="text-ink-900 text-lg font-semibold tabular-nums">
-            <MoneyDisplay
+            <AnimatedMoneyDisplay
               amount={netProceeds}
               isCashContract={isCashContract}
             />


### PR DESCRIPTION
**Stack 4 of 4**, based on #4069.

The buy and sell quotes disclose their dependence on resting limit orders. Direct fills use the same share units as the panel, including fractional stock shares. Tiny positive fills show a threshold instead of rounding to zero.

For sums-to-one markets, other-answer order dependencies are counted separately from shares of the traded answer. A quote with only indirect order matches still shows a row. Tooltip wording says the execution price *may* differ if orders change; it does not promise that cancellation necessarily moves the price.

Sale value and payout remain immediate. The proposed monetary spring animation has been removed, and the existing editable buy payout remains immediate.

Added rendering tests cover stock units, tiny fills, indirect-only dependencies, and pool-only quotes. A real calculation regression verifies a three-answer sale whose value depends on two orders on other answers.

Validation of the completed stack: full web typecheck passes; common/shared TypeScript builds pass; all 1,186 common tests and 20 React hook/rendering tests pass. New code passes lint. Existing lint findings are identical to current main. The API typecheck still reports two implicit-any errors in unchanged files (`helpers/on-create-market.ts:133` and `stripe-endpoints.ts:330`). No production trade or live outage was exercised.