### PR TITLE
Add configurable perp position alerts and liquidation warnings

### DIFF
--- a/backend/api/src/update-notif-settings.ts
+++ b/backend/api/src/update-notif-settings.ts
@@ -2,6 +2,7 @@ import { createSupabaseDirectClient } from 'shared/supabase/init'
 import { updatePrivateUser } from 'shared/supabase/users'
 import { type APIHandler } from './helpers/endpoint'
 import { broadcastUpdatedPrivateUser } from 'shared/websockets/helpers'
+import { getDefaultNotificationPreferences } from 'common/user-notification-preferences'
 
 export const updateNotifSettings: APIHandler<'update-notif-settings'> = async (
   { type, medium, enabled },
@@ -16,11 +17,16 @@ export const updateNotifSettings: APIHandler<'update-notif-settings'> = async (
   await pg.none(
     `update private_users
       set data = jsonb_set(data, '{notificationPreferences, $1:raw}',
-        coalesce(data->'notificationPreferences'->$1, '[]'::jsonb)
+        coalesce(data->'notificationPreferences'->$1, $4::jsonb)
         ${enabled ? `|| '[$2:name]'::jsonb` : `- $2`}
       )
       where id = $3`,
-    [type, medium, auth.uid]
+    [
+      type,
+      medium,
+      auth.uid,
+      JSON.stringify(getDefaultNotificationPreferences()[type] ?? []),
+    ]
   )
   broadcastUpdatedPrivateUser(auth.uid)
 }

--- a/backend/scheduler/src/jobs/index.ts
+++ b/backend/scheduler/src/jobs/index.ts
@@ -61,6 +61,7 @@ import { updateLeague } from './update-league'
 import { updateLeagueRanks } from './update-league-ranks'
 import { updateStatsCore } from './update-stats'
 import { updatePerps } from './update-perps'
+import { sendPerpPositionAlerts } from 'shared/notifications/perp-position-alerts'
 import {
   ORACLE_TICK_PERIOD_MS,
   updateOracleFeeds,
@@ -86,6 +87,7 @@ export type SchedulerJobSet = 'all' | 'main' | 'perps'
 
 const PERP_JOB_NAMES = new Set([
   'update-perps',
+  'send-perp-position-alerts',
   'update-oracle-feeds',
   'update-openrouter-share',
   'update-trump-approval',
@@ -236,6 +238,13 @@ export function createJobs(jobSet: SchedulerJobSet) {
       'update-perps',
       '0 0 * * * *', // every hour on the hour
       updatePerps
+    ),
+    // Separate from the 2s oracle tick, with bounded async DB concurrency.
+    // Keep risk warnings off the main scheduler's blocking batch jobs.
+    createJob(
+      'send-perp-position-alerts',
+      '15 * * * * *',
+      sendPerpPositionAlerts
     ),
     createJob(
       'update-oracle-feeds',

--- a/backend/shared/src/notifications/perp-position-alerts.integration.test.ts
+++ b/backend/shared/src/notifications/perp-position-alerts.integration.test.ts
@@ -1,0 +1,197 @@
+jest.mock('shared/supabase/init', () => ({
+  createSupabaseDirectClient: jest.fn(),
+}))
+jest.mock('shared/utils', () => ({ log: { error: jest.fn() } }))
+jest.mock('shared/websockets/server', () => ({ broadcast: jest.fn() }))
+jest.mock('shared/websockets/helpers', () => ({
+  broadcastUpdatedPrivateUser: jest.fn(),
+}))
+jest.mock('shared/supabase/users', () => ({ updatePrivateUser: jest.fn() }))
+jest.mock('shared/create-push-notifications', () => ({
+  createPushNotifications: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import * as pgPromise from 'pg-promise'
+import { getDefaultNotificationPreferences } from 'common/user-notification-preferences'
+import { sendPerpPositionAlertsForUser } from './perp-position-alerts'
+import { createSupabaseDirectClient } from 'shared/supabase/init'
+// Keep API sources outside the shared package's composite build root while
+// exercising the real handler (its infrastructure imports remain mocked).
+const { updateNotifSettings } = jest.requireActual<{
+  updateNotifSettings: (
+    props: { type: string; medium: string; enabled: boolean },
+    auth: { uid: string },
+    req: unknown
+  ) => Promise<unknown>
+}>('../../../api/src/update-notif-settings')
+
+const url = process.env.PERP_ALERT_TEST_DATABASE_URL
+// This suite creates fixture tables. Only permit an explicitly named local
+// disposable database, never a deployed Manifold database.
+if (url) {
+  const parsed = new URL(url)
+  if (
+    !['127.0.0.1', 'localhost'].includes(parsed.hostname) ||
+    parsed.pathname !== '/perp_alert_test'
+  ) {
+    throw new Error(
+      'PERP_ALERT_TEST_DATABASE_URL must point to local /perp_alert_test'
+    )
+  }
+}
+const integration = url ? describe : describe.skip
+
+integration('perp alerts in PostgreSQL', () => {
+  const pgp = pgPromise()
+  const pg = url ? pgp(url) : undefined!
+  const now = Date.now()
+  beforeAll(async () => {
+    await pg.none(`
+      do $$ begin
+        if not exists (select from pg_roles where rolname = 'anon') then create role anon; end if;
+        if not exists (select from pg_roles where rolname = 'authenticated') then create role authenticated; end if;
+      end $$;
+      create table if not exists users (id text primary key);
+      create table if not exists private_users (id text primary key, data jsonb not null);
+      create table if not exists contracts (id text primary key, mechanism text, resolution_time timestamptz, data jsonb);
+      create table if not exists contract_perp_positions (
+        contract_id text, user_id text, direction text, size numeric,
+        cost_basis numeric, original_cost_basis numeric, taker_fee_cost_basis numeric,
+        entry_price numeric, leverage numeric, liquidation_price numeric,
+        opened_time timestamptz, updated_time timestamptz
+      );
+      create table if not exists user_notifications (user_id text, notification_id text, data jsonb,
+        primary key (user_id, notification_id));
+    `)
+    const migration = readFileSync(
+      resolve(
+        __dirname,
+        '../../../supabase/migrations/2026091201_perp_alert_states.sql'
+      ),
+      'utf8'
+    )
+    await pg.none(migration)
+    await pg.none(migration) // Migration is safe to reapply.
+  })
+  afterAll(() => pgp.end())
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    await pg.none(
+      `truncate users, private_users, contracts, contract_perp_positions, user_notifications, perp_alert_states cascade`
+    )
+    await pg.none(
+      `insert into users values ('u'); insert into private_users values ('u', $1)`,
+      [
+        {
+          id: 'u',
+          notificationPreferences: getDefaultNotificationPreferences(),
+        },
+      ]
+    )
+    await pg.none(`insert into contracts values ('c', 'perp', null, $1)`, [
+      {
+        id: 'c',
+        mechanism: 'perp',
+        oraclePrice: 100,
+        oraclePriceTime: now,
+        maxOraclePriceAgeMs: 3600000,
+        question: 'Test market',
+        slug: 'test',
+        creatorName: 'Creator',
+        creatorUsername: 'creator',
+        oracleFeedId: 'test',
+      },
+    ])
+    await pg.none(
+      `insert into contract_perp_positions values ('c', 'u', 'long', 1000, 100, 100, 0, 100, 10, 90, now(), now())`
+    )
+    jest.mocked(createSupabaseDirectClient).mockReturnValue(pg)
+  })
+
+  it('restricts state to the backend', async () => {
+    expect(
+      await pg.one(
+        `select relrowsecurity from pg_class where oid = 'perp_alert_states'::regclass`
+      )
+    ).toEqual({ relrowsecurity: true })
+    for (const role of ['anon', 'authenticated']) {
+      expect(
+        await pg.one(
+          `select has_table_privilege($1, 'perp_alert_states', 'select,insert,update,delete') as allowed`,
+          [role]
+        )
+      ).toEqual({ allowed: false })
+    }
+  })
+
+  it('serializes eight concurrent scans into exactly one notification', async () => {
+    await sendPerpPositionAlertsForUser(pg, 'u')
+    await pg.none(
+      `update contracts set data = jsonb_set(data, '{oraclePrice}', '110')`
+    )
+    await Promise.all(
+      Array.from({ length: 8 }, () => sendPerpPositionAlertsForUser(pg, 'u'))
+    )
+    expect(
+      await pg.one(`select count(*)::int as count from user_notifications`)
+    ).toEqual({ count: 1 })
+    expect(
+      await pg.one(
+        `select (data->'positions'->'c:long'->>'profit')::int as profit from perp_alert_states`
+      )
+    ).toEqual({ profit: 100 })
+  })
+
+  it('rolls back notification insertion if persisting state fails and permits retry', async () => {
+    await sendPerpPositionAlertsForUser(pg, 'u')
+    await pg.none(
+      `update contracts set data = jsonb_set(data, '{oraclePrice}', '110')`
+    )
+    await pg.none(`create function reject_alert_state() returns trigger language plpgsql as $$ begin raise exception 'test rollback'; end $$;
+      create trigger reject_alert_state before update on perp_alert_states for each row execute function reject_alert_state()`)
+    try {
+      await expect(sendPerpPositionAlertsForUser(pg, 'u')).rejects.toThrow(
+        'test rollback'
+      )
+      expect(
+        await pg.one(`select count(*)::int as count from user_notifications`)
+      ).toEqual({ count: 0 })
+    } finally {
+      await pg.none(
+        `drop trigger reject_alert_state on perp_alert_states; drop function reject_alert_state()`
+      )
+    }
+    await sendPerpPositionAlertsForUser(pg, 'u')
+    expect(
+      await pg.one(`select count(*)::int as count from user_notifications`)
+    ).toEqual({ count: 1 })
+  })
+
+  it('preserves the web default when disabling mobile on a previously absent preference', async () => {
+    await pg.none(
+      `update private_users set data = data #- '{notificationPreferences,perp_liquidation_warning}'`
+    )
+    await updateNotifSettings(
+      { type: 'perp_liquidation_warning', medium: 'mobile', enabled: false },
+      { uid: 'u' },
+      {}
+    )
+    expect(
+      await pg.one(
+        `select data->'notificationPreferences'->'perp_liquidation_warning' as destinations from private_users`
+      )
+    ).toEqual({ destinations: ['browser'] })
+    await updateNotifSettings(
+      { type: 'perp_liquidation_warning', medium: 'browser', enabled: false },
+      { uid: 'u' },
+      {}
+    )
+    expect(
+      await pg.one(
+        `select data->'notificationPreferences'->'perp_liquidation_warning' as destinations from private_users`
+      )
+    ).toEqual({ destinations: [] })
+  })
+})

--- a/backend/shared/src/notifications/perp-position-alerts.test.ts
+++ b/backend/shared/src/notifications/perp-position-alerts.test.ts
@@ -1,0 +1,263 @@
+jest.mock('shared/supabase/init', () => ({
+  createSupabaseDirectClient: jest.fn(),
+}))
+jest.mock('shared/utils', () => ({ log: { error: jest.fn() } }))
+jest.mock('shared/websockets/server', () => ({ broadcast: jest.fn() }))
+jest.mock('shared/create-push-notifications', () => ({
+  createPushNotifications: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { PerpContract } from 'common/contract'
+import { Notification } from 'common/notification'
+import { PerpUserAlertState } from 'common/perps/alerts'
+import { Row } from 'common/supabase/utils'
+import { getDefaultNotificationPreferences } from 'common/user-notification-preferences'
+import { DAY_MS } from 'common/util/time'
+import { createPushNotifications } from 'shared/create-push-notifications'
+import { SupabaseDirectClient } from 'shared/supabase/init'
+import { broadcast } from 'shared/websockets/server'
+import { sendPerpPositionAlertsForUser } from './perp-position-alerts'
+
+const now = 10 * DAY_MS
+const contract = () =>
+  ({
+    id: 'c',
+    mechanism: 'perp',
+    oracleFeedId: 'test',
+    question: 'Test price',
+    slug: 'test',
+    creatorName: 'Creator',
+    creatorUsername: 'creator',
+    oraclePrice: 100,
+    oraclePriceTime: now,
+    maxOraclePriceAgeMs: 60000,
+  } as PerpContract)
+const position = () => ({
+  contract_id: 'c',
+  user_id: 'u',
+  direction: 'long',
+  size: 1000,
+  cost_basis: 100,
+  original_cost_basis: 100,
+  taker_fee_cost_basis: 0,
+  entry_price: 100,
+  leverage: 10,
+  liquidation_price: 90,
+  opened_time: new Date(now - DAY_MS).toISOString(),
+  updated_time: new Date(now).toISOString(),
+  contract: contract(),
+})
+
+// Transactional DB double: assertions exercise worker behavior across commits,
+// rollbacks, and retries. PostgreSQL locking itself requires deployment QA.
+const setup = () => {
+  const preferences = getDefaultNotificationPreferences()
+  const privateUser = {
+    id: 'u',
+    pushToken: 'test-token',
+    notificationPreferences: preferences,
+  }
+  let state: PerpUserAlertState | undefined
+  let rows = [position()]
+  const notifications: Notification[] = []
+  let failCommit = false
+  let committed = false
+  const queries: string[] = []
+  const pg = {
+    tx: jest.fn(async (fn) => {
+      committed = false
+      let pendingState: PerpUserAlertState | undefined
+      const pendingNotifications: Notification[] = []
+      const tx = {
+        one: jest.fn(async (sql: string) => {
+          queries.push(sql)
+          return {}
+        }),
+        oneOrNone: jest.fn(async (sql: string) => {
+          if (sql.includes('private_users'))
+            return { data: privateUser } as unknown as Row<'private_users'>
+          if (sql.includes('perp_alert_states'))
+            return state ? { data: structuredClone(state) } : null
+          throw new Error(`Unexpected query: ${sql}`)
+        }),
+        manyOrNone: jest.fn(async () => rows),
+        none: jest.fn(async (sql: string, params: unknown[]) => {
+          if (sql.includes('insert into user_notifications'))
+            pendingNotifications.push(params[2] as Notification)
+          else if (sql.includes('insert into perp_alert_states'))
+            pendingState = params[1] as PerpUserAlertState
+          else throw new Error(`Unexpected query: ${sql}`)
+        }),
+      }
+      const result = await fn(tx)
+      if (failCommit) throw new Error('commit failed')
+      state = pendingState
+      notifications.push(...pendingNotifications)
+      committed = true
+      return result
+    }),
+  } as unknown as SupabaseDirectClient
+  return {
+    preferences,
+    notifications,
+    queries,
+    scan: () => sendPerpPositionAlertsForUser(pg, 'u'),
+    setPrice: (price: number) =>
+      rows.forEach((r) => (r.contract.oraclePrice = price)),
+    setRows: (next: typeof rows) => {
+      rows = next
+    },
+    rows: () => rows,
+    state: () => state!,
+    failCommit: (fail: boolean) => {
+      failCommit = fail
+    },
+    committed: () => committed,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.mocked(broadcast).mockReset()
+  jest.spyOn(Date, 'now').mockReturnValue(now)
+  jest.mocked(createPushNotifications).mockResolvedValue(undefined)
+})
+afterEach(() => jest.restoreAllMocks())
+
+it('commits state and browser alert together, then broadcasts; repeated scans deduplicate', async () => {
+  const db = setup()
+  await db.scan()
+  db.setPrice(110)
+  jest.mocked(broadcast).mockImplementation(() => {
+    expect(db.committed()).toBe(true)
+    expect(db.notifications).toHaveLength(1)
+  })
+  await db.scan()
+  await db.scan()
+  expect(db.notifications).toHaveLength(1)
+  expect(db.notifications[0]).toMatchObject({
+    reason: 'perp_profit',
+    sourceContractSlug: 'test',
+    data: { pnlPercent: 100 },
+  })
+  expect(db.notifications[0].sourceText).toContain('up 100%')
+  expect(broadcast).toHaveBeenCalledTimes(1)
+  expect(createPushNotifications).not.toHaveBeenCalled()
+  expect(db.queries.every((sql) => sql.includes('pg_advisory_xact_lock'))).toBe(
+    true
+  )
+})
+
+it('rolls back both dedup state and notification on commit failure, permitting retry', async () => {
+  const db = setup()
+  await db.scan()
+  db.setPrice(110)
+  db.failCommit(true)
+  await expect(db.scan()).rejects.toThrow('commit failed')
+  expect(db.state().positions['c:long'].profit).toBe(0)
+  expect(db.notifications).toHaveLength(0)
+  expect(broadcast).not.toHaveBeenCalled()
+  db.failCommit(false)
+  await db.scan()
+  expect(db.notifications).toHaveLength(1)
+})
+
+it('supports mobile-only delivery and deduplicates without browser history', async () => {
+  const db = setup()
+  db.preferences.perp_profit = ['mobile']
+  await db.scan()
+  db.setPrice(110)
+  await db.scan()
+  await db.scan()
+  expect(db.notifications).toHaveLength(0)
+  expect(createPushNotifications).toHaveBeenCalledTimes(1)
+})
+
+it('honors all-channel opt-out and does not replay muted milestones', async () => {
+  const db = setup()
+  db.preferences.opt_out_all = ['browser', 'mobile', 'email']
+  await db.scan()
+  db.setPrice(110)
+  await db.scan()
+  db.preferences.opt_out_all = []
+  await db.scan()
+  expect(db.notifications).toHaveLength(0)
+  expect(createPushNotifications).not.toHaveBeenCalled()
+})
+
+it('retains defaults for existing users missing new preference keys', async () => {
+  const db = setup()
+  delete (db.preferences as Partial<typeof db.preferences>)
+    .perp_liquidation_warning
+  db.setPrice(92.5)
+  await db.scan()
+  expect(db.notifications[0].reason).toBe('perp_liquidation_warning')
+  expect(db.notifications[0].sourceText).toContain('close to liquidation')
+  expect(createPushNotifications).toHaveBeenCalledTimes(1)
+})
+
+it.each(['stale', 'halted', 'resolved', 'unavailable'] as const)(
+  'skips %s markets and preserves previous state',
+  async (status) => {
+    const db = setup()
+    await db.scan()
+    db.setPrice(110)
+    const market = db.rows()[0].contract
+    if (status === 'stale') market.oraclePriceTime = now - DAY_MS
+    if (status === 'halted') market.solvencyHaltTime = now
+    if (status === 'resolved') market.isResolved = true
+    if (status === 'unavailable')
+      market.oracleFeedHealth = {
+        status: 'unavailable',
+        checkedAt: now,
+      } as PerpContract['oracleFeedHealth']
+    await db.scan()
+    expect(db.notifications).toHaveLength(0)
+    expect(db.state().positions['c:long'].profit).toBe(0)
+  }
+)
+
+it('shares the PnL cap across positions but permits a risk warning', async () => {
+  const db = setup()
+  const second = position()
+  second.contract_id = 'd'
+  second.contract.id = 'd'
+  db.setRows([position(), second])
+  await db.scan()
+  db.setPrice(110)
+  await db.scan()
+  expect(db.notifications).toHaveLength(1)
+  second.contract.oraclePrice = 92.5
+  await db.scan()
+  expect(db.notifications.map((n) => n.reason)).toEqual([
+    'perp_profit',
+    'perp_liquidation_warning',
+  ])
+})
+
+it('prunes closed positions and baselines a reopened position independently', async () => {
+  const db = setup()
+  await db.scan()
+  db.setRows([])
+  await db.scan()
+  expect(db.state().positions).toEqual({})
+  const reopened = position()
+  reopened.opened_time = new Date(now).toISOString()
+  db.setRows([reopened])
+  await db.scan()
+  db.setPrice(110)
+  await db.scan()
+  expect(db.notifications).toHaveLength(1)
+})
+
+it('a push outage cannot roll back or repeatedly deliver a browser risk alert', async () => {
+  const db = setup()
+  jest
+    .mocked(createPushNotifications)
+    .mockRejectedValue(new Error('Expo unavailable'))
+  db.setPrice(92.5)
+  await db.scan()
+  await db.scan()
+  expect(db.notifications).toHaveLength(1)
+  expect(createPushNotifications).toHaveBeenCalledTimes(1)
+})

--- a/backend/shared/src/notifications/perp-position-alerts.ts
+++ b/backend/shared/src/notifications/perp-position-alerts.ts
@@ -1,0 +1,251 @@
+import { PerpContract } from 'common/contract'
+import { Notification } from 'common/notification'
+import {
+  canSendPerpPnlAlert,
+  evaluatePerpPositionAlert,
+  PERP_ALERT_REASONS,
+  PerpAlert,
+  PerpUserAlertState,
+  recentPerpPnlAlertTimes,
+} from 'common/perps/alerts'
+import { getPerpOracleFreshness } from 'common/perps/oracle'
+import { formatOraclePrice } from 'common/perps/oracle-display'
+import { inferPriceDecimals } from 'common/perps/format'
+import { PerpPosition } from 'common/perps/position'
+import { getUserFacingPnl } from 'common/perps/pnl'
+import { Row } from 'common/supabase/utils'
+import { convertPrivateUser } from 'common/supabase/users'
+import { MANIFOLD_AVATAR_URL } from 'common/user'
+import { getNotificationDestinationsForUser } from 'common/user-notification-preferences'
+import { formatMoneyPrecise } from 'common/util/format'
+import { nanoid } from 'common/util/random'
+import { mapAsync } from 'common/util/promise'
+import { createPushNotifications } from 'shared/create-push-notifications'
+import { rowToPosition } from 'shared/perps/queries'
+import {
+  createSupabaseDirectClient,
+  SupabaseDirectClient,
+} from 'shared/supabase/init'
+import { log } from 'shared/utils'
+import { broadcast } from 'shared/websockets/server'
+
+export const makePerpPositionAlertNotification = (
+  contract: PerpContract,
+  position: PerpPosition,
+  alert: PerpAlert,
+  now: number
+): Notification => {
+  const price = contract.oraclePrice
+  const decimals = inferPriceDecimals([price, position.liquidationPrice])
+  const formatPrice = (p: number) =>
+    formatOraclePrice(contract.oracleFeedId, p, decimals)
+  const pnl = getUserFacingPnl(position, price)
+  const distancePercent =
+    (Math.abs(price - position.liquidationPrice) / price) * 100
+  const sourceText =
+    alert.reason === 'perp_liquidation_warning'
+      ? `Your ${position.direction} position on ${contract.question} is ${
+          alert.threshold === 10 ? 'very ' : ''
+        }close to liquidation. The oracle price is ${formatPrice(price)}, ${
+          distancePercent < 0.1 ? 'less than 0.1' : distancePercent.toFixed(1)
+        }% from your liquidation price of ${formatPrice(
+          position.liquidationPrice
+        )}. Review your position.`
+      : `Your ${position.direction} position on ${contract.question} is ${
+          alert.reason === 'perp_profit' ? 'up' : 'down'
+        } ${Math.abs(alert.pnlPercent)
+          .toFixed(1)
+          .replace(/\.0$/, '')}% (${formatMoneyPrecise(
+          pnl
+        )} unrealized P&L, including funding and opening fees).`
+  return {
+    id: `perp-alert-${nanoid(12)}`,
+    userId: position.userId,
+    reason: alert.reason,
+    createdTime: now,
+    isSeen: false,
+    sourceId: contract.id,
+    sourceType: 'contract',
+    sourceUpdateType: 'updated',
+    sourceContractId: contract.id,
+    sourceContractTitle: contract.question,
+    sourceContractSlug: contract.slug,
+    sourceContractCreatorUsername: contract.creatorUsername,
+    sourceUserName: contract.creatorName,
+    sourceUserUsername: contract.creatorUsername,
+    sourceUserAvatarUrl: contract.creatorAvatarUrl ?? MANIFOLD_AVATAR_URL,
+    sourceSlug: contract.slug,
+    sourceTitle: contract.question,
+    sourceText,
+    data: {
+      ...alert,
+      direction: position.direction,
+      openedTime: position.openedTime,
+      oraclePrice: price,
+      liquidationPrice: position.liquidationPrice,
+    },
+  }
+}
+
+export const sendPerpPositionAlerts = async () => {
+  const pg = createSupabaseDirectClient()
+  const users = await pg.manyOrNone<{ user_id: string }>(
+    `select distinct user_id from contract_perp_positions where size > 0`
+  )
+  await mapAsync(
+    users,
+    async ({ user_id }) => {
+      try {
+        await sendPerpPositionAlertsForUser(pg, user_id)
+      } catch (error) {
+        log.error('Failed to evaluate perp position alerts', {
+          userId: user_id,
+          error,
+        })
+      }
+    },
+    5
+  )
+}
+
+export const sendPerpPositionAlertsForUser = async (
+  pg: SupabaseDirectClient,
+  userId: string
+) => {
+  const delivery = await pg.tx(async (tx) => {
+    // Serializes duplicate scheduler instances and the per-user PnL cap.
+    // Separate namespace from trading locks; never holds up the price tick.
+    await tx.one(`select pg_advisory_xact_lock(1936027745, hashtext($1))`, [
+      userId,
+    ])
+    const privateUserRow = await tx.oneOrNone<Row<'private_users'>>(
+      `select * from private_users where id = $1`,
+      [userId]
+    )
+    if (!privateUserRow) return undefined
+    const privateUser = convertPrivateUser(privateUserRow)
+    const destinations = Object.fromEntries(
+      PERP_ALERT_REASONS.map((reason) => [
+        reason,
+        getNotificationDestinationsForUser(privateUser, reason),
+      ])
+    ) as Record<
+      (typeof PERP_ALERT_REASONS)[number],
+      ReturnType<typeof getNotificationDestinationsForUser>
+    >
+    const enabled = Object.fromEntries(
+      PERP_ALERT_REASONS.map((reason) => [
+        reason,
+        destinations[reason].sendToBrowser || destinations[reason].sendToMobile,
+      ])
+    ) as Record<(typeof PERP_ALERT_REASONS)[number], boolean>
+    const saved = await tx.oneOrNone<{ data: PerpUserAlertState }>(
+      `select data from perp_alert_states where user_id = $1`,
+      [userId]
+    )
+    // Read positions and their committed oracle in the SAME statement snapshot.
+    const rows = await tx.manyOrNone<
+      Row<'contract_perp_positions'> & { contract: PerpContract }
+    >(
+      `select p.*, c.data as contract from contract_perp_positions p
+       join contracts c on c.id = p.contract_id
+       where p.user_id = $1 and p.size > 0 and c.mechanism = 'perp'
+         and c.resolution_time is null
+       order by p.contract_id, p.direction`,
+      [userId]
+    )
+    const now = Date.now()
+    const state: PerpUserAlertState = {
+      positions: {},
+      pnlAlertTimes: recentPerpPnlAlertTimes(
+        saved?.data.pnlAlertTimes ?? [],
+        now
+      ),
+    }
+    const notifications: {
+      notification: Notification
+      browser: boolean
+      mobile: boolean
+    }[] = []
+    for (const row of rows) {
+      const position = rowToPosition(row)
+      const key = `${position.contractId}:${position.direction}`
+      const prior = saved?.data.positions[key]
+      const contract = row.contract
+      // Preserve previous state during a provider outage, but never notify on
+      // stale prices, a solvency halt, a resolved market, or terminal position.
+      if (prior) state.positions[key] = prior
+      if (
+        contract.isResolved ||
+        contract.solvencyHaltTime != null ||
+        getPerpOracleFreshness(contract, now).status !== 'fresh'
+      )
+        continue
+      const result = evaluatePerpPositionAlert(
+        position,
+        contract.oraclePrice,
+        prior,
+        enabled,
+        canSendPerpPnlAlert(state.pnlAlertTimes, now),
+        now
+      )
+      if (!result) continue
+      state.positions[key] = result.state
+      if (!result.alert) continue
+      const notification = makePerpPositionAlertNotification(
+        contract,
+        position,
+        result.alert,
+        now
+      )
+      const { sendToBrowser, sendToMobile } = destinations[result.alert.reason]
+      if (sendToBrowser) {
+        // Commit notification and dedup state together. Broadcast only AFTER
+        // commit, so failed transactions neither show nor suppress an alert.
+        await tx.none(
+          `insert into user_notifications (user_id, notification_id, data) values ($1, $2, $3)`,
+          [userId, notification.id, notification]
+        )
+      }
+      notifications.push({
+        notification,
+        browser: sendToBrowser,
+        mobile: sendToMobile,
+      })
+      if (result.alert.reason !== 'perp_liquidation_warning')
+        state.pnlAlertTimes.push(now)
+    }
+    await tx.none(
+      `insert into perp_alert_states (user_id, data) values ($1, $2)
+       on conflict (user_id) do update set data = excluded.data`,
+      [userId, state]
+    )
+    return { privateUser, notifications }
+  })
+  if (!delivery) return
+  for (const { notification, browser, mobile } of delivery.notifications) {
+    if (browser) broadcast(`user-notifications/${userId}`, { notification })
+    if (mobile) {
+      // Best-effort, at-most-once push attempt. No network I/O under the lock;
+      // an Expo failure cannot roll back an already visible browser alert.
+      try {
+        await createPushNotifications([
+          [
+            delivery.privateUser,
+            notification,
+            notification.reason === 'perp_liquidation_warning'
+              ? 'Perp liquidation warning'
+              : 'Perp position update',
+            notification.sourceText,
+          ],
+        ])
+      } catch (error) {
+        log.error('Failed to push perp position alert', {
+          userId,
+          notificationId: notification.id,
+          error,
+        })
+      }
+    }
+  }
+}

--- a/backend/shared/src/perps/scheduler-routing.test.ts
+++ b/backend/shared/src/perps/scheduler-routing.test.ts
@@ -43,6 +43,7 @@ const tick = loadSchedulerModule('update-oracle-feeds.ts', {
 
 const perpJobs = [
   'update-perps',
+  'send-perp-position-alerts',
   'update-oracle-feeds',
   'update-openrouter-share',
   'update-trump-approval',
@@ -93,6 +94,9 @@ it('runs all sixteen MNX feeds on the shared 2s tick and funding hourly', () => 
   expect(jobs.find((job) => job.name === 'update-perps')?.schedule).toBe(
     '0 0 * * * *'
   )
+  expect(
+    jobs.find((job) => job.name === 'send-perp-position-alerts')?.schedule
+  ).toBe('15 * * * * *')
   expect(MNX_INSTRUMENTS).toHaveLength(16)
   for (const instrument of MNX_INSTRUMENTS) {
     expect(

--- a/backend/supabase/migrations/2026091201_perp_alert_states.sql
+++ b/backend/supabase/migrations/2026091201_perp_alert_states.sql
@@ -1,0 +1,13 @@
+begin;
+
+-- Durable milestone/rate-limit state, private to the notification worker.
+-- Do not derive deduplication from user_notifications: those are pruned.
+create table if not exists public.perp_alert_states (
+  user_id text primary key references public.users(id) on delete cascade,
+  data jsonb not null default '{"positions":{},"pnlAlertTimes":[]}'::jsonb
+);
+alter table public.perp_alert_states enable row level security;
+-- No client policies: only the backend's privileged DB connection may access.
+revoke all on public.perp_alert_states from anon, authenticated;
+
+commit;

--- a/common/src/notification.ts
+++ b/common/src/notification.ts
@@ -400,6 +400,21 @@ export const NOTIFICATION_DESCRIPTIONS: notification_descriptions = {
     simple: 'Perp liquidations',
     detailed: 'When one of your perpetual futures positions is liquidated',
   },
+  perp_profit: {
+    simple: 'Perp profit milestones',
+    detailed:
+      'When your position first reaches +50%, +100%, +200%, +500%, or +1,000% return, including funding and opening fees. At most 3 gain/loss alerts per day across all positions, at least 1 hour apart.',
+  },
+  perp_loss: {
+    simple: 'Perp loss milestones',
+    detailed:
+      'When your position first reaches −25% or −50% return, including funding and opening fees. Shares the gain/loss limit of 3 alerts per day, at least 1 hour apart.',
+  },
+  perp_liquidation_warning: {
+    simple: 'Perp liquidation warnings',
+    detailed:
+      'When 25%, then 10%, of your current margin buffer remains. Warns again only after recovery above 50% and at least 6 hours since the last warning. Checked about once a minute; fast moves can liquidate before an alert arrives.',
+  },
   perp_adl: {
     simple: 'Perp auto-deleveraging',
     detailed:

--- a/common/src/perps/alerts.test.ts
+++ b/common/src/perps/alerts.test.ts
@@ -1,0 +1,239 @@
+import {
+  canSendPerpPnlAlert,
+  evaluatePerpPositionAlert,
+  PerpPositionAlertState,
+  PERP_RISK_REARM_MS,
+} from './alerts'
+import { PerpPosition } from './position'
+import { DAY_MS, HOUR_MS } from '../util/time'
+
+const now = 10 * DAY_MS
+const position: PerpPosition = {
+  userId: 'u',
+  contractId: 'c',
+  direction: 'long',
+  size: 1000,
+  costBasis: 100,
+  originalCostBasis: 100,
+  takerFeeCostBasis: 0,
+  entryPrice: 100,
+  leverage: 10,
+  liquidationPrice: 90,
+  openedTime: now - DAY_MS,
+  updatedTime: now,
+}
+const enabled = {
+  perp_profit: true,
+  perp_loss: true,
+  perp_liquidation_warning: true,
+}
+const baseline = evaluatePerpPositionAlert(
+  position,
+  100,
+  undefined,
+  enabled,
+  true,
+  now
+)!.state
+const evaluate = (
+  price: number,
+  previous: PerpPositionAlertState | undefined = baseline,
+  overrides: Partial<PerpPosition> = {},
+  time = now
+) =>
+  evaluatePerpPositionAlert(
+    { ...position, ...overrides },
+    price,
+    previous,
+    enabled,
+    true,
+    time
+  )!
+
+it('baselines pre-existing PnL without a rollout backlog', () => {
+  const result = evaluatePerpPositionAlert(
+    position,
+    120,
+    undefined,
+    enabled,
+    true,
+    now
+  )!
+  expect(result.alert).toBeUndefined()
+  expect(result.state.profit).toBe(200)
+  expect(evaluate(150, result.state).alert?.threshold).toBe(500)
+})
+
+it.each([
+  ['long', 110],
+  ['short', 90],
+] as const)('alerts at +100%% for %s', (direction, price) => {
+  const result = evaluate(price, baseline, {
+    direction,
+    liquidationPrice: direction === 'long' ? 90 : 110,
+  })
+  expect(result.alert).toMatchObject({
+    reason: 'perp_profit',
+    threshold: 100,
+    pnlPercent: 100,
+  })
+})
+
+it('collapses jumped tiers and never repeats a milestone after oscillation', () => {
+  const jumped = evaluate(151)
+  expect(jumped.alert?.threshold).toBe(500)
+  const recovered = evaluate(110, jumped.state)
+  expect(recovered.alert).toBeUndefined()
+  expect(evaluate(151, recovered.state).alert).toBeUndefined()
+})
+
+it('uses net return including funding and opening fees', () => {
+  expect(
+    evaluate(110, baseline, { takerFeeCostBasis: 10 }).alert?.threshold
+  ).toBe(50)
+  expect(evaluate(100, baseline, { costBasis: 200 }).alert?.threshold).toBe(100)
+  expect(evaluate(100, baseline, { costBasis: 60 }).alert).toMatchObject({
+    reason: 'perp_loss',
+    threshold: 25,
+  })
+})
+
+it.each([
+  [97.5, 25],
+  [95, 50],
+])('warns for losses at price %s', (price, threshold) => {
+  expect(evaluate(price).alert).toMatchObject({
+    reason: 'perp_loss',
+    threshold,
+  })
+})
+
+it('prioritizes risk over loss, including on first observation', () => {
+  const result = evaluatePerpPositionAlert(
+    position,
+    92.5,
+    undefined,
+    enabled,
+    false,
+    now
+  )!
+  expect(result.alert).toMatchObject({
+    reason: 'perp_liquidation_warning',
+    threshold: 25,
+  })
+  expect(result.state.loss).toBe(50)
+})
+
+it('escalates risk without waiting for a PnL cooldown', () => {
+  const warning = evaluate(92.5)
+  const critical = evaluate(91, warning.state)
+  expect(critical.alert?.threshold).toBe(10)
+  expect(evaluate(91, critical.state).alert).toBeUndefined()
+  expect(evaluate(92.5, critical.state).alert).toBeUndefined()
+})
+
+it('rearms risk only after substantial recovery and six hours', () => {
+  const warning = evaluate(92.5)
+  const tooSoon = evaluate(100, warning.state, {}, now + HOUR_MS)
+  expect(
+    evaluate(92.5, tooSoon.state, {}, now + 2 * HOUR_MS).alert
+  ).toBeUndefined()
+  const tooLittle = evaluate(94, warning.state, {}, now + PERP_RISK_REARM_MS)
+  expect(
+    evaluate(92.5, tooLittle.state, {}, now + PERP_RISK_REARM_MS).alert
+  ).toBeUndefined()
+  const recovered = evaluate(100, warning.state, {}, now + PERP_RISK_REARM_MS)
+  expect(
+    evaluate(92.5, recovered.state, {}, now + PERP_RISK_REARM_MS).alert
+      ?.threshold
+  ).toBe(25)
+})
+
+it('does not treat high leverage at entry as liquidation risk', () => {
+  expect(
+    evaluate(100, baseline, { size: 5000, leverage: 50, liquidationPrice: 98 })
+      .alert
+  ).toBeUndefined()
+})
+
+it('handles short liquidation risk with the opposite price direction', () => {
+  expect(
+    evaluate(107.5, baseline, { direction: 'short', liquidationPrice: 110 })
+      .alert?.threshold
+  ).toBe(25)
+})
+
+it('consumes muted and rate-limited milestones without replay on re-enable', () => {
+  for (const [settings, allowPnl] of [
+    [enabled, false],
+    [
+      { perp_profit: false, perp_loss: false, perp_liquidation_warning: false },
+      true,
+    ],
+  ] as const) {
+    const skipped = evaluatePerpPositionAlert(
+      position,
+      110,
+      baseline,
+      settings,
+      allowPnl,
+      now
+    )!
+    expect(skipped.alert).toBeUndefined()
+    expect(evaluate(110, skipped.state).alert).toBeUndefined()
+    expect(evaluate(120, skipped.state).alert?.threshold).toBe(200)
+  }
+})
+
+it('retains consumed tiers on partial close and resets after reopen', () => {
+  const hit = evaluate(110)
+  expect(
+    evaluate(110, hit.state, {
+      size: 500,
+      costBasis: 50,
+      originalCostBasis: 50,
+    }).alert
+  ).toBeUndefined()
+  const reopened = evaluate(100, hit.state, { openedTime: now })
+  expect(reopened.state.profit).toBe(0)
+  expect(
+    evaluate(110, reopened.state, { openedTime: now }).alert?.threshold
+  ).toBe(100)
+})
+
+it.each([0, -1, NaN, Infinity])('ignores invalid oracle price %s', (price) => {
+  expect(evaluate(price)).toBeUndefined()
+})
+
+it.each([
+  { size: 0 },
+  { originalCostBasis: 0 },
+  { costBasis: NaN },
+  { takerFeeCostBasis: -1 },
+  { liquidationPrice: Infinity },
+])('ignores invalid position %j', (overrides) => {
+  expect(evaluate(100, baseline, overrides)).toBeUndefined()
+})
+
+it('leaves crossed or reached liquidation prices to the engine', () => {
+  expect(evaluate(90)).toBeUndefined()
+  expect(evaluate(89)).toBeUndefined()
+  expect(
+    evaluate(111, baseline, { direction: 'short', liquidationPrice: 110 })
+  ).toBeUndefined()
+})
+
+it('caps PnL across positions with a rolling day and an hourly cooldown', () => {
+  expect(canSendPerpPnlAlert([], now)).toBe(true)
+  expect(canSendPerpPnlAlert([now - HOUR_MS + 1], now)).toBe(false)
+  expect(canSendPerpPnlAlert([now - HOUR_MS], now)).toBe(true)
+  expect(
+    canSendPerpPnlAlert(
+      [now - 3 * HOUR_MS, now - 2 * HOUR_MS, now - HOUR_MS],
+      now
+    )
+  ).toBe(false)
+  expect(
+    canSendPerpPnlAlert([now - DAY_MS, now - 2 * HOUR_MS, now - HOUR_MS], now)
+  ).toBe(true)
+})

--- a/common/src/perps/alerts.ts
+++ b/common/src/perps/alerts.ts
@@ -1,0 +1,139 @@
+import { getPositionValue, getUserFacingPnlPercent } from './pnl'
+import { PerpPosition } from './position'
+import { DAY_MS, HOUR_MS } from '../util/time'
+
+export const PERP_ALERT_REASONS = [
+  'perp_profit',
+  'perp_loss',
+  'perp_liquidation_warning',
+] as const
+export type PerpAlertReason = (typeof PERP_ALERT_REASONS)[number]
+
+export const PERP_PROFIT_MILESTONES = [50, 100, 200, 500, 1000] as const
+export const PERP_LOSS_MILESTONES = [25, 50] as const
+export const PERP_PNL_ALERT_COOLDOWN_MS = HOUR_MS
+export const PERP_PNL_ALERT_DAILY_LIMIT = 3
+export const PERP_RISK_REARM_MS = 6 * HOUR_MS
+
+export type PerpPositionAlertState = {
+  openedTime: number
+  profit: number
+  loss: number
+  risk: number
+  lastRiskTime: number
+}
+export type PerpUserAlertState = {
+  positions: Record<string, PerpPositionAlertState>
+  pnlAlertTimes: number[]
+}
+export type PerpAlert = {
+  reason: PerpAlertReason
+  threshold: number
+  pnlPercent: number
+  remainingMarginPercent: number
+}
+
+const highestMilestone = (value: number, tiers: readonly number[]) =>
+  tiers.reduce((highest, tier) => (value >= tier ? tier : highest), 0)
+
+/** Returns at most one alert per observation. State survives restarts and is
+ * independent of notification retention. Consumed milestones never replay,
+ * including while disabled or rate limited. First observation baselines PnL
+ * to avoid a rollout/re-enable backlog, but warns about existing risk. */
+export const evaluatePerpPositionAlert = (
+  position: PerpPosition,
+  price: number,
+  previous: PerpPositionAlertState | undefined,
+  enabled: Record<PerpAlertReason, boolean>,
+  allowPnl: boolean,
+  now: number
+): { state: PerpPositionAlertState; alert?: PerpAlert } | undefined => {
+  if (
+    ![
+      price,
+      position.size,
+      position.entryPrice,
+      position.costBasis,
+      position.originalCostBasis,
+      position.openedTime,
+      position.takerFeeCostBasis ?? 0,
+      position.liquidationPrice,
+    ].every(Number.isFinite) ||
+    price <= 0 ||
+    position.size <= 0 ||
+    position.entryPrice <= 0 ||
+    position.costBasis <= 0 ||
+    position.originalCostBasis <= 0 ||
+    (position.takerFeeCostBasis ?? 0) < 0
+  )
+    return undefined
+
+  const value = getPositionValue(position, price)
+  // A crossed liquidation price belongs to the liquidation engine, not a
+  // "close to liquidation" notification. Also excludes terminal positions.
+  const distance =
+    position.direction === 'long'
+      ? price - position.liquidationPrice
+      : position.liquidationPrice - price
+  if (value <= 0 || distance <= 0) return undefined
+
+  const pnlPercent = getUserFacingPnlPercent(position, price) * 100
+  const remainingMarginPercent = (value / position.costBasis) * 100
+  if (![pnlPercent, remainingMarginPercent].every(Number.isFinite))
+    return undefined
+  const profit = highestMilestone(pnlPercent, PERP_PROFIT_MILESTONES)
+  const loss = highestMilestone(-pnlPercent, PERP_LOSS_MILESTONES)
+  const prior =
+    previous?.openedTime === position.openedTime ? previous : undefined
+  const state: PerpPositionAlertState = {
+    openedTime: position.openedTime,
+    profit: Math.max(prior?.profit ?? 0, profit),
+    loss: Math.max(prior?.loss ?? 0, loss),
+    risk: prior?.risk ?? 0,
+    lastRiskTime: prior?.lastRiskTime ?? 0,
+  }
+  // Hysteresis: crossing back over the warning threshold is not recovery.
+  // Require >50% margin remaining AND six hours since the previous warning.
+  if (
+    remainingMarginPercent > 50 &&
+    now - state.lastRiskTime >= PERP_RISK_REARM_MS
+  ) {
+    state.risk = 0
+  }
+  const risk =
+    remainingMarginPercent <= 10 ? 2 : remainingMarginPercent <= 25 ? 1 : 0
+  const makeAlert = (
+    reason: PerpAlertReason,
+    threshold: number
+  ): PerpAlert => ({ reason, threshold, pnlPercent, remainingMarginPercent })
+  if (risk > state.risk) {
+    state.risk = risk
+    state.lastRiskTime = now
+    if (enabled.perp_liquidation_warning) {
+      return {
+        state,
+        alert: makeAlert('perp_liquidation_warning', risk === 2 ? 10 : 25),
+      }
+    }
+  }
+  // Suppress PnL while at risk, even if risk alerts are muted. A single price
+  // jump should not yield both a loss alert and a liquidation warning.
+  if (prior && allowPnl && risk === 0) {
+    if (profit > prior.profit && enabled.perp_profit)
+      return { state, alert: makeAlert('perp_profit', profit) }
+    if (loss > prior.loss && enabled.perp_loss)
+      return { state, alert: makeAlert('perp_loss', loss) }
+  }
+  return { state }
+}
+
+export const recentPerpPnlAlertTimes = (times: number[], now: number) =>
+  times.filter((time) => time > now - DAY_MS)
+
+export const canSendPerpPnlAlert = (times: number[], now: number) => {
+  const recent = recentPerpPnlAlertTimes(times, now)
+  return (
+    recent.length < PERP_PNL_ALERT_DAILY_LIMIT &&
+    recent.every((time) => now - time >= PERP_PNL_ALERT_COOLDOWN_MS)
+  )
+}

--- a/common/src/user-notification-preferences.ts
+++ b/common/src/user-notification-preferences.ts
@@ -60,6 +60,9 @@ export type notification_preferences = {
   // Perps
   perp_liquidation: notification_destination_types[]
   perp_adl: notification_destination_types[]
+  perp_profit: notification_destination_types[]
+  perp_loss: notification_destination_types[]
+  perp_liquidation_warning: notification_destination_types[]
 
   // Manifold.love
   new_match: notification_destination_types[]
@@ -169,6 +172,9 @@ export const getDefaultNotificationPreferences = (isDev?: boolean) => {
     // Perps
     perp_liquidation: constructPref(true, true, true),
     perp_adl: constructPref(true, false, false),
+    perp_profit: constructPref(true, false, false),
+    perp_loss: constructPref(true, false, false),
+    perp_liquidation_warning: constructPref(true, false, true),
 
     // Manifold.love
     new_match: constructPref(true, true, true),

--- a/dev-docs/perp-position-alerts.md
+++ b/dev-docs/perp-position-alerts.md
@@ -1,0 +1,50 @@
+# Perp position alerts
+
+Adds actionable position alerts before liquidation, alongside the existing liquidation and ADL notifications. Position alerts are advisory and never place or close trades.
+
+## Exchange research
+
+- [Bybit trade settings](https://www.bybit.com/my-MM/help-center/article/How-to-activate-deactivate-trade-option-settings) supports price/percentage alerts from the trading chart, including one-time alerts and repeat-frequency choices. We adopt controls in the position panel and persistent one-time milestones.
+- [OKX liquidation alerts](https://www.okx.com/en-gb/help/how-do-i-set-up-a-liquidation-alert) exposes liquidation warnings in trading preferences and supports web/push delivery. We adopt separate risk-warning controls and escalating warnings.
+
+These sources inform the interaction patterns. The thresholds below are Manifold product choices, not exchange defaults. Exchange margin ratios are not interchangeable with Manifold's isolated position math.
+
+## Behavior
+
+| Alert               | Thresholds                                        | Default channels                  |
+| ------------------- | ------------------------------------------------- | --------------------------------- |
+| Profit              | +50%, +100%, +200%, +500%, +1,000% net return     | Web                               |
+| Loss                | −25%, −50% net return                             | Web                               |
+| Liquidation warning | 25%, then 10%, of current margin buffer remaining | Web and mobile push, if available |
+
+Returns match the position card: current value minus original margin and opening/add fees, divided by original margin plus those fees. Funding is included in current value. This is the return on committed mana, not the percentage move of the underlying price. Alerts quote current observed return and unrealized P&L.
+
+Risk uses current position value / funding-adjusted cost basis. A newly opened 50× position therefore starts with roughly its full buffer, rather than immediately warning because its liquidation price is nearby in percentage terms. Risk copy includes the observed oracle price, liquidation price, and remaining price distance. Positions already at/past liquidation are left to the liquidation engine.
+
+Controls live under **Position alerts** below open positions and **Notifications → Settings → Perps**. Settings apply to all of the user's positions. Each category has independent web and mobile switches, honors channel-wide opt-outs, and offers no email option. Existing liquidation/ADL settings are unchanged.
+
+## Noise controls and lifecycle
+
+- A price jump across several tiers produces only the highest tier. Profit and loss milestones are each consumed once per position lifetime (`openedTime`); funding, adding margin, and partial closes do not rearm them.
+- Gain/loss alerts share a rolling 24-hour maximum of three per user and a one-hour cooldown across all positions. Muted and rate-limited milestones are consumed, not queued for later delivery.
+- Risk takes priority over loss at the same observation and bypasses the gain/loss cap. Each risk severity sends at most once per episode. Rearming requires observed recovery above 50% margin remaining and six hours since the last warning; escalation to 10% does not wait.
+- The first observation baselines existing profit/loss without notifications. Existing risk can warn immediately. A close/reopen starts a new lifetime, which is baselined on its first scan too. A move entirely before the first scan may not generate a profit/loss alert.
+- State remains independent of notification retention. Closed-position entries are pruned on the user's next scan; a user's final closed entry can remain until their next position opens. Reopening uses its new timestamp regardless.
+
+## Delivery and rollout
+
+Apply `backend/supabase/migrations/2026091201_perp_alert_states.sql` before deploying the scheduler. The new table has RLS enabled, no client policies, and explicit revocation of access for anon/authenticated roles. No production migration is run by this change.
+
+`send-perp-position-alerts` runs every minute on the perps scheduler, separately from the two-second oracle tick. It reads positions and committed contract prices in one snapshot and skips stale/unavailable feeds, solvency halts, resolved markets, and terminal/invalid positions. It does not change the trading engine or acquire trading locks.
+
+Per-user advisory locks serialize duplicate workers and enforce the shared cap. In-app notification inserts and alert state commit together; websocket broadcasts follow commit. Mobile delivery is best-effort with at most one attempt: process/Expo failures after commit can lose a push, but cannot cause recurring pushes or undo a web notification. There is no guaranteed warning before liquidation, especially between scans or during downtime.
+
+The settings endpoint preserves default channels when a newly introduced preference has not yet been stored. For example, disabling mobile liquidation warnings preserves the default web channel.
+
+## Validation
+
+Automated coverage exercises both position directions, thresholds, jumps, fees/funding, cooldowns, risk hysteresis, partial close/reopen, opt-outs and missing preferences, stale/paused/resolved markets, transactional rollback/retry, independent browser/mobile delivery, and push failures. A separate PostgreSQL integration suite verifies the migration and access restrictions, eight concurrent worker scans, rollback/retry, and the real settings endpoint's default-channel preservation. Deployed UI interaction and actual push delivery still need staging verification.
+
+To run integration tests, point `PERP_ALERT_TEST_DATABASE_URL` at a disposable PostgreSQL database named `perp_alert_test` on localhost and run the shared Jest suite's `perp-position-alerts.integration.test.ts`. The suite creates fixture tables and clears their data. It refuses remote hosts or other database names and is skipped when the variable is unset. It passed against PostgreSQL 16.
+
+Staging checks: apply the migration; open a position and let it baseline; cross +100%; confirm one web notification and correct market link; enable mobile and cross another eligible threshold; turn off each channel independently; cross risk levels and recover; run overlapping worker scans; confirm a forced transaction rollback permits exactly one retry notification.

--- a/mani/components/notification/notification-item.tsx
+++ b/mani/components/notification/notification-item.tsx
@@ -146,7 +146,13 @@ export function NotificationItem({
         isChildOfGroup={isChildOfGroup}
       />
     )
-  } else if (reason === 'perp_liquidation' || reason === 'perp_adl') {
+  } else if (
+    reason === 'perp_liquidation' ||
+    reason === 'perp_adl' ||
+    reason === 'perp_profit' ||
+    reason === 'perp_loss' ||
+    reason === 'perp_liquidation_warning'
+  ) {
     const { sourceContractCreatorUsername, sourceContractSlug } = notification
     const link =
       sourceContractCreatorUsername && sourceContractSlug

--- a/web/components/notification-settings.tsx
+++ b/web/components/notification-settings.tsx
@@ -17,6 +17,7 @@ import { usePersistentInMemoryState } from 'client-common/hooks/use-persistent-i
 import clsx from 'clsx'
 import { NOTIFICATION_DESCRIPTIONS } from 'common/notification'
 import { PrivateUser } from 'common/user'
+import { PERP_ALERT_REASONS } from 'common/perps/alerts'
 import {
   getDefaultNotificationPreferences,
   notification_destination_types,
@@ -86,6 +87,7 @@ const browserDisabled: Array<notification_preference> = [
 ]
 
 const mobilePushEnabled: Array<notification_preference> = [
+  ...PERP_ALERT_REASONS,
   'resolutions_on_watched_markets',
   'resolutions_on_watched_markets_with_shares_in',
   'opt_out_all',
@@ -174,7 +176,7 @@ const otherBalances: NotificationSectionData = {
 }
 const perps: NotificationSectionData = {
   label: 'Perps',
-  subscriptionTypes: ['perp_liquidation', 'perp_adl'],
+  subscriptionTypes: [...PERP_ALERT_REASONS, 'perp_liquidation', 'perp_adl'],
 }
 const userInteractions: NotificationSectionData = {
   label: 'Users',
@@ -342,6 +344,33 @@ function AppReviewPromptToggle(props: { privateUser: PrivateUser }) {
   )
 }
 
+export function PerpAlertSettings() {
+  const privateUser = usePrivateUser()
+  if (!privateUser) return null
+  return (
+    <Col className="gap-2">
+      <p className="text-ink-500 text-sm">
+        Applies to all your perp positions. Gain/loss alerts are limited to 3
+        per day, at least 1 hour apart. Risk warnings can still escalate.
+      </p>
+      {PERP_ALERT_REASONS.map((reason) => (
+        <NotificationSettingLine
+          key={reason}
+          description={NOTIFICATION_DESCRIPTIONS[reason].simple}
+          subscriptionTypeKey={reason}
+          destinations={getUsersSavedPreference(reason, privateUser)}
+          optOutAll={getUsersSavedPreference('opt_out_all', privateUser)}
+        />
+      ))}
+      <p className="text-ink-500 text-xs">
+        Alerts start tracking gains and losses when your position is first
+        checked. Fast moves can liquidate before a warning arrives. Alerts do
+        not close positions.
+      </p>
+    </Col>
+  )
+}
+
 function NotificationSettingLine(props: {
   description: string
   subscriptionTypeKey: notification_preference
@@ -360,6 +389,10 @@ function NotificationSettingLine(props: {
   const highlight = navigateToSection === subscriptionTypeKey
   const isOptOutSection = subscriptionTypeKey === 'opt_out_all'
 
+  useEffect(() => setInAppEnabled(previousInAppValue), [previousInAppValue])
+  useEffect(() => setEmailEnabled(previousEmailValue), [previousEmailValue])
+  useEffect(() => setMobileEnabled(previousMobileValue), [previousMobileValue])
+
   return (
     <Row
       className={clsx(
@@ -371,6 +404,13 @@ function NotificationSettingLine(props: {
         <Row className="text-ink-700 gap-2 font-medium">
           <span>{description}</span>
         </Row>
+        {PERP_ALERT_REASONS.some(
+          (reason) => reason === subscriptionTypeKey
+        ) && (
+          <p className="text-ink-500 text-xs">
+            {NOTIFICATION_DESCRIPTIONS[subscriptionTypeKey].detailed}
+          </p>
+        )}
         <Row className={'gap-4'}>
           {!browserDisabled.includes(subscriptionTypeKey) && (
             <SwitchSetting

--- a/web/components/notifications/notification-types.tsx
+++ b/web/components/notifications/notification-types.tsx
@@ -368,7 +368,13 @@ export function NotificationItem(props: {
         isChildOfGroup={isChildOfGroup}
       />
     )
-  } else if (reason === 'perp_liquidation' || reason === 'perp_adl') {
+  } else if (
+    reason === 'perp_liquidation' ||
+    reason === 'perp_adl' ||
+    reason === 'perp_profit' ||
+    reason === 'perp_loss' ||
+    reason === 'perp_liquidation_warning'
+  ) {
     // Must come before the contract/updated suppressor below — perp engine
     // notifications carry sourceType 'contract' + sourceUpdateType 'updated'
     // and were being swallowed into blank rows.
@@ -2557,7 +2563,8 @@ function PerpEngineNotification(props: {
 }) {
   const { notification, isChildOfGroup, highlighted, setHighlighted } = props
   const { sourceText, reason } = notification
-  const isLiquidation = reason === 'perp_liquidation'
+  const isLiquidation =
+    reason === 'perp_liquidation' || reason === 'perp_liquidation_warning'
   return (
     <NotificationFrame
       notification={notification}
@@ -2566,7 +2573,11 @@ function PerpEngineNotification(props: {
       setHighlighted={setHighlighted}
       icon={
         <div className="flex h-full w-full items-center justify-center">
-          {isLiquidation ? (
+          {reason === 'perp_profit' ? (
+            <FaArrowTrendUp className="h-6 w-6 text-teal-500" />
+          ) : reason === 'perp_loss' ? (
+            <FaArrowTrendDown className="text-scarlet-500 h-6 w-6" />
+          ) : isLiquidation ? (
             <FaBolt className="text-scarlet-500 h-6 w-6" />
           ) : (
             <FaScaleUnbalanced className="h-6 w-6 text-amber-500" />

--- a/web/components/perps/perp-position-panel.tsx
+++ b/web/components/perps/perp-position-panel.tsx
@@ -40,6 +40,7 @@ import {
 } from 'common/util/format'
 import { randomString } from 'common/util/random'
 import { Button } from 'web/components/buttons/button'
+import { PerpAlertSettings } from 'web/components/notification-settings'
 import { Col } from 'web/components/layout/col'
 import { Modal } from 'web/components/layout/modal'
 import { Row } from 'web/components/layout/row'
@@ -243,6 +244,16 @@ export const PerpPositionPanel = (props: {
           oracleTradingPaused={oracleTradingPaused}
         />
       ))}
+      {positions.length > 0 && (
+        <details className="border-ink-200 rounded-lg border p-3">
+          <summary className="text-ink-600 cursor-pointer text-sm font-medium">
+            Position alerts
+          </summary>
+          <div className="mt-3">
+            <PerpAlertSettings />
+          </div>
+        </details>
+      )}
       {pastEvents.length > 0 && (
         <PositionHistory feedId={contract.oracleFeedId} events={pastEvents} />
       )}


### PR DESCRIPTION
Adds configurable perp profit/loss milestones and warnings before liquidation. A position crossing +100% can now notify its owner with its current net return and unrealized P&L; a shrinking margin buffer triggers escalating liquidation warnings with oracle and liquidation prices.

- Profit milestones: +50%, +100%, +200%, +500%, +1,000%; loss milestones: −25%, −50%. Returns use the same funding/fee-inclusive math as the position card.
- Risk warnings at 25% and 10% of current margin remaining. Recovery above 50% plus six hours rearms warnings. Escalation bypasses gain/loss limits.
- Independent web/mobile controls below open positions and in notification settings. Defaults: web for gains/losses, web plus available mobile push for risk. Preserves other default channels when changing a newly introduced preference.
- One-time milestones, at most three gain/loss notifications per rolling day and one per hour across positions, persistent state, no catch-up backlog, and one notification for a multi-tier jump. Risk takes priority over loss.
- Minute scheduler job reads committed prices and skips stale/paused/resolved/terminal states. Notifications and dedup state commit atomically; pushes are best-effort after commit. Web and native render the new notification types.

The [design notes](https://github.com/manifoldmarkets/manifold/blob/codex/perp-position-alerts/dev-docs/perp-position-alerts.md) document Bybit/OKX research, the Manifold-specific threshold choices, first-scan baselining, and delivery limits.

**Rollout:** apply `backend/supabase/migrations/2026091201_perp_alert_states.sql` before deploying the scheduler. Migration and production delivery have not been run against deployed environments. Alerts do not prevent liquidation or execute trades.

**Validation:** 60 tests passed across alert/P&L helpers, worker behavior, scheduler routing, and PostgreSQL 16 integration. Integration covers migration reapplication and access restrictions, eight simultaneous scans yielding one notification, transactional rollback/retry, and the real preference endpoint. Common/shared compilation and web/API/scheduler type checks passed (`--preserveSymlinks` for the isolated local dependency links). New/backend/common code passed ESLint; web lint reported only two existing unused-variable warnings outside changed lines. Deployed UI interaction and real mobile push delivery remain staging checks.
