### PR TITLE
Add MNX trade CTA and click tracking for perps markets

### DIFF
--- a/backend/scripts/count-mnx-clicks.ts
+++ b/backend/scripts/count-mnx-clicks.ts
@@ -1,0 +1,158 @@
+import { ENV_CONFIG } from 'common/envs/constants'
+import { MNX_CLICK_EVENT } from 'common/perps/mnx-cta'
+import { READ_ONLY_REPEATABLE_MODE } from 'shared/supabase/init'
+import { runScript } from './run-script'
+
+/**
+ * Read-only report on click-throughs to MNX: how many, from which placement,
+ * on which instrument, and who.
+ *
+ * Usage:
+ *   yarn ts-node count-mnx-clicks.ts [days] [top]
+ *
+ * Days defaults to 7 (max 90) and top (how many clickers to name) to 25.
+ * Every query is bounded by `ts` because that is the only index on
+ * user_events — the table is hundreds of millions of rows, and filtering on
+ * `name` alone is a sequential scan that times out (the same lesson as
+ * /admin/journeys).
+ */
+
+const DEFAULT_DAYS = 7
+const MAX_DAYS = 90
+const DEFAULT_TOP = 25
+
+const [daysArg, topArg] = process.argv.slice(2)
+const days = daysArg === undefined ? DEFAULT_DAYS : Number(daysArg)
+const top = topArg === undefined ? DEFAULT_TOP : Number(topArg)
+
+if (
+  !Number.isInteger(days) ||
+  days < 1 ||
+  days > MAX_DAYS ||
+  !Number.isInteger(top) ||
+  top < 1
+) {
+  console.error(
+    `Usage: yarn ts-node count-mnx-clicks.ts [days 1-${MAX_DAYS}] [top]`
+  )
+  process.exit(1)
+}
+
+// One window, one event name, shared by every query below.
+const withMnxClicks = `
+  with mnx_clicks as (
+    select
+      user_id,
+      contract_id,
+      data->>'location' as location,
+      data->>'symbol' as symbol,
+      data->>'deviceId' as device_id
+    from user_events
+    where name = $1
+      and ts >= now() - make_interval(days => $2::int)
+  )
+`
+
+type Totals = {
+  clicks: number
+  signed_in_users: number
+  anonymous_devices: number
+  markets: number
+}
+type Breakdown = { label: string; clicks: number; users: number }
+type Clicker = { username: string; name: string; clicks: number }
+
+const pad = (value: string | number, width: number) =>
+  String(value).padStart(width)
+
+const printBreakdown = (title: string, rows: Breakdown[]) => {
+  console.log(`\n=== ${title} ===`)
+  if (!rows.length) return console.log('(none)')
+  const width = Math.max(...rows.map((r) => r.label.length))
+  for (const row of rows)
+    console.log(
+      `${row.label.padEnd(width)}  ${pad(row.clicks, 6)} clicks  ${pad(
+        row.users,
+        5
+      )} signed-in`
+    )
+}
+
+runScript(async ({ pg: database }) => {
+  await database.tx({ mode: READ_ONLY_REPEATABLE_MODE }, async (pg) => {
+    // Fail closed rather than leave a heavy scan running against the primary.
+    await pg.none("set local statement_timeout = '120s'")
+    const params = [MNX_CLICK_EVENT, days]
+
+    const totals = await pg.one<Totals>(
+      `${withMnxClicks}
+       select
+         count(*)::int as clicks,
+         count(distinct user_id)::int as signed_in_users,
+         (count(distinct device_id) filter (where user_id is null))::int
+           as anonymous_devices,
+         count(distinct contract_id)::int as markets
+       from mnx_clicks`,
+      params
+    )
+
+    const byLocation = await pg.map<Breakdown>(
+      `${withMnxClicks}
+       select
+         coalesce(location, '(unrecorded)') as label,
+         count(*)::int as clicks,
+         count(distinct user_id)::int as users
+       from mnx_clicks
+       group by 1
+       order by clicks desc, label`,
+      params,
+      (row) => row
+    )
+
+    const byInstrument = await pg.map<Breakdown>(
+      `${withMnxClicks}
+       select
+         coalesce(symbol, '(unrecorded)') as label,
+         count(*)::int as clicks,
+         count(distinct user_id)::int as users
+       from mnx_clicks
+       group by 1
+       order by clicks desc, label`,
+      params,
+      (row) => row
+    )
+
+    // Who. Signed-out clicks carry only a device id, so they are counted in
+    // the totals above and cannot appear here.
+    const clickers = await pg.map<Clicker>(
+      `${withMnxClicks}
+       select u.username, u.name, count(*)::int as clicks
+       from mnx_clicks c
+       join users u on u.id = c.user_id
+       group by 1, 2
+       order by clicks desc, u.username
+       limit $3`,
+      [...params, top],
+      (row) => row
+    )
+
+    console.log(`\n=== MNX click-throughs, last ${days} day(s) ===`)
+    console.log(`Event:              ${MNX_CLICK_EVENT}`)
+    console.log(`Clicks:             ${totals.clicks}`)
+    console.log(`Signed-in clickers: ${totals.signed_in_users}`)
+    console.log(`Anonymous devices:  ${totals.anonymous_devices}`)
+    console.log(`Markets clicked:    ${totals.markets}`)
+
+    printBreakdown('By placement', byLocation)
+    printBreakdown('By instrument', byInstrument)
+
+    console.log(`\n=== Top ${top} signed-in clickers ===`)
+    if (!clickers.length) console.log('(none)')
+    for (const clicker of clickers)
+      console.log(
+        `${pad(clicker.clicks, 5)}  ${clicker.name} — https://${
+          ENV_CONFIG.domain
+        }/${clicker.username}`
+      )
+  })
+})

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -643,9 +643,8 @@ for the cohort, sources, deployment order and environment validation.
 
 `common/perps/mnx-cta.ts` owns every link that sends a reader to MNX, and
 `web/components/perps/mnx-cta.tsx` renders them. `MnxTradeCta` is the call to
-action — "Trade `<TICKER>` with real money" — shown at the top of the market
-description, below the trading controls and position information. On the
-/perps terminal it sits after the position panel. The chart keeps its
+action — "Trade `<TICKER>` with real money" — shown below the market
+description. On the /perps terminal it sits after the position panel. The chart keeps its
 "Source: MNX" credit, with a compact UTC date/time and the full timestamp on
 hover. The CTA is withheld for non-MNX feeds and settled markets.
 
@@ -662,9 +661,8 @@ From `sm` up the card is wordmark │ pitch and instrument line │ "Trade
 line with no separate button. The entire mobile card is a link, and an
 external-link icon follows "money" in the heading. The mobile card and desktop
 button share the same URL and click tracking. Text can wrap on narrow screens.
-The card is separate from the chart
-footnote and trading controls, introducing the description instead of
-competing with the Long/Short buttons above it.
+The card sits below the description, separate from the chart footnote and
+trading controls.
 
 Every one of those clicks writes a `user_events` row named **`click mnx link`**
 carrying the placement (`market page cta`, `market page credit`,

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -644,11 +644,10 @@ for the cohort, sources, deployment order and environment validation.
 `common/perps/mnx-cta.ts` owns every link that sends a reader to MNX, and
 `web/components/perps/mnx-cta.tsx` renders them. `MnxTradeCta` is the call to
 action — "Trade `<TICKER>` with real money" — shown under the chart on a market
-page and on the /perps terminal; the source credit under the chart is a credit
-again rather than a second CTA, because there is now a real one. Both are
-withheld for markets on non-MNX feeds, and the CTA is also withheld once a
-market has settled, since MNX ending an instrument is exactly what pauses
-trading here pending administrative settlement and its page may be gone.
+page and on the /perps terminal. It replaces the MNX source/date footnote
+under the chart. Where there is no CTA, source attribution stays visible,
+including on settled markets and markets using other feeds. The CTA is
+withheld for non-MNX feeds and settled markets.
 
 The CTA wears MNX's colours, not Manifold's: their wordmark
 (`web/public/mnx-logo.svg`, white, the same asset the /jobs partner block uses)
@@ -660,14 +659,11 @@ page instead of on top of it.
 
 From `sm` up the card is wordmark │ pitch and instrument line │ "Trade
 `<TICKER>` on MNX". A phone gets the wordmark and that same button alone on one
-row: the card sits right above the bet panel, so a line spent here is a line
-taken from what people came for. The button keeps its one label at every width
-— the wordmark shrinks to `h-4` and the row to `gap-3` below `sm` instead,
-which is what leaves the button real slack rather than four pixels of it at
-360px. That holds it to one 60px line from 360px up; 320px is the only width
-where it wraps, and it wraps to two lines rather than overflowing. A longer
-label does not fit: "Trade `<TICKER>` with real money on MNX" needs a 334px
-button against 182–292px of room beside the wordmark on phones.
+row. The card is 40px tall, below the Long/Short buttons' 44px, with an 8px
+gap between its elements and a 28px trade button. The desktop copy truncates
+when space is tight, while the button keeps its full label at every width.
+The card's vertical margins reduce the gaps to the chart and bet panel, so
+the external link stays compact beside Manifold's trading controls.
 
 Every one of those clicks writes a `user_events` row named **`click mnx link`**
 carrying the placement (`market page cta`, `market page credit`,

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -656,7 +656,9 @@ on a near-black panel, with the button inverted to white. One treatment serves
 both themes, so the white wordmark never needs an inverted copy — and the panel
 is `slate-950` rather than the /jobs tile's `slate-900` because dark-mode
 `canvas-0` is itself roughly `slate-900`, which would leave it level with the
-page instead of on top of it.
+page instead of on top of it. The subtitle naming the instrument is `sm:` and
+up only: on a phone the card sits directly above the bet panel, where every
+line it costs is a line of the thing the reader came for.
 
 Every one of those clicks writes a `user_events` row named **`click mnx link`**
 carrying the placement (`market page cta`, `market page credit`,

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -658,17 +658,16 @@ is `slate-950` rather than the /jobs tile's `slate-900` because dark-mode
 `canvas-0` is itself roughly `slate-900`, which would leave it level with the
 page instead of on top of it.
 
-The offer lives in the button, once — a heading saying "Trade `<TICKER>` with
-real money" above a button saying the same thing was the sentence twice. On a
-phone the card is exactly wordmark + button ("Trade with real money": the
-wordmark beside it is the "on MNX", and the ticker is already in the market
-header), which is what keeps it to one 60px line from 360px up; the full label
-needs a 334px button and never fits beside the wordmark on a phone, so widening
-it back is a two-line button, not a tidier card. From `sm` the divider and a
-line naming the instrument appear and the button takes the full label; between
-`sm` and ~768px that button wraps onto its own row, and above it the card is a
-single line. The link's `aria-label` is the full sentence at every width, so
-the phone's shorter wording costs a screen reader nothing.
+From `sm` up the card is wordmark │ pitch and instrument line │ "Trade
+`<TICKER>` on MNX". A phone gets the wordmark and that same button alone on one
+row: the card sits right above the bet panel, so a line spent here is a line
+taken from what people came for. The button keeps its one label at every width
+— the wordmark shrinks to `h-4` and the row to `gap-3` below `sm` instead,
+which is what leaves the button real slack rather than four pixels of it at
+360px. That holds it to one 60px line from 360px up; 320px is the only width
+where it wraps, and it wraps to two lines rather than overflowing. A longer
+label does not fit: "Trade `<TICKER>` with real money on MNX" needs a 334px
+button against 182–292px of room beside the wordmark on phones.
 
 Every one of those clicks writes a `user_events` row named **`click mnx link`**
 carrying the placement (`market page cta`, `market page credit`,

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -639,6 +639,39 @@ valuation; equity marks need not equal the underlying share or the venue oracle.
 See [the launch runbook](../../../../perps-launch-runbook.md#mnx-rollout-dev-and-prod)
 for the cohort, sources, deployment order and environment validation.
 
+### Outbound MNX links and click tracking
+
+`common/perps/mnx-cta.ts` owns every link that sends a reader to MNX, and
+`web/components/perps/mnx-cta.tsx` renders them. `MnxTradeCta` is the call to
+action — "Trade `<TICKER>` with real money on MNX" — shown under the chart on a
+market page and on the /perps terminal; the source credit under the chart is a
+credit again rather than a second CTA, because there is now a real one. Both
+are withheld for markets on non-MNX feeds, and the CTA is also withheld once a
+market has settled, since MNX ending an instrument is exactly what pauses
+trading here pending administrative settlement and its page may be gone.
+
+Every one of those clicks writes a `user_events` row named **`click mnx link`**
+carrying the placement (`market page cta`, `market page credit`,
+`perps hub cta`, `perps hub credit`), the market in `contract_id`, and the feed
+id, MNX symbol and tagged url in `data` — so click-through counts and the
+identity of the clickers come from our own table rather than from MNX. Signed-out
+clicks land with a null `user_id` and the device id `track()` already attaches.
+The same href carries `utm_source=manifold&utm_medium=referral&utm_campaign=perps`
+plus a `utm_content` built from the same placement string, so MNX's own
+attribution can be reconciled with ours placement by placement.
+
+Read it with `backend/scripts/count-mnx-clicks.ts [days] [top]` (read-only;
+totals, per-placement and per-instrument breakdowns, and who clicked). Any
+ad-hoc query must bound `ts` — that is the only index on `user_events`, and the
+table is hundreds of millions of rows:
+
+```sql
+select data->>'location' as placement, count(*), count(distinct user_id)
+from user_events
+where name = 'click mnx link' and ts >= now() - interval '7 days'
+group by 1 order by 2 desc;
+```
+
 ## Scheduler
 
 - `update-oracle-feeds.ts` fires **every 2 seconds** (croner handles

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -658,9 +658,11 @@ is `slate-950` rather than the /jobs tile's `slate-900` because dark-mode
 page instead of on top of it.
 
 From `sm` up the card is wordmark │ pitch and instrument line │ "Trade
-`<TICKER>` on MNX". A phone gets the wordmark and that same button alone on one
-row. The card uses readable heading and instrument text on desktop, with
-room for the row to wrap on narrow screens. It is separate from the chart
+`<TICKER>` on MNX". A phone gets the wordmark, divider, heading and instrument
+line with no separate button. The entire mobile card is a link, and an
+external-link icon follows "money" in the heading. The mobile card and desktop
+button share the same URL and click tracking. Text can wrap on narrow screens.
+The card is separate from the chart
 footnote and trading controls, introducing the description instead of
 competing with the Long/Short buttons above it.
 

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -643,11 +643,11 @@ for the cohort, sources, deployment order and environment validation.
 
 `common/perps/mnx-cta.ts` owns every link that sends a reader to MNX, and
 `web/components/perps/mnx-cta.tsx` renders them. `MnxTradeCta` is the call to
-action — "Trade `<TICKER>` with real money" — shown under the chart on a market
-page and on the /perps terminal. It replaces the MNX source/date footnote
-under the chart. Where there is no CTA, source attribution stays visible,
-including on settled markets and markets using other feeds. The CTA is
-withheld for non-MNX feeds and settled markets.
+action — "Trade `<TICKER>` with real money" — shown at the top of the market
+description, below the trading controls and position information. On the
+/perps terminal it sits after the position panel. The chart keeps its
+"Source: MNX" credit, with a compact UTC date/time and the full timestamp on
+hover. The CTA is withheld for non-MNX feeds and settled markets.
 
 The CTA wears MNX's colours, not Manifold's: their wordmark
 (`web/public/mnx-logo.svg`, white, the same asset the /jobs partner block uses)
@@ -659,11 +659,10 @@ page instead of on top of it.
 
 From `sm` up the card is wordmark │ pitch and instrument line │ "Trade
 `<TICKER>` on MNX". A phone gets the wordmark and that same button alone on one
-row. The card is 40px tall, below the Long/Short buttons' 44px, with an 8px
-gap between its elements and a 28px trade button. The desktop copy truncates
-when space is tight, while the button keeps its full label at every width.
-The card's vertical margins reduce the gaps to the chart and bet panel, so
-the external link stays compact beside Manifold's trading controls.
+row. The card uses readable heading and instrument text on desktop, with
+room for the row to wrap on narrow screens. It is separate from the chart
+footnote and trading controls, introducing the description instead of
+competing with the Long/Short buttons above it.
 
 Every one of those clicks writes a `user_events` row named **`click mnx link`**
 carrying the placement (`market page cta`, `market page credit`,

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -656,9 +656,19 @@ on a near-black panel, with the button inverted to white. One treatment serves
 both themes, so the white wordmark never needs an inverted copy — and the panel
 is `slate-950` rather than the /jobs tile's `slate-900` because dark-mode
 `canvas-0` is itself roughly `slate-900`, which would leave it level with the
-page instead of on top of it. The subtitle naming the instrument is `sm:` and
-up only: on a phone the card sits directly above the bet panel, where every
-line it costs is a line of the thing the reader came for.
+page instead of on top of it.
+
+The offer lives in the button, once — a heading saying "Trade `<TICKER>` with
+real money" above a button saying the same thing was the sentence twice. On a
+phone the card is exactly wordmark + button ("Trade with real money": the
+wordmark beside it is the "on MNX", and the ticker is already in the market
+header), which is what keeps it to one 60px line from 360px up; the full label
+needs a 334px button and never fits beside the wordmark on a phone, so widening
+it back is a two-line button, not a tidier card. From `sm` the divider and a
+line naming the instrument appear and the button takes the full label; between
+`sm` and ~768px that button wraps onto its own row, and above it the card is a
+single line. The link's `aria-label` is the full sentence at every width, so
+the phone's shorter wording costs a screen reader nothing.
 
 Every one of those clicks writes a `user_events` row named **`click mnx link`**
 carrying the placement (`market page cta`, `market page credit`,

--- a/backend/shared/src/perps/README.md
+++ b/backend/shared/src/perps/README.md
@@ -643,12 +643,20 @@ for the cohort, sources, deployment order and environment validation.
 
 `common/perps/mnx-cta.ts` owns every link that sends a reader to MNX, and
 `web/components/perps/mnx-cta.tsx` renders them. `MnxTradeCta` is the call to
-action — "Trade `<TICKER>` with real money on MNX" — shown under the chart on a
-market page and on the /perps terminal; the source credit under the chart is a
-credit again rather than a second CTA, because there is now a real one. Both
-are withheld for markets on non-MNX feeds, and the CTA is also withheld once a
+action — "Trade `<TICKER>` with real money" — shown under the chart on a market
+page and on the /perps terminal; the source credit under the chart is a credit
+again rather than a second CTA, because there is now a real one. Both are
+withheld for markets on non-MNX feeds, and the CTA is also withheld once a
 market has settled, since MNX ending an instrument is exactly what pauses
 trading here pending administrative settlement and its page may be gone.
+
+The CTA wears MNX's colours, not Manifold's: their wordmark
+(`web/public/mnx-logo.svg`, white, the same asset the /jobs partner block uses)
+on a near-black panel, with the button inverted to white. One treatment serves
+both themes, so the white wordmark never needs an inverted copy — and the panel
+is `slate-950` rather than the /jobs tile's `slate-900` because dark-mode
+`canvas-0` is itself roughly `slate-900`, which would leave it level with the
+page instead of on top of it.
 
 Every one of those clicks writes a `user_events` row named **`click mnx link`**
 carrying the placement (`market page cta`, `market page credit`,

--- a/common/src/perps/mnx-cta.test.ts
+++ b/common/src/perps/mnx-cta.test.ts
@@ -1,0 +1,62 @@
+import { MNX_INSTRUMENTS } from './mnx'
+import {
+  MNX_CLICK_EVENT,
+  MNX_LINK_LOCATIONS,
+  getMnxTradeTarget,
+  mnxLinkContent,
+  mnxLinkUrl,
+} from './mnx-cta'
+
+it('offers every live MNX instrument a target, and nothing else', () => {
+  for (const instrument of MNX_INSTRUMENTS)
+    expect(getMnxTradeTarget({ oracleFeedId: instrument.feedId })).toBe(
+      instrument
+    )
+  for (const feedId of [undefined, 'btc-usd', 'trump-approval-rating', ''])
+    expect(getMnxTradeTarget({ oracleFeedId: feedId })).toBeUndefined()
+})
+
+it('withholds the CTA from a settled market, whose instrument may be delisted', () => {
+  const oracleFeedId = MNX_INSTRUMENTS[0].feedId
+  expect(getMnxTradeTarget({ oracleFeedId, isResolved: false })).toBeDefined()
+  expect(getMnxTradeTarget({ oracleFeedId, isResolved: true })).toBeUndefined()
+})
+
+it('tags each placement distinguishably, from one event name', () => {
+  // The event name and the utm_content are the two halves someone has to
+  // join later; neither may drift into something a query would miss.
+  expect(MNX_CLICK_EVENT).toBe('click mnx link')
+  const contents = MNX_LINK_LOCATIONS.map(mnxLinkContent)
+  expect(new Set(contents).size).toBe(MNX_LINK_LOCATIONS.length)
+  for (const content of contents) expect(content).toMatch(/^[a-z-]+$/)
+  expect(
+    mnxLinkUrl('https://app.mnx.fi/trade/anthropic', 'market page cta')
+  ).toBe(
+    'https://app.mnx.fi/trade/anthropic?utm_source=manifold&utm_medium=referral' +
+      '&utm_campaign=perps&utm_content=market-page-cta'
+  )
+})
+
+it('keeps the instrument page intact while tagging it', () => {
+  const tagged = mnxLinkUrl(
+    'https://app.mnx.fi/trade/h100?theme=dark#book',
+    'perps hub credit'
+  )
+  const parsed = new URL(tagged)
+  expect(parsed.origin + parsed.pathname).toBe('https://app.mnx.fi/trade/h100')
+  expect(parsed.hash).toBe('#book')
+  expect(parsed.searchParams.get('theme')).toBe('dark')
+  expect(parsed.searchParams.get('utm_content')).toBe('perps-hub-credit')
+  // Tagging is idempotent: a second pass replaces the params rather than
+  // sending two of each.
+  expect(mnxLinkUrl(tagged, 'perps hub credit')).toBe(tagged)
+  expect(
+    new URL(mnxLinkUrl(tagged, 'market page cta')).searchParams.getAll(
+      'utm_content'
+    )
+  ).toEqual(['market-page-cta'])
+})
+
+it('never breaks a link it cannot parse', () => {
+  expect(mnxLinkUrl('not a url', 'market page cta')).toBe('not a url')
+})

--- a/common/src/perps/mnx-cta.ts
+++ b/common/src/perps/mnx-cta.ts
@@ -1,0 +1,80 @@
+import { MnxInstrument, getMnxInstrument } from './mnx'
+
+// Outbound links to MNX: which market gets one, where the href points, and
+// the single event name every one of those clicks writes.
+//
+// Two halves that have to agree with each other:
+//   - Manifold side: every click inserts a `user_events` row named
+//     MNX_CLICK_EVENT carrying the placement, the market and the instrument.
+//     The row has the clicker's user id (null when signed out, with the
+//     device id already in `data` via track()), so "how many clicked, and
+//     who" is one query against a table we own — not a number MNX has to
+//     tell us.
+//   - MNX side: the href carries utm tags built from the SAME placement
+//     string, so their analytics and ours can be reconciled placement by
+//     placement instead of compared as two unrelated totals.
+//
+// Both halves live here rather than in the components because both are
+// contracts with something outside the component — a SQL query someone
+// writes weeks later (see backend/scripts/count-mnx-clicks.ts) and a third
+// party's analytics — so they need one testable definition instead of string
+// literals sprinkled through JSX.
+
+export const MNX_CLICK_EVENT = 'click mnx link'
+
+// Placement, not page: a reader can reach MNX from the CTA card or from the
+// source credit under the chart, and those are different clicks with
+// different intent. The surface is part of the value because the /perps hub
+// and a market page draw different traffic.
+export const MNX_LINK_LOCATIONS = [
+  'market page cta',
+  'market page credit',
+  'perps hub cta',
+  'perps hub credit',
+] as const
+
+export type MnxLinkLocation = (typeof MNX_LINK_LOCATIONS)[number]
+
+/** `utm_content` for a placement: the event's own location, hyphenated. */
+export const mnxLinkContent = (location: MnxLinkLocation) =>
+  location.replace(/\s+/g, '-')
+
+/**
+ * The MNX instrument page this market should offer a reader, or undefined
+ * when it should offer none.
+ */
+export const getMnxTradeTarget = (contract: {
+  oracleFeedId?: string
+  isResolved?: boolean
+}): MnxInstrument | undefined => {
+  const instrument = getMnxInstrument(contract.oracleFeedId)
+  // A settled market is precisely the case where the instrument may no longer
+  // exist: MNX ending one is what pauses trading here pending administrative
+  // settlement (see the note under the chart), so a "trade it on MNX" button
+  // on a settled page is the one that can point at a delisted instrument. The
+  // source credit keeps its link either way — that one is a credit, not a
+  // promotion.
+  return instrument && !contract.isResolved ? instrument : undefined
+}
+
+/**
+ * An MNX url tagged with the placement the click came from, so MNX can
+ * attribute the visit without us having to ask them for numbers.
+ */
+export const mnxLinkUrl = (url: string, location: MnxLinkLocation) => {
+  try {
+    const tagged = new URL(url)
+    // set(), not append(): re-tagging a url that already carries utm params
+    // replaces them instead of sending two of each.
+    tagged.searchParams.set('utm_source', 'manifold')
+    tagged.searchParams.set('utm_medium', 'referral')
+    tagged.searchParams.set('utm_campaign', 'perps')
+    tagged.searchParams.set('utm_content', mnxLinkContent(location))
+    return tagged.toString()
+  } catch {
+    // A url we can't parse is still a link we shouldn't break. The
+    // Manifold-side event is recorded either way, so a click is never lost
+    // for want of a tag.
+    return url
+  }
+}

--- a/common/src/perps/mnx-cta.ts
+++ b/common/src/perps/mnx-cta.ts
@@ -50,10 +50,9 @@ export const getMnxTradeTarget = (contract: {
   const instrument = getMnxInstrument(contract.oracleFeedId)
   // A settled market is precisely the case where the instrument may no longer
   // exist: MNX ending one is what pauses trading here pending administrative
-  // settlement (see the note under the chart), so a "trade it on MNX" button
-  // on a settled page is the one that can point at a delisted instrument. The
-  // source credit keeps its link either way — that one is a credit, not a
-  // promotion.
+  // settlement, so a "trade it on MNX" button on a settled page is the one
+  // that can point at a delisted instrument. The source credit keeps its link
+  // either way — that one is a credit, not a promotion.
   return instrument && !contract.isResolved ? instrument : undefined
 }
 

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -73,9 +73,9 @@ New MNX markets use the partner's category templates: `[Company] IPO Market Cap
 (MNX)` for valuation futures, `[Company] (MNX)` for equities, and `H100 GPU rental
 price (MNX)` for compute. Descriptions come from the same instrument registry;
 canonical display tickers remain unchanged (including `ANTH`, `SNDK`, and `H100`).
-The compact CTA links to the instrument on MNX independently of the market's
-editable description, replacing the source/date footnote below the chart (see
-the perps README). The delisting behaviour still holds — if MNX ends the
+The chart's source credit links to MNX with a compact UTC timestamp. A separate
+CTA sits at the top of the description, below the trading and position panels
+(see the perps README). The delisting behaviour still holds — if MNX ends the
 instrument, trading pauses pending administrative settlement and does not
 automatically roll into a replacement — but the market page no longer prints a
 standing notice saying so; a settled market shows no CTA for exactly that

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -73,8 +73,8 @@ New MNX markets use the partner's category templates: `[Company] IPO Market Cap
 (MNX)` for valuation futures, `[Company] (MNX)` for equities, and `H100 GPU rental
 price (MNX)` for compute. Descriptions come from the same instrument registry;
 canonical display tickers remain unchanged (including `ANTH`, `SNDK`, and `H100`).
-The market's oracle attribution continues to link to MNX independently of its
-editable description, and the CTA beside it links to the instrument on MNX (see
+The compact CTA links to the instrument on MNX independently of the market's
+editable description, replacing the source/date footnote below the chart (see
 the perps README). The delisting behaviour still holds — if MNX ends the
 instrument, trading pauses pending administrative settlement and does not
 automatically roll into a replacement — but the market page no longer prints a

--- a/docs/mnx-dashboard.md
+++ b/docs/mnx-dashboard.md
@@ -74,10 +74,12 @@ New MNX markets use the partner's category templates: `[Company] IPO Market Cap
 price (MNX)` for compute. Descriptions come from the same instrument registry;
 canonical display tickers remain unchanged (including `ANTH`, `SNDK`, and `H100`).
 The market's oracle attribution continues to link to MNX independently of its
-editable description. A fixed notice beside that source explains that if MNX
-ends the instrument, trading pauses pending administrative settlement and does
-not automatically roll into a replacement. Deploy the web change before running
-the copy backfill so this notice stays visible when descriptions are replaced.
+editable description, and the CTA beside it links to the instrument on MNX (see
+the perps README). The delisting behaviour still holds — if MNX ends the
+instrument, trading pauses pending administrative settlement and does not
+automatically roll into a replacement — but the market page no longer prints a
+standing notice saying so; a settled market shows no CTA for exactly that
+reason.
 
 The launch preflight reports an edited MNX-owned title as `INFO`, printing both
 the stored title and the template. Matching titles still report `PASS`; title

--- a/web/components/contract/contract-description.tsx
+++ b/web/components/contract/contract-description.tsx
@@ -14,6 +14,7 @@ import { Row } from '../layout/row'
 import { CollapsibleContent } from '../widgets/collapsible-content'
 import { PendingClarifications } from './pending-clarifications'
 import { CreatorBannedFromBettingInfo } from './creator-banned-from-betting-info'
+import { MnxTradeCta } from '../perps/mnx-cta'
 
 export function ContractDescription(props: {
   contractId: string // the description is stored on this contract
@@ -39,6 +40,13 @@ export function ContractDescription(props: {
   return (
     <>
       <div className="mb-2 mt-6">
+        {contract.mechanism === 'perp' && (
+          <MnxTradeCta
+            contract={contract}
+            location="market page cta"
+            className="mb-4"
+          />
+        )}
         {isCreator || isModOrAdmin ? (
           <EditableDescription
             contractId={contractId}

--- a/web/components/contract/contract-description.tsx
+++ b/web/components/contract/contract-description.tsx
@@ -40,13 +40,6 @@ export function ContractDescription(props: {
   return (
     <>
       <div className="mb-2 mt-6">
-        {contract.mechanism === 'perp' && (
-          <MnxTradeCta
-            contract={contract}
-            location="market page cta"
-            className="mb-4"
-          />
-        )}
         {isCreator || isModOrAdmin ? (
           <EditableDescription
             contractId={contractId}
@@ -78,6 +71,13 @@ export function ContractDescription(props: {
           <CreatorBannedFromBettingInfo
             contract={contract}
             creatorId={creatorId}
+          />
+        )}
+        {contract.mechanism === 'perp' && (
+          <MnxTradeCta
+            contract={contract}
+            location="market page cta"
+            className="mt-4"
           />
         )}
       </div>

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -551,7 +551,7 @@ export function ContractPageContent(props: ContractParams) {
                 contract={liveContract}
               />
             )}
-            {props.contract.isRanked !== false && (
+            {!isPerp && props.contract.isRanked !== false && (
               <MarketContext contractId={props.contract.id} />
             )}
 

--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -551,7 +551,7 @@ export function ContractPageContent(props: ContractParams) {
                 contract={liveContract}
               />
             )}
-            {!isPerp && props.contract.isRanked !== false && (
+            {props.contract.isRanked !== false && (
               <MarketContext contractId={props.contract.id} />
             )}
 

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -85,6 +85,12 @@ export const MnxTradeCta = (props: {
   // reader who trades on MNX notices immediately.
   const derivative =
     instrument.type === 'future' ? 'valuation future' : 'perpetual'
+  const linkProps = mnxLinkProps({
+    url: instrument.url,
+    location,
+    feedId: contract.oracleFeedId,
+    contractId: contract.id,
+  })
 
   return (
     // MNX's own colours rather than Manifold's: their wordmark is white on
@@ -97,14 +103,17 @@ export const MnxTradeCta = (props: {
     // the panel has to be darker than the page, not level with it.
     <Row
       className={clsx(
-        'flex-wrap items-center gap-x-3 gap-y-3 rounded-lg bg-slate-950 px-4 py-3 ring-1 ring-slate-800 sm:gap-x-4',
+        'relative items-center gap-x-3 gap-y-3 rounded-lg bg-slate-950 px-3 py-3 ring-1 ring-slate-800 sm:flex-wrap sm:gap-x-4 sm:px-4',
         className
       )}
     >
-      {/* Plain img, like the /jobs partner block: it is a fixed-size static
-          asset, so next/image would add a request and a wrapper for nothing.
-          alt is the brand name — on a phone it is the only thing left beside
-          the button. */}
+      {/* Cover the whole card on phones; the desktop button is a separate
+          sibling link, so one activation only records one click. */}
+      <a
+        {...linkProps}
+        aria-label={`Trade ${ticker} with real money on MNX (opens in a new tab)`}
+        className="absolute inset-0 z-10 rounded-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:hidden"
+      />
       <img
         src="/mnx-logo.svg"
         alt="MNX"
@@ -112,32 +121,27 @@ export const MnxTradeCta = (props: {
         height={103}
         className="h-4 w-auto shrink-0 sm:h-5"
       />
-      <div
-        aria-hidden
-        className="hidden w-px shrink-0 self-stretch bg-slate-700 sm:block"
-      />
-      {/* Phones show just the wordmark and trade button. */}
-      <Col className="hidden min-w-[12rem] flex-1 gap-0.5 sm:flex">
+      <div aria-hidden className="w-px shrink-0 self-stretch bg-slate-700" />
+      <Col className="min-w-0 flex-1 gap-0.5 sm:min-w-[12rem]">
         <div className="text-sm font-semibold text-white">
-          Trade {ticker} with real money
+          Trade {ticker} with real{' '}
+          <span className="whitespace-nowrap">
+            money
+            <ExternalLinkIcon
+              aria-hidden
+              className="ml-1 inline h-4 w-4 align-text-bottom sm:hidden"
+            />
+          </span>
         </div>
         <div className="text-xs text-slate-400">
           MNX's {derivative} on {instrument.name}
         </div>
       </Col>
       <a
-        {...mnxLinkProps({
-          url: instrument.url,
-          location,
-          feedId: contract.oracleFeedId,
-          contractId: contract.id,
-        })}
+        {...linkProps}
         className={clsx(
           buttonClass('sm', 'none'),
-          'gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200',
-          // Fills the row beside the wordmark on a phone, where it is the only
-          // other thing there; natural width beside the text on wider screens.
-          'max-sm:flex-1 sm:shrink-0'
+          'hidden gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200 sm:inline-flex sm:shrink-0'
         )}
       >
         Trade {ticker} on MNX

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -1,0 +1,122 @@
+import { ExternalLinkIcon } from '@heroicons/react/outline'
+import clsx from 'clsx'
+import { MouseEvent } from 'react'
+import { PerpContract } from 'common/contract'
+import { getMnxInstrument } from 'common/perps/mnx'
+import {
+  MNX_CLICK_EVENT,
+  MnxLinkLocation,
+  getMnxTradeTarget,
+  mnxLinkUrl,
+} from 'common/perps/mnx-cta'
+import { getPerpTicker } from 'common/perps/ticker'
+import { buttonClass } from 'web/components/buttons/button'
+import { track } from 'web/lib/service/analytics'
+import { Col } from '../layout/col'
+import { Row } from '../layout/row'
+
+/**
+ * Everything an outbound MNX link needs — the tagged href, the new-tab
+ * attributes and the click tracking — as one spreadable object.
+ *
+ * Deliberately not three things a call site remembers to do: the point of the
+ * CTA is to learn how many people (and which people) leave for MNX, and a
+ * placement that looks like the others but is counted by nobody is worse than
+ * no placement at all, because it silently deflates the number we act on.
+ */
+export const mnxLinkProps = (props: {
+  url: string
+  location: MnxLinkLocation
+  feedId: string | undefined
+  /** Lands in `user_events.contract_id`, so clicks group by market. */
+  contractId?: string
+}) => {
+  const { url, location, feedId, contractId } = props
+  const href = mnxLinkUrl(url, location)
+  const instrument = getMnxInstrument(feedId)
+  const record = () =>
+    track(MNX_CLICK_EVENT, {
+      location,
+      contractId,
+      feedId,
+      // The MNX-side identity of what they clicked through to, so a rename of
+      // our ticker or question doesn't orphan the history.
+      symbol: instrument?.symbol,
+      instrument: instrument?.slug,
+      url: href,
+    })
+  return {
+    href,
+    target: '_blank',
+    rel: 'noopener noreferrer',
+    // track() is fire-and-forget, which is safe here only because the link
+    // opens a new tab: this page stays mounted, so the insert is not racing a
+    // navigation that would cancel it.
+    onClick: record,
+    // A middle click opens a background tab and fires auxclick, not click —
+    // without this, those read as zero. Middle button only: right-click fires
+    // auxclick too, and opening a context menu is not a click-through.
+    onAuxClick: (e: MouseEvent<HTMLAnchorElement>) => {
+      if (e.button === 1) record()
+    },
+  }
+}
+
+/**
+ * The call to action on a market whose price comes from MNX: the same
+ * instrument, tradable there with real money.
+ *
+ * Renders nothing for a market that isn't on an MNX feed, and nothing once it
+ * has settled — see getMnxTradeTarget for why. Sits under the chart with the
+ * source credit rather than above the bet panel: it belongs to the block that
+ * explains where this price comes from, and Manifold's own trading controls
+ * stay the page's primary action.
+ */
+export const MnxTradeCta = (props: {
+  contract: PerpContract
+  location: MnxLinkLocation
+  className?: string
+}) => {
+  const { contract, location, className } = props
+  const instrument = getMnxTradeTarget(contract)
+  if (!instrument) return null
+
+  const ticker = getPerpTicker(contract)
+  // Valuation instruments are futures on a post-IPO market cap, not
+  // perpetuals; calling them the wrong thing in a CTA is the kind of detail a
+  // reader who trades on MNX notices immediately.
+  const derivative =
+    instrument.type === 'future' ? 'valuation future' : 'perpetual'
+
+  return (
+    <Row
+      className={clsx(
+        'border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-900/20 flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-lg border px-4 py-3',
+        className
+      )}
+    >
+      <Col className="min-w-[14rem] flex-1 gap-0.5">
+        <div className="text-ink-900 text-sm font-semibold">
+          Trade {ticker} with real money on MNX
+        </div>
+        <div className="text-ink-600 text-xs">
+          Positions here are in mana. This market tracks MNX's {derivative} on{' '}
+          {instrument.name} — the instrument itself trades on MNX, a separate
+          exchange.
+        </div>
+      </Col>
+      <a
+        {...mnxLinkProps({
+          url: instrument.url,
+          location,
+          feedId: contract.oracleFeedId,
+          contractId: contract.id,
+        })}
+        className={clsx(buttonClass('sm', 'indigo'), 'shrink-0 gap-1.5')}
+      >
+        Trade {ticker} on MNX
+        <ExternalLinkIcon aria-hidden className="h-4 w-4" />
+      </a>
+    </Row>
+  )
+}

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -120,12 +120,12 @@ export const MnxTradeCta = (props: {
           <div className="text-sm font-semibold text-white">
             Trade {ticker} with real money
           </div>
-          {/* Two short sentences: what the price is, and that this market is
-              not it. The wordmark, the button and the new tab say the rest —
-              nobody needs a paragraph to be told they are leaving. */}
-          <div className="text-xs text-slate-400">
-            Tracks MNX's {derivative} on {instrument.name}. Positions here are
-            in mana.
+          {/* Which instrument you'd be trading over there, and nothing else —
+              the wordmark, the button and the new tab say the rest. Dropped
+              entirely on phones, where it costs two lines of a card sitting
+              above the thing people came to use. */}
+          <div className="hidden text-xs text-slate-400 sm:block">
+            MNX's {derivative} on {instrument.name}
           </div>
         </Col>
       </Row>

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -12,6 +12,7 @@ import {
 import { getPerpTicker } from 'common/perps/ticker'
 import { buttonClass } from 'web/components/buttons/button'
 import { track } from 'web/lib/service/analytics'
+import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 
 /**
@@ -104,8 +105,8 @@ export const MnxTradeCta = (props: {
     >
       {/* Plain img, like the /jobs partner block: it is a fixed-size static
           asset, so next/image would add a request and a wrapper for nothing.
-          alt is the brand name, which is also what earns the button the right
-          to leave "on MNX" out on a phone. */}
+          alt is the brand name — on a phone it is the only thing left beside
+          the button. */}
       <img
         src="/mnx-logo.svg"
         alt="MNX"
@@ -117,14 +118,18 @@ export const MnxTradeCta = (props: {
         aria-hidden
         className="hidden w-px shrink-0 self-stretch bg-slate-700 sm:block"
       />
-      {/* Which instrument you'd be trading over there. The offer itself lives
-          in the button — saying it here as well was the same sentence twice.
-          Phones get neither this nor the divider: the card sits right above
-          the bet panel, so a line here is a line taken from what people came
-          for. */}
-      <div className="hidden min-w-[12rem] flex-1 text-sm text-slate-300 sm:block">
-        MNX's {derivative} on {instrument.name}
-      </div>
+      {/* The pitch and the instrument it's on. Phones get neither this nor the
+          divider, leaving the wordmark and the button alone on one line: the
+          card sits right above the bet panel, so a line here is a line taken
+          from what people came for, and the button already says the offer. */}
+      <Col className="hidden min-w-[12rem] flex-1 gap-0.5 sm:flex">
+        <div className="text-sm font-semibold text-white">
+          Trade {ticker} with real money
+        </div>
+        <div className="text-xs text-slate-400">
+          MNX's {derivative} on {instrument.name}
+        </div>
+      </Col>
       <a
         {...mnxLinkProps({
           url: instrument.url,
@@ -132,26 +137,17 @@ export const MnxTradeCta = (props: {
           feedId: contract.oracleFeedId,
           contractId: contract.id,
         })}
-        // The label a screen reader gets is the full one at every width, so
-        // the phone's shorter wording never costs a link its meaning.
-        aria-label={`Trade ${ticker} with real money on MNX`}
         className={clsx(
           buttonClass('sm', 'none'),
           'gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200',
-          // Fills the row beside the wordmark on a phone; natural width beside
-          // the description on wider screens, where shrinking it would squeeze
-          // the label instead of wrapping the row.
+          // Fills the row beside the wordmark on a phone, where it is the only
+          // other thing there; natural width beside the text on wider screens,
+          // where shrinking it would squeeze the label instead of wrapping the
+          // row.
           'max-sm:flex-1 sm:shrink-0'
         )}
       >
-        {/* Phones: the wordmark to its left IS the "on MNX", and the ticker is
-            in the market header — so the button carries the offer alone. That
-            is what keeps it on one line from 360px up; the full label needs
-            334px of button and never fits beside the wordmark on a phone. */}
-        <span className="sm:hidden">Trade with real money</span>
-        <span className="hidden sm:inline">
-          Trade {ticker} with real money on MNX
-        </span>
+        Trade {ticker} on MNX
         <ExternalLinkIcon aria-hidden className="h-4 w-4 shrink-0" />
       </a>
     </Row>

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -12,7 +12,6 @@ import {
 import { getPerpTicker } from 'common/perps/ticker'
 import { buttonClass } from 'web/components/buttons/button'
 import { track } from 'web/lib/service/analytics'
-import { Col } from '../layout/col'
 import { Row } from '../layout/row'
 
 /**
@@ -99,36 +98,33 @@ export const MnxTradeCta = (props: {
     // the panel has to be darker than the page, not level with it.
     <Row
       className={clsx(
-        'flex-wrap items-center gap-x-4 gap-y-3 rounded-lg bg-slate-950 px-4 py-3 ring-1 ring-slate-800',
+        'flex-wrap items-center gap-x-3 gap-y-3 rounded-lg bg-slate-950 px-4 py-3 ring-1 ring-slate-800 sm:gap-x-4',
         className
       )}
     >
-      <Row className="min-w-[13rem] flex-1 items-center gap-3">
-        {/* Plain img, like the /jobs partner block: it is a fixed-size static
-            asset, so next/image would add a request and a wrapper for nothing.
-            alt is the brand name — the heading beside it deliberately doesn't
-            repeat it. */}
-        <img
-          src="/mnx-logo.svg"
-          alt="MNX"
-          width={300}
-          height={103}
-          className="h-5 w-auto shrink-0"
-        />
-        <div aria-hidden className="w-px shrink-0 self-stretch bg-slate-700" />
-        <Col className="min-w-0 gap-0.5">
-          <div className="text-sm font-semibold text-white">
-            Trade {ticker} with real money
-          </div>
-          {/* Which instrument you'd be trading over there, and nothing else —
-              the wordmark, the button and the new tab say the rest. Dropped
-              entirely on phones, where it costs two lines of a card sitting
-              above the thing people came to use. */}
-          <div className="hidden text-xs text-slate-400 sm:block">
-            MNX's {derivative} on {instrument.name}
-          </div>
-        </Col>
-      </Row>
+      {/* Plain img, like the /jobs partner block: it is a fixed-size static
+          asset, so next/image would add a request and a wrapper for nothing.
+          alt is the brand name, which is also what earns the button the right
+          to leave "on MNX" out on a phone. */}
+      <img
+        src="/mnx-logo.svg"
+        alt="MNX"
+        width={300}
+        height={103}
+        className="h-4 w-auto shrink-0 sm:h-5"
+      />
+      <div
+        aria-hidden
+        className="hidden w-px shrink-0 self-stretch bg-slate-700 sm:block"
+      />
+      {/* Which instrument you'd be trading over there. The offer itself lives
+          in the button — saying it here as well was the same sentence twice.
+          Phones get neither this nor the divider: the card sits right above
+          the bet panel, so a line here is a line taken from what people came
+          for. */}
+      <div className="hidden min-w-[12rem] flex-1 text-sm text-slate-300 sm:block">
+        MNX's {derivative} on {instrument.name}
+      </div>
       <a
         {...mnxLinkProps({
           url: instrument.url,
@@ -136,13 +132,27 @@ export const MnxTradeCta = (props: {
           feedId: contract.oracleFeedId,
           contractId: contract.id,
         })}
+        // The label a screen reader gets is the full one at every width, so
+        // the phone's shorter wording never costs a link its meaning.
+        aria-label={`Trade ${ticker} with real money on MNX`}
         className={clsx(
           buttonClass('sm', 'none'),
-          'shrink-0 gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200'
+          'gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200',
+          // Fills the row beside the wordmark on a phone; natural width beside
+          // the description on wider screens, where shrinking it would squeeze
+          // the label instead of wrapping the row.
+          'max-sm:flex-1 sm:shrink-0'
         )}
       >
-        Trade {ticker} on MNX
-        <ExternalLinkIcon aria-hidden className="h-4 w-4" />
+        {/* Phones: the wordmark to its left IS the "on MNX", and the ticker is
+            in the market header — so the button carries the offer alone. That
+            is what keeps it on one line from 360px up; the full label needs
+            334px of button and never fits beside the wordmark on a phone. */}
+        <span className="sm:hidden">Trade with real money</span>
+        <span className="hidden sm:inline">
+          Trade {ticker} with real money on MNX
+        </span>
+        <ExternalLinkIcon aria-hidden className="h-4 w-4 shrink-0" />
       </a>
     </Row>
   )

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -89,22 +89,46 @@ export const MnxTradeCta = (props: {
     instrument.type === 'future' ? 'valuation future' : 'perpetual'
 
   return (
+    // MNX's own colours rather than Manifold's: their wordmark is white on
+    // near-black (see the partner block on /jobs, which uses the same asset),
+    // so the card is a black panel and the button inverts to white. It reads
+    // as somewhere else — which is the point of a CTA that leaves the site —
+    // and it is one treatment in both themes, so the white wordmark never
+    // needs a second, inverted copy. slate-950 rather than the /jobs tile's
+    // slate-900 because dark-mode canvas-0 IS roughly slate-900: at this size
+    // the panel has to be darker than the page, not level with it.
     <Row
       className={clsx(
-        'border-primary-200 bg-primary-50 dark:border-primary-800 dark:bg-primary-900/20 flex-wrap items-center justify-between gap-x-4 gap-y-3 rounded-lg border px-4 py-3',
+        'flex-wrap items-center gap-x-4 gap-y-3 rounded-lg bg-slate-950 px-4 py-3 ring-1 ring-slate-800',
         className
       )}
     >
-      <Col className="min-w-[14rem] flex-1 gap-0.5">
-        <div className="text-ink-900 text-sm font-semibold">
-          Trade {ticker} with real money on MNX
-        </div>
-        <div className="text-ink-600 text-xs">
-          Positions here are in mana. This market tracks MNX's {derivative} on{' '}
-          {instrument.name} — the instrument itself trades on MNX, a separate
-          exchange.
-        </div>
-      </Col>
+      <Row className="min-w-[13rem] flex-1 items-center gap-3">
+        {/* Plain img, like the /jobs partner block: it is a fixed-size static
+            asset, so next/image would add a request and a wrapper for nothing.
+            alt is the brand name — the heading beside it deliberately doesn't
+            repeat it. */}
+        <img
+          src="/mnx-logo.svg"
+          alt="MNX"
+          width={300}
+          height={103}
+          className="h-5 w-auto shrink-0"
+        />
+        <div aria-hidden className="w-px shrink-0 self-stretch bg-slate-700" />
+        <Col className="min-w-0 gap-0.5">
+          <div className="text-sm font-semibold text-white">
+            Trade {ticker} with real money
+          </div>
+          {/* Two short sentences: what the price is, and that this market is
+              not it. The wordmark, the button and the new tab say the rest —
+              nobody needs a paragraph to be told they are leaving. */}
+          <div className="text-xs text-slate-400">
+            Tracks MNX's {derivative} on {instrument.name}. Positions here are
+            in mana.
+          </div>
+        </Col>
+      </Row>
       <a
         {...mnxLinkProps({
           url: instrument.url,
@@ -112,7 +136,10 @@ export const MnxTradeCta = (props: {
           feedId: contract.oracleFeedId,
           contractId: contract.id,
         })}
-        className={clsx(buttonClass('sm', 'indigo'), 'shrink-0 gap-1.5')}
+        className={clsx(
+          buttonClass('sm', 'none'),
+          'shrink-0 gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200'
+        )}
       >
         Trade {ticker} on MNX
         <ExternalLinkIcon aria-hidden className="h-4 w-4" />

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -67,10 +67,8 @@ export const mnxLinkProps = (props: {
  * instrument, tradable there with real money.
  *
  * Renders nothing for a market that isn't on an MNX feed, and nothing once it
- * has settled — see getMnxTradeTarget for why. Sits under the chart with the
- * source credit rather than above the bet panel: it belongs to the block that
- * explains where this price comes from, and Manifold's own trading controls
- * stay the page's primary action.
+ * has settled — see getMnxTradeTarget for why. Replaces the MNX source footnote
+ * under the chart. The card is shorter than the Long/Short buttons.
  */
 export const MnxTradeCta = (props: {
   contract: PerpContract
@@ -99,7 +97,7 @@ export const MnxTradeCta = (props: {
     // the panel has to be darker than the page, not level with it.
     <Row
       className={clsx(
-        'flex-wrap items-center gap-x-3 gap-y-3 rounded-lg bg-slate-950 px-4 py-3 ring-1 ring-slate-800 sm:gap-x-4',
+        'h-10 min-w-0 items-center gap-2 rounded-lg bg-slate-950 px-3 ring-1 ring-slate-800',
         className
       )}
     >
@@ -112,21 +110,21 @@ export const MnxTradeCta = (props: {
         alt="MNX"
         width={300}
         height={103}
-        className="h-4 w-auto shrink-0 sm:h-5"
+        className="h-3.5 w-auto shrink-0 sm:h-4"
       />
       <div
         aria-hidden
-        className="hidden w-px shrink-0 self-stretch bg-slate-700 sm:block"
+        className="hidden h-7 w-px shrink-0 bg-slate-700 sm:block"
       />
       {/* The pitch and the instrument it's on. Phones get neither this nor the
           divider, leaving the wordmark and the button alone on one line: the
           card sits right above the bet panel, so a line here is a line taken
           from what people came for, and the button already says the offer. */}
-      <Col className="hidden min-w-[12rem] flex-1 gap-0.5 sm:flex">
-        <div className="text-sm font-semibold text-white">
+      <Col className="hidden min-w-0 flex-1 sm:flex">
+        <div className="truncate text-xs font-semibold leading-[14px] text-white">
           Trade {ticker} with real money
         </div>
-        <div className="text-xs text-slate-400">
+        <div className="truncate text-[11px] leading-[14px] text-slate-400">
           MNX's {derivative} on {instrument.name}
         </div>
       </Col>
@@ -138,12 +136,10 @@ export const MnxTradeCta = (props: {
           contractId: contract.id,
         })}
         className={clsx(
-          buttonClass('sm', 'none'),
-          'gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200',
+          buttonClass('2xs', 'none'),
+          'h-7 gap-1.5 whitespace-nowrap bg-white font-semibold text-slate-900 hover:bg-slate-200',
           // Fills the row beside the wordmark on a phone, where it is the only
-          // other thing there; natural width beside the text on wider screens,
-          // where shrinking it would squeeze the label instead of wrapping the
-          // row.
+          // other thing there; natural width beside the text on wider screens.
           'max-sm:flex-1 sm:shrink-0'
         )}
       >

--- a/web/components/perps/mnx-cta.tsx
+++ b/web/components/perps/mnx-cta.tsx
@@ -67,8 +67,8 @@ export const mnxLinkProps = (props: {
  * instrument, tradable there with real money.
  *
  * Renders nothing for a market that isn't on an MNX feed, and nothing once it
- * has settled — see getMnxTradeTarget for why. Replaces the MNX source footnote
- * under the chart. The card is shorter than the Long/Short buttons.
+ * has settled — see getMnxTradeTarget for why. Appears above the market
+ * description, below the trading controls and position information.
  */
 export const MnxTradeCta = (props: {
   contract: PerpContract
@@ -97,7 +97,7 @@ export const MnxTradeCta = (props: {
     // the panel has to be darker than the page, not level with it.
     <Row
       className={clsx(
-        'h-10 min-w-0 items-center gap-2 rounded-lg bg-slate-950 px-3 ring-1 ring-slate-800',
+        'flex-wrap items-center gap-x-3 gap-y-3 rounded-lg bg-slate-950 px-4 py-3 ring-1 ring-slate-800 sm:gap-x-4',
         className
       )}
     >
@@ -110,21 +110,18 @@ export const MnxTradeCta = (props: {
         alt="MNX"
         width={300}
         height={103}
-        className="h-3.5 w-auto shrink-0 sm:h-4"
+        className="h-4 w-auto shrink-0 sm:h-5"
       />
       <div
         aria-hidden
-        className="hidden h-7 w-px shrink-0 bg-slate-700 sm:block"
+        className="hidden w-px shrink-0 self-stretch bg-slate-700 sm:block"
       />
-      {/* The pitch and the instrument it's on. Phones get neither this nor the
-          divider, leaving the wordmark and the button alone on one line: the
-          card sits right above the bet panel, so a line here is a line taken
-          from what people came for, and the button already says the offer. */}
-      <Col className="hidden min-w-0 flex-1 sm:flex">
-        <div className="truncate text-xs font-semibold leading-[14px] text-white">
+      {/* Phones show just the wordmark and trade button. */}
+      <Col className="hidden min-w-[12rem] flex-1 gap-0.5 sm:flex">
+        <div className="text-sm font-semibold text-white">
           Trade {ticker} with real money
         </div>
-        <div className="truncate text-[11px] leading-[14px] text-slate-400">
+        <div className="text-xs text-slate-400">
           MNX's {derivative} on {instrument.name}
         </div>
       </Col>
@@ -136,8 +133,8 @@ export const MnxTradeCta = (props: {
           contractId: contract.id,
         })}
         className={clsx(
-          buttonClass('2xs', 'none'),
-          'h-7 gap-1.5 whitespace-nowrap bg-white font-semibold text-slate-900 hover:bg-slate-200',
+          buttonClass('sm', 'none'),
+          'gap-1.5 bg-white font-semibold text-slate-900 hover:bg-slate-200',
           // Fills the row beside the wordmark on a phone, where it is the only
           // other thing there; natural width beside the text on wider screens.
           'max-sm:flex-1 sm:shrink-0'

--- a/web/components/perps/perp-oracle-attribution.tsx
+++ b/web/components/perps/perp-oracle-attribution.tsx
@@ -4,6 +4,15 @@ import { MnxLinkLocation } from 'common/perps/mnx-cta'
 import { getOracleAttribution } from 'common/perps/oracle-attribution'
 import { mnxLinkProps } from './mnx-cta'
 
+const mnxAsOfFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hourCycle: 'h23',
+  timeZone: 'UTC',
+})
+
 // Source credit for the oracle feed, rendered as a chart footnote.
 //
 // Deliberately a component rather than prose in the market description: some
@@ -19,7 +28,7 @@ export const PerpOracleAttribution = (props: {
    * Count clicks on an MNX credit as coming from this placement. Optional
    * because this line is a credit first — a placement that doesn't care where
    * its clicks came from renders the plain link it always did — but every
-   * placement that sits next to a CTA should pass it, or the CTA's numbers
+   * placement that also has a CTA should pass it, or the CTA's numbers
    * look better than the page's.
    */
   mnxLinkLocation?: MnxLinkLocation
@@ -34,6 +43,7 @@ export const PerpOracleAttribution = (props: {
   if (!attribution) return null
 
   const { source, url, licence, licenceUrl, showAsOf } = attribution
+  const isMnx = getMnxInstrument(feedId) != null
   const validAsOfTime =
     typeof asOfTime === 'number' && Number.isFinite(asOfTime) && asOfTime > 0
       ? asOfTime
@@ -44,7 +54,7 @@ export const PerpOracleAttribution = (props: {
   // The href is still tagged and counted, since a reader who clicks the credit
   // line left for MNX just the same.
   const trackedMnxLink =
-    url && mnxLinkLocation && getMnxInstrument(feedId)
+    url && mnxLinkLocation && isMnx
       ? mnxLinkProps({
           url,
           location: mnxLinkLocation,
@@ -88,7 +98,20 @@ export const PerpOracleAttribution = (props: {
           ` (${licence})`
         ))}
       {showAsOf &&
-        (validAsOfTime == null
+        (isMnx
+          ? validAsOfTime != null && (
+              <>
+                {' · '}
+                <time
+                  dateTime={new Date(validAsOfTime).toISOString()}
+                  title={new Date(validAsOfTime).toISOString()}
+                  className="whitespace-nowrap"
+                >
+                  {mnxAsOfFormatter.format(validAsOfTime)} UTC
+                </time>
+              </>
+            )
+          : validAsOfTime == null
           ? ', source as-of unavailable.'
           : `, as of ${new Date(validAsOfTime).toISOString()}.`)}
     </div>

--- a/web/components/perps/perp-oracle-attribution.tsx
+++ b/web/components/perps/perp-oracle-attribution.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx'
 import { getMnxInstrument } from 'common/perps/mnx'
+import { MnxLinkLocation } from 'common/perps/mnx-cta'
 import { getOracleAttribution } from 'common/perps/oracle-attribution'
+import { mnxLinkProps } from './mnx-cta'
 
 // Source credit for the oracle feed, rendered as a chart footnote.
 //
@@ -13,32 +15,57 @@ export const PerpOracleAttribution = (props: {
   feedId: string | undefined
   /** Provider-declared source timestamp, not Manifold's observation time. */
   asOfTime?: number | null
+  /**
+   * Count clicks on an MNX credit as coming from this placement. Optional
+   * because this line is a credit first — a placement that doesn't care where
+   * its clicks came from renders the plain link it always did — but every
+   * placement that sits next to a CTA should pass it, or the CTA's numbers
+   * look better than the page's.
+   */
+  mnxLinkLocation?: MnxLinkLocation
+  /** Groups those clicks by market. Only read alongside mnxLinkLocation. */
+  contractId?: string
   className?: string
 }) => {
-  const { feedId, asOfTime, className } = props
+  const { feedId, asOfTime, mnxLinkLocation, contractId, className } = props
   const attribution = getOracleAttribution(feedId)
   // An unregistered or brand-new feed renders nothing rather than "Source:
   // undefined".
   if (!attribution) return null
 
   const { source, url, licence, licenceUrl, showAsOf } = attribution
-  const isMnx = getMnxInstrument(feedId) != null
   const validAsOfTime =
     typeof asOfTime === 'number' && Number.isFinite(asOfTime) && asOfTime > 0
       ? asOfTime
       : null
+  // The credit used to double as the only route to MNX ("Trade with real money
+  // on MNX"), because there was no CTA. There is one now, so this goes back to
+  // reading as what it is — a credit — and the selling happens in MnxTradeCta.
+  // The href is still tagged and counted, since a reader who clicks the credit
+  // line left for MNX just the same.
+  const trackedMnxLink =
+    url && mnxLinkLocation && getMnxInstrument(feedId)
+      ? mnxLinkProps({
+          url,
+          location: mnxLinkLocation,
+          feedId,
+          contractId,
+        })
+      : undefined
 
   return (
     <div className={clsx('text-ink-400 text-xs', className)}>
-      {isMnx ? 'Source: MNX · ' : 'Source: '}
+      Source:{' '}
       {url ? (
         <a
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
+          {...(trackedMnxLink ?? {
+            href: url,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          })}
           className="hover:text-ink-600 underline underline-offset-2"
         >
-          {isMnx ? 'Trade with real money on MNX' : source}
+          {source}
         </a>
       ) : (
         source

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -1,6 +1,5 @@
 import { ORACLE_HEALTH_MAX_AGE_MS } from 'common/perps/oracle-health'
 import { getMnxInstrument } from 'common/perps/mnx'
-import { getMnxTradeTarget } from 'common/perps/mnx-cta'
 import { formatOraclePrice } from 'common/perps/oracle-display'
 import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
@@ -23,7 +22,6 @@ import { Tooltip } from 'web/components/widgets/tooltip'
 import { useIsClient } from 'web/hooks/use-is-client'
 import { PerpChart } from './perp-chart'
 import { PerpBetPanel } from './perp-bet-panel'
-import { MnxTradeCta } from './mnx-cta'
 import { PerpOracleAttribution } from './perp-oracle-attribution'
 import { PerpPositionPanel } from './perp-position-panel'
 import { useLivePerpContract } from './use-live-perp-contract'
@@ -239,18 +237,11 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
           mean the credit is absent for anything reading raw HTML. Fixing that
           means restructuring the page, not moving this line — it renders no
           earlier inside PerpChart. */}
-      {!getMnxTradeTarget(contract) && (
-        <PerpOracleAttribution
-          feedId={contract.oracleFeedId}
-          asOfTime={contract.oracleSourceTime}
-          mnxLinkLocation="market page credit"
-          contractId={contract.id}
-        />
-      )}
-      <MnxTradeCta
-        contract={contract}
-        location="market page cta"
-        className="-my-2"
+      <PerpOracleAttribution
+        feedId={contract.oracleFeedId}
+        asOfTime={contract.oracleSourceTime}
+        mnxLinkLocation="market page credit"
+        contractId={contract.id}
       />
 
       {contract.isResolved ? (

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -247,13 +247,6 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
       {/* The click-through to MNX itself, directly under the credit that names
           it as the source: same instrument, real money. */}
       <MnxTradeCta contract={contract} location="market page cta" />
-      {/* Keep settlement behavior visible even when MNX edits its description. */}
-      {getMnxInstrument(contract.oracleFeedId) && (
-        <p className="text-ink-500 text-sm">
-          If MNX ends this instrument, trading pauses pending administrative
-          settlement; it will not automatically roll into a replacement.
-        </p>
-      )}
 
       {contract.isResolved ? (
         <div className="border-primary-200 bg-primary-50 text-ink-700 dark:bg-primary-900/20 rounded-lg border px-4 py-3 text-sm">

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -22,6 +22,7 @@ import { Tooltip } from 'web/components/widgets/tooltip'
 import { useIsClient } from 'web/hooks/use-is-client'
 import { PerpChart } from './perp-chart'
 import { PerpBetPanel } from './perp-bet-panel'
+import { MnxTradeCta } from './mnx-cta'
 import { PerpOracleAttribution } from './perp-oracle-attribution'
 import { PerpPositionPanel } from './perp-position-panel'
 import { useLivePerpContract } from './use-live-perp-contract'
@@ -240,7 +241,12 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
       <PerpOracleAttribution
         feedId={contract.oracleFeedId}
         asOfTime={contract.oracleSourceTime}
+        mnxLinkLocation="market page credit"
+        contractId={contract.id}
       />
+      {/* The click-through to MNX itself, directly under the credit that names
+          it as the source: same instrument, real money. */}
+      <MnxTradeCta contract={contract} location="market page cta" />
       {/* Keep settlement behavior visible even when MNX edits its description. */}
       {getMnxInstrument(contract.oracleFeedId) && (
         <p className="text-ink-500 text-sm">

--- a/web/components/perps/perp-overview.tsx
+++ b/web/components/perps/perp-overview.tsx
@@ -1,5 +1,6 @@
 import { ORACLE_HEALTH_MAX_AGE_MS } from 'common/perps/oracle-health'
 import { getMnxInstrument } from 'common/perps/mnx'
+import { getMnxTradeTarget } from 'common/perps/mnx-cta'
 import { formatOraclePrice } from 'common/perps/oracle-display'
 import { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
@@ -238,15 +239,19 @@ export const PerpOverview = (props: { contract: PerpContract }) => {
           mean the credit is absent for anything reading raw HTML. Fixing that
           means restructuring the page, not moving this line — it renders no
           earlier inside PerpChart. */}
-      <PerpOracleAttribution
-        feedId={contract.oracleFeedId}
-        asOfTime={contract.oracleSourceTime}
-        mnxLinkLocation="market page credit"
-        contractId={contract.id}
+      {!getMnxTradeTarget(contract) && (
+        <PerpOracleAttribution
+          feedId={contract.oracleFeedId}
+          asOfTime={contract.oracleSourceTime}
+          mnxLinkLocation="market page credit"
+          contractId={contract.id}
+        />
+      )}
+      <MnxTradeCta
+        contract={contract}
+        location="market page cta"
+        className="-my-2"
       />
-      {/* The click-through to MNX itself, directly under the credit that names
-          it as the source: same instrument, real money. */}
-      <MnxTradeCta contract={contract} location="market page cta" />
 
       {contract.isResolved ? (
         <div className="border-primary-200 bg-primary-50 text-ink-700 dark:bg-primary-900/20 rounded-lg border px-4 py-3 text-sm">

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -28,6 +28,7 @@ import {
 import { useIsClient } from 'web/hooks/use-is-client'
 import { getPerpTakerFeeBps } from 'common/perps/fees'
 import { getMnxCreatorId } from 'common/perps/creator-accounts'
+import { getMnxTradeTarget } from 'common/perps/mnx-cta'
 import { getPerpTicker } from 'common/perps/ticker'
 import {
   fundingPeriodNoun,
@@ -1748,13 +1749,19 @@ const Terminal = (props: {
           bleed && '-mx-4'
         )}
       />
-      <PerpOracleAttribution
-        feedId={contract.oracleFeedId}
-        asOfTime={contract.oracleSourceTime}
-        mnxLinkLocation="perps hub credit"
-        contractId={contract.id}
+      {!getMnxTradeTarget(contract) && (
+        <PerpOracleAttribution
+          feedId={contract.oracleFeedId}
+          asOfTime={contract.oracleSourceTime}
+          mnxLinkLocation="perps hub credit"
+          contractId={contract.id}
+        />
+      )}
+      <MnxTradeCta
+        contract={contract}
+        location="perps hub cta"
+        className="-my-2"
       />
-      <MnxTradeCta contract={contract} location="perps hub cta" />
 
       <PerpBetPanel
         contract={contract}

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -28,7 +28,6 @@ import {
 import { useIsClient } from 'web/hooks/use-is-client'
 import { getPerpTakerFeeBps } from 'common/perps/fees'
 import { getMnxCreatorId } from 'common/perps/creator-accounts'
-import { getMnxTradeTarget } from 'common/perps/mnx-cta'
 import { getPerpTicker } from 'common/perps/ticker'
 import {
   fundingPeriodNoun,
@@ -1749,18 +1748,11 @@ const Terminal = (props: {
           bleed && '-mx-4'
         )}
       />
-      {!getMnxTradeTarget(contract) && (
-        <PerpOracleAttribution
-          feedId={contract.oracleFeedId}
-          asOfTime={contract.oracleSourceTime}
-          mnxLinkLocation="perps hub credit"
-          contractId={contract.id}
-        />
-      )}
-      <MnxTradeCta
-        contract={contract}
-        location="perps hub cta"
-        className="-my-2"
+      <PerpOracleAttribution
+        feedId={contract.oracleFeedId}
+        asOfTime={contract.oracleSourceTime}
+        mnxLinkLocation="perps hub credit"
+        contractId={contract.id}
       />
 
       <PerpBetPanel
@@ -1777,6 +1769,7 @@ const Terminal = (props: {
         positions={positions}
         oracleTradingPaused={oracleTradingPaused}
       />
+      <MnxTradeCta contract={contract} location="perps hub cta" />
     </Col>
   )
 }

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -45,6 +45,7 @@ import { Row } from 'web/components/layout/row'
 import { SEO } from 'web/components/SEO'
 import { BackButton } from 'web/components/contract/back-button'
 import { ContractStatusLabel } from 'web/components/contract/contracts-table'
+import { MnxTradeCta } from 'web/components/perps/mnx-cta'
 import { PerpBetPanel } from 'web/components/perps/perp-bet-panel'
 import { PerpChart, prefetchPerpChart } from 'web/components/perps/perp-chart'
 import { PerpOracleAttribution } from 'web/components/perps/perp-oracle-attribution'
@@ -1750,7 +1751,10 @@ const Terminal = (props: {
       <PerpOracleAttribution
         feedId={contract.oracleFeedId}
         asOfTime={contract.oracleSourceTime}
+        mnxLinkLocation="perps hub credit"
+        contractId={contract.id}
       />
+      <MnxTradeCta contract={contract} location="perps hub cta" />
 
       <PerpBetPanel
         contract={contract}
@@ -2532,7 +2536,11 @@ const MarketParameters = (props: { contract: PerpContract }) => {
           </Col>
         ))}
         <div className="px-4 py-3">
-          <PerpOracleAttribution feedId={contract.oracleFeedId} />
+          <PerpOracleAttribution
+            feedId={contract.oracleFeedId}
+            mnxLinkLocation="perps hub credit"
+            contractId={contract.id}
+          />
         </div>
       </Col>
     </Col>


### PR DESCRIPTION
Adds a branded MNX trade card below the market description. On the perps hub, the card appears after the position panel. Desktop retains the pitch, instrument details and trade button. On mobile, the entire card is clickable and shows the MNX wordmark, divider and pitch without a separate button. An external-link icon after “money” indicates that the link opens MNX.

The chart retains its “Source: MNX” link. MNX timestamps use a compact UTC date/time, with the complete timestamp available on hover. Other providers’ attribution and timestamps are preserved.

Click tracking uses the shared `click mnx link` event, records placement, market and instrument, and supports both left and middle clicks. Placement-specific UTM tags support MNX attribution. The read-only `count-mnx-clicks.ts` script reports totals, placement/instrument breakdowns and signed-in clickers over a bounded time window.

The CTA is limited to registered MNX feeds on unsettled markets. Attribution remains available on settled markets.

Validation: five added common tests and five focused click/render checks pass. Rendered all 16 instruments at 320, 360, 390, 640 and 1024px without overflow. Verified one visible link per card and that the mobile link covers the whole card. The market card follows the description, while the perps hub retains its placement after the position panel.

https://claude.ai/code/session_01KfqHY1hFE4dKL5bcWF8Un8