### PR TITLE
Improve perps navigation and related-market discovery

### DIFF
--- a/web/hooks/use-draggable-ticker.ts
+++ b/web/hooks/use-draggable-ticker.ts
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from 'react'
+
+const RESUME_DELAY_MS = 2000
+const DRAG_THRESHOLD_PX = 6
+
+// Keep animation and dragging on the same offset so grabbing the tape never
+// jumps back to the beginning of a CSS animation.
+export const useDraggableTicker = (marketCount: number) => {
+  const viewportRef = useRef<HTMLDivElement>(null)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const groupRef = useRef<HTMLDivElement>(null)
+  const [copies, setCopies] = useState(2)
+
+  useEffect(() => {
+    const viewport = viewportRef.current
+    const track = trackRef.current
+    const group = groupRef.current
+    if (!viewport || !track || !group) return
+
+    const duration = Math.max(24, marketCount * 9)
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
+    let width = 0
+    let offset = 0
+    let velocity = 0
+    let hovered = false
+    let focused = false
+    let resumeAt = 0
+    let suppressClick = false
+    let gesture:
+      | {
+          id: number
+          startX: number
+          startY: number
+          x: number
+          time: number
+          dragging: boolean
+        }
+      | undefined
+
+    const draw = () => {
+      if (!width) return
+      offset = ((offset % width) + width) % width
+      track.style.transform = `translateX(${-offset}px)`
+    }
+    const measure = () => {
+      width = group.getBoundingClientRect().width
+      // Fill even a wide screen with only one or two available markets.
+      if (width) setCopies(Math.ceil(viewport.clientWidth / width) + 1)
+      draw()
+    }
+    const observer = new ResizeObserver(measure)
+    observer.observe(viewport)
+    observer.observe(group)
+    measure()
+
+    const pause = () => {
+      resumeAt = performance.now() + RESUME_DELAY_MS
+    }
+    const down = (event: PointerEvent) => {
+      if (!event.isPrimary || event.button !== 0) return
+      velocity = 0
+      suppressClick = false
+      gesture = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        x: event.clientX,
+        time: performance.now(),
+        dragging: false,
+      }
+    }
+    const move = (event: PointerEvent) => {
+      if (!gesture || gesture.id !== event.pointerId) return
+      const dx = event.clientX - gesture.startX
+      const dy = event.clientY - gesture.startY
+      if (!gesture.dragging) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < DRAG_THRESHOLD_PX) return
+        // Leave vertical gestures to the page. touch-action allows pan-y.
+        if (Math.abs(dy) > Math.abs(dx)) {
+          gesture = undefined
+          pause()
+          return
+        }
+        gesture.dragging = true
+        suppressClick = true
+        viewport.setPointerCapture(event.pointerId)
+      }
+      const now = performance.now()
+      const delta = gesture.x - event.clientX
+      velocity = Math.max(
+        -3,
+        Math.min(3, delta / Math.max(1, now - gesture.time))
+      )
+      offset += delta
+      gesture.x = event.clientX
+      gesture.time = now
+      draw()
+    }
+    const end = (event: PointerEvent) => {
+      // Touch starts with implicit capture on the button. Transferring that
+      // capture to the viewport must not end the gesture.
+      if (event.type === 'lostpointercapture' && event.target !== viewport)
+        return
+      if (!gesture || gesture.id !== event.pointerId) return
+      if (
+        event.type !== 'pointerup' ||
+        !gesture.dragging ||
+        performance.now() - gesture.time > 100 ||
+        reducedMotion.matches
+      )
+        velocity = 0
+      gesture = undefined
+      if (viewport.hasPointerCapture(event.pointerId))
+        viewport.releasePointerCapture(event.pointerId)
+      pause()
+    }
+    const click = (event: MouseEvent) => {
+      // Keyboard activation (detail === 0) must still work after a swipe.
+      if (!suppressClick || event.detail === 0) return
+      event.preventDefault()
+      event.stopPropagation()
+      suppressClick = false
+    }
+    const enter = (event: PointerEvent) => {
+      if (event.pointerType === 'mouse') hovered = true
+    }
+    const leave = (event: PointerEvent) => {
+      if (event.pointerType === 'mouse') hovered = false
+      if (gesture && !gesture.dragging) end(event)
+    }
+    const focus = (event: FocusEvent) => {
+      const target = event.target
+      if (!(target instanceof HTMLElement) || !target.matches(':focus-visible'))
+        return
+      focused = true
+      velocity = 0
+      // The browser may scroll overflow:hidden when focusing an offscreen
+      // button. Move our offset instead, keeping the keyboard target visible.
+      viewport.scrollLeft = 0
+      const bounds = target.getBoundingClientRect()
+      const view = viewport.getBoundingClientRect()
+      if (bounds.left < view.left) offset += bounds.left - view.left
+      else if (bounds.right > view.right) offset += bounds.right - view.right
+      draw()
+    }
+    const blur = (event: FocusEvent) => {
+      if (
+        event.relatedTarget instanceof Node &&
+        viewport.contains(event.relatedTarget)
+      )
+        return
+      focused = false
+      pause()
+    }
+    let previous = performance.now()
+    let frame: number
+    const animate = (now: number) => {
+      const elapsed = Math.min(now - previous, 64)
+      previous = now
+      if (!gesture && !focused && !document.hidden) {
+        if (Math.abs(velocity) > 0.015 && !reducedMotion.matches) {
+          offset += velocity * elapsed
+          velocity *= Math.exp(-elapsed / 250)
+          pause()
+        } else if (!hovered && now >= resumeAt && !reducedMotion.matches) {
+          velocity = 0
+          offset += (width * elapsed) / (duration * 1000)
+        }
+        draw()
+      }
+      frame = requestAnimationFrame(animate)
+    }
+    frame = requestAnimationFrame(animate)
+    viewport.addEventListener('pointerdown', down)
+    viewport.addEventListener('pointermove', move)
+    viewport.addEventListener('pointerup', end)
+    viewport.addEventListener('pointercancel', end)
+    viewport.addEventListener('lostpointercapture', end)
+    viewport.addEventListener('click', click, true)
+    viewport.addEventListener('pointerenter', enter)
+    viewport.addEventListener('pointerleave', leave)
+    viewport.addEventListener('focusin', focus)
+    viewport.addEventListener('focusout', blur)
+    return () => {
+      observer.disconnect()
+      cancelAnimationFrame(frame)
+      viewport.removeEventListener('pointerdown', down)
+      viewport.removeEventListener('pointermove', move)
+      viewport.removeEventListener('pointerup', end)
+      viewport.removeEventListener('pointercancel', end)
+      viewport.removeEventListener('lostpointercapture', end)
+      viewport.removeEventListener('click', click, true)
+      viewport.removeEventListener('pointerenter', enter)
+      viewport.removeEventListener('pointerleave', leave)
+      viewport.removeEventListener('focusin', focus)
+      viewport.removeEventListener('focusout', blur)
+    }
+  }, [marketCount])
+
+  return { viewportRef, trackRef, groupRef, copies }
+}

--- a/web/hooks/use-draggable-ticker.ts
+++ b/web/hooks/use-draggable-ticker.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
 
-const RESUME_DELAY_MS = 2000
 const DRAG_THRESHOLD_PX = 6
 
 // Keep animation and dragging on the same offset so grabbing the tape never
@@ -22,9 +21,7 @@ export const useDraggableTicker = (marketCount: number) => {
     let width = 0
     let offset = 0
     let velocity = 0
-    let hovered = false
     let focused = false
-    let resumeAt = 0
     let suppressClick = false
     let gesture:
       | {
@@ -53,12 +50,10 @@ export const useDraggableTicker = (marketCount: number) => {
     observer.observe(group)
     measure()
 
-    const pause = () => {
-      resumeAt = performance.now() + RESUME_DELAY_MS
-    }
     const down = (event: PointerEvent) => {
       if (!event.isPrimary || event.button !== 0) return
       velocity = 0
+      focused = false
       suppressClick = false
       gesture = {
         id: event.pointerId,
@@ -78,7 +73,6 @@ export const useDraggableTicker = (marketCount: number) => {
         // Leave vertical gestures to the page. touch-action allows pan-y.
         if (Math.abs(dy) > Math.abs(dx)) {
           gesture = undefined
-          pause()
           return
         }
         gesture.dragging = true
@@ -112,7 +106,6 @@ export const useDraggableTicker = (marketCount: number) => {
       gesture = undefined
       if (viewport.hasPointerCapture(event.pointerId))
         viewport.releasePointerCapture(event.pointerId)
-      pause()
     }
     const click = (event: MouseEvent) => {
       // Keyboard activation (detail === 0) must still work after a swipe.
@@ -121,11 +114,7 @@ export const useDraggableTicker = (marketCount: number) => {
       event.stopPropagation()
       suppressClick = false
     }
-    const enter = (event: PointerEvent) => {
-      if (event.pointerType === 'mouse') hovered = true
-    }
     const leave = (event: PointerEvent) => {
-      if (event.pointerType === 'mouse') hovered = false
       if (gesture && !gesture.dragging) end(event)
     }
     const focus = (event: FocusEvent) => {
@@ -150,7 +139,6 @@ export const useDraggableTicker = (marketCount: number) => {
       )
         return
       focused = false
-      pause()
     }
     let previous = performance.now()
     let frame: number
@@ -161,8 +149,7 @@ export const useDraggableTicker = (marketCount: number) => {
         if (Math.abs(velocity) > 0.015 && !reducedMotion.matches) {
           offset += velocity * elapsed
           velocity *= Math.exp(-elapsed / 250)
-          pause()
-        } else if (!hovered && now >= resumeAt && !reducedMotion.matches) {
+        } else if (!reducedMotion.matches) {
           velocity = 0
           offset += (width * elapsed) / (duration * 1000)
         }
@@ -177,7 +164,6 @@ export const useDraggableTicker = (marketCount: number) => {
     viewport.addEventListener('pointercancel', end)
     viewport.addEventListener('lostpointercapture', end)
     viewport.addEventListener('click', click, true)
-    viewport.addEventListener('pointerenter', enter)
     viewport.addEventListener('pointerleave', leave)
     viewport.addEventListener('focusin', focus)
     viewport.addEventListener('focusout', blur)
@@ -190,7 +176,6 @@ export const useDraggableTicker = (marketCount: number) => {
       viewport.removeEventListener('pointercancel', end)
       viewport.removeEventListener('lostpointercapture', end)
       viewport.removeEventListener('click', click, true)
-      viewport.removeEventListener('pointerenter', enter)
       viewport.removeEventListener('pointerleave', leave)
       viewport.removeEventListener('focusin', focus)
       viewport.removeEventListener('focusout', blur)

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -26,6 +26,7 @@ import {
   inferPriceDecimals,
 } from 'common/perps/format'
 import { useIsClient } from 'web/hooks/use-is-client'
+import { useDraggableTicker } from 'web/hooks/use-draggable-ticker'
 import { getPerpTakerFeeBps } from 'common/perps/fees'
 import { getMnxCreatorId } from 'common/perps/creator-accounts'
 import { getPerpTicker } from 'common/perps/ticker'
@@ -595,7 +596,6 @@ const windowMs = (w: ChangeWindow) => (w === '24h' ? DAY_MS : 7 * DAY_MS)
 // column drops out below 360px.
 const WATCH_GRID =
   'grid items-center gap-x-2 grid-cols-[3.25rem_minmax(0,1fr)_3.25rem_3.75rem] min-[360px]:grid-cols-[3.25rem_minmax(0,1fr)_3.25rem_3.5rem_3.75rem]'
-const DEFAULT_ROWS = 5
 
 export default function PerpsPage(props: { perps: Contract[] }) {
   const initial = useMemo(() => props.perps.filter(isListed), [props.perps])
@@ -1246,26 +1246,36 @@ const TickerTape = (props: {
   onSelect: (id: string) => void
 }) => {
   const { contracts, week, onSelect } = props
+  const { viewportRef, trackRef, groupRef, copies } = useDraggableTicker(
+    contracts.length
+  )
   if (contracts.length === 0) return null
-  const items = [...contracts, ...contracts]
-  const duration = Math.max(24, contracts.length * 9)
   return (
-    <div className="border-ink-200 dark:border-ink-300 bg-canvas-0 group sticky top-0 z-20 overflow-hidden whitespace-nowrap border-b">
-      <style>{`
-        @keyframes perps-marquee { from { transform: translateX(0) } to { transform: translateX(-50%) } }
-        @media (prefers-reduced-motion: reduce) { .perps-marquee { animation: none !important } }
-      `}</style>
-      <div
-        className="perps-marquee inline-block py-1.5 group-hover:[animation-play-state:paused]"
-        style={{ animation: `perps-marquee ${duration}s linear infinite` }}
-      >
-        {items.map((c, i) => (
-          <TickerItem
-            key={c.id + i}
-            contract={c}
-            series={week[c.id]}
-            onSelect={() => onSelect(c.id)}
-          />
+    <div
+      ref={viewportRef}
+      role="region"
+      aria-label="Perpetual markets ticker"
+      className="bg-canvas-0 sticky top-0 z-20 cursor-grab select-none overflow-hidden whitespace-nowrap active:cursor-grabbing"
+      style={{ touchAction: 'pan-y pinch-zoom' }}
+    >
+      <div ref={trackRef} className="flex w-max will-change-transform">
+        {Array.from({ length: copies }, (_, copy) => (
+          <div
+            key={copy}
+            ref={copy === 0 ? groupRef : undefined}
+            aria-hidden={copy !== 0 ? true : undefined}
+            className="flex shrink-0"
+          >
+            {contracts.map((c) => (
+              <TickerItem
+                key={c.id}
+                contract={c}
+                series={week[c.id]}
+                onSelect={() => onSelect(c.id)}
+                tabIndex={copy === 0 ? 0 : -1}
+              />
+            ))}
+          </div>
         ))}
       </div>
     </div>
@@ -1276,17 +1286,19 @@ const TickerItem = (props: {
   contract: PerpContract
   series: WeekSeries | undefined
   onSelect: () => void
+  tabIndex: number
 }) => {
-  const { contract, series, onSelect } = props
+  const { contract, series, onSelect, tabIndex } = props
   const price = Number(contract.oraclePrice)
   const flash = useTickFlash(price)
   const change = weekChange(series, contract)
   return (
     <button
+      tabIndex={tabIndex}
       onClick={onSelect}
       onPointerEnter={() => warmChart(contract)}
       onFocus={() => warmChart(contract)}
-      className="hover:bg-canvas-50 inline-flex items-center gap-2 px-4 text-sm"
+      className="hover:bg-canvas-50 inline-flex h-11 shrink-0 items-center gap-2 px-4 text-sm"
     >
       <span className="text-ink-900 font-mono font-semibold">
         {getPerpTicker(contract)}
@@ -1771,7 +1783,7 @@ const Terminal = (props: {
 }
 
 // ---------------------------------------------------------------------------
-// Watchlist: every open perp, sortable, top rows only until expanded.
+// Watchlist: every open perp, sortable, with a bounded scrolling body.
 
 const Watchlist = (props: {
   contracts: PerpContract[]
@@ -1793,90 +1805,100 @@ const Watchlist = (props: {
     onChangeWindow,
     onSelect,
   } = props
-  const [showAll, setShowAll] = useState(false)
-  const visible = showAll ? contracts : contracts.slice(0, DEFAULT_ROWS)
-  const hidden = contracts.length - visible.length
+  const listRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const list = listRef.current
+    const selected = list?.querySelector<HTMLElement>('[aria-current="true"]')
+    if (!list || !selected) return
+    // Ticker/position selections reveal their row without scrolling the page.
+    const row = selected.getBoundingClientRect()
+    const bounds = list.getBoundingClientRect()
+    const top =
+      bounds.top + (list.firstElementChild?.getBoundingClientRect().height ?? 0)
+    if (row.top < top) list.scrollTop += row.top - top
+    else if (row.bottom > bounds.bottom)
+      list.scrollTop += row.bottom - bounds.bottom
+  }, [selectedId])
   const header = { sort, onSort }
 
   return (
     <Col className="border-ink-200 dark:border-ink-300 bg-canvas-0 overflow-hidden rounded-xl border">
       <div
-        className={clsx(
-          WATCH_GRID,
-          'border-ink-200 dark:border-ink-300 border-b px-3 py-2 text-[11px] font-medium'
-        )}
+        ref={listRef}
+        role="region"
+        aria-label="Perpetual markets"
+        className="max-h-[min(28rem,60vh)] overflow-y-auto overscroll-contain"
       >
-        <SortHeader {...header} label="Market" sortKey="volume" />
-        <SortHeader {...header} label="Price" className="text-right" />
-        {HUB_FEATURES.changeWindow ? (
-          // The change column doubles as the window switch: click the
-          // inactive window to switch to it (and sort by it), click the
-          // active one to flip sort direction.
-          <span className="flex justify-end gap-1.5">
-            {(['24h', '7d'] as const).map((w) => {
-              const isWindow = changeWindow === w
-              const active = isWindow && sort.key === 'change'
-              return (
-                <button
-                  key={w}
-                  onClick={() => {
-                    if (isWindow) onSort('change')
-                    else {
-                      onChangeWindow(w)
-                      if (sort.key !== 'change') onSort('change')
-                    }
-                  }}
-                  className={clsx(
-                    'hover:text-ink-700 uppercase tracking-wider',
-                    isWindow ? 'text-ink-800' : 'text-ink-400'
-                  )}
-                >
-                  {w}
-                  {active && (
-                    <span className="ml-0.5 text-[9px]">
-                      {sort.desc ? '▼' : '▲'}
-                    </span>
-                  )}
-                </button>
-              )
-            })}
-          </span>
-        ) : (
+        <div
+          className={clsx(
+            WATCH_GRID,
+            'border-ink-200 dark:border-ink-300 bg-canvas-0 sticky top-0 z-10 border-b px-3 py-2 text-[11px] font-medium'
+          )}
+        >
+          <SortHeader {...header} label="Market" sortKey="volume" />
+          <SortHeader {...header} label="Price" className="text-right" />
+          {HUB_FEATURES.changeWindow ? (
+            // The change column doubles as the window switch: click the
+            // inactive window to switch to it (and sort by it), click the
+            // active one to flip sort direction.
+            <span className="flex justify-end gap-1.5">
+              {(['24h', '7d'] as const).map((w) => {
+                const isWindow = changeWindow === w
+                const active = isWindow && sort.key === 'change'
+                return (
+                  <button
+                    key={w}
+                    onClick={() => {
+                      if (isWindow) onSort('change')
+                      else {
+                        onChangeWindow(w)
+                        if (sort.key !== 'change') onSort('change')
+                      }
+                    }}
+                    className={clsx(
+                      'hover:text-ink-700 uppercase tracking-wider',
+                      isWindow ? 'text-ink-800' : 'text-ink-400'
+                    )}
+                  >
+                    {w}
+                    {active && (
+                      <span className="ml-0.5 text-[9px]">
+                        {sort.desc ? '▼' : '▲'}
+                      </span>
+                    )}
+                  </button>
+                )
+              })}
+            </span>
+          ) : (
+            <SortHeader
+              {...header}
+              label="7d"
+              sortKey="change"
+              className="text-right"
+            />
+          )}
+          <span className="hidden min-[360px]:block" />
           <SortHeader
             {...header}
-            label="7d"
-            sortKey="change"
+            label="Lean"
+            sortKey="lean"
             className="text-right"
           />
-        )}
-        <span className="hidden min-[360px]:block" />
-        <SortHeader
-          {...header}
-          label="Lean"
-          sortKey="lean"
-          className="text-right"
-        />
+        </div>
+        <Col className="divide-ink-200 dark:divide-ink-300 divide-y">
+          {contracts.map((c) => (
+            <WatchRow
+              key={c.id}
+              contract={c}
+              series={week[c.id]}
+              changeWindow={changeWindow}
+              selected={c.id === selectedId}
+              onSelect={() => onSelect(c.id)}
+            />
+          ))}
+        </Col>
       </div>
-      <Col className="divide-ink-200 dark:divide-ink-300 divide-y">
-        {visible.map((c) => (
-          <WatchRow
-            key={c.id}
-            contract={c}
-            series={week[c.id]}
-            changeWindow={changeWindow}
-            selected={c.id === selectedId}
-            onSelect={() => onSelect(c.id)}
-          />
-        ))}
-      </Col>
-      {(hidden > 0 || showAll) && (
-        <button
-          onClick={() => setShowAll((s) => !s)}
-          className="text-ink-500 hover:bg-canvas-50 hover:text-ink-700 border-ink-200 dark:border-ink-300 border-t px-3 py-2 text-xs"
-        >
-          {showAll ? 'Show fewer' : `Show all ${contracts.length}`}
-        </button>
-      )}
     </Col>
   )
 }

--- a/web/pages/perps.tsx
+++ b/web/pages/perps.tsx
@@ -10,6 +10,7 @@ import { getUserFacingPnl, getUserFacingPnlPercent } from 'common/perps/pnl'
 import { PerpPosition } from 'common/perps/position'
 import { getDisplayProbability } from 'common/calculate'
 import { Contract, PerpContract, contractPath } from 'common/contract'
+import { isEligibleRelatedMarket } from 'common/related-markets'
 import {
   ENV,
   ENV_CONFIG,
@@ -358,41 +359,53 @@ const changeSince = (
 const weekChange = (series: WeekSeries | undefined, c: PerpContract) =>
   changeSince(series, c, 7 * DAY_MS)
 
-// Related markets per perp, via the group-overlap endpoint behind the contract
-// page's related-questions rail: everything sharing a topic with the perp,
-// ranked by importance.
+// Semantic matches come first, using the existing embedding-similarity and
+// importance ranking. Topic matches fill gaps, including for perps without
+// embeddings. Neither source depends on the other succeeding.
 // Fetched on demand for the SELECTED market and kept for the session, so
-// the first paint costs one request rather than one per market, and
+// the first paint costs two requests rather than two per market, and
 // switching back to a market is instant.
 const useRelatedMarkets = (selectedId: string | undefined) => {
   const [byPerp, setByPerp] = useState<Record<string, Contract[]>>({})
+  const loaded = useRef(new Set<string>())
 
   useEffect(() => {
-    if (!selectedId || byPerp[selectedId]) return
+    if (!selectedId || loaded.current.has(selectedId)) return
     let cancelled = false
-    api('get-related-markets-by-group', {
-      contractId: selectedId,
-      limit: 30,
-      offset: 0,
+    Promise.allSettled([
+      api('get-related-markets', { contractId: selectedId, limit: 30 }),
+      api('get-related-markets-by-group', {
+        contractId: selectedId,
+        limit: 30,
+        offset: 0,
+      }),
+    ]).then(([semantic, topical]) => {
+      if (cancelled) return
+      const seen = new Set<string>()
+      const markets = [
+        ...(semantic.status === 'fulfilled'
+          ? semantic.value.marketsFromEmbeddings
+          : []),
+        ...(topical.status === 'fulfilled' ? topical.value.groupContracts : []),
+      ].filter((c) => {
+        if (seen.has(c.id)) return false
+        seen.add(c.id)
+        return true
+      })
+      setByPerp((prev) => ({ ...prev, [selectedId]: markets }))
+      // A failed source can be retried when the user returns to this perp.
+      if (semantic.status === 'fulfilled' && topical.status === 'fulfilled')
+        loaded.current.add(selectedId)
     })
-      .then((r) => {
-        if (!cancelled)
-          setByPerp((prev) => ({ ...prev, [selectedId]: r.groupContracts }))
-      })
-      .catch(() => {
-        if (!cancelled) setByPerp((prev) => ({ ...prev, [selectedId]: [] }))
-      })
     return () => {
       cancelled = true
     }
-    // byPerp is read only as a "have we fetched this yet" guard.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId])
 
   return byPerp
 }
 
-// get-related-markets-by-group returns contracts without their answers, so a
+// Related-market endpoints return contracts without their answers, so a
 // multiple-choice row had nothing to show. markets-by-ids attaches answers;
 // hydrate just those rows, one batched request per new set of ids.
 const answersOf = (c: Contract): Answer[] | undefined =>
@@ -2010,7 +2023,7 @@ const RelatedMarkets = (props: {
       (c) =>
         !perpIds.has(c.id) &&
         c.mechanism !== 'perp' &&
-        !c.isResolved &&
+        isEligibleRelatedMarket(c) &&
         !isNearCertain(c)
     )
     .slice(0, 6)


### PR DESCRIPTION
The perps page's growing market list can expand far beyond the trading terminal, the ticker cannot be repositioned by touch, and related recommendations rely only on shared topics. This adds scrolling and direct ticker control, and uses semantic similarity to improve related-market discovery.

- Show all markets inside a panel capped at `min(28rem, 60vh)`, with pinned sort controls. Selecting an offscreen market reveals its row without moving the page.
- Hold the ticker to pause, drag in either direction, and coast after a flick. Movement resumes immediately on release or when momentum settles; hovering does not pause it. Preserve vertical page gestures, keyboard-focus pausing, and reduced-motion preferences, and suppress clicks after a drag.
- Make ticker buttons fill its 44px height and remove the ticker's top/bottom borders.
- Query the existing embedding-based related-market endpoint and topic endpoint for the selected perp. Preserve semantic/importance ranking first, deduplicate IDs, and fill gaps with topic matches. Either source can fail independently, and failed lookups retry when returning to that perp. Filter current eligibility, other perps, and near-certain markets before taking six rows.

Validation:
- 22 Chrome navigation assertions passed against actual components with fixture data, covering a 50-market list, headers, selection, sorting, full-height targets, keyboard navigation, mobile gestures, immediate resume, momentum, wraparound, reduced motion, and empty/single-market states.
- 13 additional browser assertions passed for related-market ordering, matches without shared tags, deduplication, eligibility, six-row backfill, caching, rapid switching, missing embeddings, independent endpoint failures, retries, and empty results. Discovery responses were mocked; existing backend similarity ranking is reused unchanged.
- ESLint and Prettier passed for changed files. The new ticker hook passed focused typechecking.
- Full web typechecking encountered Zod type conflicts in the reused local dependencies; no dependency files were changed. Mobile touch coverage used Chrome emulation; physical iPhone/Safari verification remains outstanding.

The published Git tree matches the tested local files exactly.