### PR TITLE
Fix notifications crash when browser storage is full

### DIFF
--- a/web/lib/util/local.test.cjs
+++ b/web/lib/util/local.test.cjs
@@ -1,0 +1,94 @@
+// Run with: node --test web/lib/util/local.test.cjs
+const assert = require('node:assert/strict')
+const { readFileSync } = require('node:fs')
+const { join } = require('node:path')
+const { test } = require('node:test')
+const vm = require('node:vm')
+const ts = require('typescript')
+
+const source = ts.transpileModule(
+  readFileSync(join(__dirname, 'local.ts'), 'utf8'),
+  { compilerOptions: { module: ts.ModuleKind.CommonJS } }
+).outputText
+
+function loadStorage(storage) {
+  const exports = {}
+  vm.runInNewContext(source, {
+    exports,
+    localStorage: storage,
+    sessionStorage: storage,
+    console: { warn() {} },
+  })
+  return exports
+}
+
+function createStorage() {
+  const data = new Map()
+  return {
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => data.set(key, value),
+    removeItem: (key) => data.delete(key),
+    clear: () => data.clear(),
+  }
+}
+
+for (const name of ['safeLocalStorage', 'safeSessionStorage']) {
+  test(`${name}: reads, writes, and removes values`, () => {
+    const safe = loadStorage(createStorage())[name]
+    assert.equal(safe.getItem('missing'), null)
+    safe.setItem('key', 'value')
+    assert.equal(safe.getItem('key'), 'value')
+    safe.removeItem('key')
+    assert.equal(safe.getItem('key'), null)
+  })
+
+  test(`${name}: an oversized write does not throw or erase other data`, () => {
+    const storage = createStorage()
+    const safe = loadStorage(storage)[name]
+    safe.setItem('draft', 'unsent comment')
+    safe.setItem('notifications-user', 'previous notifications')
+    const originalSetItem = storage.setItem
+    storage.setItem = () => {
+      throw new DOMException('Storage is full', 'QuotaExceededError')
+    }
+
+    assert.doesNotThrow(() => safe.setItem('notifications-user', 'too large'))
+    assert.equal(safe.getItem('draft'), 'unsent comment')
+    assert.equal(safe.getItem('notifications-user'), 'previous notifications')
+
+    storage.setItem = originalSetItem
+    safe.setItem('notifications-user', 'smaller value')
+    assert.equal(safe.getItem('notifications-user'), 'smaller value')
+  })
+
+  test(`${name}: storage already full at startup remains readable`, () => {
+    const storage = createStorage()
+    storage.setItem('draft', 'unsent comment')
+    storage.setItem = () => {
+      throw new DOMException('Storage is full', 'QuotaExceededError')
+    }
+    const safe = loadStorage(storage)[name]
+    assert.equal(safe.getItem('draft'), 'unsent comment')
+    assert.doesNotThrow(() => safe.setItem('notifications-user', 'too large'))
+  })
+
+  test(`${name}: later storage access failures do not escape`, () => {
+    const storage = createStorage()
+    const safe = loadStorage(storage)[name]
+    for (const method of ['getItem', 'setItem', 'removeItem']) {
+      storage[method] = () => {
+        throw new DOMException('Storage access denied', 'SecurityError')
+      }
+    }
+    assert.equal(safe.getItem('key'), null)
+    assert.doesNotThrow(() => safe.setItem('key', 'value'))
+    assert.doesNotThrow(() => safe.removeItem('key'))
+  })
+}
+
+test('importing without browser storage is safe', () => {
+  const exports = {}
+  vm.runInNewContext(source, { exports })
+  assert.equal(exports.safeLocalStorage, undefined)
+  assert.equal(exports.safeSessionStorage, undefined)
+})

--- a/web/lib/util/local.ts
+++ b/web/lib/util/local.ts
@@ -4,27 +4,33 @@ export interface Store {
   removeItem: (key: string) => void
 }
 
-function getStorageProxy(store: Storage): Store | undefined {
-  try {
-    store.setItem('test', '')
-    store.getItem('test')
-    store.removeItem('test')
-  } catch (e) {
-    console.warn(e)
-    return undefined
-  }
+function getStorageProxy(store: Storage): Store {
+  // Storage can become full or unavailable after initialization. Treat every
+  // operation as best effort, so persistence failures don't crash the UI.
   return {
-    getItem: (key: string) => store.getItem(key) ?? null,
+    getItem: (key: string) => {
+      try {
+        return store.getItem(key) ?? null
+      } catch (e) {
+        console.warn(e)
+        return null
+      }
+    },
     setItem: (key: string, value: string) => {
       try {
         store.setItem(key, value)
       } catch (e) {
-        store.clear()
-        // try again
-        store.setItem(key, value)
+        // Keep the caller's in-memory state and leave other stored data intact.
+        console.warn(e)
       }
     },
-    removeItem: (key: string) => store.removeItem(key),
+    removeItem: (key: string) => {
+      try {
+        store.removeItem(key)
+      } catch (e) {
+        console.warn(e)
+      }
+    },
   }
 }
 


### PR DESCRIPTION
Loading notifications can crash with `QuotaExceededError` when the cached notification payload no longer fits in browser storage. The storage helper previously cleared all site storage and retried the same write without catching another failure.

Make local and session storage operations best effort: failed writes leave the UI's in-memory state and unrelated stored data intact, failed reads return null, and failed removals do not throw. Remove the startup write probe so a full store remains readable.

Validation:
- All 9 storage regression tests pass (`node --test web/lib/util/local.test.cjs`), covering quota failures, preservation of existing data, recovery, blocked access, and server-side imports.
- Web TypeScript check, targeted ESLint, Prettier, and `git diff --check` pass.
