### PR TITLE
Fix client error on /links from user lookup by id vs username

### DIFF
--- a/common/src/supabase/users.ts
+++ b/common/src/supabase/users.ts
@@ -10,6 +10,14 @@ export async function getUserForStaticProps(
   return convertUser(data[0] ?? null)
 }
 
+export async function getUserByIdForStaticProps(
+  db: SupabaseClient,
+  userId: string
+) {
+  const { data } = await run(db.from('users').select().eq('id', userId))
+  return convertUser(data[0] ?? null)
+}
+
 // assumes logged in
 export async function getUserAndPrivateUserForStaticProps(
   db: SupabaseClient,

--- a/web/hooks/use-can-send-mana.ts
+++ b/web/hooks/use-can-send-mana.ts
@@ -3,12 +3,13 @@ import { canSendMana } from 'common/can-send-mana'
 import { User, UserBan } from 'common/user'
 import { api } from 'web/lib/api/api'
 
-export const useCanSendMana = (user: User) => {
+export const useCanSendMana = (user: User | null | undefined) => {
   const [canSend, setCanSend] = useState({
     canSend: false,
     message: '',
   })
   useEffect(() => {
+    if (!user) return
     api('get-user-bans', { userId: user.id })
       .then((res) => canSendMana(user, res.bans as UserBan[]))
       .then(setCanSend)

--- a/web/pages/links.tsx
+++ b/web/pages/links.tsx
@@ -25,7 +25,7 @@ import {
   getUserManalinks,
   getUserManalinkClaims,
 } from 'web/lib/supabase/manalinks'
-import { getUserForStaticProps } from 'common/supabase/users'
+import { getUserByIdForStaticProps } from 'common/supabase/users'
 
 type LinkAndClaims = { link: ManalinkInfo; claims: ClaimInfo[] }
 
@@ -34,7 +34,7 @@ const LINKS_PER_PAGE = 24
 export const getServerSideProps = redirectIfLoggedOut('/', async (_, creds) => {
   const adminDb = await initSupabaseAdmin()
   const [user, links, claims] = await Promise.all([
-    getUserForStaticProps(adminDb, creds.uid),
+    getUserByIdForStaticProps(adminDb, creds.uid),
     getUserManalinks(creds.uid, adminDb),
     getUserManalinkClaims(creds.uid, adminDb),
   ])
@@ -51,7 +51,7 @@ export function getManalinkUrl(slug: string) {
 }
 
 export default function LinkPage(props: {
-  user: User
+  user: User | null
   userLinks: LinkAndClaims[]
 }) {
   const { user, userLinks } = props


### PR DESCRIPTION
## Problem

`/links` threw a client error on every load for anyone who reached it.

`getUserForStaticProps(db, username)` filters on `.eq('username', ...)`, but `links.tsx` passed `creds.uid` — a Firebase user id. Both params are `string`, so TypeScript couldn't catch it. The query matched zero rows, `convertUser(null)` returned `null`, and the page handed `user: null` to a component declared `user: User`.

The actual throw was in `useCanSendMana`, which dereferenced `user.id` unconditionally inside its effect:

```
TypeError: Cannot read properties of null (reading 'id')
```

A hint this was long-standing: `links.tsx` already guarded `user && isAdminId(user.id)` one line above — someone hit the null user before and patched only that call site, not the source.

This is an admin-only page (creating manalinks is gated on `isAdminId` in `create-manalink.ts`), which is likely why a hard crash went unnoticed.

## Fix

- **`common/src/supabase/users.ts`** — add `getUserByIdForStaticProps`, querying `.eq('id', userId)`. Added as a sibling rather than changing `getUserForStaticProps`, whose other caller (`pages/[username]/index.tsx`) correctly passes a username and would have broken.
- **`web/pages/links.tsx`** — use the new helper; type the prop `User | null` so the SSR boundary stops lying to the compiler.
- **`web/hooks/use-can-send-mana.ts`** — accept `User | null | undefined` and bail early. Defense in depth; the page now gets a real user regardless.

## Testing

`tsc --noEmit` over `web` passes clean. Widening the hook param is a strict superset, so the other consumer (`payments.tsx`) compiles unchanged.

Not yet loaded in a browser — worth a quick check of `/links` while signed in as an admin to confirm the page renders and lists existing manalinks.

## Deploy

Web-only, no `backend/` changes — no API deploy needed.
