### PR TITLE
Remove the "Market context" AI panel from the market page

### DIFF
--- a/web/components/contract/contract-page.tsx
+++ b/web/components/contract/contract-page.tsx
@@ -87,7 +87,6 @@ import { SpiceCoin } from 'web/public/custom-components/spiceCoin'
 import { FollowMarketButton } from '../buttons/follow-market-button'
 import { LogoIcon } from '../icons/logo-icon'
 import { CreatorSharePanel, NonCreatorSharePanel } from './creator-share-panel'
-import { MarketContext } from './market-context'
 import { YourTrades } from './your-trades'
 
 export function ContractPageContent(props: ContractParams) {
@@ -514,7 +513,7 @@ export function ContractPageContent(props: ContractParams) {
               // Perps render the description directly above the boost/share
               // panel so the oracle context (e.g. "30-day trailing average
               // Trump approval rating") is visible near the top of the page
-              // flow, not buried below MarketContext.
+              // flow, rather than further down.
               <ContractDescription
                 contractId={props.contract.id}
                 creatorId={props.contract.creatorId}
@@ -551,9 +550,13 @@ export function ContractPageContent(props: ContractParams) {
                 contract={liveContract}
               />
             )}
-            {props.contract.isRanked !== false && (
-              <MarketContext contractId={props.contract.id} />
-            )}
+            {/* The "Market context" AI panel was removed here. The component
+                (./market-context) and its get-market-context endpoint are all
+                still in place — to bring the button back, restore the import
+                and re-add:
+                {props.contract.isRanked !== false && (
+                  <MarketContext contractId={props.contract.id} />
+                )} */}
 
             <Row className="mb-4 mt-2 items-center gap-2">
               <MarketTopics


### PR DESCRIPTION
Takes the "Market context" Generate button off the market page.

### Why

The button was never instrumented. `handleClick` only flipped two local
`useState` booleans — no `track()` call, unlike every sibling component in
`web/components/contract/` (`trades-button`, `market-topics`,
`related-contracts-widget` all track their clicks). So we have no usage data
for it, and can't get any retroactively:

- no matching event name exists in `user_events`
- the `get-market-context` endpoint is `authed: false` and writes no rows, so
  there's no per-user trace even in principle
- it's cached `public, max-age=3600`, so repeat clicks on a market never reach
  our backend for an hour
- the Gemini calls are unlabelled and share one API key with ~24 other
  callers, so provider-side telemetry can't isolate this feature either

Rather than add tracking to a feature we're unsure about, remove it.

### Reversibility

This unwires the **call site only**. Left fully intact:

- `web/components/contract/market-context.tsx`
- `backend/api/src/get-market-context.ts`
- its `routes.ts` entry and `common/src/api/schema.ts` entry

Restoring the panel means putting back the import and the three-line JSX
block — both recorded verbatim in a comment at the removal site, so no
git archaeology needed.

### Notes

- Web-only; **no API deploy required**. The endpoint stays live and simply
  stops being called. Retiring it too would be a separate backend change —
  leaving it is what keeps the revert cheap.
- Also fixes a comment that referenced `MarketContext` as a layout landmark
  for perps, which would have gone stale.

### Testing

`tsc --noEmit` on the web package: 0 errors.